### PR TITLE
docs(prior-art): adopt CloudEvents bus envelope + Debezium CDC (before/after/op = Z-set delta) anchor

### DIFF
--- a/docs/PRIOR-ART-LIST.md
+++ b/docs/PRIOR-ART-LIST.md
@@ -24,6 +24,12 @@ with a ⭐ below and add a row there.
   closure-table-style `Hierarchy.fs`.
 - **XTDB 2** ⭐ — Arrow bitemporal indexes; temporal-query
   inspiration.
+- **CloudEvents** ⭐ — CNCF event-envelope standard (v1.0); to be the bus
+  envelope over Zeta's busses. See `docs/research/2026-06-07-cloudevents-bus-envelope-and-debezium-cdc-as-zset-delta-anchor-aaron.md`.
+- **Debezium / CDC** ⭐ — Red Hat; the `before/after/op/source/ts_ms` change-event
+  envelope = a **DBSP Z-set delta** (c=+after, d=−before, u=−before+after). Anchor
+  for our `DeltaLog`/`ZSet` deltas + schema-on-stream (Kafka Schema Registry ≅
+  SchemaEvolution/B-0930). Emits CloudEvents (`CloudEventsConverter`).
 - **Reaqtor / IQbservable / Nuqleon / Bonsai** ⭐ — **Bart DeSmet**
   (built for Bing; now under the .NET Foundation). Stateful
   event-processing + the **Bonsai/Nuqleon** serialized-expression-tree

--- a/docs/research/2026-06-07-cloudevents-bus-envelope-and-debezium-cdc-as-zset-delta-anchor-aaron.md
+++ b/docs/research/2026-06-07-cloudevents-bus-envelope-and-debezium-cdc-as-zset-delta-anchor-aaron.md
@@ -1,0 +1,72 @@
+# CloudEvents as the bus-envelope standard + Debezium CDC format as the change-event anchor (Aaron, 2026-06-07)
+
+> Aaron: *"we should probably look up Debezium for prior art around schema on event store/stream and what
+> their event format looks like — maybe it's a standard we could use. I know we should also use the standard
+> CloudEvents over our busses."*
+
+Two standards to adopt rather than reinvent (the Beacon discipline — `anchor-to-human-prior-art`). The
+striking finding: **Debezium's change-event format is a Z-set delta in disguise**, so we independently
+arrived at an established model and should name it.
+
+## 1. CloudEvents (CNCF) — adopt as the bus envelope
+
+**CloudEvents** (CNCF graduated; spec v1.0) is the vendor-neutral envelope for event data. Required
+attributes: `id`, `source`, `specversion`, `type`; optional: `time`, `subject`, `datacontenttype`,
+`dataschema`; plus **extension attributes** and the `data` payload. It has protocol **bindings** (HTTP,
+Kafka, AMQP, NATS, MQTT) and **formats** (JSON, Avro, Protobuf), with structured and binary content modes.
+
+**Adopt over Zeta's busses** (the agent-bus, the Log/Delta streams): wear the CloudEvents envelope so our
+events interoperate with the ecosystem instead of carrying a bespoke header. Our `ZetaId` → `id`/`source`;
+the change kind → `type`; the canonical-CBOR/JSON payload → `data` (`datacontenttype`); schema version →
+`dataschema` (ties to SchemaEvolution/B-0930); our extra fields → CloudEvents **extension attributes**
+(exactly how Debezium maps its source fields).
+
+## 2. Debezium CDC envelope ≅ a DBSP Z-set delta (the anchor)
+
+Debezium's change-event envelope: `{ before, after, source, op, ts_ms, transaction }`, where **`op`** ∈
+`c` (create), `u` (update), `d` (delete), `r` (read/snapshot), `t` (truncate). Map it to our substrate:
+
+| Debezium `op` | before / after | **Z-set delta (DBSP)** |
+|---------------|----------------|------------------------|
+| `c` create | after | `+1 · after` |
+| `d` delete | before | `−1 · before` |
+| `u` update | before, after | `−1 · before  +1 · after` |
+| `r` snapshot | after | `+1 · after` |
+
+So **Debezium's `before`/`after`/`op` IS the retraction-native Z-set delta** our `DeltaLog`/`ZSet` already
+emit (an update = retract-old + insert-new is the canonical Z-set update). We did not invent the CDC change
+shape — Debezium (and CDC generally) is the human prior art; name it. This also means a Debezium stream is
+*directly* ingestible as Z-set deltas, and our deltas are *directly* expressible as Debezium-shaped CDC.
+
+**Schema-on-stream:** Debezium pairs with the **Kafka Schema Registry** (schema embedded/registered per
+event, evolved over time) — which is exactly **SchemaEvolution / B-0930** ("schema-registry-over-DBSP").
+Our schema-evolution work is the Debezium + Schema-Registry pattern, reimplemented over DBSP with the
+bidirectional/dump guarantees.
+
+**Debezium already emits CloudEvents** (`io.debezium.converters.CloudEventsConverter`, structured mode,
+JSON/Avro envelope+data) — direct precedent for wrapping CDC deltas in a CloudEvents envelope. So the
+combined target: **a Z-set delta (Debezium-shaped before/after/op) as the CloudEvents `data`, on the bus.**
+
+## Decision surface (Aaron's call)
+
+- **Adopt CloudEvents** as the canonical bus envelope (id/source/type/specversion/time/data + extensions).
+- **Align the change-event `data` shape with Debezium CDC** (before/after/op ≅ Z-set delta) — name the
+  anchor in the Beacon register; consider Debezium-format ingest/emit interop.
+- Both are *standards*, not coinage — they reduce our unanchored surface. Backlogged for adoption.
+
+## Ties
+
+- `src/Core/DeltaLog.fs` / `ZSet` (the deltas that ARE Debezium before/after/op) · `SchemaEvolution` +
+  B-0930 (the Schema-Registry analog) · the agent-bus (G-Set comms, B-0954) · CloudEvents over busses ·
+  canonical CBOR/JSON codecs (the `data` encodings) · `081KTGTJC1Q` (the store the stream feeds).
+
+## Beacon anchors
+
+- **CloudEvents** — CNCF (v1.0, graduated); the standard event envelope + bindings/formats. · **Debezium**
+  — Red Hat / Randall Hauch et al.; CDC over Kafka Connect; the `before/after/op/source/ts_ms` envelope +
+  the CloudEvents converter. · **Change Data Capture** generally (log-based CDC). · **Kafka Schema
+  Registry** (Confluent) — schema-on-stream + evolution/compatibility. · **DBSP** (Budiu et al.) — the
+  Z-set delta the CDC envelope coincides with. · Kleppmann *DDIA* — "turning the database inside out" /
+  logs as the source of truth. Honest novelty: none in the envelope/CDC model (deliberately — we adopt the
+  standards); the contribution is that our retraction-native Z-set delta and Debezium's CDC envelope are
+  the *same object*, unified over DBSP with the schema-evolution guarantees.

--- a/workitems/081KTH0WQ3C08QG0R002CDCT71-adopt-cloudevents-as-the-bus-envelope-align-change-event-dat.md
+++ b/workitems/081KTH0WQ3C08QG0R002CDCT71-adopt-cloudevents-as-the-bus-envelope-align-change-event-dat.md
@@ -1,0 +1,46 @@
+---
+id: 081KTH0WQ3C08QG0R002CDCT71
+type: task
+state: backlog
+priority: P2
+slug: adopt-cloudevents-as-the-bus-envelope-align-change-event-dat
+title: "Adopt CloudEvents as the bus envelope + align change-event data with Debezium CDC (before/after/op = Z-set delta)"
+created: 2026-06-07T12:28:30.700Z
+depends_on: []
+composes_with: ["B-0930", "B-0954"]
+---
+
+# Adopt CloudEvents as the bus envelope + align change-event data with Debezium CDC (before/after/op = Z-set delta)
+
+<!-- Work-item body. ZetaId-keyed (conflict-free, time-sortable). "Backlog" is a
+     STATE = this folder; completion moves the file to workitems/done/YYYY/MM/.
+     Identity is the zetaid prefix — resolve cross-refs by `081KTH0WQ3C08QG0R002CDCT71-*.md` glob. -->
+
+## Purpose
+
+Adopt two established standards instead of bespoke envelopes (Aaron 2026-06-07; Beacon discipline). Full
+analysis: `docs/research/2026-06-07-cloudevents-bus-envelope-and-debezium-cdc-as-zset-delta-anchor-aaron.md`.
+
+## Two adoptions
+
+1. **CloudEvents (CNCF v1.0) as the bus envelope.** Wear `id`/`source`/`specversion`/`type` (+ `time`,
+   `subject`, `datacontenttype`, `dataschema`, extension attributes, `data`) over the agent-bus + Log/Delta
+   streams. Map ZetaId->id/source; change kind->type; canonical CBOR/JSON->data; schema version->dataschema;
+   extra fields->extension attributes. Bindings (Kafka/HTTP/NATS/AMQP/MQTT), JSON/Avro/Protobuf formats.
+2. **Align change-event `data` with the Debezium CDC envelope** (`before/after/op/source/ts_ms`) — which
+   IS a DBSP Z-set delta (c=+after, d=-before, u=-before+after, r=+snapshot). Our DeltaLog/ZSet deltas
+   already are this; name the anchor + consider Debezium-format ingest/emit interop. Debezium pairs with the
+   Kafka Schema Registry = SchemaEvolution/B-0930 over DBSP. Debezium already emits CloudEvents
+   (CloudEventsConverter) -> precedent: a Z-set delta (Debezium-shaped) as the CloudEvents `data`.
+
+## Acceptance
+
+A CloudEvents envelope type over the bus (with the ZetaId/extension mapping), round-trippable via the
+canonical codecs; change-event data documented as the Debezium before/after/op shape ≅ Z-set delta;
+both anchored in the Beacon register / PRIOR-ART-LIST. Standards adoption — no new coinage.
+
+## Anchors
+
+- CloudEvents (CNCF) · Debezium/CDC (Red Hat) · Kafka Schema Registry · DBSP (Z-set delta) ·
+  src/Core/DeltaLog.fs + ZSet · SchemaEvolution + B-0930 · agent-bus B-0954 · docs/PRIOR-ART-LIST.md.
+


### PR DESCRIPTION
## What — Aaron's prior-art lead (2026-06-07), captured + Beacon-anchored

- **CloudEvents (CNCF v1.0)** → adopt as the **bus envelope** (`id`/`source`/`type`/`specversion`/`time`/`data` + extension attributes) over the agent-bus + Log/Delta streams. A standard, not coinage.
- **Debezium CDC envelope** (`before/after/op/source/ts_ms`) **IS a DBSP Z-set delta**: `c`=+after, `d`=−before, `u`=−before+after, `r`=+snapshot. Our `DeltaLog`/`ZSet` deltas already are this shape — so we name the anchor rather than claim novelty. Schema-on-stream (Kafka Schema Registry) ≅ **SchemaEvolution/B-0930** over DBSP. Debezium already emits **CloudEvents** → precedent for "Z-set delta (Debezium-shaped) as the CloudEvents `data`."

Research doc + **PRIOR-ART-LIST** entries (CloudEvents, Debezium) + adoption workitem **`081KTH0WQ3C`** (P2, composes with B-0930 + agent-bus B-0954). Docs only.

## Sources
- [Debezium — Exporting CloudEvents](https://debezium.io/documentation/reference/stable/integrations/cloudevents.html)
- [Debezium — Event Record Changes](https://debezium.io/documentation/reference/stable/transformations/event-changes.html)

🤖 Generated with [Claude Code](https://claude.com/claude-code)