### PR TITLE
feat(Crdt): LwwMap — LWW-keyed map CRDT (composes LwwRegister) + backlog correction

### DIFF
--- a/src/Core/Crdt.fs
+++ b/src/Core/Crdt.fs
@@ -135,3 +135,47 @@ with
         elif a.Timestamp < b.Timestamp then b
         elif String.Compare(a.Replica, b.Replica, StringComparison.Ordinal) >= 0 then a
         else b
+
+/// **LWW-Map** — a last-writer-wins keyed map: each key independently holds an `LwwRegister`, merged
+/// per-key via `LwwRegister.Merge`. Inherits commutative + associative + idempotent merge ⇒ a CRDT (the
+/// common local-first keyed-document structure). Keys use F# structural comparison — **ordinal for `string`
+/// (B-0969-clean)**. Composes `LwwRegister` (no duplicate merge logic). Removal is LWW too: `Remove` writes
+/// a tombstone register; readers skip tombstoned keys. (081KTH4Q782 — local-first CRDTs on the substrate.)
+[<NoComparison; NoEquality>]
+type LwwMap<'K, 'V when 'K: comparison> =
+    { Entries: Map<'K, LwwRegister<'V option>> }
+
+    static member Empty: LwwMap<'K, 'V> = { Entries = Map.empty }
+
+    /// Set `key` to `value` at `(timestamp, replica)` — LWW-merged against any existing register for the key.
+    member this.Set(key: 'K, value: 'V, timestamp: int64, replica: string) : LwwMap<'K, 'V> =
+        let reg = LwwRegister<'V option>.Create(Some value, timestamp, replica)
+        let merged =
+            match Map.tryFind key this.Entries with
+            | Some existing -> LwwRegister.Merge existing reg
+            | None -> reg
+        { Entries = Map.add key merged this.Entries }
+
+    /// Remove `key` at `(timestamp, replica)` — a LWW tombstone (a later set wins, a later remove wins).
+    member this.Remove(key: 'K, timestamp: int64, replica: string) : LwwMap<'K, 'V> =
+        let reg = LwwRegister<'V option>.Create(None, timestamp, replica)
+        let merged =
+            match Map.tryFind key this.Entries with
+            | Some existing -> LwwRegister.Merge existing reg
+            | None -> reg
+        { Entries = Map.add key merged this.Entries }
+
+    /// The live value at `key` (None if absent or tombstoned).
+    member this.TryGet(key: 'K) : 'V option =
+        Map.tryFind key this.Entries |> Option.bind (fun r -> r.Value)
+
+    /// Merge two LWW-Maps: union of keys, per-key `LwwRegister.Merge`. Commutative, associative, idempotent.
+    static member Merge (a: LwwMap<'K, 'V>) (b: LwwMap<'K, 'V>) : LwwMap<'K, 'V> =
+        let mutable acc = a.Entries
+        for kv in b.Entries do
+            let merged =
+                match Map.tryFind kv.Key acc with
+                | Some existing -> LwwRegister.Merge existing kv.Value
+                | None -> kv.Value
+            acc <- Map.add kv.Key merged acc
+        { Entries = acc }

--- a/tests/Tests.FSharp/Crdt/Lww.Tests.fs
+++ b/tests/Tests.FSharp/Crdt/Lww.Tests.fs
@@ -34,3 +34,46 @@ let ``LwwRegister wins by replica on timestamp tie`` () =
     let a = LwwRegister<string>.Create("a", 5L, "replica-a")
     let b = LwwRegister<string>.Create("b", 5L, "replica-b")
     (LwwRegister.Merge a b).Value |> should equal "b"
+
+// ═══════════════════════════════════════════════════════════════════
+// LwwMap (LWW-keyed map; 081KTH4Q782 — local-first CRDTs on the substrate)
+// ═══════════════════════════════════════════════════════════════════
+
+[<Fact>]
+let ``LwwMap: later write wins per key; reads see the live value`` () =
+    let m =
+        LwwMap<string, string>.Empty
+            .Set("k", "old", 100L, "r1")
+            .Set("k", "new", 200L, "r2")
+    m.TryGet "k" |> should equal (Some "new")
+    m.TryGet "absent" |> should equal (None: string option)
+
+[<Fact>]
+let ``LwwMap: Remove is a LWW tombstone; a later set resurrects`` () =
+    let m = LwwMap<string, int>.Empty.Set("k", 1, 100L, "r1").Remove("k", 200L, "r1")
+    m.TryGet "k" |> should equal (None: int option)
+    let m2 = m.Set("k", 9, 300L, "r1")
+    m2.TryGet "k" |> should equal (Some 9)
+
+[<Fact>]
+let ``LwwMap: merge is commutative and idempotent (CRDT convergence)`` () =
+    let a = LwwMap<string, string>.Empty.Set("x", "a", 100L, "r1").Set("y", "y1", 50L, "r1")
+    let b = LwwMap<string, string>.Empty.Set("x", "b", 200L, "r2").Set("z", "z1", 70L, "r2")
+    let ab = LwwMap.Merge a b
+    let ba = LwwMap.Merge b a
+    // commutative: same live values both ways
+    [ "x"; "y"; "z" ] |> List.iter (fun k -> ab.TryGet k |> should equal (ba.TryGet k))
+    ab.TryGet "x" |> should equal (Some "b") // later ts wins
+    // idempotent: merging again changes nothing observable
+    let abab = LwwMap.Merge ab ab
+    [ "x"; "y"; "z" ] |> List.iter (fun k -> abab.TryGet k |> should equal (ab.TryGet k))
+
+[<Fact>]
+let ``LwwMap: merge is associative (CRDT convergence)`` () =
+    let a = LwwMap<string, int>.Empty.Set("k", 1, 100L, "r1")
+    let b = LwwMap<string, int>.Empty.Set("k", 2, 200L, "r2")
+    let c = LwwMap<string, int>.Empty.Set("k", 3, 150L, "r3")
+    let left = LwwMap.Merge (LwwMap.Merge a b) c
+    let right = LwwMap.Merge a (LwwMap.Merge b c)
+    left.TryGet "k" |> should equal (right.TryGet "k")
+    left.TryGet "k" |> should equal (Some 2) // ts 200 wins

--- a/workitems/081KTH4Q78208QG0R0022E5Z3Z-local-first-crdt-primitives-on-z-set-lww-register-or-set-rga.md
+++ b/workitems/081KTH4Q78208QG0R0022E5Z3Z-local-first-crdt-primitives-on-z-set-lww-register-or-set-rga.md
@@ -16,6 +16,14 @@ composes_with: ["B-0959"]
      STATE = this folder; completion moves the file to workitems/done/YYYY/MM/.
      Identity is the zetaid prefix — resolve cross-refs by `081KTH4Q78208QG0R0022E5Z3Z-*.md` glob. -->
 
+## STATUS (Otto 2026-06-07, corrected against the code)
+
+Already in `src/Core/Crdt.fs` (with tests): **GCounter, PNCounter, OrSet, LwwRegister** — the workitem
+over-listed LWW-Register/OR-Set as "missing"; they exist + are ordinal-clean. **LWW-Map LANDED** this round
+(`LwwMap<'K,'V>` — per-key LwwRegister, tombstone remove, merge commutative/assoc/idempotent; 4 tests).
+**Genuinely remaining:** (1) **RGA / sequence CRDT** (collaborative ordered list/text — the hard one,
+positions + tombstones + causal order); (2) **PSI** as a private Z-set intersection over the `.zc` transform.
+
 ## Purpose
 
 Aaron 2026-06-07 ("we should do it in zset if it makes sense") after the privacy-first/local-first talk:


### PR DESCRIPTION
## What — local-first CRDT-on-Z-set (`081KTH4Q782`)
**`LwwMap<'K,'V>`**: each key independently holds an `LwwRegister<'V option>`; `Set` / `Remove` (LWW tombstone) / `TryGet`; **`Merge` = per-key `LwwRegister.Merge`** → commutative + associative + idempotent (a CRDT). Keys use F# structural comparison (**ordinal for string, B-0969-clean**). Composes the existing `LwwRegister` (no duplicate merge logic).

**Backlog corrected:** GCounter/PNCounter/OrSet/LwwRegister **already existed** (the item over-listed them as missing); `LwwMap` now added; **genuinely remaining = RGA/sequence CRDT** (the hard one) + **PSI** over the `.zc` transform.

## Test
`dotnet test … --filter LwwTests` → **7 passed** (4 new: per-key LWW, tombstone-remove + resurrect, merge commutative+idempotent, merge associative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)