### PR TITLE
feat(core): RayTensor — F# impl of the full ray-traceable capability vector

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -30,6 +30,7 @@
     <Compile Include="Bag.fs" />
     <Compile Include="ZSet.fs" />
     <Compile Include="WeightedSet.fs" />
+    <Compile Include="RayTensor.fs" />
     <Compile Include="ToffoliGate.fs" />
     <Compile Include="IndexedZSet.fs" />
     <Compile Include="Codec.fs" />

--- a/src/Core/RayTensor.fs
+++ b/src/Core/RayTensor.fs
@@ -1,0 +1,114 @@
+namespace Zeta.Core
+
+open System.Collections.Generic
+open Zeta.Core.Abstractions
+
+/// **Ray-traceable sparse tensor — the full capability vector in F# (the reference oracle).**
+///
+/// Composes a `WeightedSet<'K,'W>` (sparse storage / Z-set generalization) with a **geospatial embedding**
+/// (`position: 'K -> double[]` — a coordinate's point in the metric locality space) and its weight
+/// `ISemiring<'W>`, and implements the unified `IRayTraceable<'K,'W>` contract = `ITensor` (skip empty) +
+/// `ISampleable` (light) + `IIntrospectable` (walk) + `IGeospatial` (locality) + `Trace` (accumulate via a
+/// semiring). This is the F# implementation Vera/Lior port to C#/Rust/TS (4-oracle parity); F# is the
+/// reference.
+///
+/// Design notes:
+/// - `Sample` returns the semiring `Zero` where a coordinate is absent (sparse default) — exactly the
+///   `ISampleable` contract and `WeightedSet.weight`'s behaviour.
+/// - `Neighbors` are the stored support coordinates other than `at`, **nearest-first by Euclidean distance in
+///   position space** — locality stepping (the geospatial analogue of graph adjacency for a sparse field).
+/// - `Trace` folds the ray, sampling each coordinate and combining via the *passed* `accumulate` semiring;
+///   absent coordinates are **skipped** (sparsity), so the ray skips empty space. The trace is deterministic
+///   (a left fold over the ray), hence replayable — a *proof* when cast from an `ITravelerFrame` whose
+///   `IsDeterministic` holds. With `'W = SoftValue` + a probability semiring it propagates irreducible
+///   uncertainty (the result is itself soft), per the `IRayTraceable` contract.
+///
+/// API-review pending (Ilyana) before any public/NuGet exposure.
+type RayTensor<'K, 'W when 'K: comparison and 'W: equality>
+    (sr: ISemiring<'W>, dimensions: int, position: 'K -> double[], data: WeightedSet.WeightedSet<'K, 'W>) =
+
+    /// The backing sparse tensor.
+    member _.Data = data
+    /// The weight semiring (sampling / Zero-where-absent).
+    member _.Semiring = sr
+
+    /// Euclidean distance in position space (locality metric for stepping).
+    static member private Distance(a: double[], b: double[]) : double =
+        let mutable acc = 0.0
+        for d in 0 .. min a.Length b.Length - 1 do
+            let diff = a.[d] - b.[d]
+            acc <- acc + diff * diff
+        sqrt acc
+
+    // ── ITensor (read contract) — delegate to the WeightedSet (semiring-free stored support) ──
+    interface ITensor<'K, 'W> with
+        member _.StoredCount = (data :> ITensor<'K, 'W>).StoredCount
+        member _.IsSparse = true
+        member _.StoredEntries = (data :> ITensor<'K, 'W>).StoredEntries
+
+    // ── ISampleable (light) — value at a coordinate, semiring Zero where absent ──
+    interface ISampleable<'K, 'W> with
+        member _.Sample(at: 'K) : 'W = WeightedSet.weight sr at data
+
+    // ── IIntrospectable — exists + locality-ordered stepping ──
+    interface IIntrospectable<'K> with
+        member _.Exists(at: 'K) : bool = WeightedSet.weight sr at data <> sr.Zero
+
+        member _.Neighbors(at: 'K) : IEnumerable<'K> =
+            let pa = position at
+            (data :> ITensor<'K, 'W>).StoredEntries
+            |> Seq.map (fun kv -> kv.Key)
+            |> Seq.filter (fun k -> k <> at)
+            |> Seq.sortBy (fun k -> RayTensor<'K, 'W>.Distance(pa, position k))
+
+    // ── IGeospatial — locality topology (where/when/what-to-attend) ──
+    interface IGeospatial<'K> with
+        member _.Dimensions = dimensions
+        member _.Position(at: 'K) : IReadOnlyList<double> = position at :> IReadOnlyList<double>
+
+        member _.Within(lo: IReadOnlyList<double>, hi: IReadOnlyList<double>) : IEnumerable<'K> =
+            (data :> ITensor<'K, 'W>).StoredEntries
+            |> Seq.map (fun kv -> kv.Key)
+            |> Seq.filter (fun k ->
+                let p = position k
+                let mutable inside = true
+                for d in 0 .. dimensions - 1 do
+                    if d < p.Length && d < lo.Count && d < hi.Count then
+                        if p.[d] < lo.[d] || p.[d] > hi.[d] then inside <- false
+                inside)
+
+    // ── IRayTraceable — cast a ray from any frame, accumulate sampled values along it ──
+    interface IRayTraceable<'K, 'W> with
+        member _.Trace(_from: IFrame, ray: IReadOnlyList<'K>, accumulate: ISemiring<'W>) : 'W =
+            // Skip-empty via sparsity (absent coords sample to Zero and are dropped); combine via the
+            // passed accumulate semiring's Add. Deterministic left fold ⇒ replayable ⇒ a proof from a
+            // deterministic traveler frame.
+            let mutable acc = accumulate.Zero
+            for k in ray do
+                let v = WeightedSet.weight sr k data
+                if v <> sr.Zero then
+                    acc <- accumulate.Add(acc, v)
+            acc
+
+
+/// Construction helpers for `RayTensor`.
+[<RequireQualifiedAccess>]
+module RayTensor =
+
+    /// Wrap an existing `WeightedSet` with a geospatial embedding.
+    let create
+        (sr: ISemiring<'W>)
+        (dimensions: int)
+        (position: 'K -> double[])
+        (data: WeightedSet.WeightedSet<'K, 'W>)
+        : RayTensor<'K, 'W> =
+        RayTensor<'K, 'W>(sr, dimensions, position, data)
+
+    /// Build a `RayTensor` from (coordinate, weight) pairs + a geospatial embedding.
+    let ofSeq
+        (sr: ISemiring<'W>)
+        (dimensions: int)
+        (position: 'K -> double[])
+        (pairs: ('K * 'W) seq)
+        : RayTensor<'K, 'W> =
+        RayTensor<'K, 'W>(sr, dimensions, position, WeightedSet.ofSeq sr pairs)

--- a/tests/Tests.FSharp/RayTensor.Tests.fs
+++ b/tests/Tests.FSharp/RayTensor.Tests.fs
@@ -1,0 +1,71 @@
+module Zeta.Tests.RayTensorTests
+
+open global.Xunit
+open Zeta.Core
+open Zeta.Core.Abstractions
+
+// Reference-oracle tests for the F# ray-traceable capability vector (RayTensor implements the full
+// IRayTraceable = ITensor + ISampleable + IIntrospectable + IGeospatial + Trace). Vera/Lior port to C#/Rust/TS.
+
+let private sr = IntegerRing.Instance
+
+// A tiny 2-D integer field: coordinates are string keys placed on a line of points.
+//   "a"@(0,0)=1   "b"@(1,0)=2   "c"@(2,0)=3   "d"@(5,0)=10
+let private pos (k: string) : double[] =
+    match k with
+    | "a" -> [| 0.0; 0.0 |]
+    | "b" -> [| 1.0; 0.0 |]
+    | "c" -> [| 2.0; 0.0 |]
+    | "d" -> [| 5.0; 0.0 |]
+    | _   -> [| 0.0; 0.0 |]
+
+let private rt : RayTensor<string, int64> =
+    RayTensor.ofSeq sr 2 pos [ "a", 1L; "b", 2L; "c", 3L; "d", 10L ]
+
+let private tensor = rt :> ITensor<string, int64>
+let private light  = rt :> ISampleable<string, int64>
+let private walk   = rt :> IIntrospectable<string>
+let private geo    = rt :> IGeospatial<string>
+let private ray    = rt :> IRayTraceable<string, int64>
+
+// Any frame works — ray-traceability is "from ANY arbitrary frame" (a plain vantage point here).
+let private frame : IFrame = { new IFrame }
+
+[<Fact>]
+let ``ITensor: sparse, stored support = 4`` () =
+    Assert.True(tensor.IsSparse)
+    Assert.Equal(4L, tensor.StoredCount)
+
+[<Fact>]
+let ``ISampleable: sample present = value, absent = semiring Zero`` () =
+    Assert.Equal(3L, light.Sample "c")
+    Assert.Equal(0L, light.Sample "z")   // absent ⇒ Zero (sparse default)
+
+[<Fact>]
+let ``IIntrospectable: Exists present/absent; Neighbors are locality-ordered (nearest first)`` () =
+    Assert.True(walk.Exists "a")
+    Assert.False(walk.Exists "z")
+    // from "a"@(0,0): nearest stored neighbor is "b"@(1,0), farthest is "d"@(5,0)
+    let nbrs = walk.Neighbors "a" |> List.ofSeq
+    Assert.Equal<string list>([ "b"; "c"; "d" ], nbrs)
+
+[<Fact>]
+let ``IGeospatial: Dimensions, Position, Within (box query)`` () =
+    Assert.Equal(2, geo.Dimensions)
+    Assert.Equal<double list>([ 2.0; 0.0 ], geo.Position "c" |> List.ofSeq)
+    // box [0,0]..[2,0] contains a,b,c but not d@(5,0)
+    let inBox = geo.Within([| 0.0; 0.0 |], [| 2.0; 0.0 |]) |> Set.ofSeq
+    Assert.Equal<Set<string>>(set [ "a"; "b"; "c" ], inBox)
+
+[<Fact>]
+let ``Trace: accumulates sampled values along a ray, skipping empty coordinates`` () =
+    // ray a→b→c→(z absent, skipped)→d  = 1 + 2 + 3 + 10 = 16
+    let total = ray.Trace(frame, [| "a"; "b"; "c"; "z"; "d" |], sr)
+    Assert.Equal(16L, total)
+
+[<Fact>]
+let ``Trace from a deterministic traveler frame is replayable (same ray ⇒ same result)`` () =
+    let r1 = ray.Trace(frame, [| "a"; "c"; "d" |], sr)
+    let r2 = ray.Trace(frame, [| "a"; "c"; "d" |], sr)
+    Assert.Equal(14L, r1)   // 1 + 3 + 10
+    Assert.Equal(r1, r2)    // deterministic ⇒ replayable

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -90,6 +90,7 @@
     <Compile Include="SoftValueInfo.Tests.fs" />
     <Compile Include="WeightedSet.Tests.fs" />
     <Compile Include="CayleyWeightedSet.Tests.fs" />
+    <Compile Include="RayTensor.Tests.fs" />
     <Compile Include="ITensor.Tests.fs" />
     <Compile Include="SagaSnapshot.Tests.fs" />
     <Compile Include="DagFs.Tests.fs" />


### PR DESCRIPTION
Closes the interface-rewrite gap: ray-trace vector was interface-only. RayTensor<'K,'W> = WeightedSet + geospatial embedding + semiring, implementing IRayTraceable (ITensor+ISampleable+IIntrospectable+IGeospatial+Trace). F# reference oracle for Vera/Lior 4-lang ports. 0 warnings; 6/6 tests green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)