### PR TITLE
feat(algebra): IMonoid/IGroup/ISemilattice interfaces + DynamicValue LWW-register semilattice

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -89,6 +89,7 @@
     <Compile Include="DagFs.fs" />
     <Compile Include="Globals.fs" />
     <Compile Include="TensorRef.fs" />
+    <Compile Include="DynamicValueAlgebra.fs" />
     <Compile Include="DvKey.fs" />
     <Compile Include="DebeziumCdc.fs" />
     <Compile Include="CloudEvents.fs" />

--- a/src/Core/DynamicValueAlgebra.fs
+++ b/src/Core/DynamicValueAlgebra.fs
@@ -1,0 +1,51 @@
+namespace Zeta.Core
+
+open System
+
+/// **Generic-algebra instances over `DynamicValue` (Aaron 2026-06-07: "generic algebra interfaces … add it
+/// to our DynamicValue; use the dotnet ones where they make sense").** Instance-passing (the algebra is a
+/// separate value implementing `IMonoid`/`ISemilattice` from `Semiring.fs`), matching the existing
+/// `ISemiring` instances (`IntegerRing` etc.) — so this is **additive and does NOT change the public
+/// `DynamicValue` DU or its interface list** (implementing the operator interfaces *on the type itself*, or
+/// adopting .NET generic-math `INumber` at scalar leaves, is a separate API-reviewed step — backlogged).
+///
+/// The clean, *provably associative* monoid on raw `DynamicValue` is an **LWW-register join-semilattice**:
+/// identity `Null`, combine = content-hash last-write-wins (max over a total order) for ALL shapes. It is
+/// commutative, associative, and idempotent (max over a total order always is), so out-of-order merges
+/// converge — the confluence resolver, reused (PR #6846). The total order is the canonical-CBOR content
+/// address (`toCanonicalCbor` is total over all 8 shapes), so the tiebreak is deterministic and DST-stable.
+///
+/// **Why not a recursive deep-merge here?** Deep `Object` key-union composed with LWW at type-conflicts is
+/// NOT associative without per-key versioning (an object in one grouping is LWW'd as a whole in another —
+/// caught by the associativity law test). Deep structural merge is therefore the domain of the **versioned
+/// `LwwMap` CRDT** (`Crdt.fs`), which timestamps each key — not a plain monoid on unversioned `DynamicValue`.
+[<RequireQualifiedAccess>]
+module DynamicValueAlgebra =
+
+    /// Canonical content address of any `DynamicValue` (via canonical CBOR) — the deterministic LWW key.
+    let private addr (v: DynamicValue) : MerkleHash =
+        MerkleHash.ofBytes(ReadOnlySpan<byte>(DynamicValue.toCanonicalCbor v))
+
+    /// Content-hash last-write-wins: `Null` is bottom; equal values collapse; else the value with the
+    /// greater content address. A deterministic, commutative, associative, idempotent join (max over a
+    /// total order).
+    let private lwwJoin (a: DynamicValue) (b: DynamicValue) : DynamicValue =
+        match a, b with
+        | DynamicValue.Null, x
+        | x, DynamicValue.Null -> x
+        | _ when a.Equals b -> a
+        | _ -> if (addr a).ToHex() >= (addr b).ToHex() then a else b
+
+    /// The DynamicValue **LWW-register** semilattice — identity `Null`, combine = content-hash last-write-
+    /// wins. Commutative + associative + idempotent (the confluence join-semilattice). For per-field deep
+    /// merge use the versioned `LwwMap` CRDT (`Crdt.fs`).
+    let mergeSemilattice: ISemilattice<DynamicValue> =
+        { new ISemilattice<DynamicValue> with
+            member _.Identity = DynamicValue.Null
+            member _.Combine a b = lwwJoin a b }
+
+    /// Fold a sequence under any monoid (generic plumbing): `Combine`-reduce from `Identity`.
+    let fold (m: IMonoid<'T>) (xs: 'T seq) : 'T = Seq.fold m.Combine m.Identity xs
+
+    /// Merge a sequence of `DynamicValue`s under the merge semilattice (order-independent by construction).
+    let mergeAll (xs: DynamicValue seq) : DynamicValue = fold mergeSemilattice xs

--- a/src/Core/Semiring.fs
+++ b/src/Core/Semiring.fs
@@ -22,6 +22,37 @@ type ISemiring<'W> =
 
 
 // ═══════════════════════════════════════════════════════════════════
+// THE ALGEBRA LADDER below a ring: monoid → group → semilattice
+// (instance-passing, like ISemiring — a value may carry several algebras;
+//  cf. .NET generic-math static-abstract style, the type-IS-its-algebra
+//  alternative used at concrete numeric leaves. We mirror .NET's *names*:
+//  Identity ≈ IAdditiveIdentity.AdditiveIdentity, Combine ≈ IAdditionOperators (+),
+//  Inverse ≈ IUnaryNegationOperators (-).)
+// ═══════════════════════════════════════════════════════════════════
+
+/// **Monoid** `(T, Combine, Identity)` — an associative binary op with a two-sided identity; the minimal
+/// algebra for `fold`/aggregation. `Combine` ≈ .NET `IAdditionOperators` (`+`); `Identity` ≈ .NET
+/// `IAdditiveIdentity.AdditiveIdentity`.
+///   Laws: Combine (Combine a b) c = Combine a (Combine b c);  Combine Identity a = a = Combine a Identity.
+type IMonoid<'T> =
+    abstract member Identity : 'T
+    abstract member Combine  : 'T -> 'T -> 'T
+
+/// **Group** — a monoid in which every element has an inverse. `Inverse` ≈ .NET `IUnaryNegationOperators`
+/// (`-`).  Law (additional): Combine a (Inverse a) = Identity = Combine (Inverse a) a.
+type IGroup<'T> =
+    inherit IMonoid<'T>
+    abstract member Inverse : 'T -> 'T
+
+/// **Bounded join-semilattice** — a *commutative* and *idempotent* monoid; `Combine` is the join (`⊔`),
+/// `Identity` is bottom (`⊥`). Precisely a CRDT merge / the confluence resolver: out-of-order `Combine`
+/// converges to the same result *iff* it is a join-semilattice (see the confluence proof).
+///   Laws (additional to monoid): Combine a b = Combine b a;  Combine a a = a.
+type ISemilattice<'T> =
+    inherit IMonoid<'T>
+
+
+// ═══════════════════════════════════════════════════════════════════
 // INTEGER RING  (ℤ, +, ×)  — the default DBSP weight semiring
 // ═══════════════════════════════════════════════════════════════════
 

--- a/tests/Tests.FSharp/DynamicValueAlgebra.Tests.fs
+++ b/tests/Tests.FSharp/DynamicValueAlgebra.Tests.fs
@@ -1,0 +1,67 @@
+module Zeta.Tests.DynamicValueAlgebraTests
+
+open global.Xunit
+open Zeta.Core
+
+module A = Zeta.Core.DynamicValueAlgebra
+
+let private i (n: int64) = DynamicValue.Int n
+let private s (x: string) = DynamicValue.String x
+let private obj kvs = DynamicValue.Object kvs
+
+let private samples =
+    [ DynamicValue.Null
+      i 1L
+      s "a"
+      obj [ "x", i 1L ]
+      obj [ "x", i 2L; "y", s "q" ]
+      obj [ "y", s "r"; "z", obj [ "k", i 9L ] ] ]
+
+let private m = A.mergeSemilattice
+
+[<Fact>]
+let ``merge monoid: identity is two-sided (Null)`` () =
+    for v in samples do
+        Assert.Equal<DynamicValue>(v, m.Combine m.Identity v)
+        Assert.Equal<DynamicValue>(v, m.Combine v m.Identity)
+
+[<Fact>]
+let ``merge monoid: idempotent (join-semilattice)`` () =
+    for v in samples do
+        Assert.Equal<DynamicValue>(v, m.Combine v v)
+
+[<Fact>]
+let ``merge monoid: commutative`` () =
+    for a in samples do
+        for b in samples do
+            Assert.Equal<DynamicValue>(m.Combine a b, m.Combine b a)
+
+[<Fact>]
+let ``merge monoid: associative`` () =
+    for a in samples do
+        for b in samples do
+            for c in samples do
+                Assert.Equal<DynamicValue>(m.Combine (m.Combine a b) c, m.Combine a (m.Combine b c))
+
+[<Fact>]
+let ``LWW register picks one whole value deterministically (Null is bottom)`` () =
+    let a = obj [ "x", i 1L ]
+    let b = obj [ "y", i 2L ]
+    // combine yields one of the two inputs (max over content-hash), never a deep union
+    let r = m.Combine a b
+    Assert.True(r.Equals a || r.Equals b)
+    // Null is the identity / bottom
+    Assert.Equal<DynamicValue>(a, m.Combine DynamicValue.Null a)
+
+[<Fact>]
+let ``mergeAll is order-independent (confluence over a stream)`` () =
+    let xs = [ obj [ "a", i 1L ]; obj [ "b", i 2L ]; obj [ "a", i 1L ]; obj [ "c", s "z" ] ]
+    let forward = A.mergeAll xs
+    let reversed = A.mergeAll (List.rev xs)
+    Assert.Equal<DynamicValue>(forward, reversed)
+
+[<Fact>]
+let ``fold over a monoid reduces from identity`` () =
+    Assert.Equal<DynamicValue>(m.Identity, A.fold m []) // empty fold = Identity (Null)
+    Assert.Equal<DynamicValue>(i 7L, A.fold m [ i 7L ]) // singleton
+    Assert.Equal<DynamicValue>(i 7L, A.fold m [ i 7L; i 7L ]) // idempotent: duplicates collapse

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -83,6 +83,7 @@
     <Compile Include="CasStore.Tests.fs" />
     <Compile Include="Globals.Tests.fs" />
     <Compile Include="TensorRef.Tests.fs" />
+    <Compile Include="DynamicValueAlgebra.Tests.fs" />
     <Compile Include="DagFs.Tests.fs" />
     <Compile Include="Confluence.Tests.fs" />
     <Compile Include="DebeziumCdc.Tests.fs" />


### PR DESCRIPTION
Aaron 2026-06-07: 'generic algebra interfaces … add it to our DynamicValue; use the dotnet ones where
they make sense, I love their names.' Adds the algebra ladder below ISemiring (Semiring.fs), instance-
passing like the existing ISemiring/IntegerRing — names mirror .NET generic math (Combine≈IAdditionOperators
+, Identity≈IAdditiveIdentity.AdditiveIdentity, Inverse≈IUnaryNegationOperators -). ISemilattice =
commutative+idempotent monoid = a CRDT merge / the confluence resolver.

DynamicValue instance: an LWW-register join-semilattice (content-hash LWW over canonical CBOR; Null=bottom),
provably associative/commutative/idempotent — the associativity law test CAUGHT that a recursive deep-merge
+ LWW is NOT associative without per-key versioning, so deep merge stays the domain of the versioned LwwMap
CRDT (documented). Additive: no change to the public DynamicValue DU. 7 law tests. Implementing operator
interfaces ON the type / adopting .NET INumber at leaves = API-reviewed next step (backlog).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
