### PR TITLE
feat(CasStore): per-row compare-and-swap over the content store — lock-free runtime coordination

### DIFF
--- a/src/Core/CasStore.fs
+++ b/src/Core/CasStore.fs
@@ -1,0 +1,60 @@
+namespace Zeta.Core
+
+/// **Per-row compare-and-swap over the content-addressed store — the lock-free runtime coordination
+/// primitive (Aaron 2026-06-07; "maybe we don't need Orleans").** Each row (`'K`) holds the **content
+/// address** (`MerkleHash`) of its current value; `trySwap` commits a new value **iff the row's current
+/// address still equals the caller's `expected`** — otherwise it fails *without committing* and returns the
+/// *actual* current address so the caller can re-read and retry. So a writer that fails mid-turn simply
+/// never commits (the new store version is never adopted); no single-activation, no lock — **manifesto §2
+/// lock/wait-free**. This is the runtime under the actor / SerializedSaga lane for single-row state (the
+/// multi-row-atomic case escalates to the serialized bus / saga). DST-simulatable.
+///
+/// Composes `ContentStore` (values are content-addressed + dedup'd). Ties: B-0962 (optimistic-CAS
+/// claim-locks, deadlock-free by construction), SlateDB (CAS-manifest + writer-epoch fencing).
+[<RequireQualifiedAccess>]
+module CasStore =
+
+    [<NoEquality; NoComparison>]
+    type Store<'K, 'V when 'K: comparison> =
+        private
+            { Rows: Map<'K, MerkleHash> // row key -> current content address
+              Content: ContentStore.Store<'V> }
+
+    /// A store keyed by `hashOf` for value content-addressing (e.g. `ZSetMerkle.root enc`).
+    let create (hashOf: 'V -> MerkleHash) : Store<'K, 'V> =
+        { Rows = Map.empty; Content = ContentStore.create hashOf }
+
+    /// The current content address at `key` (None if the row is absent).
+    let currentHash (key: 'K) (s: Store<'K, 'V>) : MerkleHash option = Map.tryFind key s.Rows
+
+    /// Read the current `(address, value)` at `key`, or None.
+    let read (key: 'K) (s: Store<'K, 'V>) : (MerkleHash * 'V) option =
+        match Map.tryFind key s.Rows with
+        | Some h -> ContentStore.get h s.Content |> Option.map (fun v -> h, v)
+        | None -> None
+
+    /// **Compare-and-swap one row.** `expected` is the address the caller last observed (`None` = expect the
+    /// row absent, i.e. CAS-create). Commits `next` and returns the new store **iff** the row's current
+    /// address equals `expected`; otherwise returns `Error currentAddress` (the value at `key` is unchanged)
+    /// so the caller can re-read and retry. Lock-free; a non-committing call mutates nothing.
+    let trySwap (key: 'K) (expected: MerkleHash option) (next: 'V) (s: Store<'K, 'V>) : Result<Store<'K, 'V>, MerkleHash option> =
+        let current = Map.tryFind key s.Rows
+        if current = expected then
+            let h, content' = ContentStore.put next s.Content
+            Ok { Rows = Map.add key h s.Rows; Content = content' }
+        else
+            Error current
+
+    /// `trySwap` retried internally against the current value: `update key f` reads the row and applies `f`
+    /// to its current value (or None for absent), CAS-swapping the result. Since this store is immutable
+    /// (single logical timeline), one attempt always succeeds; the `Result` shape stays for the concurrent
+    /// caller who holds a *stale* version (their `expected` won't match → they retry).
+    let update (key: 'K) (f: 'V option -> 'V) (s: Store<'K, 'V>) : Store<'K, 'V> =
+        let cur = Map.tryFind key s.Rows
+        let curVal = cur |> Option.bind (fun h -> ContentStore.get h s.Content)
+        match trySwap key cur (f curVal) s with
+        | Ok s' -> s'
+        | Error _ -> s // unreachable on a single timeline; defensive
+
+    /// Number of live rows.
+    let rowCount (s: Store<'K, 'V>) : int = s.Rows.Count

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -85,6 +85,7 @@
     <Compile Include="ZSetMerkle.fs" />
     <Compile Include="ContentHasher.fs" />
     <Compile Include="ContentStore.fs" />
+    <Compile Include="CasStore.fs" />
     <Compile Include="DagFs.fs" />
     <Compile Include="DvKey.fs" />
     <Compile Include="DebeziumCdc.fs" />

--- a/tests/Tests.FSharp/CasStore.Tests.fs
+++ b/tests/Tests.FSharp/CasStore.Tests.fs
@@ -1,0 +1,52 @@
+module Zeta.Tests.CasStoreTests
+
+open System
+open global.Xunit
+open Zeta.Core
+
+module CAS = Zeta.Core.CasStore
+
+let private encI (i: int) : byte[] =
+    let b = Array.zeroCreate<byte> 4
+    System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(Span<byte> b, i)
+    b
+
+let private store () : CAS.Store<string, ZSet<int>> = CAS.create (ZSetMerkle.root encI)
+let private v xs = ZSet.ofSeq xs
+
+[<Fact>]
+let ``CAS-create (expected None) succeeds on an absent row; read round-trips`` () =
+    match CAS.trySwap "k" None (v [ 1, 1L ]) (store ()) with
+    | Ok s ->
+        Assert.True((CAS.currentHash "k" s).IsSome)
+        Assert.Equal<ZSet<int> option>(Some(v [ 1, 1L ]), CAS.read "k" s |> Option.map snd)
+    | Error _ -> Assert.Fail "expected create to succeed on absent row"
+
+[<Fact>]
+let ``CAS-create fails (Error current) if the row already exists`` () =
+    let s = match CAS.trySwap "k" None (v [ 1, 1L ]) (store ()) with Ok s -> s | Error _ -> failwith "setup"
+    let h = (CAS.currentHash "k" s).Value
+    match CAS.trySwap "k" None (v [ 2, 2L ]) s with
+    | Error cur -> Assert.Equal<MerkleHash option>(Some h, cur) // returns the actual current address
+    | Ok _ -> Assert.Fail "expected create to fail on existing row"
+
+[<Fact>]
+let ``CAS-update succeeds when expected matches; a stale expected conflicts (lost-update prevention)`` () =
+    let s0 = match CAS.trySwap "k" None (v [ 1, 1L ]) (store ()) with Ok s -> s | Error _ -> failwith "setup"
+    let h0 = (CAS.currentHash "k" s0).Value
+    // writer A swaps with the observed hash -> Ok
+    let s1 = match CAS.trySwap "k" (Some h0) (v [ 2, 2L ]) s0 with Ok s -> s | Error _ -> failwith "A"
+    let h1 = (CAS.currentHash "k" s1).Value
+    Assert.NotEqual(h0, h1)
+    // writer B held the STALE h0 and applies to s1 -> conflict, returns the real current h1, value unchanged
+    match CAS.trySwap "k" (Some h0) (v [ 9, 9L ]) s1 with
+    | Error cur ->
+        Assert.Equal<MerkleHash option>(Some h1, cur)
+        Assert.Equal<ZSet<int> option>(Some(v [ 2, 2L ]), CAS.read "k" s1 |> Option.map snd) // unchanged
+    | Ok _ -> Assert.Fail "expected stale CAS to conflict"
+
+[<Fact>]
+let ``update applies f to the current value, swapping the result`` () =
+    let s0 = match CAS.trySwap "k" None (v [ 1, 1L ]) (store ()) with Ok s -> s | Error _ -> failwith "setup"
+    let s1 = s0 |> CAS.update "k" (fun cur -> (cur |> Option.defaultValue ZSet.Empty) + v [ 2, 1L ])
+    Assert.Equal<ZSet<int> option>(Some(ZSet.ofSeq [ 1, 1L; 2, 1L ]), CAS.read "k" s1 |> Option.map snd)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -80,6 +80,7 @@
     <Compile Include="Blake3Hasher.Tests.fs" />
     <Compile Include="ContentHash256.Tests.fs" />
     <Compile Include="ContentStore.Tests.fs" />
+    <Compile Include="CasStore.Tests.fs" />
     <Compile Include="DagFs.Tests.fs" />
     <Compile Include="DebeziumCdc.Tests.fs" />
     <Compile Include="DvKey.Tests.fs" />


### PR DESCRIPTION
## What — you selected this
**`CasStore`** — per-row compare-and-swap over `ContentStore`. Each row holds the content address (`MerkleHash`) of its value; **`trySwap` commits iff the row's current address == `expected`**, else returns **`Error currentAddress`** (value unchanged) for re-read + retry. A writer that fails mid-turn **never commits** → no single-activation, no lock → **manifesto §2 lock/wait-free**. The runtime under the actor / SerializedSaga lane for single-row state ("maybe we don't need Orleans"); multi-row-atomic escalates to the serialized bus/saga. DST-simulatable.

- `create` / `read` / `currentHash` / `trySwap` (`expected = None` ⇒ CAS-create) / `update` / `rowCount`.
- Composes `ContentStore` (values content-addressed + dedup'd). Ties **B-0962** (optimistic-CAS claim-locks) + **SlateDB** (CAS-manifest / writer-epoch fencing).

## Test
`dotnet test … --filter CasStoreTests` → **4 passed**: CAS-create on absent, create-conflict on existing, CAS-update success + **stale-expected conflict (lost-update prevention)**, `update`-applies-f.

🤖 Generated with [Claude Code](https://claude.com/claude-code)