### PR TITLE
feat(floor): unify Cayley-Dickson towers onto the floor — IStarRing : ISemiring, retire IAlgebra

### DIFF
--- a/src/Bayesian/Message.fs
+++ b/src/Bayesian/Message.fs
@@ -47,7 +47,7 @@ namespace Zeta.Bayesian
 /// are cross-checked against `Zeta.Bayesian.BayesianAggregate`.
 
 /// An exponential-family message algebra as a dictionary value
-/// (cf. `Zeta.Core.IAlgebra`): `Product` combines (= add natural
+/// (cf. `Zeta.Core.IStarRing`): `Product` combines (= add natural
 /// parameters), `Divide` forms the EP cavity (= subtract), `Uniform` is
 /// the identity. The generic-math static members on each family are the
 /// SRTP twin of this; this interface is the *runtime-polymorphic* form

--- a/src/Core.Abstractions/IStarRing.cs
+++ b/src/Core.Abstractions/IStarRing.cs
@@ -1,0 +1,26 @@
+namespace Zeta.Core;
+
+/// <summary>
+/// A *-ring: a ring (<see cref="ISemiring{TWeight}"/> — Zero/One/Add/Mul/Negate) extended with an
+/// involution <see cref="Conj"/>. This is the unified floor rung for Cayley–Dickson hypercomplex towers
+/// (Complex / Quaternion / Octonion / Sedenion): each tower is an <c>IStarRing</c>, hence an
+/// <see cref="ISemiring{TWeight}"/>, so the generic semiring substrate (<c>WeightedSet&lt;'K, 'W&gt;</c>,
+/// hypercomplex Z-sets, the soft layer, the instance-swap) carries hypercomplex weights for free — by
+/// instance-selection alone, no per-tower code.
+///
+/// <para>
+/// <b>Law profile (carried as documentation, not types):</b> <c>Add</c> is always commutative + associative;
+/// <c>Mul</c> loses commutativity above ℂ, associativity above ℍ, and alternativity above 𝕆. Consumers that
+/// require <c>Mul</c> associativity (e.g. matrix-style contraction) must stay at ℍ or below. The interface is
+/// a lawful dictionary of operations; the per-instance <c>Mul</c> guarantees are the caller's responsibility.
+/// </para>
+///
+/// Replaces the former F#-local <c>CayleyDickson.IAlgebra</c> (which lacked <c>One</c> and was disjoint from
+/// the floor); authored in C# per the contract-library convention (interface libs are C#, language-neutral).
+/// </summary>
+/// <typeparam name="TWeight">The element type (a hypercomplex tower level, or any *-ring element).</typeparam>
+public interface IStarRing<TWeight> : ISemiring<TWeight>
+{
+    /// <summary>The involution (conjugation): identity on ℝ, complex conjugate on ℂ, recursive beyond.</summary>
+    TWeight Conj(TWeight a);
+}

--- a/src/Core/CayleyDickson.fs
+++ b/src/Core/CayleyDickson.fs
@@ -32,19 +32,12 @@ namespace Zeta.Core
 /// algebra" surface that's the entire point.
 type Doubled<'A> = { Real: 'A; Imag: 'A }
 
-/// Algebra operations required for Cayley–Dickson doubling. A type
-/// `'A` qualifies as a (suitably-structured) algebra by providing
-/// zero, addition, negation, multiplication, and conjugation. The
-/// conjugation operation is the involutive antihomomorphism that
-/// makes the doubling well-defined — for ℝ it's the identity; for ℂ
-/// it's the standard complex conjugate; for ℍ and beyond it's defined
-/// recursively by the doubling formula above.
-type IAlgebra<'A> =
-    abstract Zero : 'A
-    abstract Add : 'A * 'A -> 'A
-    abstract Negate : 'A -> 'A
-    abstract Mul : 'A * 'A -> 'A
-    abstract Conj : 'A -> 'A
+// The algebra contract for Cayley–Dickson doubling is now the unified floor rung
+// `IStarRing<'A>` (Zero/One/Add/Mul/Negate + Conj) from `Zeta.Core.Abstractions` — a *-ring. The former
+// F#-local `IAlgebra<'A>` (no `One`, disjoint from the floor) is retired: a tower is now an `IStarRing`,
+// hence an `ISemiring`, so `WeightedSet<'K,'W>` and the rest of the generic semiring substrate carry
+// hypercomplex weights for free. `Conj` is the involutive antihomomorphism (identity on ℝ, complex
+// conjugate on ℂ, recursive beyond) that makes the doubling well-defined.
 
 [<RequireQualifiedAccess>]
 module Doubled =
@@ -52,38 +45,35 @@ module Doubled =
     /// Construct a doubled element from its real and imaginary parts.
     let make (real: 'A) (imag: 'A) : Doubled<'A> = { Real = real; Imag = imag }
 
-    /// Lift an algebra on `'A` to an algebra on `Doubled<'A>`.
+    /// Lift a *-ring on `'A` to a *-ring on `Doubled<'A>`.
     /// This IS the Cayley–Dickson construction; everything else
-    /// in this module is bookkeeping.
-    let algebra (inner: IAlgebra<'A>) : IAlgebra<Doubled<'A>> =
-        { new IAlgebra<Doubled<'A>> with
-            member _.Zero =
-                { Real = inner.Zero; Imag = inner.Zero }
+    /// in this module is bookkeeping. `One = (inner.One, inner.Zero)` (real 1, imaginary 0).
+    let algebra (inner: IStarRing<'A>) : IStarRing<Doubled<'A>> =
+        { new IStarRing<Doubled<'A>> with
+            member _.Zero = { Real = inner.Zero; Imag = inner.Zero }
+
+            member _.One = { Real = inner.One; Imag = inner.Zero }
 
             member _.Add(x, y) =
                 { Real = inner.Add(x.Real, y.Real)
                   Imag = inner.Add(x.Imag, y.Imag) }
 
-            member _.Negate x =
+            member _.Negate(x) =
                 { Real = inner.Negate x.Real
                   Imag = inner.Negate x.Imag }
 
             // (a, b) · (c, d) = (a·c − d̄·b, d·a + b·c̄)
             member _.Mul(x, y) =
                 let realPart =
-                    inner.Add(
-                        inner.Mul(x.Real, y.Real),
-                        inner.Negate(inner.Mul(inner.Conj y.Imag, x.Imag))
-                    )
+                    inner.Add(inner.Mul(x.Real, y.Real), inner.Negate(inner.Mul(inner.Conj y.Imag, x.Imag)))
+
                 let imagPart =
-                    inner.Add(
-                        inner.Mul(y.Imag, x.Real),
-                        inner.Mul(x.Imag, inner.Conj y.Real)
-                    )
+                    inner.Add(inner.Mul(y.Imag, x.Real), inner.Mul(x.Imag, inner.Conj y.Real))
+
                 { Real = realPart; Imag = imagPart }
 
             // conj (a, b) = (conj a, −b)
-            member _.Conj x =
+            member _.Conj(x) =
                 { Real = inner.Conj x.Real
                   Imag = inner.Negate x.Imag } }
 
@@ -97,14 +87,15 @@ module Doubled =
 [<RequireQualifiedAccess>]
 module Real =
 
-    let algebra : IAlgebra<float> =
-        { new IAlgebra<float> with
+    let algebra : IStarRing<float> =
+        { new IStarRing<float> with
             member _.Zero = 0.0
+            member _.One = 1.0
             member _.Add(x, y) = x + y
-            member _.Negate x = -x
+            member _.Negate(x) = -x
             member _.Mul(x, y) = x * y
             // ℝ-conjugation is identity (no imaginary part to flip).
-            member _.Conj x = x }
+            member _.Conj(x) = x }
 
 
 /// Type aliases for the first few levels of the imaginary stack.
@@ -119,15 +110,16 @@ type Octonion = Doubled<Quaternion>
 type Sedenion = Doubled<Octonion>
 
 
-/// Pre-computed algebra instances at each level of the imaginary
+/// Pre-computed *-ring instances at each level of the imaginary
 /// stack. Constructing these once and reusing them is correct because
-/// `IAlgebra<'A>` carries no state — it's a pure dictionary of
+/// `IStarRing<'A>` carries no state — it's a pure dictionary of
 /// operations. The instances are the structural fact "ℝ → ℂ → ℍ → 𝕆
-/// is the imaginary stack" made concrete.
+/// is the imaginary stack" made concrete — and since each is an
+/// `ISemiring`, they drop straight into `WeightedSet` & the floor.
 [<RequireQualifiedAccess>]
 module ImaginaryStack =
 
-    let complex : IAlgebra<Complex> = Doubled.algebra Real.algebra
-    let quaternion : IAlgebra<Quaternion> = Doubled.algebra complex
-    let octonion : IAlgebra<Octonion> = Doubled.algebra quaternion
-    let sedenion : IAlgebra<Sedenion> = Doubled.algebra octonion
+    let complex : IStarRing<Complex> = Doubled.algebra Real.algebra
+    let quaternion : IStarRing<Quaternion> = Doubled.algebra complex
+    let octonion : IStarRing<Octonion> = Doubled.algebra quaternion
+    let sedenion : IStarRing<Sedenion> = Doubled.algebra octonion

--- a/tests/Tests.FSharp/CayleyWeightedSet.Tests.fs
+++ b/tests/Tests.FSharp/CayleyWeightedSet.Tests.fs
@@ -1,0 +1,44 @@
+module Zeta.Tests.CayleyWeightedSetTests
+
+open global.Xunit
+open Zeta.Core
+
+module WS = Zeta.Core.WeightedSet
+
+// Quaternion = Doubled<Complex> = Doubled<Doubled<float>>
+let private cplx a b : Complex = { Real = a; Imag = b }
+let private quat a b c d : Quaternion = { Real = cplx a b; Imag = cplx c d }
+
+// the unified floor: a tower is an IStarRing, hence an ISemiring — drops straight into WeightedSet
+let private q = ImaginaryStack.quaternion :> ISemiring<Quaternion>
+
+let private one = quat 1.0 0.0 0.0 0.0
+let private i = quat 0.0 1.0 0.0 0.0
+
+[<Fact>]
+let ``WeightedSet carries quaternion weights through the unified floor (ISemiring)`` () =
+    let a = WS.ofSeq q [ "x", i; "y", one ]
+    Assert.Equal<Quaternion>(i, WS.weight q "x" a)
+    Assert.Equal<Quaternion>(one, WS.weight q "y" a)
+
+[<Fact>]
+let ``quaternion-weighted WeightedSet is retraction-native: a + (-a) = empty`` () =
+    let a = WS.ofSeq q [ "x", i; "y", one ]
+    // Add is commutative + associative for every tower, so retraction holds
+    Assert.True(WS.isEmpty (WS.add q a (WS.negate q a)))
+
+[<Fact>]
+let ``add combines shared coordinates via quaternion addition (i + 1 = 1 + i)`` () =
+    let a = WS.ofSeq q [ "x", i ]
+    let b = WS.ofSeq q [ "x", one ]
+    Assert.Equal<Quaternion>(quat 1.0 1.0 0.0 0.0, WS.weight q "x" (WS.add q a b))
+
+[<Fact>]
+let ``scale by One is identity (proves the tower carries a multiplicative identity)`` () =
+    let a = WS.ofSeq q [ "x", i; "y", one ]
+    Assert.Equal<WS.WeightedSet<string, Quaternion>>(a, WS.scale q one a)
+
+[<Fact>]
+let ``scale by Zero annihilates (proves Zero + Mul on the tower)`` () =
+    let a = WS.ofSeq q [ "x", i; "y", one ]
+    Assert.True(WS.isEmpty (WS.scale q (q.Zero) a))

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -89,6 +89,7 @@
     <Compile Include="SoftValueNumeric.Tests.fs" />
     <Compile Include="SoftValueInfo.Tests.fs" />
     <Compile Include="WeightedSet.Tests.fs" />
+    <Compile Include="CayleyWeightedSet.Tests.fs" />
     <Compile Include="ITensor.Tests.fs" />
     <Compile Include="SagaSnapshot.Tests.fs" />
     <Compile Include="DagFs.Tests.fs" />


### PR DESCRIPTION
The greenfield floor unification (designed #6874/#6875, deferred behind Lior's checkpoint — now landed/settled).
Adds C# IStarRing<TWeight> : ISemiring<TWeight> (+ Conj) to Zeta.Core.Abstractions — a *-ring. Migrates the
CayleyDickson towers (Real/Doubled/ImaginaryStack) to implement IStarRing (adding One = (inner.One, inner.Zero)),
and RETIRES the F#-local IAlgebra (its only real consumer was the tower code; Message.fs was a doc-comment
ref, updated). Now every tower IS an ISemiring, so WeightedSet<'K,'W> and the whole generic semiring substrate
carry hypercomplex weights for free. Law profile documented (Mul loses commut>ℂ, assoc>ℍ, alt>𝕆). Proof: 5
new tests — WeightedSet<string,Quaternion> add/retraction/scale-by-One/scale-by-Zero through the unified floor.
Core+Abstractions build 0/0; 32 Cayley+WeightedSet tests green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
