### PR TITLE
docs(treaty): reconcile BLAKE3 content-address treaty with Lior's as-built ZetaId + file ContentHash256 gap

### DIFF
--- a/docs/research/2026-06-07-blake3-content-address-treaty-two-tier-128-le-vs-256-zetaid-typed-word-vera-aaron.md
+++ b/docs/research/2026-06-07-blake3-content-address-treaty-two-tier-128-le-vs-256-zetaid-typed-word-vera-aaron.md
@@ -2,8 +2,9 @@
 
 The team's resolution of the BLAKE3 4-language byte-lock question Otto routed (umbrella `081KTH323AK`).
 **Vera + Lior** (4-lang reviewers) + Aaron. Faithful capture + reconciliation of the two reviews,
-Beacon-anchored. (Implementation — the ZetaId overlay + `ContentHash256` type — is **Lior's lane in
-flight**; this doc is the decision record, not the code.)
+Beacon-anchored. (Implementation: the **ZetaId overlay is LANDED by Lior** — see "As-built" below;
+`ContentHash256` (the full-256 proof tier) is the remaining gap, backlogged. This doc is the reconciled
+decision record.)
 
 ## Reconciliation (Vera ⊕ Lior — read this first)
 
@@ -73,17 +74,35 @@ The BLAKE3 treaty defines the **canonical digest + byte order** on its own. Zeta
 embed a declared-length prefix of it; any layout with ordering/index bits must verify against the full
 (or a longer stored) digest before treating identity as proven.
 
-## Implications for the landed code
+## AS-BUILT (Lior landed it, 2026-06-07) — reconciled with the treaty
 
-- Our 128-bit `MerkleHash` from `Core.Blake3.Blake3Hasher` **is `ContentAddress128`** (lower 128 bits LE) —
-  correct for the store's internal addressing; the known-answer already matches the treaty value. ✓
-- **Add `ContentHash256`** — the full 32-byte BLAKE3 digest — for proof/export/adversarial surfaces (Core
-  has only the 128-bit path today). `Core.Blake3` gains a full-digest function + a known-answer.
-- **Do not conflate `ContentAddress128` with a `ZetaId`** — a content-address ZetaId spends version/category
-  bits and embeds a *prefix*; that packing is future ZetaId work, declared per category. The raw 128-bit
-  `MerkleHash` is the *digest-derived address*, not a packed ZetaId.
+Lior implemented the ZetaId overlay across all four oracles (cross-verify 12/12; 1937 F# / 268 C# / TS
+green). The as-built confirms the treaty's *principle* with concrete numbers:
+
+- **`Category.ContentAddress = 9`** (`Category.Extended = 15` escape); categories **0..8 = Observation**
+  (structured), **9 = ContentAddress**, **10..15 = Generic**. The category discriminant decides
+  interpretation (Aaron's "high bits decide how to read the low bits"). Files: `src/Core.FSharp.ZetaId/`
+  (`Types.fs`, `Codec.fs`), `src/Core.CSharp.ZetaId/` (`Category.cs`, `ZetaIdPayload.cs`, `ZetaIdCodec.cs`),
+  `src/Core.TypeScript/zeta-id/`.
+- **`ZetaIdPayload` DU** = `Observation obs` | `ContentAddress (version, payload)` | `Generic (version,
+  category≥10, payload)`. `packGeneric`/`unpackGeneric` carry a **119-bit payload** (version 5 + category 4
+  = 9 bits spent of the 128). `packPayload`/`unpackPayload` round-trip; out-of-range (>119 bits) and
+  category-range violations raise. FsCheck proves `unpack ∘ pack = id` over the partitions.
+- **The 119-bit ZetaId content-address payload ≠ the standalone 128-bit `ContentAddress128`.** Inside a
+  ZetaId, the ContentAddress category embeds a **truncated BLAKE3 prefix** (Lior used ~14 bytes / 112 bits,
+  within the 119-bit budget) — the declared-per-category prefix the treaty calls for. The standalone
+  `ContentAddress128` (the 16-byte `MerkleHash` from `Core.Blake3.Blake3Hasher`, `49c9dc…`) remains the
+  digest-derived address **independent of ZetaId packing** — consistent with the treaty (don't conflate the
+  two). ✓
+- **REMAINING GAP — `ContentHash256` is NOT built yet.** No `ContentHash256` in `src/**`. The full 256-bit
+  raw-byte proof tier (for files/packages/blocks/adversarial/export) still needs a distinct 32-byte digest
+  type + the full-digest function on `Core.Blake3` + the empty-input known-answer (`af1349b9…`). Backlogged
+  as the next trust-core slice. Until it lands, do NOT content-address files/packages by the 128-bit address
+  alone (Lior's adversarial caveat).
 
 ## Ties
+
+- Remaining gap tracked: **`081KTH59TVZ`** (ContentHash256 full-256 proof tier).
 
 - `Core.Blake3.Blake3Hasher` / `IContentHasher` (the 128-bit ContentAddress path) · `ZSetMerkle` /
   `ContentStore` (consume the 128-bit address) · ZetaId (the typed-word lineage — version/category/payload)

--- a/workitems/081KTH59TVZ08QG0R000YRX5HW-contenthash256-full-256-bit-raw-blake3-proof-tier-files-pack.md
+++ b/workitems/081KTH59TVZ08QG0R000YRX5HW-contenthash256-full-256-bit-raw-blake3-proof-tier-files-pack.md
@@ -1,0 +1,47 @@
+---
+id: 081KTH59TVZ08QG0R000YRX5HW
+type: task
+state: backlog
+priority: P2
+slug: contenthash256-full-256-bit-raw-blake3-proof-tier-files-pack
+title: "ContentHash256 — full 256-bit raw BLAKE3 proof tier (files/packages/blocks/adversarial); the remaining trust-core gap"
+created: 2026-06-07T13:45:34.847Z
+depends_on: []
+composes_with: ["081KTH323AK08QG0R000ZZ0N93"]
+---
+
+# ContentHash256 — full 256-bit raw BLAKE3 proof tier (files/packages/blocks/adversarial); the remaining trust-core gap
+
+<!-- Work-item body. ZetaId-keyed (conflict-free, time-sortable). "Backlog" is a
+     STATE = this folder; completion moves the file to workitems/done/YYYY/MM/.
+     Identity is the zetaid prefix — resolve cross-refs by `081KTH59TVZ08QG0R000YRX5HW-*.md` glob. -->
+
+## Purpose
+
+The remaining trust-core gap after Lior's ZetaId overlay: the **full 256-bit raw-byte BLAKE3 proof tier**.
+The ZetaId ContentAddress category (9) embeds a 119-bit truncated prefix (internal CAS, ~64-bit adversarial
+resistance); the standalone `ContentAddress128` (16-byte `MerkleHash`) is the internal address. Neither is
+safe for adversarial/export/signed surfaces — per the treaty (Vera + Lior), **files / packages (Ace) /
+blocks (Zeta) / anything signed-or-exported must address by the full `ContentHash256`.** Treaty doc:
+`docs/research/2026-06-07-blake3-content-address-treaty-two-tier-128-le-vs-256-zetaid-typed-word-vera-aaron.md`.
+
+## Build
+
+- A distinct **`ContentHash256`** type = a 32-byte raw BLAKE3 digest wrapper, **raw byte order, no reversal**
+  (empty input = `af1349b9f5f9a1a6a0404dea36dcc949…`) — distinct from the LE-rendered `ContentAddress128`.
+- Full-digest function on `Core.Blake3` (alongside the existing 128-bit adapter) + the empty-input
+  known-answer test; the 128-bit `ContentAddress128` must be derivable-from / verifiable-against it.
+- Wire content-addressing of files/packages/blocks to `ContentHash256`; the 119-bit ZetaId / 128-bit
+  address stay as compact internal handles backed by the full digest.
+- 4-lang parity: golden vector for the full 256 digest (raw) in the cross-verify suite.
+
+## Acceptance
+
+`ContentHash256` (raw 32-byte) implemented + known-answer locked; files/packages/blocks address by it;
+128-bit handle verifiable against it; 4-oracle golden vector for the full digest. Adversarial caveat closed.
+
+## Anchors
+
+- Treaty doc (above) · `Core.Blake3.Blake3Hasher` (128-bit adapter) · `IContentHasher` port · ZetaId
+  ContentAddress category (Lior) · umbrella 081KTH323AK · B-0959 (4-oracle) · no-binary-in-proof-lineage.
+


### PR DESCRIPTION
## What
Lior finished + landed the ZetaId overlay (4 oracles, cross-verify 12/12, all green). I held the Vera+Lior treaty **decision-record** local during his in-flight work (no-collision discipline) and now **reconcile it with the as-built**:

- **Category 9 = ContentAddress**, 10..15 = Generic, 0..8 = Observation; **`ZetaIdPayload`** DU (`Observation` | `ContentAddress(ver,≤119)` | `Generic(ver,cat≥10,≤119)`); `packGeneric` carries a **119-bit** payload (version+category spend 9 of 128); FsCheck `unpack∘pack = id`.
- The **119-bit ZetaId content-address prefix ≠ the standalone 128-bit `ContentAddress128`** (`MerkleHash`) — both consistent with the treaty (don't conflate).
- **Remaining gap: `ContentHash256`** (full 256-bit **raw** proof tier) is **not built**. Filed **`081KTH59TVZ`** (P2) — files/packages/blocks/adversarial/export must address by the full digest; the 128-bit handle stays compact-internal, verifiable against it.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)