### PR TITLE
docs: AST-as-essence — store code/docs as AST-in-YAML, render per-developer style views

### DIFF
--- a/docs/research/2026-06-07-canonical-essence-bit-perfect-serializers-ast-as-essence-yaml-per-developer-style-views-aaron.md
+++ b/docs/research/2026-06-07-canonical-essence-bit-perfect-serializers-ast-as-essence-yaml-per-developer-style-views-aaron.md
@@ -1,0 +1,69 @@
+# Canonical essence for content-addressing: bit-perfect serializers → AST-as-essence (YAML) with per-developer style views (Aaron, 2026-06-07)
+
+The resolution of the formatting/canonicalization thread, riffing off the confluence proof
+(`2026-06-07-content-addressing-is-a-confluence-lemma-...`). Faithful capture; Beacon-anchored.
+
+## The chain (why)
+
+Confluence + content-addressing **require a canonical, bit-perfect representation**: same logical content ⇒
+same bytes ⇒ same hash ⇒ dedup / clean merge / confluence. Formatting noise breaks that. Aaron's chain:
+
+1. **Bit-perfect serializers — even the text-based ones.** *"This is why we want all our serializers, even
+   the text-based ones, to be bit-perfect."* JSON/XML/YAML must be **canonical/byte-exact**, not just CBOR —
+   else the same `DynamicValue` serializes to different bytes → different hash → breaks dedup/confluence
+   (ties B-0969 collation + the 4-oracle byte-lock golden vectors).
+2. **The code/doc problem.** Source text carries whitespace/formatting/style noise, so the *same logical
+   code or doc* hashes differently → spurious diffs, merge conflicts, no dedup.
+3. **First answer — format/lint/auto-style on check-in** (*"docs… and code too"*): canonicalize the TEXT to
+   one team style → stable bytes. Works, but **forces team style on everyone**.
+4. **The better answer (Aaron's key move) — store the AST (essence), not the text.** *"custom file handlers
+   for code and structured document types that save the AST in YAML instead of the C#, to remove all
+   formatting/whitespace/style issues — they can all be generated from editorconfig almost if you have the
+   essence; so each dev gets their own view of code, not just line endings but style per developer — you are
+   not forced into team style."*
+
+## The model: AST is the content, style is a per-developer LENS
+
+- **The AST (in YAML) is the canonical essence** — content-addressed, **zero formatting noise**, so the
+  confluence/merge proofs apply directly (two devs editing the same logic produce the **same AST node**).
+- **Style is a per-developer view**, generated from the AST + the dev's style config (**editorconfig**,
+  "almost"): braces, spacing, line length, naming *display*, line endings — **full style, per developer.**
+- **No one is forced into team style.** Devs A and B with different styles edit the same AST; their *views*
+  differ, the *essence* is one content-addressed node → **merges cleanly (no formatting conflicts ever),
+  dedups, confluent.** Only genuine *semantic* conflicts surface (AST-level, not textual).
+
+This is **lens-relativity applied to code** (the same theme as randomness-is-lens-relative / Mirror-Beacon):
+the AST is the content; style is the lens; same essence, many views. It's also the **compression-as-
+generators** idea — the AST is the essence, the rendered source is *generated* from it + a style program.
+
+## Where it slots into Zeta
+
+- **ZetaFS custom file handlers / per-file-type plugins** (roadmap: per-file-type open/closed plugins) — code
+  + structured-doc types get an **AST handler** (text→AST on save, AST→styled-text on open).
+- **Content-addressing / confluence** — AST nodes are the canonical content; merge is **semantic (AST-level),
+  not textual** → no whitespace/style conflicts, only real conflicts; the confluence theorem (`081KTH8RSXS`)
+  applies directly.
+- **DynamicValue / behavior-as-data / Bonsai** — the AST *is* a `DynamicValue` tree (a Bonsai expr-tree for
+  code); rendering = a generator over it.
+- **editorconfig as the style-lens** — captures much of the per-dev style ("almost"); full rendering may need
+  a richer style config beyond editorconfig.
+
+## Honest scope (the hard parts)
+
+- **Round-trip fidelity per language is the real challenge** — text→AST→text must preserve *semantics*, and
+  crucially **comments / doc-comments / intentional formatting** (most naive ASTs drop comments; they must be
+  preserved as AST trivia/annotations). A parser+printer per language is needed.
+- **"almost from editorconfig"** — editorconfig doesn't capture all style; per-dev rendering needs more.
+- This is a **per-file-type capability**, landed incrementally (one language handler at a time), not a
+  big-bang. Backlogged.
+
+## Beacon anchors
+
+- **Unison** (Hickey-adjacent; Paul Chiusano & Rúnar Bjarnason) — **content-addressed code**: definitions are
+  hashed by their AST, **names are metadata**, *no formatting in the hash* — the strongest prior art for
+  exactly this. · **Projectional / structural editors** — JetBrains **MPS**, **Lamdu** (edit the AST, render
+  views). · **tree-sitter / Roslyn** (faithful ASTs, incl. trivia/comments). · **gofmt / Prettier**
+  (canonical-form precedent — but ONE style; this generalizes to *per-dev* style). · **editorconfig** (the
+  style-lens). · **Smalltalk image** (code-as-data). Honest novelty: not content-addressed code (Unison did
+  it) nor projectional editing (MPS/Lamdu) — but **AST-as-essence in the content-addressed ZetaFS with
+  per-developer style views + semantic (AST-level) merge** unifying them with the confluence/dedup substrate.

--- a/workitems/081KTH98A4E08QG0R000SQQBYH-ast-as-essence-file-handlers-store-code-structured-docs-as-a.md
+++ b/workitems/081KTH98A4E08QG0R000SQQBYH-ast-as-essence-file-handlers-store-code-structured-docs-as-a.md
@@ -1,0 +1,53 @@
+---
+id: 081KTH98A4E08QG0R000SQQBYH
+type: task
+state: backlog
+priority: P2
+slug: ast-as-essence-file-handlers-store-code-structured-docs-as-a
+title: "AST-as-essence file handlers: store code/structured-docs as AST-in-YAML, render per-developer style from editorconfig (semantic merge, no formatting noise)"
+created: 2026-06-07T14:54:39.246Z
+depends_on: []
+composes_with: ["081KTGTJC1Q08QG0R002VCB55A", "B-0969"]
+---
+
+# AST-as-essence file handlers: store code/structured-docs as AST-in-YAML, render per-developer style from editorconfig (semantic merge, no formatting noise)
+
+<!-- Work-item body. ZetaId-keyed (conflict-free, time-sortable). "Backlog" is a
+     STATE = this folder; completion moves the file to workitems/done/YYYY/MM/.
+     Identity is the zetaid prefix — resolve cross-refs by `081KTH98A4E08QG0R000SQQBYH-*.md` glob. -->
+
+## Purpose
+
+Aaron 2026-06-07: custom file handlers for code + structured-doc types that store the **AST (in YAML)**
+instead of the source text, removing all formatting/whitespace/style noise. The AST is the content-addressed
+**essence** (confluent, dedupable, semantic-merge); **style is a per-developer lens** rendered from the AST +
+editorconfig ("almost") — each dev gets their own view, NOT forced into team style. Full design:
+`docs/research/2026-06-07-canonical-essence-bit-perfect-serializers-ast-as-essence-yaml-per-developer-style-views-aaron.md`.
+
+## Why (the chain)
+
+Content-addressing/confluence need a canonical essence (same logic -> same hash). Source text carries style
+noise -> spurious diffs/conflicts. Storing the AST removes it: AST = content; style = per-dev view. Better
+than format-on-checkin (which forces ONE team style) — per-dev style freedom + semantic (AST-level) merge.
+
+## Build (incremental, per file type)
+
+- A ZetaFS custom file handler (per-file-type plugin): on save text->AST(YAML, canonical); on open
+  AST->styled-text per the dev's editorconfig/style config. Round-trip-faithful (MUST preserve comments /
+  doc-comments / trivia as AST annotations).
+- AST node = a DynamicValue/Bonsai tree, content-addressed; merge is semantic (AST-level) -> no whitespace
+  /style conflicts, only real conflicts.
+- Start with ONE language (e.g. F# or a structured-doc like markdown/JSON) end-to-end; expand per language.
+
+## Acceptance
+
+For one file type: text->AST->text round-trips preserving semantics + comments; two devs with different
+style configs see different views of the same AST node (same content hash); a formatting-only change
+produces NO diff; a semantic change merges at the AST level.
+
+## Anchors
+
+- canonical-essence research doc · ZetaFS per-file-type plugins (081KTGTJC1Q) · confluence (081KTH8RSXS) ·
+  bit-perfect serializers / B-0969 · DynamicValue/Bonsai (AST-as-data) · Unison (content-addressed code),
+  MPS/Lamdu (projectional), tree-sitter/Roslyn (faithful AST incl. trivia), editorconfig, gofmt/Prettier.
+


### PR DESCRIPTION
## What — Aaron 2026-06-07 (resolves the bit-perfect / format-on-checkin thread)
Custom file handlers store the **AST (in YAML)** instead of source text → removes all formatting/whitespace/style noise.

- **AST = the content-addressed essence** (confluent, dedupable, **semantic AST-level merge**).
- **Style = a per-developer lens**, rendered from the AST + editorconfig ("almost") — each dev gets **their own view** (full style, not just line endings), **not forced into team style**.
- **Better than format-on-checkin** (which forces ONE team style): per-dev freedom + no formatting conflicts ever; only real semantic conflicts surface.

Lens-relativity applied to code (AST = content, style = lens) + the compression-as-generators idea (AST = essence, source = generated). Slots into ZetaFS per-file-type plugins + the confluence/content-addressing substrate.

**Honest hard part:** round-trip fidelity per language, esp. preserving comments/trivia. Anchors: **Unison** (content-addressed code — strongest), MPS/Lamdu (projectional), tree-sitter/Roslyn, gofmt/Prettier, editorconfig.

Research doc + backlog item (incremental, per file type). Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)