### PR TITLE
feat(CloudEvents): CNCF v1.0 envelope over DynamicValue + DagFs edit-convergence proof

### DIFF
--- a/src/Core/CloudEvents.fs
+++ b/src/Core/CloudEvents.fs
@@ -1,0 +1,101 @@
+namespace Zeta.Core
+
+/// **CloudEvents (CNCF v1.0) envelope over DynamicValue — the bus-envelope standard (081KTH0WQ3C).**
+///
+/// Aaron 2026-06-07: use the standard **CloudEvents** envelope over Zeta's busses instead of a bespoke
+/// header. Required attributes `id`/`source`/`specversion`/`type`; optional `time`/`subject`/
+/// `datacontenttype`/`dataschema`; plus **extension attributes** and the `data` payload. The envelope
+/// rides our canonical codecs by mapping to/from `DynamicValue` (`toDynamic`/`ofDynamic` round-trip), so a
+/// CloudEvent is just another self-describing value — JSON/CBOR/XML for free, byte-lockable.
+///
+/// Typical Zeta mapping: `ZetaId` → `id`/`source`; change kind → `type`; a Debezium-shaped Z-set delta
+/// (`DebeziumCdc`) → `data`; schema version → `dataschema`; our extra fields → extension attributes
+/// (exactly how Debezium's CloudEventsConverter maps its source fields).
+[<RequireQualifiedAccess>]
+module CloudEvents =
+
+    /// A CloudEvents v1.0 event. `Extensions` are string-valued attributes outside the core set
+    /// (CloudEvents extension attributes are simple-typed; we carry strings, in order).
+    type CloudEvent =
+        { Id: string
+          Source: string
+          SpecVersion: string
+          Type: string
+          Time: string option
+          Subject: string option
+          DataContentType: string option
+          DataSchema: string option
+          Extensions: (string * string) list
+          Data: DynamicValue option }
+
+    /// The reserved core attribute names (everything else in an envelope object is an extension).
+    let private coreKeys =
+        set [ "specversion"; "id"; "source"; "type"; "time"; "subject"; "datacontenttype"; "dataschema"; "data" ]
+
+    /// A minimal valid event (specversion defaults to "1.0").
+    let create (id: string) (source: string) (typ: string) (data: DynamicValue option) : CloudEvent =
+        { Id = id
+          Source = source
+          SpecVersion = "1.0"
+          Type = typ
+          Time = None
+          Subject = None
+          DataContentType = None
+          DataSchema = None
+          Extensions = []
+          Data = data }
+
+    /// Validate the REQUIRED attributes are present + non-empty (CloudEvents v1.0 constraint).
+    let validate (e: CloudEvent) : Result<unit, string> =
+        let missing =
+            [ "id", e.Id; "source", e.Source; "specversion", e.SpecVersion; "type", e.Type ]
+            |> List.filter (fun (_, v) -> System.String.IsNullOrEmpty v)
+            |> List.map fst
+        if List.isEmpty missing then Ok()
+        else Error(sprintf "CloudEvent missing required attribute(s): %s" (String.concat ", " missing))
+
+    /// Serialize to `DynamicValue.Object` (rides the canonical codecs). Attribute order is stable:
+    /// specversion, id, source, type, then present optionals, then extensions, then data.
+    let toDynamic (e: CloudEvent) : DynamicValue =
+        let opt k = function Some v -> [ k, DynamicValue.String v ] | None -> []
+        DynamicValue.Object(
+            [ "specversion", DynamicValue.String e.SpecVersion
+              "id", DynamicValue.String e.Id
+              "source", DynamicValue.String e.Source
+              "type", DynamicValue.String e.Type ]
+            @ opt "time" e.Time
+            @ opt "subject" e.Subject
+            @ opt "datacontenttype" e.DataContentType
+            @ opt "dataschema" e.DataSchema
+            @ (e.Extensions |> List.map (fun (k, v) -> k, DynamicValue.String v))
+            @ (match e.Data with Some d -> [ "data", d ] | None -> [])
+        )
+
+    /// Parse from a `DynamicValue.Object`. Unknown string-valued keys (outside the core set) become
+    /// extension attributes, in order. Errors if not an object or a required attribute is missing.
+    let ofDynamic (dv: DynamicValue) : Result<CloudEvent, string> =
+        match dv with
+        | DynamicValue.Object kvs ->
+            let str k =
+                kvs |> List.tryPick (fun (kk, v) -> match v with DynamicValue.String s when kk = k -> Some s | _ -> None)
+            match str "id", str "source", str "type" with
+            | Some id, Some source, Some typ ->
+                let extensions =
+                    kvs
+                    |> List.choose (fun (k, v) ->
+                        match v with
+                        | DynamicValue.String s when not (coreKeys.Contains k) -> Some(k, s)
+                        | _ -> None)
+                Ok
+                    { Id = id
+                      Source = source
+                      SpecVersion = defaultArg (str "specversion") "1.0"
+                      Type = typ
+                      Time = str "time"
+                      Subject = str "subject"
+                      DataContentType = str "datacontenttype"
+                      DataSchema = str "dataschema"
+                      Extensions = extensions
+                      Data = kvs |> List.tryPick (fun (k, v) -> if k = "data" then Some v else None) }
+            | _ -> Error "CloudEvent object missing required attribute(s): id / source / type"
+        | _ -> Error "CloudEvent must be a DynamicValue.Object"

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -86,6 +86,7 @@
     <Compile Include="ContentStore.fs" />
     <Compile Include="DagFs.fs" />
     <Compile Include="DebeziumCdc.fs" />
+    <Compile Include="CloudEvents.fs" />
     <Compile Include="Residuated.fs" />
     <Compile Include="Aggregate.fs" />
     <Compile Include="RobustStats.fs" />

--- a/tests/Tests.FSharp/CloudEvents.Tests.fs
+++ b/tests/Tests.FSharp/CloudEvents.Tests.fs
@@ -1,0 +1,49 @@
+module Zeta.Tests.CloudEventsTests
+
+open global.Xunit
+open Zeta.Core
+
+module CE = Zeta.Core.CloudEvents
+
+[<Fact>]
+let ``create yields a valid v1.0 event; validate catches a missing required attribute`` () =
+    let e = CE.create "id-1" "/zeta/source" "com.zeta.change" (Some(DynamicValue.Int 7L))
+    Assert.Equal("1.0", e.SpecVersion)
+    Assert.Equal<Result<unit, string>>(Ok(), CE.validate e)
+    match CE.validate { e with Id = "" } with
+    | Error msg -> Assert.Contains("id", msg)
+    | Ok () -> Assert.Fail "expected missing-id error"
+
+[<Fact>]
+let ``toDynamic ∘ ofDynamic round-trips (required + optionals + extensions + data)`` () =
+    let e =
+        { CE.create "id-2" "/s" "t" (Some(DynamicValue.String "payload")) with
+            Time = Some "2026-06-07T00:00:00Z"
+            DataSchema = Some "schema://v2"
+            Extensions = [ "iodebeziumop", "c"; "traceparent", "abc" ] }
+    Assert.Equal<Result<CE.CloudEvent, string>>(Ok e, CE.ofDynamic (CE.toDynamic e))
+
+[<Fact>]
+let ``ofDynamic rejects a non-object and an object missing required attributes`` () =
+    Assert.True(match CE.ofDynamic (DynamicValue.Int 1L) with Error _ -> true | _ -> false)
+    Assert.True(
+        match CE.ofDynamic (DynamicValue.Object [ "id", DynamicValue.String "x" ]) with
+        | Error _ -> true
+        | _ -> false
+    ) // missing source/type
+
+[<Fact>]
+let ``unknown string keys become extension attributes, core keys do not`` () =
+    let dv =
+        DynamicValue.Object
+            [ "specversion", DynamicValue.String "1.0"
+              "id", DynamicValue.String "i"
+              "source", DynamicValue.String "s"
+              "type", DynamicValue.String "t"
+              "myext", DynamicValue.String "v"
+              "data", DynamicValue.Int 5L ]
+    match CE.ofDynamic dv with
+    | Ok e ->
+        Assert.Equal<(string * string) list>([ "myext", "v" ], e.Extensions)
+        Assert.Equal<DynamicValue option>(Some(DynamicValue.Int 5L), e.Data)
+    | Error m -> Assert.Fail m

--- a/tests/Tests.FSharp/DagFs.Tests.fs
+++ b/tests/Tests.FSharp/DagFs.Tests.fs
@@ -50,3 +50,16 @@ let ``link is copy-on-write; unlink drops the path`` () =
     Assert.Equal(1, FS.pathCount t1)
     let t2 = FS.unlink "/a" t1
     Assert.Equal<ZSet<int> option>(None, FS.resolve "/a" t2)
+
+[<Fact>]
+let ``editLocal to content identical to an existing file converges — pointers move to the shared node (no duplicate)`` () =
+    // Aaron 2026-06-07: if an edit lands on the same content address as an existing file, it just moves
+    // pointers (content-addressing makes convergence automatic / single-instance).
+    let c1 = v [ 1, 1L ]
+    let c2 = v [ 2, 2L ]
+    let t = tree () |> FS.link "/a" c1 |> FS.link "/b" c2
+    Assert.NotEqual((FS.addressAt "/a" t).Value, (FS.addressAt "/b" t).Value)
+    let t2 = FS.editLocal "/a" c2 t // edit /a to equal /b's content
+    Assert.Equal((FS.addressAt "/a" t2).Value, (FS.addressAt "/b" t2).Value) // converged: same node
+    Assert.Equal<ZSet<int> option>(Some c2, FS.resolve "/a" t2)
+    Assert.Equal<string list>([ "/a"; "/b" ] |> List.sort, FS.pathsOf (FS.addressAt "/b" t2).Value t2 |> List.sort)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -79,6 +79,7 @@
     <Compile Include="ContentStore.Tests.fs" />
     <Compile Include="DagFs.Tests.fs" />
     <Compile Include="DebeziumCdc.Tests.fs" />
+    <Compile Include="CloudEvents.Tests.fs" />
     <Compile Include="Collation.Tests.fs" />
     <Compile Include="EvolutionWindow.Tests.fs" />
     <Compile Include="SerializationSeed.FullVertical.Tests.fs" />


### PR DESCRIPTION
## What
**CloudEvents** bus-envelope adoption (`081KTH0WQ3C`) — rides our DynamicValue codecs:
- `CloudEvent` record: required `id`/`source`/`specversion`/`type` + optional `time`/`subject`/`datacontenttype`/`dataschema` + extension attributes + `data`.
- `create` / `validate` / `toDynamic` / `ofDynamic` (unknown string keys → extensions). **4 tests** incl. round-trip.
- Mapping: ZetaId→id/source, change kind→type, Debezium-shaped Z-set delta→`data` (matches Debezium's CloudEventsConverter).

**Also answers your convergence question with a proof:** `editLocal` to content identical to an existing file **converges** — content-addressing dedups, so the path just moves to the shared node (no duplicate). New `DagFs` test asserts both paths resolve to the same address after the edit.

## Test
`dotnet test … --filter DagFs|CloudEvents` → **9 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)