### PR TITLE
feat(SoftValueNumeric): distribution arithmetic on SoftValue — uncertainty propagation

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -93,6 +93,7 @@
     <Compile Include="TensorRef.fs" />
     <Compile Include="DynamicValueAlgebra.fs" />
     <Compile Include="DynamicValueNumeric.fs" />
+    <Compile Include="SoftValueNumeric.fs" />
     <Compile Include="DvKey.fs" />
     <Compile Include="DebeziumCdc.fs" />
     <Compile Include="CloudEvents.fs" />

--- a/src/Core/SoftValueNumeric.fs
+++ b/src/Core/SoftValueNumeric.fs
@@ -1,0 +1,109 @@
+namespace Zeta.Core
+
+/// **Numerics on `SoftValue` — distribution arithmetic that PROPAGATES uncertainty (Aaron 2026-06-07, the
+/// real target).** A `SoftValue` is a normalized distribution over `DynamicValue` candidates; arithmetic is
+/// **convolution**: pair every candidate of `a` with every candidate of `b`, apply the leaf op
+/// (`DynamicValueNumeric`) to the *values*, **multiply** the probabilities, then merge duplicate result-
+/// values and renormalize (`SoftValue.ofWeighted`). So `certain ⊕ certain` stays a point mass, but
+/// `spread ⊕ spread` widens — uncertainty compounds. This is the probability monad over the leaf numerics.
+///
+/// Two variants mirror the leaf op:
+/// - top-level (`add`/`mul`/`negate`/`subtract`/`mean`) — **Result-typed** (CPU/correctness): a single
+///   non-numeric/overflow candidate declines the whole op (no silent coercion).
+/// - `Sat` — **shader-lowerable**: total, candidates that go out-of-domain become `Float NaN` and propagate;
+///   the distribution is always returned.
+///
+/// `SoftValue` is effectively a `WeightedSet<DynamicValue, float>` over the probability semiring; this is its
+/// arithmetic. Anchors: probability monad / distribution semiring (Giry monad), `DynamicValueNumeric` (the
+/// per-candidate leaf op), `ProbabilitySemiring`.
+[<RequireQualifiedAccess>]
+module SoftValueNumeric =
+
+    module N = DynamicValueNumeric
+
+    /// Apply a Result-typed leaf op across the candidate cartesian product (probabilities multiply), short-
+    /// circuiting on the first declined pair, then rebuild + renormalize the distribution.
+    let private convolve
+        (leaf: DynamicValue -> DynamicValue -> Result<DynamicValue, N.NumericError>)
+        (a: SoftValue.SoftValue)
+        (b: SoftValue.SoftValue)
+        : Result<SoftValue.SoftValue, N.NumericError> =
+        let pairs =
+            [ for v1, p1 in SoftValue.candidates a do
+                  for v2, p2 in SoftValue.candidates b do
+                      yield v1, v2, p1 * p2 ]
+
+        let rec trav acc =
+            function
+            | [] -> Ok(List.rev acc)
+            | (v1, v2, p) :: rest ->
+                match leaf v1 v2 with
+                | Ok v -> trav ((v, p) :: acc) rest
+                | Error e -> Error e
+
+        match trav [] pairs with
+        | Ok weighted ->
+            match SoftValue.ofWeighted weighted with
+            | Some s -> Ok s
+            | None -> Error(N.NotNumeric("soft-op", "empty-distribution"))
+        | Error e -> Error e
+
+    /// `a + b` — convolution under leaf addition; uncertainty propagates.
+    let add (a: SoftValue.SoftValue) (b: SoftValue.SoftValue) : Result<SoftValue.SoftValue, N.NumericError> =
+        convolve N.add a b
+
+    /// `a * b` — convolution under leaf multiplication.
+    let mul (a: SoftValue.SoftValue) (b: SoftValue.SoftValue) : Result<SoftValue.SoftValue, N.NumericError> =
+        convolve N.mul a b
+
+    /// `a - b` — convolution under leaf subtraction.
+    let subtract (a: SoftValue.SoftValue) (b: SoftValue.SoftValue) : Result<SoftValue.SoftValue, N.NumericError> =
+        convolve N.subtract a b
+
+    /// Negate every candidate value (probabilities unchanged).
+    let negate (a: SoftValue.SoftValue) : Result<SoftValue.SoftValue, N.NumericError> =
+        let rec trav acc =
+            function
+            | [] -> Ok(List.rev acc)
+            | (v, p) :: rest ->
+                match N.negate v with
+                | Ok nv -> trav ((nv, p) :: acc) rest
+                | Error e -> Error e
+
+        match trav [] (SoftValue.candidates a) with
+        | Ok weighted ->
+            match SoftValue.ofWeighted weighted with
+            | Some s -> Ok s
+            | None -> Error(N.NotNumeric("soft-negate", "empty-distribution"))
+        | Error e -> Error e
+
+    /// Expectation `E[X] = Σ pᵢ·valueᵢ` over numeric candidates (`Int`/`Float`); declines if any candidate is
+    /// non-numeric.
+    let mean (sv: SoftValue.SoftValue) : Result<float, N.NumericError> =
+        (Ok 0.0, SoftValue.candidates sv)
+        ||> List.fold (fun acc (v, p) ->
+            acc
+            |> Result.bind (fun a ->
+                match v with
+                | DynamicValue.Int x -> Ok(a + p * float x)
+                | DynamicValue.Float x -> Ok(a + p * x)
+                | _ -> Error(N.NotNumeric("mean", "non-numeric-candidate"))))
+
+    /// **Shader-lowerable sibling — total distribution arithmetic (candidates poison to NaN, never decline).**
+    [<RequireQualifiedAccess>]
+    module Sat =
+
+        let private convolve (leaf: DynamicValue -> DynamicValue -> DynamicValue) a b : SoftValue.SoftValue =
+            [ for v1, p1 in SoftValue.candidates a do
+                  for v2, p2 in SoftValue.candidates b do
+                      yield leaf v1 v2, p1 * p2 ]
+            |> SoftValue.ofWeighted
+            |> Option.defaultValue (SoftValue.certain (DynamicValue.Float nan))
+
+        let add (a: SoftValue.SoftValue) (b: SoftValue.SoftValue) : SoftValue.SoftValue = convolve N.Sat.add a b
+        let mul (a: SoftValue.SoftValue) (b: SoftValue.SoftValue) : SoftValue.SoftValue = convolve N.Sat.mul a b
+
+        let negate (a: SoftValue.SoftValue) : SoftValue.SoftValue =
+            [ for v, p in SoftValue.candidates a -> N.Sat.negate v, p ]
+            |> SoftValue.ofWeighted
+            |> Option.defaultValue (SoftValue.certain (DynamicValue.Float nan))

--- a/tests/Tests.FSharp/SoftValueNumeric.Tests.fs
+++ b/tests/Tests.FSharp/SoftValueNumeric.Tests.fs
@@ -1,0 +1,77 @@
+module Zeta.Tests.SoftValueNumericTests
+
+open global.Xunit
+open Zeta.Core
+
+module SN = Zeta.Core.SoftValueNumeric
+
+let private i n = DynamicValue.Int n
+let private cert n = SoftValue.certain (i n)
+/// a fair coin over two int values
+let private coin a b =
+    SoftValue.ofWeighted [ i a, 0.5; i b, 0.5 ] |> Option.get
+
+[<Fact>]
+let ``certain + certain stays a point mass`` () =
+    match SN.add (cert 2L) (cert 3L) with
+    | Ok s ->
+        Assert.Equal(1.0, SoftValue.confidence s, 9) // still certain
+        Assert.Equal<DynamicValue option>(Some(i 5L), SoftValue.resolve 0.0 s)
+    | Error e -> Assert.Fail $"{e}"
+
+[<Fact>]
+let ``spread + spread convolves and propagates uncertainty`` () =
+    // {0,2} ⊕ {0,2} = {0:.25, 2:.5, 4:.25} — 3 outcomes, no longer certain
+    match SN.add (coin 0L 2L) (coin 0L 2L) with
+    | Ok s ->
+        let cs = SoftValue.candidates s
+        Assert.Equal(3, List.length cs) // 0, 2, 4
+        Assert.True(SoftValue.confidence s < 1.0) // uncertainty propagated
+        Assert.Equal(0.5, SoftValue.confidence s, 9) // the mode (2) has p=0.5
+    | Error e -> Assert.Fail $"{e}"
+
+[<Fact>]
+let ``mean is the probability-weighted expectation`` () =
+    // E[{0:.5, 2:.5}] = 1.0
+    match SN.mean (coin 0L 2L) with
+    | Ok m -> Assert.Equal(1.0, m, 9)
+    | Error e -> Assert.Fail $"{e}"
+    // E[ coin ⊕ coin ] = 2.0
+    match SN.add (coin 0L 2L) (coin 0L 2L) |> Result.bind SN.mean with
+    | Ok m -> Assert.Equal(2.0, m, 9)
+    | Error e -> Assert.Fail $"{e}"
+
+[<Fact>]
+let ``mul, negate, subtract compose over distributions`` () =
+    match SN.mul (cert 3L) (cert 4L) with
+    | Ok s -> Assert.Equal<DynamicValue option>(Some(i 12L), SoftValue.resolve 0.0 s)
+    | Error e -> Assert.Fail $"{e}"
+
+    match SN.subtract (cert 10L) (cert 7L) with
+    | Ok s -> Assert.Equal<DynamicValue option>(Some(i 3L), SoftValue.resolve 0.0 s)
+    | Error e -> Assert.Fail $"{e}"
+
+[<Fact>]
+let ``a non-numeric candidate declines the whole op (Result variant)`` () =
+    let bad = SoftValue.ofWeighted [ i 1L, 0.5; DynamicValue.String "x", 0.5 ] |> Option.get
+    match SN.add bad (cert 1L) with
+    | Error _ -> () // the String candidate poisons the convolution -> clean decline
+    | Ok _ -> Assert.Fail "expected the non-numeric candidate to decline"
+
+[<Fact>]
+let ``Sat variant is total: a bad candidate becomes NaN, distribution still returned`` () =
+    let bad = SoftValue.ofWeighted [ i 1L, 0.5; DynamicValue.String "x", 0.5 ] |> Option.get
+    let s = SN.Sat.add bad (cert 1L) // total — no decline
+    // one outcome is NaN-poisoned; the clean candidate (1+1=2) survives
+    let hasNaN =
+        SoftValue.candidates s
+        |> List.exists (fun (v, _) ->
+            match v with
+            | DynamicValue.Float x -> System.Double.IsNaN x
+            | _ -> false)
+
+    let hasTwo =
+        SoftValue.candidates s |> List.exists (fun (v, _) -> v = i 2L)
+
+    Assert.True(hasNaN)
+    Assert.True(hasTwo)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -86,6 +86,7 @@
     <Compile Include="TensorRef.Tests.fs" />
     <Compile Include="DynamicValueAlgebra.Tests.fs" />
     <Compile Include="DynamicValueNumeric.Tests.fs" />
+    <Compile Include="SoftValueNumeric.Tests.fs" />
     <Compile Include="WeightedSet.Tests.fs" />
     <Compile Include="ITensor.Tests.fs" />
     <Compile Include="SagaSnapshot.Tests.fs" />


### PR DESCRIPTION
Aaron 2026-06-07 (the real target — he meant SoftValue, not DynamicValue). SoftValue = a normalized
distribution over DynamicValue candidates (~ WeightedSet<DynamicValue,float> over the probability semiring);
arithmetic = CONVOLUTION lifting the DynamicValueNumeric leaf op over candidates (pair, inner-op values,
multiply probabilities, merge+renormalize via SoftValue.ofWeighted). certain+certain stays a point mass;
spread+spread widens — uncertainty compounds (the probability monad). add/mul/subtract/negate + mean
(expectation E[X]=Σpᵢvᵢ), Result-typed (a non-numeric candidate declines the whole op). Sat sibling: total,
out-of-domain candidates poison to NaN, distribution always returned (shader-lowerable). Builds on the
DynamicValueNumeric foundation (#6870). 6 tests.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
