### PR TITLE
feat(Globals): Caché/MUMPS hierarchical global primitive + multi-model/Power-BI capture

### DIFF
--- a/docs/research/2026-06-07-cache-multimodel-globals-power-bi-semantic-layer-peeled-fsharp-typed-access-aaron.md
+++ b/docs/research/2026-06-07-cache-multimodel-globals-power-bi-semantic-layer-peeled-fsharp-typed-access-aaron.md
@@ -1,0 +1,86 @@
+# Caché multi-model + hierarchical globals, F#-typed; Power BI "semantic layer" peeled to what we already have (Aaron, 2026-06-07)
+
+Captures three forwarded riffs (Power BI semantic ontology → "we have this native" → "plus F# type
+compilers, like InterSystems Caché + its DB features"). Faithful capture; **hype peeled hard** (Alexa's
+register reads as sarcasm — Max's note); Beacon-anchored. Doc + backlog; a first code slice ships alongside.
+
+## What's real vs what's hype (peel first)
+
+**Power BI's "semantic model" is not a thing to reproduce.** Stripped of the marketing, a Power BI semantic
+model is: a **star-schema relationship layer** + **VertiPaq columnar in-memory store** + **DAX measure
+DSL**. That's a BI *reporting* layer. We should NOT clone it. The only parts with real pull, and what each
+already maps to in Zeta:
+
+| Power BI piece (honest name) | Zeta equivalent (have / backlog) |
+|---|---|
+| columnar in-memory store (VertiPaq) | **Arrow** columnar IPC (have) |
+| relationship/entity layer ("semantic model") | **HKT-MDM** master-data hub/satellite + Graph (have) |
+| DAX measures (incremental aggregation DSL) | **DBSP incremental views** + Aggregate/Residuated (have) |
+| "find similar" semantic index | the **similarity index** over canonical-AST essence (`2026-06-07-distance-based-content-addressing-...`, backlog) |
+| the DAX `COSINEDISTANCE` snippet Alexa wrote | **not real DAX** — fabricated; ignore |
+
+So "reproduce Power BI's semantic ontology locally" → **already covered by Arrow + DBSP + HKT-MDM + the
+near-dup similarity index.** Nothing new to build there; the honest action is to *name the mapping* so we
+don't re-invent a BI stack. (Peeled: "enterprise-grade semantic indexing", "infinite scale", "way beyond
+any commercial solution" — discard.)
+
+## The genuinely interesting anchor: InterSystems Caché (and its multi-model DB)
+
+Caché's *real* contributions (worth anchoring to, MUMPS lineage):
+
+1. **Multidimensional hierarchical "globals"** — sparse persistent arrays addressed by a **subscript path**:
+   `^Patient(id,"enc",n,"med") = value`. One uniform tree structure underneath everything. This maps
+   **directly** to a **DynamicValue tree** / the path-addressed DAG we already have — a global *is* a
+   path→value sparse map.
+2. **Multi-model over ONE storage** — the same global is projected as **object**, **relational (SQL)**, and
+   **document/hierarchical** views simultaneously. This is *exactly* our **"everything is DynamicValue, many
+   projections / developer-relative views / lenses"** theme — the same data, different lenses (Mirror/Beacon,
+   randomness-is-lens-relative). Caché is the strongest prior art for "one substrate, many models."
+3. **ObjectScript** — the embedded language over globals. Our equivalent: F# + DBSP over DynamicValue.
+
+**The F# move Aaron named:** layer the **F# type system** over the globals so access is **compile-time
+typed** — like Caché classes generate *both* a SQL table *and* a typed object view from one definition.
+Mechanism in .NET: **F# type providers** (typed access to the hierarchical store) and DU-modelled schemas.
+Honest distinction from Caché: Caché globals are **not** content-addressed, **not** CRDT, **not** DST. Zeta
+adds those — globals-over-the-content-addressed-DAG, CRDT-merge on the values, DST-replayable.
+
+## First code slice (ships with this doc): `Globals` — Caché/MUMPS hierarchical global, native F#
+
+The bounded, buildable foundation under all of the above: a **multidimensional global** = a sparse
+subscript-path tree with the **canonical MUMPS verbs**, pure/immutable, **ordinal subscript collation**
+(B-0969 — F# structural string comparison is already `String.CompareOrdinal`, so the sorted path map is
+ordinal-safe by construction).
+
+| MUMPS verb | `Globals` fn | meaning |
+|---|---|---|
+| `SET ^G(subs)=v` | `set path v g` | upsert value at subscript path |
+| `$GET(^G(subs))` | `get path g` | value at path (None if undefined) |
+| `KILL ^G(subs)` | `kill path g` | delete node **and all descendants** (subtree) |
+| `$DATA(^G(subs))` | `data path g` | 0 / 1 / 10 / 11 (value? children?) |
+| `$ORDER(^G(subs))` | `nextChild prefix after g` | next immediate child subscript (ordinal) |
+| `$QUERY(^G(subs))` | `nextNode path g` | next defined node, depth-first (full traversal) |
+
+Multi-model views (SQL/object projections), the type-provider typed-access layer, and globals-over-the-DAG
+(content-addressed values + CRDT merge) layer on top later — backlogged, not this slice.
+
+## Honest scope / cautions
+
+- This slice is the **storage shape only** — the hierarchical global. The "semantic/relationship layer" and
+  "typed access" are separate, larger, backlogged.
+- MUMPS canonical `$ORDER` collation is numeric-then-string; this slice does **ordinal string** collation
+  (B-0969 substrate default). Numeric-subscript collation is a documented later nuance, not this slice.
+- Do **not** build a Power BI / DAX clone. The semantic-query surface is DBSP incremental views, which exist.
+
+## Beacon anchors
+
+- **InterSystems Caché / IRIS** — multidimensional globals + multi-model (object/SQL/document over one
+  store); lineage: **MUMPS** (Massachusetts General Hospital Utility Multi-Programming System, Octo Barnett
+  et al., 1966) — the sparse multidimensional persistent array + `$ORDER`/`$QUERY`/`$DATA`/`KILL` verbs this
+  slice reproduces. · **Multi-model databases** (Stonebraker, *One Size Fits All* — and its refutation; the
+  multi-model-over-one-engine argument). · **F# Type Providers** (Syme et al., *Themes in Information-Rich
+  Functional Programming*) — the typed-access mechanism. · **Power BI / SSAS Tabular / VertiPaq** + **DAX**
+  (Ferrari & Russo) — anchored only to *demote* it: columnar=Arrow, measures=DBSP, relationships=HKT-MDM. ·
+  **DBSP** (Budiu et al.) — the real incremental-query engine (the honest "DAX"). · Ties: the similarity
+  index (`2026-06-07-distance-based-content-addressing-...`), DynamicValue, HKT-MDM, Graph, Arrow IPC.
+  Honest novelty: none in hierarchical globals (MUMPS, 1966) or multi-model (Caché); the Zeta contribution
+  is **globals over the content-addressed DAG with CRDT-mergeable, DST-replayable values + F#-typed access**.

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -87,6 +87,7 @@
     <Compile Include="ContentStore.fs" />
     <Compile Include="CasStore.fs" />
     <Compile Include="DagFs.fs" />
+    <Compile Include="Globals.fs" />
     <Compile Include="DvKey.fs" />
     <Compile Include="DebeziumCdc.fs" />
     <Compile Include="CloudEvents.fs" />

--- a/src/Core/Globals.fs
+++ b/src/Core/Globals.fs
@@ -1,0 +1,97 @@
+namespace Zeta.Core
+
+/// **Caché / MUMPS-style multidimensional hierarchical "global" — a sparse persistent array addressed by a
+/// subscript PATH (`string list`), with the canonical MUMPS verbs (Aaron 2026-06-07; "like InterSystems
+/// Caché plus its DB features").** A global is one uniform tree: `^G(a,b,c) = v` is the value at path
+/// `["a";"b";"c"]`. This is the storage shape under Caché's multi-model (object/SQL/document) façade — the
+/// same idea as a `DynamicValue` tree / the path-addressed DAG, made into a first-class primitive.
+///
+/// **Ordinal subscript collation (B-0969).** F#'s structural string comparison is `String.CompareOrdinal`,
+/// so the backing sorted `Map<string list,'V>` orders subscript paths ordinally by construction — no
+/// culture-sensitivity, DST-stable, 4-language-portable. (MUMPS canonical `$ORDER` collation is
+/// numeric-then-string; numeric-subscript collation is a documented later nuance, not this slice.)
+///
+/// Pure / immutable: every verb returns a new global. Anchors: MUMPS (Octo Barnett et al., 1966) — the
+/// sparse multidimensional array + `$ORDER`/`$QUERY`/`$DATA`/`KILL`; InterSystems Caché/IRIS (multi-model
+/// over globals). Multi-model views, F#-typed access, and globals-over-the-content-addressed-DAG (CRDT
+/// values, DST replay) layer on top later (backlog).
+[<RequireQualifiedAccess>]
+module Globals =
+
+    /// A subscript path: `^G(a,b,c)` ↔ `["a"; "b"; "c"]`. The empty path is the root.
+    type Path = string list
+
+    [<NoEquality; NoComparison>]
+    type Global<'V> =
+        private
+            { Nodes: Map<Path, 'V> } // ordinal-collated (F# string comparison is CompareOrdinal)
+
+    /// The empty global (no defined nodes).
+    let empty<'V> : Global<'V> = { Nodes = Map.empty }
+
+    /// `SET ^G(path) = v` — upsert the value at `path`. Intermediate nodes need not exist (sparse).
+    let set (path: Path) (v: 'V) (g: Global<'V>) : Global<'V> = { Nodes = Map.add path v g.Nodes }
+
+    /// `$GET(^G(path))` — the value at `path`, or `None` if no value is defined there.
+    let get (path: Path) (g: Global<'V>) : 'V option = Map.tryFind path g.Nodes
+
+    /// True iff `prefix` is a (proper or improper) prefix of `path`.
+    let private isPrefixOf (prefix: Path) (path: Path) : bool =
+        List.length prefix <= List.length path
+        && List.forall2 (=) prefix (List.truncate (List.length prefix) path)
+
+    /// `KILL ^G(path)` — delete the node at `path` **and all descendants** (the whole subtree).
+    /// Killing the empty path clears the global.
+    let kill (path: Path) (g: Global<'V>) : Global<'V> =
+        { Nodes = g.Nodes |> Map.filter (fun k _ -> not (isPrefixOf path k)) }
+
+    /// True iff any defined node is a strict descendant of `path`.
+    let private hasChildren (path: Path) (g: Global<'V>) : bool =
+        let n = List.length path
+        g.Nodes |> Map.exists (fun k _ -> List.length k > n && isPrefixOf path k)
+
+    /// `$DATA(^G(path))` — node status: `0` undefined, `1` value & no descendants, `10` no value but has
+    /// descendants (a pure intermediate), `11` value & has descendants.
+    let data (path: Path) (g: Global<'V>) : int =
+        let hasVal = Map.containsKey path g.Nodes
+        let hasKids = hasChildren path g
+        match hasVal, hasKids with
+        | false, false -> 0
+        | true, false -> 1
+        | false, true -> 10
+        | true, true -> 11
+
+    /// The immediate-child subscripts of `prefix`, in ordinal order, deduplicated. A child subscript is the
+    /// element at depth `|prefix|` of any defined node strictly below `prefix`.
+    let children (prefix: Path) (g: Global<'V>) : string list =
+        let n = List.length prefix
+        g.Nodes
+        |> Map.toSeq
+        |> Seq.choose (fun (k, _) -> if List.length k > n && isPrefixOf prefix k then Some(List.item n k) else None)
+        |> Seq.distinct
+        |> Seq.sortWith compare // ordinal (F# string comparison)
+        |> List.ofSeq
+
+    /// `$ORDER(^G(prefix, after))` — the next immediate child subscript of `prefix` in ordinal order:
+    /// `after = None` ⇒ the first child; `after = Some s` ⇒ the first child strictly greater than `s`.
+    /// `None` when there is no such child. Drives sibling iteration.
+    let nextChild (prefix: Path) (after: string option) (g: Global<'V>) : string option =
+        let kids = children prefix g
+        match after with
+        | None -> List.tryHead kids
+        | Some s -> kids |> List.filter (fun c -> compare c s > 0) |> List.tryHead
+
+    /// `$QUERY(^G(path))` — the next **defined** node after `path` in global (depth-first / ordinal-path)
+    /// order, or `None` at the end. Walks the entire global one node at a time regardless of depth.
+    let nextNode (path: Path) (g: Global<'V>) : Path option =
+        g.Nodes
+        |> Map.toSeq
+        |> Seq.map fst
+        |> Seq.filter (fun k -> compare k path > 0)
+        |> Seq.tryHead
+
+    /// All defined `(path, value)` pairs in ordinal-path order.
+    let toSeq (g: Global<'V>) : (Path * 'V) seq = Map.toSeq g.Nodes
+
+    /// The number of defined nodes (values), not counting pure intermediates.
+    let count (g: Global<'V>) : int = g.Nodes.Count

--- a/tests/Tests.FSharp/Globals.Tests.fs
+++ b/tests/Tests.FSharp/Globals.Tests.fs
@@ -1,0 +1,66 @@
+module Zeta.Tests.GlobalsTests
+
+open global.Xunit
+open Zeta.Core
+
+module G = Zeta.Core.Globals
+
+let private sample () =
+    G.empty
+    |> G.set [ "patient"; "1"; "name" ] "Ada"
+    |> G.set [ "patient"; "1"; "enc"; "1" ] "visit-a"
+    |> G.set [ "patient"; "1"; "enc"; "2" ] "visit-b"
+    |> G.set [ "patient"; "2"; "name" ] "Grace"
+
+[<Fact>]
+let ``set then get round-trips a value at a subscript path`` () =
+    let g = sample ()
+    Assert.Equal<string option>(Some "Ada", G.get [ "patient"; "1"; "name" ] g)
+    Assert.Equal<string option>(None, G.get [ "patient"; "1"; "missing" ] g)
+
+[<Fact>]
+let ``kill removes the node and all descendants (subtree)`` () =
+    let g = sample () |> G.kill [ "patient"; "1" ]
+    Assert.Equal<string option>(None, G.get [ "patient"; "1"; "name" ] g)
+    Assert.Equal<string option>(None, G.get [ "patient"; "1"; "enc"; "1" ] g)
+    Assert.Equal<string option>(Some "Grace", G.get [ "patient"; "2"; "name" ] g) // sibling untouched
+
+[<Fact>]
+let ``data reports 0/1/10/11 by value-and-children status`` () =
+    // give "patient";"1";"enc" its own value too, so it is value+children (11)
+    let g = sample () |> G.set [ "patient"; "1"; "enc" ] "enc-root"
+    Assert.Equal(0, G.data [ "patient"; "9" ] g) // undefined
+    Assert.Equal(1, G.data [ "patient"; "1"; "name" ] g) // value, no children
+    Assert.Equal(10, G.data [ "patient"; "1" ] g) // no own value, has children
+    Assert.Equal(11, G.data [ "patient"; "1"; "enc" ] g) // value AND children
+
+[<Fact>]
+let ``nextChild iterates immediate subscripts in ordinal order ($ORDER)`` () =
+    let g = sample ()
+    Assert.Equal<string option>(Some "1", G.nextChild [ "patient" ] None g) // first child
+    Assert.Equal<string option>(Some "2", G.nextChild [ "patient" ] (Some "1") g) // next after "1"
+    Assert.Equal<string option>(None, G.nextChild [ "patient" ] (Some "2") g) // end
+    Assert.Equal<string option>(Some "1", G.nextChild [ "patient"; "1"; "enc" ] None g)
+    Assert.Equal<string option>(Some "2", G.nextChild [ "patient"; "1"; "enc" ] (Some "1") g)
+
+[<Fact>]
+let ``nextNode walks every defined node depth-first ($QUERY) and terminates`` () =
+    let g = sample ()
+    // start before the first node; collect the full traversal
+    let rec walk acc (p: G.Path) =
+        match G.nextNode p g with
+        | Some n -> walk (n :: acc) n
+        | None -> List.rev acc
+
+    let all = walk [] []
+    Assert.Equal(4, List.length all)
+    // ordinal-path order: enc subscripts sort before "name" ('e' < 'n')
+    Assert.Equal<G.Path>([ "patient"; "1"; "enc"; "1" ], List.head all)
+    Assert.Equal<G.Path>([ "patient"; "2"; "name" ], List.last all)
+
+[<Fact>]
+let ``children lists deduped immediate subscripts; count is defined-node count`` () =
+    let g = sample ()
+    Assert.Equal<string list>([ "1"; "2" ], G.children [ "patient" ] g)
+    Assert.Equal<string list>([ "1"; "2" ], G.children [ "patient"; "1"; "enc" ] g)
+    Assert.Equal(4, G.count g)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -81,6 +81,7 @@
     <Compile Include="ContentHash256.Tests.fs" />
     <Compile Include="ContentStore.Tests.fs" />
     <Compile Include="CasStore.Tests.fs" />
+    <Compile Include="Globals.Tests.fs" />
     <Compile Include="DagFs.Tests.fs" />
     <Compile Include="Confluence.Tests.fs" />
     <Compile Include="DebeziumCdc.Tests.fs" />


### PR DESCRIPTION
Aaron 2026-06-07: 'like InterSystems Caché plus its DB features.' Captures three forwarded riffs and
peels the hype: Power BI 'semantic model' demoted to what we already have (Arrow columnar + DBSP
incremental views + HKT-MDM relationships + the near-dup similarity index); the real anchor is Caché's
multidimensional GLOBALS (MUMPS, 1966) + multi-model-over-one-store, which maps to our DynamicValue-tree
/ many-projections theme.

First code slice: Globals — a sparse subscript-path tree with the canonical MUMPS verbs (set/get/kill/
data/nextChild=$ORDER/nextNode=$QUERY), pure/immutable, ordinal subscript collation (B-0969; F#
string comparison is CompareOrdinal so the sorted path map is ordinal-safe by construction). 6 tests.
Multi-model views, F#-typed access, globals-over-the-content-addressed-DAG layer on later (backlog).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
