### PR TITLE
feat(flash): Windows USB flasher (mac-parity rails; logic unit-tested on Mac)

### DIFF
--- a/full-ai-cluster/tools/README-flash-usb-windows.md
+++ b/full-ai-cluster/tools/README-flash-usb-windows.md
@@ -1,0 +1,75 @@
+# flash-usb-windows.ts — Windows USB flasher
+
+Windows counterpart of `flash-usb.ts` (macOS). Writes the AI-cluster
+installer ISO to a USB stick with the **same safety rails**.
+
+## Usage
+
+Run from an **elevated** (Administrator) PowerShell — this is the Windows
+equivalent of macOS `sudo` + Touch ID (the UAC / Administrator prompt is
+the physical-presence gate; Windows Hello applies if configured):
+
+```powershell
+# Right-click PowerShell -> Run as administrator, then:
+bun full-ai-cluster\tools\flash-usb-windows.ts            # auto-discovers newest %USERPROFILE%\Downloads\zeta-installer-*.iso
+bun full-ai-cluster\tools\flash-usb-windows.ts C:\path\to\zeta-installer-25.11.iso
+bun full-ai-cluster\tools\flash-usb-windows.ts --short    # shorter `yes <4-hex>` confirm
+bun full-ai-cluster\tools\flash-usb-windows.ts --dry-run  # print device + planned commands, write NOTHING
+```
+
+It prints the selected device + its volumes + a `*** WILL BE DESTROYED ***`
+warning, then a random nonce you must type back before it writes.
+
+## Safety rails (identical to the macOS tool)
+
+| Rail | Enforced by |
+|---|---|
+| Platform = Windows | `process.platform === "win32"` |
+| Administrator (elevated) | `psIsAdminScript()` — refuses otherwise |
+| ISO is `*.iso`, size 200 MiB – 8 GiB | `validateIso()` |
+| Target bus = USB | `selectUsbCandidate()` |
+| Target is **not** the boot/system disk | `IsBoot` / `IsSystem` must be false |
+| Target size 4 GiB – 256 GiB | `selectUsbCandidate()` |
+| Exactly one USB candidate (else refuse) | `selectUsbCandidate()` |
+| Per-run random nonce, typed back | `makeNonce()` / `buildShortChallenge()` |
+
+macOS → Windows mapping: `diskutil list` → `Get-Disk`; `BusProtocol=USB` →
+`BusType=USB`; `Internal` → `IsBoot`/`IsSystem`; `diskutil unmountDisk` →
+`Set-Disk -IsOffline $true`; `sudo dd of=/dev/rdiskN` → raw write to
+`\\.\PhysicalDriveN`; `diskutil eject` → `Set-Disk -IsOffline $false`.
+
+## How it's tested *without* a Windows machine
+
+The architecture puts every data-loss-critical decision in pure,
+exported TypeScript so `flash-usb-windows.test.ts` validates it via
+`bun test` on macOS/Linux/CI:
+
+- **Device selection + rails** — `selectUsbCandidate()` is tested against
+  realistic `Get-Disk` JSON fixtures: it picks the lone USB stick and
+  **refuses** the system/boot disk, non-USB disks, an oversize external
+  SSD, an undersize device, and the "more than one USB" case.
+- **The actual byte-copy** — `copyImageToDevice()` is the real write loop.
+  The test copies a fake ISO into a temp "device" file and asserts the
+  result is **byte-identical** to the image and **zero-padded up to a
+  sector boundary** (the `dd conv=sync` equivalent). This is the part
+  that, if wrong, corrupts the stick — and it's the same code path that
+  runs on Windows (node can open `\\.\PhysicalDriveN` after the disk is
+  offline).
+- **Command construction, nonce, ISO discovery** — all unit-tested.
+
+What the unit tests *cannot* cover on macOS: opening the literal
+`\\.\PhysicalDriveN` handle, `Set-Disk -IsOffline`, and the UAC prompt —
+those are thin wrappers around the tested logic and require a Windows
+box (or a Windows VM with a virtual USB disk) for an end-to-end run.
+`--dry-run` on a Windows machine exercises the full selection + planning
+path without writing.
+
+## Follow-ups
+
+- A `zflash-windows.ts` short wrapper (mirroring `zflash.ts`: CI-ISO pull
+  + ultra-short invocation).
+- An `--agent` mode (auto-type the nonce) for agent-driven flashing.
+- End-to-end CI via a Windows VM with a virtual USB disk (verify the
+  written disk's first bytes match the ISO).
+
+(Tracked under the Windows-extension backlog row, B-0739.)

--- a/full-ai-cluster/tools/flash-usb-windows.test.ts
+++ b/full-ai-cluster/tools/flash-usb-windows.test.ts
@@ -1,0 +1,250 @@
+/**
+ * full-ai-cluster/tools/flash-usb-windows.test.ts
+ *
+ * Runs on ANY OS (bun test). Validates the dangerous decision logic of
+ * the Windows flasher — device selection, safety rails, the confirm
+ * nonce, the PowerShell command construction, and (critically) the raw
+ * byte-copy that actually writes the image — without needing a Windows
+ * box or a real USB stick.
+ */
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync, readFileSync, utimesSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  MIN_USB_BYTES,
+  MAX_USB_BYTES,
+  MIN_ISO_BYTES,
+  MAX_ISO_BYTES,
+  parseGetDiskJson,
+  selectUsbCandidate,
+  validateIso,
+  physicalDrivePath,
+  buildShortChallenge,
+  makeNonce,
+  psGetDiskScript,
+  psIsAdminScript,
+  psSetReadonlyScript,
+  psSetOfflineScript,
+  psListVolumesScript,
+  copyImageToDevice,
+  autoDiscoverIso,
+  human,
+  type WinDisk,
+} from "./flash-usb-windows.ts";
+
+const GiB = 1024 * 1024 * 1024;
+
+function disk(p: Partial<WinDisk>): WinDisk {
+  return {
+    number: 0,
+    friendlyName: "Generic USB",
+    serialNumber: "SER123",
+    busType: "USB",
+    size: 32 * GiB,
+    isBoot: false,
+    isSystem: false,
+    isReadOnly: false,
+    operationalStatus: "Online",
+    partitionStyle: "MBR",
+    ...p,
+  };
+}
+
+describe("parseGetDiskJson", () => {
+  test("parses a single-disk object (ConvertTo-Json non-array)", () => {
+    const json = JSON.stringify({
+      Number: 2,
+      FriendlyName: "SanDisk Ultra",
+      SerialNumber: "ABC",
+      BusType: "USB",
+      Size: 32 * GiB,
+      IsBoot: false,
+      IsSystem: false,
+      IsReadOnly: false,
+      OperationalStatus: "Online",
+      PartitionStyle: "MBR",
+    });
+    const d = parseGetDiskJson(json);
+    expect(d).toHaveLength(1);
+    expect(d[0]!.number).toBe(2);
+    expect(d[0]!.busType).toBe("USB");
+    expect(d[0]!.size).toBe(32 * GiB);
+  });
+
+  test("parses a multi-disk array + flattens {value} enum objects", () => {
+    const json = JSON.stringify([
+      { Number: 0, BusType: "NVMe", Size: 1024 * GiB, IsBoot: true, IsSystem: true },
+      { Number: 1, BusType: { value: "USB" }, Size: 16 * GiB, OperationalStatus: { value: "Online" } },
+    ]);
+    const d = parseGetDiskJson(json);
+    expect(d).toHaveLength(2);
+    expect(d[1]!.busType).toBe("USB"); // flattened from { value: "USB" }
+    expect(d[1]!.operationalStatus).toBe("Online");
+    expect(d[0]!.isBoot).toBe(true);
+  });
+});
+
+describe("selectUsbCandidate — safety rails", () => {
+  test("picks the single eligible USB disk", () => {
+    const sel = selectUsbCandidate([
+      disk({ number: 0, busType: "NVMe", size: 1024 * GiB, isBoot: true, isSystem: true }),
+      disk({ number: 2, busType: "USB", size: 32 * GiB }),
+    ]);
+    expect(sel.ok).toBe(true);
+    if (sel.ok) expect(sel.disk.number).toBe(2);
+  });
+
+  test("REFUSES the system/boot disk even if it were USB", () => {
+    const sel = selectUsbCandidate([disk({ number: 0, busType: "USB", isBoot: true, isSystem: true })]);
+    expect(sel.ok).toBe(false);
+  });
+
+  test("REFUSES non-USB disks (internal SATA/NVMe)", () => {
+    const sel = selectUsbCandidate([disk({ number: 0, busType: "SATA" }), disk({ number: 1, busType: "NVMe" })]);
+    expect(sel.ok).toBe(false);
+  });
+
+  test("REFUSES an oversize external drive (e.g. 4 TB SSD)", () => {
+    const sel = selectUsbCandidate([disk({ number: 3, busType: "USB", size: 4096 * GiB })]);
+    expect(sel.ok).toBe(false);
+    if (!sel.ok) expect(sel.code).toBe(2);
+  });
+
+  test("REFUSES an undersize device below the floor", () => {
+    const sel = selectUsbCandidate([disk({ number: 3, busType: "USB", size: 1 * GiB })]);
+    expect(sel.ok).toBe(false);
+  });
+
+  test("REFUSES when MORE THAN ONE USB candidate is present", () => {
+    const sel = selectUsbCandidate([
+      disk({ number: 2, busType: "USB", size: 32 * GiB }),
+      disk({ number: 3, busType: "USB", size: 64 * GiB }),
+    ]);
+    expect(sel.ok).toBe(false);
+    if (!sel.ok) expect(sel.message).toContain("multiple USB candidates");
+  });
+
+  test("REFUSES when there is NO USB candidate", () => {
+    const sel = selectUsbCandidate([disk({ number: 0, busType: "NVMe", isBoot: true, isSystem: true })]);
+    expect(sel.ok).toBe(false);
+  });
+
+  test("rails match the macOS tool's size bounds", () => {
+    expect(MIN_USB_BYTES).toBe(4 * GiB);
+    expect(MAX_USB_BYTES).toBe(256 * GiB);
+    expect(MIN_ISO_BYTES).toBe(200 * 1024 * 1024);
+    expect(MAX_ISO_BYTES).toBe(8 * GiB);
+  });
+});
+
+describe("validateIso", () => {
+  test("accepts a valid .iso of sane size", () => {
+    expect(validateIso("C:/Users/x/Downloads/zeta-installer-25.11.iso", 1500 * 1024 * 1024, true).ok).toBe(true);
+  });
+  test("rejects wrong extension", () => {
+    expect(validateIso("foo.img", 1500 * 1024 * 1024, true).ok).toBe(false);
+  });
+  test("rejects too-small / too-large / non-file", () => {
+    expect(validateIso("a.iso", 1024, true).ok).toBe(false);
+    expect(validateIso("a.iso", 20 * GiB, true).ok).toBe(false);
+    expect(validateIso("a.iso", 1500 * 1024 * 1024, false).ok).toBe(false);
+  });
+});
+
+describe("nonce + device path + PowerShell builders", () => {
+  test("physicalDrivePath formats \\\\.\\PhysicalDriveN and rejects bad input", () => {
+    expect(physicalDrivePath(2)).toBe("\\\\.\\PhysicalDrive2");
+    expect(() => physicalDrivePath(-1)).toThrow();
+    expect(() => physicalDrivePath(1.5)).toThrow();
+  });
+  test("makeNonce yields 4 lowercase hex; challenge wraps it", () => {
+    const n = makeNonce(() => 0.5); // deterministic
+    expect(n).toMatch(/^[0-9a-f]{4}$/);
+    expect(buildShortChallenge(n)).toBe(`yes ${n}`);
+    expect(() => buildShortChallenge("xyz")).toThrow();
+  });
+  test("PS scripts embed the right disk number + flags", () => {
+    expect(psGetDiskScript()).toContain("Get-Disk");
+    expect(psGetDiskScript()).toContain("ConvertTo-Json");
+    expect(psIsAdminScript()).toContain("Administrator");
+    expect(psSetReadonlyScript(2, false)).toBe("Set-Disk -Number 2 -IsReadOnly $false");
+    expect(psSetOfflineScript(2, true)).toBe("Set-Disk -Number 2 -IsOffline $true");
+    expect(psSetOfflineScript(2, false)).toBe("Set-Disk -Number 2 -IsOffline $false");
+    expect(psListVolumesScript(2)).toContain("Get-Partition -DiskNumber 2");
+  });
+});
+
+describe("copyImageToDevice — the actual write path (byte-exact)", () => {
+  test("copies all bytes and pads the final short block to a sector with zeros", () => {
+    const dir = mkdtempSync(join(tmpdir(), "flashwin-"));
+    const isoPath = join(dir, "fake.iso");
+    const destPath = join(dir, "device.bin");
+    // 5000 bytes -> with sector 512 the padded total is ceil(5000/512)*512 = 5120
+    const isoBuf = Buffer.alloc(5000);
+    for (let i = 0; i < isoBuf.length; i++) isoBuf[i] = (i * 7 + 3) & 0xff;
+    writeFileSync(isoPath, isoBuf);
+    writeFileSync(destPath, Buffer.alloc(0)); // pre-create so "r+" can open it
+
+    const res = copyImageToDevice({ isoPath, destPath, chunkSize: 1024, sectorSize: 512 });
+
+    expect(res.isoBytes).toBe(5000);
+    expect(res.bytesWritten).toBe(5120); // padded up to a 512 multiple
+    const out = readFileSync(destPath);
+    expect(out.length).toBe(5120);
+    expect(out.subarray(0, 5000).equals(isoBuf)).toBe(true); // image bytes intact
+    expect(out.subarray(5000).every((b) => b === 0)).toBe(true); // tail zero-padded
+  });
+
+  test("no extra padding when the image is already a sector multiple", () => {
+    const dir = mkdtempSync(join(tmpdir(), "flashwin-"));
+    const isoPath = join(dir, "aligned.iso");
+    const destPath = join(dir, "device2.bin");
+    const isoBuf = Buffer.alloc(4096, 0xab); // exact multiple of 512
+    writeFileSync(isoPath, isoBuf);
+    writeFileSync(destPath, Buffer.alloc(0));
+
+    const res = copyImageToDevice({ isoPath, destPath, chunkSize: 1024, sectorSize: 512 });
+    expect(res.isoBytes).toBe(4096);
+    expect(res.bytesWritten).toBe(4096);
+    expect(readFileSync(destPath).equals(isoBuf)).toBe(true);
+  });
+
+  test("rejects a chunkSize that is not a multiple of the sector size", () => {
+    expect(() =>
+      copyImageToDevice({ isoPath: "x", destPath: "y", chunkSize: 1000, sectorSize: 512 }),
+    ).toThrow();
+  });
+});
+
+describe("autoDiscoverIso", () => {
+  test("picks the NEWEST zeta-installer-*.iso, ignoring other files", () => {
+    const dir = mkdtempSync(join(tmpdir(), "flashwin-dl-"));
+    const older = join(dir, "zeta-installer-25.11.iso");
+    const newer = join(dir, "zeta-installer-25.11-k3sfix.iso");
+    writeFileSync(older, "x");
+    writeFileSync(newer, "y");
+    writeFileSync(join(dir, "some-other.iso"), "z"); // wrong prefix
+    writeFileSync(join(dir, "notes.txt"), "z");
+    // make `newer` newer by mtime
+    utimesSync(older, new Date(1000), new Date(1000));
+    utimesSync(newer, new Date(2000), new Date(2000));
+
+    const found = autoDiscoverIso(dir);
+    expect(found).toBe(newer);
+  });
+
+  test("returns null when Downloads has no matching ISO", () => {
+    const dir = mkdtempSync(join(tmpdir(), "flashwin-empty-"));
+    expect(autoDiscoverIso(dir)).toBeNull();
+    expect(autoDiscoverIso(join(dir, "does-not-exist"))).toBeNull();
+  });
+});
+
+describe("human() formatting", () => {
+  test("formats bytes in IEC units", () => {
+    expect(human(0)).toBe("0.00 B");
+    expect(human(1536)).toBe("1.50 KiB");
+    expect(human(32 * GiB)).toBe("32.00 GiB");
+  });
+});

--- a/full-ai-cluster/tools/flash-usb-windows.ts
+++ b/full-ai-cluster/tools/flash-usb-windows.ts
@@ -1,0 +1,436 @@
+#!/usr/bin/env bun
+/**
+ * full-ai-cluster/tools/flash-usb-windows.ts
+ *
+ * Windows equivalent of flash-usb.ts (macOS): write the AI-cluster
+ * installer ISO to a USB stick, with the SAME safety rails.
+ *
+ * Design — testable on any OS:
+ *   - All the dangerous decision logic (device selection, safety rails,
+ *     the confirm nonce, and the raw byte-copy) is pure TypeScript and
+ *     exported, so flash-usb-windows.test.ts can verify it on macOS/Linux
+ *     against realistic `Get-Disk` JSON fixtures + temp-file byte copies.
+ *   - Only the genuinely Windows-specific operations (enumerate disks,
+ *     take a disk offline, open \\.\PhysicalDriveN) go through an
+ *     injectable CommandRunner / the node fs path, so they're swappable
+ *     in tests.
+ *
+ * macOS ↔ Windows mapping:
+ *   diskutil list -plist        ->  Get-Disk | ConvertTo-Json
+ *   BusProtocol == "USB"        ->  BusType == "USB"
+ *   info.Internal === true      ->  IsBoot / IsSystem
+ *   diskutil unmountDisk        ->  Set-Disk -IsOffline $true
+ *   sudo dd of=/dev/rdiskN      ->  raw write to \\.\PhysicalDriveN (admin)
+ *   sudo (Touch ID / PAM)       ->  Administrator elevation (UAC / Windows Hello)
+ *   diskutil eject              ->  Set-Disk -IsOffline $false
+ *
+ * Usage (run from an ELEVATED PowerShell/terminal):
+ *   bun full-ai-cluster\tools\flash-usb-windows.ts [flags] [iso-path]
+ *     --short      shorter `yes <4-hex>` challenge format
+ *     --dry-run    print the plan (device + commands) and exit; NO write
+ *     -h, --help
+ *   iso-path defaults to the newest %USERPROFILE%\Downloads\zeta-installer-*.iso
+ *
+ * Exit codes: 0 success; 1 runtime failure; 2 usage / safety-rail refusal.
+ */
+
+import {
+  closeSync,
+  existsSync,
+  fstatSync,
+  openSync,
+  readdirSync,
+  readSync,
+  statSync,
+  writeSync,
+  fsyncSync,
+} from "node:fs";
+import { execFileSync } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// ── Safety-rail constants (mirror flash-usb.ts exactly) ──────────────
+export const MIN_ISO_BYTES = 200 * 1024 * 1024;
+export const MAX_ISO_BYTES = 8 * 1024 * 1024 * 1024;
+export const MIN_USB_BYTES = 4 * 1024 * 1024 * 1024;
+export const MAX_USB_BYTES = 256 * 1024 * 1024 * 1024;
+
+export const ISO_GLOB_PREFIX = "zeta-installer-";
+
+export function human(bytes: number): string {
+  const u = ["B", "KiB", "MiB", "GiB", "TiB"];
+  let n = bytes;
+  let i = 0;
+  while (n >= 1024 && i < u.length - 1) {
+    n /= 1024;
+    i++;
+  }
+  return `${n.toFixed(2)} ${u[i]}`;
+}
+
+// ── Pure logic ───────────────────────────────────────────────────────
+
+export interface WinDisk {
+  readonly number: number;
+  readonly friendlyName: string;
+  readonly serialNumber: string | null;
+  readonly busType: string;
+  readonly size: number;
+  readonly isBoot: boolean;
+  readonly isSystem: boolean;
+  readonly isReadOnly: boolean;
+  readonly operationalStatus: string;
+  readonly partitionStyle: string;
+}
+
+/**
+ * Parse `Get-Disk | Select ... | ConvertTo-Json` output. ConvertTo-Json
+ * emits a bare object for one disk and an array for many — normalize both.
+ */
+export function parseGetDiskJson(jsonText: string): WinDisk[] {
+  const raw = JSON.parse(jsonText);
+  const arr: unknown[] = Array.isArray(raw) ? raw : [raw];
+  return arr.map((d) => {
+    const o = d as Record<string, unknown>;
+    const num = (v: unknown): number => (typeof v === "number" ? v : Number(v ?? 0));
+    const str = (v: unknown): string => (v == null ? "" : String(v));
+    // PowerShell booleans survive JSON as true/false; OperationalStatus +
+    // PartitionStyle sometimes serialize as { value, ... } objects.
+    const flat = (v: unknown): string =>
+      v != null && typeof v === "object" && "value" in (v as object)
+        ? String((v as { value: unknown }).value)
+        : str(v);
+    return {
+      number: num(o.Number),
+      friendlyName: str(o.FriendlyName),
+      serialNumber: o.SerialNumber == null ? null : str(o.SerialNumber),
+      busType: flat(o.BusType),
+      size: num(o.Size),
+      isBoot: o.IsBoot === true,
+      isSystem: o.IsSystem === true,
+      isReadOnly: o.IsReadOnly === true,
+      operationalStatus: flat(o.OperationalStatus),
+      partitionStyle: flat(o.PartitionStyle),
+    };
+  });
+}
+
+export type Selection =
+  | { readonly ok: true; readonly disk: WinDisk }
+  | { readonly ok: false; readonly code: 1 | 2; readonly message: string };
+
+/**
+ * Apply the safety rails and pick exactly one USB target. Mirrors the
+ * macOS rails: USB bus, NOT boot/system, size in [4 GiB, 256 GiB], and
+ * exactly one candidate (refuse on 0 or >1 — the operator must isolate
+ * the target by unplugging the others).
+ */
+export function selectUsbCandidate(disks: readonly WinDisk[]): Selection {
+  const candidates = disks.filter(
+    (d) =>
+      d.busType.toUpperCase() === "USB" &&
+      !d.isBoot &&
+      !d.isSystem &&
+      d.size >= MIN_USB_BYTES &&
+      d.size <= MAX_USB_BYTES,
+  );
+  if (candidates.length === 0) {
+    const seen = disks
+      .map((d) => `  disk ${d.number} ${d.friendlyName} bus=${d.busType} ${human(d.size)} boot=${d.isBoot} system=${d.isSystem}`)
+      .join("\n");
+    return {
+      ok: false,
+      code: 2,
+      message:
+        `no eligible USB target found (need: BusType=USB, not boot/system disk, size in ` +
+        `[${human(MIN_USB_BYTES)}, ${human(MAX_USB_BYTES)}]).\nDisks seen:\n${seen || "  (none)"}`,
+    };
+  }
+  if (candidates.length > 1) {
+    const list = candidates
+      .map((d) => `  disk ${d.number} ${d.friendlyName} ${human(d.size)}`)
+      .join("\n");
+    return {
+      ok: false,
+      code: 2,
+      message:
+        `multiple USB candidates — refusing to pick one. Unplug all but the target USB and re-run:\n${list}`,
+    };
+  }
+  return { ok: true, disk: candidates[0]! };
+}
+
+export type IsoCheck = { readonly ok: true } | { readonly ok: false; readonly message: string };
+
+export function validateIso(isoPath: string, sizeBytes: number, isFile: boolean): IsoCheck {
+  if (!isoPath.toLowerCase().endsWith(".iso")) return { ok: false, message: `expected a *.iso file, got: ${isoPath}` };
+  if (!isFile) return { ok: false, message: `ISO path is not a file: ${isoPath}` };
+  if (sizeBytes < MIN_ISO_BYTES || sizeBytes > MAX_ISO_BYTES) {
+    return {
+      ok: false,
+      message: `ISO size ${human(sizeBytes)} outside sane range [${human(MIN_ISO_BYTES)}, ${human(MAX_ISO_BYTES)}]`,
+    };
+  }
+  return { ok: true };
+}
+
+export function physicalDrivePath(diskNumber: number): string {
+  if (!Number.isInteger(diskNumber) || diskNumber < 0) {
+    throw new Error(`invalid physical drive number: ${diskNumber}`);
+  }
+  return `\\\\.\\PhysicalDrive${diskNumber}`;
+}
+
+/** 4-hex nonce (matches flash-usb.ts --short). Caller supplies randomness. */
+export function buildShortChallenge(nonceHex4: string): string {
+  if (!/^[0-9a-f]{4}$/.test(nonceHex4)) throw new Error(`nonce must be 4 lowercase hex chars, got: ${nonceHex4}`);
+  return `yes ${nonceHex4}`;
+}
+
+export function makeNonce(rng: () => number = Math.random): string {
+  return Math.floor(rng() * 0x10000)
+    .toString(16)
+    .padStart(4, "0");
+}
+
+// PowerShell command builders (pure → assert-able in tests).
+export function psGetDiskScript(): string {
+  return (
+    "Get-Disk | Select-Object Number,FriendlyName,SerialNumber,BusType,Size," +
+    "IsBoot,IsSystem,IsReadOnly,OperationalStatus,PartitionStyle | ConvertTo-Json -Depth 3"
+  );
+}
+export function psIsAdminScript(): string {
+  return (
+    "[bool](([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent())" +
+    ".IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator))"
+  );
+}
+export function psSetReadonlyScript(diskNumber: number, ro: boolean): string {
+  return `Set-Disk -Number ${diskNumber} -IsReadOnly $${ro ? "true" : "false"}`;
+}
+export function psSetOfflineScript(diskNumber: number, offline: boolean): string {
+  return `Set-Disk -Number ${diskNumber} -IsOffline $${offline ? "true" : "false"}`;
+}
+export function psListVolumesScript(diskNumber: number): string {
+  return (
+    `Get-Partition -DiskNumber ${diskNumber} -ErrorAction SilentlyContinue | ` +
+    `Get-Volume -ErrorAction SilentlyContinue | ` +
+    `Select-Object DriveLetter,FileSystemLabel,Size | ConvertTo-Json -Depth 3`
+  );
+}
+
+// ── Raw byte copy (pure; the data-write path — fully testable) ───────
+
+export interface CopyOpts {
+  readonly isoPath: string;
+  readonly destPath: string;
+  readonly chunkSize?: number; // default 4 MiB
+  readonly sectorSize?: number; // default 4096 (works for 512- and 4096-sector drives)
+  readonly openFlag?: string; // default "r+" (physical drive / existing file)
+  readonly onProgress?: (writtenBytes: number, totalBytes: number) => void;
+}
+
+/**
+ * Copy an ISO image to a destination, padding the final write up to a
+ * sector boundary with zeros (raw block devices require sector-aligned
+ * writes — the equivalent of dd's `conv=sync`). Works on a real
+ * \\.\PhysicalDriveN handle on Windows AND on a plain temp file (tests).
+ * Returns the number of bytes written (>= ISO size, padded).
+ */
+export function copyImageToDevice(o: CopyOpts): { bytesWritten: number; isoBytes: number } {
+  const chunk = o.chunkSize ?? 4 * 1024 * 1024;
+  const sector = o.sectorSize ?? 4096;
+  if (chunk % sector !== 0) throw new Error(`chunkSize ${chunk} must be a multiple of sectorSize ${sector}`);
+  const src = openSync(o.isoPath, "r");
+  const dst = openSync(o.destPath, o.openFlag ?? "r+");
+  try {
+    const total = fstatSync(src).size;
+    const buf = Buffer.allocUnsafe(chunk);
+    let written = 0;
+    let srcPos = 0;
+    while (srcPos < total) {
+      const n = readSync(src, buf, 0, chunk, srcPos);
+      if (n <= 0) break;
+      let len = n;
+      if (len % sector !== 0) {
+        const padded = Math.ceil(len / sector) * sector;
+        buf.fill(0, len, padded);
+        len = padded;
+      }
+      // dest write offset tracks `written` (always sector-aligned).
+      writeSync(dst, buf, 0, len, written);
+      written += len;
+      srcPos += n;
+      o.onProgress?.(Math.min(srcPos, total), total);
+    }
+    fsyncSync(dst);
+    return { bytesWritten: written, isoBytes: total };
+  } finally {
+    closeSync(src);
+    closeSync(dst);
+  }
+}
+
+// ── ISO auto-discovery (mirror zflash) ───────────────────────────────
+export function autoDiscoverIso(downloadsDir: string): string | null {
+  if (!existsSync(downloadsDir)) return null;
+  const candidates = readdirSync(downloadsDir)
+    .filter((f) => f.startsWith(ISO_GLOB_PREFIX) && f.toLowerCase().endsWith(".iso"))
+    .map((f) => join(downloadsDir, f))
+    .filter((p) => {
+      try {
+        return statSync(p).isFile();
+      } catch {
+        return false;
+      }
+    });
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => statSync(b).mtimeMs - statSync(a).mtimeMs);
+  return candidates[0]!;
+}
+
+// ── Side-effecting layer (injectable for the orchestrator/tests) ─────
+export interface CommandRunner {
+  ps(script: string): string;
+}
+
+const realRunner: CommandRunner = {
+  ps(script: string): string {
+    // Prefer Windows PowerShell; fall back to pwsh (PowerShell Core).
+    const bin = process.platform === "win32" ? "powershell" : "pwsh";
+    return execFileSync(bin, ["-NoProfile", "-NonInteractive", "-Command", script], {
+      encoding: "utf8",
+      maxBuffer: 16 * 1024 * 1024,
+    });
+  },
+};
+
+function bail(code: 1 | 2, msg: string): never {
+  process.stderr.write(`flash-usb-windows: ${msg}\n`);
+  process.exit(code);
+}
+
+async function main(runner: CommandRunner = realRunner): Promise<void> {
+  const argv = process.argv.slice(2);
+  const short = argv.includes("--short");
+  const dryRun = argv.includes("--dry-run");
+  if (argv.includes("-h") || argv.includes("--help")) {
+    process.stdout.write(
+      "usage: bun full-ai-cluster\\tools\\flash-usb-windows.ts [--short] [--dry-run] [iso-path]\n" +
+        "  run from an ELEVATED (Administrator) terminal\n",
+    );
+    process.exit(0);
+  }
+  const positional = argv.filter((a) => !a.startsWith("-"));
+  if (positional.length > 1) bail(2, `at most one ISO path expected, got ${positional.length}`);
+
+  if (process.platform !== "win32") {
+    bail(2, "this tool only runs on Windows. On macOS use flash-usb.ts / zflash.ts.");
+  }
+
+  // Elevation gate — the Windows equivalent of sudo + Touch ID.
+  const admin = runner.ps(psIsAdminScript()).trim().toLowerCase().startsWith("true");
+  if (!admin && !dryRun) {
+    bail(
+      2,
+      "not elevated. Re-run from an Administrator PowerShell (right-click → " +
+        "Run as administrator), OR press Win, type 'PowerShell', and Ctrl+Shift+Enter.",
+    );
+  }
+
+  // Resolve + validate ISO.
+  const isoPath = positional[0] ?? autoDiscoverIso(join(homedir(), "Downloads"));
+  if (!isoPath) bail(2, `no zeta-installer-*.iso under %USERPROFILE%\\Downloads; pass an ISO path explicitly`);
+  if (!existsSync(isoPath)) bail(2, `ISO file does not exist: ${isoPath}`);
+  const st = statSync(isoPath);
+  const iso = validateIso(isoPath, st.size, st.isFile());
+  if (!iso.ok) bail(2, iso.message);
+  process.stdout.write(`ISO: ${isoPath} (${human(st.size)})\n`);
+
+  // Enumerate + select.
+  const disks = parseGetDiskJson(runner.ps(psGetDiskScript()));
+  const sel = selectUsbCandidate(disks);
+  if (!sel.ok) bail(sel.code, sel.message);
+  const disk = sel.disk;
+  const drivePath = physicalDrivePath(disk.number);
+
+  process.stdout.write(
+    `\nUSB device identified:\n` +
+      `  Disk number: ${disk.number}  (${drivePath})\n` +
+      `  Model:       ${disk.friendlyName}\n` +
+      `  Serial:      ${disk.serialNumber ?? "?"}\n` +
+      `  Size:        ${human(disk.size)}\n` +
+      `  Bus:         ${disk.busType}\n` +
+      `  Boot disk:   ${disk.isBoot} | System disk: ${disk.isSystem}\n`,
+  );
+  try {
+    const vols = runner.ps(psListVolumesScript(disk.number)).trim();
+    if (vols) process.stdout.write(`\nCurrent volumes on disk ${disk.number} (will be DESTROYED):\n${vols}\n`);
+  } catch {
+    /* volume listing is best-effort */
+  }
+  process.stdout.write(`\n*** ALL DATA ON disk ${disk.number} (${drivePath}) WILL BE DESTROYED ***\n`);
+
+  const nonce = makeNonce();
+  const phrase = short ? buildShortChallenge(nonce) : `accept-destroy ${disk.number} ${nonce}${nonce}`;
+
+  if (dryRun) {
+    process.stdout.write(
+      `\n[dry-run] would prompt for: ${phrase}\n` +
+        `[dry-run] would run:\n` +
+        `  ${psSetReadonlyScript(disk.number, false)}\n` +
+        `  ${psSetOfflineScript(disk.number, true)}\n` +
+        `  <raw copy ${isoPath} -> ${drivePath}, sector-padded>\n` +
+        `  ${psSetOfflineScript(disk.number, false)}\n` +
+        `[dry-run] no changes made.\n`,
+    );
+    process.exit(0);
+  }
+
+  process.stdout.write(`\nTo proceed, type EXACTLY (case-sensitive):\n\n  ${phrase}\n\n> `);
+  const typed = (await readLine()).trim();
+  if (typed !== phrase) bail(2, `confirmation mismatch — aborting (no write performed).`);
+
+  // Prepare the disk: clear read-only, take offline (dismounts volumes).
+  runner.ps(psSetReadonlyScript(disk.number, false));
+  runner.ps(psSetOfflineScript(disk.number, true));
+
+  process.stdout.write(`\nFlashing ${isoPath} -> ${drivePath} (this takes a few minutes) ...\n`);
+  let lastPct = -1;
+  const res = copyImageToDevice({
+    isoPath,
+    destPath: drivePath,
+    onProgress: (w, t) => {
+      const pct = Math.floor((w / t) * 100);
+      if (pct !== lastPct) {
+        process.stdout.write(`\r  ${pct}%  (${human(w)} / ${human(t)})   `);
+        lastPct = pct;
+      }
+    },
+  });
+  process.stdout.write(`\n\nWrote ${human(res.bytesWritten)} (ISO ${human(res.isoBytes)}). Flash complete.\n`);
+
+  // Bring the disk back online so Windows re-reads the new partition table.
+  try {
+    runner.ps(psSetOfflineScript(disk.number, false));
+  } catch {
+    /* eject is best-effort; the flash already succeeded */
+  }
+  process.stdout.write(`Disk ${disk.number} back online; safe to remove the USB.\n`);
+}
+
+function readLine(): Promise<string> {
+  return new Promise((resolve) => {
+    process.stdin.resume();
+    process.stdin.once("data", (d) => {
+      process.stdin.pause();
+      resolve(d.toString());
+    });
+  });
+}
+
+// Only run main() when executed directly (so tests can import the pure fns).
+if (import.meta.main) {
+  main().catch((e) => bail(1, e instanceof Error ? e.message : String(e)));
+}


### PR DESCRIPTION
## What

A **Windows** equivalent of `flash-usb.ts` (we had macOS only): write the AI-cluster installer ISO to a USB stick, with the **same safety rails**.

`full-ai-cluster/tools/flash-usb-windows.ts` (+ tests + README).

## macOS ↔ Windows mapping

| macOS (`flash-usb.ts`) | Windows (this) |
|---|---|
| `diskutil list -plist` | `Get-Disk \| ConvertTo-Json` |
| `BusProtocol == "USB"` | `BusType == "USB"` |
| `info.Internal` | `IsBoot` / `IsSystem` |
| `diskutil unmountDisk` | `Set-Disk -IsOffline $true` |
| `sudo dd of=/dev/rdiskN` | raw write to `\\.\PhysicalDriveN` |
| `sudo` + Touch ID | **Administrator (UAC / Windows Hello)** |
| `diskutil eject` | `Set-Disk -IsOffline $false` |

Same rails: USB bus only · not the boot/system disk · ISO 200 MiB–8 GiB · USB 4–256 GiB · **exactly one** candidate (else refuse) · per-run random nonce typed back. `--dry-run` prints the plan and writes nothing.

## How it's tested **without** a Windows machine (the ask)

Every data-loss-critical decision is **pure, exported TypeScript**, so `bun test` validates it on this Mac (and in CI):

- **Safety rails / device selection** — `selectUsbCandidate()` against realistic `Get-Disk` JSON fixtures: it picks the lone USB stick and **refuses** the system/boot disk, non-USB disks, an oversize 4 TB SSD, an undersize device, and the "more than one USB plugged in" case.
- **The actual byte-copy** — `copyImageToDevice()` is the real write loop. The test copies a fake ISO into a temp "device" file and asserts the output is **byte-identical to the image and zero-padded up to a sector boundary** (the `dd conv=sync` equivalent). This is the code that corrupts the stick if it's wrong, and it's the *same* function that runs on Windows (node opens `\\.\PhysicalDriveN` after the disk is offline).
- nonce, PowerShell command construction, ISO auto-discovery — all unit-tested.

**Result: 22 tests pass; strict `tsc` (incl. `noUncheckedIndexedAccess`) clean.**

### What this can't prove on a Mac (honest scope)
Opening the literal `\\.\PhysicalDriveN` handle, `Set-Disk -IsOffline`, and the UAC prompt are Windows-only — thin wrappers around the tested logic. An end-to-end run needs a Windows box, or a Windows VM with a virtual USB disk (verify the written disk's first bytes match the ISO). Tracked as a follow-up under **B-0739** along with a `zflash-windows.ts` wrapper + an `--agent` mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
