### PR TITLE
docs(research): Adinkras spread across network topology — distributed ECC on the ray-traceable geospatial map

### DIFF
--- a/docs/research/2026-06-07-adinkra-ecc-spread-across-network-topology-on-the-ray-traceable-geospatial-map-aaron.md
+++ b/docs/research/2026-06-07-adinkra-ecc-spread-across-network-topology-on-the-ray-traceable-geospatial-map-aaron.md
@@ -1,0 +1,40 @@
+# Adinkras spread across the network topology — distributed ECC on the ray-traceable geospatial map (Aaron, 2026-06-07)
+
+Aaron: *"once we do that [the unified ray-traceable + geospatial interfaces] it's easy to create Adinkras that
+spread across the network topology."* The next link: distributed error-correction placed over the geospatial
+**network memory map**. Grounded in `AdinkraCode.fs` + B-0623; faithful capture.
+
+## What it composes
+
+| piece | what it is | role |
+|---|---|---|
+| **Adinkra** (`AdinkraCode.fs`, B-0623) | Adinkras ↔ **doubly-even binary linear codes** (Gates, Iga et al.); N=4 = the [8,4] extended Hamming code — an **ECC** decorating the hypercomplex/SUSY structure with colored-edge information | the error-correcting code |
+| **geospatial network map** (`IGeospatial`, #6889) | the locality topology's **network** axis — which node/cell holds which region (distributed placement) | *where* the code-shards live |
+| **ray-traceable** (`IRayTraceable`, #6889) | trace/route across partitions from any frame | *how* shards are reached / recovered |
+| **IStarRing floor** (#6888) | Cayley-Dickson towers as ISemiring; Clifford/GA direction | the algebra the Adinkra decorates |
+
+## The claim
+
+Because the geospatial facet now exposes the **network memory map** (distributed placement) and the
+ray-traceable interface routes/traces **across partitions**, you can **spread an Adinkra ECC across the
+network topology**: encode state with the doubly-even Adinkra code and **place the codewords/shards across
+nodes by their geospatial (network-locality) position**. The result is **distributed erasure-correction** —
+state survives node loss (the code recovers from erased shards), and recovery is a cross-partition ray-trace
+that gathers the surviving shards (locality-optimized: gather the nearest sufficient set, skip far/cold
+nodes). It is the same "what's missing → which capability" compass, now at the *durability* layer:
+introspection finds shards, geospatial places/locates them, sparsity skips empties, the semiring accumulates
+the decode, the traveler frame makes the recovery **provable** (deterministic replay of the decode).
+
+So the chain closes: **floor (IStarRing) → ray-traceable facets (#6889) → Adinkra ECC over the network map →
+resilient, recoverable distributed state.** The Adinkra was always the ECC that "decorates the hypercomplex
+structure"; the network geospatial map is what lets it *decorate the distributed substrate* too.
+
+## Honest scope
+
+Connective/forward capture — it names the composition; it authorizes no build. The buildable seed: an
+`Adinkra`-coded placement that uses `IGeospatial` (network axis) to distribute codewords + a cross-partition
+`Trace` to recover, with a provable (traveler-frame) decode. Depends on the ray-traceable *implementations*
+(facets are contracts only today) and a network-map backing. Anchors: erasure coding (Reed-Solomon was the
+principle-prover in `ErasureDistance`; Adinkra doubly-even codes are the genuine code), distributed storage
+(Ceph/IPFS-style sharded redundancy). Ties: `AdinkraCode.fs`, B-0623/B-0699, the ray-traceable interfaces
+(#6889), the IStarRing floor (#6888), the geospatial network/locality topology.


### PR DESCRIPTION
Aaron 2026-06-07: 'once we do that it's easy to create Adinkras that spread across the network topology.'
Adinkras (AdinkraCode.fs, B-0623) = doubly-even binary linear codes (Gates/Iga; [8,4] Hamming) — an ECC.
Composing with the new geospatial NETWORK memory map + cross-partition ray-tracing (#6889) over the IStarRing
floor (#6888): encode state with the Adinkra code, place codewords across nodes by geospatial network
locality -> distributed ERASURE-CORRECTION; recovery is a cross-partition ray-trace gathering nearest
surviving shards, provable via traveler-frame deterministic replay of the decode. Closes the chain floor ->
ray-traceable facets -> Adinkra ECC over the network map -> resilient recoverable distributed state.
Connective capture; no build authorized.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
