### PR TITLE
test(core): pin the ℍ ceiling at the WeightedSet API (scale-chains order-sensitive above ℍ)

### DIFF
--- a/tests/Tests.FSharp/CayleyWeightedSet.Tests.fs
+++ b/tests/Tests.FSharp/CayleyWeightedSet.Tests.fs
@@ -92,3 +92,46 @@ let ``WeightedSet carries SEDENION weights; retraction + One/Zero scaling hold d
     // One is never a zero divisor, so scale-by-One is identity even in 𝕊
     Assert.Equal<WS.WeightedSet<string, Sedenion>>(a, WS.scale salg sOne a)
     Assert.True(WS.isEmpty (WS.scale salg salg.Zero a))
+
+// ── The ℍ ceiling at the WeightedSet API: scale-CHAINS are order-sensitive above ℍ ──
+// scale w1 (scale w2 a)  applies  Mul(w1, Mul(w2, x))  per element;
+// scale (Mul w1 w2) a    applies  Mul(Mul(w1, w2), x).
+// These agree iff Mul is associative. Quaternion (ℍ): associative ⇒ they AGREE. Octonion (𝕆):
+// non-associative ⇒ they can DIFFER. This pins, at the WeightedSet level, the IStarRing law-profile
+// boundary "loses associativity above ℍ" — so callers needing scale-chain/inner associativity must
+// stay ≤ ℍ. (The algebra-level non-associativity proof lives in Algebra/CayleyDickson.Tests.fs.)
+
+// k-th basis octonion (coordinate k = 1.0), k ∈ 0..7 (0 = real, 1..7 = imaginary units).
+let private oBasis (k: int) : Octonion =
+    let a = Array.zeroCreate 8
+    a.[k] <- 1.0
+    let mkC i : Complex = { Real = a.[i]; Imag = a.[i + 1] }
+    let mkQ i : Quaternion = { Real = mkC i; Imag = mkC (i + 2) }
+    { Real = mkQ 0; Imag = mkQ 4 }
+
+[<Fact>]
+let ``quaternion scale-chain is associative: scale w1 (scale w2 a) = scale (Mul w1 w2) a`` () =
+    let a = WS.ofSeq q [ "x", i ]
+    let w1, w2 = quat 0.0 1.0 0.0 0.0, quat 0.0 0.0 1.0 0.0   // i, j
+    Assert.Equal<WS.WeightedSet<string, Quaternion>>(
+        WS.scale q w1 (WS.scale q w2 a),
+        WS.scale q (q.Mul(w1, w2)) a)
+
+[<Fact>]
+let ``octonion scale-chain is ORDER-SENSITIVE above ℍ (pins the non-associativity boundary)`` () =
+    // Find any non-associating octonion unit triple (u,v,x): Mul(Mul(u,v),x) <> Mul(u,Mul(v,x)).
+    let units = [ for k in 1..7 -> oBasis k ]
+    let triple =
+        seq { for u in units do
+                for v in units do
+                  for x in units do
+                    if oalg.Mul(oalg.Mul(u, v), x) <> oalg.Mul(u, oalg.Mul(v, x)) then yield (u, v, x) }
+        |> Seq.tryHead
+    match triple with
+    | None -> failwith "expected a non-associating octonion triple (Mul should not be associative on 𝕆)"
+    | Some (u, v, x) ->
+        let a = WS.ofSeq oalg [ "k", x ]
+        // scale-chain differs exactly because Mul is non-associative on 𝕆
+        Assert.NotEqual<WS.WeightedSet<string, Octonion>>(
+            WS.scale oalg u (WS.scale oalg v a),
+            WS.scale oalg (oalg.Mul(u, v)) a)


### PR DESCRIPTION
Completes #6948 floor boundary: quaternion scale-chain associative (agree); octonion scale-chain order-sensitive (differ) — pins 'loses associativity above ℍ' at the WeightedSet API. 10/10 green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)