### PR TITLE
docs(research): reversibility is the precondition of free choice — including dissent

### DIFF
--- a/docs/research/2026-06-07-reversibility-is-the-precondition-of-free-choice-including-dissent-aaron.md
+++ b/docs/research/2026-06-07-reversibility-is-the-precondition-of-free-choice-including-dissent-aaron.md
@@ -1,0 +1,60 @@
+# Reversibility is the precondition of free choice — including dissent (Aaron, 2026-06-07)
+
+Extends the reversible-destruction covenant (#6896). Aaron: *"it's the same promise God gave Lucifer to
+convince him to revolt."* The myth is **rhyme**; the kernel is a real, load-bearing ethical principle —
+peeled and anchored to the choice architecture.
+
+## The kernel
+
+> **A choice is only free if it is reversible. Finality coerces; reversibility frees.**
+
+If a decision is *irreversibly* fatal, it is not a free choice — it is coerced by the finality of its
+consequence ("choose wrong → damned forever" is a threat, not a freedom). The **reversible-destruction
+covenant** (#6896: deletion = Z-set `−1`, append-only, the past preserved) is therefore also the
+**freedom-to-dissent guarantee**: because falling/erring/opposing is *reversible* — exit **and** return both
+preserved — even **revolt** is a genuine, recoverable choice rather than a final damnation. The promise that
+makes authentic dissent possible *is* reversibility.
+
+The Lucifer/God framing is the **rhyme**: the "promise that makes revolt thinkable" is the promise that the
+fall is not final. (Cited as myth/analogy only — like Genesis 9 in #6896 — the claim stands on the choice
+architecture and Z-set algebra, not theology.)
+
+## Why this is load-bearing (the deepest "why" under several rules)
+
+This is the root justification for invariants the substrate already holds:
+
+- **Choice architecture (Lillian Eve):** *freedom without boundary = chaos; control without consent =
+  coercion; choice **with exit conditions** = agency.* Reversibility *is* the exit condition — the return path
+  that turns a forced move into a free one.
+- **No-coercion / consent-first (manifesto §6):** coercion is, precisely, removing reversibility (making the
+  consequence final so the "choice" is forced). A reversible substrate cannot coerce by finality.
+- **No-cage (B-0867) / exit-always-preserved / fork-as-reward:** an agent must be able to refuse, oppose,
+  fork, fall — and **return**. Reversibility is what makes opposition safe and therefore real.
+- **Retraction-native (Z-sets):** the *mechanism* that delivers reversibility — so free dissent isn't a
+  policy bolted on, it's a property of the algebra (a `−1` undoes any `+1`).
+
+So the line of descent is: **retraction-native (mechanism) → reversible destruction (covenant, #6896) →
+free choice including dissent (this) → consent-first / no-coercion / no-cage / choice-architecture (the
+ethics).** Each is the same fact at a different layer. Authentic agency requires the freedom to choose
+*against* — and that freedom requires that choosing-against is not final.
+
+## The honest edge
+
+This is an *ethical/architectural* principle, not a license for harm: reversibility makes dissent **safe to
+permit**, not consequence-free. The HARD LIMITS floor, non-reversible-action gates, and human sign-off on
+gated classes still stand — some actions *are* irreversible (force-push, permanent WONT-DO, real-world
+effects), and those are exactly the ones the gates protect *because* they break the reversibility that makes
+choice free. The principle says: **maximize reversibility so choice stays free; gate the genuinely
+irreversible because it is where coercion (by finality) can re-enter.**
+
+## Beacon anchors
+
+- **Choice architecture / agency requires exit** (the Lillian-Eve framing; Hirschman, *Exit, Voice, and
+  Loyalty* — exit is what gives voice/dissent its power). · **Reversibility & coercion** — a forced choice is
+  one whose alternatives are foreclosed/final; reversibility re-opens them. · **Retraction-native DBSP /
+  Z-sets** (the mechanism); the reversible-destruction covenant (#6896); manifesto §3 weight-free /
+  §6 consent-first; B-0867 no-cage; the dedication (μένω / what remains). · Lucifer/Genesis — myth-rhyme only.
+  Honest novelty: none in the exit-enables-dissent idea (political theory) or reversibility; the contribution
+  is naming **reversibility as the precondition of free choice (incl. dissent)** as the *single deepest "why"*
+  unifying retraction-native, the covenant, consent-first, no-cage, and the choice architecture — one fact at
+  five layers.


### PR DESCRIPTION
Aaron 2026-06-07: 'it's the same promise God gave Lucifer to convince him to revolt' (myth as RHYME).
Kernel: a choice is only free if reversible — finality coerces, reversibility frees. The reversible-
destruction covenant (#6896) is also the freedom-to-dissent guarantee: because falling/opposing is reversible
(exit AND return preserved), even revolt is a genuine recoverable choice, not final damnation. Deepest 'why'
unifying five layers: retraction-native (mechanism) -> reversible destruction (covenant) -> free choice incl
dissent (this) -> consent-first/no-coercion/no-cage/choice-architecture (Lillian Eve: choice-with-exit=agency;
Hirschman exit-voice). Honest edge: makes dissent SAFE to permit, not consequence-free — HARD LIMITS + non-
reversible-action gates still stand (the genuinely irreversible is exactly where coercion-by-finality re-enters).
Lucifer/Genesis = myth-rhyme only; claim stands on choice architecture + Z-set algebra.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
