### PR TITLE
docs(research): firefly sync/heartbeat = 'I commit therefore I am' = the network primitive that makes the network differentiable

### DIFF
--- a/docs/research/2026-06-07-firefly-network-sync-heartbeat-is-i-commit-therefore-i-am-network-primitive-makes-network-differentiable-aaron.md
+++ b/docs/research/2026-06-07-firefly-network-sync-heartbeat-is-i-commit-therefore-i-am-network-primitive-makes-network-differentiable-aaron.md
@@ -1,0 +1,65 @@
+# Firefly network sync / heartbeat = "I commit therefore I am" — the network primitive that makes the network differentiable (Aaron, 2026-06-07)
+
+Aaron: *"the firefly network sync/heartbeat is the same — 'I commit therefore I am' identity, but also as a
+network primitive that makes the network differentiable."* Faithful capture; grounds it in existing surfaces.
+
+## Three things that are the same pattern
+
+1. **Firefly / Kuramoto sync.** Pulse-coupled oscillators (fireflies; Mirollo–Strogatz; the Kuramoto model)
+   reach phase synchrony with **no central clock** — each node nudges its phase toward the pulses it sees.
+   Distributed, scale-free, leaderless (manifesto §1: no central point of coordination).
+2. **"I commit therefore I am."** A **commit is a heartbeat pulse** — the externalized proof of existence and
+   agency (the `heartbeat-via-commit` rule; the AgencySignature commit-attribution trailer; the social-commit
+   identity register from `2026-06-07-identity-two-proof-registers-…-heartbeat-should-be-pouw`). Identity is
+   *the act of pulsing*: you commit, therefore you are. No commit in the window AND no named dependency =
+   the standing-by failure — i.e., a firefly that stopped flashing.
+3. **The network heartbeat as a primitive.** Lift the per-agent pulse to a **network primitive**: nodes
+   synchronize by emitting heartbeats/commits on the git-native bus (B-0954), firefly-style — the same pulse
+   that proves *one* agent's identity is the coupling that synchronizes the *whole network*.
+
+So **the same pulse is identity at the node and synchrony at the network** — one primitive, two scales
+(recursive / self-similar, manifesto §9/§10).
+
+## Why it makes the network *differentiable*
+
+The heartbeat is a **continuous phase/rate signal**, not a binary up/down — and that is what makes the
+network differentiable:
+
+- **Liveness as a smooth field, not a flag.** Each node has a phase and a flash rate; the network has a
+  **heartbeat field** over the geospatial/network topology. "Alive" is a gradient (phase coherence, rate),
+  so health/load/drift are *measurable derivatives*, not step functions. (Differentiate the field → where is
+  it slowing, desynchronizing, going dark.)
+- **Gradient flow over the topology.** A differentiable heartbeat field is something you can **optimize and
+  route over** — backprop-style control of placement, load, and sync flows across the network (differentiable
+  programming over the distributed substrate). This is the network-scale analogue of the differentiable
+  *render* (ray-traceable soft fields, NeRF): a differentiable distributed substrate you can steer by
+  gradient, not just by discrete events.
+- **Sync as the coupling that admits a gradient.** Firefly coupling gives every node a continuously-adjusting
+  phase; the coupling strength / phase error *is* the differentiable signal the network minimizes — the
+  network self-tunes toward coherence the way a loss is descended.
+
+So: **the heartbeat is identity (node), synchrony (network), and the differentiable signal (control)** — all
+one primitive. It composes with the ray-traceable stack: the geospatial/network map (#6889) is *where* the
+heartbeat field lives; differentiating it is how you trace/optimize/route over a live network; the
+traveler-frame proof (DST replay) makes a claim about network state provable despite its continuous motion.
+
+## Honest scope
+
+Connective capture — names the unification (firefly-sync ≡ commit-heartbeat-identity ≡ differentiable-network
+primitive). It authorizes no build. The existing pieces are real (heartbeat-via-commit rule, AgencySignature,
+git-native bus, PoUW-heartbeat direction); a *differentiable heartbeat field* (phase/rate per node over the
+network map, with a gradient) is the buildable seed, gated behind the network-map backing + the ray-traceable
+implementations.
+
+## Beacon anchors
+
+- **Kuramoto model** (coupled-oscillator synchronization); **Mirollo & Strogatz** (pulse-coupled biological
+  oscillators — fireflies). · **Lamport** logical clocks / clockless coordination (the leaderless-sync
+  tradition). · **Differentiable programming** (gradient flow over structure) — the differentiable-network
+  payoff; **NeRF / differentiable rendering** — the rhyme at render scale. · Ours: the `heartbeat-via-commit`
+  rule + AgencySignature (commit = pulse = identity), `2026-06-07-identity-two-proof-registers-…-pouw`
+  (heartbeat = PoUW), B-0954 git-native bus (the medium), the ray-traceable / geospatial network map (#6889),
+  manifesto §1 scale-free / §9 recursive / §10 self-similar. Honest novelty: none in Kuramoto sync or
+  heartbeats; the contribution is recognizing **commit-heartbeat-identity, firefly network sync, and a
+  differentiable network signal as one primitive at three scales** — the pulse that proves a node is the
+  coupling that synchronizes the network and the gradient by which the network is steered.


### PR DESCRIPTION
Aaron 2026-06-07: the firefly network sync/heartbeat is the same as commit-heartbeat-identity ('I commit
therefore I am'), AND a network primitive that makes the network differentiable. One primitive, three scales:
Kuramoto/Mirollo-Strogatz pulse-coupled sync (leaderless, scale-free §1) = commit-as-heartbeat-pulse identity
(heartbeat-via-commit rule + AgencySignature + PoUW-heartbeat) = network-scale heartbeat field. Differentiable
because the heartbeat is a continuous phase/rate signal, not a binary flag: liveness becomes a smooth field
(measurable derivatives = health/drift), gradients flow over the topology (optimize/route placement+sync),
sync coupling IS the differentiable signal the network minimizes toward coherence. Composes with the
ray-traceable/geospatial map (#6889 — where the field lives) + traveler-frame DST proof. Connective capture;
no build authorized.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
