### PR TITLE
feat(ContentHasher): hexagonal content-hashing port — own the interface, generic over algorithms

### DIFF
--- a/src/Core/ContentHasher.fs
+++ b/src/Core/ContentHasher.fs
@@ -1,0 +1,39 @@
+namespace Zeta.Core
+
+open System
+
+/// **Content-hashing PORT (hexagonal) — we OWN the interface; algorithms are pluggable adapters.**
+///
+/// Aaron 2026-06-07: *"hexagonal the blake dep and make sure we own the interface; also we can go generic —
+/// there are many algos that could match our interface, not just blake."* So the store/Merkle depend on
+/// THIS port, never on a concrete hash library. XxHash128 (`MerkleHash.ofBytes`) is the default adapter
+/// today; **BLAKE3** (cryptographic, tamper-evident — the decided git-replacement hash) drops in as an
+/// adapter behind this port *without touching callers* and with the external dependency isolated to its
+/// adapter; SHA-256, etc. equally conform. `ZSetMerkle.rootWith` / `ContentStore.create` already take the
+/// hash as a function — `IContentHasher.Hash` IS that function, now behind a named, ownable boundary.
+type IContentHasher =
+    /// A stable name for the algorithm (for golden-vector labelling + diagnostics).
+    abstract member Name: string
+    /// Hash bytes to a `MerkleHash` content address.
+    abstract member Hash: byte[] -> MerkleHash
+
+[<RequireQualifiedAccess>]
+module ContentHasher =
+
+    /// The default adapter: **XxHash128** (fast, non-cryptographic — dedup/history grade; B-0969-adjacent).
+    /// NOT tamper-evident — for the git-replacement store, select a BLAKE3 adapter behind this same port.
+    [<Sealed>]
+    type XxHash128Hasher() =
+        interface IContentHasher with
+            member _.Name = "xxhash128"
+            member _.Hash(bytes: byte[]) : MerkleHash = MerkleHash.ofBytes(ReadOnlySpan<byte> bytes)
+
+    /// The shipped default hasher (XxHash128). Swap to a BLAKE3 adapter for tamper-evidence.
+    let defaultHasher: IContentHasher = XxHash128Hasher() :> IContentHasher
+
+    /// Adapt a port to the plain `byte[] -> MerkleHash` function `ZSetMerkle.rootWith` / `ContentStore`
+    /// consume — so callers depend on the port, not a concrete algorithm.
+    let hashOf (hasher: IContentHasher) : byte[] -> MerkleHash = hasher.Hash
+
+    // BLAKE3 adapter (future): a `Blake3Hasher` implementing IContentHasher, with the BLAKE3 NuGet
+    // dependency isolated to that one adapter file — the rest of the codebase stays algorithm-agnostic.

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -83,6 +83,7 @@
     <Compile Include="FastCdc.fs" />
     <Compile Include="Merkle.fs" />
     <Compile Include="ZSetMerkle.fs" />
+    <Compile Include="ContentHasher.fs" />
     <Compile Include="ContentStore.fs" />
     <Compile Include="DagFs.fs" />
     <Compile Include="DvKey.fs" />

--- a/tests/Tests.FSharp/ContentHasher.Tests.fs
+++ b/tests/Tests.FSharp/ContentHasher.Tests.fs
@@ -1,0 +1,34 @@
+module Zeta.Tests.ContentHasherTests
+
+open System
+open global.Xunit
+open Zeta.Core
+
+module CH = Zeta.Core.ContentHasher
+
+[<Fact>]
+let ``default hasher is xxhash128, deterministic, and matches MerkleHash.ofBytes`` () =
+    let h = CH.defaultHasher
+    Assert.Equal("xxhash128", h.Name)
+    let bytes = [| 1uy; 2uy; 3uy; 4uy |]
+    Assert.Equal(h.Hash bytes, h.Hash bytes) // deterministic
+    Assert.Equal(MerkleHash.ofBytes(ReadOnlySpan<byte> bytes), h.Hash bytes) // same as the default digest
+
+[<Fact>]
+let ``hashOf adapts a port to the byte[] -> MerkleHash function the store/Merkle consume`` () =
+    let f = CH.hashOf CH.defaultHasher
+    let bytes = [| 9uy; 9uy |]
+    Assert.Equal(CH.defaultHasher.Hash bytes, f bytes)
+
+[<Fact>]
+let ``a custom adapter conforms to the same port (generic over algorithms, not just blake)`` () =
+    // a trivial alternate adapter proves the port is algorithm-agnostic (BLAKE3 will be one such adapter)
+    let alt =
+        { new IContentHasher with
+            member _.Name = "swap-hi-lo"
+            member _.Hash(b: byte[]) =
+                let m = MerkleHash.ofBytes(ReadOnlySpan<byte> b)
+                MerkleHash(m.Lo, m.Hi) }
+    let bytes = [| 5uy; 6uy; 7uy |]
+    Assert.Equal("swap-hi-lo", alt.Name)
+    Assert.NotEqual(CH.defaultHasher.Hash bytes, alt.Hash bytes)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -76,6 +76,7 @@
     <Compile Include="Clock.FullVertical.Tests.fs" />
     <Compile Include="Merkle.FullVertical.Tests.fs" />
     <Compile Include="ZSetMerkle.Tests.fs" />
+    <Compile Include="ContentHasher.Tests.fs" />
     <Compile Include="ContentStore.Tests.fs" />
     <Compile Include="DagFs.Tests.fs" />
     <Compile Include="DebeziumCdc.Tests.fs" />


### PR DESCRIPTION
## What — your BLAKE3 hexagonal directive
> *"hexagonal the blake dep and make sure we own the interface; also we can go generic — many algos could match our interface, not just blake."*

- **`IContentHasher`** port (`Name` + `Hash: byte[] -> MerkleHash`): the store/Merkle depend on **this**, never on a concrete hash library.
- **`XxHash128Hasher`** default adapter (= `MerkleHash.ofBytes`); **`ContentHasher.hashOf`** adapts a port to the `byte[] -> MerkleHash` function `ZSetMerkle.rootWith`/`ContentStore.create` already take.
- **BLAKE3** (the decided tamper-evident hash) becomes **one adapter behind this port**, with the NuGet dependency **isolated to that adapter** — the rest of the codebase stays algorithm-agnostic. Resolves the BLAKE3 gating via *abstraction ownership* (no direct dep added yet — the port is the deliverable; the BLAKE3 adapter lands behind it when we add the dep).

## Test
`dotnet test … --filter ContentHasher` → **3 passed** (default xxhash128 = `MerkleHash.ofBytes`; `hashOf` adapter; a custom adapter conforms — proving generic-over-algorithms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)