### PR TITLE
feat(DagFs/ContentStore): merge two ZetaFS — content-union (free) + path resolve + folder-uniqueness capture

### DIFF
--- a/docs/research/2026-06-07-filesystem-backend-needs-a-merkle-dag-for-command-parity-with-git-aaron.md
+++ b/docs/research/2026-06-07-filesystem-backend-needs-a-merkle-dag-for-command-parity-with-git-aaron.md
@@ -129,6 +129,31 @@ new closure table, but **Merkle-hashing the DBSP Z-set so the content-addressed 
 retractable, the DAG itself a Z-set closure table with content-hash single-instance multi-parent nodes**,
 materialized single- or multi-file under one command interface.
 
+## Merging two ZetaFS + folder name-uniqueness (Aaron, 2026-06-07)
+
+> Aaron: *"since we have content-based addressing, if we have two single-file ZetaFS we can easily merge
+> them — folders are basically just labels and the content is the real address."* … *"well not exactly
+> labels — you have to support filename uniqueness within the folder, that's why we have the closure table;
+> but you found some other data structures that might fit better."*
+
+**Merge is nearly free at the content layer.** Content-addressing makes merging two filesystems an
+**unconditional, conflict-free union of content nodes** (identical content ⇒ identical hash ⇒ one node;
+auto-dedup). The only real conflict is at the **path/name layer**. **LANDED:** `ContentStore.merge`
+(content union) + `DagFs.merge resolve a b` (content union + path resolution); the path layer's only
+conflict is **same path → different content**, handed to `resolve`. Tested incl. the edge case Aaron named:
+**same folder + filename, different content hashes → the resolver fires** (commutative resolver ⇒
+path-convergent both merge directions).
+
+**But folders are NOT just labels — filename-uniqueness-within-a-folder is a structural constraint.** A flat
+path→hash map enforces it *implicitly* (a full path `folder/name` is a unique key), which is what
+`DagFs.merge` uses today. The **richer model** is folders as a **per-folder name→entry map** (names unique
+per folder) + the **closure table** (`Hierarchy.fs`) for ancestry/DAG. The data-structure candidates from
+the forwarded vids fit the per-folder name-map better than a flat map: **HAMT** (general name keys),
+**Patricia** (compact name prefixes), **Hitchhiker tree** (sorted folder listings / range scans), with the
+**closure table** for the multi-parent DAG ancestry. Merge then becomes: content-union (free) + per-folder
+**name-map merge** (a name collision in a folder = the conflict, resolved like an LWW/OR-map). Backlogged as
+the folder-structured upgrade.
+
 ## Ties
 
 - `docs/research/2026-06-07-command-surface-not-1to1-git-...` (the one-interface-over-git-and-fs steer this

--- a/src/Core/ContentStore.fs
+++ b/src/Core/ContentStore.fs
@@ -57,5 +57,14 @@ module ContentStore =
     /// The number of distinct (single-instanced) nodes.
     let count (s: Store<'V>) : int = s.byHash.Count
 
+    /// **Merge two content stores** (same `hashOf`): union by content address. CONFLICT-FREE — identical
+    /// content has the identical hash (single-instance), so the union just dedups; this is the whole point
+    /// of content-addressing for filesystem merge (Aaron 2026-06-07). Structural sharing via ImmutableDictionary.
+    let merge (a: Store<'V>) (b: Store<'V>) : Store<'V> =
+        let mutable d = a.byHash
+        for kv in b.byHash do
+            if not (d.ContainsKey kv.Key) then d <- d.Add(kv.Key, kv.Value)
+        { a with byHash = d }
+
     /// All content addresses currently stored.
     let addresses (s: Store<'V>) : MerkleHash seq = s.byHash.Keys

--- a/src/Core/DagFs.fs
+++ b/src/Core/DagFs.fs
@@ -81,3 +81,27 @@ module DagFs =
 
     /// Number of distinct stored nodes (single-instanced).
     let nodeCount (t: Tree<'V>) : int = ContentStore.count t.store
+
+    /// **Merge two file trees** (same `hashOf`) — content-addressing makes this nearly free (Aaron 2026-06-07).
+    /// The CONTENT layer is an unconditional, conflict-free union (identical content = identical node → dedup).
+    /// The PATH layer enforces name-uniqueness: a path is a unique key (a full path `folder/name` ⇒ per-folder
+    /// name uniqueness is implied), so the only real conflict is **same path → different content**, resolved
+    /// by `resolve path valueA valueB`. (NB folders are not *just* labels — name-uniqueness-within-folder is a
+    /// structural constraint; this flat-path model handles it via full-path keys, the richer folder-structured
+    /// model — closure table / per-folder name-map over HAMT/Patricia/Hitchhiker — is the upgrade. See the
+    /// fs-Merkle research doc.)
+    let merge (resolve: string -> 'V -> 'V -> 'V) (a: Tree<'V>) (b: Tree<'V>) : Tree<'V> =
+        let mutable store = ContentStore.merge a.store b.store
+        let mutable links = a.links
+        for kv in b.links do
+            match a.links.TryGetValue kv.Key with
+            | true, ha when ha = kv.Value -> () // same path, same content — no conflict
+            | true, ha -> // same path, different content — resolve the two values
+                let va = ContentStore.get ha store |> Option.get
+                let vb = ContentStore.get kv.Value store |> Option.get
+                let winner = resolve kv.Key va vb
+                let h, store' = ContentStore.put winner store
+                store <- store'
+                links <- links.SetItem(kv.Key, h)
+            | _ -> links <- links.SetItem(kv.Key, kv.Value) // only in b
+        { store = store; links = links }

--- a/tests/Tests.FSharp/DagFs.Tests.fs
+++ b/tests/Tests.FSharp/DagFs.Tests.fs
@@ -63,3 +63,47 @@ let ``editLocal to content identical to an existing file converges — pointers 
     Assert.Equal((FS.addressAt "/a" t2).Value, (FS.addressAt "/b" t2).Value) // converged: same node
     Assert.Equal<ZSet<int> option>(Some c2, FS.resolve "/a" t2)
     Assert.Equal<string list>([ "/a"; "/b" ] |> List.sort, FS.pathsOf (FS.addressAt "/b" t2).Value t2 |> List.sort)
+
+// ── merging two ZetaFS: content union is conflict-free; path collisions are the only conflict ──
+
+[<Fact>]
+let ``merge: identical content under different paths dedups to one node (content union is free)`` () =
+    let shared = v [ 1, 1L ]
+    let a = tree () |> FS.link "/a/photo" shared
+    let b = tree () |> FS.link "/b/photo" shared
+    let m = FS.merge (fun _ x _ -> x) a b
+    Assert.Equal(1, FS.nodeCount m) // same content => one node across both filesystems
+    Assert.Equal(2, FS.pathCount m)
+    Assert.Equal((FS.addressAt "/a/photo" m).Value, (FS.addressAt "/b/photo" m).Value)
+
+[<Fact>]
+let ``merge: disjoint paths just unite; same path + same content = no conflict`` () =
+    let a = tree () |> FS.link "/x" (v [ 1, 1L ]) |> FS.link "/shared" (v [ 9, 9L ])
+    let b = tree () |> FS.link "/y" (v [ 2, 2L ]) |> FS.link "/shared" (v [ 9, 9L ]) // same path, same content
+    let m = FS.merge (fun _ x _ -> failwith "should not conflict") a b
+    Assert.Equal<ZSet<int> option>(Some(v [ 1, 1L ]), FS.resolve "/x" m)
+    Assert.Equal<ZSet<int> option>(Some(v [ 2, 2L ]), FS.resolve "/y" m)
+    Assert.Equal<ZSet<int> option>(Some(v [ 9, 9L ]), FS.resolve "/shared" m)
+
+[<Fact>]
+let ``merge EDGE CASE: same folder+filename, DIFFERENT content -> resolver fires (Aaron 2026-06-07)`` () =
+    // both filesystems have "/docs/report" but with different content => the real conflict
+    let a = tree () |> FS.link "/docs/report" (v [ 1, 1L ])
+    let b = tree () |> FS.link "/docs/report" (v [ 2, 2L ])
+    let mutable conflictedPath = ""
+    let resolve path (x: ZSet<int>) (y: ZSet<int>) =
+        conflictedPath <- path
+        x + y // example policy: merge both (any deterministic resolver works)
+    let m = FS.merge resolve a b
+    Assert.Equal("/docs/report", conflictedPath) // resolver saw the colliding path
+    Assert.Equal<ZSet<int> option>(Some(ZSet.ofSeq [ 1, 1L; 2, 2L ]), FS.resolve "/docs/report" m)
+
+[<Fact>]
+let ``merge is content-convergent: order of merge gives the same nodes (resolver must be commutative for path-convergence)`` () =
+    let a = tree () |> FS.link "/k" (v [ 1, 1L ])
+    let b = tree () |> FS.link "/k" (v [ 2, 2L ])
+    // a commutative resolver (set-union via +) => path-convergent both merge directions
+    let r _ (x: ZSet<int>) (y: ZSet<int>) = x + y
+    let ab = FS.merge r a b
+    let ba = FS.merge r b a
+    Assert.Equal<ZSet<int> option>(FS.resolve "/k" ab, FS.resolve "/k" ba)

--- a/workitems/081KTH8BTYF08QG0R001REKVQE-folder-structured-zetafs-per-folder-name-entry-map-hamt-patr.md
+++ b/workitems/081KTH8BTYF08QG0R001REKVQE-folder-structured-zetafs-per-folder-name-entry-map-hamt-patr.md
@@ -1,0 +1,45 @@
+---
+id: 081KTH8BTYF08QG0R001REKVQE
+type: task
+state: backlog
+priority: P2
+slug: folder-structured-zetafs-per-folder-name-entry-map-hamt-patr
+title: "Folder-structured ZetaFS: per-folder name->entry map (HAMT/Patricia/Hitchhiker) + closure-table ancestry + folder-by-folder merge"
+created: 2026-06-07T14:39:06.191Z
+depends_on: []
+composes_with: ["081KTGTJC1Q08QG0R002VCB55A"]
+---
+
+# Folder-structured ZetaFS: per-folder name->entry map (HAMT/Patricia/Hitchhiker) + closure-table ancestry + folder-by-folder merge
+
+<!-- Work-item body. ZetaId-keyed (conflict-free, time-sortable). "Backlog" is a
+     STATE = this folder; completion moves the file to workitems/done/YYYY/MM/.
+     Identity is the zetaid prefix — resolve cross-refs by `081KTH8BTYF08QG0R001REKVQE-*.md` glob. -->
+
+## Purpose
+
+Aaron 2026-06-07: folders are NOT just labels — **filename-uniqueness-within-a-folder** is a structural
+constraint (the closure table currently carries it). The flat `DagFs` path->hash map enforces it implicitly
+(full path = unique key) + a working `merge` is landed; the richer model is **folders as a per-folder
+name->entry map** + closure-table ancestry, which also makes **folder-by-folder merge** natural (a name
+collision in a folder = the conflict). Full context: the fs-Merkle research doc (§"Merging two ZetaFS").
+
+## Build
+
+- Folder = a per-folder **name -> entry** map (entry = content-hash | subfolder), names unique per folder.
+  Candidate structures (from the forwarded vids): **HAMT** (general name keys), **Patricia** (name prefixes),
+  **Hitchhiker tree** (sorted listings / range scans) — pick per access pattern. **Closure table**
+  (`Hierarchy.fs`) for multi-parent DAG ancestry.
+- Merge = `ContentStore.merge` (content union, free) + **per-folder name-map merge** (name collision =
+  conflict, resolved LWW/OR-map style). Generalizes the landed flat `DagFs.merge`.
+
+## Acceptance
+
+A folder-structured tree with enforced per-folder name uniqueness; list-folder + move-folder; folder-by-
+folder merge with content-union + name-collision resolution; convergent under commutative resolver.
+
+## Anchors
+
+- fs-Merkle doc (§Merging two ZetaFS) · `DagFs.fs` (flat merge, landed) · `ContentStore.merge` ·
+  `Hierarchy.fs` (closure table) · HAMT/Patricia/Hitchhiker prior-art (ip-questionable captures) · 081KTGTJC1Q.
+


### PR DESCRIPTION
## What — Aaron 2026-06-07 (merging two ZetaFS)
Content-addressing makes filesystem merge nearly free:
- **`ContentStore.merge`** — conflict-free content union (identical content = identical hash = one node, auto-dedup).
- **`DagFs.merge resolve a b`** — content union + path resolution; the only conflict is **same path → different content** (handed to `resolve`).

**Tested incl. your edge case:** same folder+filename, **different content hashes → resolver fires**; commutative resolver ⇒ path-convergent both merge directions. Plus identical-content-different-paths → one node; disjoint + same-content no-conflict. **9 DagFs tests green.**

**Captured your refinement:** folders are **not just labels** — filename-uniqueness-within-folder is structural (the closure table carries it; the flat path map enforces it via full-path keys). The richer model = **per-folder name→entry map** over **HAMT/Patricia/Hitchhiker** + **closure-table** ancestry, with folder-by-folder merge → backlog `081KTH8BTYF` + fs-Merkle doc section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)