### PR TITLE
chore(memory): regenerate MEMORY.md index after amara bootstrap copy (fix memory-index-drift)

### DIFF
--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -2,7 +2,7 @@
 
 **📌 Fast path: read `CURRENT-aaron.md`, `CURRENT-amara.md`, `CURRENT-ani.md`, `CURRENT-vera.md`, `CURRENT-riven.md`, and `CURRENT-otto.md` first.**
 
-> **Stack-vs-heap framing (Aaron 2026-05-12):** This file is the **STACK** — indexed, ordered, traversable canonical view. Recent memory files in `memory/` with timestamps newer than the most-current entries here may be **HEAP** — floating cache, not yet indexed, accessible by direct path. Both are easily accessible: stack via traversal, heap via timestamp/filename. Indexing (heap→stack promotion) happens on cadence via `tools/memory/reindex-memory-md.ts` (B-0423), callable from the autonomous-loop tick. Last reindex: 2026-06-06.
+> **Stack-vs-heap framing (Aaron 2026-05-12):** This file is the **STACK** — indexed, ordered, traversable canonical view. Recent memory files in `memory/` with timestamps newer than the most-current entries here may be **HEAP** — floating cache, not yet indexed, accessible by direct path. Both are easily accessible: stack via traversal, heap via timestamp/filename. Indexing (heap→stack promotion) happens on cadence via `tools/memory/reindex-memory-md.ts` (B-0423), callable from the autonomous-loop tick. Last reindex: 2026-06-07.
 
 <!-- BEGIN AUTO-INDEX (B-0423 reindex-memory-md.ts) -->
 - [**soraya-b1019-dst-vacuity-review-portfolio-routing**](feedback_soraya_b1019_dst_vacuity_review_content_only_signature_three_valued_portfolio_routing_2026-06-06.md) — Soraya's vacuity+routing review of the B-1019 DST harness (2026-06-06): the honest design is a PORTFOLIO (F# DST rung-1 + TLC no-cycle + Lean pigeonhole); the F# harness must use a CONTENT-ONLY signature (exclude all counters), seed ONCE +…


### PR DESCRIPTION
PR #6885 added 11 files to memory/persona/amara/bootstrap/ without regenerating the memory heap index, so
the memory-index-drift CI gate went red on main. Regenerated via tools/memory/reindex-memory-md.ts (1514
entries); --check now exits 0. My own fault — the harness reindex hook didn't fire on the bulk cp.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
