### PR TITLE
docs(Evolution): forward-projection garbage dump — lossless rollback for lossy removals

### DIFF
--- a/docs/research/2026-06-07-evolution-schema-and-index-as-proven-projections-parallel-experiment-timelines-merge-contract-aaron-amara.md
+++ b/docs/research/2026-06-07-evolution-schema-and-index-as-proven-projections-parallel-experiment-timelines-merge-contract-aaron-amara.md
@@ -93,7 +93,36 @@ needs a lossless flat projection of it`. This is the down-direction of the inver
 *temporally*: a write is admissible only when its backward projection to every still-living reader is
 lossless (or no such reader exists). It's a correctness barrier, not a policy convenience — emitting
 richer-only data during the window would owe a lossy down-projection to a flat reader and corrupt it.
-(Mechanizable: track the window/contract state; gate expand-into writes on "no flat reader remains".)
+**LANDED:** `src/Core/EvolutionWindow.fs` mechanizes exactly this — `mayExpandInto`/`guardExpandInto` over a
+live-reader set; `readerLeaves` = contract.
+
+**Reduction-side complement — the temporary GARBAGE DUMP for lossy removals (Aaron 2026-06-07).** The
+expand-into gate covers the *expansion* side; reduction (a forward projection that REMOVES a relation) is
+the dual, and it's where the lossy/non-invertible row of the taxonomy gets its concrete mechanism:
+
+> *"when a forward projection removes a relation then you need a temporary garbage dump on the new schema to
+> hold the lossy data in case a rollback is needed; it can be dropped after full migration including
+> cleaning up the old schema."*
+
+A `removeField`/relation-drop loses the removed data, so its down-migration can only restore a default
+(lossy / "names the loss" — see `removeFieldMigration`). To make the removal **rollback-safe during the
+window**, **stash the removed data in a temporary garbage dump on the new schema** instead of discarding it:
+
+```
+forward (reduce):  remove relation R  →  move R's data into the dump (don't discard)
+rollback:          restore R from the dump  →  LOSSLESS rollback (not just a default)
+GC the dump:       only after FULL migration + old-schema cleanup (the rollback horizon / contract-complete)
+```
+
+This is the taxonomy's *"lossy = invertible only if shadow/history is retained"* row made concrete: **the
+dump IS the retained shadow.** It upgrades a lossy removal to an effectively-lossless rollback *for the
+duration of the window*, then GCs once rollback is no longer possible/needed — the **same contract-complete
+horizon** the `EvolutionWindow` already tracks (so dump-GC and expand-into-enable fire at the same gate).
+Cheap on the COW/content-addressed store (the dump is content-addressed side state, dedup'd, dropped by
+forgetting a root). Implementation sketch: a `removeFieldMigration` variant that stashes the removed value
+under a reserved dump key and whose `Down` restores from the dump (real value, not default) while the dump
+lives — turning the only non-invertible primitive op into a window-scoped lossless one. Together: **expand
+is gated on contract; reduce is made reversible by a contract-scoped dump — full bidirectional safety.**
 
 For zero-downtime rollback of destructive DDL you **retain shadow state** (old column/table/translation
 log/tombstones/derivable indexes) until the **rollback horizon** expires. Keeper: *DDL becomes stream

--- a/workitems/081KTGYQ3A508QG0R002Y8Y5N2-evolution-extension-bidirectional-schema-migration-proof-par.md
+++ b/workitems/081KTGYQ3A508QG0R002Y8Y5N2-evolution-extension-bidirectional-schema-migration-proof-par.md
@@ -41,6 +41,14 @@ algebra + forward/backward compat, 8 tests) into the full capability Amara + Aar
    a lossless flat projection of it`. Mechanizable: track window/contract state, gate expand-into writes.
    A correctness barrier, not policy. Full: the Evolution research doc §1.
 
+1c. **Reduction-side garbage dump for lossy removals (Aaron 2026-06-07).** When a forward projection
+   REMOVES a relation, stash the removed data in a TEMPORARY garbage dump on the new schema so rollback is
+   LOSSLESS (restore from the dump, not a default); GC the dump only after full migration + old-schema
+   cleanup (the rollback horizon = contract-complete, the same gate EvolutionWindow tracks). This is the
+   taxonomy's "lossy = invertible iff shadow retained" made concrete — the dump IS the shadow. Build: a
+   removeFieldMigration variant that stashes the removed value + Down restores from the dump while it lives.
+   LANDED so far: `src/Core/EvolutionWindow.fs` (the expansion-side expand-into gate, 5 tests).
+
 2. **Parallel production experiment-timelines + continual merge contract.** Many experiments forked from
    `main`, each with full code+data+schema+side-effect-sandbox freedom, governed by an `ExperimentContract`
    (baseMainRoot/experimentRoot/code/data/schema/mainToExperimentMerge/experimentToMainProjection/


### PR DESCRIPTION
## What
Captures Aaron's 2026-06-07 reduction-side insight: *"when a forward projection removes a relation, you need a temporary garbage dump on the new schema to hold the lossy data in case of rollback; drop it after full migration + old-schema cleanup."*

- A relation-drop is lossy → its down can only restore a default. **Stash the removed data in a temporary garbage dump** instead → rollback is **lossless** (restore from the dump).
- **GC the dump only at the rollback horizon** (full migration + old-schema cleanup = **contract-complete**) — the *same gate* `EvolutionWindow` already tracks, so dump-GC and expand-into-enable fire together.
- This is the taxonomy's *"lossy = invertible iff shadow retained"* row made concrete — **the dump IS the shadow**. Cheap on the COW/content-addressed store.
- Together with the landed expand-into gate (`EvolutionWindow.fs`): **expand gated on contract; reduce reversible via a contract-scoped dump = full bidirectional safety.**

Captured in the Evolution doc §1 + workitem `081KTGYQ3A5`. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)