### PR TITLE
docs: content-addressing is a confluence lemma — proving out-of-order events → same result

### DIFF
--- a/docs/research/2026-06-07-content-addressing-is-a-confluence-lemma-out-of-order-events-same-result-aaron.md
+++ b/docs/research/2026-06-07-content-addressing-is-a-confluence-lemma-out-of-order-events-same-result-aaron.md
@@ -1,0 +1,58 @@
+# Content-addressing is a confluence lemma — proving out-of-order events end up with the same result (Aaron, 2026-06-07)
+
+> Aaron, on the content-merge "dedups across strangers / ancestry-free" property: *"this is going to come in
+> handy on proof that proves out-of-order events end up with same results."*
+
+The property to prove (the **confluence / order-independence theorem**): for the commutative lane, applying
+the same set of events in **any order** (and with duplicates / from any origin) yields the **same final
+state**. Content-addressing supplies a key lemma.
+
+## Why content-addressing is the lemma
+
+A content node's **identity is its hash — independent of arrival order AND of origin repo/stream**. So:
+
+- **Idempotence for free:** the same event/datum seen twice (or arriving reordered) hashes to the same node
+  → `put` dedups → no double-count. (`apply-N == apply-1` on the content set.)
+- **Origin-independence:** "the same data" is recognized as one node whether it came from us or a stranger
+  (the ancestry-free merge) → no divergence based on *where* an event entered.
+- **Canonical form:** the hash is a canonical representative; two computation orders that produce equal
+  content produce **equal hashes** → the store cannot tell the orders apart → they converge.
+
+## The proof scaffold (lemmas we already have)
+
+`final-state(apply events in order π₁) = final-state(apply in order π₂)` for any permutations π, because:
+
+1. **The merge is a join-semilattice op** — commutative + associative + idempotent — proven for the CRDTs
+   (`GSet`/`LwwMap`/`Rga` convergence tests; Z3 abstract-join laws) and the **Z-set** signed-multiset join
+   (DBSP). Commutative+associative ⇒ order doesn't matter; idempotent ⇒ duplicates don't matter.
+2. **Content-addressing adds canonical idempotence** (above) — reordered/duplicated/foreign events collapse
+   to the same nodes (`ContentStore`/`DagFs.merge` dedup; the **ancestry-free** cross-repo merge).
+3. **de Finetti exchangeability** — the belief/observation limit is order-independent for exchangeable
+   sequences (`BeliefConvergence.fs`; memory `project-de-finetti-...`, B-1020) — the probabilistic analogue
+   of confluence (the homeostat reaches the same fixpoint regardless of observation order).
+
+Together: **algebraic confluence (1) + canonical idempotence (2) + exchangeable convergence (3)** discharge
+"out-of-order events → same result" on the **CommutativeView** lane.
+
+## Honest scope — confluence holds on the COMMUTATIVE lane, not the serialized one
+
+This is the **CommutativeView** (Z-set/CRDT/content-merge) property. The **SerializedSaga** lane is
+*deliberately order-DEPENDENT* (arrival order is canonical, no retraction — the actor/bus cursor). So the
+theorem is "out-of-order → same result **for commutative/monotone operations**" (CALM: monotonic ⇒
+coordination-free ⇒ confluent); genuinely order-sensitive operations escalate to the serialized lane and do
+**not** claim confluence. Stating the boundary is part of the proof's honesty.
+
+## Math-leg / proof target
+
+Discharge it: **FsCheck** — generate event multisets, apply under random permutations (+ duplicates + split
+across "repos"), assert equal final root/state; **Z3/Lean** — the algebraic confluence (commutative +
+associative + idempotent join + content-canonical idempotence). Filed for the formal portfolio (Soraya).
+
+## Beacon anchors
+
+- **Confluence / Church-Rosser** (term rewriting) · **Join-semilattice / lattice** convergence ·
+  **CRDTs** (Shapiro et al. — strong eventual consistency = confluence) · **CALM** (Hellerstein —
+  monotonic ⇒ coordination-free) · **de Finetti exchangeability** (BeliefConvergence/B-1020) · **DBSP**
+  (Z-set commutative merge) · **content-addressing as canonical form** (git/IPFS). Ties:
+  `ContentStore.merge`/`DagFs.merge` (ancestry-free), the CRDT laws, the cells-as-geodes CommutativeView vs
+  SerializedSaga split.

--- a/workitems/081KTH8RSXS08QG0R0039TF0AF-proof-out-of-order-events-converge-confluence-content-addres.md
+++ b/workitems/081KTH8RSXS08QG0R0039TF0AF-proof-out-of-order-events-converge-confluence-content-addres.md
@@ -1,0 +1,50 @@
+---
+id: 081KTH8RSXS08QG0R0039TF0AF
+type: task
+state: backlog
+priority: P2
+slug: proof-out-of-order-events-converge-confluence-content-addres
+title: "Proof: out-of-order events converge (confluence) — content-addressed canonical idempotence + join-semilattice merge + de Finetti"
+created: 2026-06-07T14:46:11.129Z
+depends_on: []
+composes_with: ["B-1020"]
+---
+
+# Proof: out-of-order events converge (confluence) — content-addressed canonical idempotence + join-semilattice merge + de Finetti
+
+<!-- Work-item body. ZetaId-keyed (conflict-free, time-sortable). "Backlog" is a
+     STATE = this folder; completion moves the file to workitems/done/YYYY/MM/.
+     Identity is the zetaid prefix — resolve cross-refs by `081KTH8RSXS08QG0R0039TF0AF-*.md` glob. -->
+
+## Purpose
+
+Aaron 2026-06-07: the content-addressed-merge property (dedup-across-strangers, ancestry-free) "is going to
+come in handy on proof that proves out-of-order events end up with same results." Discharge the **confluence
+/ order-independence** theorem for the CommutativeView lane. Full scaffold:
+`docs/research/2026-06-07-content-addressing-is-a-confluence-lemma-out-of-order-events-same-result-aaron.md`.
+
+## Claim
+
+`final-state(events in order π1) = final-state(events in order π2)` for any permutations (+ duplicates +
+foreign origins), on the commutative lane. Lemmas: (1) join-semilattice merge (commutative+associative+
+idempotent — CRDTs + Z-set, mostly proven); (2) content-addressed canonical idempotence (reordered/
+duplicate/foreign events dedup to the same nodes); (3) de Finetti exchangeability (BeliefConvergence/B-1020).
+
+## Build (math-leg)
+
+- FsCheck: generate event multisets; apply under random permutations, with duplicates, split across "repos";
+  assert equal final root/state (over ContentStore/DagFs/Z-set/CRDT).
+- Z3/Lean: algebraic confluence (join laws + content-canonical idempotence).
+- State the boundary: holds on CommutativeView (monotone/commutative — CALM); SerializedSaga is order-
+  dependent by design (no confluence claim there).
+
+## Acceptance
+
+A property test proving permutation-invariance of final state over the commutative substrate; an algebraic
+(Z3/Lean) confluence statement; the CommutativeView-vs-SerializedSaga boundary stated.
+
+## Anchors
+
+- confluence-lemma research doc · CRDT laws (Crdt.Laws.Tests/Z3) · ZSetMerkle/ContentStore/DagFs.merge ·
+  BeliefConvergence (B-1020) · CALM · cells-as-geodes (CommutativeView vs SerializedSaga) · Soraya portfolio.
+


### PR DESCRIPTION
## What — Aaron 2026-06-07
> the content-merge "dedups across strangers / ancestry-free" property "is going to come in handy on proof that proves out-of-order events end up with same results."

Captured the **confluence / order-independence** proof scaffold. Content-addressing supplies **canonical idempotence**: the same datum reordered / duplicated / from any origin hashes to the same node → no double-count, no order-divergence. With:
1. **join-semilattice merge** (commutative + associative + idempotent — CRDTs + Z-set, mostly proven),
2. **content-addressed canonical idempotence** (ContentStore/DagFs.merge dedup; ancestry-free),
3. **de Finetti exchangeability** (BeliefConvergence / B-1020),

this discharges **"out-of-order events → same result"** on the **CommutativeView** lane. Honest boundary: holds for commutative/monotone ops (CALM); the **SerializedSaga** lane is order-dependent by design (no confluence claim there).

Math-leg proof target **`081KTH8RSXS`** (FsCheck permutation-invariance + Z3/Lean algebraic confluence) for the formal portfolio. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)