### PR TITLE
feat(core): ZetaCli — the seam/verb/noun command grammar as data (zs/zc CLI foundation)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -166,6 +166,7 @@
     <Compile Include="DeltaCrdt.fs" />
     <Compile Include="SignalQuality.fs" />
     <Compile Include="Maji.fs" />
+    <Compile Include="ZetaCli.fs" />
     <Compile Include="Consent/KskAuthorization.fs" />
   </ItemGroup>
 

--- a/src/Core/ZetaCli.fs
+++ b/src/Core/ZetaCli.fs
@@ -1,0 +1,51 @@
+namespace Zeta.Core
+
+/// **The Zeta CLI command grammar — `zeta <seam> <verb> <noun>` (#6957), as DATA.**
+///
+/// A command is a *value* (`ZetaCommand`), homoiconic with the CLI line and the `.ace` file (#6962): parse a
+/// line → `ZetaCommand`, `render` it back → canonical line, and the round-trip is stable. This is the
+/// reference-oracle parse layer the `zs` (interpreter) and `zc` (durable CLI) front-ends thin-wrap over the
+/// data-plane verbs (`Command.fs` `DbCommand`). F# is the reference; C#/Rust/TS ports follow (Vera/Lior).
+///
+/// Grammar:
+///   `zeta <seam> <verb> <noun>`        — explicit seam (the integration plane)
+///   `zeta <verb> <noun>`               — implicit seam (the local cell)
+///   `ace <verb> <noun>`                — the `ace` seam (package-manager front-end, #6959)
+///   `zs`                               — shorthand for `zeta run shell`
+///   `zc`                               — shorthand for `zeta run cell`
+/// seam = integration plane (None = implicit/local); verb = action; noun = ZetaId / unique-in-scope name
+/// (e.g. `npm[www.privaterepo.com].bar`, `compiler.rust`, `cell`).
+module ZetaCli =
+
+    /// A parsed command. `Seam = None` means the implicit (local cell) plane.
+    type ZetaCommand =
+        { Seam: string option
+          Verb: string
+          Noun: string }
+
+    /// Parse already-split argv into a `ZetaCommand`. Shorthands (`zs`/`zc`) and the `ace`/`zeta` programs
+    /// all canonicalize to the same `seam/verb/noun` shape.
+    let parseArgs (argv: string list) : Result<ZetaCommand, string> =
+        match argv with
+        | [] -> Error "empty command"
+        | "zs" :: _ -> Ok { Seam = None; Verb = "run"; Noun = "shell" }
+        | "zc" :: _ -> Ok { Seam = None; Verb = "run"; Noun = "cell" }
+        | "ace" :: verb :: noun :: _ -> Ok { Seam = Some "ace"; Verb = verb; Noun = noun }
+        | "ace" :: _ -> Error "ace requires: ace <verb> <noun>"
+        | "zeta" :: [ verb; noun ] -> Ok { Seam = None; Verb = verb; Noun = noun }
+        | "zeta" :: [ seam; verb; noun ] -> Ok { Seam = Some seam; Verb = verb; Noun = noun }
+        | "zeta" :: _ -> Error "zeta requires: zeta [<seam>] <verb> <noun>"
+        | other :: _ -> Error (sprintf "unknown program '%s' (expected zeta|ace|zs|zc)" other)
+
+    /// Parse a whitespace-delimited command line.
+    let parse (line: string) : Result<ZetaCommand, string> =
+        line.Split([| ' '; '\t' |], System.StringSplitOptions.RemoveEmptyEntries)
+        |> List.ofArray
+        |> parseArgs
+
+    /// Render a command back to its canonical `zeta [<seam>] <verb> <noun>` form (homoiconic round-trip:
+    /// `parse (render c) = Ok c`).
+    let render (cmd: ZetaCommand) : string =
+        match cmd.Seam with
+        | None -> sprintf "zeta %s %s" cmd.Verb cmd.Noun
+        | Some s -> sprintf "zeta %s %s %s" s cmd.Verb cmd.Noun

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -91,6 +91,7 @@
     <Compile Include="WeightedSet.Tests.fs" />
     <Compile Include="CayleyWeightedSet.Tests.fs" />
     <Compile Include="RayTensor.Tests.fs" />
+    <Compile Include="ZetaCli.Tests.fs" />
     <Compile Include="ITensor.Tests.fs" />
     <Compile Include="SagaSnapshot.Tests.fs" />
     <Compile Include="DagFs.Tests.fs" />

--- a/tests/Tests.FSharp/ZetaCli.Tests.fs
+++ b/tests/Tests.FSharp/ZetaCli.Tests.fs
@@ -1,0 +1,61 @@
+module Zeta.Tests.ZetaCliTests
+
+open global.Xunit
+open Zeta.Core
+open Zeta.Core.ZetaCli
+
+[<Fact>]
+let ``zeta explicit seam: zeta git clone <noun>`` () =
+    Assert.Equal<Result<ZetaCommand, string>>(
+        Ok { Seam = Some "git"; Verb = "clone"; Noun = "abc123" },
+        parse "zeta git clone abc123")
+
+[<Fact>]
+let ``zeta implicit seam: zeta run cell`` () =
+    Assert.Equal<Result<ZetaCommand, string>>(
+        Ok { Seam = None; Verb = "run"; Noun = "cell" },
+        parse "zeta run cell")
+
+[<Fact>]
+let ``zs and zc shorthands canonicalize to run shell / run cell`` () =
+    Assert.Equal<Result<ZetaCommand, string>>(Ok { Seam = None; Verb = "run"; Noun = "shell" }, parse "zs")
+    Assert.Equal<Result<ZetaCommand, string>>(Ok { Seam = None; Verb = "run"; Noun = "cell" }, parse "zc")
+
+[<Fact>]
+let ``ace seam: ace ensure with a source-bracketed dotted noun`` () =
+    Assert.Equal<Result<ZetaCommand, string>>(
+        Ok { Seam = Some "ace"; Verb = "ensure"; Noun = "npm[www.privaterepo.com].bar" },
+        parse "ace ensure npm[www.privaterepo.com].bar")
+
+[<Fact>]
+let ``test seam: zeta test run cell (DST plane)`` () =
+    Assert.Equal<Result<ZetaCommand, string>>(
+        Ok { Seam = Some "test"; Verb = "run"; Noun = "cell" },
+        parse "zeta test run cell")
+
+[<Fact>]
+let ``render produces canonical zeta form (implicit vs explicit seam)`` () =
+    Assert.Equal("zeta run cell", render { Seam = None; Verb = "run"; Noun = "cell" })
+    Assert.Equal("zeta git clone abc", render { Seam = Some "git"; Verb = "clone"; Noun = "abc" })
+
+[<Fact>]
+let ``homoiconic round-trip: parse (render c) = Ok c`` () =
+    for c in
+        [ { Seam = None; Verb = "run"; Noun = "shell" }
+          { Seam = Some "git"; Verb = "clone"; Noun = "zid" }
+          { Seam = Some "ace"; Verb = "ensure"; Noun = "npm[r].bar" }
+          { Seam = Some "test"; Verb = "message"; Noun = "otto-cli1" } ] do
+        Assert.Equal<Result<ZetaCommand, string>>(Ok c, parse (render c))
+
+[<Fact>]
+let ``shorthands canonicalize: render (parse zc) = zeta run cell`` () =
+    match parse "zc" with
+    | Ok c -> Assert.Equal("zeta run cell", render c)
+    | Error e -> failwith e
+
+[<Fact>]
+let ``errors: empty, bad arity, unknown program`` () =
+    Assert.True(match parse "" with Error _ -> true | _ -> false)
+    Assert.True(match parse "zeta" with Error _ -> true | _ -> false)
+    Assert.True(match parse "ace ensure" with Error _ -> true | _ -> false)
+    Assert.True(match parse "frobnicate x y" with Error _ -> true | _ -> false)


### PR DESCRIPTION
First brick of zs/zc (#6957): ZetaCommand {Seam;Verb;Noun} parse/render over 'zeta <seam> <verb> <noun>' + ace + zs/zc shorthands; homoiconic round-trip (#6962). Reference-oracle parse layer over Command.fs DbCommand. 0 warnings, 9/9 tests green. REPL + type-reification + migration = next bricks. 🤖 Generated with [Claude Code](https://claude.com/claude-code)