### PR TITLE
feat(core): ZetaCli — dependson clause + context model (grammar -> graph-builder)

### DIFF
--- a/src/Core/ZetaCli.fs
+++ b/src/Core/ZetaCli.fs
@@ -1,41 +1,68 @@
 namespace Zeta.Core
 
-/// **The Zeta CLI command grammar — `zeta <seam> <verb> <noun>` (#6957), as DATA.**
+/// **The Zeta CLI command grammar — `[seam] verb noun [dependson …]`, context-aware, as DATA.**
 ///
 /// A command is a *value* (`ZetaCommand`), homoiconic with the CLI line and the `.ace` file (#6962): parse a
-/// line → `ZetaCommand`, `render` it back → canonical line, and the round-trip is stable. This is the
-/// reference-oracle parse layer the `zs` (interpreter) and `zc` (durable CLI) front-ends thin-wrap over the
-/// data-plane verbs (`Command.fs` `DbCommand`). F# is the reference; C#/Rust/TS ports follow (Vera/Lior).
+/// line → `ZetaCommand`, `render` it back → canonical line, round-trip stable. The reference-oracle parse layer
+/// the `zs` (interpreter) and `zc` (durable CLI) front-ends thin-wrap over the data-plane verbs (`Command.fs`
+/// `DbCommand`). F# is the reference; C#/Rust/TS ports follow (Vera/Lior).
 ///
-/// Grammar:
-///   `zeta <seam> <verb> <noun>`        — explicit seam (the integration plane)
-///   `zeta <verb> <noun>`               — implicit seam (the local cell)
-///   `ace <verb> <noun>`                — the `ace` seam (package-manager front-end, #6959)
-///   `zs`                               — shorthand for `zeta run shell`
-///   `zc`                               — shorthand for `zeta run cell`
-/// seam = integration plane (None = implicit/local); verb = action; noun = ZetaId / unique-in-scope name
-/// (e.g. `npm[www.privaterepo.com].bar`, `compiler.rust`, `cell`).
+/// Grammar (#6957/#6971/#6975):
+///   `zeta <seam> <verb> <noun>`            — explicit seam (the integration plane)
+///   `zeta <verb> <noun>`                   — implicit seam (filled from Context)
+///   `ace <verb> <noun>`                    — the `ace` seam (#6959)
+///   `zs` / `zc`                            — shorthands for `zeta run shell` / `zeta run cell`
+///   `… dependson <noun> <noun> …`          — trailing dependency clause (the graph edges, #6971)
+/// seam = integration plane (None = implicit, filled by Context); verb = action; noun = ZetaId / unique-in-
+/// scope name (e.g. `npm[www.privaterepo.com].bar`, `compiler.rust`, `cell`); dependson = the deps this node
+/// requires (edges). A statement is a NODE; `dependson` are its EDGES (#6971) — the infinite assembly's graph.
 module ZetaCli =
 
-    /// A parsed command. `Seam = None` means the implicit (local cell) plane.
+    /// A parsed command: a node (`[seam] verb noun`) plus its outgoing dependency edges (`DependsOn`, #6971).
+    /// `Seam = None` means implicit (resolved from `Context`).
     type ZetaCommand =
         { Seam: string option
           Verb: string
-          Noun: string }
+          Noun: string
+          DependsOn: string list }
 
-    /// Parse already-split argv into a `ZetaCommand`. Shorthands (`zs`/`zc`) and the `ace`/`zeta` programs
-    /// all canonicalize to the same `seam/verb/noun` shape.
+    /// The resolution context that fills the "short, context-aware" omissions (#6971): the implicit seam and
+    /// the namespace bare nouns resolve in. `empty` supplies nothing (everything must be explicit).
+    type Context =
+        { Seam: string option
+          Namespace: string option }
+
+        static member Empty = { Seam = None; Namespace = None }
+
+    [<Literal>]
+    let private DependsOnKw = "dependson"
+
+    /// A noun is "bare" (unqualified) when it carries no namespace/source/path marker — eligible for
+    /// `Context.Namespace` qualification.
+    let private isBare (noun: string) : bool =
+        not (noun.Contains "." || noun.Contains "[" || noun.Contains "/" || noun.Contains ":")
+
+    /// Parse already-split argv (a `dependson` clause may trail) into a `ZetaCommand`.
     let parseArgs (argv: string list) : Result<ZetaCommand, string> =
-        match argv with
+        // Split off a trailing `dependson <noun…>` clause, if present.
+        let baseTokens, deps =
+            match List.tryFindIndex (fun t -> t = DependsOnKw) argv with
+            | Some i -> List.truncate i argv, List.skip (i + 1) argv
+            | None -> argv, []
+
+        let withDeps (cmd: ZetaCommand) = { cmd with DependsOn = deps }
+
+        match baseTokens with
         | [] -> Error "empty command"
-        | "zs" :: _ -> Ok { Seam = None; Verb = "run"; Noun = "shell" }
-        | "zc" :: _ -> Ok { Seam = None; Verb = "run"; Noun = "cell" }
-        | "ace" :: verb :: noun :: _ -> Ok { Seam = Some "ace"; Verb = verb; Noun = noun }
-        | "ace" :: _ -> Error "ace requires: ace <verb> <noun>"
-        | "zeta" :: [ verb; noun ] -> Ok { Seam = None; Verb = verb; Noun = noun }
-        | "zeta" :: [ seam; verb; noun ] -> Ok { Seam = Some seam; Verb = verb; Noun = noun }
-        | "zeta" :: _ -> Error "zeta requires: zeta [<seam>] <verb> <noun>"
-        | other :: _ -> Error (sprintf "unknown program '%s' (expected zeta|ace|zs|zc)" other)
+        | "zs" :: _ -> Ok(withDeps { Seam = None; Verb = "run"; Noun = "shell"; DependsOn = [] })
+        | "zc" :: _ -> Ok(withDeps { Seam = None; Verb = "run"; Noun = "cell"; DependsOn = [] })
+        | "ace" :: [ verb; noun ] -> Ok(withDeps { Seam = Some "ace"; Verb = verb; Noun = noun; DependsOn = [] })
+        | "ace" :: _ -> Error "ace requires: ace <verb> <noun> [dependson …]"
+        | "zeta" :: [ verb; noun ] -> Ok(withDeps { Seam = None; Verb = verb; Noun = noun; DependsOn = [] })
+        | "zeta" :: [ seam; verb; noun ] ->
+            Ok(withDeps { Seam = Some seam; Verb = verb; Noun = noun; DependsOn = [] })
+        | "zeta" :: _ -> Error "zeta requires: zeta [<seam>] <verb> <noun> [dependson …]"
+        | other :: _ -> Error(sprintf "unknown program '%s' (expected zeta|ace|zs|zc)" other)
 
     /// Parse a whitespace-delimited command line.
     let parse (line: string) : Result<ZetaCommand, string> =
@@ -43,9 +70,30 @@ module ZetaCli =
         |> List.ofArray
         |> parseArgs
 
-    /// Render a command back to its canonical `zeta [<seam>] <verb> <noun>` form (homoiconic round-trip:
-    /// `parse (render c) = Ok c`).
+    /// Resolve a command in a `Context` (#6971 "context-aware"): fill the implicit seam from the context, and
+    /// qualify bare nouns (the noun + each `dependson`) with the context namespace. Idempotent: resolving an
+    /// already-resolved command in the same context is a no-op (already explicit ⇒ unchanged).
+    let resolve (ctx: Context) (cmd: ZetaCommand) : ZetaCommand =
+        let seam = match cmd.Seam with Some _ -> cmd.Seam | None -> ctx.Seam
+
+        let qualify (noun: string) =
+            match ctx.Namespace with
+            | Some ns when isBare noun -> sprintf "%s.%s" ns noun
+            | _ -> noun
+
+        { cmd with
+            Seam = seam
+            Noun = qualify cmd.Noun
+            DependsOn = cmd.DependsOn |> List.map qualify }
+
+    /// Render a command back to its canonical `zeta [<seam>] <verb> <noun> [dependson …]` form (homoiconic
+    /// round-trip: `parse (render c) = Ok c`).
     let render (cmd: ZetaCommand) : string =
-        match cmd.Seam with
-        | None -> sprintf "zeta %s %s" cmd.Verb cmd.Noun
-        | Some s -> sprintf "zeta %s %s %s" s cmd.Verb cmd.Noun
+        let head =
+            match cmd.Seam with
+            | None -> sprintf "zeta %s %s" cmd.Verb cmd.Noun
+            | Some s -> sprintf "zeta %s %s %s" s cmd.Verb cmd.Noun
+
+        match cmd.DependsOn with
+        | [] -> head
+        | deps -> sprintf "%s %s %s" head DependsOnKw (String.concat " " deps)

--- a/tests/Tests.FSharp/ZetaCli.Tests.fs
+++ b/tests/Tests.FSharp/ZetaCli.Tests.fs
@@ -4,47 +4,56 @@ open global.Xunit
 open Zeta.Core
 open Zeta.Core.ZetaCli
 
+let private cmd seam verb noun deps = { Seam = seam; Verb = verb; Noun = noun; DependsOn = deps }
+
 [<Fact>]
 let ``zeta explicit seam: zeta git clone <noun>`` () =
-    Assert.Equal<Result<ZetaCommand, string>>(
-        Ok { Seam = Some "git"; Verb = "clone"; Noun = "abc123" },
-        parse "zeta git clone abc123")
+    Assert.Equal<Result<ZetaCommand, string>>(Ok(cmd (Some "git") "clone" "abc123" []), parse "zeta git clone abc123")
 
 [<Fact>]
 let ``zeta implicit seam: zeta run cell`` () =
-    Assert.Equal<Result<ZetaCommand, string>>(
-        Ok { Seam = None; Verb = "run"; Noun = "cell" },
-        parse "zeta run cell")
+    Assert.Equal<Result<ZetaCommand, string>>(Ok(cmd None "run" "cell" []), parse "zeta run cell")
 
 [<Fact>]
 let ``zs and zc shorthands canonicalize to run shell / run cell`` () =
-    Assert.Equal<Result<ZetaCommand, string>>(Ok { Seam = None; Verb = "run"; Noun = "shell" }, parse "zs")
-    Assert.Equal<Result<ZetaCommand, string>>(Ok { Seam = None; Verb = "run"; Noun = "cell" }, parse "zc")
+    Assert.Equal<Result<ZetaCommand, string>>(Ok(cmd None "run" "shell" []), parse "zs")
+    Assert.Equal<Result<ZetaCommand, string>>(Ok(cmd None "run" "cell" []), parse "zc")
 
 [<Fact>]
 let ``ace seam: ace ensure with a source-bracketed dotted noun`` () =
     Assert.Equal<Result<ZetaCommand, string>>(
-        Ok { Seam = Some "ace"; Verb = "ensure"; Noun = "npm[www.privaterepo.com].bar" },
+        Ok(cmd (Some "ace") "ensure" "npm[www.privaterepo.com].bar" []),
         parse "ace ensure npm[www.privaterepo.com].bar")
 
 [<Fact>]
 let ``test seam: zeta test run cell (DST plane)`` () =
+    Assert.Equal<Result<ZetaCommand, string>>(Ok(cmd (Some "test") "run" "cell" []), parse "zeta test run cell")
+
+[<Fact>]
+let ``dependson clause: edges parsed into DependsOn`` () =
     Assert.Equal<Result<ZetaCommand, string>>(
-        Ok { Seam = Some "test"; Verb = "run"; Noun = "cell" },
-        parse "zeta test run cell")
+        Ok(cmd (Some "ace") "ensure" "npm.foo" [ "compiler.rust"; "npm.bar" ]),
+        parse "ace ensure npm.foo dependson compiler.rust npm.bar")
 
 [<Fact>]
-let ``render produces canonical zeta form (implicit vs explicit seam)`` () =
-    Assert.Equal("zeta run cell", render { Seam = None; Verb = "run"; Noun = "cell" })
-    Assert.Equal("zeta git clone abc", render { Seam = Some "git"; Verb = "clone"; Noun = "abc" })
+let ``dependson with implicit seam`` () =
+    Assert.Equal<Result<ZetaCommand, string>>(
+        Ok(cmd None "build" "app" [ "lib1"; "lib2" ]),
+        parse "zeta build app dependson lib1 lib2")
 
 [<Fact>]
-let ``homoiconic round-trip: parse (render c) = Ok c`` () =
+let ``render produces canonical zeta form, incl. dependson`` () =
+    Assert.Equal("zeta run cell", render (cmd None "run" "cell" []))
+    Assert.Equal("zeta git clone abc", render (cmd (Some "git") "clone" "abc" []))
+    Assert.Equal("zeta ace ensure foo dependson a b", render (cmd (Some "ace") "ensure" "foo" [ "a"; "b" ]))
+
+[<Fact>]
+let ``homoiconic round-trip: parse (render c) = Ok c (with deps)`` () =
     for c in
-        [ { Seam = None; Verb = "run"; Noun = "shell" }
-          { Seam = Some "git"; Verb = "clone"; Noun = "zid" }
-          { Seam = Some "ace"; Verb = "ensure"; Noun = "npm[r].bar" }
-          { Seam = Some "test"; Verb = "message"; Noun = "otto-cli1" } ] do
+        [ cmd None "run" "shell" []
+          cmd (Some "git") "clone" "zid" []
+          cmd (Some "ace") "ensure" "npm[r].bar" [ "compiler.rust" ]
+          cmd (Some "test") "message" "otto-cli1" [ "a"; "b"; "c" ] ] do
         Assert.Equal<Result<ZetaCommand, string>>(Ok c, parse (render c))
 
 [<Fact>]
@@ -52,6 +61,24 @@ let ``shorthands canonicalize: render (parse zc) = zeta run cell`` () =
     match parse "zc" with
     | Ok c -> Assert.Equal("zeta run cell", render c)
     | Error e -> failwith e
+
+[<Fact>]
+let ``context: implicit seam filled from Context; bare nouns namespace-qualified`` () =
+    let ctx = { Seam = Some "ace"; Namespace = Some "npm" }
+    let resolved = resolve ctx (cmd None "ensure" "foo" [ "bar" ])
+    Assert.Equal<ZetaCommand>(cmd (Some "ace") "ensure" "npm.foo" [ "npm.bar" ], resolved)
+
+[<Fact>]
+let ``context: explicit seam + already-qualified nouns unchanged + idempotent`` () =
+    let ctx = { Seam = Some "ace"; Namespace = Some "npm" }
+    let c = cmd (Some "git") "clone" "compiler.rust" [ "x[src].y" ]
+    Assert.Equal<ZetaCommand>(c, resolve ctx c)
+    Assert.Equal<ZetaCommand>(resolve ctx c, resolve ctx (resolve ctx c))
+
+[<Fact>]
+let ``context: empty context changes nothing`` () =
+    let c = cmd None "ensure" "foo" [ "bar" ]
+    Assert.Equal<ZetaCommand>(c, resolve Context.Empty c)
 
 [<Fact>]
 let ``errors: empty, bad arity, unknown program`` () =


### PR DESCRIPTION
Extends #6967 per #6971/#6975: ZetaCommand gains DependsOn (trailing 'dependson <noun...>' = graph edges); Context {Seam;Namespace} + resolve fills implicit seam + namespace-qualifies bare nouns (idempotent). render/round-trip incl. deps. The parser is now a graph-builder + scope resolver. 0 warnings, 14/14 green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)