### PR TITLE
feat(DebeziumCdc): read & write Debezium CDC change events as Z-set deltas

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -85,6 +85,7 @@
     <Compile Include="ZSetMerkle.fs" />
     <Compile Include="ContentStore.fs" />
     <Compile Include="DagFs.fs" />
+    <Compile Include="DebeziumCdc.fs" />
     <Compile Include="Residuated.fs" />
     <Compile Include="Aggregate.fs" />
     <Compile Include="RobustStats.fs" />

--- a/src/Core/DebeziumCdc.fs
+++ b/src/Core/DebeziumCdc.fs
@@ -1,0 +1,79 @@
+namespace Zeta.Core
+
+/// **Debezium CDC ↔ DBSP Z-set delta — read & write the Debezium change-event format (081KTH0WQ3C).**
+///
+/// Debezium's change-event envelope (`before`/`after`/`op`/`source`/`ts_ms`) is **a Z-set delta in
+/// disguise** (Aaron 2026-06-07; anchor: Debezium / Red Hat, CDC):
+///   `c` create → `+1·after`   ·   `d` delete → `−1·before`   ·   `u` update → `−1·before +1·after`
+///   `r` snapshot-read → `+1·after`   ·   `t` truncate → retract-all (needs the full key set; see note).
+/// So we get **huge ecosystem interop**: read a Debezium stream straight into Z-set deltas, and emit our
+/// deltas as Debezium events. Lossless at the *delta* level; an `update` round-trips through the Z-set as a
+/// `delete`+`create` pair (the Z-set is a multiset of rows, not row-identity-tracked — the honest semantics
+/// of CDC-as-Z-set). Wrap in a CloudEvents envelope on the bus (separate, follow-up).
+///
+/// Generic over the row type `'K` (which must be a Z-set key, i.e. `comparison`). Debezium rows are
+/// `DynamicValue`-shaped; since `DynamicValue` is `NoComparison`, the caller keys rows by a canonical
+/// encoding (e.g. canonical-CBOR bytes / the `ZSetMerkle` leaf) — that wiring is the integration follow-up.
+[<RequireQualifiedAccess>]
+module DebeziumCdc =
+
+    /// The Debezium operation code.
+    type Op =
+        | Create // "c"
+        | Update // "u"
+        | Delete // "d"
+        | Read // "r" (snapshot)
+        | Truncate // "t"
+
+    /// Map an op code string to/from `Op` (the on-the-wire `op` field).
+    let opOfCode (code: string) : Op option =
+        match code with
+        | "c" -> Some Create
+        | "u" -> Some Update
+        | "d" -> Some Delete
+        | "r" -> Some Read
+        | "t" -> Some Truncate
+        | _ -> None
+
+    let codeOfOp (op: Op) : string =
+        match op with
+        | Create -> "c"
+        | Update -> "u"
+        | Delete -> "d"
+        | Read -> "r"
+        | Truncate -> "t"
+
+    /// A Debezium change event over a row of type `'K` (`source`/`ts_ms` ride as metadata, elsewhere).
+    type ChangeEvent<'K> =
+        { Op: Op
+          Before: 'K option
+          After: 'K option }
+
+    /// **READ: Debezium change event → Z-set delta** (rows ARE the keys).
+    /// `Truncate` returns the empty delta — a truncate retracts the whole relation and can't be expressed
+    /// as a bounded delta without the current key set (handle truncate at the stream/store level).
+    let toZSetDelta (e: ChangeEvent<'K>) : ZSet<'K> =
+        let plus (v: 'K) = ZSet.singleton v 1L
+        let minus (v: 'K) = ZSet.singleton v -1L
+        match e.Op, e.Before, e.After with
+        | Create, _, Some a -> plus a
+        | Read, _, Some a -> plus a
+        | Delete, Some b, _ -> minus b
+        | Update, Some b, Some a -> minus b + plus a
+        | Update, None, Some a -> plus a // degenerate update with no before
+        | _, _, _ -> ZSet.Empty
+
+    /// **WRITE: Z-set delta → Debezium change events.** Each positive-weight row → `create` (repeated by
+    /// multiplicity); each negative-weight row → `delete`. Updates are emitted as a delete+create pair
+    /// (Z-set deltas don't carry row-identity to re-pair an `update`) — delta-equivalent to the input.
+    let ofZSetDelta (delta: ZSet<'K>) : ChangeEvent<'K> list =
+        [ for entry in delta do
+              let w = entry.Weight
+              if w > 0L then
+                  for _ in 1L .. w -> { Op = Create; Before = None; After = Some entry.Key }
+              elif w < 0L then
+                  for _ in 1L .. (-w) -> { Op = Delete; Before = Some entry.Key; After = None } ]
+
+    let create (after: 'K) : ChangeEvent<'K> = { Op = Create; Before = None; After = Some after }
+    let delete (before: 'K) : ChangeEvent<'K> = { Op = Delete; Before = Some before; After = None }
+    let update (before: 'K) (after: 'K) : ChangeEvent<'K> = { Op = Update; Before = Some before; After = Some after }

--- a/tests/Tests.FSharp/DebeziumCdc.Tests.fs
+++ b/tests/Tests.FSharp/DebeziumCdc.Tests.fs
@@ -1,0 +1,42 @@
+module Zeta.Tests.DebeziumCdcTests
+
+open global.Xunit
+open FsCheck
+open FsCheck.FSharp
+open FsCheck.Xunit
+open Zeta.Core
+
+module CDC = Zeta.Core.DebeziumCdc
+
+// Debezium CDC <-> Z-set delta (081KTH0WQ3C): read a Debezium change stream into Z-set deltas and emit our
+// deltas as Debezium events. before/after/op IS the delta: c=+after, d=-before, u=-before+after, r=+after.
+
+[<Fact>]
+let ``op code round-trips for every op`` () =
+    for op in [ CDC.Create; CDC.Update; CDC.Delete; CDC.Read; CDC.Truncate ] do
+        Assert.Equal<CDC.Op option>(Some op, CDC.opOfCode (CDC.codeOfOp op))
+    Assert.Equal<CDC.Op option>(None, CDC.opOfCode "?")
+
+[<Fact>]
+let ``read: each op maps to the right Z-set delta`` () =
+    Assert.Equal<ZSet<int>>(ZSet.singleton 7 1L, CDC.toZSetDelta (CDC.create 7))
+    Assert.Equal<ZSet<int>>(ZSet.singleton 7 -1L, CDC.toZSetDelta (CDC.delete 7))
+    Assert.Equal<ZSet<int>>(ZSet.singleton 7 1L, CDC.toZSetDelta { Op = CDC.Read; Before = None; After = Some 7 })
+    // update = retract old + insert new
+    Assert.Equal<ZSet<int>>(ZSet.ofSeq [ 1, -1L; 2, 1L ], CDC.toZSetDelta (CDC.update 1 2))
+    // truncate can't be a bounded delta -> empty
+    Assert.Equal<ZSet<int>>(ZSet.Empty, CDC.toZSetDelta { Op = CDC.Truncate; Before = None; After = None })
+
+[<Fact>]
+let ``write: positive weights become creates, negative become deletes (with multiplicity)`` () =
+    let delta = ZSet.ofSeq [ 1, 2L; 2, -1L ]
+    let events = CDC.ofZSetDelta delta
+    Assert.Equal(2, events |> List.filter (fun e -> e.Op = CDC.Create && e.After = Some 1) |> List.length)
+    Assert.Equal(1, events |> List.filter (fun e -> e.Op = CDC.Delete && e.Before = Some 2) |> List.length)
+
+[<Property>]
+let ``law: read∘write = id at the delta level (sum of emitted events' deltas = original)`` (pairs: (int * int64) list) =
+    // bound weights small so the multiplicity expansion stays finite/cheap
+    let delta = pairs |> List.map (fun (k, w) -> k, (w % 5L)) |> ZSet.ofSeq
+    let roundTrip = CDC.ofZSetDelta delta |> List.map CDC.toZSetDelta |> List.fold (+) ZSet.Empty
+    roundTrip = delta

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -78,6 +78,7 @@
     <Compile Include="ZSetMerkle.Tests.fs" />
     <Compile Include="ContentStore.Tests.fs" />
     <Compile Include="DagFs.Tests.fs" />
+    <Compile Include="DebeziumCdc.Tests.fs" />
     <Compile Include="Collation.Tests.fs" />
     <Compile Include="EvolutionWindow.Tests.fs" />
     <Compile Include="SerializationSeed.FullVertical.Tests.fs" />


### PR DESCRIPTION
## What — ecosystem interop you greenlit (`081KTH0WQ3C`)
Debezium's `before`/`after`/`op` envelope **is a DBSP Z-set delta** — so we can read a Debezium stream into Z-set deltas and emit our deltas as Debezium events.

- **`toZSetDelta`** (READ): `c`/`r` → `+after`, `d` → `−before`, `u` → `−before+after`, `t` → empty (truncate = retract-all, handled at stream level).
- **`ofZSetDelta`** (WRITE): +weight → `create` (×N), −weight → `delete` (×N); updates decompose to delete+create (Z-set is a multiset of rows) — delta-equivalent.
- Generic over the row type `'K` (`DynamicValue` is `NoComparison`, so DynamicValue rows key by a canonical encoding — integration follow-up; CloudEvents envelope wrap is the other follow-up).

## Test
`dotnet test … --filter DebeziumCdc` → **4 passed** incl. FsCheck law **read∘write = id** at the delta level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)