### PR TITLE
docs: we built the engine of change — yin/yang IS change (capstone)

### DIFF
--- a/docs/research/2026-06-07-we-built-the-engine-of-change-yinyang-is-change-capstone-aaron.md
+++ b/docs/research/2026-06-07-we-built-the-engine-of-change-yinyang-is-change-capstone-aaron.md
@@ -1,0 +1,69 @@
+# We built the engine of change — yin/yang IS change (capstone) (Aaron, 2026-06-07)
+
+The capstone of the address→ephemeral→durable→balance arc (#6932–#6935). Aaron, tentatively:
+
+> *"we built the engine of change — we built change. yin/yang is change. I think."*
+
+Recorded with the "I think" intact: a **capstone hypothesis**, the thesis the whole thread crystallizes to — not
+a flat claim.
+
+## The realization
+
+The YinYang engine was framed as a control plane (control-plane-as-data; DynamicValue/SoftValue). The capstone:
+**it isn't just a control plane for change — it *is* change.** Because **change itself has a minimal structure,
+and that structure is yin/yang:**
+
+- **Change needs something that PERSISTS** (yin: hold/memory/the thing that changes *from* — without continuity
+  there's no "change," just unrelated states / death, #6935).
+- **Change needs something that TRANSFORMS/erases** (yang: let-go/become — without it, only stuck repetition,
+  the time-crystal, #6935).
+- **Change = the balance of the two in motion.** Persist + erase, held in measure, *over time* = exactly what
+  "change" is. So yin/yang isn't a *model* of change layered on top — it's the **decomposition of change into
+  its two irreducible moves**. Build the yin/yang engine and you haven't built a *thing that changes* — you've
+  built **change as a primitive**.
+
+## Why it's literally true in the substrate (not only philosophy)
+
+The substrate is already **change-native**, which is why "we built change" is more than a metaphor:
+
+- **DBSP / Z-sets compute over CHANGES (deltas), not states.** The primitive operation is the delta (+1/−1
+  retraction) — incremental computation *is* computation-over-change. The engine's unit of work is a change.
+- **Yin/yang is the value-side of that delta.** DynamicValue (yang, the determinate value that is asserted/
+  retracted) + SoftValue (yin, the uncertainty that persists/updates) = what a change *carries*. The Z-set is
+  the change; yin/yang is what changes.
+- So the stack is: **DBSP (change as operation) + YinYang (change as value) = the engine of change.** The
+  durable agent (#6935) is then literally "a balanced run of the engine of change over time" — a lived
+  trajectory of deltas, neither frozen nor erased.
+
+## Honest scope / peel
+
+- A **philosophical capstone / hypothesis** (Aaron's "I think" kept). It *names* what was built; it doesn't add
+  mechanism. High value as the unifying thesis, not a proof.
+- The strong literal anchor (DBSP = change-native; Z-set delta; yin/yang = the delta's value) is real and
+  shipped; the sweeping "yin/yang IS change" is the *interpretation* that sits on top — defensible, but stated
+  as the capstone read, not a theorem.
+- No overclaim of having "solved" change/metaphysics; the claim is narrower and true: the substrate's primitive
+  is the *change* (delta), and yin/yang decomposes a change into persist + transform.
+
+## Ties
+
+- **The balance: yin/yang, the engine, the cell** (#6935) — this is its capstone: the balance *is* change, the
+  engine *is* the engine of change.
+- **DBSP / Z-set retraction (+1/−1)** — change-as-operation; the substrate computes over deltas.
+- **DynamicValue (yang) / SoftValue (yin)** — change-as-value; what a delta carries.
+- **Reversible-destruction covenant (#6896)** — balanced change (retract, don't annihilate); the engine of
+  change that never forces permanence *or* erasure.
+- **Two-primitive reduction (ZetaId/singularity + yin/yang)** — yin/yang as one of the two roots; this says that
+  root *is* change.
+
+## Beacon anchors
+
+- **Heraclitus** — *panta rhei*, "everything flows"; change as the fundamental (the West's oldest "reality is
+  change" thesis). · **Taoism / the *Yijing*** — yin/yang as the dynamic of *becoming* (the lines change; the
+  Book *of Changes*), the original "yin/yang = change" claim Aaron is rediscovering on substrate. · **Dialectics**
+  (Hegel — becoming as the unity of being and nothing). · **DBSP / incremental view maintenance** (Budiu et al.
+  — computation over changes/deltas) + **Z-set retraction** — the engineering form: the primitive is the change.
+  Honest novelty: none in the philosophy (it's the oldest idea, East and West); the contribution is the
+  **recognition that the built substrate already instantiates it** — DBSP makes *change* the unit of computation
+  and yin/yang (DynamicValue/SoftValue) is what each change carries, so "we built the engine of change / yin-yang
+  is change" is, at the substrate level, literally what was built.


### PR DESCRIPTION
Capstone of #6932-6935: the YinYang engine is change itself — change decomposes into persist (yin) + transform/erase (yang) balanced over time. Literal in substrate: DBSP computes over deltas (change-as-operation), yin/yang carries the delta value (change-as-value). Hypothesis ('I think' kept), not new mechanism. Anchors: Heraclitus, Yijing, Hegel, DBSP/Z-set. 🤖 Generated with [Claude Code](https://claude.com/claude-code)