### PR TITLE
feat(ContentStore): content-addressed single-instance store — COW Merkle-DAG backend foundation

### DIFF
--- a/src/Core/ContentStore.fs
+++ b/src/Core/ContentStore.fs
@@ -1,0 +1,61 @@
+namespace Zeta.Core
+
+open System.Collections.Immutable
+
+/// **Content-addressed, single-instance store — the COW Merkle-DAG backend foundation (081KTGTJC1Q).**
+///
+/// A value is stored ONCE, keyed by the hash of its content (the key IS the content address). Properties
+/// that make this the git-compatible / APFS-like substrate:
+///
+///   - **Single-instance / dedup** — identical content under any number of references is one stored node;
+///     `put` of already-present content is a no-op on the set of nodes (idempotent — discipline #6).
+///   - **Copy-on-write** — `put` returns a NEW `Store` version; the prior version is unchanged, so old
+///     roots persist as **cheap branches** (the fork-from-prod / experiment-timeline substrate). Backed by
+///     an immutable `Map`, so sharing is structural (no copy).
+///   - **Hash-parameterized** — the content hash comes from an injected `hashOf`; XxHash128 (`MerkleHash`)
+///     today, **BLAKE3** for the tamper-evident git-replacement store (Aaron's decision; B-0969-adjacent).
+///     The `ZSetMerkle` root is the natural `hashOf` for Z-set-valued nodes.
+///
+/// This is the object/blob layer; the multi-parent closure-table DAG (folders → nodes, hardlink-shaped)
+/// and the garbage-dump null-writer write path land on top (`Hierarchy.fs` + the merge engine).
+[<RequireQualifiedAccess>]
+module ContentStore =
+
+    /// An immutable content-addressed store. `hashOf` makes the address; `byHash` is the single-instance
+    /// node set. Construct via `create`; evolve via `put` (each returns a new COW version).
+    [<NoEquality; NoComparison>]
+    type Store<'V> =
+        private
+            { byHash: ImmutableDictionary<MerkleHash, 'V>
+              hashOf: 'V -> MerkleHash }
+
+    /// A store keyed by `hashOf` (e.g. `ZSetMerkle.root enc` for Z-sets, or a canonical-CBOR hash).
+    /// `ImmutableDictionary` keys on `MerkleHash`'s custom equality (no ordering needed) and stays
+    /// structurally-shared/immutable, so each `put` is a cheap COW version.
+    let create (hashOf: 'V -> MerkleHash) : Store<'V> =
+        { byHash = ImmutableDictionary.Create<MerkleHash, 'V>(); hashOf = hashOf }
+
+    /// The content address of a value WITHOUT storing it (pure; for lookup-before-put / equality checks).
+    let addressOf (v: 'V) (s: Store<'V>) : MerkleHash = s.hashOf v
+
+    /// Idempotent content-addressed put: returns the content hash + the new (COW) store version. Storing
+    /// content already present leaves the node set unchanged (single-instance dedup) — `apply-N == apply-1`.
+    let put (v: 'V) (s: Store<'V>) : MerkleHash * Store<'V> =
+        let h = s.hashOf v
+        if s.byHash.ContainsKey h then h, s // dedup: already single-instanced
+        else h, { s with byHash = s.byHash.Add(h, v) }
+
+    /// Fetch content by its address.
+    let get (h: MerkleHash) (s: Store<'V>) : 'V option =
+        match s.byHash.TryGetValue h with
+        | true, v -> Some v
+        | _ -> None
+
+    /// Is this address present?
+    let contains (h: MerkleHash) (s: Store<'V>) : bool = s.byHash.ContainsKey h
+
+    /// The number of distinct (single-instanced) nodes.
+    let count (s: Store<'V>) : int = s.byHash.Count
+
+    /// All content addresses currently stored.
+    let addresses (s: Store<'V>) : MerkleHash seq = s.byHash.Keys

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -83,6 +83,7 @@
     <Compile Include="FastCdc.fs" />
     <Compile Include="Merkle.fs" />
     <Compile Include="ZSetMerkle.fs" />
+    <Compile Include="ContentStore.fs" />
     <Compile Include="Residuated.fs" />
     <Compile Include="Aggregate.fs" />
     <Compile Include="RobustStats.fs" />

--- a/tests/Tests.FSharp/ContentStore.Tests.fs
+++ b/tests/Tests.FSharp/ContentStore.Tests.fs
@@ -1,0 +1,55 @@
+module Zeta.Tests.ContentStoreTests
+
+open System
+open global.Xunit
+open Zeta.Core
+
+module CS = Zeta.Core.ContentStore
+
+// Content-addressed single-instance store (081KTGTJC1Q). Keyed by the ZSetMerkle root, so identical Z-set
+// content dedups to one node; put is idempotent; each put is a COW version (old versions persist).
+
+let private encI (i: int) : byte[] =
+    let b = Array.zeroCreate<byte> 4
+    System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(Span<byte> b, i)
+    b
+
+let private store () : CS.Store<ZSet<int>> = CS.create (ZSetMerkle.root encI)
+
+[<Fact>]
+let ``put returns the content address; get round-trips`` () =
+    let z = ZSet.ofSeq [ 1, 1L; 2, 1L ]
+    let h, s = CS.put z (store ())
+    Assert.Equal(h, CS.addressOf z s)
+    Assert.Equal<ZSet<int> option>(Some z, CS.get h s)
+
+[<Fact>]
+let ``identical content dedups to one node (single-instance); put is idempotent`` () =
+    let z = ZSet.ofSeq [ 1, 2L; 3, 4L ]
+    let h1, s1 = CS.put z (store ())
+    let h2, s2 = CS.put z s1 // put the SAME content again
+    Assert.Equal(h1, h2)
+    Assert.Equal(1, CS.count s2) // still one node — dedup
+    Assert.Equal(CS.count s1, CS.count s2) // apply-twice == apply-once (effect)
+
+[<Fact>]
+let ``distinct content yields distinct addresses and two nodes`` () =
+    let a = ZSet.ofSeq [ 1, 1L ]
+    let b = ZSet.ofSeq [ 1, 2L ] // same key, different weight => different content
+    let ha, s1 = CS.put a (store ())
+    let hb, s2 = CS.put b s1
+    Assert.NotEqual(ha, hb)
+    Assert.Equal(2, CS.count s2)
+    Assert.Equal<ZSet<int> option>(Some a, CS.get ha s2)
+    Assert.Equal<ZSet<int> option>(Some b, CS.get hb s2)
+
+[<Fact>]
+let ``put is copy-on-write — the prior store version is unchanged (cheap branches)`` () =
+    let empty = store ()
+    let z = ZSet.ofSeq [ 7, 1L ]
+    let h, s1 = CS.put z empty
+    // the original version never saw the node — old roots persist as branches
+    Assert.Equal(0, CS.count empty)
+    Assert.False(CS.contains h empty)
+    Assert.Equal(1, CS.count s1)
+    Assert.True(CS.contains h s1)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -76,6 +76,7 @@
     <Compile Include="Clock.FullVertical.Tests.fs" />
     <Compile Include="Merkle.FullVertical.Tests.fs" />
     <Compile Include="ZSetMerkle.Tests.fs" />
+    <Compile Include="ContentStore.Tests.fs" />
     <Compile Include="Collation.Tests.fs" />
     <Compile Include="EvolutionWindow.Tests.fs" />
     <Compile Include="SerializationSeed.FullVertical.Tests.fs" />


### PR DESCRIPTION
## What — first non-dep slice of the COW store (`081KTGTJC1Q`)
A value stored once, keyed by its content hash (the key IS the address):
- **Single-instance / dedup** — `put` of already-present content is a no-op on the node set (idempotent).
- **Copy-on-write** — `put` returns a **new** `Store` version; the prior is unchanged, so old roots persist as **cheap branches** (the fork-from-prod / experiment-timeline substrate). `ImmutableDictionary` (structural sharing; `MerkleHash` custom equality, no ordering needed).
- **Hash-parameterized** — address from injected `hashOf`: XxHash128 (`ZSetMerkle.root`) today, **BLAKE3** for the git-replacement store (pending the dep add).

## Test
`dotnet test … --filter ContentStore` → **4 passed** (address round-trip, dedup+idempotent put, distinct-content→distinct-nodes, COW version isolation).

Next: multi-parent closure-table DAG (folders → nodes) on top of `Hierarchy.fs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)