### PR TITLE
refactor(Blake3): rename Core.Blake3 -> Core.FSharp.Blake3 (per-language oracle family)

### DIFF
--- a/Zeta.sln
+++ b/Zeta.sln
@@ -149,9 +149,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Core.FSharp.ObserveBridge",
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Zeta.Core.FSharp.ObserveBridge", "src\Core.FSharp.ObserveBridge\Zeta.Core.FSharp.ObserveBridge.fsproj", "{177D8601-36C6-4AB6-BD7A-F790C96CA458}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Core.Blake3", "Core.Blake3", "{CDEC9628-3A7E-5B06-3B47-67082715C17B}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Core.FSharp.Blake3", "Core.FSharp.Blake3", "{CDEC9628-3A7E-5B06-3B47-67082715C17B}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Zeta.Core.Blake3", "src\Core.Blake3\Zeta.Core.Blake3.fsproj", "{D1452D3D-B660-4C3D-B33A-BAAEB9F9A9F1}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Zeta.Core.FSharp.Blake3", "src\Core.FSharp.Blake3\Zeta.Core.FSharp.Blake3.fsproj", "{D1452D3D-B660-4C3D-B33A-BAAEB9F9A9F1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Core.FSharp.Blake3/Blake3Hasher.fs
+++ b/src/Core.FSharp.Blake3/Blake3Hasher.fs
@@ -1,4 +1,4 @@
-namespace Zeta.Core.Blake3
+namespace Zeta.Core.FSharp.Blake3
 
 open System
 open System.Buffers.Binary

--- a/src/Core.FSharp.Blake3/ContentHash256.fs
+++ b/src/Core.FSharp.Blake3/ContentHash256.fs
@@ -1,4 +1,4 @@
-namespace Zeta.Core.Blake3
+namespace Zeta.Core.FSharp.Blake3
 
 open System
 open System.Buffers.Binary

--- a/src/Core.FSharp.Blake3/Zeta.Core.FSharp.Blake3.fsproj
+++ b/src/Core.FSharp.Blake3/Zeta.Core.FSharp.Blake3.fsproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <RootNamespace>Zeta.Core.Blake3</RootNamespace>
-    <AssemblyName>Zeta.Core.Blake3</AssemblyName>
+    <RootNamespace>Zeta.Core.FSharp.Blake3</RootNamespace>
+    <AssemblyName>Zeta.Core.FSharp.Blake3</AssemblyName>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/tests/Tests.FSharp/Blake3Hasher.Tests.fs
+++ b/tests/Tests.FSharp/Blake3Hasher.Tests.fs
@@ -2,7 +2,7 @@ module Zeta.Tests.Blake3HasherTests
 
 open global.Xunit
 open Zeta.Core
-open Zeta.Core.Blake3
+open Zeta.Core.FSharp.Blake3
 
 module CH = Zeta.Core.ContentHasher
 

--- a/tests/Tests.FSharp/ContentHash256.Tests.fs
+++ b/tests/Tests.FSharp/ContentHash256.Tests.fs
@@ -2,9 +2,9 @@ module Zeta.Tests.ContentHash256Tests
 
 open global.Xunit
 open Zeta.Core
-open Zeta.Core.Blake3
+open Zeta.Core.FSharp.Blake3
 
-module C256 = Zeta.Core.Blake3.ContentHash256
+module C256 = Zeta.Core.FSharp.Blake3.ContentHash256
 
 [<Fact>]
 let ``ContentHash256 known-answer: empty input is the full raw BLAKE3-256 digest (no reversal)`` () =

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -277,7 +277,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Core\Core.fsproj" />
-    <ProjectReference Include="..\..\src\Core.Blake3\Zeta.Core.Blake3.fsproj" />
+    <ProjectReference Include="..\..\src/Core.FSharp.Blake3/Zeta.Core.FSharp.Blake3.fsproj" />
     <ProjectReference Include="..\..\src\Core.CSharp.Merkle\Zeta.Core.CSharp.Merkle.csproj" />
     <ProjectReference Include="..\..\src\Core.CSharp.Metric\Zeta.Core.CSharp.Metric.csproj" />
     <ProjectReference Include="..\..\src\Core.FSharp.ZetaId\Zeta.Core.FSharp.ZetaId.fsproj" />


### PR DESCRIPTION
Aaron 2026-06-07: BLAKE3 is a hash PRIMITIVE on the 4-lang dispatch board (C#/Rust/TS oracle siblings
coming for byte-lock parity), so it belongs in the Zeta.Core.<Lang>.<Primitive> family alongside
Core.FSharp.Sha256 — not the language-neutral dep-isolation name (Core.Git pattern). A neutral
Core.Blake3 would collide with Core.CSharp/Rust/TS.Blake3. Cheap now: one consumer, freshly landed.

Renames dir, fsproj, RootNamespace/AssemblyName, the two source namespaces, test opens, ProjectReference,
and the .sln folder+project entries. GUIDs unchanged. Core + Tests.FSharp build clean (0/0).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
