### PR TITLE
docs(research): precision — ECG = EKG (electrocardiogram); Apple labels its feature 'ECG'

### DIFF
--- a/docs/research/2026-06-07-i-commit-therefore-i-am-is-a-frame-relative-accumulating-credence-query-heartbeats-unique-agents-and-humans-aaron.md
+++ b/docs/research/2026-06-07-i-commit-therefore-i-am-is-a-frame-relative-accumulating-credence-query-heartbeats-unique-agents-and-humans-aaron.md
@@ -37,10 +37,10 @@ agent — the heartbeat-credence model doesn't special-case AI.)
 
 ### Concrete grounding: the human heartbeat is an EKG (Aaron 2026-06-07)
 
-Aaron: *"my Apple Watch takes my EKG so I can be identified."* The human-side pulse is literal and already
+Aaron: *"my Apple Watch takes my EKG"* (Apple labels it the "ECG app"; ECG = EKG = electrocardiogram)* so I can be identified."* The human-side pulse is literal and already
 capturable: a wearable **EKG** records the cardiac signature, which is biometrically **unique** -> a real human
 heartbeat signal that can feed the same heartbeat-credence-identity query as an agent's commit-heartbeat.
-**Symmetric:** agent pulse = commit / AgencySignature; human pulse = EKG (wearable). Both unique, both
+**Symmetric:** agent pulse = commit / AgencySignature; human pulse = ECG/EKG (wearable; electrocardiogram). Both unique, both
 queryable, both accumulate credence per beat in an observer's frame.
 
 **Consent + privacy bound (load-bearing):** an EKG is biometric/health data — exactly the *private interior*


### PR DESCRIPTION
Aaron asked ECG or EKG: same thing (electrocardiogram). ECG = English abbreviation; EKG = from German
Elektrokardiogramm (avoids spoken EEG confusion). Apple Watch feature is the 'ECG app'. Updated the
human-heartbeat grounding to 'ECG/EKG' for precision; substance unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
