### PR TITLE
feat(EvolutionWindow): mechanize the backward-projection constraint — expand-into gate

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -50,6 +50,7 @@
     <Compile Include="DynamicValueFold.fs" />
     <Compile Include="SchemaEvolution.fs" />
     <Compile Include="SchemaRegistry.fs" />
+    <Compile Include="EvolutionWindow.fs" />
     <Compile Include="Protobuf.fs" />
     <Compile Include="SoftValue.fs" />
     <Compile Include="BonsaiSoft.fs" />

--- a/src/Core/EvolutionWindow.fs
+++ b/src/Core/EvolutionWindow.fs
@@ -1,0 +1,54 @@
+namespace Zeta.Core
+
+/// **Evolution migration-window gate — the backward-projection constraint mechanized (Aaron 2026-06-07).**
+///
+/// During an expand/migrate/contract evolution, *adding* a relation is reversible, but **writing data that
+/// only the new (expanded) shape can represent** — "expand-INTO" — is unsafe while any older reader still
+/// lives: serving that reader requires projecting the richer shape back down to its flatter shape, a LOSSY
+/// backward projection. So expand-into is GATED on contract-complete: you may expand into version `targetV`
+/// only once every live reader is already at `>= targetV` (no one is owed a lossless flat projection of it).
+///
+/// This module tracks the live-reader set and answers `mayExpandInto`; `guardExpandInto` turns the
+/// constraint into a `Result` so an attempted unsafe write is a clean Error, not corruption. Pairs with the
+/// SchemaEvolution down-direction (the projection that WOULD be lossy is exactly the missing/None inverse).
+[<RequireQualifiedAccess>]
+module EvolutionWindow =
+
+    /// The migration window: which schema versions still have a LIVE reader. (A reader at version `v` can
+    /// losslessly receive any value whose shape is `<= v`; it would need a lossy down-projection for data
+    /// authored at a version `> v`.)
+    type Window = { LiveReaderVersions: Set<int> }
+
+    /// No readers — vacuously safe to expand into anything.
+    let empty: Window = { LiveReaderVersions = Set.empty }
+
+    /// Register a live reader at schema version `v`.
+    let readerJoins (v: int) (w: Window) : Window =
+        { w with LiveReaderVersions = Set.add v w.LiveReaderVersions }
+
+    /// Drop a live reader at schema version `v` (e.g. its deployment was retired — part of CONTRACT).
+    let readerLeaves (v: int) (w: Window) : Window =
+        { w with LiveReaderVersions = Set.remove v w.LiveReaderVersions }
+
+    /// The oldest live reader version, or `None` if there are no readers.
+    let minLiveVersion (w: Window) : int option =
+        if Set.isEmpty w.LiveReaderVersions then None else Some(Set.minElement w.LiveReaderVersions)
+
+    /// May we expand INTO version `targetV`? Iff every live reader is already at `>= targetV` — i.e. no
+    /// older reader remains that would be owed a lossy flat projection of the expanded data.
+    let mayExpandInto (targetV: int) (w: Window) : bool =
+        w.LiveReaderVersions |> Set.forall (fun rv -> rv >= targetV)
+
+    /// `mayExpandInto` as a guard: `Ok ()` when safe, else an `Error` naming the oldest blocking reader.
+    /// Use before authoring expanded-only data so an unsafe expand-into is a clean failure, not corruption.
+    let guardExpandInto (targetV: int) (w: Window) : Result<unit, string> =
+        if mayExpandInto targetV w then
+            Ok()
+        else
+            let oldest = minLiveVersion w |> Option.defaultValue targetV
+            Error(
+                sprintf
+                    "cannot expand-into v%d: a live reader at v%d remains (would owe a lossy backward projection; contract first)"
+                    targetV
+                    oldest
+            )

--- a/tests/Tests.FSharp/EvolutionWindow.Tests.fs
+++ b/tests/Tests.FSharp/EvolutionWindow.Tests.fs
@@ -1,0 +1,44 @@
+module Zeta.Tests.EvolutionWindowTests
+
+open global.Xunit
+open FsCheck
+open FsCheck.FSharp
+open FsCheck.Xunit
+open Zeta.Core
+
+module EW = Zeta.Core.EvolutionWindow
+
+// The backward-projection constraint mechanized: expand-into vN is safe iff every live reader is >= vN.
+
+[<Fact>]
+let ``no readers => expand-into anything is vacuously safe`` () =
+    Assert.True(EW.mayExpandInto 5 EW.empty)
+    Assert.Equal<Result<unit, string>>(Ok(), EW.guardExpandInto 5 EW.empty)
+    Assert.Equal(None, EW.minLiveVersion EW.empty)
+
+[<Fact>]
+let ``an older live reader blocks expand-into; guard names it`` () =
+    let w = EW.empty |> EW.readerJoins 1 |> EW.readerJoins 3
+    Assert.False(EW.mayExpandInto 2 w) // reader at v1 < 2 blocks
+    Assert.Equal(Some 1, EW.minLiveVersion w)
+    match EW.guardExpandInto 2 w with
+    | Error msg -> Assert.Contains("v1", msg)
+    | Ok () -> Assert.Fail "expected the v1 reader to block expand-into v2"
+
+[<Fact>]
+let ``after the old reader leaves (contract), expand-into becomes safe`` () =
+    let w = EW.empty |> EW.readerJoins 1 |> EW.readerJoins 2
+    Assert.False(EW.mayExpandInto 2 w)
+    let w2 = EW.readerLeaves 1 w // contract: retire the v1 reader
+    Assert.True(EW.mayExpandInto 2 w2)
+    Assert.Equal<Result<unit, string>>(Ok(), EW.guardExpandInto 2 w2)
+
+[<Property>]
+let ``law: mayExpandInto targetV iff every live reader >= targetV`` (readers: int list) (targetV: int) =
+    let w = readers |> List.fold (fun acc v -> EW.readerJoins v acc) EW.empty
+    EW.mayExpandInto targetV w = (readers |> List.forall (fun v -> v >= targetV))
+
+[<Property>]
+let ``law: guardExpandInto is Ok exactly when mayExpandInto is true`` (readers: int list) (targetV: int) =
+    let w = readers |> List.fold (fun acc v -> EW.readerJoins v acc) EW.empty
+    (EW.guardExpandInto targetV w = Ok()) = EW.mayExpandInto targetV w

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -77,6 +77,7 @@
     <Compile Include="Merkle.FullVertical.Tests.fs" />
     <Compile Include="ZSetMerkle.Tests.fs" />
     <Compile Include="Collation.Tests.fs" />
+    <Compile Include="EvolutionWindow.Tests.fs" />
     <Compile Include="SerializationSeed.FullVertical.Tests.fs" />
     <Compile Include="Identity.FullVertical.Tests.fs" />
     <Compile Include="Predicate3.Tests.fs" />


### PR DESCRIPTION
## What — Evolution extension (`081KTGYQ3A5`)
The expansion-side safety barrier (the backward-projection constraint) as code.

- **`EvolutionWindow`** tracks the live-reader set by schema version; **`mayExpandInto targetV`** = every live reader is already `>= targetV` (no older reader owed a lossy flat projection of the expanded data).
- **`guardExpandInto`** → `Result` so an unsafe expand-into is a clean **Error naming the oldest blocking reader**, not corruption.
- `readerJoins`/`readerLeaves` model the window; a reader leaving is part of **CONTRACT**.

## Test
`dotnet test … --filter EvolutionWindow` → **5 passed** (3 example + 2 FsCheck laws).

The reduction-side complement (garbage-dump for lossy removals) is captured separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)