### PR TITLE
feat(DvKey): content-addressed comparable key — DynamicValue rows through ZSet + DebeziumCdc

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -85,6 +85,7 @@
     <Compile Include="ZSetMerkle.fs" />
     <Compile Include="ContentStore.fs" />
     <Compile Include="DagFs.fs" />
+    <Compile Include="DvKey.fs" />
     <Compile Include="DebeziumCdc.fs" />
     <Compile Include="CloudEvents.fs" />
     <Compile Include="Residuated.fs" />

--- a/src/Core/DvKey.fs
+++ b/src/Core/DvKey.fs
@@ -1,0 +1,63 @@
+namespace Zeta.Core
+
+open System
+open System.Collections.Generic
+
+/// **Content-addressed, COMPARABLE key for a `DynamicValue` row.** `DynamicValue` is `NoComparison`, so it
+/// can't be a `ZSet` key or a Debezium row directly. `DvKey` wraps a value with its **canonical CBOR
+/// bytes** (`DynamicValue.toCanonicalCbor` — byte-locked, cross-language) and orders/compares by those
+/// bytes (ordinal, lexicographic — EXACT, no hash-collision risk). So real self-describing rows flow
+/// through `ZSet` / `IndexedZSet` / `DebeziumCdc` and the data plane. The canonical bytes also ARE the
+/// content address (hash them for the `ContentStore`/Merkle key), so identity is consistent end-to-end.
+[<CustomEquality; CustomComparison>]
+type DvKey =
+    { Value: DynamicValue
+      Canonical: byte[] }
+
+    /// Lexicographic ordinal compare of the canonical bytes (the cross-language canonical order — same as
+    /// `ZSetMerkle` leaf ordering).
+    static member private CompareBytes(a: byte[], b: byte[]) : int =
+        let n = min a.Length b.Length
+        let mutable i = 0
+        let mutable r = 0
+        while r = 0 && i < n do
+            r <- compare a.[i] b.[i]
+            i <- i + 1
+        if r <> 0 then r else compare a.Length b.Length
+
+    override this.Equals(o: obj) : bool =
+        match o with
+        | :? DvKey as other -> DvKey.CompareBytes(this.Canonical, other.Canonical) = 0
+        | _ -> false
+
+    override this.GetHashCode() : int =
+        // FNV-1a over the canonical bytes — consistent with Equals (equal canonical ⇒ equal hash).
+        let mutable h = 2166136261u
+        for b in this.Canonical do
+            h <- (h ^^^ uint32 b) * 16777619u
+        int h
+
+    interface IEquatable<DvKey> with
+        member this.Equals(other: DvKey) : bool = DvKey.CompareBytes(this.Canonical, other.Canonical) = 0
+
+    interface IComparable<DvKey> with
+        member this.CompareTo(other: DvKey) : int = DvKey.CompareBytes(this.Canonical, other.Canonical)
+
+    interface IComparable with
+        member this.CompareTo(o: obj) : int =
+            match o with
+            | :? DvKey as other -> DvKey.CompareBytes(this.Canonical, other.Canonical)
+            | _ -> invalidArg "o" "cannot compare DvKey with a non-DvKey"
+
+[<RequireQualifiedAccess>]
+module DvKey =
+
+    /// Wrap a `DynamicValue` as a comparable, content-addressed row key (computes its canonical CBOR once).
+    let ofValue (v: DynamicValue) : DvKey =
+        { Value = v; Canonical = DynamicValue.toCanonicalCbor v }
+
+    /// The underlying value.
+    let value (k: DvKey) : DynamicValue = k.Value
+
+    /// The canonical CBOR bytes (the content identity; hash these for the Merkle/ContentStore address).
+    let canonical (k: DvKey) : byte[] = k.Canonical

--- a/tests/Tests.FSharp/DvKey.Tests.fs
+++ b/tests/Tests.FSharp/DvKey.Tests.fs
@@ -1,0 +1,34 @@
+module Zeta.Tests.DvKeyTests
+
+open global.Xunit
+open Zeta.Core
+
+module CDC = Zeta.Core.DebeziumCdc
+
+let private row (kvs: (string * DynamicValue) list) = DvKey.ofValue (DynamicValue.Object kvs)
+
+[<Fact>]
+let ``equal DynamicValue rows give equal keys; distinct give distinct keys`` () =
+    let a = row [ "id", DynamicValue.Int 1L; "name", DynamicValue.String "x" ]
+    let a2 = row [ "id", DynamicValue.Int 1L; "name", DynamicValue.String "x" ]
+    let b = row [ "id", DynamicValue.Int 2L; "name", DynamicValue.String "x" ]
+    Assert.Equal<DvKey>(a, a2)
+    Assert.Equal(a.GetHashCode(), a2.GetHashCode())
+    Assert.NotEqual<DvKey>(a, b)
+
+[<Fact>]
+let ``DvKey rows work as ZSet keys (DynamicValue rows in a Z-set)`` () =
+    let z = ZSet.ofSeq [ row [ "id", DynamicValue.Int 1L ], 1L; row [ "id", DynamicValue.Int 2L ], 1L ]
+    Assert.Equal(2, z.Count)
+    Assert.Equal(1L, ZSet.lookup (row [ "id", DynamicValue.Int 1L ]) z)
+
+[<Fact>]
+let ``Debezium change events over DynamicValue rows convert to Z-set deltas (end-to-end)`` () =
+    let before = row [ "id", DynamicValue.Int 1L; "v", DynamicValue.String "old" ]
+    let after = row [ "id", DynamicValue.Int 1L; "v", DynamicValue.String "new" ]
+    // an update of a DynamicValue row = retract old + insert new
+    Assert.Equal<ZSet<DvKey>>(ZSet.ofSeq [ before, -1L; after, 1L ], CDC.toZSetDelta (CDC.update before after))
+    // and the delta round-trips at the delta level
+    let delta = CDC.toZSetDelta (CDC.create after)
+    let rt = CDC.ofZSetDelta delta |> List.map CDC.toZSetDelta |> List.fold (+) ZSet.Empty
+    Assert.Equal<ZSet<DvKey>>(delta, rt)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -79,6 +79,7 @@
     <Compile Include="ContentStore.Tests.fs" />
     <Compile Include="DagFs.Tests.fs" />
     <Compile Include="DebeziumCdc.Tests.fs" />
+    <Compile Include="DvKey.Tests.fs" />
     <Compile Include="CloudEvents.Tests.fs" />
     <Compile Include="Collation.Tests.fs" />
     <Compile Include="EvolutionWindow.Tests.fs" />


### PR DESCRIPTION
## What
Bridges `DynamicValue` (which is `NoComparison`) into the data plane: **`DvKey`** wraps a value with its **canonical CBOR bytes** (`DynamicValue.toCanonicalCbor`) and orders/compares by those bytes (ordinal lexicographic — **exact, no hash-collision risk**). The canonical bytes also **are the content address** (hash them for `ContentStore`/Merkle), so row identity is consistent end-to-end.

Now real self-describing rows flow through `ZSet`/`IndexedZSet`/`DebeziumCdc`: a Debezium update of a DynamicValue row = retract-old + insert-new as a Z-set delta.

## Test
`dotnet test … --filter DvKey` → **3 passed** (equal/distinct keys + hash consistency, DvKey as ZSet key, Debezium events over DynamicValue rows → Z-set deltas end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)