### PR TITLE
feat(TensorRef): content-addressed reference to our ITensor, carried in DynamicValue

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -88,6 +88,7 @@
     <Compile Include="CasStore.fs" />
     <Compile Include="DagFs.fs" />
     <Compile Include="Globals.fs" />
+    <Compile Include="TensorRef.fs" />
     <Compile Include="DvKey.fs" />
     <Compile Include="DebeziumCdc.fs" />
     <Compile Include="CloudEvents.fs" />

--- a/src/Core/TensorRef.fs
+++ b/src/Core/TensorRef.fs
@@ -1,0 +1,128 @@
+namespace Zeta.Core
+
+open System
+open System.Globalization
+
+/// **A content-addressed reference to *our* tensor (`ITensor`), carried inside a `DynamicValue` (Aaron
+/// 2026-06-07: "we should allow tensors to be referenced from DynamicValue — our ITensor").** A tensor leaf
+/// in a ragged `DynamicValue` tree (e.g. a model `state_dict` node) is **not** stored inline — the dense
+/// buffer / sparse Z-set lives in the content-addressed store, and the `DynamicValue` holds a *reference*:
+/// its content address (`MerkleHash`) plus shape + dtype + backing kind. So you **navigate to** the tensor
+/// with the MUMPS verbs (`Globals`) and the leaf you reach is a `TensorRef`; you **dereference** it to get
+/// the bytes, then **index into** the dense buffer with BLAS / `TensorPrimitives` (the dense-leaf compute
+/// layer — Aaron's BLAS/Boost-uBLAS-at-MacVector anchor) or fold the sparse Z-set over a semiring.
+///
+/// **Additive — no change to the public `DynamicValue` DU.** The reference is encoded as a
+/// `DynamicValue.Object` with reserved keys (sentinel `$tensor`), riding the canonical CBOR/JSON/XML codecs
+/// like `CloudEvents`/`DvKey`. Content-addressing gives free dedup of identical tensor blobs across
+/// checkpoints; `kind` is fork-agnostic about the `ITensor` backing (dense `Tensor<T>` vs sparse
+/// `ZSet`/`WeightedSet`).
+///
+/// Anchors: content-addressed references (Git/IPFS); safetensors/GGUF (named-tensor model blobs the address
+/// points at); BLAS / Boost uBLAS / `System.Numerics.Tensors` (the dense-leaf compute); `ContentStore`,
+/// `MerkleHash`, `IContentHasher` (ours). ZetaId-pointer-not-authority: a `TensorRef` is a pointer.
+[<RequireQualifiedAccess>]
+module TensorRef =
+
+    /// Which `ITensor` backing the reference resolves to.
+    type Kind =
+        | Dense // contiguous buffer → Tensor<T> / TensorPrimitives / BLAS
+        | Sparse // coordinate→weight → ZSet / WeightedSet over a semiring
+
+    let private kindToString =
+        function
+        | Dense -> "dense"
+        | Sparse -> "sparse"
+
+    let private kindOfString =
+        function
+        | "dense" -> Some Dense
+        | "sparse" -> Some Sparse
+        | _ -> None
+
+    /// A reference to a content-addressed tensor: its address + shape (dims; `[]` = scalar) + dtype
+    /// (ordinal token, e.g. "f32"/"f64"/"i64") + backing kind.
+    [<NoComparison; CustomEquality>]
+    type TensorRef =
+        { Address: MerkleHash
+          Shape: int list
+          Dtype: string
+          Kind: Kind }
+
+        override this.Equals(o) =
+            match o with
+            | :? TensorRef as r ->
+                this.Address.Equals r.Address
+                && this.Shape = r.Shape
+                && String.Equals(this.Dtype, r.Dtype, StringComparison.Ordinal)
+                && this.Kind = r.Kind
+            | _ -> false
+
+        override this.GetHashCode() = this.Address.GetHashCode()
+
+    /// The sentinel key that marks a `DynamicValue.Object` as a tensor reference.
+    [<Literal>]
+    let SentinelKey = "$tensor"
+
+    let create (address: MerkleHash) (shape: int list) (dtype: string) (kind: Kind) : TensorRef =
+        { Address = address
+          Shape = shape
+          Dtype = dtype
+          Kind = kind }
+
+    /// Parse a 32-char lowercase-hex `MerkleHash` (the `ToHex` form: Hi[16] ++ Lo[16]).
+    let private parseHex (s: string) : MerkleHash option =
+        if s.Length <> 32 then
+            None
+        else
+            let tryU64 (sub: string) =
+                match UInt64.TryParse(sub, NumberStyles.HexNumber, CultureInfo.InvariantCulture) with
+                | true, v -> Some v
+                | _ -> None
+
+            match tryU64 (s.Substring(0, 16)), tryU64 (s.Substring(16, 16)) with
+            | Some hi, Some lo -> Some(MerkleHash(hi, lo))
+            | _ -> None
+
+    /// Encode a `TensorRef` as a `DynamicValue.Object` (rides the canonical codecs). Key order is stable.
+    let toDynamic (r: TensorRef) : DynamicValue =
+        DynamicValue.Object
+            [ SentinelKey, DynamicValue.String(r.Address.ToHex())
+              "shape", DynamicValue.Array(r.Shape |> List.map (fun d -> DynamicValue.Int(int64 d)))
+              "dtype", DynamicValue.String r.Dtype
+              "kind", DynamicValue.String(kindToString r.Kind) ]
+
+    /// Recognize + decode a tensor-reference leaf; `None` if `dv` is not a well-formed `$tensor` object.
+    let tryOfDynamic (dv: DynamicValue) : TensorRef option =
+        match dv with
+        | DynamicValue.Object kvs ->
+            let find k =
+                kvs |> List.tryPick (fun (kk, v) -> if String.Equals(kk, k, StringComparison.Ordinal) then Some v else None)
+
+            match find SentinelKey, find "shape", find "dtype", find "kind" with
+            | Some(DynamicValue.String hex),
+              Some(DynamicValue.Array dims),
+              Some(DynamicValue.String dtype),
+              Some(DynamicValue.String kindStr) ->
+                let shape =
+                    dims
+                    |> List.choose (function
+                        | DynamicValue.Int n -> Some(int n)
+                        | _ -> None)
+
+                match parseHex hex, kindOfString kindStr with
+                | Some addr, Some kind when List.length shape = List.length dims ->
+                    Some
+                        { Address = addr
+                          Shape = shape
+                          Dtype = dtype
+                          Kind = kind }
+                | _ -> None
+            | _ -> None
+        | _ -> None
+
+    /// True iff `dv` is a tensor-reference leaf.
+    let isTensorRef (dv: DynamicValue) : bool = (tryOfDynamic dv).IsSome
+
+    /// Dereference: fetch the tensor blob from a content store keyed by the reference's address.
+    let tryResolve (store: ContentStore.Store<'V>) (r: TensorRef) : 'V option = ContentStore.get r.Address store

--- a/tests/Tests.FSharp/TensorRef.Tests.fs
+++ b/tests/Tests.FSharp/TensorRef.Tests.fs
@@ -1,0 +1,51 @@
+module Zeta.Tests.TensorRefTests
+
+open global.Xunit
+open Zeta.Core
+
+module TR = Zeta.Core.TensorRef
+
+let private addr () = MerkleHash(0xDEADBEEFUL, 0x0123456789ABCDEFUL)
+
+[<Fact>]
+let ``toDynamic then tryOfDynamic round-trips a dense reference`` () =
+    let r = TR.create (addr ()) [ 4096; 4096 ] "f32" TR.Dense
+    let dv = TR.toDynamic r
+    Assert.True(TR.isTensorRef dv)
+    Assert.Equal<TR.TensorRef option>(Some r, TR.tryOfDynamic dv)
+
+[<Fact>]
+let ``round-trips a sparse reference and a scalar (empty shape)`` () =
+    let r1 = TR.create (addr ()) [ 1000000 ] "i64" TR.Sparse
+    let r2 = TR.create (addr ()) [] "f64" TR.Dense // scalar
+    Assert.Equal<TR.TensorRef option>(Some r1, TR.toDynamic r1 |> TR.tryOfDynamic)
+    Assert.Equal<TR.TensorRef option>(Some r2, TR.toDynamic r2 |> TR.tryOfDynamic)
+
+[<Fact>]
+let ``a plain object / scalar is not mistaken for a tensor reference`` () =
+    Assert.False(TR.isTensorRef (DynamicValue.String "not a tensor"))
+    Assert.False(TR.isTensorRef (DynamicValue.Object [ "name", DynamicValue.String "Ada" ]))
+    Assert.Equal<TR.TensorRef option>(None, TR.tryOfDynamic (DynamicValue.Int 42L))
+
+[<Fact>]
+let ``a tensor reference is navigable as a Globals leaf (state_dict shape)`` () =
+    // model state_dict: encoder.layer.0.weight -> a dense tensor reference
+    let wref = TR.create (addr ()) [ 768; 768 ] "f32" TR.Dense
+
+    let model =
+        Globals.empty
+        |> Globals.set [ "encoder"; "layer"; "0"; "weight" ] (TR.toDynamic wref)
+
+    // navigate to the leaf with MUMPS verbs, then decode the reference
+    let leaf = Globals.get [ "encoder"; "layer"; "0"; "weight" ] model
+    Assert.True(leaf.IsSome)
+    Assert.Equal<TR.TensorRef option>(Some wref, leaf |> Option.bind TR.tryOfDynamic)
+
+[<Fact>]
+let ``tryResolve dereferences the blob from a content store`` () =
+    // a content store of byte[] blobs keyed by content hash
+    let store = ContentStore.create (fun (b: byte[]) -> MerkleHash.ofBytes (System.ReadOnlySpan<byte> b))
+    let blob = [| 1uy; 2uy; 3uy; 4uy |]
+    let h, store = ContentStore.put blob store
+    let r = TR.create h [ 4 ] "u8" TR.Dense
+    Assert.Equal<byte[] option>(Some blob, TR.tryResolve store r)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -82,6 +82,7 @@
     <Compile Include="ContentStore.Tests.fs" />
     <Compile Include="CasStore.Tests.fs" />
     <Compile Include="Globals.Tests.fs" />
+    <Compile Include="TensorRef.Tests.fs" />
     <Compile Include="DagFs.Tests.fs" />
     <Compile Include="Confluence.Tests.fs" />
     <Compile Include="DebeziumCdc.Tests.fs" />


### PR DESCRIPTION
Aaron 2026-06-07: 'we should allow tensors to be referenced from DynamicValue — our ITensor.' A tensor
leaf in a ragged DynamicValue tree (e.g. a model state_dict node) is NOT stored inline; the dense buffer /
sparse Z-set lives in the content-addressed store and DynamicValue holds a reference: address (MerkleHash)
+ shape + dtype + backing kind (Dense=Tensor<T>/BLAS/TensorPrimitives, Sparse=ZSet/WeightedSet). Navigate
TO the leaf with Globals' MUMPS verbs, dereference, index INTO the dense buffer with BLAS (Aaron's
Boost-uBLAS-at-MacVector anchor).

Additive: encoded as a DynamicValue.Object with sentinel $tensor key (rides canonical codecs like
CloudEvents/DvKey) — NO change to the public DynamicValue DU; fork-agnostic about the ITensor backing.
Free dedup of identical tensor blobs across checkpoints via content-addressing. 5 tests; Core green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
