### PR TITLE
docs: the Ace file is a universal content-addressed 'Dockerfile' — idempotent layers, cross-OS patch sets

### DIFF
--- a/docs/research/2026-06-07-ace-file-is-a-universal-content-addressed-dockerfile-idempotent-layers-cross-os-patch-sets-aaron.md
+++ b/docs/research/2026-06-07-ace-file-is-a-universal-content-addressed-dockerfile-idempotent-layers-cross-os-patch-sets-aaron.md
@@ -1,0 +1,84 @@
+# The Ace file is a universal, content-addressed "Dockerfile" — idempotent layers, cross-OS patch sets (Aaron, 2026-06-07)
+
+Synthesis of the Ace thread (#6939/#6959). Aaron:
+
+> *"It can read like a Dockerfile for anything that's script-shaped — able to declare its dependencies
+> idempotently so it's reproducible, and cacheable per layer too in our FS (efficiency gains), and even have
+> patch sets applicable to multiple OSes at once. We write universal Docker-like files with Ace that work on
+> Ace OS for setup."*
+
+## The kernel: an Ace file = a declarative, idempotent, content-addressed, cross-OS build file
+
+An **Ace file** reads like a Dockerfile but is built from the pieces already in the thread:
+
+- **Dockerfile-shaped, for anything script-shaped.** A readable, ordered file of setup steps — but each step is
+  an **idempotent `ensure`** (#6959: `ace ensure namespace[source].package`), declaring dependencies
+  *declaratively*, not imperative `RUN`-and-hope. So the file *is* a desired-state spec (the YinYang/IDL form),
+  legible top-to-bottom.
+- **Idempotent ⇒ reproducible.** Because every step is idempotent (apply-N == apply-once, #6959), re-running the
+  file converges to the same environment — reproducible by construction (Nix-grade), no "works on my machine."
+  Non-idempotent steps are the fenced exception (workflow/DU, #6959).
+- **Cacheable per layer, content-addressed in our FS.** Each step/layer is **content-addressed** (BLAKE3 /
+  `ContentStore` / `DagFs`, #6925/#6939). A layer's cache key *is* its content hash, so:
+  - identical layers **dedup** across builds, projects, *and OSes* (one copy in the content store);
+  - a changed step only invalidates *downstream* layers (Docker/BuildKit-style layer cache, but content-
+    addressed and shared in the Zeta FS) → the efficiency gain Aaron names.
+- **Cross-OS patch sets from one file.** A single **universal** Ace file emits **per-OS patch sets** — the
+  OS-specific deltas (the holographic projection of the n-dimensional dependency space, B-0824, projected onto
+  each target OS, B-0806 cross-OS). Write once; Ace resolves the per-OS realization. "Patch sets applicable to
+  multiple OSes at once" = the same desired-state, materialized per OS, sharing every content-identical layer.
+- **"Ace OS for setup."** Ace is the **setup substrate** — the universal Docker-like file is how a machine (any
+  OS, or Ace OS) is brought to a desired state. Ace-as-installer (the one-liner bootstrap #6942) lays down the
+  host; the Ace file declares what the host should *become*.
+
+## Why it composes (the thread converges here)
+
+- **= idempotent `ensure` (#6959) sequenced** — an Ace file is just an ordered set of `ensure` nouns; idempotency
+  is what makes it reproducible + safely re-runnable + cache-coherent.
+- **= the external-state closure (#6939) as a file** — the file *is* the declarative closure over the env (deps
+  across OS/app/cluster, #6941), written down; compile-time conflict resolution (#6940) applies to the whole
+  file.
+- **content-addressed layers = the substrate's own FS** (`ContentStore`/`DagFs`/BLAKE3) — not a bespoke layer
+  cache; the *same* content-addressing that backs ZetaId/pointers backs the layer cache (dedup + DAG-FS copy-on-
+  write).
+- **cross-OS = B-0824 holographic projection + B-0806 cross-OS** — one n-dimensional dep spec → per-OS patch
+  sets.
+- **DST-able (#6958)** — because layers are idempotent + content-addressed, an Ace file build replays
+  deterministically under the `test` seam (simulate the build; cache hits are deterministic).
+
+## Honest scope / peel
+
+- **Vision/design, not built.** Ace, the Ace file format, per-layer content-addressed caching wiring, the
+  cross-OS patch-set emitter, and "Ace OS" are the frontier (Ace lane B-0824/#6939/#6942; cross-OS B-0806). The
+  pieces (idempotent ensure, content store, DagFs, cross-OS) exist or are scoped; the Ace-file *format* + the
+  per-OS projection are the new spec.
+- **Reproducibility is bounded by step honesty** — a step that reaches outside its declared deps (hidden global
+  state, network nondeterminism) breaks reproducibility/caching, exactly as a non-hermetic Docker `RUN` does.
+  Hermeticity (Nix-style) is the discipline that makes the layer cache sound; non-idempotent steps must be
+  DU/workflow-fenced (#6959).
+- Not a claim to replace Docker/Nix — it's their *union* on the Zeta substrate: Dockerfile legibility + Nix
+  reproducibility + content-addressed dedup + idempotent ensure + cross-OS projection, as one file format.
+
+## Ties
+
+- **ace ensure / idempotent-by-default (#6959)** — the file is sequenced idempotent ensures; non-idempotent =
+  DU/workflow.
+- **Ace external-state closure / one dep map (#6939/#6941) + compile-time conflicts (#6940)** — the file is the
+  closure written down.
+- **Content store / DagFs / BLAKE3 (#6925)** — content-addressed per-layer cache + dedup in the Zeta FS.
+- **n-dim dep / holographic projection (B-0824) + cross-OS (B-0806)** — one universal file → per-OS patch sets.
+- **One-liner bootstrap (#6942) / Ace OS** — Ace lays down the host; the file declares what it becomes.
+- **Test seam DST (#6958)** — idempotent+content-addressed ⇒ the build replays deterministically.
+- **Zeta IDL (#6955) / YinYang file (#6953)** — the Ace file is a spec-as-data document (DynamicValue).
+
+## Beacon anchors
+
+- **Dockerfile / OCI images + layer caching** (the legible, layered build-file shape) and **BuildKit** content-
+  addressed cache. · **Nix / NixOS** (declarative, reproducible, hermetic; binary cache by content hash —
+  reproducibility + dedup). · **Content-addressed storage** (Docker layer digests; Nix store paths; IPFS) —
+  per-layer cache key = content hash. · **Idempotent provisioning** (Ansible/Chef/Puppet desired-state). ·
+  **Cross-platform packaging / overlays** (patch-set/overlay per target). Honest novelty: none in the
+  primitives; the contribution is the **union as one file format** — a Dockerfile-legible, **idempotent**
+  (`ensure`-sequenced, reproducible), **content-addressed-per-layer-cached** (in the Zeta FS, deduped across
+  builds *and OSes*), **cross-OS** (one universal file → per-OS patch sets via B-0824 projection) Ace file, for
+  setting up any host / Ace OS.


### PR DESCRIPTION
Synthesis: an Ace file = Dockerfile-legible + Nix-reproducible (idempotent ensure #6959) + content-addressed per-layer cache in the Zeta FS (dedup across builds/OSes, #6925) + one universal file -> per-OS patch sets (B-0824 projection x B-0806 cross-OS). = the external-state closure (#6939) written down; DST-able via the test seam (#6958). Vision/design; reproducibility bounded by step hermeticity. 🤖 Generated with [Claude Code](https://claude.com/claude-code)