### PR TITLE
feat(B-0976): SagaSnapshot — resume-not-replay snapshot for self-evolving sagas

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -49,6 +49,7 @@
     <Compile Include="Diplomacy.fs" />
     <Compile Include="DurableDiplomacy.fs" />
     <Compile Include="DynamicValueFold.fs" />
+    <Compile Include="SagaSnapshot.fs" />
     <Compile Include="SchemaEvolution.fs" />
     <Compile Include="SchemaRegistry.fs" />
     <Compile Include="EvolutionWindow.fs" />

--- a/src/Core/SagaSnapshot.fs
+++ b/src/Core/SagaSnapshot.fs
@@ -1,0 +1,88 @@
+namespace Zeta.Core
+
+open System
+
+/// **B-0976 slice — resume-not-replay snapshot for self-evolving sagas (Aaron 2026-06-01).** `DurableSaga.fs`
+/// recovers by FULL log replay and explicitly defers a state snapshot ("a `'TState` snapshot is a follow-up");
+/// this is that follow-up, and it is the B-0976 differentiator over the replay family (Durable Functions /
+/// Temporal / Dapr Workflow).
+///
+/// A snapshot captures both halves of a self-evolving saga:
+/// - **the pattern** — the `Bonsai.Expr` expression-tree ("the pattern is data"); editable in flight, so the
+///   *pattern itself* evolves, not only the state (the superset the replay family structurally cannot do).
+/// - **the closure state** — a `DynamicValue` at the cursor.
+///
+/// `resume` restores both **directly** — it does NOT re-run the body from the start. So the body constraints
+/// are looser than replay: **non-determinism in the body is fine**, because we snapshot the *value* rather
+/// than re-deriving it. The whole snapshot serialises to `DynamicValue` (pattern via `Bonsai.serialize`),
+/// riding the canonical codecs, and the `Seq` cursor is the position on the Z-set/IndexedZSet ladder.
+///
+/// Anchors: Nuqleon/Reaqtor Bonsai (serialized expr-trees), Temporal/Durable Functions (the interface to
+/// meet, replay family we beat on pattern-evolution), B-0668 (saga compensation = Z-set retraction). This
+/// slice is the snapshot + resume + pattern-swap; the Z-set-of-subtrees retraction operator for fine-grained
+/// pattern evolution is the next slice.
+[<RequireQualifiedAccess>]
+module SagaSnapshot =
+
+    /// A resume-not-replay snapshot: the pattern (Bonsai expr-tree), the closure state, and the stream cursor.
+    [<NoComparison>]
+    type Snapshot =
+        { Pattern: Bonsai.Expr // the serialized expression-tree — editable in flight (pattern-as-data)
+          State: DynamicValue // the closure state at the cursor
+          Seq: int64 } // stream position on the Z-set ladder
+
+    let create (pattern: Bonsai.Expr) (state: DynamicValue) (seq: int64) : Snapshot =
+        { Pattern = pattern; State = state; Seq = seq }
+
+    /// **resume, not replay** — restore the snapshot directly: return the `(pattern, state)` to continue
+    /// *from*, with no re-execution of the body up to `Seq`. This is the differentiator over the replay family.
+    let resume (s: Snapshot) : Bonsai.Expr * DynamicValue = s.Pattern, s.State
+
+    /// Advance to the next cursor with updated closure state (the pattern unchanged).
+    let advance (newState: DynamicValue) (s: Snapshot) : Snapshot =
+        { s with
+            State = newState
+            Seq = s.Seq + 1L }
+
+    /// **Pattern evolution** — swap the pattern (the "pattern is data" edit: retract the old expr-tree, admit
+    /// a new one). The principled operator is the Z-set retraction (B-0668: compensation = additive inverse);
+    /// this bounded form is a whole-pattern swap at the cursor. Both pattern AND state can now evolve.
+    let evolvePattern (newPattern: Bonsai.Expr) (s: Snapshot) : Snapshot = { s with Pattern = newPattern }
+
+    [<Literal>]
+    let private PatternKey = "pattern"
+
+    [<Literal>]
+    let private StateKey = "state"
+
+    [<Literal>]
+    let private SeqKey = "seq"
+
+    /// Serialise a snapshot to `DynamicValue.Object` (rides the canonical codecs). The pattern is emitted via
+    /// `Bonsai.serialize` (the cross-oracle byte contract); `Error` if the pattern declines serialisation.
+    let toDynamic (s: Snapshot) : Result<DynamicValue, Bonsai.BonsaiFeedback> =
+        match Bonsai.serialize s.Pattern with
+        | Ok patternStr ->
+            Ok(
+                DynamicValue.Object
+                    [ PatternKey, DynamicValue.String patternStr
+                      StateKey, s.State
+                      SeqKey, DynamicValue.Int s.Seq ]
+            )
+        | Error f -> Error f
+
+    /// Parse a snapshot from a `DynamicValue.Object`. `Error` if a field is missing/ill-typed or the pattern
+    /// string declines parsing. `toDynamic`/`ofDynamic` round-trip: `ofDynamic (toDynamic s) = Ok s`.
+    let ofDynamic (dv: DynamicValue) : Result<Snapshot, Bonsai.BonsaiFeedback> =
+        match dv with
+        | DynamicValue.Object kvs ->
+            let find k =
+                kvs |> List.tryPick (fun (kk, v) -> if String.Equals(kk, k, StringComparison.Ordinal) then Some v else None)
+
+            match find PatternKey, find StateKey, find SeqKey with
+            | Some(DynamicValue.String patternStr), Some state, Some(DynamicValue.Int seq) ->
+                match Bonsai.parse patternStr with
+                | Ok pattern -> Ok { Pattern = pattern; State = state; Seq = seq }
+                | Error f -> Error f
+            | _ -> Error(Bonsai.BonsaiFeedback.MalformedJson "snapshot: missing/ill-typed pattern, state, or seq field")
+        | _ -> Error(Bonsai.BonsaiFeedback.MalformedJson "snapshot: missing/ill-typed pattern, state, or seq field")

--- a/tests/Tests.FSharp/SagaSnapshot.Tests.fs
+++ b/tests/Tests.FSharp/SagaSnapshot.Tests.fs
@@ -1,0 +1,65 @@
+module Zeta.Tests.SagaSnapshotTests
+
+open global.Xunit
+open Zeta.Core
+
+module SS = Zeta.Core.SagaSnapshot
+
+// a small pattern: fun x -> if x then 1 else 2   (exercises Lambda/Cond/Const/Var)
+let private pattern () =
+    Bonsai.Expr.Lambda(
+        [ "x" ],
+        Bonsai.Expr.Cond(
+            Bonsai.Expr.Param "x",
+            Bonsai.Expr.Const(Bonsai.ConstValue.CInt 1L),
+            Bonsai.Expr.Const(Bonsai.ConstValue.CInt 2L)
+        )
+    )
+
+let private state () =
+    DynamicValue.Object [ "step", DynamicValue.Int 3L; "acc", DynamicValue.String "partial" ]
+
+[<Fact>]
+let ``resume restores pattern and state directly (resume-not-replay)`` () =
+    let snap = SS.create (pattern ()) (state ()) 7L
+    let p, s = SS.resume snap
+    Assert.Equal<Bonsai.Expr>(pattern (), p) // pattern restored as-is
+    Assert.Equal<DynamicValue>(state (), s) // state restored as-is, not recomputed
+
+[<Fact>]
+let ``toDynamic then ofDynamic round-trips the whole snapshot`` () =
+    let snap = SS.create (pattern ()) (state ()) 7L
+
+    match SS.toDynamic snap with
+    | Ok dv ->
+        match SS.ofDynamic dv with
+        | Ok back ->
+            Assert.Equal<Bonsai.Expr>(snap.Pattern, back.Pattern)
+            Assert.Equal<DynamicValue>(snap.State, back.State)
+            Assert.Equal(snap.Seq, back.Seq)
+        | Error f -> Assert.Fail $"ofDynamic declined: {f}"
+    | Error f -> Assert.Fail $"toDynamic declined: {f}"
+
+[<Fact>]
+let ``advance bumps the cursor and updates state, pattern unchanged`` () =
+    let snap = SS.create (pattern ()) (state ()) 7L
+    let next = SS.advance (DynamicValue.Object [ "step", DynamicValue.Int 4L ]) snap
+    Assert.Equal(8L, next.Seq)
+    Assert.Equal<DynamicValue>(DynamicValue.Object [ "step", DynamicValue.Int 4L ], next.State)
+    Assert.Equal<Bonsai.Expr>(pattern (), next.Pattern) // pattern survives a state advance
+
+[<Fact>]
+let ``evolvePattern swaps the pattern in flight (pattern-as-data) while state persists`` () =
+    let snap = SS.create (pattern ()) (state ()) 7L
+    // the replay family cannot do this: change the PATTERN mid-saga without losing accumulated state
+    let newPattern = Bonsai.Expr.Const(Bonsai.ConstValue.CInt 99L)
+    let evolved = SS.evolvePattern newPattern snap
+    Assert.Equal<Bonsai.Expr>(newPattern, evolved.Pattern) // pattern evolved
+    Assert.Equal<DynamicValue>(state (), evolved.State) // state preserved across pattern change
+    Assert.Equal(7L, evolved.Seq)
+
+[<Fact>]
+let ``ofDynamic declines a malformed snapshot object`` () =
+    match SS.ofDynamic (DynamicValue.Object [ "pattern", DynamicValue.String "not-bonsai" ]) with
+    | Error _ -> () // missing state/seq (and/or unparseable pattern) -> clean Error, no throw
+    | Ok _ -> Assert.Fail "expected a malformed snapshot to decline"

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -86,6 +86,7 @@
     <Compile Include="DynamicValueAlgebra.Tests.fs" />
     <Compile Include="WeightedSet.Tests.fs" />
     <Compile Include="ITensor.Tests.fs" />
+    <Compile Include="SagaSnapshot.Tests.fs" />
     <Compile Include="DagFs.Tests.fs" />
     <Compile Include="Confluence.Tests.fs" />
     <Compile Include="DebeziumCdc.Tests.fs" />


### PR DESCRIPTION
Aaron 2026-06-01 (B-0976), built under 'go for it you can sequence.' The differentiator DurableSaga.fs
explicitly defers ('v1 recovers by FULL log replay; a snapshot is a follow-up'). A snapshot captures BOTH
halves of a self-evolving saga: the PATTERN (Bonsai.Expr expr-tree, pattern-as-data, editable in flight)
and the closure STATE (DynamicValue), at a Seq cursor on the Z-set ladder. resume restores both DIRECTLY
— no re-running the body from the start (so non-determinism in the body is fine; we snapshot the value).
evolvePattern swaps the pattern mid-saga while state persists — the superset the replay family (Durable
Functions/Temporal/Dapr) structurally cannot do. toDynamic/ofDynamic round-trip (pattern via Bonsai.serialize,
rides canonical codecs). 5 tests. Next slice: Z-set-of-subtrees retraction for fine-grained pattern evolution.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
