### PR TITLE
test(core): WeightedSet octonion/sedenion floor coverage (add-side retraction envelope)

### DIFF
--- a/tests/Tests.FSharp/CayleyWeightedSet.Tests.fs
+++ b/tests/Tests.FSharp/CayleyWeightedSet.Tests.fs
@@ -42,3 +42,53 @@ let ``scale by One is identity (proves the tower carries a multiplicative identi
 let ``scale by Zero annihilates (proves Zero + Mul on the tower)`` () =
     let a = WS.ofSeq q [ "x", i; "y", one ]
     Assert.True(WS.isEmpty (WS.scale q (q.Zero) a))
+
+// ── Hard rungs: Octonion (non-associative Mul) and Sedenion (zero divisors) ──
+// The floor promise is "EVERY Cayley–Dickson tower is an IStarRing, hence an ISemiring, so it
+// drops into WeightedSet." Quaternion is covered above; here we pin the HARD levels on the
+// ADD-SIDE — the retraction-native Z-set core — which is sound at every tower because Add is
+// always a commutative group (the ℍ ceiling only bites Mul). The Mul-law DEGRADATION itself
+// (octonion non-associativity; octonion alternativity; sedenion zero divisors) is proven at the
+// algebra level in Algebra/Octonion.Laws.Tests.fs + Algebra/CayleyDickson.Tests.fs. Consequence,
+// per the IStarRing law profile: WeightedSet.inner / scale-CHAINS are order-sensitive above ℍ —
+// so these tests assert only the law-safe envelope (additive structure + One/Zero scaling).
+
+let private qzero : Quaternion = quat 0.0 0.0 0.0 0.0
+let private ozero : Octonion = { Real = qzero; Imag = qzero }
+
+// Octonion = Doubled<Quaternion>
+let private oalg = ImaginaryStack.octonion :> ISemiring<Octonion>
+let private oOne : Octonion = { Real = one; Imag = qzero }
+let private oI   : Octonion = { Real = i; Imag = qzero }    // an imaginary unit (lower half)
+let private oE4  : Octonion = { Real = qzero; Imag = one }  // the doubling unit e4 (upper half)
+
+[<Fact>]
+let ``WeightedSet carries OCTONION weights; retraction holds despite non-associative Mul (add-side sound)`` () =
+    let a = WS.ofSeq oalg [ "x", oI; "y", oE4 ]
+    Assert.Equal<Octonion>(oI, WS.weight oalg "x" a)
+    Assert.True(WS.isEmpty (WS.add oalg a (WS.negate oalg a)))
+
+[<Fact>]
+let ``octonion WeightedSet: add combines coordinates; scale by One identity, by Zero annihilates`` () =
+    let a = WS.ofSeq oalg [ "x", oI ]
+    let b = WS.ofSeq oalg [ "x", oE4 ]
+    Assert.Equal<Octonion>({ Real = i; Imag = one }, WS.weight oalg "x" (WS.add oalg a b))
+    let c = WS.ofSeq oalg [ "x", oI; "y", oOne ]
+    Assert.Equal<WS.WeightedSet<string, Octonion>>(c, WS.scale oalg oOne c)
+    Assert.True(WS.isEmpty (WS.scale oalg oalg.Zero c))
+
+// Sedenion = Doubled<Octonion>
+let private salg = ImaginaryStack.sedenion :> ISemiring<Sedenion>
+let private sOne : Sedenion = { Real = oOne; Imag = ozero }
+let private sI   : Sedenion = { Real = oI;   Imag = ozero }
+let private sE8  : Sedenion = { Real = ozero; Imag = oOne }  // the doubling unit e8
+
+[<Fact>]
+let ``WeightedSet carries SEDENION weights; retraction + One/Zero scaling hold despite zero divisors`` () =
+    let a = WS.ofSeq salg [ "x", sI; "y", sE8 ]
+    Assert.Equal<Sedenion>(sI, WS.weight salg "x" a)
+    // Add is a commutative group at every tower — retraction is sound even though Mul has zero divisors here
+    Assert.True(WS.isEmpty (WS.add salg a (WS.negate salg a)))
+    // One is never a zero divisor, so scale-by-One is identity even in 𝕊
+    Assert.Equal<WS.WeightedSet<string, Sedenion>>(a, WS.scale salg sOne a)
+    Assert.True(WS.isEmpty (WS.scale salg salg.Zero a))


### PR DESCRIPTION
Pins the floor promise at the hard rungs: octonion (non-assoc) + sedenion (zero-divisor) weights carry through WeightedSet on the add-side (retraction-native Z-set core, sound at every tower). Mul-law degradation already proven at algebra level; this is the law-safe WeightedSet envelope + ℍ-ceiling cross-ref. 8/8 green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)