### PR TITLE
feat(DynamicValueNumeric): Result-typed + shader-saturating leaf numerics (foundation for SoftValue arithmetic)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -92,6 +92,7 @@
     <Compile Include="Globals.fs" />
     <Compile Include="TensorRef.fs" />
     <Compile Include="DynamicValueAlgebra.fs" />
+    <Compile Include="DynamicValueNumeric.fs" />
     <Compile Include="DvKey.fs" />
     <Compile Include="DebeziumCdc.fs" />
     <Compile Include="CloudEvents.fs" />

--- a/src/Core/DynamicValueNumeric.fs
+++ b/src/Core/DynamicValueNumeric.fs
@@ -1,0 +1,155 @@
+namespace Zeta.Core
+
+/// **Numerics inside `DynamicValue` — Result-typed, total, no silent coercion (Aaron 2026-06-07).**
+/// Arithmetic over the numeric leaves (`Int`/`Float`): `Int+Int = Int`; `Int`↔`Float` **widens** to `Float`;
+/// `Null` is the **additive identity** (acts as 0, so `add Null x = x`) and the **multiplicative annihilator**
+/// (`mul Null x = Null`, i.e. ×0 = 0); `Int 1` is the multiplicative identity. Every other shape
+/// (`Bool`/`String`/`Bytes`/`Array`/`Object`) or mixed pair **declines with `Error`** — never a silent
+/// coercion, never an exception on the hot path (integer overflow is caught and returned as `Error`).
+///
+/// This is the leaf-numeric algebra *inside* `DynamicValue`. It is a **partial ring expressed total via
+/// `Result`** — so it is deliberately NOT an `ISemiring<DynamicValue>` (that interface mandates total
+/// `Add`/`Mul`). The .NET generic-math interfaces (`IAdditionOperators` etc.) likewise want *total*
+/// operators returning the element type, so they are not applied here; a `DvNumber` newtype could carry them
+/// later if ever wanted (the deferred "numeric-only newtype" option). Complements
+/// `DynamicValueAlgebra.mergeSemilattice` (the merge/LWW semilattice) — different algebra, same value.
+[<RequireQualifiedAccess>]
+module DynamicValueNumeric =
+
+    /// Why a numeric op declined.
+    type NumericError =
+        /// A binary op got a shape pair it has no rule for (e.g. `String` + `Int`).
+        | TypeMismatch of op: string * left: string * right: string
+        /// A unary op got a non-numeric shape.
+        | NotNumeric of op: string * shape: string
+        /// An integer op overflowed `int64` (caught, not thrown).
+        | Overflow of op: string
+
+    let private shapeName =
+        function
+        | DynamicValue.Null -> "Null"
+        | DynamicValue.Bool _ -> "Bool"
+        | DynamicValue.Int _ -> "Int"
+        | DynamicValue.Float _ -> "Float"
+        | DynamicValue.String _ -> "String"
+        | DynamicValue.Bytes _ -> "Bytes"
+        | DynamicValue.Array _ -> "Array"
+        | DynamicValue.Object _ -> "Object"
+
+    /// Additive identity (0).
+    let zero: DynamicValue = DynamicValue.Null
+
+    /// Multiplicative identity (1).
+    let one: DynamicValue = DynamicValue.Int 1L
+
+    /// `a + b` over numeric leaves; `Null` is identity; `Int`↔`Float` widens; else `Error`.
+    let add (a: DynamicValue) (b: DynamicValue) : Result<DynamicValue, NumericError> =
+        match a, b with
+        | DynamicValue.Null, x
+        | x, DynamicValue.Null -> Ok x // 0 identity
+        | DynamicValue.Int x, DynamicValue.Int y ->
+            try
+                Ok(DynamicValue.Int(Checked.(+) x y))
+            with :? System.OverflowException ->
+                Error(Overflow "add")
+        | DynamicValue.Float x, DynamicValue.Float y -> Ok(DynamicValue.Float(x + y))
+        | DynamicValue.Int x, DynamicValue.Float y -> Ok(DynamicValue.Float(float x + y)) // widen
+        | DynamicValue.Float x, DynamicValue.Int y -> Ok(DynamicValue.Float(x + float y))
+        | _ -> Error(TypeMismatch("add", shapeName a, shapeName b))
+
+    /// `a * b` over numeric leaves; `Null` annihilates (×0 = 0); `Int`↔`Float` widens; else `Error`.
+    let mul (a: DynamicValue) (b: DynamicValue) : Result<DynamicValue, NumericError> =
+        match a, b with
+        | DynamicValue.Null, _
+        | _, DynamicValue.Null -> Ok DynamicValue.Null // ×0 = 0 (annihilator)
+        | DynamicValue.Int x, DynamicValue.Int y ->
+            try
+                Ok(DynamicValue.Int(Checked.(*) x y))
+            with :? System.OverflowException ->
+                Error(Overflow "mul")
+        | DynamicValue.Float x, DynamicValue.Float y -> Ok(DynamicValue.Float(x * y))
+        | DynamicValue.Int x, DynamicValue.Float y -> Ok(DynamicValue.Float(float x * y)) // widen
+        | DynamicValue.Float x, DynamicValue.Int y -> Ok(DynamicValue.Float(x * float y))
+        | _ -> Error(TypeMismatch("mul", shapeName a, shapeName b))
+
+    /// Additive inverse over numeric leaves; `Null` → `Null` (−0 = 0); else `Error`.
+    let negate (a: DynamicValue) : Result<DynamicValue, NumericError> =
+        match a with
+        | DynamicValue.Null -> Ok DynamicValue.Null
+        | DynamicValue.Int x ->
+            try
+                Ok(DynamicValue.Int(Checked.(~-) x))
+            with :? System.OverflowException ->
+                Error(Overflow "negate") // Int64.MinValue
+        | DynamicValue.Float x -> Ok(DynamicValue.Float(-x))
+        | other -> Error(NotNumeric("negate", shapeName other))
+
+    /// `a - b` = `a + (-b)`.
+    let subtract (a: DynamicValue) (b: DynamicValue) : Result<DynamicValue, NumericError> =
+        negate b |> Result.bind (add a)
+
+    /// Sum a sequence under `add`, from `zero`; short-circuits on the first `Error`.
+    let sum (xs: DynamicValue seq) : Result<DynamicValue, NumericError> =
+        (Ok zero, xs)
+        ||> Seq.fold (fun acc x -> acc |> Result.bind (fun a -> add a x))
+
+    /// **Shader-lowerable sibling — total, no Result, no escaping exceptions (the GPU-idiom variant).**
+    /// Same widening + `Null`-identity/annihilator rules as the Result variant, but **total**: integer
+    /// overflow **saturates** (clamp to `Int64.MinValue/MaxValue`) and any out-of-domain pair (non-numeric or
+    /// mixed) **poisons** to `Float NaN`, which then propagates through later float ops — exactly GPU
+    /// saturating-arithmetic + NaN-propagation. No `Result`, no thrown exception escapes (the internal
+    /// overflow probe is caught), so the *semantics* lower to a shader.
+    ///
+    /// Caveat: `DynamicValue` itself is a heap DU and is never the GPU carrier — actual shader execution runs
+    /// these rules on the **flat dense tensor leaf** (`Tensor<T>` / numeric `WeightedSet` buffer). This module
+    /// is the CPU stand-in defining *which* rules the shader path uses; pick the Result variant for
+    /// correctness/audit, this one for the GPU-lowerable hot path.
+    [<RequireQualifiedAccess>]
+    module Sat =
+
+        let private poison = DynamicValue.Float nan
+
+        let private satAddI (x: int64) (y: int64) : int64 =
+            try
+                Checked.(+) x y
+            with :? System.OverflowException ->
+                if x > 0L then System.Int64.MaxValue else System.Int64.MinValue
+
+        let private satMulI (x: int64) (y: int64) : int64 =
+            try
+                Checked.(*) x y
+            with :? System.OverflowException ->
+                if (x > 0L) = (y > 0L) then System.Int64.MaxValue else System.Int64.MinValue
+
+        /// Total `a + b`: `Null` identity; `Int`↔`Float` widen; int overflow saturates; else NaN-poison.
+        let add (a: DynamicValue) (b: DynamicValue) : DynamicValue =
+            match a, b with
+            | DynamicValue.Null, x
+            | x, DynamicValue.Null -> x
+            | DynamicValue.Int x, DynamicValue.Int y -> DynamicValue.Int(satAddI x y)
+            | DynamicValue.Float x, DynamicValue.Float y -> DynamicValue.Float(x + y)
+            | DynamicValue.Int x, DynamicValue.Float y -> DynamicValue.Float(float x + y)
+            | DynamicValue.Float x, DynamicValue.Int y -> DynamicValue.Float(x + float y)
+            | _ -> poison
+
+        /// Total `a * b`: `Null` annihilates (×0=0); widen; int overflow saturates; else NaN-poison.
+        let mul (a: DynamicValue) (b: DynamicValue) : DynamicValue =
+            match a, b with
+            | DynamicValue.Null, _
+            | _, DynamicValue.Null -> DynamicValue.Null
+            | DynamicValue.Int x, DynamicValue.Int y -> DynamicValue.Int(satMulI x y)
+            | DynamicValue.Float x, DynamicValue.Float y -> DynamicValue.Float(x * y)
+            | DynamicValue.Int x, DynamicValue.Float y -> DynamicValue.Float(float x * y)
+            | DynamicValue.Float x, DynamicValue.Int y -> DynamicValue.Float(x * float y)
+            | _ -> poison
+
+        /// Total negate: `Null`→`Null`; `Int.MinValue` saturates to `MaxValue`; non-numeric → NaN-poison.
+        let negate (a: DynamicValue) : DynamicValue =
+            match a with
+            | DynamicValue.Null -> DynamicValue.Null
+            | DynamicValue.Int x -> DynamicValue.Int(if x = System.Int64.MinValue then System.Int64.MaxValue else -x)
+            | DynamicValue.Float x -> DynamicValue.Float(-x)
+            | _ -> poison
+
+        /// Total sum from `zero` (NaN, once introduced, propagates — no short-circuit).
+        let sum (xs: DynamicValue seq) : DynamicValue = Seq.fold add zero xs

--- a/tests/Tests.FSharp/DynamicValueNumeric.Tests.fs
+++ b/tests/Tests.FSharp/DynamicValueNumeric.Tests.fs
@@ -1,0 +1,77 @@
+module Zeta.Tests.DynamicValueNumericTests
+
+open global.Xunit
+open Zeta.Core
+
+module N = Zeta.Core.DynamicValueNumeric
+
+let private i n = DynamicValue.Int n
+let private f x = DynamicValue.Float x
+
+// ── Result-typed variant (CPU / correctness) ──────────────────────────────────
+
+[<Fact>]
+let ``add: Int+Int, widen Int+Float, Null identity`` () =
+    Assert.Equal<Result<DynamicValue, _>>(Ok(i 5L), N.add (i 2L) (i 3L))
+    Assert.Equal<Result<DynamicValue, _>>(Ok(f 3.0), N.add (i 2L) (f 1.0)) // widen
+    Assert.Equal<Result<DynamicValue, _>>(Ok(i 7L), N.add DynamicValue.Null (i 7L)) // 0 identity
+    Assert.Equal<Result<DynamicValue, _>>(Ok(i 7L), N.add (i 7L) DynamicValue.Null)
+
+[<Fact>]
+let ``add: type mismatch declines, no silent coercion`` () =
+    match N.add (DynamicValue.String "a") (i 1L) with
+    | Error(N.TypeMismatch("add", "String", "Int")) -> ()
+    | other -> Assert.Fail $"expected TypeMismatch, got {other}"
+
+[<Fact>]
+let ``add: integer overflow is a caught Error, never a throw`` () =
+    match N.add (i System.Int64.MaxValue) (i 1L) with
+    | Error(N.Overflow "add") -> ()
+    | other -> Assert.Fail $"expected Overflow, got {other}"
+
+[<Fact>]
+let ``mul: Null annihilates; one is identity; negate and subtract`` () =
+    Assert.Equal<Result<DynamicValue, _>>(Ok DynamicValue.Null, N.mul DynamicValue.Null (i 9L)) // ×0=0
+    Assert.Equal<Result<DynamicValue, _>>(Ok(i 9L), N.mul N.one (i 9L)) // ×1=x
+    Assert.Equal<Result<DynamicValue, _>>(Ok(i -4L), N.negate (i 4L))
+    Assert.Equal<Result<DynamicValue, _>>(Ok(i 3L), N.subtract (i 10L) (i 7L))
+    match N.negate (DynamicValue.String "x") with
+    | Error(N.NotNumeric("negate", "String")) -> ()
+    | other -> Assert.Fail $"expected NotNumeric, got {other}"
+
+[<Fact>]
+let ``sum folds and short-circuits on the first Error`` () =
+    Assert.Equal<Result<DynamicValue, _>>(Ok(i 6L), N.sum [ i 1L; i 2L; i 3L ])
+    match N.sum [ i 1L; DynamicValue.Bool true; i 3L ] with
+    | Error _ -> ()
+    | Ok _ -> Assert.Fail "expected the Bool to decline the sum"
+
+// ── Saturating / shader-lowerable variant ─────────────────────────────────────
+
+[<Fact>]
+let ``Sat.add: integer overflow saturates (clamp), never errors`` () =
+    Assert.Equal<DynamicValue>(i System.Int64.MaxValue, N.Sat.add (i System.Int64.MaxValue) (i 1L))
+    Assert.Equal<DynamicValue>(i System.Int64.MinValue, N.Sat.add (i System.Int64.MinValue) (i -1L))
+    Assert.Equal<DynamicValue>(i 5L, N.Sat.add (i 2L) (i 3L)) // normal case still exact
+
+[<Fact>]
+let ``Sat: out-of-domain poisons to NaN and propagates`` () =
+    let poisoned = N.Sat.add (DynamicValue.String "a") (i 1L)
+
+    match poisoned with
+    | DynamicValue.Float x -> Assert.True(System.Double.IsNaN x)
+    | other -> Assert.Fail $"expected NaN poison, got {other}"
+
+    // NaN propagates through a subsequent op
+    match N.Sat.add poisoned (i 10L) with
+    | DynamicValue.Float x -> Assert.True(System.Double.IsNaN x)
+    | other -> Assert.Fail $"expected NaN to propagate, got {other}"
+
+[<Fact>]
+let ``Sat: Null identity/annihilator and widening match the Result variant on the happy path`` () =
+    Assert.Equal<DynamicValue>(i 7L, N.Sat.add DynamicValue.Null (i 7L)) // identity
+    Assert.Equal<DynamicValue>(DynamicValue.Null, N.Sat.mul DynamicValue.Null (i 9L)) // annihilator
+    Assert.Equal<DynamicValue>(f 3.0, N.Sat.add (i 2L) (f 1.0)) // widen
+    Assert.Equal<DynamicValue>(i -4L, N.Sat.negate (i 4L))
+    // Int.MinValue negate saturates instead of overflowing
+    Assert.Equal<DynamicValue>(i System.Int64.MaxValue, N.Sat.negate (i System.Int64.MinValue))

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -84,6 +84,7 @@
     <Compile Include="Globals.Tests.fs" />
     <Compile Include="TensorRef.Tests.fs" />
     <Compile Include="DynamicValueAlgebra.Tests.fs" />
+    <Compile Include="DynamicValueNumeric.Tests.fs" />
     <Compile Include="WeightedSet.Tests.fs" />
     <Compile Include="ITensor.Tests.fs" />
     <Compile Include="SagaSnapshot.Tests.fs" />


### PR DESCRIPTION
Aaron 2026-06-07: numerics inside the value. Two variants over DynamicValue's numeric leaves (Int/Float):
- Result-typed (CPU/correctness): add/mul/negate/subtract/sum returning Result; Int+Int=Int, Int<->Float
  widen, Null=additive identity (0) / mul annihilator, overflow CAUGHT->Error, non-numeric->Error (no silent
  coercion, no escaping exception).
- Sat (shader-lowerable): total, no Result; overflow SATURATES (clamp), out-of-domain POISONS to Float NaN
  that propagates — GPU saturating-arithmetic + NaN-propagation idioms. (DynamicValue is never the GPU
  carrier; the flat dense tensor leaf is — this defines the rules that path runs.)

This is the per-VALUE leaf op; SoftValue arithmetic (distribution convolution) lifts it over candidates
(next). 8 tests. Aaron clarified the real target is SoftValue — this is its foundation, not the end.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
