### PR TITLE
docs: ACE = Awesome Closure Engine (backronym names the closure thread)

### DIFF
--- a/docs/research/2026-06-07-ace-awesome-closure-engine-backronym-names-the-closure-thread-aaron.md
+++ b/docs/research/2026-06-07-ace-awesome-closure-engine-backronym-names-the-closure-thread-aaron.md
@@ -1,0 +1,46 @@
+# ACE = Awesome Closure Engine (the backronym names the closure thread) (Aaron, 2026-06-07)
+
+> Aaron: *"ACE = awesome closure engine lol."*
+
+A playful backronym that lands as the **naming capstone** of the closure thread (#6932 → #6942). It's not just a
+joke — it states what Ace *is* now that the thread is complete:
+
+- **Closure** — Ace is the **external-state closure** (#6939): declarative pointers closing over the whole
+  dependency space (OS/NixOS + app PMs + cluster k8s/ArgoCD/Flux, #6941), reference-not-copy (#6916/#6925),
+  resolved on demand. It even closes over its own *host* via the one-liner bootstrap register (#6942) — a
+  self-installing closure.
+- **Engine** — it's an *engine*, not a static map: it resolves, reconciles desired-state, and surfaces cross-PM
+  conflicts as compile-time errors (#6940). Pairs with the YinYang engine (the internal-state / engine-of-change
+  side, #6936): **YinYang engine = internal-state engine of change; Ace = Awesome Closure Engine = external-state
+  closure engine.** Two engines, internal + external, the two halves of #6932.
+- **Awesome** — the *lol* part; keep the levity, it's Aaron's. (A backronym, retrofit to the existing name
+  "Ace"; honest about that — the letters were the name first, the expansion names what it became.)
+
+## Why record a backronym
+
+- **It crystallizes the thread into the name** (Mirror→Beacon: the whole external-state-closure arc compresses to
+  three letters that *mean* it). Good names that encode the architecture are load-bearing (glossary discipline).
+- **It pairs the two engines cleanly:** internal = YinYang engine (#6936), external = Ace/closure engine (#6939)
+  — symmetric, memorable, and true to the closure frame's internal/external split (#6932).
+
+## Honest scope
+
+- A **naming note / backronym**, not architecture or mechanism. Final naming (if it ever goes public/glossary)
+  is subject to `naming-expert` + human review per the naming discipline; recorded here as Aaron's coinage and
+  the thread's capstone. Keep the "lol" — it's not a solemn rebrand, it's a true and funny crystallization.
+
+## Ties
+
+- **Closures over state / Reticulum (#6932)** — Ace = the external-state-closure half, now named.
+- **Ace external-state closure (#6939) + all-layers pointers (#6941) + compile-time conflicts (#6940) + one-liner
+  bootstrap (#6942)** — what the "Closure Engine" does.
+- **Engine of change / YinYang engine (#6936)** — the internal-state engine; Ace is its external-state twin.
+- **Naming/glossary discipline** (`naming-expert`, anchor-to-human-prior-art) — backronyms are Beacon naming;
+  gate public use on review.
+
+## Beacon anchors
+
+- **Backronym** (a reverse-acronym retrofit to an existing name). · **Closures** (#6932 anchor — code + captured
+  environment). · **Mirror→Beacon compression** (the arc → three letters that mean it). Honest novelty: none —
+  a naming crystallization: ACE = *Awesome Closure Engine* names the completed external-state-closure thread and
+  pairs it with the YinYang engine (internal) as the two engines of #6932.


### PR DESCRIPTION
Naming capstone of #6932->#6942: Ace = the external-state Closure Engine (pointers over OS/app/cluster, self-installing) paired with the YinYang engine (internal-state engine of change #6936) = the two halves of #6932. Backronym, recorded as Aaron's coinage; public use gated on naming-expert review. 🤖 Generated with [Claude Code](https://claude.com/claude-code)