### PR TITLE
docs: compression-as-self-bootstrapping-compiler-over-generators (DST regen) — the substrate Shannon lacks

### DIFF
--- a/docs/research/2026-06-07-compression-as-self-bootstrapping-compiler-over-generators-dst-regeneration-the-substrate-shannon-lacks-aaron.md
+++ b/docs/research/2026-06-07-compression-as-self-bootstrapping-compiler-over-generators-dst-regeneration-the-substrate-shannon-lacks-aaron.md
@@ -1,0 +1,101 @@
+# Compression that compiles into a self-bootstrapping compiler running common generator functions — the substrate Shannon's theory lacks (Aaron, 2026-06-07)
+
+Riffing on the 3Blue1Brown / Shannon "compression is intelligence" capture
+(`ip-questionable/2026-06-07-3blue1brown-...`), Aaron named the white space and Zeta's move into it.
+Faithful capture; this is a flagship treaty-seed. Beacon-anchored; hype-peeled.
+
+## 1. The gap: Shannon's theory has no substrate (Aaron's read is correct)
+
+> Aaron: *"I don't think that last video thought about a substrate, or am I missing it somewhere?"*
+
+You're not missing it. The Shannon / 3b1b material is pure information **theory** — entropy, the compression
+*limit*, prediction≡compression — deliberately at "a higher layer of abstraction." It proposes **no
+substrate**: no storage engine, no compute, no concrete decompressor beyond "map symbols to codewords / use
+a language model as the predictor." That absence is exactly the white space Zeta fills.
+
+## 2. The move: compress INTO a self-bootstrapping compiler that runs common generator functions
+
+> Aaron: *"They don't combine compression plus generators where the compression can regenerate data using
+> deterministic simulation, like test data generation."* … *"My compression compresses into a
+> self-bootstrapping compiler that can run common generator functions."*
+
+Zeta's compressed form is **not a passive encoding — it's an executable program**:
+
+- the payload is **references to a shared library of common generator functions** + their **seeds /
+  parameters**;
+- **decompression = run those generators under Deterministic Simulation (DST)** — same seed ⇒ bit-identical
+  output (manifesto §7) — to **regenerate** the exact data;
+- the runner is a **self-bootstrapping compiler** (it can build itself + interpret the generator programs),
+  so the codebook is *executable*, not just a static dictionary.
+
+**Test-data generation is the canonical example:** don't store the generated data — store the **generator +
+seed** and regenerate it identically on demand (FsCheck generator + seed). The same move generalizes to any
+data with structure a generator can capture.
+
+## 3. Why this is Kolmogorov complexity *made runnable*
+
+Two compression bounds: **Shannon** = the *statistical* limit (entropy, over a distribution); **Kolmogorov**
+= the *algorithmic* limit — the length of the **shortest program that outputs the data** (uncomputable in
+general). Zeta operationalizes the Kolmogorov view: compress to the **smallest generator-invocation over a
+shared executable codebook**, run by a self-bootstrapping compiler, with **DST making regeneration
+deterministic + verifiable**. Shannon gives the bound; Kolmogorov gives the *form* (a program); Zeta's
+substrate makes that program **runnable, deterministic, and content-verified**.
+
+## 4. The pieces already in Zeta
+
+- **Self-bootstrapping compiler** = Ace / Nucleus microcore (bootstraps from foundational docs; "can't be a
+  plugin over itself") + the `self-boot` capability. The runner of the generator programs.
+- **Behavior-as-data / Bonsai** = the generator program is a **serialized expression-tree inside a
+  `DynamicValue`** (a value that *describes and runs* behavior) — so a generator IS data, content-addressable
+  like everything else.
+- **DST** (manifesto §7) = same seed ⇒ same orbit ⇒ bit-identical regeneration (the correctness guarantee
+  that makes generative compression *lossless*).
+- **Common generator functions** = a shared, executable codebook the compiler knows; the compressed payload
+  only carries a reference + seed/params (the codebook is amortized across all data).
+- **Content-addressing (`ContentHash256` / `ContentAddress128`)** = the verification boundary: regenerate,
+  hash, check against the digest — so a generative encoding is *provably* the same bytes.
+- **Prediction≡compression** (Shannon) = the generator IS the model; running it predicts/regenerates.
+
+## 5. Concrete design — the dual-representation content node
+
+A store node can be **materialized OR generative**, both addressed by the SAME content hash:
+
+```
+Node =
+  | Materialized of bytes                                   // store the data
+  | Generative   of { compilerRef; generatorRef; seed; params }  // store the program that makes the data
+both ⇒ ContentHash256(regenerate(node)) is identical  ⇒  same content address
+```
+
+Store **whichever is smaller** (raw bytes vs generator+seed). "Decompression" = run the generator under DST
+and **verify** the output hashes to the node's `ContentHash256`. This unifies **compression + generators +
+DST + content-addressing** in one node type — and slots straight into the COW Merkle-DAG store
+(`081KTGTJC1Q`) + git-as-event-store (events+fold = a generative regeneration of state). Backlogged.
+
+## Honest scope (hype-peeled)
+
+The *pieces* exist (DST, Bonsai behavior-as-data, the Ace/Nucleus self-boot, content-addressing); the
+**generative content node + the shared generator codebook + the compile-to-generator compressor are
+designed/captured, NOT built.** This is a strong synthesis, not a shipped feature. The win is real where
+data has generator-capturable structure; it is *not* a general-purpose compressor for incompressible data
+(random data has no short generator — Kolmogorov says so).
+
+## Ties
+
+- `2026-06-07-3blue1brown-compression-is-intelligence-...` (the theory this gives a substrate to) · DST
+  (manifesto §7) · Bonsai behavior-as-data / `DynamicValue` · Ace/Nucleus self-boot · `ContentHash256` /
+  `ContentStore` / the COW Merkle-DAG store (`081KTGTJC1Q`) · git-as-event-store (events+fold) · `ByteCost`
+  · generative/property testing (FsCheck).
+
+## Beacon anchors
+
+- **Kolmogorov complexity** (Kolmogorov, Solomonoff, Chaitin) — shortest generating program = ultimate
+  compression. · **Solomonoff induction / Hutter (AIXI, Hutter Prize)** — compression ⇔ prediction ⇔
+  intelligence. · **Shannon** (the statistical bound). · **Deterministic simulation** (FoundationDB / Will
+  Wilson) — same seed ⇒ same run. · **Procedural generation / demoscene** — `.kkrieger` (a ~96 KB FPS that
+  generates *all* assets from generators at load) is exactly "compress into generators run by a small
+  engine." · **Metacircular / self-bootstrapping compilers** (Reflections on Trusting Trust). ·
+  **QuickCheck** (generators + seed). Honest novelty: not Kolmogorov/DST individually, but **unifying them
+  into a content-addressed substrate where the compressed form is an executable generator run deterministically
+  and verified by hash** — the runnable, lossless, content-verified Kolmogorov compressor Shannon's theory
+  only bounds.

--- a/workitems/081KTH5N5ZJ08QG0R002JDT704-generative-content-node-compile-to-generator-compressor-dual.md
+++ b/workitems/081KTH5N5ZJ08QG0R002JDT704-generative-content-node-compile-to-generator-compressor-dual.md
@@ -1,0 +1,48 @@
+---
+id: 081KTH5N5ZJ08QG0R002JDT704
+type: task
+state: backlog
+priority: P2
+slug: generative-content-node-compile-to-generator-compressor-dual
+title: "Generative content node + compile-to-generator compressor (dual materialized/generative, DST-regenerated, ContentHash256-verified)"
+created: 2026-06-07T13:51:46.674Z
+depends_on: []
+composes_with: ["081KTGTJC1Q08QG0R002VCB55A"]
+---
+
+# Generative content node + compile-to-generator compressor (dual materialized/generative, DST-regenerated, ContentHash256-verified)
+
+<!-- Work-item body. ZetaId-keyed (conflict-free, time-sortable). "Backlog" is a
+     STATE = this folder; completion moves the file to workitems/done/YYYY/MM/.
+     Identity is the zetaid prefix — resolve cross-refs by `081KTH5N5ZJ08QG0R002JDT704-*.md` glob. -->
+
+## Purpose
+
+Aaron 2026-06-07: "my compression compresses into a self-bootstrapping compiler that can run common
+generator functions" + "compression + generators where the compression regenerates data via deterministic
+simulation (like test data generation)." Operationalize Kolmogorov-style compression as a RUNNABLE,
+content-verified substrate. Full synthesis:
+`docs/research/2026-06-07-compression-as-self-bootstrapping-compiler-over-generators-...md`.
+
+## Build
+
+- A dual-representation content node: `Materialized of bytes | Generative of {compilerRef; generatorRef;
+  seed; params}`; both content-address to the same `ContentHash256` (regenerate -> hash -> verify).
+- A shared library of "common generator functions" (executable codebook; Bonsai expr-trees in DynamicValue),
+  referenced by the generative payload.
+- A compressor that, where data has generator-capturable structure, emits the generative form when smaller;
+  decompress = run the generator under DST + verify the hash.
+- Self-bootstrapping compiler/runner = Ace/Nucleus; DST = same seed -> bit-identical output.
+
+## Acceptance
+
+A node round-trips through the generative path (generator+seed -> regenerate -> hashes to the same
+ContentHash256 as the materialized bytes); pick-smaller works; DST replay is bit-identical; falls back to
+materialized for incompressible/no-generator data.
+
+## Anchors
+
+- compression-as-self-bootstrapping-compiler research doc · DST (manifesto §7) · Bonsai/behavior-as-data ·
+  Ace/Nucleus self-boot · ContentHash256/ContentStore · 081KTGTJC1Q (COW store) · git-as-event-store ·
+  Kolmogorov/Solomonoff/Hutter; demoscene .kkrieger; QuickCheck.
+


### PR DESCRIPTION
## What — Aaron 2026-06-07, a flagship synthesis (3 messages) on the Shannon capture

- **The Shannon video has no substrate** (theory only: entropy, limits, prediction≡compression) — your read is right; that's the white space.
- **Zeta's compression compiles into a self-bootstrapping compiler that runs common generator functions:** payload = generator refs + seed/params; **decompression = run them under DST** (same seed → bit-identical) to regenerate. Test-data generation is the canonical case (store generator+seed, not data).
- **Kolmogorov made runnable:** smallest generator-invocation over a shared executable codebook, DST-deterministic + **`ContentHash256`-verified**. Shannon bounds it; Kolmogorov gives the form; Zeta's substrate makes it runnable/lossless/verified.

Pieces we already have: Ace/Nucleus self-boot · Bonsai behavior-as-data · DST · content-addressing · prediction≡compression. Concrete design: a **dual `Materialized | Generative` content node**, both addressed by the same `ContentHash256` (regenerate → hash → verify). **Hype peeled** (the generative node + codebook + compressor are designed-not-built; not a general compressor for incompressible data — Kolmogorov says random data has no short generator).

Research doc + backlog item (composes with the COW store `081KTGTJC1Q`). Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)