### PR TITLE
docs(research): spatial/legal boundaries are frame-relative — no privileged global map (peel the dominion misreading)

### DIFF
--- a/docs/research/2026-06-07-spatial-legal-boundaries-are-frame-relative-no-privileged-global-map-aaron.md
+++ b/docs/research/2026-06-07-spatial-legal-boundaries-are-frame-relative-no-privileged-global-map-aaron.md
@@ -1,0 +1,64 @@
+# Spatial/legal boundaries are frame-relative — there is no privileged global map (Aaron, 2026-06-07)
+
+Extends the jurisdiction-parameterized legal frame (#6893) to **geography itself**. Aaron: *"Earth's and
+space borders are even drawn jurisdiction-relative … in my meta-jurisdiction the Earth is just one color,
+mine."* The defensible architectural insight, with a **firm peel of the "planetary sovereignty" misreading**.
+
+## The insight: boundaries are constructs, drawn per frame
+
+Spatial-legal boundaries are **not natural facts** — they are jurisdiction-relative constructs, exactly like
+the legal priors in #6893:
+
+- The **Kármán line** is 100 km (FAI) vs 80 km (NASA); there is *no agreed legal definition* of where outer
+  space begins. National airspace has no agreed vertical extent. The 1967 Outer Space Treaty governs "outer
+  space" without defining it. Borders attach to airports/seaports regardless of physical geography.
+- So **even the geography carries jurisdiction-specific Bayesian priors** (`SoftValue`): "where the boundary
+  is" is itself probabilistic and frame-relative. The geospatial frame's borders are part of the *legal
+  overlay*, not the physical substrate — there is no global border any more than there is a global clock or a
+  global causal order (manifesto §1; `TravelerFrame.fs` Layer-0: "no global frame, perspectival").
+
+## "In my meta-jurisdiction the Earth is one color, mine" — the frame-relativity reading
+
+The honest, architecture-consistent reading: **each meta-frame draws its own map**, and *from within a
+sovereign frame, that frame's domain is whole and undivided* — "one color, mine." This is the **traveler-
+frame / sovereign-shore principle applied to geography**: every frame is sovereign over *its own view*; no
+frame's map is privileged over another's. In your frame, your jurisdiction is one undivided whole — and in
+*every other* frame, theirs is too. The maps differ; none is the global truth.
+
+## The peel (load-bearing): frame-relativity is ANTI-dominion, not dominion
+
+Alexa read this as *"universal planetary authority / transcendent sovereignty / unified global control / Zeta
+operates under one authority."* **That is wrong, and it's the dangerous misreading.** Frame-relativity says
+the *opposite* of one-authority-over-all:
+
+- **No privileged global frame** means **no frame can impose its map on another** — that is the whole point
+  of traveler-frame-relativity, sovereign shores, consent-first crossing (manifesto §6), and the
+  Lillian-Eve choice architecture. "Each frame sees its own undivided map" is **many sovereign frames**, not
+  one ruling all.
+- "The Earth is one color in *my* frame" is a statement about *perspective* (my view is whole *to me*), not a
+  claim to *rule* the Earth. Reading it as planetary dominion inverts the principle into exactly the coercive,
+  global-authority shape the architecture is built to forbid (no global causal order, no coercive actor
+  boundary, exit always preserved).
+- So the keeper is: **boundaries are frame-relative constructs; every frame is sovereign over its own map and
+  none over anyone else's.** That is decentralization and consent, not sovereignty-over-others. If a reading
+  of "one color, mine" can't compress to "frame-relative perspective + no privileged global map," it has gone
+  too far (Mirror coinage failing the Beacon test).
+
+## Architectural payoff (small, honest)
+
+The geospatial frame (#6889) and the legal overlay (#6893) already make this expressible: boundary
+definitions are **per-jurisdiction priors** on the geospatial frame, not constants. A cross-boundary trace
+carries each frame's spatial-legal prior (cross-partition soft uncertainty over *where the line is*). Nothing
+new to build; this is the principle that keeps the geospatial/legal stack honest — **frame-relative, never
+globally-imposed.** The actual legal/territorial treatment stays threat-model + human-sign-off territory.
+
+## Beacon anchors
+
+- **No global frame** — relativity (no universal simultaneity); distributed systems (no global clock / causal
+  order — Lamport); the manifesto §1 scale-free / §6 consent-first; `TravelerFrame.fs`. · **Borders as social
+  constructs** — Kármán line dispute, 1967 Outer Space Treaty (undefined "outer space"); cartographic
+  relativism. · The jurisdiction-parameterized legal frame (#6893), geospatial frame (#6889), sovereign-shore
+  / traveler-frame meeting protocol (the beach). Honest novelty: none in frame-relativity or border-
+  constructivism; the contribution is **stating spatial-legal boundaries as per-frame priors on the geospatial
+  frame** and **explicitly fencing off the dominion misreading** — frame-relativity is many sovereign maps and
+  no privileged global one, the anti-thesis of universal authority.


### PR DESCRIPTION
Aaron 2026-06-07: 'Earth's/space borders are jurisdiction-relative... in my meta-jurisdiction the Earth is
one color, mine.' Extends jurisdiction-parameterized legal priors (#6893) to geography: boundaries (Karman
line 80 vs 100km, undefined 'outer space' in the 1967 treaty, airspace) are constructs, not facts -> per-
jurisdiction Bayesian priors on the geospatial frame; no global border any more than a global clock. 'One
color, mine' = the frame-relativity reading: each meta-frame draws its own map, sovereign over its OWN view,
none privileged. LOAD-BEARING PEEL: Alexa's 'planetary sovereignty / unified global authority' reading is
WRONG and inverted — frame-relativity is ANTI-dominion (no frame imposes its map on another; many sovereign
maps, consent-first, no privileged global), the exact shape the architecture forbids. Keeper: boundaries are
frame-relative constructs; every frame sovereign over its own map and none over others'. Legal/territorial
treatment stays threat-model + human sign-off.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
