### PR TITLE
feat(flash-usb-windows): auto-inject operator SSH pubkey into ESP (fail-loud)

### DIFF
--- a/full-ai-cluster/tools/README-flash-usb-windows.md
+++ b/full-ai-cluster/tools/README-flash-usb-windows.md
@@ -11,14 +11,48 @@ the physical-presence gate; Windows Hello applies if configured):
 
 ```powershell
 # Right-click PowerShell -> Run as administrator, then:
-bun full-ai-cluster\tools\flash-usb-windows.ts            # auto-discovers newest %USERPROFILE%\Downloads\zeta-installer-*.iso
+bun full-ai-cluster\tools\flash-usb-windows.ts                       # auto-discovers newest %USERPROFILE%\Downloads\zeta-installer-*.iso
 bun full-ai-cluster\tools\flash-usb-windows.ts C:\path\to\zeta-installer-25.11.iso
-bun full-ai-cluster\tools\flash-usb-windows.ts --short    # shorter `yes <4-hex>` confirm
-bun full-ai-cluster\tools\flash-usb-windows.ts --dry-run  # print device + planned commands, write NOTHING
+bun full-ai-cluster\tools\flash-usb-windows.ts --short              # shorter `yes <4-hex>` confirm
+bun full-ai-cluster\tools\flash-usb-windows.ts --dry-run            # print device + planned commands, write NOTHING
+bun full-ai-cluster\tools\flash-usb-windows.ts --ssh-key C:\k\x.pub # inject a specific public key
+bun full-ai-cluster\tools\flash-usb-windows.ts --no-inject          # skip key injection (password-only login)
 ```
 
 It prints the selected device + its volumes + a `*** WILL BE DESTROYED ***`
 warning, then a random nonce you must type back before it writes.
+
+## SSH-key injection (on by default — zero-typing first boot)
+
+Mirrors the macOS path (`zflash.ts` iter-4.2): after the raw write the tool
+**mounts the freshly-flashed USB's EFI System Partition and drops your SSH
+public key on it** as `zeta-authorized-keys.pub`. The on-node `zeta-install.sh`
+reads that file off the boot media and injects it into `operator-ssh-keys.nix`
+before `nixos-install`, so the installed node trusts your key with no typing.
+
+- **Key source**: `--ssh-key <path>`, else the first of `~\.ssh\id_ed25519.pub`,
+  `id_ecdsa.pub`, `id_rsa.pub` that exists and validates.
+- **Resolved *before* the destructive write** — a missing/malformed key aborts
+  the run **before** the USB is wiped, not after.
+- **Private-key guard** — refuses anything that looks like a private key
+  (you can never accidentally write `id_ed25519` instead of `id_ed25519.pub`).
+- **Fail-loud + read-back verify** — the tool writes the key, **reads it back**,
+  and treats any failure (couldn't mount the ESP, write failed, read-back
+  mismatch) as a **hard error (exit 1)**. The macOS path was once burned by a
+  *silent* inject failure (bootable USB, no key); this never green-by-skips.
+- **`--no-inject`** opts out explicitly (password-only first boot).
+
+### Mounting the ESP on Windows
+
+An EFI System Partition is often hidden (no auto drive-letter), so the tool
+mounts it via a fallback ladder, most-reliable first:
+
+1. partition already has a drive letter (removable FAT auto-mount);
+2. `diskpart assign letter=` (works on `System`-type partitions where the
+   Storage cmdlets refuse) — the reliable path for a USB ESP;
+3. `Add-PartitionAccessPath -AssignDriveLetter` (last resort).
+
+It un-mounts the letter it assigned when done.
 
 ## Safety rails (identical to the macOS tool)
 
@@ -32,6 +66,9 @@ warning, then a random nonce you must type back before it writes.
 | Target size 4 GiB – 256 GiB | `selectUsbCandidate()` |
 | Exactly one USB candidate (else refuse) | `selectUsbCandidate()` |
 | Per-run random nonce, typed back | `makeNonce()` / `buildShortChallenge()` |
+| SSH key resolved + validated **before** wipe | `resolveSshPubkey()` / `validatePubkeyContent()` |
+| Refuses to inject a **private** key | `validatePubkeyContent()` |
+| Inject failure is a **hard error**, read-back verified | `injectPubkeyIntoEsp()` |
 
 macOS → Windows mapping: `diskutil list` → `Get-Disk`; `BusProtocol=USB` →
 `BusType=USB`; `Internal` → `IsBoot`/`IsSystem`; `diskutil unmountDisk` →
@@ -56,13 +93,21 @@ exported TypeScript so `flash-usb-windows.test.ts` validates it via
   runs on Windows (node can open `\\.\PhysicalDriveN` after the disk is
   offline).
 - **Command construction, nonce, ISO discovery** — all unit-tested.
+- **SSH-key injection** — `validatePubkeyContent()` (accepts ed25519/rsa/ecdsa/sk,
+  rejects empty/multi/unknown-type/non-base64 and, critically, **private keys**),
+  `resolveSshPubkey()` (search order + explicit-path), `selectEspPartition()`
+  (picks the tiny FAT ESP, **never** the 1.5 GiB ISO9660 data region, on both
+  GPT and MBR layouts), and the **whole `injectPubkeyIntoEsp()` orchestration**
+  driven by a fake runner that simulates `Get-Partition`, `diskpart assign`, and
+  an in-memory ESP filesystem — including the **corrupt-write → read-back
+  mismatch → `ok=false`** case (proves no silent green-by-skip).
 
 What the unit tests *cannot* cover on macOS: opening the literal
-`\\.\PhysicalDriveN` handle, `Set-Disk -IsOffline`, and the UAC prompt —
-those are thin wrappers around the tested logic and require a Windows
-box (or a Windows VM with a virtual USB disk) for an end-to-end run.
-`--dry-run` on a Windows machine exercises the full selection + planning
-path without writing.
+`\\.\PhysicalDriveN` handle, `Set-Disk -IsOffline`, the real `diskpart`/ESP
+mount, and the UAC prompt — those are thin wrappers around the tested logic and
+require a Windows box (or a Windows VM with a virtual USB disk) for an
+end-to-end run. `--dry-run` on a Windows machine exercises the full selection +
+key-resolution + planning path without writing.
 
 ## Follow-ups
 

--- a/full-ai-cluster/tools/flash-usb-windows.test.ts
+++ b/full-ai-cluster/tools/flash-usb-windows.test.ts
@@ -31,7 +31,27 @@ import {
   autoDiscoverIso,
   human,
   type WinDisk,
+  // SSH-key injection surface
+  ESP_PUBKEY_FILENAME,
+  ESP_GPT_TYPE_GUID,
+  validatePubkeyContent,
+  pubkeyFileContent,
+  resolveSshPubkey,
+  parseGetPartitionJson,
+  isEspLike,
+  selectEspPartition,
+  firstFreeDriveLetter,
+  psGetPartitionScript,
+  diskpartAssignScript,
+  diskpartRemoveLetterScript,
+  psAddAccessPathAssignScript,
+  injectPubkeyIntoEsp,
+  type PubkeyFsLike,
+  type CommandRunner,
+  type WinPartition,
 } from "./flash-usb-windows.ts";
+
+const VALID_ED25519 = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIabc123def456ghi789jkl012mno345pqr678stu90 zeta@operator";
 
 const GiB = 1024 * 1024 * 1024;
 
@@ -246,5 +266,283 @@ describe("human() formatting", () => {
     expect(human(0)).toBe("0.00 B");
     expect(human(1536)).toBe("1.50 KiB");
     expect(human(32 * GiB)).toBe("32.00 GiB");
+  });
+});
+
+// ── SSH-key injection ────────────────────────────────────────────────
+
+describe("validatePubkeyContent()", () => {
+  test("accepts a well-formed ed25519 public key with comment", () => {
+    expect(validatePubkeyContent(VALID_ED25519).ok).toBe(true);
+  });
+  test("accepts rsa / ecdsa / sk- key types", () => {
+    expect(validatePubkeyContent("ssh-rsa AAAAB3NzaC1yc2EAAAAabcdef user@h").ok).toBe(true);
+    expect(validatePubkeyContent("ecdsa-sha2-nistp256 AAAAE2VjZHNhabc x").ok).toBe(true);
+    expect(validatePubkeyContent("sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1abc y").ok).toBe(true);
+  });
+  test("tolerates CRLF and surrounding whitespace", () => {
+    expect(validatePubkeyContent(`\r\n  ${VALID_ED25519}  \r\n`).ok).toBe(true);
+  });
+  test("REJECTS a private key (the worst footgun)", () => {
+    const priv = "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXk=\n-----END OPENSSH PRIVATE KEY-----";
+    const r = validatePubkeyContent(priv);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.message).toContain("PRIVATE");
+  });
+  test("rejects empty, multi-key, unknown-type, and non-base64 blobs", () => {
+    expect(validatePubkeyContent("").ok).toBe(false);
+    expect(validatePubkeyContent("   \n  ").ok).toBe(false);
+    expect(validatePubkeyContent(`${VALID_ED25519}\n${VALID_ED25519}`).ok).toBe(false);
+    expect(validatePubkeyContent("ssh-banana AAAAB x").ok).toBe(false);
+    expect(validatePubkeyContent("ssh-ed25519 not!base64! x").ok).toBe(false);
+    expect(validatePubkeyContent("ssh-ed25519").ok).toBe(false);
+  });
+});
+
+describe("pubkeyFileContent()", () => {
+  test("normalizes to LF body with exactly one trailing newline", () => {
+    expect(pubkeyFileContent(VALID_ED25519)).toBe(`${VALID_ED25519}\n`);
+    expect(pubkeyFileContent(`${VALID_ED25519}\r\n`)).toBe(`${VALID_ED25519}\n`);
+    expect(pubkeyFileContent(`${VALID_ED25519}\n\n\n`)).toBe(`${VALID_ED25519}\n`);
+    expect(pubkeyFileContent(VALID_ED25519).includes("\r")).toBe(false);
+  });
+});
+
+describe("resolveSshPubkey()", () => {
+  const home = "/home/op";
+  const fsWith = (files: Record<string, string>): PubkeyFsLike => ({
+    exists: (p) => p in files,
+    read: (p) => files[p]!,
+  });
+
+  test("explicit --ssh-key path wins and is validated", () => {
+    const r = resolveSshPubkey("/keys/mine.pub", home, fsWith({ "/keys/mine.pub": VALID_ED25519 }));
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.path).toBe("/keys/mine.pub");
+  });
+  test("explicit missing path is an error", () => {
+    const r = resolveSshPubkey("/nope.pub", home, fsWith({}));
+    expect(r.ok).toBe(false);
+  });
+  test("explicit private key is rejected (not silently passed through)", () => {
+    const r = resolveSshPubkey("/keys/priv", home, fsWith({ "/keys/priv": "-----BEGIN OPENSSH PRIVATE KEY-----\nx\n-----END OPENSSH PRIVATE KEY-----" }));
+    expect(r.ok).toBe(false);
+  });
+  test("default search prefers id_ed25519.pub over id_rsa.pub", () => {
+    const r = resolveSshPubkey(undefined, home, fsWith({
+      [join(home, ".ssh/id_ed25519.pub")]: VALID_ED25519,
+      [join(home, ".ssh/id_rsa.pub")]: "ssh-rsa AAAAB other key",
+    }));
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.path).toBe(join(home, ".ssh/id_ed25519.pub"));
+  });
+  test("falls back to id_rsa.pub when ed25519 absent", () => {
+    const r = resolveSshPubkey(undefined, home, fsWith({ [join(home, ".ssh/id_rsa.pub")]: "ssh-rsa AAAAB k u" }));
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.path).toBe(join(home, ".ssh/id_rsa.pub"));
+  });
+  test("no key anywhere → actionable error mentioning ssh-keygen + --no-inject", () => {
+    const r = resolveSshPubkey(undefined, home, fsWith({}));
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.message).toContain("ssh-keygen");
+      expect(r.message).toContain("--no-inject");
+    }
+  });
+});
+
+describe("parseGetPartitionJson() + isEspLike() + selectEspPartition()", () => {
+  // A realistic isohybrid USB: big ISO9660 data region + tiny FAT ESP.
+  const gptUsb = JSON.stringify([
+    { PartitionNumber: 1, Size: 1_600_000_000, Type: "Unknown", GptType: "{ebd0a0a2-b9e5-4433-87c0-68b6b72699c7}", DriveLetter: null, IsHidden: true },
+    { PartitionNumber: 2, Size: 3_145_728, Type: "System", GptType: `{${ESP_GPT_TYPE_GUID.toUpperCase()}}`, DriveLetter: null, IsHidden: false },
+  ]);
+  const mbrUsb = JSON.stringify([
+    { PartitionNumber: 1, Size: 1_600_000_000, Type: "Unknown", MbrType: 0, DriveLetter: null },
+    { PartitionNumber: 2, Size: 3_145_728, Type: "Unknown", MbrType: 239 /* 0xEF */, DriveLetter: "S" },
+  ]);
+
+  test("ConvertTo-Json single-object form normalizes to an array", () => {
+    const one = parseGetPartitionJson(JSON.stringify({ PartitionNumber: 1, Size: 100, Type: "FAT32", DriveLetter: "E" }));
+    expect(one).toHaveLength(1);
+    expect(one[0]!.driveLetter).toBe("E");
+  });
+  test("empty input yields no partitions (not a throw)", () => {
+    expect(parseGetPartitionJson("")).toEqual([]);
+  });
+  test("isEspLike picks the GPT ESP by type GUID (case/braces-insensitive)", () => {
+    const parts = parseGetPartitionJson(gptUsb);
+    expect(isEspLike(parts[0]!)).toBe(false);
+    expect(isEspLike(parts[1]!)).toBe(true);
+    expect(parts[1]!.gptType).toBe(ESP_GPT_TYPE_GUID);
+  });
+  test("isEspLike picks the MBR 0xEF partition", () => {
+    const parts = parseGetPartitionJson(mbrUsb);
+    expect(isEspLike(parts[1]!)).toBe(true);
+    expect(parts[1]!.driveLetter).toBe("S");
+  });
+  test("selectEspPartition chooses the tiny FAT ESP, never the 1.5 GiB data region", () => {
+    const g = selectEspPartition(parseGetPartitionJson(gptUsb));
+    expect(g.ok).toBe(true);
+    if (g.ok) expect(g.partition.number).toBe(2);
+    const m = selectEspPartition(parseGetPartitionJson(mbrUsb));
+    expect(m.ok).toBe(true);
+    if (m.ok) expect(m.partition.number).toBe(2);
+  });
+  test("size-heuristic fallback when no explicit EFI signal", () => {
+    const noSignal = JSON.stringify([
+      { PartitionNumber: 1, Size: 1_600_000_000, Type: "Unknown", MbrType: 0, DriveLetter: null },
+      { PartitionNumber: 2, Size: 50_000_000, Type: "Unknown", MbrType: 0, DriveLetter: null },
+    ]);
+    const s = selectEspPartition(parseGetPartitionJson(noSignal));
+    expect(s.ok).toBe(true);
+    if (s.ok) expect(s.partition.number).toBe(2);
+  });
+  test("refuses when nothing plausible (all huge)", () => {
+    const huge = JSON.stringify([{ PartitionNumber: 1, Size: 2_000_000_000, Type: "Unknown", MbrType: 0, DriveLetter: null }]);
+    expect(selectEspPartition(parseGetPartitionJson(huge)).ok).toBe(false);
+  });
+});
+
+describe("firstFreeDriveLetter()", () => {
+  test("returns first of S..Z not in use", () => {
+    expect(firstFreeDriveLetter([])).toBe("S");
+    expect(firstFreeDriveLetter(["S", "T"])).toBe("U");
+    expect(firstFreeDriveLetter(["s:", "T", "u"])).toBe("V");
+  });
+  test("throws if S..Z all taken", () => {
+    expect(() => firstFreeDriveLetter("STUVWXYZ".split(""))).toThrow();
+  });
+});
+
+describe("ESP-mount script builders", () => {
+  test("diskpart assign/remove scripts target the right disk+partition with CRLF", () => {
+    expect(diskpartAssignScript(2, 2, "S")).toBe("select disk 2\r\nselect partition 2\r\nassign letter=S");
+    expect(diskpartRemoveLetterScript(2, 2, "S")).toContain("remove letter=S");
+  });
+  test("Add-PartitionAccessPath script is well-formed", () => {
+    expect(psAddAccessPathAssignScript(2, 2)).toBe("Add-PartitionAccessPath -DiskNumber 2 -PartitionNumber 2 -AssignDriveLetter");
+  });
+  test("psGetPartitionScript selects the fields the parser reads", () => {
+    const s = psGetPartitionScript(2);
+    for (const f of ["PartitionNumber", "GptType", "MbrType", "DriveLetter"]) expect(s).toContain(f);
+  });
+});
+
+describe("injectPubkeyIntoEsp() — full orchestration via a fake runner", () => {
+  // A fake runner that simulates: Get-Partition, diskpart assign (mounts a
+  // letter), and an in-memory ESP filesystem for write/read-back.
+  function makeFakeRunner(opts: {
+    partitions: WinPartition[];
+    autoLetter?: string; // if the ESP already has a drive letter
+    diskpartWorks?: boolean;
+    corruptWrite?: boolean; // simulate a bad read-back (silent-failure guard)
+  }): { runner: CommandRunner; files: Map<string, string>; calls: string[] } {
+    const files = new Map<string, string>();
+    const calls: string[] = [];
+    let assigned: string | null = opts.autoLetter ?? null;
+    const partJson = () =>
+      JSON.stringify(
+        opts.partitions.map((p) => ({
+          PartitionNumber: p.number,
+          Size: p.size,
+          Type: p.type,
+          GptType: p.gptType ? `{${p.gptType}}` : null,
+          MbrType: p.mbrType,
+          DriveLetter: assigned && isEsp(p) ? assigned : p.driveLetter || null,
+          IsHidden: p.isHidden,
+        })),
+      );
+    const isEsp = (p: WinPartition) => isEspLike(p);
+    const runner: CommandRunner = {
+      ps(script: string): string {
+        calls.push(`ps:${script.slice(0, 28)}`);
+        if (script.startsWith("Get-Partition")) return partJson();
+        if (script.includes("Get-Volume")) return "C"; // used letters
+        if (script.startsWith("Add-PartitionAccessPath")) {
+          assigned = "V";
+          return "";
+        }
+        return "";
+      },
+      diskpart(script: string): string {
+        calls.push(`diskpart:${script.split("\r\n").pop()}`);
+        if (!opts.diskpartWorks) throw new Error("diskpart refused");
+        if (script.includes("assign letter=")) assigned = script.split("assign letter=")[1]!.trim();
+        if (script.includes("remove letter=")) assigned = null;
+        return "";
+      },
+      writeFile(path: string, content: string): void {
+        calls.push(`write:${path}`);
+        files.set(path, opts.corruptWrite ? content.slice(0, 5) : content);
+      },
+      readFile(path: string): string {
+        if (!files.has(path)) throw new Error("not found");
+        return files.get(path)!;
+      },
+    };
+    return { runner, files, calls };
+  }
+
+  const espGpt: WinPartition = {
+    number: 2,
+    size: 3_145_728,
+    type: "System",
+    gptType: ESP_GPT_TYPE_GUID,
+    mbrType: null,
+    driveLetter: "",
+    isHidden: false,
+  };
+  const dataRegion: WinPartition = {
+    number: 1,
+    size: 1_600_000_000,
+    type: "Unknown",
+    gptType: "ebd0a0a2-b9e5-4433-87c0-68b6b72699c7",
+    mbrType: null,
+    driveLetter: "",
+    isHidden: true,
+  };
+
+  test("auto-mounted removable FAT: writes + verifies, no diskpart assign needed", () => {
+    const { runner, files, calls } = makeFakeRunner({ partitions: [dataRegion, espGpt], autoLetter: "E" });
+    const r = injectPubkeyIntoEsp(runner, 3, VALID_ED25519);
+    expect(r.ok).toBe(true);
+    expect(r.verified).toBe(true);
+    expect(r.driveLetter).toBe("E");
+    expect(files.get(`E:\\${ESP_PUBKEY_FILENAME}`)).toBe(`${VALID_ED25519}\n`);
+    expect(calls.some((c) => c.startsWith("diskpart:assign"))).toBe(false);
+  });
+
+  test("hidden ESP: mounts via diskpart, writes, verifies, then unmounts", () => {
+    const { runner, files, calls } = makeFakeRunner({ partitions: [dataRegion, espGpt], diskpartWorks: true });
+    const r = injectPubkeyIntoEsp(runner, 3, VALID_ED25519);
+    expect(r.ok).toBe(true);
+    expect(r.assignedLetter).toBe(true);
+    expect([...files.values()][0]).toBe(`${VALID_ED25519}\n`);
+    expect(calls.some((c) => c.startsWith("diskpart:assign"))).toBe(true);
+    expect(calls.some((c) => c.startsWith("diskpart:remove"))).toBe(true);
+  });
+
+  test("diskpart refuses → falls back to Add-PartitionAccessPath", () => {
+    const { runner, calls } = makeFakeRunner({ partitions: [dataRegion, espGpt], diskpartWorks: false });
+    const r = injectPubkeyIntoEsp(runner, 3, VALID_ED25519);
+    expect(r.ok).toBe(true);
+    expect(r.driveLetter).toBe("V");
+    expect(calls.some((c) => c.startsWith("ps:Add-PartitionAccessPath"))).toBe(true);
+  });
+
+  test("corrupt write is caught by read-back verify → ok=false (NO silent green)", () => {
+    const { runner } = makeFakeRunner({ partitions: [dataRegion, espGpt], autoLetter: "E", corruptWrite: true });
+    const r = injectPubkeyIntoEsp(runner, 3, VALID_ED25519);
+    expect(r.ok).toBe(false);
+    expect(r.verified).toBe(false);
+    expect(r.message).toContain("re-flash");
+  });
+
+  test("no ESP on disk → ok=false with a diagnostic", () => {
+    const { runner } = makeFakeRunner({ partitions: [dataRegion] /* only the huge data region */ });
+    // make the lone partition truly non-ESP + too big for the size fallback
+    const r = injectPubkeyIntoEsp(runner, 3, VALID_ED25519);
+    expect(r.ok).toBe(false);
   });
 });

--- a/full-ai-cluster/tools/flash-usb-windows.ts
+++ b/full-ai-cluster/tools/flash-usb-windows.ts
@@ -40,13 +40,16 @@ import {
   fstatSync,
   openSync,
   readdirSync,
+  readFileSync,
   readSync,
   statSync,
+  unlinkSync,
+  writeFileSync,
   writeSync,
   fsyncSync,
 } from "node:fs";
 import { execFileSync } from "node:child_process";
-import { homedir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 
 // ── Safety-rail constants (mirror flash-usb.ts exactly) ──────────────
@@ -56,6 +59,37 @@ export const MIN_USB_BYTES = 4 * 1024 * 1024 * 1024;
 export const MAX_USB_BYTES = 256 * 1024 * 1024 * 1024;
 
 export const ISO_GLOB_PREFIX = "zeta-installer-";
+
+// ── SSH-pubkey injection constants (mirror zflash.ts iter-4.2) ───────
+// zeta-install.sh reads this exact filename off the boot media's ESP and
+// injects it into operator-ssh-keys.nix before `nixos-install`. The name
+// MUST match the on-node installer (do not rename without updating it).
+export const ESP_PUBKEY_FILENAME = "zeta-authorized-keys.pub";
+
+// GPT EFI System Partition type GUID (RFC-style, lowercased, no braces).
+export const ESP_GPT_TYPE_GUID = "c12a7328-f81f-11d2-ba4b-00a0c93ec93b";
+// MBR partition type 0xEF == EFI System Partition (239 decimal).
+export const ESP_MBR_TYPE = 0xef;
+
+// Default key search order — mirrors zflash's DEFAULT_SSH_KEY plus the
+// usual fallbacks. First that exists AND validates wins.
+export const DEFAULT_SSH_KEY_CANDIDATES = [
+  ".ssh/id_ed25519.pub",
+  ".ssh/id_ecdsa.pub",
+  ".ssh/id_rsa.pub",
+] as const;
+
+// Recognized OpenSSH public-key type tokens (first field of the line).
+export const SSH_PUBKEY_TYPES: readonly string[] = [
+  "ssh-ed25519",
+  "ssh-rsa",
+  "ssh-dss",
+  "ecdsa-sha2-nistp256",
+  "ecdsa-sha2-nistp384",
+  "ecdsa-sha2-nistp521",
+  "sk-ssh-ed25519@openssh.com",
+  "sk-ecdsa-sha2-nistp256@openssh.com",
+];
 
 export function human(bytes: number): string {
   const u = ["B", "KiB", "MiB", "GiB", "TiB"];
@@ -181,6 +215,176 @@ export function physicalDrivePath(diskNumber: number): string {
   return `\\\\.\\PhysicalDrive${diskNumber}`;
 }
 
+// ── SSH pubkey: validation, resolution, on-disk file body (pure) ──────
+
+export type PubkeyCheck = { readonly ok: true } | { readonly ok: false; readonly message: string };
+
+/**
+ * Accept ONLY a single-line OpenSSH PUBLIC key. Hard-reject anything that
+ * looks like a PRIVATE key — the #1 footgun is injecting `id_ed25519`
+ * (the private half) instead of `id_ed25519.pub`. Trailing comment is OK.
+ */
+export function validatePubkeyContent(text: string): PubkeyCheck {
+  const normalized = text.replace(/\r\n/g, "\n").trim();
+  if (normalized.length === 0) return { ok: false, message: "SSH key file is empty" };
+  if (/-----BEGIN[\s\S]*PRIVATE KEY-----/.test(normalized) || /\bPRIVATE KEY\b/.test(normalized)) {
+    return { ok: false, message: "refusing to inject a PRIVATE key — pass the .pub (public) key instead" };
+  }
+  const lines = normalized.split("\n").filter((l) => l.trim().length > 0);
+  if (lines.length !== 1) {
+    return { ok: false, message: `expected exactly one public-key line, found ${lines.length}` };
+  }
+  const fields = lines[0]!.trim().split(/\s+/);
+  if (fields.length < 2) return { ok: false, message: "malformed public key (need '<type> <base64> [comment]')" };
+  const type = fields[0]!;
+  if (!SSH_PUBKEY_TYPES.includes(type)) {
+    return { ok: false, message: `unrecognized key type '${type}' (expected one of: ${SSH_PUBKEY_TYPES.join(", ")})` };
+  }
+  if (!/^[A-Za-z0-9+/]+={0,3}$/.test(fields[1]!)) {
+    return { ok: false, message: "public-key blob is not valid base64" };
+  }
+  return { ok: true };
+}
+
+/** Normalize the file body written to the ESP: LF endings, single trailing newline. */
+export function pubkeyFileContent(content: string): string {
+  return content.replace(/\r\n/g, "\n").replace(/\n+$/, "") + "\n";
+}
+
+export interface PubkeyFsLike {
+  exists(path: string): boolean;
+  read(path: string): string;
+}
+
+export type PubkeyResolution =
+  | { readonly ok: true; readonly path: string; readonly content: string }
+  | { readonly ok: false; readonly message: string };
+
+/**
+ * Resolve the operator's SSH PUBLIC key. `explicitPath` (from --ssh-key)
+ * wins; otherwise probe DEFAULT_SSH_KEY_CANDIDATES under `home` in order.
+ * Always validates — an existing-but-malformed (or private) key is an error,
+ * not a silent skip.
+ */
+export function resolveSshPubkey(
+  explicitPath: string | undefined,
+  home: string,
+  fs: PubkeyFsLike,
+): PubkeyResolution {
+  if (explicitPath) {
+    if (!fs.exists(explicitPath)) return { ok: false, message: `--ssh-key not found: ${explicitPath}` };
+    const content = fs.read(explicitPath);
+    const v = validatePubkeyContent(content);
+    if (!v.ok) return { ok: false, message: `${explicitPath}: ${v.message}` };
+    return { ok: true, path: explicitPath, content: content.replace(/\r\n/g, "\n").trim() };
+  }
+  const tried: string[] = [];
+  for (const rel of DEFAULT_SSH_KEY_CANDIDATES) {
+    const p = join(home, rel);
+    tried.push(p);
+    if (!fs.exists(p)) continue;
+    const content = fs.read(p);
+    const v = validatePubkeyContent(content);
+    if (!v.ok) return { ok: false, message: `${p}: ${v.message}` };
+    return { ok: true, path: p, content: content.replace(/\r\n/g, "\n").trim() };
+  }
+  return {
+    ok: false,
+    message:
+      `no SSH public key found (looked for: ${tried.join(", ")}).\n` +
+      `  Create one with:  ssh-keygen -t ed25519\n` +
+      `  Or pass an explicit key:  --ssh-key C:\\path\\to\\key.pub\n` +
+      `  Or skip key injection (password login only):  --no-inject`,
+  };
+}
+
+// ── ESP partition discovery + drive-letter selection (pure) ──────────
+
+export interface WinPartition {
+  readonly number: number;
+  readonly size: number;
+  readonly type: string; // Get-Partition .Type (e.g. "System", "FAT32", "IFS", "Basic")
+  readonly gptType: string; // GPT type GUID (lowercased, braces stripped) or ""
+  readonly mbrType: number | null; // MBR partition type byte, or null on GPT disks
+  readonly driveLetter: string; // "" when unmounted
+  readonly isHidden: boolean;
+}
+
+export function parseGetPartitionJson(jsonText: string): WinPartition[] {
+  const t = jsonText.trim();
+  if (t.length === 0) return [];
+  const raw = JSON.parse(t);
+  const arr: unknown[] = Array.isArray(raw) ? raw : [raw];
+  return arr.map((d) => {
+    const o = d as Record<string, unknown>;
+    const num = (v: unknown): number => (typeof v === "number" ? v : Number(v ?? 0));
+    const flat = (v: unknown): string =>
+      v != null && typeof v === "object" && "value" in (v as object)
+        ? String((v as { value: unknown }).value)
+        : v == null
+          ? ""
+          : String(v);
+    // DriveLetter serializes as a single char, 0, null, or "" when unset.
+    const dl = o.DriveLetter;
+    const driveLetter =
+      dl == null || dl === 0 || dl === "0" || dl === " " ? "" : String(dl).trim().replace(/[:\\]/g, "");
+    const gpt = flat(o.GptType).toLowerCase().replace(/[{}]/g, "");
+    const mbrRaw = o.MbrType;
+    return {
+      number: num(o.PartitionNumber),
+      size: num(o.Size),
+      type: flat(o.Type),
+      gptType: gpt,
+      mbrType: mbrRaw == null ? null : num(mbrRaw),
+      driveLetter: /^[A-Za-z]$/.test(driveLetter) ? driveLetter.toUpperCase() : "",
+      isHidden: o.IsHidden === true,
+    };
+  });
+}
+
+/** True if the partition is (or looks like) the FAT EFI System Partition. */
+export function isEspLike(p: WinPartition): boolean {
+  if (p.gptType === ESP_GPT_TYPE_GUID) return true;
+  if (p.mbrType === ESP_MBR_TYPE) return true;
+  const t = p.type.toLowerCase();
+  return t === "system" || t.includes("efi") || t.startsWith("fat");
+}
+
+export type EspSelection =
+  | { readonly ok: true; readonly partition: WinPartition }
+  | { readonly ok: false; readonly message: string };
+
+/**
+ * Pick the ESP on the freshly-flashed isohybrid USB. The disk has a big
+ * ISO9660 data region (~1.5 GiB) and a tiny FAT ESP (a few MiB → a couple
+ * hundred MiB). Prefer an explicit EFI signal (GPT GUID / MBR 0xEF / type);
+ * fall back to "smallest partition under 512 MiB". Among ties, smallest wins.
+ */
+export function selectEspPartition(parts: readonly WinPartition[]): EspSelection {
+  const bySizeAsc = (a: WinPartition, b: WinPartition) => a.size - b.size;
+  const explicit = parts.filter(isEspLike).slice().sort(bySizeAsc);
+  if (explicit.length > 0) return { ok: true, partition: explicit[0]! };
+  const small = parts
+    .filter((p) => p.size > 0 && p.size < 512 * 1024 * 1024)
+    .slice()
+    .sort(bySizeAsc);
+  if (small.length > 0) return { ok: true, partition: small[0]! };
+  const seen = parts.map((p) => `  part ${p.number} ${human(p.size)} type=${p.type} mbr=${p.mbrType ?? "-"}`).join("\n");
+  return {
+    ok: false,
+    message: `could not identify the EFI System Partition on this disk.\nPartitions seen:\n${seen || "  (none)"}`,
+  };
+}
+
+/** First free drive letter in S..Z not already in use. Throws if none free. */
+export function firstFreeDriveLetter(used: readonly string[]): string {
+  const taken = new Set(used.map((l) => l.toUpperCase().replace(/[:\\]/g, "")));
+  for (const c of "STUVWXYZ") {
+    if (!taken.has(c)) return c;
+  }
+  throw new Error("no free drive letter in S..Z to mount the ESP");
+}
+
 /** 4-hex nonce (matches flash-usb.ts --short). Caller supplies randomness. */
 export function buildShortChallenge(nonceHex4: string): string {
   if (!/^[0-9a-f]{4}$/.test(nonceHex4)) throw new Error(`nonce must be 4 lowercase hex chars, got: ${nonceHex4}`);
@@ -218,6 +422,43 @@ export function psListVolumesScript(diskNumber: number): string {
     `Get-Volume -ErrorAction SilentlyContinue | ` +
     `Select-Object DriveLetter,FileSystemLabel,Size | ConvertTo-Json -Depth 3`
   );
+}
+
+// ── ESP-mount script builders (pure → assert-able in tests) ──────────
+export function psGetPartitionScript(diskNumber: number): string {
+  return (
+    `Get-Partition -DiskNumber ${diskNumber} -ErrorAction SilentlyContinue | ` +
+    `Select-Object PartitionNumber,Size,Type,GptType,MbrType,DriveLetter,IsHidden | ` +
+    `ConvertTo-Json -Depth 3`
+  );
+}
+export function psUsedDriveLettersScript(): string {
+  return `(Get-Volume | Where-Object DriveLetter | Select-Object -ExpandProperty DriveLetter) -join ''`;
+}
+export function psAddAccessPathAssignScript(diskNumber: number, partitionNumber: number): string {
+  return `Add-PartitionAccessPath -DiskNumber ${diskNumber} -PartitionNumber ${partitionNumber} -AssignDriveLetter`;
+}
+export function psRemoveAccessPathScript(diskNumber: number, partitionNumber: number, letter: string): string {
+  return `Remove-PartitionAccessPath -DiskNumber ${diskNumber} -PartitionNumber ${partitionNumber} -AccessPath "${letter}:\\"`;
+}
+/**
+ * diskpart script that assigns a drive letter to an ESP/System partition.
+ * diskpart succeeds here where the Storage cmdlets refuse on `System`-type
+ * partitions — it is the reliable mount path for a USB EFI partition.
+ */
+export function diskpartAssignScript(diskNumber: number, partitionNumber: number, letter: string): string {
+  return [
+    `select disk ${diskNumber}`,
+    `select partition ${partitionNumber}`,
+    `assign letter=${letter}`,
+  ].join("\r\n");
+}
+export function diskpartRemoveLetterScript(diskNumber: number, partitionNumber: number, letter: string): string {
+  return [
+    `select disk ${diskNumber}`,
+    `select partition ${partitionNumber}`,
+    `remove letter=${letter}`,
+  ].join("\r\n");
 }
 
 // ── Raw byte copy (pure; the data-write path — fully testable) ───────
@@ -293,6 +534,12 @@ export function autoDiscoverIso(downloadsDir: string): string | null {
 // ── Side-effecting layer (injectable for the orchestrator/tests) ─────
 export interface CommandRunner {
   ps(script: string): string;
+  /** Run a diskpart script (reliable ESP-letter assignment). */
+  diskpart(script: string): string;
+  /** Write a text file (LF body) to a mounted ESP path like "S:\zeta-authorized-keys.pub". */
+  writeFile(path: string, content: string): void;
+  /** Read a text file back (for the read-back-verify step). */
+  readFile(path: string): string;
 }
 
 const realRunner: CommandRunner = {
@@ -304,7 +551,156 @@ const realRunner: CommandRunner = {
       maxBuffer: 16 * 1024 * 1024,
     });
   },
+  diskpart(script: string): string {
+    // diskpart reads its commands from a script file (`/s`). Use a temp file.
+    const tmp = join(tmpdir(), `zeta-diskpart-${process.pid}-${Date.now()}.txt`);
+    writeFileSync(tmp, script.endsWith("\r\n") ? script : script + "\r\n", "ascii");
+    try {
+      return execFileSync("diskpart", ["/s", tmp], { encoding: "utf8", maxBuffer: 4 * 1024 * 1024 });
+    } finally {
+      try {
+        unlinkSync(tmp);
+      } catch {
+        /* best-effort cleanup */
+      }
+    }
+  },
+  writeFile(path: string, content: string): void {
+    writeFileSync(path, content, "utf8");
+  },
+  readFile(path: string): string {
+    return readFileSync(path, "utf8");
+  },
 };
+
+export interface EspInjectResult {
+  readonly ok: boolean;
+  readonly partitionNumber: number;
+  readonly driveLetter: string;
+  readonly assignedLetter: boolean; // true if we mounted it (so caller un-mounts)
+  readonly verified: boolean;
+  readonly message: string;
+}
+
+/**
+ * Mount the freshly-flashed USB's EFI System Partition, write the operator's
+ * pubkey as `zeta-authorized-keys.pub`, READ IT BACK to prove the write
+ * landed, then unmount. Mirrors zflash.ts iter-4.2 (macOS mount_msdos path).
+ *
+ * Fail-loud by contract: returns ok=false on any failure. The caller treats
+ * a false result as a hard error (the macOS path's "silent inject failure →
+ * keyless USB" lesson — never green-by-skip).
+ *
+ * Mount-letter ladder (most-reliable first):
+ *   1. partition already has a DriveLetter (removable FAT auto-mount)
+ *   2. diskpart `assign letter=` (works on System/ESP partitions)
+ *   3. Add-PartitionAccessPath -AssignDriveLetter (last resort)
+ */
+export function injectPubkeyIntoEsp(
+  runner: CommandRunner,
+  diskNumber: number,
+  pubkeyContent: string,
+  log: (s: string) => void = () => {},
+): EspInjectResult {
+  const fail = (message: string, partitionNumber = -1, driveLetter = "", assignedLetter = false): EspInjectResult => ({
+    ok: false,
+    partitionNumber,
+    driveLetter,
+    assignedLetter,
+    verified: false,
+    message,
+  });
+
+  const parts = parseGetPartitionJson(runner.ps(psGetPartitionScript(diskNumber)));
+  const sel = selectEspPartition(parts);
+  if (!sel.ok) return fail(sel.message);
+  const esp = sel.partition;
+  log(`inject: ESP is partition ${esp.number} (${human(esp.size)}, type=${esp.type})`);
+
+  let letter = esp.driveLetter;
+  let assignedLetter = false;
+
+  if (!letter) {
+    // Rung 2: diskpart assign (reliable for ESP).
+    try {
+      const used = runner.ps(psUsedDriveLettersScript()).trim();
+      const usedArr = used.split("").filter((c) => /[A-Za-z]/.test(c));
+      const cand = firstFreeDriveLetter(usedArr);
+      runner.diskpart(diskpartAssignScript(diskNumber, esp.number, cand));
+      // Re-query to confirm the letter actually attached.
+      const after = parseGetPartitionJson(runner.ps(psGetPartitionScript(diskNumber)));
+      const got = after.find((p) => p.number === esp.number)?.driveLetter;
+      letter = got || cand;
+      assignedLetter = true;
+      log(`inject: mounted ESP at ${letter}: via diskpart`);
+    } catch (e) {
+      log(`inject: diskpart assign failed (${e instanceof Error ? e.message : String(e)}); trying Add-PartitionAccessPath`);
+    }
+  }
+
+  if (!letter) {
+    // Rung 3: Storage cmdlet.
+    try {
+      runner.ps(psAddAccessPathAssignScript(diskNumber, esp.number));
+      const after = parseGetPartitionJson(runner.ps(psGetPartitionScript(diskNumber)));
+      letter = after.find((p) => p.number === esp.number)?.driveLetter ?? "";
+      assignedLetter = letter.length > 0;
+      if (letter) log(`inject: mounted ESP at ${letter}: via Add-PartitionAccessPath`);
+    } catch (e) {
+      log(`inject: Add-PartitionAccessPath failed (${e instanceof Error ? e.message : String(e)})`);
+    }
+  }
+
+  if (!letter) {
+    return fail(
+      `could not mount the ESP (no drive letter could be assigned). The USB is bootable but has NO operator key.\n` +
+        `  Manually mount the small FAT partition on disk ${diskNumber} and copy your .pub key to it as\n` +
+        `  ${ESP_PUBKEY_FILENAME}, or re-run after closing anything holding the disk.`,
+      esp.number,
+    );
+  }
+
+  const dest = `${letter}:\\${ESP_PUBKEY_FILENAME}`;
+  const body = pubkeyFileContent(pubkeyContent);
+  try {
+    runner.writeFile(dest, body);
+  } catch (e) {
+    return fail(`writing ${dest} failed: ${e instanceof Error ? e.message : String(e)}`, esp.number, letter, assignedLetter);
+  }
+
+  // Read-back verify — prove the key actually landed (assert, don't skip).
+  let verified = false;
+  try {
+    verified = runner.readFile(dest).replace(/\r\n/g, "\n").trim() === pubkeyContent.replace(/\r\n/g, "\n").trim();
+  } catch (e) {
+    return fail(`read-back of ${dest} failed: ${e instanceof Error ? e.message : String(e)}`, esp.number, letter, assignedLetter);
+  }
+
+  // Unmount the access path we added (best-effort; the bytes are already
+  // flushed by the read-back). Skip if the letter was auto-mounted.
+  if (assignedLetter) {
+    try {
+      runner.diskpart(diskpartRemoveLetterScript(diskNumber, esp.number, letter));
+    } catch {
+      try {
+        runner.ps(psRemoveAccessPathScript(diskNumber, esp.number, letter));
+      } catch {
+        /* leaving the letter mapped is harmless; the write is done */
+      }
+    }
+  }
+
+  return {
+    ok: verified,
+    partitionNumber: esp.number,
+    driveLetter: letter,
+    assignedLetter,
+    verified,
+    message: verified
+      ? `pubkey written to ${dest} and verified`
+      : `WROTE ${dest} but read-back did NOT match — DO NOT trust this USB's key; re-flash`,
+  };
+}
 
 function bail(code: 1 | 2, msg: string): never {
   process.stderr.write(`flash-usb-windows: ${msg}\n`);
@@ -315,14 +711,26 @@ async function main(runner: CommandRunner = realRunner): Promise<void> {
   const argv = process.argv.slice(2);
   const short = argv.includes("--short");
   const dryRun = argv.includes("--dry-run");
+  const noInject = argv.includes("--no-inject");
   if (argv.includes("-h") || argv.includes("--help")) {
     process.stdout.write(
-      "usage: bun full-ai-cluster\\tools\\flash-usb-windows.ts [--short] [--dry-run] [iso-path]\n" +
-        "  run from an ELEVATED (Administrator) terminal\n",
+      "usage: bun full-ai-cluster\\tools\\flash-usb-windows.ts [flags] [iso-path]\n" +
+        "  run from an ELEVATED (Administrator) terminal\n" +
+        "    --short            shorter `yes <4-hex>` confirm phrase\n" +
+        "    --dry-run          print the plan and exit; NO write\n" +
+        "    --ssh-key <path>   public key to inject (default: ~/.ssh/id_ed25519.pub)\n" +
+        "    --no-inject        skip SSH-key injection (password login only)\n",
     );
     process.exit(0);
   }
-  const positional = argv.filter((a) => !a.startsWith("-"));
+  // --ssh-key takes a value; pull it out before computing positionals.
+  let sshKeyPath: string | undefined;
+  const skIdx = argv.indexOf("--ssh-key");
+  if (skIdx !== -1) {
+    sshKeyPath = argv[skIdx + 1];
+    if (!sshKeyPath || sshKeyPath.startsWith("-")) bail(2, "--ssh-key requires a path argument");
+  }
+  const positional = argv.filter((a, i) => !a.startsWith("-") && !(skIdx !== -1 && i === skIdx + 1));
   if (positional.length > 1) bail(2, `at most one ISO path expected, got ${positional.length}`);
 
   if (process.platform !== "win32") {
@@ -347,6 +755,19 @@ async function main(runner: CommandRunner = realRunner): Promise<void> {
   const iso = validateIso(isoPath, st.size, st.isFile());
   if (!iso.ok) bail(2, iso.message);
   process.stdout.write(`ISO: ${isoPath} (${human(st.size)})\n`);
+
+  // Resolve the operator SSH pubkey NOW — BEFORE the destructive write — so a
+  // missing/malformed key fails before the USB is wiped (not after).
+  const realFs: PubkeyFsLike = { exists: existsSync, read: (p) => readFileSync(p, "utf8") };
+  let pubkey: { path: string; content: string } | null = null;
+  if (!noInject) {
+    const r = resolveSshPubkey(sshKeyPath, homedir(), realFs);
+    if (!r.ok) bail(2, `SSH key injection required (default). ${r.message}`);
+    pubkey = { path: r.path, content: r.content };
+    process.stdout.write(`SSH key to inject: ${pubkey.path}\n`);
+  } else {
+    process.stdout.write(`SSH key injection: DISABLED (--no-inject; password login only)\n`);
+  }
 
   // Enumerate + select.
   const disks = parseGetDiskJson(runner.ps(psGetDiskScript()));
@@ -383,6 +804,9 @@ async function main(runner: CommandRunner = realRunner): Promise<void> {
         `  ${psSetOfflineScript(disk.number, true)}\n` +
         `  <raw copy ${isoPath} -> ${drivePath}, sector-padded>\n` +
         `  ${psSetOfflineScript(disk.number, false)}\n` +
+        (pubkey
+          ? `  <mount ESP, write ${ESP_PUBKEY_FILENAME} = ${pubkey.path}, read-back verify, unmount>\n`
+          : `  <SSH-key injection skipped (--no-inject)>\n`) +
         `[dry-run] no changes made.\n`,
     );
     process.exit(0);
@@ -411,12 +835,32 @@ async function main(runner: CommandRunner = realRunner): Promise<void> {
   });
   process.stdout.write(`\n\nWrote ${human(res.bytesWritten)} (ISO ${human(res.isoBytes)}). Flash complete.\n`);
 
-  // Bring the disk back online so Windows re-reads the new partition table.
+  // Bring the disk back online so Windows enumerates the new partition table
+  // (required before we can mount the ESP to inject the key).
   try {
     runner.ps(psSetOfflineScript(disk.number, false));
   } catch {
     /* eject is best-effort; the flash already succeeded */
   }
+
+  // SSH-key injection (fail-loud — mirrors zflash.ts iter-4.2). A keyless
+  // USB is the silent-failure trap the macOS path was burned by, so a failed
+  // inject is a HARD error: the flash succeeded but the result is unusable for
+  // zero-typing first boot.
+  if (pubkey) {
+    process.stdout.write(`\nInjecting ${pubkey.path} into the USB ESP as ${ESP_PUBKEY_FILENAME} ...\n`);
+    const inj = injectPubkeyIntoEsp(runner, disk.number, pubkey.content, (s) => process.stdout.write(`  ${s}\n`));
+    if (!inj.ok) {
+      bail(
+        1,
+        `SSH-KEY INJECTION FAILED — ${inj.message}\n` +
+          `  The ISO is flashed but the operator key is NOT on the USB. First boot would be\n` +
+          `  password-only. Fix the cause and re-run, or re-run with --no-inject to accept that.`,
+      );
+    }
+    process.stdout.write(`  ${inj.message}\n`);
+  }
+
   process.stdout.write(`Disk ${disk.number} back online; safe to remove the USB.\n`);
 }
 


### PR DESCRIPTION
## What

Brings the **Windows flasher** (`flash-usb-windows.ts`) to parity with the macOS `zflash.ts` **iter-4.2** path: after the raw ISO write, mount the freshly-flashed USB's **EFI System Partition** and drop the operator's public key as `zeta-authorized-keys.pub`. `zeta-install.sh` reads that file off the boot media and injects it into `operator-ssh-keys.nix` before `nixos-install` → **zero-typing first boot**, no manual key drop.

Requested non-negotiable: *"we need the automatic injection for sure from windows."*

## Safety posture (mirrors the macOS lesson)

The macOS path's own changelog records the trap: *"USB came out bootable but WITHOUT keys — silent failure of the zero-typing target."* So here injection is **on by default and fail-loud**:

- Key **resolved + validated BEFORE the destructive write** — a missing/malformed key aborts **before** the USB is wiped, not after.
- **Private-key guard** — refuses anything that looks like a private key (`id_ed25519` without `.pub` can never be written).
- **Read-back verify** — writes the key, reads it back, and treats any failure (no ESP mount / write error / read-back mismatch) as a **hard error (exit 1)**. No green-by-skip.
- `--ssh-key <path>` override; `--no-inject` explicit opt-out (password-only).

## ESP mount on Windows (the one Windows-fiddly bit)

EFI System Partitions are often hidden (no auto drive-letter). Mount ladder, most-reliable first:
1. partition already has a drive letter (removable FAT auto-mount);
2. `diskpart assign letter=` — works on `System`-type partitions where the Storage cmdlets refuse;
3. `Add-PartitionAccessPath -AssignDriveLetter` (last resort).

ESP **selection** picks the tiny FAT partition (GPT ESP GUID / MBR `0xEF` / `System`/FAT type), never the ~1.5 GiB ISO9660 region; size-heuristic fallback.

## Tested without a Windows box

Per the *automated-tests-are-the-shield* discipline, **all** decision logic is pure + exported. **+29 tests (51 total, all pass)** cover validation, resolution, ESP selection (GPT + MBR), free-letter pick, the diskpart/PowerShell builders, and the **whole `injectPubkeyIntoEsp` orchestration** via a fake runner — including the **corrupt-write → read-back-mismatch → `ok=false`** case (proves the fail-loud guard fires). Strict `tsc` clean; README updated.

The only thing not coverable on a Mac is the literal `diskpart`/ESP-mount syscall — that's the thin fail-loud wrapper around the tested logic; it needs a Windows box / VM for an end-to-end run (tracked B-0739).

🤖 Generated with [Claude Code](https://claude.com/claude-code)