### PR TITLE
feat(Crdt): Rga — RGA sequence CRDT for collaborative ordered text/lists

### DIFF
--- a/src/Core/Crdt.fs
+++ b/src/Core/Crdt.fs
@@ -179,3 +179,79 @@ type LwwMap<'K, 'V when 'K: comparison> =
                 | None -> kv.Value
             acc <- Map.add kv.Key merged acc
         { Entries = acc }
+
+/// A unique RGA element id: `(lamport, replica)` — Lamport clock for causal-ish ordering, replica for the
+/// deterministic tiebreak. F# struct-tuple comparison is structural (int64 then **ordinal** string —
+/// B-0969-clean).
+type RgaId = (struct (int64 * string))
+
+[<NoComparison; NoEquality>]
+type RgaElem<'T> =
+    { Value: 'T
+      After: RgaId option // the element this was inserted after (None = sequence head)
+      Tombstone: bool }
+
+/// **RGA (Replicated Growable Array)** — the sequence/list CRDT for collaborative ordered text/lists
+/// (081KTH4Q782; the remaining CRDT gap). Each element has a unique `RgaId` and an `After` anchor; the
+/// sequence is the causal tree flattened with **siblings ordered by id DESCENDING** (the standard RGA rule:
+/// later/higher-id concurrent inserts at the same anchor come first), which makes concurrent inserts
+/// **converge** deterministically. Removal is a **tombstone** (the element keeps its position as an anchor).
+/// `Merge` = union of elements by id + OR of tombstones ⇒ commutative + associative + idempotent ⇒ a CRDT;
+/// `ToList` is a pure function of the element set, so equal sets ⇒ equal sequences ⇒ convergence.
+/// (Honest scope: deterministic + convergent with the standard sibling rule; perfect no-interleave of
+/// concurrent *runs* is a known RGA subtlety — convergence is guaranteed, run-contiguity is best-effort.)
+[<NoComparison; NoEquality>]
+type Rga<'T> =
+    { Elements: Map<RgaId, RgaElem<'T>> }
+
+    static member Empty: Rga<'T> = { Elements = Map.empty }
+
+    /// Insert `value` with unique `id`, anchored after `after` (None = head). Idempotent on `id`.
+    member this.Insert(id: RgaId, value: 'T, after: RgaId option) : Rga<'T> =
+        if Map.containsKey id this.Elements then this
+        else { Elements = Map.add id { Value = value; After = after; Tombstone = false } this.Elements }
+
+    /// Tombstone the element `id` (keeps its position as an anchor for later inserts).
+    member this.Remove(id: RgaId) : Rga<'T> =
+        match Map.tryFind id this.Elements with
+        | Some e when not e.Tombstone -> { Elements = Map.add id { e with Tombstone = true } this.Elements }
+        | _ -> this
+
+    /// Merge two RGAs: union by id, OR the tombstones. Commutative + associative + idempotent.
+    static member Merge (a: Rga<'T>) (b: Rga<'T>) : Rga<'T> =
+        let mutable acc = a.Elements
+        for kv in b.Elements do
+            match Map.tryFind kv.Key acc with
+            | Some existing -> acc <- Map.add kv.Key { existing with Tombstone = existing.Tombstone || kv.Value.Tombstone } acc
+            | None -> acc <- Map.add kv.Key kv.Value acc
+        { Elements = acc }
+
+    /// The live sequence (tombstoned elements skipped but kept as anchors). Pure in `Elements` ⇒ convergent.
+    member this.ToList() : 'T list =
+        // Head children (After = None) tracked separately — F# `option` None is `null` at runtime and
+        // cannot be a Dictionary key; the children map is keyed by the non-null parent `RgaId`.
+        let roots = ResizeArray<RgaId>()
+        let childrenOf = Dictionary<RgaId, ResizeArray<RgaId>>()
+        for kv in this.Elements do
+            match kv.Value.After with
+            | None -> roots.Add kv.Key
+            | Some parent ->
+                match childrenOf.TryGetValue parent with
+                | true, lst -> lst.Add kv.Key
+                | _ ->
+                    let lst = ResizeArray<RgaId>()
+                    lst.Add kv.Key
+                    childrenOf.[parent] <- lst
+        // siblings ordered by id DESCENDING (the RGA convergence rule)
+        let sortDesc (lst: ResizeArray<RgaId>) = lst.Sort(System.Comparison<RgaId>(fun x y -> compare y x))
+        sortDesc roots
+        for kvp in childrenOf do sortDesc kvp.Value
+        let out = ResizeArray<'T>()
+        let rec walk (nodeId: RgaId) =
+            let e = this.Elements.[nodeId]
+            if not e.Tombstone then out.Add e.Value
+            match childrenOf.TryGetValue nodeId with
+            | true, kids -> for k in kids do walk k
+            | _ -> ()
+        for r in roots do walk r
+        List.ofSeq out

--- a/tests/Tests.FSharp/Crdt/Rga.Tests.fs
+++ b/tests/Tests.FSharp/Crdt/Rga.Tests.fs
@@ -1,0 +1,55 @@
+module Zeta.Tests.Crdt.RgaTests
+#nowarn "0893"
+
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Core
+
+// RGA sequence CRDT (081KTH4Q782): collaborative ordered list/text. Convergence is the must-have —
+// concurrent inserts must yield the SAME sequence on every replica (deterministic sibling ordering).
+
+let private id (lamport: int64) (replica: string) : RgaId = struct (lamport, replica)
+
+[<Fact>]
+let ``RGA: sequential inserts produce in-order sequence; tombstone removes`` () =
+    let a = id 1L "r1"
+    let b = id 2L "r1"
+    let c = id 3L "r1"
+    let rga =
+        Rga<string>.Empty.Insert(a, "a", None).Insert(b, "b", Some a).Insert(c, "c", Some b)
+    rga.ToList() |> should equal [ "a"; "b"; "c" ]
+    (rga.Remove b).ToList() |> should equal [ "a"; "c" ] // b tombstoned, still anchors c
+
+[<Fact>]
+let ``RGA: concurrent inserts at the same anchor CONVERGE (same sequence both merge orders)`` () =
+    // two replicas each insert at head concurrently
+    let r1 = Rga<string>.Empty.Insert(id 1L "r1", "x", None)
+    let r2 = Rga<string>.Empty.Insert(id 2L "r2", "y", None)
+    let ab = (Rga.Merge r1 r2).ToList()
+    let ba = (Rga.Merge r2 r1).ToList()
+    ab |> should equal ba // convergence: order-independent of merge direction
+    // sibling rule: higher id (2,"r2") comes before (1,"r1")
+    ab |> should equal [ "y"; "x" ]
+
+[<Fact>]
+let ``RGA: merge is idempotent and associative (CRDT convergence)`` () =
+    let a = Rga<int>.Empty.Insert(id 1L "r1", 1, None)
+    let b = Rga<int>.Empty.Insert(id 2L "r2", 2, Some(id 1L "r1"))
+    let c = Rga<int>.Empty.Insert(id 3L "r3", 3, Some(id 1L "r1"))
+    let ab = Rga.Merge a b
+    // idempotent
+    (Rga.Merge ab ab).ToList() |> should equal (ab.ToList())
+    // associative
+    let left = (Rga.Merge (Rga.Merge a b) c).ToList()
+    let right = (Rga.Merge a (Rga.Merge b c)).ToList()
+    left |> should equal right
+    // both concurrent inserts after r1's "1" appear, higher-id first: 1, then 3 (r3) before 2 (r2)
+    left |> should equal [ 1; 3; 2 ]
+
+[<Fact>]
+let ``RGA: a replica's run stays contiguous (chain anchoring)`` () =
+    // r1 types "ab" (a head, b after a); r2 concurrently inserts "Z" at head
+    let r1 = Rga<string>.Empty.Insert(id 1L "r1", "a", None).Insert(id 2L "r1", "b", Some(id 1L "r1"))
+    let r2 = Rga<string>.Empty.Insert(id 5L "r2", "Z", None)
+    let merged = (Rga.Merge r1 r2).ToList()
+    merged |> should equal [ "Z"; "a"; "b" ] // r1's a->b chain stays together; Z (higher head id) leads

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -226,6 +226,7 @@
     <Compile Include="Crdt/PNCounter.Tests.fs" />
     <Compile Include="Crdt/OrSet.Tests.fs" />
     <Compile Include="Crdt/Lww.Tests.fs" />
+    <Compile Include="Crdt/Rga.Tests.fs" />
     <Compile Include="Crdt/DeltaCrdt.Tests.fs" />
 
     <!-- Plugin/ -->

--- a/workitems/081KTH4Q78208QG0R0022E5Z3Z-local-first-crdt-primitives-on-z-set-lww-register-or-set-rga.md
+++ b/workitems/081KTH4Q78208QG0R0022E5Z3Z-local-first-crdt-primitives-on-z-set-lww-register-or-set-rga.md
@@ -21,8 +21,9 @@ composes_with: ["B-0959"]
 Already in `src/Core/Crdt.fs` (with tests): **GCounter, PNCounter, OrSet, LwwRegister** — the workitem
 over-listed LWW-Register/OR-Set as "missing"; they exist + are ordinal-clean. **LWW-Map LANDED** this round
 (`LwwMap<'K,'V>` — per-key LwwRegister, tombstone remove, merge commutative/assoc/idempotent; 4 tests).
-**Genuinely remaining:** (1) **RGA / sequence CRDT** (collaborative ordered list/text — the hard one,
-positions + tombstones + causal order); (2) **PSI** as a private Z-set intersection over the `.zc` transform.
+**RGA / sequence CRDT LANDED** this round (`Rga<'T>` — unique-id elements, After-anchor, tombstone remove,
+sibling-order-by-id-DESC for convergence; merge commutative/assoc/idempotent; 4 tests incl. concurrent-insert
+convergence). **Genuinely remaining:** **PSI** as a private Z-set intersection over the `.zc` transform.
 
 ## Purpose
 


### PR DESCRIPTION
## What — the remaining hard CRDT (`081KTH4Q782`)
**`Rga<'T>`** — the sequence/list CRDT (collaborative ordered text/lists): unique-id elements `(lamport, replica)`, `After`-anchor, tombstone `Remove`; **`ToList`** flattens the causal tree with **siblings ordered by id DESCENDING** (the standard RGA rule → concurrent inserts **converge** deterministically); **`Merge`** = union by id + OR tombstones → commutative + associative + idempotent. `ToList` is pure in the element set ⇒ equal sets ⇒ equal sequences ⇒ convergence.

Bug fixed in dev: F# `option` `None` is `null` at runtime and can't be a `Dictionary` key → head children (`After=None`) tracked via a separate roots list. Keys ordinal (B-0969-clean).

## Test
`dotnet test … --filter RgaTests` → **4 passed**: sequential+tombstone, concurrent-insert convergence (same both merge orders), idempotent+associative, contiguous-run anchoring.

Backlog: RGA done; **PSI** over `.zc` remains the last CRDT-on-Z-set item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)