### PR TITLE
docs(prior-art): Jumprope (Vokes, Strange Loop 2012) — CAS prior art for the COW store

### DIFF
--- a/docs/PRIOR-ART-LIST.md
+++ b/docs/PRIOR-ART-LIST.md
@@ -96,6 +96,13 @@ with a ⭐ below and add a row there.
 - **KLL quantile** — Karnin-Lang-Liberty 2016.
 - **HyperMinHash** — Cohen-Lemire; a sketch we ship.
 - **FastCDC** — Xia et al. USENIX ATC 2016; our `FastCdc.fs`.
+- **Jumprope / Scott Vokes** ⭐ — *Data Structures: The Code That Isn't There*
+  (Strange Loop 2012); content-addressed large-file storage as a skiplist whose
+  probability function is a hash (Leaf/Limb/Trunk; CAS-not-pointers; rolling-hash
+  chunking; tunable; seekable). Prior art for `ContentStore`/`DagFs`/Merkle-DAG fs.
+  See `docs/research/2026-06-07-jumprope-vokes-content-addressed-storage-skiplist-hash-prior-art-aaron.md`.
+- **Skip Lists / William Pugh** (1990) — probabilistic balanced structure; the
+  Jumprope's hash-as-probability backbone.
 - **Merkle trees** — Merkle 1979; our `Merkle.fs`.
 - **Blake3 / CRC32C / XxHash** — hashing primitives we use or
   reference.

--- a/docs/research/2026-06-07-jumprope-vokes-content-addressed-storage-skiplist-hash-prior-art-aaron.md
+++ b/docs/research/2026-06-07-jumprope-vokes-content-addressed-storage-skiplist-hash-prior-art-aaron.md
@@ -1,0 +1,61 @@
+# Jumprope (Scott Vokes, Strange Loop 2012) — content-addressed storage with a hash-as-probability skiplist; prior art for our COW store (Aaron, 2026-06-07)
+
+Aaron shared **Scott Vokes — "Data Structures: The Code That Isn't There"** (Strange Loop 2012), whose
+**Jumprope** is direct prior art for our content-addressed store (`ContentStore`/`DagFs`/Merkle-DAG fs).
+Beacon anchor (`anchor-to-human-prior-art`). The "content-based hashing with distance measurements" Aaron
+noted = the **skiplist express-lanes** (jump-by-2, jump-by-4) used for seeking, with a **hash as the
+probability function** so the structure is deterministic from content.
+
+## The Jumprope (verbatim shape from the talk)
+
+Content-addressable storage for large binary strings/files — *"kind of like a git repo but much better for
+big files."* Three structural elements, backed by a key-value store:
+
+- **Leaf** — a chunk of raw data.
+- **Limb** — a series of content hashes + their links, stored in an array.
+- **Trunk** — a limb with a big end node.
+
+Properties: *"somewhat like a skiplist that uses a hash as its probability function"*; **persistent +
+immutable** (cache anywhere); **CAS instead of pointers** (lock-free, emergence from local behavior);
+**rolling hash** for content-defined chunking (deterministic breaks, cheap block matching — the rsync
+family); **tunable** bad-performance guarantees (1%, .1%, …); excellent **seeking** for streaming /
+pipelining content; ~2 KB limb-node / 64 KB leaf-node overhead; trivial to fetch / stream / mirror; used
+for a distributed FS ("scatterbrain"), "similar to Amazon Dynamo."
+
+Framing quotes worth keeping: *"A data structure is just a stupid programming language"* (Gosper) → *"A data
+structure is just a [tiny] virtual machine"* (Vokes); *"The cheapest, fastest, and most reliable components
+are those that aren't there"* (Gordon Bell) — the talk's thesis that the right data structure **subtracts
+code**.
+
+## How it anchors / informs Zeta
+
+- **Our content-addressed store IS the Jumprope/CAS family** — name the anchor rather than claim novelty.
+  `ContentStore` (single-instance, CAS, immutable/COW) + the Merkle-DAG fs are the same lineage.
+- **We already have the rolling-hash chunker:** `FastCdc.fs` (Xia et al., USENIX ATC 2016) = the
+  content-defined chunking Vokes uses; `Merkle.fs` hashes the chunks. So `FastCdc` + `Merkle` + the new
+  `ContentStore` = a Jumprope, modulo the seekable skiplist layer.
+- **The gap a Jumprope fills (a design lead, backlogged):** `ZSetMerkle` is a Merkle tree over *structured
+  Z-set* data; a **Jumprope-style skiplist-over-content-hashes** is the right node type for **large blobs /
+  streaming** — seekable, tunable, dedup'd. A `DagFs` leaf whose content is a big file should be a Jumprope
+  (Leaf/Limb/Trunk over `FastCdc` chunks), not a single ZSet-Merkle node. Complementary, not a replacement.
+- **CAS-not-pointers + emergence-from-local + tunable guarantees** map onto our standing disciplines:
+  lock-free/wait-free (#2), scale-free (#1), weight-free (#3), DST-tunable. *"Roundabouts, not traffic
+  lights"* (decentralized, local decisions, low lock contention) is the same intuition as our scale-free bus.
+- *"A data structure is a tiny virtual machine"* is a nice Beacon framing for **DynamicValue-as-carrier /
+  behavior-as-data** (the value describes + runs behavior).
+
+## Backlogged
+
+A Jumprope-style seekable large-blob content node (Leaf/Limb/Trunk skiplist over `FastCdc` chunks +
+`Merkle`/content hashes) as the big-file leaf type in the store — filed for when the store handles blobs.
+
+## Beacon anchors
+
+- **Scott Vokes**, *Data Structures: The Code That Isn't There* (Strange Loop 2012) — the **Jumprope**
+  (content-addressed large-file storage; skiplist-with-hash-probability; Leaf/Limb/Trunk; CAS; tunable). ·
+  **William Pugh**, *Skip Lists* (1990) — probabilistic balanced structure. · **Andrew Tridgell**, rsync
+  rolling hash; **FastCDC** (Xia et al., 2016) — content-defined chunking (we ship it). · **Bagwell /
+  Okasaki** — persistent immutable structures. · **Amazon Dynamo** (DeCandia et al., 2007) — CAS / gossip /
+  tunable consistency. · **Merkle** (1987); **git object model**; **IPFS** (Merkle-DAG CAS). Honest novelty:
+  none in CAS itself — we adopt the lineage; the contribution is unifying it with the DBSP Z-set / Merkle /
+  schema-evolution substrate under one interface.

--- a/workitems/081KTH1Z6G708QG0R002KCPHWF-jumprope-style-seekable-large-blob-content-node-leaf-limb-tr.md
+++ b/workitems/081KTH1Z6G708QG0R002KCPHWF-jumprope-style-seekable-large-blob-content-node-leaf-limb-tr.md
@@ -1,0 +1,44 @@
+---
+id: 081KTH1Z6G708QG0R002KCPHWF
+type: task
+state: backlog
+priority: P3
+slug: jumprope-style-seekable-large-blob-content-node-leaf-limb-tr
+title: "Jumprope-style seekable large-blob content node (Leaf/Limb/Trunk skiplist over FastCdc chunks) for the COW store"
+created: 2026-06-07T12:47:20.583Z
+depends_on: []
+composes_with: ["081KTGTJC1Q08QG0R002VCB55A"]
+---
+
+# Jumprope-style seekable large-blob content node (Leaf/Limb/Trunk skiplist over FastCdc chunks) for the COW store
+
+<!-- Work-item body. ZetaId-keyed (conflict-free, time-sortable). "Backlog" is a
+     STATE = this folder; completion moves the file to workitems/done/YYYY/MM/.
+     Identity is the zetaid prefix — resolve cross-refs by `081KTH1Z6G708QG0R002KCPHWF-*.md` glob. -->
+
+## Purpose
+
+A Jumprope-style (Scott Vokes, Strange Loop 2012) seekable large-blob content node for the COW store
+(081KTGTJC1Q): the right leaf type for BIG FILES / streaming, complementing `ZSetMerkle` (which is for
+structured Z-set data). Full prior-art:
+`docs/research/2026-06-07-jumprope-vokes-content-addressed-storage-skiplist-hash-prior-art-aaron.md`.
+
+## Build
+
+- Leaf (raw chunk) / Limb (array of content hashes + links) / Trunk (limb with big end node), over a KV /
+  ContentStore backing. Chunk with the existing `FastCdc.fs` (rolling hash); content-hash chunks with
+  `Merkle.fs`. Skiplist-with-hash-as-probability for O(log n) seek (the "distance" express-lanes).
+- CAS-not-pointers (lock-free); persistent/immutable (COW, cache anywhere); tunable guarantees.
+- A `DagFs` leaf whose content is a large file resolves to a Jumprope instead of a single Merkle node.
+
+## Acceptance
+
+Store/stream a large blob as Leaf/Limb/Trunk over FastCdc chunks; content-addressed + dedup'd; seek to an
+offset in O(log n); round-trip (store -> fetch == original); two blobs sharing chunks dedup at the chunk
+level.
+
+## Anchors
+
+- Vokes Jumprope (Strange Loop 2012) · Pugh skip lists · `FastCdc.fs` · `Merkle.fs` · `ContentStore.fs` ·
+  `DagFs.fs` · 081KTGTJC1Q (the store) · PRIOR-ART-LIST.
+


### PR DESCRIPTION
## What — prior-art anchor you shared (Aaron 2026-06-07)
**Scott Vokes — "Data Structures: The Code That Isn't There"** (Strange Loop 2012). The **Jumprope** = content-addressed large-file storage as a **skiplist whose probability function is a hash** (the "distance measurements" = seek express-lanes): **Leaf** (raw chunk) / **Limb** (content-hash array) / **Trunk**; CAS-not-pointers; rolling-hash chunking; persistent/immutable; tunable; seekable. *"Like a git repo but better for big files."*

- **Anchors** our content-addressed store (`ContentStore`/`DagFs`/Merkle-DAG) to the Jumprope/CAS lineage — we already ship the rolling-hash chunker (`FastCdc`, Xia 2016) + `Merkle`.
- **Design lead captured:** a Jumprope is the right node type for large **blobs / streaming** (seekable), complementing `ZSetMerkle` (structured Z-set data).

Research doc + **PRIOR-ART-LIST** entries (Jumprope/Vokes, Skip Lists/Pugh) + backlog **`081KTH1Z6G7`** (P3). Docs only.

## Sources
- [Data Structures: The Code That Isn't There (InfoQ)](https://www.infoq.com/presentations/Data-Structures/)
- [Strange Loop 2012 abstract](https://thestrangeloop.com/2012/data-structures-the-code-that-isnt-there.html)

🤖 Generated with [Claude Code](https://claude.com/claude-code)