### PR TITLE
refactor(Core.Git): rename Core.Git -> Core.FSharp.Git + naming-convention doc

### DIFF
--- a/Zeta.sln
+++ b/Zeta.sln
@@ -139,9 +139,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Core.CSharp.Mediator.Handle
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Zeta.Core.CSharp.Mediator.Handlers", "src\Core.CSharp.Mediator.Handlers\Zeta.Core.CSharp.Mediator.Handlers.csproj", "{E401E830-2199-469D-8D34-EE0409535CEB}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Core.Git", "Core.Git", "{678BEB8D-980C-8504-53B1-31124DFFC07B}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Core.FSharp.Git", "Core.FSharp.Git", "{678BEB8D-980C-8504-53B1-31124DFFC07B}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Zeta.Core.Git", "src\Core.Git\Zeta.Core.Git.fsproj", "{B5CE1764-C6F0-43B9-A7AC-AD5A2059E789}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Zeta.Core.FSharp.Git", "src\Core.FSharp.Git\Zeta.Core.FSharp.Git.fsproj", "{B5CE1764-C6F0-43B9-A7AC-AD5A2059E789}"
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Tests.FSharp.Git", "tests\Tests.FSharp.Git\Tests.FSharp.Git.fsproj", "{E84DC2EA-3AE3-491A-8D4F-E21951451552}"
 EndProject

--- a/docs/research/2026-06-07-project-naming-convention-interface-libs-csharp-language-neutral-impls-language-segmented-aaron.md
+++ b/docs/research/2026-06-07-project-naming-convention-interface-libs-csharp-language-neutral-impls-language-segmented-aaron.md
@@ -1,0 +1,61 @@
+# Project naming convention: interface libs are C# + language-neutral; implementations are language-segmented (Aaron, 2026-06-07)
+
+The principle behind the `Core.Blake3`→`Core.FSharp.Blake3` and `Core.Git`→`Core.FSharp.Git` renames.
+Faithful capture; a convention proposal (naming-expert / Ilyana review before it becomes a rule).
+
+## The carved principle (Aaron)
+
+> *"C# interfaces support in and out [declaration-site variance] so it would be the canonical interface
+> language for dotnet. You can implement them in F# and C#, so the interface libraries would not need a
+> language name."*
+
+Two project classes, two naming families:
+
+| class | names | language | why |
+|---|---|---|---|
+| **contract / interface** (ports, abstractions) | **language-neutral** — `Zeta.Core.Abstractions`, `Zeta.Core.Ports` | **C#** | C# has declaration-site variance (`in`/`out`); F# **cannot declare** variant interfaces. C# is the canonical .NET interface language. No language segment — both F# and C# implement against the *same* contract. |
+| **implementation / adapter / oracle** | **language-segmented** — `Zeta.Core.<Lang>.<X>` (`Core.FSharp.Sha256`, `Core.CSharp.Merkle`, `Core.Rust.ZetaId`) | F# / C# / Rust / TS | implementations **must not share code across languages** (4-oracle independence / byte-lock parity). The language segment is load-bearing: it says "this is *one language's* impl," leaving room for siblings. |
+
+## Why implementations don't share code
+
+The 4-language oracle discipline (B-0959) requires each language to implement a primitive **independently**
+and prove byte-identical results via hex-in-JSON golden vectors. Shared code would defeat the cross-check —
+a bug in shared code can't be caught by agreement. So `Core.FSharp.Blake3` and `Core.CSharp.Blake3` are
+*separate projects with separate code*, agreeing only at the wire (golden vectors), both implementing the
+neutral C# `IContentHasher` contract.
+
+## The two renames this produced
+
+- **`Core.Blake3` → `Core.FSharp.Blake3`** (PR #6852): BLAKE3 is a hash *primitive* on the 4-lang dispatch
+  board (C#/Rust/TS oracle siblings coming) — belongs in the per-language family, not a neutral name.
+- **`Core.Git` → `Core.FSharp.Git`** (this PR): `Core.Git` is an **F# implementation** (LibGit2Sharp adapter
+  implementing the `IDeltaLog`/`ISnapshotStore` ports) wearing a neutral name — the same smell. A future C#
+  git backend would collide. Renamed; the neutral name is freed for the *contract* library.
+
+## The distinction from a backend-variant (why `Core.Git` was confusing)
+
+The honest test: **does this project's variation come from *language* or from *backend/dependency*?**
+- *Language* variation (4 oracles of one primitive) → language segment: `Core.<Lang>.<X>`.
+- *Backend* variation (LibGit2Sharp now, pure-managed later — same language) → that's **multiple impls of one
+  port**, each its own project, but the *port* is the neutral C# contract lib. `Core.Git` mistakenly used the
+  neutral name for an F# *impl*; the neutral name belongs to the **port**, and the impl is
+  `Core.FSharp.Git` (LibGit2Sharp/F#), with a later `Core.FSharp.Git.Managed` or `Core.CSharp.Git` as
+  sibling backends.
+
+## Backlog (deferred — API-reviewed extraction)
+
+1. **Extract a C# language-neutral contract library** (`Zeta.Core.Abstractions` or `Zeta.Core.Ports`) holding
+   the ports currently in F# `Core` (`IContentHasher`, `IDeltaLog<'K>`, `ISnapshotStore<'K>`, …), authored in
+   C# to get declaration-site variance. Both `Core.FSharp.*` and `Core.CSharp.*` reference it. Needs
+   public-API review (Ilyana) — moving an interface is a contract change.
+2. **Audit remaining neutral-named projects** for the same smell (any `Core.<X>` that is actually one
+   language's impl, not a contract).
+
+## Beacon anchors
+
+- **Declaration-site variance** — C# `in`/`out` on interfaces/delegates (Eric Lippert's variance series); F#
+  supports *consuming* variant types but not *declaring* variance — hence C# as the canonical .NET contract
+  language. · **Hexagonal architecture / ports & adapters** (Alistair Cockburn) — the port (neutral
+  contract) vs adapter (language/backend impl) split this convention encodes. · **4-oracle byte-lock** (ours,
+  B-0959) — why impls stay independent/unshared. · Ties: the `Core.FSharp.Sha256` family (the convention
+  already followed), `Core.Git`/`Core.FSharp.Git`, `Core.Blake3`/`Core.FSharp.Blake3`.

--- a/src/Core.FSharp.Blake3/Zeta.Core.FSharp.Blake3.fsproj
+++ b/src/Core.FSharp.Blake3/Zeta.Core.FSharp.Blake3.fsproj
@@ -10,7 +10,7 @@
   <!-- BLAKE3 adapter for the IContentHasher port (hexagonal — Aaron 2026-06-07: "own the interface,
        go generic, many algos not just blake"). The Blake3 NuGet dep (xoofx, managed wrapper over the
        BLAKE3 Rust SIMD impl) is ISOLATED to this adapter project, never in Core — same pattern as
-       Core.Git isolates LibGit2Sharp. Tamper-evident hash for the git-replacement store. -->
+       Core.FSharp.Git isolates LibGit2Sharp. Tamper-evident hash for the git-replacement store. -->
   <ItemGroup>
     <ProjectReference Include="../Core/Core.fsproj" />
     <PackageReference Include="Blake3" />

--- a/src/Core.FSharp.Git/CliParse.fs
+++ b/src/Core.FSharp.Git/CliParse.fs
@@ -1,4 +1,4 @@
-namespace Zeta.Core.Git
+namespace Zeta.Core.FSharp.Git
 
 /// CLI argument parser for the git-ref command verbs (roadmap #1, no-git-CLI; core-library-first). PURE:
 /// `argv -> GitCommand` (or a usage error). Kept a library function so it's CI-tested; the runnable

--- a/src/Core.FSharp.Git/CredentialSource.fs
+++ b/src/Core.FSharp.Git/CredentialSource.fs
@@ -1,4 +1,4 @@
-namespace Zeta.Core.Git
+namespace Zeta.Core.FSharp.Git
 
 open System
 open LibGit2Sharp

--- a/src/Core.FSharp.Git/GitCommand.fs
+++ b/src/Core.FSharp.Git/GitCommand.fs
@@ -1,4 +1,4 @@
-namespace Zeta.Core.Git
+namespace Zeta.Core.FSharp.Git
 
 open System
 open LibGit2Sharp

--- a/src/Core.FSharp.Git/GitDeltaLog.fs
+++ b/src/Core.FSharp.Git/GitDeltaLog.fs
@@ -1,4 +1,4 @@
-namespace Zeta.Core.Git
+namespace Zeta.Core.FSharp.Git
 
 open System
 open System.Collections.Generic

--- a/src/Core.FSharp.Git/GitSnapshotStore.fs
+++ b/src/Core.FSharp.Git/GitSnapshotStore.fs
@@ -1,4 +1,4 @@
-namespace Zeta.Core.Git
+namespace Zeta.Core.FSharp.Git
 
 open System
 open System.Collections.Generic

--- a/src/Core.FSharp.Git/Zeta.Core.FSharp.Git.fsproj
+++ b/src/Core.FSharp.Git/Zeta.Core.FSharp.Git.fsproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <RootNamespace>Zeta.Core.Git</RootNamespace>
-    <AssemblyName>Zeta.Core.Git</AssemblyName>
+    <RootNamespace>Zeta.Core.FSharp.Git</RootNamespace>
+    <AssemblyName>Zeta.Core.FSharp.Git</AssemblyName>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/tests/Tests.FSharp.Git/CliParse.Tests.fs
+++ b/tests/Tests.FSharp.Git/CliParse.Tests.fs
@@ -1,7 +1,7 @@
 module Zeta.Tests.Git.CliParseTests
 
 open global.Xunit
-open Zeta.Core.Git
+open Zeta.Core.FSharp.Git
 
 // The CLI arg parser (roadmap #1, no-git-CLI). Pure argv -> GitCommand; the runnable `zeta` exe is a
 // trivial shell over this + GitCommand.run. Keeping the brain a tested library fn = the exe stays thin.

--- a/tests/Tests.FSharp.Git/CredentialSource.Tests.fs
+++ b/tests/Tests.FSharp.Git/CredentialSource.Tests.fs
@@ -2,7 +2,7 @@ module Zeta.Tests.Git.CredentialSourceTests
 
 open System
 open global.Xunit
-open Zeta.Core.Git
+open Zeta.Core.FSharp.Git
 
 // Pluggable, host-agnostic credential source (roadmap #1 push/sync). GitHub/gh/GitLab are HOST PLUGINS,
 // not git-native (Aaron 2026-06-07) — the git layer only knows "a source yields a handler or an error".

--- a/tests/Tests.FSharp.Git/DurableDiplomacyGit.Tests.fs
+++ b/tests/Tests.FSharp.Git/DurableDiplomacyGit.Tests.fs
@@ -6,7 +6,7 @@ open System.Threading
 open global.Xunit
 open LibGit2Sharp
 open Zeta.Core
-open Zeta.Core.Git
+open Zeta.Core.FSharp.Git
 
 module D = Zeta.Core.Diplomacy
 module DD = Zeta.Core.DurableDiplomacy

--- a/tests/Tests.FSharp.Git/DurableObserveGit.Tests.fs
+++ b/tests/Tests.FSharp.Git/DurableObserveGit.Tests.fs
@@ -6,7 +6,7 @@ open System.Threading
 open global.Xunit
 open LibGit2Sharp
 open Zeta.Core
-open Zeta.Core.Git
+open Zeta.Core.FSharp.Git
 open Zeta.Core.FSharp.Observe
 open Zeta.Core.FSharp.ObserveBridge
 

--- a/tests/Tests.FSharp.Git/DurableSagaGit.Tests.fs
+++ b/tests/Tests.FSharp.Git/DurableSagaGit.Tests.fs
@@ -7,7 +7,7 @@ open FsUnit.Xunit
 open global.Xunit
 open LibGit2Sharp
 open Zeta.Core
-open Zeta.Core.Git
+open Zeta.Core.FSharp.Git
 
 
 // ═══════════════════════════════════════════════════════════════════

--- a/tests/Tests.FSharp.Git/DurableYinYangGit.Tests.fs
+++ b/tests/Tests.FSharp.Git/DurableYinYangGit.Tests.fs
@@ -7,7 +7,7 @@ open global.Xunit
 open LibGit2Sharp
 open Zeta.Core
 open Zeta.Core.Bonsai
-open Zeta.Core.Git
+open Zeta.Core.FSharp.Git
 
 
 // ═══════════════════════════════════════════════════════════════════

--- a/tests/Tests.FSharp.Git/GitCommand.Tests.fs
+++ b/tests/Tests.FSharp.Git/GitCommand.Tests.fs
@@ -5,7 +5,7 @@ open System.IO
 open System.Threading
 open LibGit2Sharp
 open global.Xunit
-open Zeta.Core.Git
+open Zeta.Core.FSharp.Git
 
 // Git-ref command verbs (roadmap #1, no-git-CLI) — branch/checkout/commit/log/status over a real working
 // repo via LibGit2Sharp. The CLI + MCP thin-wrap GitCommand.run; these tests drive it directly.

--- a/tests/Tests.FSharp.Git/GitDeltaLog.Tests.fs
+++ b/tests/Tests.FSharp.Git/GitDeltaLog.Tests.fs
@@ -7,7 +7,7 @@ open FsUnit.Xunit
 open global.Xunit
 open LibGit2Sharp
 open Zeta.Core
-open Zeta.Core.Git
+open Zeta.Core.FSharp.Git
 
 
 // ═══════════════════════════════════════════════════════════════════

--- a/tests/Tests.FSharp.Git/GitRecoverableSpine.Tests.fs
+++ b/tests/Tests.FSharp.Git/GitRecoverableSpine.Tests.fs
@@ -7,7 +7,7 @@ open FsUnit.Xunit
 open global.Xunit
 open LibGit2Sharp
 open Zeta.Core
-open Zeta.Core.Git
+open Zeta.Core.FSharp.Git
 
 
 // ═══════════════════════════════════════════════════════════════════

--- a/tests/Tests.FSharp.Git/GitSnapshotStore.Tests.fs
+++ b/tests/Tests.FSharp.Git/GitSnapshotStore.Tests.fs
@@ -7,7 +7,7 @@ open FsUnit.Xunit
 open global.Xunit
 open LibGit2Sharp
 open Zeta.Core
-open Zeta.Core.Git
+open Zeta.Core.FSharp.Git
 
 
 // ═══════════════════════════════════════════════════════════════════

--- a/tests/Tests.FSharp.Git/SubstrateFerryGit.Tests.fs
+++ b/tests/Tests.FSharp.Git/SubstrateFerryGit.Tests.fs
@@ -6,7 +6,7 @@ open System.Threading
 open global.Xunit
 open LibGit2Sharp
 open Zeta.Core
-open Zeta.Core.Git
+open Zeta.Core.FSharp.Git
 open Zeta.Core.FSharp.ObserveBridge
 
 module E = Zeta.Core.FSharp.ObserveBridge.Effects

--- a/tests/Tests.FSharp.Git/Tests.FSharp.Git.fsproj
+++ b/tests/Tests.FSharp.Git/Tests.FSharp.Git.fsproj
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Core\Core.fsproj" />
-    <ProjectReference Include="..\..\src\Core.Git\Zeta.Core.Git.fsproj" />
+    <ProjectReference Include="..\..\src\Core.FSharp.Git\Zeta.Core.FSharp.Git.fsproj" />
     <ProjectReference Include="..\..\src\Core.FSharp.Observe\Zeta.Core.FSharp.Observe.fsproj" />
     <ProjectReference Include="..\..\src\Core.FSharp.ObserveBridge\Zeta.Core.FSharp.ObserveBridge.fsproj" />
   </ItemGroup>

--- a/tools/zeta-cli/Program.fs
+++ b/tools/zeta-cli/Program.fs
@@ -2,11 +2,11 @@ module Zeta.Cli.Program
 
 open System
 open LibGit2Sharp
-open Zeta.Core.Git
+open Zeta.Core.FSharp.Git
 
 /// The thin `zeta` CLI shell over the command core (roadmap #1, no-git-CLI; core-library-first). All the
 /// logic lives in CliParse (argv -> GitCommand) + GitCommand.run (over the repo) — both CI-tested in
-/// Zeta.Core.Git. This shell just opens the repo in the cwd, runs, prints, and returns an exit code.
+/// Zeta.Core.FSharp.Git. This shell just opens the repo in the cwd, runs, prints, and returns an exit code.
 ///
 /// Network verbs (push / fetch) get a host-agnostic credential source: env token (GH_TOKEN / GITHUB_TOKEN)
 /// over HTTPS. GitHub is a plugin, not git-native — the source only yields a handler or a clean error.

--- a/tools/zeta-cli/Zeta.Cli.fsproj
+++ b/tools/zeta-cli/Zeta.Cli.fsproj
@@ -12,6 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Core.Git\Zeta.Core.Git.fsproj" />
+    <ProjectReference Include="..\..\src\Core.FSharp.Git\Zeta.Core.FSharp.Git.fsproj" />
   </ItemGroup>
 </Project>

--- a/tools/zeta-mcp/Program.fs
+++ b/tools/zeta-mcp/Program.fs
@@ -3,7 +3,7 @@ module Zeta.Mcp.Program
 open System
 open System.Text.Json.Nodes
 open LibGit2Sharp
-open Zeta.Core.Git
+open Zeta.Core.FSharp.Git
 
 // Minimal MCP stdio server (newline-delimited JSON-RPC 2.0) exposing the git-ref command verbs as tools
 // (roadmap #1, no-git-CLI; the step that lets Otto drive the verbs as native tools). Server-only — the

--- a/tools/zeta-mcp/Zeta.Mcp.fsproj
+++ b/tools/zeta-mcp/Zeta.Mcp.fsproj
@@ -10,6 +10,6 @@
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Core.Git\Zeta.Core.Git.fsproj" />
+    <ProjectReference Include="..\..\src\Core.FSharp.Git\Zeta.Core.FSharp.Git.fsproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Aaron 2026-06-07: Core.Git is an F# IMPLEMENTATION (LibGit2Sharp adapter for IDeltaLog/ISnapshotStore),
not an interface library — same misnaming as Core.Blake3. Interface/contract libs are C# (declaration-site
in/out variance; F# can't declare variance) + language-NEUTRAL named; implementations are language-SEGMENTED
(Core.<Lang>.<X>) and must not share code (4-oracle independence). A future C#/managed git backend would
collide with the neutral name.

Renames dir/fsproj/RootNamespace/AssemblyName/namespaces across 5 src files + 11 test files + 2 tool
consumers (zeta-cli, zeta-mcp) + .sln. Captures the general convention as a doc (naming-expert/Ilyana
review before it becomes a rule) with a backlog item to extract a C# neutral contract lib (Core.Abstractions)
for the ports now in F# Core. All consumers build clean (Core.FSharp.Git, cli, mcp, Tests.FSharp.Git).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
