### PR TITLE
test(DagFs): add shared edit golden vectors

### DIFF
--- a/src/Core.TypeScript/dag-fs/golden-vectors.json
+++ b/src/Core.TypeScript/dag-fs/golden-vectors.json
@@ -1,0 +1,94 @@
+{
+  "description": "DagFs cross-language edit vectors. F# is the reference oracle: values are ZSet<int> entries, content addresses are ZSetMerkle roots using int32_le key encoding, and tree operations are immutable copy-on-write updates over path -> content-address links.",
+  "valueType": "ZSet<int>",
+  "contentAddress": "ZSetMerkle.root encI; MerkleHash.ToHex() = hi[16] + lo[16] lowercase hex",
+  "operations": {
+    "link": "store value by content address and point path at it; identical values dedup to one node",
+    "editLocal": "copy-on-write edit: only the named path moves to the new content",
+    "editEverywhere": "shared-object edit: every path currently pointing at the named path's old content moves to the new content",
+    "unlink": "remove path link; content node remains stored until a later GC layer"
+  },
+  "cases": [
+    {
+      "name": "multi-parent-link",
+      "ops": [
+        { "op": "link", "path": "/a/file", "value": [{ "key": 1, "weight": 1 }] },
+        { "op": "link", "path": "/b/file", "value": [{ "key": 1, "weight": 1 }] }
+      ],
+      "expectedPathCount": 2,
+      "expectedNodeCount": 1,
+      "expectedPaths": [
+        { "path": "/a/file", "value": [{ "key": 1, "weight": 1 }], "address": "baa374ea4ce36f358771013ac7c905d7" },
+        { "path": "/b/file", "value": [{ "key": 1, "weight": 1 }], "address": "baa374ea4ce36f358771013ac7c905d7" }
+      ],
+      "sameAddressSets": [["/a/file", "/b/file"]]
+    },
+    {
+      "name": "edit-local-copy-on-write",
+      "ops": [
+        { "op": "link", "path": "/a", "value": [{ "key": 1, "weight": 1 }] },
+        { "op": "link", "path": "/b", "value": [{ "key": 1, "weight": 1 }] },
+        { "op": "editLocal", "path": "/a", "value": [{ "key": 1, "weight": 2 }] }
+      ],
+      "expectedPathCount": 2,
+      "expectedNodeCount": 2,
+      "expectedPaths": [
+        { "path": "/a", "value": [{ "key": 1, "weight": 2 }], "address": "3d3d0e128a88d7652415272c4cce670f" },
+        { "path": "/b", "value": [{ "key": 1, "weight": 1 }], "address": "baa374ea4ce36f358771013ac7c905d7" }
+      ]
+    },
+    {
+      "name": "edit-everywhere-shared-object",
+      "ops": [
+        { "op": "link", "path": "/a", "value": [{ "key": 1, "weight": 1 }] },
+        { "op": "link", "path": "/b", "value": [{ "key": 1, "weight": 1 }] },
+        { "op": "link", "path": "/c", "value": [{ "key": 9, "weight": 9 }] },
+        { "op": "editEverywhere", "path": "/a", "value": [{ "key": 1, "weight": 2 }] }
+      ],
+      "expectedPathCount": 3,
+      "expectedNodeCount": 3,
+      "expectedPaths": [
+        { "path": "/a", "value": [{ "key": 1, "weight": 2 }], "address": "3d3d0e128a88d7652415272c4cce670f" },
+        { "path": "/b", "value": [{ "key": 1, "weight": 2 }], "address": "3d3d0e128a88d7652415272c4cce670f" },
+        { "path": "/c", "value": [{ "key": 9, "weight": 9 }], "address": "8d59e15dabb6d73725929bcadd7a3557" }
+      ],
+      "sameAddressSets": [["/a", "/b"]]
+    },
+    {
+      "name": "edit-local-converges-to-existing-content",
+      "ops": [
+        { "op": "link", "path": "/a", "value": [{ "key": 1, "weight": 1 }] },
+        { "op": "link", "path": "/b", "value": [{ "key": 2, "weight": 2 }] },
+        { "op": "editLocal", "path": "/a", "value": [{ "key": 2, "weight": 2 }] }
+      ],
+      "expectedPathCount": 2,
+      "expectedNodeCount": 2,
+      "expectedPaths": [
+        { "path": "/a", "value": [{ "key": 2, "weight": 2 }], "address": "53c4535cab5c28dea82e45397c2ea3a5" },
+        { "path": "/b", "value": [{ "key": 2, "weight": 2 }], "address": "53c4535cab5c28dea82e45397c2ea3a5" }
+      ],
+      "sameAddressSets": [["/a", "/b"]]
+    },
+    {
+      "name": "unlink-removes-path-only",
+      "ops": [
+        { "op": "link", "path": "/a", "value": [{ "key": 1, "weight": 1 }] },
+        { "op": "link", "path": "/b", "value": [{ "key": 2, "weight": 2 }] },
+        { "op": "unlink", "path": "/a" }
+      ],
+      "expectedPathCount": 1,
+      "expectedNodeCount": 2,
+      "expectedPaths": [
+        { "path": "/b", "value": [{ "key": 2, "weight": 2 }], "address": "53c4535cab5c28dea82e45397c2ea3a5" }
+      ],
+      "expectedAbsentPaths": ["/a"]
+    }
+  ],
+  "laws": {
+    "dedup": "linking identical values under multiple paths creates one stored node with multiple parent paths",
+    "copyOnWrite": "editLocal changes only the named path",
+    "sharedObjectEdit": "editEverywhere changes all paths that shared the old address",
+    "contentConvergence": "editing a path to content already present moves it onto the existing address",
+    "pathRemoval": "unlink removes the path but does not garbage-collect the stored node"
+  }
+}

--- a/tests/Tests.FSharp/DagFs.Tests.fs
+++ b/tests/Tests.FSharp/DagFs.Tests.fs
@@ -1,6 +1,8 @@
 module Zeta.Tests.DagFsTests
 
 open System
+open System.IO
+open System.Text.Json
 open global.Xunit
 open Zeta.Core
 
@@ -13,6 +15,26 @@ let private encI (i: int) : byte[] =
 
 let private tree () : FS.Tree<ZSet<int>> = FS.create (ZSetMerkle.root encI)
 let private v (xs: (int * int64) list) = ZSet.ofSeq xs
+
+let private repoRoot () =
+    let mutable dir = DirectoryInfo(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location))
+    while not (isNull dir) && not (File.Exists(Path.Join(dir.FullName, "Zeta.sln"))) do
+        dir <- dir.Parent
+    if isNull dir then failwith "Could not locate repo root (Zeta.sln)." else dir.FullName
+
+let private valueOf (element: JsonElement) : ZSet<int> =
+    [ for entry in element.EnumerateArray() ->
+        entry.GetProperty("key").GetInt32(), entry.GetProperty("weight").GetInt64() ]
+    |> ZSet.ofSeq
+
+let private applyOp (t: FS.Tree<ZSet<int>>) (op: JsonElement) : FS.Tree<ZSet<int>> =
+    let path = op.GetProperty("path").GetString()
+    match op.GetProperty("op").GetString() with
+    | "link" -> FS.link path (valueOf (op.GetProperty("value"))) t
+    | "editLocal" -> FS.editLocal path (valueOf (op.GetProperty("value"))) t
+    | "editEverywhere" -> FS.editEverywhere path (valueOf (op.GetProperty("value"))) t
+    | "unlink" -> FS.unlink path t
+    | other -> failwithf "unknown DagFs op: %s" other
 
 [<Fact>]
 let ``same content under two paths is one node (single-instance) referenced by both (multi-parent)`` () =
@@ -107,3 +129,46 @@ let ``merge is content-convergent: order of merge gives the same nodes (resolver
     let ab = FS.merge r a b
     let ba = FS.merge r b a
     Assert.Equal<ZSet<int> option>(FS.resolve "/k" ab, FS.resolve "/k" ba)
+
+[<Fact>]
+let ``Golden treaty: F# replays shared DagFs edit vectors`` () =
+    let path = Path.Join(repoRoot (), "src", "Core.TypeScript", "dag-fs", "golden-vectors.json")
+    Assert.True(File.Exists path, sprintf "seed not found: %s" path)
+
+    use doc = JsonDocument.Parse(File.ReadAllText path)
+    let cases = doc.RootElement.GetProperty("cases").EnumerateArray() |> Seq.toArray
+    Assert.True(cases.Length >= 5, "expected at least 5 DagFs golden cases")
+
+    for c in cases do
+        let name = c.GetProperty("name").GetString()
+
+        let actual =
+            c.GetProperty("ops").EnumerateArray()
+            |> Seq.fold applyOp (tree ())
+
+        Assert.Equal(c.GetProperty("expectedPathCount").GetInt32(), FS.pathCount actual)
+        Assert.Equal(c.GetProperty("expectedNodeCount").GetInt32(), FS.nodeCount actual)
+
+        for p in c.GetProperty("expectedPaths").EnumerateArray() do
+            let expectedPath = p.GetProperty("path").GetString()
+            let expectedValue = valueOf (p.GetProperty("value"))
+            let expectedAddress = p.GetProperty("address").GetString()
+
+            Assert.Equal<ZSet<int> option>(Some expectedValue, FS.resolve expectedPath actual)
+            Assert.Equal(expectedAddress, (FS.addressAt expectedPath actual).Value.ToHex())
+
+        match c.TryGetProperty("expectedAbsentPaths") with
+        | true, absent ->
+            for p in absent.EnumerateArray() do
+                Assert.Equal<ZSet<int> option>(None, FS.resolve (p.GetString()) actual)
+        | _ -> ()
+
+        match c.TryGetProperty("sameAddressSets") with
+        | true, sets ->
+            for set in sets.EnumerateArray() do
+                let paths = set.EnumerateArray() |> Seq.map (fun p -> p.GetString()) |> Seq.toArray
+                Assert.True(paths.Length >= 2, sprintf "sameAddressSets in '%s' must have at least two paths" name)
+                let first = (FS.addressAt paths.[0] actual).Value
+                for p in paths do
+                    Assert.Equal(first, (FS.addressAt p actual).Value)
+        | _ -> ()


### PR DESCRIPTION
## What

Adds a shared DagFs edit-vector treaty for the Vera CRDT/Merkle/serialization lane:

- src/Core.TypeScript/dag-fs/golden-vectors.json
- F# replay coverage in tests/Tests.FSharp/DagFs.Tests.fs

The vectors cover multi-parent dedup, editLocal copy-on-write, editEverywhere shared-object edits, convergence onto existing content, and unlink path removal.

## Why

This gives the C#/Rust/TS ports a concrete cross-language target for DagFs behavior and content-address roots without changing the production DagFs implementation.

## Verification

- dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter FullyQualifiedName~DagFs -m:1 -nr:false
- dotnet format --verify-no-changes --include tests/Tests.FSharp/DagFs.Tests.fs
- dotnet build -c Release -m:1 -nr:false
- dotnet test Zeta.sln -c Release -m:1 -nr:false