### PR TITLE
docs: Orleans actors on the git-native bus — sequential pointer, arrival-order canonical, no retraction

### DIFF
--- a/docs/research/2026-06-07-orleans-actors-simulated-on-git-native-bus-sequential-pointer-arrival-order-canonical-no-retraction-aaron.md
+++ b/docs/research/2026-06-07-orleans-actors-simulated-on-git-native-bus-sequential-pointer-arrival-order-canonical-no-retraction-aaron.md
@@ -1,0 +1,83 @@
+# Orleans virtual actors simulated on the git-native bus: a sequential pointer, arrival-order-canonical, no retraction (Aaron, 2026-06-07)
+
+Concretizes the **SerializedSaga** coordination lane (from cells-as-geodes,
+`2026-06-07-cells-as-geodes-...-cross-cell-sagas-as-partitioned-orleans-actors`) into a specific mechanism
+on infrastructure we already have. Faithful capture; Beacon-anchored.
+
+## The mechanism
+
+> Aaron: *"we can simulate Orleans actors with a git-native bus like we already have, and a pointer
+> sequentially reading messages that treats arrival order as the canonical order of events and does not
+> support retraction."*
+
+An Orleans **virtual actor (grain)** is, operationally, a **single-threaded mailbox processed one message
+at a time in arrival order.** That is *exactly*:
+
+```
+git-native bus (B-0954)  =  the grain's mailbox        (an append-ordered ZetaId-keyed message stream)
+sequential read pointer  =  the grain's single-threaded turn loop (process message N, then N+1, …)
+arrival order            =  the CANONICAL total order of events for this actor
+no retraction            =  append-only; you don't undo a processed message — you emit a COMPENSATING
+                            message (saga-style), never a Z-set −1.
+```
+
+So we get the Orleans grain's defining properties for free from existing pieces:
+
+| Orleans grain property | git-bus + pointer realization |
+|---|---|
+| single-threaded turn-based processing | one sequential pointer, one message at a time |
+| mailbox / message ordering | the bus stream's append order (arrival order) |
+| location transparency | the bus address (ZetaId persona⊕surface⊕…) = the grain identity |
+| durability + replay | the git log IS the event history; pointer position + log = state (DST-replayable) |
+| activate-on-demand | a pointer is spun up at the stream when the grain is addressed |
+
+## The crux: this lane has NO retraction — and that's deliberate
+
+This is the **complement** of the Z-set/CRDT side. Two coordination classes (cells-as-geodes):
+
+| | **CommutativeView** (default) | **SerializedSaga** (escalation — THIS) |
+|---|---|---|
+| primitive | Z-set / CRDT (G-Set/LwwMap/Rga) | actor on the git-native bus + sequential pointer |
+| order | order-independent (commutative merge) | **arrival order IS canonical** (total order) |
+| undo | **retraction-native** (`+1`/`−1`) | **no retraction** — compensation only (saga) |
+| consistency | AP / eventual-C (cross-cell default) | CP / serialized (the reserved escalation) |
+| when | order doesn't matter; `f(ownStream, otherStream)` | order matters; can't be made commutative |
+
+Picking the lane is the decision the cross-cell DU already declares (CommutativeView if each side can compute
+the transition order-independently, else SerializedSaga). **Orleans-on-the-bus is how the SerializedSaga arm
+is actually built** — and it stays **DST-replayable** (replay the log from the start through the pointer ⇒
+same actor state), so even the serialized side keeps determinism. It also realizes the **Loom** cross-cell
+saga layer's mechanism, and composes with **B-0976** (self-evolving saga / serialized deferred-execution
+Bonsai — resume-not-replay): the grain's behavior can be a Bonsai closure resumed at the pointer.
+
+## Why this is the right shape (not just convenient)
+
+- The actor model's "no shared mutable state, communicate by messages, one-at-a-time" *is* a sequential fold
+  over an ordered message log — and an append-ordered log is precisely what git/the bus already is. We don't
+  need an Orleans runtime; we need a **cursor discipline** over the bus.
+- Arrival-order-as-canonical gives a free, durable **total order per actor** without a consensus protocol —
+  the order is just "what the bus appended," which is already agreed (single-writer-per-stream / the bus's
+  ordering). For cross-actor total order you escalate to the serialized bus (the Saga), exactly as designed.
+- No-retraction is the honest contract for an ordered side: once a message is processed in order, undo is a
+  *new* compensating event, never a rewrite — which keeps the log append-only and replayable (and matches
+  the "git only adds corrections" / CPT-reversible-by-compensation theme).
+
+## Ties
+
+- `2026-06-07-cells-as-geodes-...-cross-cell-sagas-as-partitioned-orleans-actors` (the lane this builds) ·
+  **B-0954** (git-native cross-machine agent bus — the mailbox) · **B-0976** (self-evolving serialized saga
+  / Bonsai deferred execution — the grain behavior) · Loom (cross-cell saga layer) · `GSet`/`LwwMap`/`Rga`
+  (the CommutativeView complement) · DST (pointer + log ⇒ replayable state) · the AP-vs-CP / commutative-vs-
+  serialized split. Backlogged: an actor-cursor over the bus (sequential pointer, arrival-canonical, compensation-only).
+
+## Beacon anchors
+
+- **Orleans** — Bernstein, Bykov, et al. (Microsoft Research) — the **virtual actor** (grain) model:
+  activate-on-demand, single-threaded, location-transparent. · **Actor model** — Hewitt; Agha. ·
+  **Erlang/OTP** `gen_server` — the sequential-mailbox process. · **Event sourcing** — arrival order as the
+  source of truth; replay to rebuild state. · **CALM** (Hellerstein) — monotonic/commutative needs no
+  coordination (CommutativeView); non-monotonic needs order (SerializedSaga). · **Virtual synchrony / total
+  order broadcast** — the consensus you escalate to for cross-actor order. Honest novelty: none in the actor
+  model; the contribution is realizing it as a **cursor discipline over the existing git-native bus** (no
+  separate runtime), with arrival-order-canonical + compensation-not-retraction as the explicit
+  SerializedSaga contract complementing the retraction-native Z-set lane.

--- a/workitems/081KTH7EJZG08QG0R000VTMQ54-actor-cursor-over-the-git-native-bus-orleans-grain-simulatio.md
+++ b/workitems/081KTH7EJZG08QG0R000VTMQ54-actor-cursor-over-the-git-native-bus-orleans-grain-simulatio.md
@@ -1,0 +1,46 @@
+---
+id: 081KTH7EJZG08QG0R000VTMQ54
+type: task
+state: backlog
+priority: P2
+slug: actor-cursor-over-the-git-native-bus-orleans-grain-simulatio
+title: "Actor-cursor over the git-native bus: Orleans-grain simulation (sequential pointer, arrival-order canonical, compensation-not-retraction)"
+created: 2026-06-07T14:23:07.760Z
+depends_on: []
+composes_with: ["B-0954", "B-0976"]
+---
+
+# Actor-cursor over the git-native bus: Orleans-grain simulation (sequential pointer, arrival-order canonical, compensation-not-retraction)
+
+<!-- Work-item body. ZetaId-keyed (conflict-free, time-sortable). "Backlog" is a
+     STATE = this folder; completion moves the file to workitems/done/YYYY/MM/.
+     Identity is the zetaid prefix — resolve cross-refs by `081KTH7EJZG08QG0R000VTMQ54-*.md` glob. -->
+
+## Purpose
+
+Aaron 2026-06-07: simulate Orleans virtual actors on the git-native bus we already have (B-0954) + a
+sequential read pointer that treats arrival order as the canonical event order and does NOT support
+retraction. Realizes the SerializedSaga coordination lane (cells-as-geodes) as a cursor discipline — no
+separate actor runtime. Full design:
+`docs/research/2026-06-07-orleans-actors-simulated-on-git-native-bus-sequential-pointer-...md`.
+
+## Build
+
+- An actor-cursor over a bus stream: per-grain ZetaId-keyed message stream (the mailbox) + a sequential
+  pointer (single-threaded turn loop, one message at a time). Arrival order = canonical total order.
+- NO retraction: a processed message is never undone; undo = a new COMPENSATING message (saga). Append-only.
+- DST-replayable: pointer position + log => state (replay from start reproduces actor state).
+- Grain behavior may be a Bonsai closure resumed at the pointer (compose with B-0976 resume-not-replay).
+- Activate-on-demand: spin a cursor at the stream when the grain is addressed.
+
+## Acceptance
+
+A grain processes its bus mailbox sequentially in arrival order; replay (pointer from 0) reproduces state
+(DST); a "rollback" is shown to be a compensating message, not a retraction; cross-actor total order
+escalates to the serialized bus. Complements the CommutativeView (Z-set/CRDT) lane.
+
+## Anchors
+
+- B-0954 (git-native bus) · B-0976 (serialized saga / Bonsai deferred exec) · cells-as-geodes (SerializedSaga
+  vs CommutativeView) · Loom (cross-cell saga layer) · DST · Orleans/actor-model/Erlang-gen_server/event-sourcing.
+


### PR DESCRIPTION
## What — Aaron 2026-06-07
> "we can simulate Orleans actors with a git-native bus like we already have, and a pointer sequentially reading messages that treats arrival order as the canonical order of events and does not support retraction."

Concretizes the **SerializedSaga** lane (cells-as-geodes) into a **cursor discipline** on existing infra — no separate actor runtime:

| Orleans grain | git-bus + pointer |
|---|---|
| single-threaded turn loop | one sequential pointer, one message at a time |
| mailbox / ordering | the bus stream's **arrival order = canonical total order** |
| location transparency | bus address (ZetaId) = grain identity |
| durability + replay | git log = history; **pointer + log ⇒ state** (DST-replayable) |

**No retraction (deliberate):** undo = a compensating message (saga), never a Z-set `−1` — the complement of the retraction-native Z-set/CRDT **CommutativeView** lane. Composes with **Loom** + **B-0976** (Bonsai resume-not-replay grain behavior). Research doc + backlog item. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)