### PR TITLE
feat(WeightedSet): semiring-generic sparse tensor (ZSet generalized over the weight)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -29,6 +29,7 @@
     <Compile Include="GSet.fs" />
     <Compile Include="Bag.fs" />
     <Compile Include="ZSet.fs" />
+    <Compile Include="WeightedSet.fs" />
     <Compile Include="ToffoliGate.fs" />
     <Compile Include="IndexedZSet.fs" />
     <Compile Include="Codec.fs" />

--- a/src/Core/WeightedSet.fs
+++ b/src/Core/WeightedSet.fs
@@ -1,0 +1,108 @@
+namespace Zeta.Core
+
+/// **Semiring-generic sparse tensor — coordinate (`'K`) → weight (`'W` in an `ISemiring`) (Aaron 2026-06-07,
+/// the tensor-algebra tie-in).** The generalization of `ZSet` over the *weight*: `ZSet` is the `IntegerRing`
+/// instance (int64, perf-tuned hot path — kept SEPARATE and unchanged); the **soft tensor** is the
+/// `IntervalRing` / `ProbabilitySemiring` instance (uncertainty / probability weights); a 0/1-weighted
+/// instance is an **SDR** (Numenta — `support` = active set, `inner` = overlap). One sparse tensor, the
+/// semiring picks the meaning.
+///
+/// Instance-passing semiring (the `ISemiring<'W>` is threaded through ops, like the existing `IntegerRing`
+/// usage). Pure / immutable. **Canonical:** Zero-weight coordinates are pruned, so `add a (negate a) = empty`
+/// — retraction-native, exactly like `ZSet`. GraphBLAS-shaped: ⊕ = `add`, ⊗ = `scale`, contraction = `inner`.
+[<RequireQualifiedAccess>]
+module WeightedSet =
+
+    /// A sparse map of coordinate → weight. Structural equality (needs `'W : equality`); no ordering.
+    [<NoComparison>]
+    type WeightedSet<'K, 'W when 'K: comparison and 'W: equality> = private { Entries: Map<'K, 'W> }
+
+    /// The empty (all-Zero) sparse tensor.
+    let empty<'K, 'W when 'K: comparison and 'W: equality> : WeightedSet<'K, 'W> = { Entries = Map.empty }
+
+    let isEmpty (ws: WeightedSet<'K, 'W>) : bool = Map.isEmpty ws.Entries
+
+    let count (ws: WeightedSet<'K, 'W>) : int = ws.Entries.Count
+
+    /// Weight at a coordinate (semiring `Zero` if the coordinate is absent).
+    let weight (sr: ISemiring<'W>) (k: 'K) (ws: WeightedSet<'K, 'W>) : 'W =
+        match Map.tryFind k ws.Entries with
+        | Some w -> w
+        | None -> sr.Zero
+
+    /// Set/prune one coordinate (a `Zero` weight is removed → canonical form).
+    let private setW (sr: ISemiring<'W>) (k: 'K) (w: 'W) (m: Map<'K, 'W>) : Map<'K, 'W> =
+        if w = sr.Zero then Map.remove k m else Map.add k w m
+
+    /// Build from pairs, combining duplicate coordinates via ⊕ and pruning `Zero`.
+    let ofSeq (sr: ISemiring<'W>) (pairs: ('K * 'W) seq) : WeightedSet<'K, 'W> =
+        let m =
+            pairs
+            |> Seq.fold
+                (fun acc (k, w) ->
+                    let cur =
+                        match Map.tryFind k acc with
+                        | Some c -> c
+                        | None -> sr.Zero
+
+                    setW sr k (sr.Add cur w) acc)
+                Map.empty
+
+        { Entries = m }
+
+    let singleton (sr: ISemiring<'W>) (k: 'K) (w: 'W) : WeightedSet<'K, 'W> = ofSeq sr [ k, w ]
+
+    /// ⊕ — union; shared coordinates combine via `Add`; `Zero` results are pruned (retraction-native).
+    let add (sr: ISemiring<'W>) (a: WeightedSet<'K, 'W>) (b: WeightedSet<'K, 'W>) : WeightedSet<'K, 'W> =
+        let m =
+            b.Entries
+            |> Map.fold
+                (fun acc k w ->
+                    let cur =
+                        match Map.tryFind k acc with
+                        | Some c -> c
+                        | None -> sr.Zero
+
+                    setW sr k (sr.Add cur w) acc)
+                a.Entries
+
+        { Entries = m }
+
+    /// Negate every weight (ring inverse — for retraction / subtraction).
+    let negate (sr: ISemiring<'W>) (ws: WeightedSet<'K, 'W>) : WeightedSet<'K, 'W> =
+        { Entries = ws.Entries |> Map.map (fun _ w -> sr.Negate w) }
+
+    /// `a − b` = `a ⊕ (−b)`.
+    let subtract (sr: ISemiring<'W>) (a: WeightedSet<'K, 'W>) (b: WeightedSet<'K, 'W>) : WeightedSet<'K, 'W> =
+        add sr a (negate sr b)
+
+    /// Scale every weight by `w` on the left (⊗); `Zero` results pruned (`×Zero` annihilates).
+    let scale (sr: ISemiring<'W>) (w: 'W) (ws: WeightedSet<'K, 'W>) : WeightedSet<'K, 'W> =
+        let m = ws.Entries |> Map.fold (fun acc k wk -> setW sr k (sr.Mul w wk) acc) Map.empty
+        { Entries = m }
+
+    /// Contraction / inner product over shared coordinates: `Σ_k a[k] ⊗ b[k]` (⊕-folded). Over a 0/1
+    /// integer weighting this is the **SDR overlap count**; over a probability semiring, an expectation;
+    /// over the integer ring, the Z-set dot product.
+    let inner (sr: ISemiring<'W>) (a: WeightedSet<'K, 'W>) (b: WeightedSet<'K, 'W>) : 'W =
+        a.Entries
+        |> Map.fold
+            (fun acc k wa ->
+                match Map.tryFind k b.Entries with
+                | Some wb -> sr.Add acc (sr.Mul wa wb)
+                | None -> acc)
+            sr.Zero
+
+    /// Map coordinates (collisions combine via ⊕, `Zero` pruned).
+    let mapKeys (sr: ISemiring<'W>) (f: 'K -> 'K2) (ws: WeightedSet<'K, 'W>) : WeightedSet<'K2, 'W> =
+        ws.Entries |> Map.toSeq |> Seq.map (fun (k, w) -> f k, w) |> ofSeq sr
+
+    /// ⊕-fold a sequence (order-independent: `add` is commutative + associative).
+    let sum (sr: ISemiring<'W>) (xs: WeightedSet<'K, 'W> seq) : WeightedSet<'K, 'W> =
+        Seq.fold (add sr) empty xs
+
+    /// The nonzero coordinates (the support / SDR active set), ordinal-ordered.
+    let support (ws: WeightedSet<'K, 'W>) : 'K list = ws.Entries |> Map.toList |> List.map fst
+
+    /// All `(coordinate, weight)` pairs, ordinal-ordered.
+    let toSeq (ws: WeightedSet<'K, 'W>) : ('K * 'W) seq = Map.toSeq ws.Entries

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -84,6 +84,7 @@
     <Compile Include="Globals.Tests.fs" />
     <Compile Include="TensorRef.Tests.fs" />
     <Compile Include="DynamicValueAlgebra.Tests.fs" />
+    <Compile Include="WeightedSet.Tests.fs" />
     <Compile Include="DagFs.Tests.fs" />
     <Compile Include="Confluence.Tests.fs" />
     <Compile Include="DebeziumCdc.Tests.fs" />

--- a/tests/Tests.FSharp/WeightedSet.Tests.fs
+++ b/tests/Tests.FSharp/WeightedSet.Tests.fs
@@ -1,0 +1,74 @@
+module Zeta.Tests.WeightedSetTests
+
+open global.Xunit
+open Zeta.Core
+
+module WS = Zeta.Core.WeightedSet
+
+let private sr = IntegerRing.Instance // the ring ZSet uses; WeightedSet<_,int64> is the Z-set instance
+
+[<Fact>]
+let ``ofSeq combines duplicate coordinates via Add and prunes Zero`` () =
+    let ws = WS.ofSeq sr [ "a", 1L; "b", 2L; "a", 3L; "c", 0L ]
+    Assert.Equal(4L, WS.weight sr "a" ws) // 1+3
+    Assert.Equal(2L, WS.weight sr "b" ws)
+    Assert.Equal(0L, WS.weight sr "c" ws) // 0 weight pruned -> absent -> Zero
+    Assert.Equal(2, WS.count ws) // c not stored
+    Assert.Equal<string list>([ "a"; "b" ], WS.support ws)
+
+[<Fact>]
+let ``add is retraction-native: a + (-a) = empty`` () =
+    let a = WS.ofSeq sr [ "x", 5L; "y", -2L ]
+    Assert.True(WS.isEmpty (WS.add sr a (WS.negate sr a)))
+    // partial cancellation prunes the zeroed coordinate
+    let b = WS.ofSeq sr [ "x", -5L ]
+    let r = WS.add sr a b
+    Assert.Equal<string list>([ "y" ], WS.support r)
+    Assert.Equal(-2L, WS.weight sr "y" r)
+
+[<Fact>]
+let ``add is commutative and associative (semiring laws lift)`` () =
+    let a = WS.ofSeq sr [ "p", 1L; "q", 2L ]
+    let b = WS.ofSeq sr [ "q", 3L; "r", 4L ]
+    let c = WS.ofSeq sr [ "p", -1L; "s", 5L ]
+    Assert.Equal<WS.WeightedSet<string, int64>>(WS.add sr a b, WS.add sr b a)
+    Assert.Equal<WS.WeightedSet<string, int64>>(WS.add sr (WS.add sr a b) c, WS.add sr a (WS.add sr b c))
+
+[<Fact>]
+let ``scale by Zero annihilates; scale by One is identity; scale distributes over add`` () =
+    let a = WS.ofSeq sr [ "a", 2L; "b", 3L ]
+    Assert.True(WS.isEmpty (WS.scale sr 0L a)) // ×Zero annihilator
+    Assert.Equal<WS.WeightedSet<string, int64>>(a, WS.scale sr 1L a) // ×One identity
+
+    let b = WS.ofSeq sr [ "b", 1L; "c", 4L ]
+    // k*(a+b) = k*a + k*b
+    let lhs = WS.scale sr 3L (WS.add sr a b)
+    let rhs = WS.add sr (WS.scale sr 3L a) (WS.scale sr 3L b)
+    Assert.Equal<WS.WeightedSet<string, int64>>(lhs, rhs)
+
+[<Fact>]
+let ``inner is the contraction over shared coordinates (SDR overlap for 0/1 weights)`` () =
+    // dot product over the integer ring
+    let a = WS.ofSeq sr [ "x", 2L; "y", 3L; "z", 1L ]
+    let b = WS.ofSeq sr [ "y", 4L; "z", 5L; "w", 9L ]
+    Assert.Equal(3L * 4L + 1L * 5L, WS.inner sr a b) // shared y,z only
+
+    // SDR overlap: 0/1 weights, inner = count of shared active coordinates
+    let sdr xs = WS.ofSeq sr [ for k in xs -> k, 1L ]
+    let s1 = sdr [ "f1"; "f3"; "f7"; "f9" ]
+    let s2 = sdr [ "f3"; "f7"; "f8" ]
+    Assert.Equal(2L, WS.inner sr s1 s2) // f3, f7 overlap
+
+[<Fact>]
+let ``sum is order-independent; mapKeys merges collisions`` () =
+    let parts = [ WS.ofSeq sr [ "a", 1L ]; WS.ofSeq sr [ "b", 2L ]; WS.ofSeq sr [ "a", 1L ] ]
+    let forward = WS.sum sr parts
+    let reversed = WS.sum sr (List.rev parts)
+    Assert.Equal<WS.WeightedSet<string, int64>>(forward, reversed)
+    Assert.Equal(2L, WS.weight sr "a" forward) // 1+1 across parts
+
+    // mapKeys collapsing two coordinates onto one merges their weights via Add
+    let ws = WS.ofSeq sr [ "a", 1L; "b", 2L ]
+    let collapsed = WS.mapKeys sr (fun _ -> "k") ws
+    Assert.Equal(3L, WS.weight sr "k" collapsed)
+    Assert.Equal(1, WS.count collapsed)


### PR DESCRIPTION
Aaron 2026-06-07 (picked next): the tensor-algebra gap. WeightedSet<'K,'W> = coordinate -> weight over an
ISemiring<'W>, instance-passing. ZSet stays the IntegerRing instance (int64 hot path untouched, parallel
not generalized); soft tensor = IntervalRing/ProbabilitySemiring instance; 0/1 weights = SDR (support=active
set, inner=overlap). Canonical (Zero pruned -> add a (negate a)=empty, retraction-native like ZSet).
GraphBLAS-shaped: add=⊕, scale=⊗, inner=contraction. 6 law tests (combine/retraction/commut+assoc/
distributivity/annihilator/SDR-overlap/order-independence). Core+tests green. ITensor C# contract over
{dense Tensor<T>, sparse WeightedSet} remains the API-reviewed next step.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
