### PR TITLE
feat(abstractions): unified ray-traceable interface + capability facets (any frame; traveler-frame=proof; geospatial locality)

### DIFF
--- a/docs/research/2026-06-07-unified-ray-traceable-interface-capability-facets-any-frame-traveler-proof-cross-partition-soft-homoiconic-aaron.md
+++ b/docs/research/2026-06-07-unified-ray-traceable-interface-capability-facets-any-frame-traveler-proof-cross-partition-soft-homoiconic-aaron.md
@@ -1,0 +1,121 @@
+# The unified ray-traceable interface — capability facets, any-frame trace, traveler-frame proofs, cross-partition soft uncertainty, homoiconic memory↔function routing (Aaron, 2026-06-07)
+
+Builds the ray-traceability capability vector (#6876/#6877, Amara's build-compass #6882) into **C# contracts**
+in `Zeta.Core.Abstractions`. Faithful capture of Aaron's streamed refinements; design doc for the landed
+interfaces.
+
+## The facets (the capability vector as one-type-per-file C# contracts)
+
+| facet | interface | role in the ray trace |
+|---|---|---|
+| sparse + enumerate | `ITensor<TCoord,TValue>` (existing) | skip empty space; the support |
+| **light** | `ISampleable<TCoord,TValue>` | sample values along the ray (the field carries light) |
+| **introspection** | `IIntrospectable<TCoord>` | walk/query the structure (MUMPS/Globals-style) |
+| **geospatial** | `IGeospatial<TCoord>` | metric **locality topology** — makes a "ray" geometric |
+| **weighted** | `ISemiring<TValue>` (existing, passed to `Trace`) | accumulate along the ray |
+| frame | `IFrame` / `ITravelerFrame` | where the ray is cast *from* |
+| unified | `IRayTraceable<TCoord,TValue>` | composes the above + `Trace(from, ray, accumulate)` |
+
+A structure missing a facet is **"dark" in that dimension** — the gap-finder: the missing capability is the
+next build (the compass made into types).
+
+## Any frame is the capability; the traveler frame is the proof
+
+> Aaron: *"from any arbitrary frame actually — that's what ray-traceable gives you. The traveler frame gives
+> you proofs you can prove across all self-propagating patterns including Zeta itself."*
+
+- **`Trace(IFrame from, …)`** — ray-traceability is the ability to trace from **any** frame (a view from any
+  vantage point).
+- **`ITravelerFrame` (`IsDeterministic`)** — the distinguished, **proof-bearing** frame: DST-deterministic →
+  replayable → **provable**. A trace from a traveler frame is a *theorem*, not just an observation, and it
+  holds **across all self-propagating patterns — including Zeta itself** (a self-propagating pattern proving
+  things about itself; self-reference made sound by determinism).
+
+## Cross-partition + irreducible uncertainty (soft tracing)
+
+> Aaron: *"it lets you [do] cross-partition ray tracing based on others' DynamicValue/SoftValue and their
+> irreducible uncertainty."*
+
+The ray may cross partition boundaries and sample other partitions' `DynamicValue`/`SoftValue` fields. With
+`TValue = SoftValue` and a probability `ISemiring`, the trace **propagates each partition's irreducible
+uncertainty** — you cannot sample away another partition's residual; it is theirs and carries forward. So a
+cross-partition trace returns a *soft* result, and the traveler-frame proof becomes a proof about
+*distributions/bounds* (provable despite — and about — the uncertainty), not point values. (NeRF-shaped:
+a probabilistic radiance field, but bit-perfect-consensus + DST instead of float-fuzzy.)
+
+## Geospatial = a unified locality topology (not just lat/lon)
+
+> Aaron: *"the geospatial holds the Sequoia-like Stanford memory topology … the network memory map and
+> generator function map … remember when / pay attention."*
+
+`IGeospatial` is the metric **where/when/what-to-attend** topology. The "space" generalizes to:
+
+- **Hierarchical memory** — Sequoia (Fatahalian et al., Stanford 2006): a recursive memory-level tree;
+  position = locality in the memory hierarchy.
+- **Network memory map** — distributed placement across nodes/cells (which machine holds it); proximity =
+  network locality → enables cross-partition tracing.
+- **Generator-function map** — where the generators/compressors live (compression-as-generators); position
+  locates a region's *producer*.
+- **Spatio-temporal + attention** — a `when` axis and an attention weighting ("remember when / pay
+  attention"); attention is learned proximity/relevance in this space — the substrate's analogue of
+  transformer attention.
+
+So a coordinate's position is its location in (memory hierarchy × network × generator-space × time ×
+attention); a ray respects locality across all of these at once.
+
+## The homoiconic payoff — route memory↔function both ways
+
+> Aaron: *"this way you can route memory to functions and functions to memory both — they are all homoiconic
+> data."*
+
+Because the substrate is **homoiconic** — functions are Bonsai expr-trees, and Bonsai expr-trees are
+`DynamicValue`, the same `DynamicValue` that memory is — **the memory map and the generator-function map are
+the same map.** So the locality topology routes **bidirectionally**: a ray goes from a memory region to the
+**generator function that produces it**, and from a function to the **memory it reads/writes** — one
+addressable, ray-traceable space for code and data alike. (Lisp/Smalltalk homoiconicity + content-addressed
+code (Unison), realized as routable locality: code-as-data isn't just storable, it's *traceable in the same
+space as the data*.)
+
+## Geometry as the optimizer — and geospatial in Clifford (geometric-algebra) space
+
+> Aaron: *"and optimize with geometry geospatial … I'd love to do geospatial in Clifford space too if we can."*
+
+- **Geometry IS the optimizer.** The geospatial embedding turns the trace into a geometric problem, so the
+  classic acceleration structures apply: BVH / sparse-voxel-octree / R-tree / geohash skip empty and far
+  regions; nearest/within queries prune the ray. Locality (memory/network) + geometry (space) jointly make
+  the trace sub-linear instead of a full scan.
+- **Clifford / geometric-algebra (GA) space (desired direction).** Embed the locality space as a **Clifford
+  algebra** (multivectors, rotors) rather than plain ℝⁿ. Two reasons it's the right home:
+  1. **GA is built for ray geometry.** A ray and a surface are blades; their **meet** (`∨`) *is* the
+     intersection — ray-object intersection becomes one algebraic operation. Rotors do rotation/orientation
+     without gimbal/quaternion-glue.
+  2. **It composes with the floor we just unified.** Clifford algebras subsume the Cayley-Dickson towers:
+     **quaternions = the even subalgebra Cl⁺(3,0)** (rotors in 3-space); complex = Cl⁺(2,0). So the
+     `IStarRing` hypercomplex floor (#6888) and a GA geospatial space are the *same* algebraic family —
+     `WeightedSet<_, multivector>` over a Clifford `IStarRing` would give GA weights *and* GA geometry in one
+     substrate. (Honest scope: a Clifford `IStarRing` instance + a GA-backed `IGeospatial` is a backlog
+     build, gated on a conformal-vs-Euclidean GA signature choice; "if we can" → yes, and it slots cleanly
+     into the existing floor + facets.)
+
+## Status / next
+
+Landed: the C# contract facets (`IFrame`, `ITravelerFrame`, `ISampleable`, `IIntrospectable`, `IGeospatial`,
+`IRayTraceable`) in `Zeta.Core.Abstractions` (one-type-per-file; Abstractions + Core build 0/0). **No
+implementations yet** — these are the contracts; the buildable next step (per Amara's first-proof) is one
+structure adopting the facets + a `trace(R, S_before/after)` that is deterministic, inspectable, replayable
+from a traveler frame over one small scene. `Globals` (introspection ✓) + `WeightedSet` (sparse+weighted ✓)
+are the closest existing structures; the gaps are `ISampleable`/`IGeospatial` impls + the `Trace` operator.
+
+## Beacon anchors
+
+- **Sequoia** (Fatahalian, Knight et al., Stanford 2006 — memory-hierarchy-as-tree). · **Ray marching /
+  volumetric (NeRF) rendering**; sparse-voxel-octree / R-tree / BVH (geometric acceleration). · **Homoiconicity**
+  (Lisp; Smalltalk image) + **Unison** (content-addressed code). · **Transformer attention** (learned
+  proximity in an embedding space) — the geospatial attention dimension. · **DST** (the traveler-frame proof
+  property). · Ours: `ITensor`/`ISemiring`/`IStarRing` (the floor), `Globals` (introspection), `WeightedSet`
+  (sparse/weighted), `SoftValue` (irreducible uncertainty), `Bonsai` (functions-as-DynamicValue),
+  `TravelerFrame`, the capability-vector captures (#6876/#6877/#6882). Honest novelty: none in ray tracing or
+  homoiconicity individually; the contribution is the **unified ray-traceable contract** — one
+  facet-composed interface, traced from any frame (proof from the traveler frame), cross-partition over soft
+  fields, over a locality topology that unifies memory/network/generator/time-attention, routing code↔data
+  homoiconically.

--- a/src/Core.Abstractions/IFrame.cs
+++ b/src/Core.Abstractions/IFrame.cs
@@ -1,0 +1,8 @@
+namespace Zeta.Core;
+
+/// <summary>
+/// A frame a ray/query is cast <i>from</i>. **Ray-traceability is the capability of being traced from ANY
+/// arbitrary frame** (Aaron 2026-06-07: *"from any arbitrary frame actually — that's what ray-traceable gives
+/// you"*). Most frames are just observation vantage points; <see cref="ITravelerFrame"/> is the proof-bearing one.
+/// </summary>
+public interface IFrame { }

--- a/src/Core.Abstractions/IGeospatial.cs
+++ b/src/Core.Abstractions/IGeospatial.cs
@@ -1,0 +1,37 @@
+namespace Zeta.Core;
+
+/// <summary>
+/// Capability facet — <b>geospatial</b> (Aaron 2026-06-07): coordinates are embedded in a <b>metric locality
+/// space</b>, which is what makes a "ray" a <i>geometric</i> object (a line through real space) rather than
+/// only an abstract path through a graph. <see cref="Position"/> gives a coordinate's point in that space;
+/// <see cref="Within"/> is the spatial range query (the geometric acceleration structure — R-tree / geohash /
+/// BVH style) that lets a ray skip empty/far regions.
+///
+/// <para>
+/// The "space" is general — it is the substrate's unified <b>where / when / what-to-attend</b> topology:
+/// </para>
+/// <list type="bullet">
+///   <item><b>Hierarchical memory</b> — a Sequoia-like recursive memory-level tree (Fatahalian et al.,
+///     Stanford 2006): position = locality in the memory hierarchy; proximity = cache/region locality.</item>
+///   <item><b>Network memory map</b> — distributed placement across nodes/partitions (which machine/cell
+///     holds the data); proximity = network locality. Enables cross-partition ray-tracing.</item>
+///   <item><b>Generator-function map</b> — where the generators/compressors live (compression-as-generators);
+///     position locates the producer of a region's content.</item>
+///   <item><b>Spatio-temporal + attention</b> — "remember when / pay attention": a time axis (when) and an
+///     attention weighting (what to attend to). Attention is learned proximity/relevance in this space —
+///     the substrate's analogue of transformer attention.</item>
+/// </list>
+/// So "geospatial" = a coordinate's location in (memory hierarchy × network × generator-space × time ×
+/// attention). A ray traversing it respects locality across all of these at once.
+/// </summary>
+public interface IGeospatial<TCoord>
+{
+    /// <summary>Number of dimensions of the locality space (2 = lat/lon, 3 = x/y/z, N = the general topology).</summary>
+    int Dimensions { get; }
+
+    /// <summary>The coordinate's position in the metric locality space the ray travels through.</summary>
+    IReadOnlyList<double> Position(TCoord at);
+
+    /// <summary>Coordinates whose position lies within the axis-aligned box [min, max] (locality/region query).</summary>
+    IEnumerable<TCoord> Within(IReadOnlyList<double> min, IReadOnlyList<double> max);
+}

--- a/src/Core.Abstractions/IIntrospectable.cs
+++ b/src/Core.Abstractions/IIntrospectable.cs
@@ -1,0 +1,14 @@
+namespace Zeta.Core;
+
+/// <summary>
+/// Capability facet — <b>introspection</b>: the structure can be walked/queried (MUMPS/Globals-style), so a
+/// ray can step through it.
+/// </summary>
+public interface IIntrospectable<TCoord>
+{
+    /// <summary>Whether a coordinate is defined (a node exists there).</summary>
+    bool Exists(TCoord at);
+
+    /// <summary>The immediate next coordinates from <paramref name="at"/> (the ray's stepping options).</summary>
+    IEnumerable<TCoord> Neighbors(TCoord at);
+}

--- a/src/Core.Abstractions/IRayTraceable.cs
+++ b/src/Core.Abstractions/IRayTraceable.cs
@@ -1,0 +1,35 @@
+using Zeta.Core.Abstractions; // ITensor lives in this namespace; ISemiring lives in Zeta.Core
+
+namespace Zeta.Core;
+
+/// <summary>
+/// **The unified ray-traceable interface** — the tensor capability vector composed into one contract
+/// (Aaron 2026-06-07). A structure is ray-traceable when it is:
+/// <list type="bullet">
+///   <item><b>sparse</b> + enumerable — <see cref="ITensor{TCoord,TValue}"/> (skip empty space)</item>
+///   <item><b>light</b> — <see cref="ISampleable{TCoord,TValue}"/> (sample values along the ray)</item>
+///   <item><b>introspectable</b> — <see cref="IIntrospectable{TCoord}"/> (walk the structure)</item>
+///   <item><b>geospatial</b> — <see cref="IGeospatial{TCoord}"/> (locality topology: memory/network/generator/time-attention)</item>
+///   <item><b>weighted</b> — accumulation via an <see cref="ISemiring{TValue}"/> passed to <see cref="Trace"/></item>
+/// </list>
+/// Missing any facet ⇒ "dark" in that dimension (the gap-finder: the missing capability is the next build).
+///
+/// <para>
+/// <b>Cross-partition + irreducible uncertainty:</b> the ray may cross partition boundaries and sample other
+/// partitions' <c>DynamicValue</c>/<c>SoftValue</c> fields. With <c>TValue = SoftValue</c> and a probability
+/// <see cref="ISemiring{TValue}"/>, the trace <b>propagates each partition's irreducible uncertainty</b> —
+/// you cannot sample away another partition's residual; it carries forward. So the result is itself soft.
+/// </para>
+/// </summary>
+public interface IRayTraceable<TCoord, TValue> : ITensor<TCoord, TValue>, ISampleable<TCoord, TValue>, IIntrospectable<TCoord>, IGeospatial<TCoord>
+{
+    /// <summary>
+    /// Cast a ray (a path of coordinates) from <paramref name="from"/> — **any** frame — accumulating the
+    /// sampled values along it via <paramref name="accumulate"/> (skip empty via sparsity, walk via
+    /// introspection + geospatial locality, sample via light, combine via the semiring). When
+    /// <paramref name="from"/> is an <see cref="ITravelerFrame"/> with <c>IsDeterministic = true</c>, the
+    /// trace is replayable and the result is a **proof** (holds across self-propagating patterns, Zeta
+    /// included), even when the field carries irreducible (soft) uncertainty.
+    /// </summary>
+    TValue Trace(IFrame from, IReadOnlyList<TCoord> ray, ISemiring<TValue> accumulate);
+}

--- a/src/Core.Abstractions/ISampleable.cs
+++ b/src/Core.Abstractions/ISampleable.cs
@@ -1,0 +1,10 @@
+namespace Zeta.Core;
+
+/// <summary>
+/// Capability facet — <b>light</b>: values can be sampled (the field "carries light" a ray can read).
+/// </summary>
+public interface ISampleable<TCoord, TValue>
+{
+    /// <summary>The value at a coordinate (the semiring Zero/default where absent).</summary>
+    TValue Sample(TCoord at);
+}

--- a/src/Core.Abstractions/ITravelerFrame.cs
+++ b/src/Core.Abstractions/ITravelerFrame.cs
@@ -1,0 +1,13 @@
+namespace Zeta.Core;
+
+/// <summary>
+/// The distinguished, **proof-bearing** frame. A trace cast from a traveler frame is **DST-deterministic →
+/// replayable → provable**: it yields proofs you can carry **across all self-propagating patterns — including
+/// Zeta itself** (a self-propagating pattern reasoning about itself). Arbitrary frames give you the view; the
+/// traveler frame gives you the proof.
+/// </summary>
+public interface ITravelerFrame : IFrame
+{
+    /// <summary>The DST guarantee — the trace from this frame replays identically, so its result is provable.</summary>
+    bool IsDeterministic { get; }
+}


### PR DESCRIPTION
Aaron 2026-06-07: 'interfaces for the things that make an algebra ray-traceable + a unified ray-traceable
interface from the traveler frame... from any arbitrary frame.' Adds C# contracts (one-type-per-file) in
Zeta.Core.Abstractions: IFrame (trace from ANY frame = the capability), ITravelerFrame (IsDeterministic =
the PROOF-bearing frame: DST->replayable->provable across all self-propagating patterns incl Zeta itself),
ISampleable (light), IIntrospectable (introspection/walk), IGeospatial (the metric LOCALITY topology), and
IRayTraceable composing ITensor(sparse)+ISampleable+IIntrospectable+IGeospatial with Trace(from,ray,semiring).
Geospatial 'space' generalizes to memory hierarchy (Sequoia/Stanford), network map, generator-function map,
spatio-temporal+attention. Cross-partition over SoftValue propagates irreducible uncertainty. Homoiconic:
memory<->function route both ways (both DynamicValue; memory map = generator map). Geometry optimizes (BVH/
R-tree); Clifford/GA space desired (quaternions=Cl+(3,0) rotors; meet=ray intersection) — composes with the
IStarRing floor. Contracts only (no impls yet); Abstractions+Core build 0/0.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
