### PR TITLE
feat(SoftValueInfo): cross-entropy + KL divergence on SoftValue distributions

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -94,6 +94,7 @@
     <Compile Include="DynamicValueAlgebra.fs" />
     <Compile Include="DynamicValueNumeric.fs" />
     <Compile Include="SoftValueNumeric.fs" />
+    <Compile Include="SoftValueInfo.fs" />
     <Compile Include="DvKey.fs" />
     <Compile Include="DebeziumCdc.fs" />
     <Compile Include="CloudEvents.fs" />

--- a/src/Core/SoftValueInfo.fs
+++ b/src/Core/SoftValueInfo.fs
@@ -1,0 +1,44 @@
+namespace Zeta.Core
+
+/// **Information-theoretic floor for `SoftValue` distributions — cross-entropy and KL divergence (Aaron
+/// 2026-06-07).** Complements `SoftValue.entropy` (H(p)); same convention — **nats** (natural log), with the
+/// `EPS` guard for zero-probability terms. A `SoftValue` is a normalized distribution over `DynamicValue`
+/// candidates, so these are the standard discrete-distribution measures over the candidate support.
+///
+/// Additive module (no edit to `SoftValue.fs`). Anchors: Shannon entropy; Kullback–Leibler divergence;
+/// cross-entropy (the ML training objective) — the same information geometry the soft/Bayesian layer needs.
+[<RequireQualifiedAccess>]
+module SoftValueInfo =
+
+    [<Literal>]
+    let private EPS = 1e-12
+
+    /// `q` as a probability lookup keyed by candidate value (absent ⇒ 0). `DynamicValue` carries content
+    /// equality + hash, so it is a valid dictionary key.
+    let private probOf (q: SoftValue.SoftValue) : DynamicValue -> float =
+        let m = System.Collections.Generic.Dictionary<DynamicValue, float>()
+        for v, p in SoftValue.candidates q do
+            m[v] <- p
+
+        fun x ->
+            match m.TryGetValue x with
+            | true, p -> p
+            | _ -> 0.0
+
+    /// **Cross-entropy** `H(p, q) = −Σ p(x)·ln q(x)` (nats). Returns `+∞` if `q` assigns ~zero probability to
+    /// an outcome `p` supports (the standard divergent case). `H(p, p) = H(p)` (the entropy).
+    let crossEntropy (p: SoftValue.SoftValue) (q: SoftValue.SoftValue) : float =
+        let qp = probOf q
+
+        SoftValue.candidates p
+        |> List.sumBy (fun (x, px) ->
+            if px <= EPS then
+                0.0
+            else
+                let qx = qp x
+                if qx <= EPS then infinity else -px * log qx)
+
+    /// **KL divergence** `D(p ‖ q) = Σ p(x)·ln(p(x)/q(x)) = H(p, q) − H(p)` (nats). Always `≥ 0` (Gibbs); `0`
+    /// iff `p = q`; `+∞` if `support(p) ⊄ support(q)`. Not symmetric.
+    let klDivergence (p: SoftValue.SoftValue) (q: SoftValue.SoftValue) : float =
+        crossEntropy p q - SoftValue.entropy p

--- a/tests/Tests.FSharp/SoftValueInfo.Tests.fs
+++ b/tests/Tests.FSharp/SoftValueInfo.Tests.fs
@@ -1,0 +1,44 @@
+module Zeta.Tests.SoftValueInfoTests
+
+open global.Xunit
+open Zeta.Core
+
+module SI = Zeta.Core.SoftValueInfo
+
+let private i n = DynamicValue.Int n
+let private dist xs = SoftValue.ofWeighted xs |> Option.get
+
+[<Fact>]
+let ``crossEntropy of a distribution with itself equals its entropy`` () =
+    let p = dist [ i 0L, 0.25; i 1L, 0.25; i 2L, 0.5 ]
+    Assert.Equal(SoftValue.entropy p, SI.crossEntropy p p, 9)
+
+[<Fact>]
+let ``KL divergence is zero iff the distributions are equal`` () =
+    let p = dist [ i 0L, 0.5; i 1L, 0.5 ]
+    Assert.Equal(0.0, SI.klDivergence p p, 9)
+    let q = dist [ i 0L, 0.9; i 1L, 0.1 ]
+    Assert.True(SI.klDivergence p q > 0.0) // Gibbs: strictly positive when p ≠ q
+
+[<Fact>]
+let ``KL is non-negative and asymmetric`` () =
+    let p = dist [ i 0L, 0.7; i 1L, 0.3 ]
+    let q = dist [ i 0L, 0.4; i 1L, 0.6 ]
+    Assert.True(SI.klDivergence p q >= 0.0)
+    Assert.True(SI.klDivergence q p >= 0.0)
+    Assert.NotEqual(SI.klDivergence p q, SI.klDivergence q p) // D(p‖q) ≠ D(q‖p) in general
+
+[<Fact>]
+let ``cross-entropy diverges when q misses an outcome p supports`` () =
+    let p = dist [ i 0L, 0.5; i 1L, 0.5 ]
+    let q = dist [ i 0L, 1.0 ] // assigns 0 to outcome 1, which p supports
+    Assert.True(System.Double.IsPositiveInfinity(SI.crossEntropy p q))
+    Assert.True(System.Double.IsPositiveInfinity(SI.klDivergence p q))
+
+[<Fact>]
+let ``cross-entropy matches the closed form on a known example`` () =
+    // p = {0:.5, 1:.5}, q = {0:.25, 1:.75}; H(p,q) = -.5 ln .25 - .5 ln .75
+    let p = dist [ i 0L, 0.5; i 1L, 0.5 ]
+    let q = dist [ i 0L, 0.25; i 1L, 0.75 ]
+    let expected = -0.5 * log 0.25 - 0.5 * log 0.75
+    Assert.Equal(expected, SI.crossEntropy p q, 9)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -87,6 +87,7 @@
     <Compile Include="DynamicValueAlgebra.Tests.fs" />
     <Compile Include="DynamicValueNumeric.Tests.fs" />
     <Compile Include="SoftValueNumeric.Tests.fs" />
+    <Compile Include="SoftValueInfo.Tests.fs" />
     <Compile Include="WeightedSet.Tests.fs" />
     <Compile Include="ITensor.Tests.fs" />
     <Compile Include="SagaSnapshot.Tests.fs" />


### PR DESCRIPTION
Aaron 2026-06-07: 'general math floor … make sure DynamicValue and SoftValue can represent … and the cross
entropy.' Adds the information-theoretic floor for SoftValue (distribution over DynamicValue candidates),
matching SoftValue.entropy's convention (nats, EPS-guarded): crossEntropy H(p,q)=-Σp·ln q (+∞ if q misses
p's support) and klDivergence D(p‖q)=H(p,q)-H(p) (≥0 Gibbs, 0 iff p=q, asymmetric). Additive module (no edit
to SoftValue.fs). 5 tests incl. H(p,p)=H(p), KL≥0, divergence-on-missing-support, closed-form check.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
