### PR TITLE
docs(research): universal action grammar (Xbox controller) ties into the geospatial network map — location-contextual actions

### DIFF
--- a/docs/research/2026-06-07-universal-action-grammar-xbox-controller-ties-into-geospatial-network-map-location-contextual-actions-aaron.md
+++ b/docs/research/2026-06-07-universal-action-grammar-xbox-controller-ties-into-geospatial-network-map-location-contextual-actions-aaron.md
@@ -1,0 +1,48 @@
+# Universal action grammar (Xbox controller) ties into the geospatial network map — location-contextual actions (Aaron, 2026-06-07)
+
+Aaron: *"then you can have the universal action grammar / Xbox controller interface tie into the geolocation
+data of the network too."* The two traveler-frame layers meet. Faithful capture; grounded in `ActionGrid.fs`.
+
+## The two layers, made one interface
+
+`ActionGrid.fs` already states the split explicitly — **the 4×4 universal action grammar (Layer-2 of the
+traveler frame)** is *orthogonal* to the frame:
+
+- **Frame (Layer-1) = WHERE / WHEN** — now the **`IGeospatial` locality topology** (#6889): memory hierarchy
+  × network map × generator map × time/attention.
+- **Action grammar (Layer-2) = WHAT YOU CAN DO** — the **Xbox-controller 4×4 grid** (`ActionGrid`, B-0867):
+  the *button layout is fixed*, but *what each button does is per-context* — "the same way an Xbox
+  controller's layout is fixed but what each button does is per-game."
+
+Aaron's move: **tie the action grammar into the geolocation data** → "per-game" becomes **"per-location."**
+The controller stays universal (any traveler drives the same 4×4), but **the meaning of each action is a
+function of *where you are* in the geospatial network** — the action grammar reads the frame.
+
+## What this gives
+
+- **One universal pilot interface over the ray-traceable network.** Any traveler navigates and acts across
+  the geospatial network map with the same controller; the substrate contextualizes the actions by network
+  location (which node/cell/region/memory-level you're at). Drive the ray-traceable space like a game world.
+- **Inclusive at the substrate level** (the xbox-controller rule): *any* traveler — human or agent — drives
+  the *same* controller, so the spatial-action interface is uniform across the fleet.
+- **Location-contextual semantics, fixed grammar.** Fixed 16-action surface (legible, learnable once) whose
+  effects vary with frame — the same legibility/uniformity Xbox controllers give across games, now across
+  network locations. Pairs with the firefly heartbeat (the network's live phase field, #6891) so the
+  controller acts on a *live, differentiable* network, and with the traveler-frame proof (DST) so an action's
+  effect is replayable/provable from where it was taken.
+
+So the stack reads: **`IGeospatial` (where/when) × `ActionGrid` (what) = a universal, location-contextual
+action interface over the ray-traceable, heartbeat-live network** — drive the network's geolocation with the
+universal controller.
+
+## Honest scope
+
+Connective capture — it joins two existing surfaces (`ActionGrid`/B-0867 and the geospatial map #6889); no
+build authorized. Buildable seed: an `ActionGrid` whose action-resolution takes an `IGeospatial` position so
+the 4×4 actions resolve per network location; gated behind the ray-traceable implementations + a network-map
+backing. Anchors: `ActionGrid.fs` (4×4 grammar), B-0867 workflow engine, the `xbox-controller-universal-
+action-grammar` rule (any-traveler-same-controller, inclusive), `IGeospatial` (#6889), the traveler-frame
+layer model (frame=where/when, action-grid=what), the firefly heartbeat field (#6891). Honest novelty: none in
+fixed-grammar/contextual-action controllers; the contribution is **binding the universal action grammar to the
+geospatial network frame** so a single controller pilots the ray-traceable, live network with
+location-contextual action semantics.


### PR DESCRIPTION
Aaron 2026-06-07: tie the universal action grammar / Xbox-controller interface into the network geolocation.
The two traveler-frame layers meet: ActionGrid.fs already says frame=WHERE/WHEN, action-grammar=WHAT-YOU-CAN-DO
(4x4 grid, fixed layout, per-context meaning like an Xbox controller per-game). Tying it to IGeospatial
(#6889, the where/when locality topology) makes 'per-game' into 'per-location': fixed universal controller,
action meaning a function of network location. Gives one universal pilot interface over the ray-traceable,
heartbeat-live (#6891) network; inclusive (any traveler same controller); location-contextual semantics with
fixed grammar; DST-provable action effects. Connective capture; no build authorized.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
