### PR TITLE
fix(k3s): disable checkReversePath — NixOS rpfilter black-holes Cilium pod->host

### DIFF
--- a/full-ai-cluster/nixos/modules/k3s-agent.nix
+++ b/full-ai-cluster/nixos/modules/k3s-agent.nix
@@ -35,6 +35,12 @@
       8472
     ];
     trustedInterfaces = [ "cilium_host" "cilium_net" "cni0" "lxc+" ];
+
+    # Cilium REQUIRES reverse-path filtering OFF — NixOS' default
+    # `checkReversePath` rpfilter (mangle PREROUTING) drops Cilium's
+    # asymmetric pod->host traffic before conntrack, black-holing every
+    # pod->node packet. Same fix + rationale as k3s-server.nix.
+    checkReversePath = false;
   };
 
   systemd.tmpfiles.rules = [

--- a/full-ai-cluster/nixos/modules/k3s-server.nix
+++ b/full-ai-cluster/nixos/modules/k3s-server.nix
@@ -159,6 +159,23 @@
       8472    # VXLAN (Cilium can also run native-routing)
     ];
     trustedInterfaces = [ "cilium_host" "cilium_net" "cni0" "lxc+" ];
+
+    # Cilium REQUIRES reverse-path filtering OFF. NixOS' default
+    # `checkReversePath` installs an iptables `-m rpfilter` DROP in the
+    # mangle PREROUTING chain (`nixos-fw-rpfilter`). Cilium's eBPF datapath
+    # delivers pod->host traffic on an asymmetric path that this rpfilter
+    # marks as failing and DROPS *before conntrack* — so every pod->node
+    # packet (pod->apiserver via the kubernetes ClusterIP, kubelet, etc.)
+    # vanishes with no conntrack entry and no counter. Symptom: node goes
+    # Ready, Cilium is healthy, pod->internet and pod->pod work, but CoreDNS
+    # can't reach 10.43.0.1 -> in-cluster DNS dies -> every helm/app chart
+    # CrashLoops on DNS. The sysctl `net.ipv4.conf.*.rp_filter` being loose
+    # is NOT enough; the iptables rpfilter module is separate and must be
+    # disabled. Confirmed on node-09485d (2026-06-07): inserting a RETURN for
+    # the pod/service CIDR ahead of the rpfilter DROP immediately restored
+    # pod->apiserver and the whole cluster recovered.
+    # See Cilium docs: "rp_filter must be disabled".
+    checkReversePath = false;
   };
 
   environment.variables = {


### PR DESCRIPTION
## Problem

A freshly-installed node comes up `Ready` with Cilium healthy, but **every app pod CrashLoops**: CoreDNS can't reach the apiserver ClusterIP (10.43.0.1), so in-cluster DNS dies and all helm/app charts fail to resolve their chart repos.

Root cause: pods cannot reach the **node's own IP** on any port (apiserver, kubelet, sshd). pod->internet and pod->pod work; host->pod works. Isolated to a single mechanism:

NixOS' default `networking.firewall.checkReversePath` installs an iptables `-m rpfilter` DROP in the **mangle PREROUTING** chain (`nixos-fw-rpfilter`). Cilium's eBPF datapath delivers pod->host traffic on an asymmetric path that rpfilter marks as failing and **DROPs before conntrack** — the packet vanishes with no conntrack entry and no counter (confirmed via a host `nc` listener never seeing SYN-RECV).

The `net.ipv4.conf.*.rp_filter` sysctl being loose is **not** sufficient — the iptables rpfilter module is separate. Cilium documents that rp_filter must be disabled.

## Fix

`networking.firewall.checkReversePath = false;` on both `k3s-server.nix` (control-plane) and `k3s-agent.nix` (worker).

## Validation (node-09485d, 2026-06-07)

Inserting a RETURN for the pod/service CIDR ahead of the rpfilter DROP **immediately** fixed it live:
- pod->host:6443 / pod->apiCIP 10.43.0.1:443: FAIL -> **OK**
- in-cluster DNS: EPERM -> resolves `kubernetes.default` -> 10.43.0.1
- CoreDNS, metrics-server -> Running; cert-manager / vault / external-secrets / argocd / trust-manager helm installs -> Completed

Ruled out (none fixed it): WireGuard encryption, host firewall trust rules, rp_filter sysctl, hostLegacyRouting, BPF-masquerade on/off, native↔tunnel routing, Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)