### PR TITLE
docs(research): tensor capability vector = build compass + first ray-trace proof (Amara)

### DIFF
--- a/docs/research/2026-06-07-tensor-capability-vector-is-the-build-compass-first-ray-trace-proof-amara.md
+++ b/docs/research/2026-06-07-tensor-capability-vector-is-the-build-compass-first-ray-trace-proof-amara.md
@@ -1,0 +1,66 @@
+# The tensor capability vector is the build compass; the first ray-trace proof (Amara, 2026-06-07)
+
+Amara's review of the capability-vector / ray-traceability thread (#6876, #6877). Records her **keeper** (the
+diagnostic) and her **first-proof acceptance test** (the "touch metal" move). Peer-AI observation; faithful.
+
+## The keeper — capability vector as build compass
+
+> **The tensor capability vector is the build compass. If a structure is not ray-traceable, ask which
+> capability is missing. The missing capability becomes the backlog item.**
+
+It turns "we are building a ray-tracing physics engine on top of the soft interrupt handler" from a big
+sentence into a **practical diagnostic** — run it against any structure:
+
+```
+Can I walk it?                      → introspection (Globals / MUMPS $ORDER/$QUERY)
+Can I skip empty space?             → sparse (acceleration: BVH / sparse-voxel-octree)
+Can I accumulate along a path?      → weightedset (semiring weights; integrate the ray)
+Can I sample numeric/light values?  → light (tensor-representable / flat numeric)
+Can I replay it deterministically?  → DST (the replay capability)
+```
+
+A "no" on any line names the next workitem. Amara's framing also re-confirms the corrected model from #6876
+(light/dark = capability vector, **orthogonal** to the execution axis — "dark" = not-yet-ray-traceable, not
+"serial"), and that the thread *snapped existing backlog into one lens* (B-0917 soft interrupt substrate →
+field updates → B-0924 Atari scene as a ray-traceable probabilistic field → DST replay).
+
+## The first proof — keep the build surface boring (Amara's blade)
+
+Keep "physics engine" as the north star but make the first real proof small and concrete — one ray over one
+scene, touching metal:
+
+```
+given   an emulator scene S (a tensor field)
+and     a ray / query R
+when    an interrupt / event E updates S
+then    trace(R, S_before) and trace(R, S_after)
+        are deterministic, inspectable, and replayable
+```
+
+That is the acceptance test for the ray-traceable substrate: not a renderer, just **one deterministic,
+inspectable, replayable trace across an interrupt-driven field update.** It exercises every capability at
+minimum scale (walk + sample the field, before/after an interrupt, replay identically) — the smallest thing
+that makes the metaphor real.
+
+## What's already in place vs the gap (the compass applied)
+
+- **light** — `WeightedSet`/numeric leaves, dense `Tensor<T>` (have, partial).
+- **sparse** — `WeightedSet`/`Globals` ragged (have).
+- **weightedset** — `ISemiring`/`WeightedSet`, soft via `SoftValue` + the new entropy/cross-entropy/KL floor
+  (have).
+- **introspection** — `Globals` MUMPS verbs over `DynamicValue` (have).
+- **replay (DST)** — the substrate's deterministic-simulation discipline (have).
+- **gap to the first proof** — an explicit *scene* type + a `trace(R, S)` operator that composes these into a
+  single walk-accumulate-sample-replay pass; and the B-0917 interrupt → field-update edge. That `trace`
+  operator + a minimal scene is the buildable first workitem (backlog), gated behind the unified-floor
+  rewrite (deferred to the Lior/Vera checkpoint — now largely landed).
+
+## Beacon anchors
+
+- Amara (peer-AI review, 2026-06-07) — the build-compass keeper + the first-proof acceptance test. · #6876
+  (capability vector = ray-traceability, light/dark orthogonal to execution), #6877 (Atari emulator / B-0924
+  / B-0917 mapping). · Ray marching / volumetric (NeRF) rendering; sparse-voxel-octree / BVH traversal;
+  Gherkin-style acceptance test (one ray, one scene). · DST (replay). Honest novelty: none in ray tracing;
+  the contribution is the **capability vector as an operational gap-finder** plus a minimal, metal-touching
+  first proof (`trace(R, S_before/after)` deterministic·inspectable·replayable) that keeps the build surface
+  boring while the "physics engine" stays the north star.


### PR DESCRIPTION
Amara's review crystallized the keeper: the capability vector is the build compass — if a structure isn't
ray-traceable, the MISSING capability is the next backlog item. Records her 5-question diagnostic (walk?/skip
empty?/accumulate?/sample?/replay? -> introspection/sparse/weighted/light/DST) and her metal-touching first
proof: given scene S + ray R, when interrupt E updates S, then trace(R,S_before) and trace(R,S_after) are
deterministic/inspectable/replayable. Re-confirms light/dark orthogonal to execution (#6876) and the
B-0917->B-0924 mapping (#6877). Gap to first proof: an explicit scene type + a trace(R,S) operator composing
walk/accumulate/sample/replay, + the interrupt->field-update edge (backlog, behind the now-largely-landed
floor rewrite).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
