### PR TITLE
feat(DagFs): multi-parent content-addressed file tree + two edit modes (COW store)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -84,6 +84,7 @@
     <Compile Include="Merkle.fs" />
     <Compile Include="ZSetMerkle.fs" />
     <Compile Include="ContentStore.fs" />
+    <Compile Include="DagFs.fs" />
     <Compile Include="Residuated.fs" />
     <Compile Include="Aggregate.fs" />
     <Compile Include="RobustStats.fs" />

--- a/src/Core/DagFs.fs
+++ b/src/Core/DagFs.fs
@@ -1,0 +1,83 @@
+namespace Zeta.Core
+
+open System.Collections.Immutable
+
+/// **Multi-parent content-addressed file tree — the "same file in many folders" + two edit modes
+/// (Aaron 2026-06-07; 081KTGTJC1Q).** A thin path layer over `ContentStore`: paths map to CONTENT
+/// ADDRESSES, so identical content under N paths is ONE stored node (single-instance / dedup), and a node
+/// can live under many paths at once (multi-parent — hardlink- / git-blob-shaped). Immutable/COW: every
+/// mutation returns a new `Tree` version (old roots persist as cheap branches).
+///
+/// The two edit modes Aaron specified:
+///   - **`editLocal`** (DEFAULT, regular-filesystem feel): copy-on-write fork — only THIS path sees the
+///     change; other paths sharing the old content keep it.
+///   - **`editEverywhere`**: content update — every path that referenced the old content follows the new
+///     content (the shared-object edit).
+[<RequireQualifiedAccess>]
+module DagFs =
+
+    /// A file tree: a content-addressed `store` of nodes + a `links` map from path -> content address.
+    [<NoEquality; NoComparison>]
+    type Tree<'V> =
+        private
+            { store: ContentStore.Store<'V>
+              links: ImmutableDictionary<string, MerkleHash> }
+
+    /// Empty tree over a content store keyed by `hashOf`.
+    let create (hashOf: 'V -> MerkleHash) : Tree<'V> =
+        { store = ContentStore.create hashOf
+          links = ImmutableDictionary.Create<string, MerkleHash>() }
+
+    /// Link `path` to `value`: store the content (dedup) and point `path` at its address. If another path
+    /// already holds identical content, they share the single node (multi-parent). Returns the new tree.
+    let link (path: string) (value: 'V) (t: Tree<'V>) : Tree<'V> =
+        let h, store' = ContentStore.put value t.store
+        { store = store'; links = t.links.SetItem(path, h) }
+
+    /// Resolve `path` to its content, or `None` if unlinked.
+    let resolve (path: string) (t: Tree<'V>) : 'V option =
+        match t.links.TryGetValue path with
+        | true, h -> ContentStore.get h t.store
+        | _ -> None
+
+    /// The content ADDRESS at `path` (without fetching), or `None`.
+    let addressAt (path: string) (t: Tree<'V>) : MerkleHash option =
+        match t.links.TryGetValue path with
+        | true, h -> Some h
+        | _ -> None
+
+    /// Remove the link at `path` (the node stays in the store — it may be shared / GC is separate).
+    let unlink (path: string) (t: Tree<'V>) : Tree<'V> =
+        { t with links = t.links.Remove path }
+
+    /// Every path that currently points at content address `h` (the multi-parent / reverse view — the
+    /// "which folders hold this file" question). Order unspecified.
+    let pathsOf (h: MerkleHash) (t: Tree<'V>) : string list =
+        t.links
+        |> Seq.filter (fun kv -> kv.Value = h)
+        |> Seq.map (fun kv -> kv.Key)
+        |> List.ofSeq
+
+    /// **Edit just this folder (DEFAULT — copy-on-write fork).** Store the new content and repoint ONLY
+    /// `path`; any other path that shared the old content is untouched. No-op if `path` is unlinked.
+    let editLocal (path: string) (value: 'V) (t: Tree<'V>) : Tree<'V> =
+        match t.links.TryGetValue path with
+        | true, _ -> link path value t
+        | _ -> t
+
+    /// **Content update everywhere.** Repoint EVERY path that referenced `path`'s current content to the
+    /// new content (the shared-object edit). No-op if `path` is unlinked.
+    let editEverywhere (path: string) (value: 'V) (t: Tree<'V>) : Tree<'V> =
+        match t.links.TryGetValue path with
+        | true, oldH ->
+            let newH, store' = ContentStore.put value t.store
+            let affected = pathsOf oldH t
+            let links' = affected |> List.fold (fun (m: ImmutableDictionary<string, MerkleHash>) p -> m.SetItem(p, newH)) t.links
+            { store = store'; links = links' }
+        | _ -> t
+
+    /// Number of linked paths.
+    let pathCount (t: Tree<'V>) : int = t.links.Count
+
+    /// Number of distinct stored nodes (single-instanced).
+    let nodeCount (t: Tree<'V>) : int = ContentStore.count t.store

--- a/tests/Tests.FSharp/DagFs.Tests.fs
+++ b/tests/Tests.FSharp/DagFs.Tests.fs
@@ -1,0 +1,52 @@
+module Zeta.Tests.DagFsTests
+
+open System
+open global.Xunit
+open Zeta.Core
+
+module FS = Zeta.Core.DagFs
+
+let private encI (i: int) : byte[] =
+    let b = Array.zeroCreate<byte> 4
+    System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(Span<byte> b, i)
+    b
+
+let private tree () : FS.Tree<ZSet<int>> = FS.create (ZSetMerkle.root encI)
+let private v (xs: (int * int64) list) = ZSet.ofSeq xs
+
+[<Fact>]
+let ``same content under two paths is one node (single-instance) referenced by both (multi-parent)`` () =
+    let content = v [ 1, 1L ]
+    let t = tree () |> FS.link "/a/file" content |> FS.link "/b/file" content
+    Assert.Equal(2, FS.pathCount t)
+    Assert.Equal(1, FS.nodeCount t) // dedup — one stored node
+    let h = (FS.addressAt "/a/file" t).Value
+    Assert.Equal<string list>([ "/a/file"; "/b/file" ] |> List.sort, FS.pathsOf h t |> List.sort)
+    Assert.Equal<ZSet<int> option>(Some content, FS.resolve "/b/file" t)
+
+[<Fact>]
+let ``editLocal forks copy-on-write — only this path changes (default, regular-fs feel)`` () =
+    let t =
+        tree () |> FS.link "/a" (v [ 1, 1L ]) |> FS.link "/b" (v [ 1, 1L ]) // shared content
+    let t2 = FS.editLocal "/a" (v [ 1, 2L ]) t
+    Assert.Equal<ZSet<int> option>(Some(v [ 1, 2L ]), FS.resolve "/a" t2) // changed
+    Assert.Equal<ZSet<int> option>(Some(v [ 1, 1L ]), FS.resolve "/b" t2) // untouched
+    Assert.Equal(2, FS.nodeCount t2) // now two distinct nodes
+
+[<Fact>]
+let ``editEverywhere updates every path that shared the content (shared-object edit)`` () =
+    let t =
+        tree () |> FS.link "/a" (v [ 1, 1L ]) |> FS.link "/b" (v [ 1, 1L ]) |> FS.link "/c" (v [ 9, 9L ])
+    let t2 = FS.editEverywhere "/a" (v [ 1, 2L ]) t
+    Assert.Equal<ZSet<int> option>(Some(v [ 1, 2L ]), FS.resolve "/a" t2)
+    Assert.Equal<ZSet<int> option>(Some(v [ 1, 2L ]), FS.resolve "/b" t2) // followed the shared edit
+    Assert.Equal<ZSet<int> option>(Some(v [ 9, 9L ]), FS.resolve "/c" t2) // unrelated, unchanged
+
+[<Fact>]
+let ``link is copy-on-write; unlink drops the path`` () =
+    let t0 = tree ()
+    let t1 = FS.link "/a" (v [ 1, 1L ]) t0
+    Assert.Equal(0, FS.pathCount t0) // prior version unchanged (cheap branch)
+    Assert.Equal(1, FS.pathCount t1)
+    let t2 = FS.unlink "/a" t1
+    Assert.Equal<ZSet<int> option>(None, FS.resolve "/a" t2)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -77,6 +77,7 @@
     <Compile Include="Merkle.FullVertical.Tests.fs" />
     <Compile Include="ZSetMerkle.Tests.fs" />
     <Compile Include="ContentStore.Tests.fs" />
+    <Compile Include="DagFs.Tests.fs" />
     <Compile Include="Collation.Tests.fs" />
     <Compile Include="EvolutionWindow.Tests.fs" />
     <Compile Include="SerializationSeed.FullVertical.Tests.fs" />


### PR DESCRIPTION
## What — COW store slice (`081KTGTJC1Q`)
The "same file in many folders" + the two edit modes, over `ContentStore`. Paths map to content **addresses**, so identical content under N paths is **one node** (single-instance/dedup) and a node lives under **many paths at once** (multi-parent, hardlink/git-blob shaped). Immutable/COW.

- `link`/`resolve`/`addressAt`/`unlink`/`pathsOf` (multi-parent reverse view)
- **`editLocal`** — DEFAULT copy-on-write fork (only this path changes)
- **`editEverywhere`** — content update (every path sharing the old content follows)

## Test
`dotnet test … --filter DagFs` → **4 passed** (single-instance+multi-parent, editLocal fork, editEverywhere propagate, link-COW+unlink).

🤖 Generated with [Claude Code](https://claude.com/claude-code)