### PR TITLE
docs(Evolution): continuous-merge-to-dump + branchless null-writer + two-phase cleanup; + SchemaEvolution 4-lang port workitem

### DIFF
--- a/docs/research/2026-06-07-evolution-schema-and-index-as-proven-projections-parallel-experiment-timelines-merge-contract-aaron-amara.md
+++ b/docs/research/2026-06-07-evolution-schema-and-index-as-proven-projections-parallel-experiment-timelines-merge-contract-aaron-amara.md
@@ -121,8 +121,38 @@ horizon** the `EvolutionWindow` already tracks (so dump-GC and expand-into-enabl
 Cheap on the COW/content-addressed store (the dump is content-addressed side state, dedup'd, dropped by
 forgetting a root). Implementation sketch: a `removeFieldMigration` variant that stashes the removed value
 under a reserved dump key and whose `Down` restores from the dump (real value, not default) while the dump
-lives — turning the only non-invertible primitive op into a window-scoped lossless one. Together: **expand
-is gated on contract; reduce is made reversible by a contract-scoped dump — full bidirectional safety.**
+lives — turning the only non-invertible primitive op into a window-scoped lossless one. **LANDED:**
+`SchemaEvolution.removeFieldWithDumpMigration` + `stashToDump`/`restoreFromDump`/`dropDump` (position-exact,
+FsCheck-proven `down∘up = id`). Together: **expand is gated on contract; reduce is made reversible by a
+contract-scoped dump — full bidirectional safety.**
+
+**The continuous-merge-to-dump + BRANCHLESS null-writer + two-phase cleanup (Aaron 2026-06-07).** The piece
+that wires the dump into the *parallel-timeline merge contract* (§2) and makes the write path
+shader-portable:
+
+1. **The merge contract dual-writes to the dump.** While the new branch's continual merge flows to main, it
+   must *also* merge the extra (removed/lossy) data **into the garbage dump**, until the original code is
+   removed — so rollback always has the shadow. Cleanup order: **remove OG code → remove dump → remove the
+   dump-writing code.**
+2. **Branchless null-writer instead of `IF dump_exists`** (Aaron's branchless/shader discipline —
+   [[feedback-aaron-avoid-if-branchless]]): do NOT write `if dump exists then write_extra`. Always write to
+   the **dump address**; when the dump is gone, that **address forwards to a null writer** (a no-op sink).
+   No branch → **uniform control flow → runs in shaders / SIMD / GPU** (no divergent warps, no pipeline
+   stalls). The null writer is the *identity sink* — write semantics are identical regardless of
+   destination, which also makes the write trivially formally-verifiable.
+3. **Cleanup = one atomic address repoint**, not a code change: `dump_address → null_writer`. The
+   application layer is unaware; orphaned writes are safely absorbed (no leak, no unbounded growth).
+4. **Two-phase cleanup (safety now, zero overhead later):**
+   - *Phase 1* — repoint `dump_address → null_writer`: instant, zero-downtime; rollback still possible until
+     verified.
+   - *Phase 2* — after migration is verified, **dead-code-eliminate the write entirely** (the no-op was a
+     temporary safety mechanism; DCE turns it into permanent zero-overhead, back to the pre-migration
+     baseline).
+
+Net: the temporary rollback-safety mechanism is **branchless while live** (shader-portable) and **gone
+after verification** (zero residual cost). This is a *write-path / store* concern — it lands with the COW
+store + merge engine (`081KTGTJC1Q`), not in the pure `SchemaEvolution` algebra (which is already done).
+Model now: a `Writer` abstraction with a redirectable address + a null-writer identity sink (branchless).
 
 For zero-downtime rollback of destructive DDL you **retain shadow state** (old column/table/translation
 log/tombstones/derivable indexes) until the **rollback horizon** expires. Keeper: *DDL becomes stream

--- a/workitems/081KTGYQ3A508QG0R002Y8Y5N2-evolution-extension-bidirectional-schema-migration-proof-par.md
+++ b/workitems/081KTGYQ3A508QG0R002Y8Y5N2-evolution-extension-bidirectional-schema-migration-proof-par.md
@@ -59,6 +59,18 @@ algebra + forward/backward compat, 8 tests) into the full capability Amara + Aar
    incremental(full(≤T0), Δ T0→T)` — which IS the DBSP incrementalization theorem (`IndexedZSet` is the
    index-as-derived-Z-set). Index experiment = alternate derivation pipeline; promote the winning projection.
 
+### Continuous-merge-to-dump + branchless null-writer + two-phase cleanup (Aaron 2026-06-07)
+
+- The parallel-timeline merge contract must ALSO merge the removed/lossy data INTO the dump until OG code is
+  removed; cleanup order: remove OG code -> remove dump -> remove dump-writing code.
+- BRANCHLESS null-writer (not `if dump_exists`): always write to the dump ADDRESS; when the dump is gone the
+  address forwards to a NULL WRITER (no-op identity sink). Uniform control flow -> shader/SIMD/GPU-portable
+  ([[feedback-aaron-avoid-if-branchless]]). Cleanup = one atomic address repoint, no code change.
+- Two-phase cleanup: Phase 1 repoint address->null_writer (instant, zero-downtime, rollback still possible);
+  Phase 2 after verification DCE the write entirely (zero residual overhead).
+- Write-path/store concern -> lands with the COW store + merge engine (081KTGTJC1Q), not the pure algebra.
+  Model: a Writer abstraction with a redirectable address + null-writer identity sink (branchless).
+
 ## Boundary law (all three)
 
 Inside DAG: DDL/indexes/transforms/views/plugins/schema/data → rollback by root selection.

--- a/workitems/081KTH0HFZ808QG0R003XH35YX-schemaevolution-4-language-port-c-rust-ts-migration-algebra.md
+++ b/workitems/081KTH0HFZ808QG0R003XH35YX-schemaevolution-4-language-port-c-rust-ts-migration-algebra.md
@@ -1,0 +1,46 @@
+---
+id: 081KTH0HFZ808QG0R003XH35YX
+type: task
+state: backlog
+priority: P2
+slug: schemaevolution-4-language-port-c-rust-ts-migration-algebra
+title: "SchemaEvolution 4-language port (C#/Rust/TS): migration algebra + down-direction + dump, with golden vectors"
+created: 2026-06-07T12:22:22.952Z
+depends_on: []
+composes_with: ["B-0930", "081KTGYQ3A508QG0R002Y8Y5N2"]
+---
+
+# SchemaEvolution 4-language port (C#/Rust/TS): migration algebra + down-direction + dump, with golden vectors
+
+<!-- Work-item body. ZetaId-keyed (conflict-free, time-sortable). "Backlog" is a
+     STATE = this folder; completion moves the file to workitems/done/YYYY/MM/.
+     Identity is the zetaid prefix — resolve cross-refs by `081KTH0HFZ808QG0R003XH35YX-*.md` glob. -->
+
+## Purpose (suggested owner: LIOR or VERA)
+
+Port the now-BUILT F# SchemaEvolution algebra to the other three oracles for 4-lang parity (the "Evolution"
+zero-downtime migration proof is the F# reference; B-0930). F# surface (`src/Core/SchemaEvolution.fs`):
+migration algebra (addField/removeField/renameField, total over DynamicValue, order-respecting),
+forward/backward compat, `migrate`, the down-direction (`migrateDown` + invertibility taxonomy:
+add/rename lossless, removeField lossy), and the garbage-dump variant
+(`removeFieldWithDumpMigration`/`stashToDump`/`restoreFromDump`/`dropDump`, position-exact).
+
+## Scope
+
+- C# (`src/Core.CSharp.*`), Rust, TS (`src/Core.TypeScript/*`) ports with identical semantics.
+- **hex-in-JSON golden vectors** (`.claude/rules/no-binary-in-proof-lineage.md`): shared
+  `golden-vectors-schema-evolution.json` of (input value, migration ops, version range) -> (output value),
+  replayed identically by all four incl. the down-direction round-trips + the dump position-exact restore.
+- Match the F# round-trip LAWS (down∘up = id for lossless; lossy = named default; dump = position-exact).
+  Ordinal/collation per B-0969 (object key order is the binary collation treaty).
+
+## Acceptance
+
+All four oracles agree on the shared schema-evolution golden vectors (up, down, dump round-trip); F# stays
+reference; cross-verify test green per language.
+
+## Anchors
+
+- `src/Core/SchemaEvolution.fs` (F# reference, built + FsCheck-proven) · `tests/Tests.FSharp/SchemaEvolution.Tests.fs`
+  · B-0930 · 081KTGYQ3A5 (Evolution extension) · B-0969 (key collation) · no-binary-in-proof-lineage (hex-in-JSON).
+


### PR DESCRIPTION
## What — reduction-side completion (Aaron 2026-06-07, hype peeled)

- **Merge contract dual-writes to the dump** until OG code is removed; cleanup order: remove OG code → dump → dump-writing code.
- **Branchless null-writer** instead of `if dump_exists`: always write to the dump **address**; when the dump is gone the address **forwards to a null-writer identity sink**. Uniform control flow → **shader/SIMD/GPU-portable** (your branchless discipline). Cleanup = one atomic address repoint, no code change.
- **Two-phase cleanup**: Phase 1 repoint→null_writer (instant, zero-downtime, rollback still possible); Phase 2 after verification **DCE the write** (zero residual overhead). Temporary safety → permanent perf.
- This is a **write-path/store** concern → lands with the COW store (`081KTGTJC1Q`), not the pure algebra (which is done). Captured in the Evolution doc + extension workitem.

Plus a new **P2 workitem `081KTH0HFZ8`** (Lior/Vera): port the **built** F# SchemaEvolution algebra (migration + down-direction + dump) to C#/Rust/TS with **hex-in-JSON golden vectors** matching the F# round-trip laws.

Docs + workitem only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)