### PR TITLE
fix(cluster): healthy single-node install — storage (open-iscsi/Longhorn) + gatekeeper deadlock + dup default StorageClass

### DIFF
--- a/full-ai-cluster/k8s/applications/longhorn/Application.yaml
+++ b/full-ai-cluster/k8s/applications/longhorn/Application.yaml
@@ -21,10 +21,15 @@ spec:
       valuesObject:
         defaultSettings:
           defaultDataPath: /var/lib/longhorn
-          defaultReplicaCount: 2   # bump to 3 once 3+ workers exist
+          # Single control-plane node today. A replica count > the number of
+          # schedulable nodes leaves every volume permanently "Degraded"
+          # (Longhorn can't place the extra replicas), which surfaces as
+          # unhappy PVCs on a fresh single-node install. Keep this == node
+          # count; bump to 2 (then 3) as workers join for real HA.
+          defaultReplicaCount: 1
         persistence:
           defaultClass: false
-          defaultClassReplicaCount: 2
+          defaultClassReplicaCount: 1   # match defaultReplicaCount (single-node)
           reclaimPolicy: Retain
         ingress:
           enabled: false   # turn on after cert-manager + ingress-nginx

--- a/full-ai-cluster/k8s/applications/open-policy-agent/Application.yaml
+++ b/full-ai-cluster/k8s/applications/open-policy-agent/Application.yaml
@@ -17,11 +17,32 @@ spec:
     helm:
       releaseName: gatekeeper
       valuesObject:
-        replicas: 3
+        replicas: 1   # single control-plane node; bump for HA once workers exist
         controllerManager:
           metricsPort: 8888
-        validatingWebhookFailurePolicy: Fail
-        mutatingWebhookFailurePolicy: Ignore   # safer default while iterating
+          # Never let admission control touch system/infra namespaces — these
+          # carry the control plane, CNI, storage and GitOps that gatekeeper
+          # itself depends on. Defence-in-depth alongside the fail-open policy.
+          exemptNamespaces:
+            - kube-system
+            - kube-node-lease
+            - kube-public
+            - gatekeeper-system
+            - cilium
+            - longhorn-system
+            - argocd
+        # FAIL-OPEN, not fail-closed. With failurePolicy: Fail the validating
+        # webhook intercepts EVERY write cluster-wide — including k3s's own
+        # cluster-scoped CRD updates (e.g. addons.k3s.cattle.io). If gatekeeper
+        # has no ready endpoints (pods still starting, or any outage) those
+        # writes are rejected and k3s aborts controller startup → the whole
+        # control plane crash-loops. Observed on node-09485d (2026-06-07): 41
+        # k3s restarts in 10 min, API permanently 503, cluster bricked. A
+        # policy engine must never be able to take down the API server, so it
+        # fails OPEN (admit when the engine is unreachable). Namespaced policy
+        # enforcement still applies whenever gatekeeper is up (the normal case).
+        validatingWebhookFailurePolicy: Ignore
+        mutatingWebhookFailurePolicy: Ignore
   destination:
     server: https://kubernetes.default.svc
     namespace: gatekeeper-system

--- a/full-ai-cluster/nixos/modules/common.nix
+++ b/full-ai-cluster/nixos/modules/common.nix
@@ -14,6 +14,10 @@
   imports = [
     ./injected-hostname.nix
     ./login-banner.nix
+    # Longhorn node prerequisites (open-iscsi + nfs). Without these every
+    # `longhorn` PVC stays Pending and the whole stateful layer is dead.
+    # Imported here so control-plane AND workers get them uniformly.
+    ./longhorn-prereqs.nix
     # iter-5.4.0 (B-0794 homelab-mode): operator SSH pubkeys captured
     # via `gh ssh-key list` during zeta-install.sh Step 6.8. Composes
     # additively with iter-4.2 static maintainer keys.

--- a/full-ai-cluster/nixos/modules/k3s-agent.nix
+++ b/full-ai-cluster/nixos/modules/k3s-agent.nix
@@ -35,6 +35,12 @@
       8472
     ];
     trustedInterfaces = [ "cilium_host" "cilium_net" "cni0" "lxc+" ];
+
+    # Cilium REQUIRES reverse-path filtering OFF — NixOS' default
+    # `checkReversePath` rpfilter (mangle PREROUTING) drops Cilium's
+    # asymmetric pod->host traffic before conntrack, black-holing every
+    # pod->node packet. Same fix + rationale as k3s-server.nix.
+    checkReversePath = false;
   };
 
   systemd.tmpfiles.rules = [

--- a/full-ai-cluster/nixos/modules/k3s-server.nix
+++ b/full-ai-cluster/nixos/modules/k3s-server.nix
@@ -62,6 +62,15 @@
       "--disable=servicelb"
       "--disable=traefik"
 
+      # Disable the bundled local-path-provisioner. local-storage.nix
+      # re-declares it as `zeta-local-path` (the single default class) with
+      # a fixed path; leaving k3s' built-in enabled creates a SECOND
+      # StorageClass *also* marked default (`local-path (default)` AND
+      # `zeta-local-path (default)`), which is an invalid/ambiguous config —
+      # a class-less PVC then binds non-deterministically. Observed on
+      # node-09485d (2026-06-07). Keep exactly one default.
+      "--disable=local-storage"
+
       # Cluster CIDR — give Cilium a /16 to work with.
       "--cluster-cidr=10.42.0.0/16"
       "--service-cidr=10.43.0.0/16"

--- a/full-ai-cluster/nixos/modules/k3s-server.nix
+++ b/full-ai-cluster/nixos/modules/k3s-server.nix
@@ -159,6 +159,23 @@
       8472    # VXLAN (Cilium can also run native-routing)
     ];
     trustedInterfaces = [ "cilium_host" "cilium_net" "cni0" "lxc+" ];
+
+    # Cilium REQUIRES reverse-path filtering OFF. NixOS' default
+    # `checkReversePath` installs an iptables `-m rpfilter` DROP in the
+    # mangle PREROUTING chain (`nixos-fw-rpfilter`). Cilium's eBPF datapath
+    # delivers pod->host traffic on an asymmetric path that this rpfilter
+    # marks as failing and DROPS *before conntrack* — so every pod->node
+    # packet (pod->apiserver via the kubernetes ClusterIP, kubelet, etc.)
+    # vanishes with no conntrack entry and no counter. Symptom: node goes
+    # Ready, Cilium is healthy, pod->internet and pod->pod work, but CoreDNS
+    # can't reach 10.43.0.1 -> in-cluster DNS dies -> every helm/app chart
+    # CrashLoops on DNS. The sysctl `net.ipv4.conf.*.rp_filter` being loose
+    # is NOT enough; the iptables rpfilter module is separate and must be
+    # disabled. Confirmed on node-09485d (2026-06-07): inserting a RETURN for
+    # the pod/service CIDR ahead of the rpfilter DROP immediately restored
+    # pod->apiserver and the whole cluster recovered.
+    # See Cilium docs: "rp_filter must be disabled".
+    checkReversePath = false;
   };
 
   environment.variables = {

--- a/full-ai-cluster/nixos/modules/longhorn-prereqs.nix
+++ b/full-ai-cluster/nixos/modules/longhorn-prereqs.nix
@@ -1,0 +1,43 @@
+# full-ai-cluster/nixos/modules/longhorn-prereqs.nix
+#
+# Node-level prerequisites for Longhorn distributed storage. Imported by
+# common.nix so EVERY cluster node (control-plane + workers) has them.
+#
+# Longhorn's engine attaches each volume to its consumer pod over a
+# host-local iSCSI target, so open-iscsi (iscsid + the iscsiadm binary +
+# the iscsi_tcp kernel module) MUST be present and running on every node.
+# Without it, longhorn-manager cannot create working volumes, so every
+# PVC bound to the `longhorn` StorageClass stays Pending forever and all
+# stateful workloads (vault, spire, kube-prometheus-stack, nats, weaviate,
+# and any agent StatefulSet for persistent memory) never schedule.
+#
+# Observed on node-09485d (2026-06-07): open-iscsi was configured nowhere,
+# Longhorn never provisioned, and vault-0 was stuck on an unbound PVC. This
+# module is the storage analog of the checkReversePath/rpfilter fix — a
+# missing node prerequisite that silently breaks the whole stateful layer.
+#
+# nfs-utils + the NFS client are needed for Longhorn RWX (ReadWriteMany)
+# volumes, which are exported over NFSv4. RWO volumes need only iSCSI.
+{ config, pkgs, lib, ... }:
+
+{
+  # iSCSI initiator — Longhorn's volume-attach transport. Requires a
+  # globally-unique initiator name per node (derived from the hostname).
+  services.openiscsi = {
+    enable = true;
+    name = "iqn.2026-06.dev.zeta:${config.networking.hostName}";
+  };
+  boot.kernelModules = [ "iscsi_tcp" ];
+
+  # RWX (ReadWriteMany) Longhorn volumes are served over NFSv4; the
+  # node needs the userspace tools + client to mount them.
+  environment.systemPackages = [ pkgs.nfs-utils ];
+
+  # Longhorn's default data path. On real installs zeta-install.sh mounts a
+  # dedicated partition under /var/lib/longhorn-disk1; this just guarantees
+  # the default directory exists so longhorn-manager can start cleanly even
+  # on a single-disk / minimal install.
+  systemd.tmpfiles.rules = [
+    "d /var/lib/longhorn 0700 root root - -"
+  ];
+}


### PR DESCRIPTION
Hardens a fresh install so it comes up healthy on its own. Every gap was found debugging node-09485d (2026-06-07); companion to the rpfilter fix [#6938](https://github.com/Lucent-Financial-Group/Zeta/pull/6938).

## What was broken (and is now fixed)

### 1. Storage was completely dead — `open-iscsi` missing
Longhorn attaches volumes over iSCSI, but `open-iscsi` was configured on **no** node. So the `longhorn` StorageClass could never provision and **every** stateful workload (vault, spire, kube-prometheus-stack, nats, weaviate, and any agent StatefulSet for persistent memory) sat `Pending` forever.
→ New `modules/longhorn-prereqs.nix` (open-iscsi + `iscsi_tcp` + nfs-utils for RWX + `/var/lib/longhorn`), imported by `common.nix` so **every** node gets it. The storage analog of the rpfilter fix.

### 2. Gatekeeper bricked the control plane
`validatingWebhookFailurePolicy: Fail` makes the webhook intercept **every** write cluster-wide — including k3s's own cluster-scoped CRD updates (`addons.k3s.cattle.io`). With gatekeeper's pods not ready (no endpoints), those writes are rejected and **k3s aborts startup → the apiserver crash-loops** (observed: 41 restarts in 10 min, API permanently 503).
→ Validating webhook → `Ignore` (fail-open; matches the mutating one), exempt system/infra namespaces, replicas → 1. A policy engine must never be able to take down the apiserver.

### 3. Longhorn replica count > node count
`defaultReplicaCount: 2` on a single node leaves every volume permanently `Degraded`. → `1` (bump as workers join).

### 4. Two default StorageClasses
k3s ships `local-path` (default) **and** `local-storage.nix` declares `zeta-local-path` (default) — invalid; class-less PVCs bind non-deterministically. → `--disable=local-storage` so `zeta-local-path` is the single default.

## Result
A reinstall should now reach: node Ready → DNS up → Longhorn provisions → vault/spire/stateful PVCs bind → gatekeeper can't deadlock the API. Nothing here changes multi-node intent (replica counts carry 'bump as workers join' notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)