### PR TITLE
feat(core): ZetaGraph — dependson dependency graph + topological-order resolver

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -167,6 +167,7 @@
     <Compile Include="SignalQuality.fs" />
     <Compile Include="Maji.fs" />
     <Compile Include="ZetaCli.fs" />
+    <Compile Include="ZetaGraph.fs" />
     <Compile Include="Consent/KskAuthorization.fs" />
   </ItemGroup>
 

--- a/src/Core/ZetaGraph.fs
+++ b/src/Core/ZetaGraph.fs
@@ -1,0 +1,69 @@
+namespace Zeta.Core
+
+/// **Dependency graph + topological order over `ZetaCli` commands.**
+///
+/// A set of `ZetaCommand`s (#6983) is a graph: each command is a **node** keyed by its `Noun`; its `DependsOn`
+/// entries are its **edges** (#6971). `topoOrder` derives execution order from those edges — **deps before
+/// dependents** — so order comes from `dependson`, NOT from input/text order (#6975). The result is
+/// **deterministic** (ordinal tie-break, culture-invariant) and **input-order-independent**.
+///
+/// Cycles: the assembly graph can be cyclic (#6969/#6975); a strict topological order exists only for the
+/// acyclic case, so `topoOrder` **reports the cyclic nodes** (an `Error`) rather than guessing. Full
+/// fixpoint-over-SCC resolution for cyclic deps is deferred (the #6975/#6977 work). `dependson` edges to nouns
+/// NOT in the input set are treated as **external** (assumed already present — e.g. push-down/global #6977) and
+/// don't constrain in-set ordering. F# reference oracle; C#/Rust/TS ports follow.
+module ZetaGraph =
+
+    open ZetaCli
+
+    let private cmpOrdinal a b = System.String.CompareOrdinal(a, b)
+
+    /// Topologically order commands so each comes AFTER the (in-set) commands it `dependson`. Nodes keyed by
+    /// `Noun`; external deps (not in the set) are ignored for ordering. `Ok ordered` (deps first, deterministic)
+    /// or `Error cycleNouns` (the nouns participating in a dependency cycle, sorted).
+    let topoOrder (cmds: ZetaCommand list) : Result<ZetaCommand list, string list> =
+        let byNoun = cmds |> List.map (fun c -> c.Noun, c) |> Map.ofList
+
+        let depsOf (c: ZetaCommand) =
+            c.DependsOn
+            |> List.filter (fun d -> Map.containsKey d byNoun) // in-set only; external deps ignored
+            |> List.distinct
+            |> List.sortWith cmpOrdinal
+
+        let order = ResizeArray<ZetaCommand>()
+        let state = System.Collections.Generic.Dictionary<string, int>() // 1 = visiting (gray), 2 = done (black)
+        let mutable cycle: string list option = None
+
+        // DFS post-order = deps appended before the node. Back-edge to a gray node ⇒ cycle.
+        let rec visit (path: string list) (n: string) =
+            if cycle.IsNone then
+                match state.TryGetValue n with
+                | true, 2 -> () // done
+                | true, 1 -> // gray ⇒ n is an ancestor ⇒ cycle: n + the path back down to n
+                    cycle <- Some((n :: (path |> List.takeWhile (fun s -> s <> n))) |> List.distinct |> List.sortWith cmpOrdinal)
+                | _ ->
+                    state.[n] <- 1
+                    for d in depsOf byNoun.[n] do
+                        visit (n :: path) d
+                    state.[n] <- 2
+                    order.Add byNoun.[n]
+
+        // Visit roots in ordinal order ⇒ deterministic, input-order-independent.
+        byNoun
+        |> Map.toSeq
+        |> Seq.map fst
+        |> Seq.sortWith cmpOrdinal
+        |> Seq.iter (visit [])
+
+        match cycle with
+        | Some c -> Error c
+        | None -> Ok(List.ofSeq order)
+
+    /// The in-set nouns a command (transitively) is blocked by, and the direct dependents of a noun — small
+    /// helpers over the same graph (kept minimal; the planner builds on `topoOrder`).
+    let directDependents (cmds: ZetaCommand list) (noun: string) : string list =
+        cmds
+        |> List.filter (fun c -> List.contains noun c.DependsOn)
+        |> List.map (fun c -> c.Noun)
+        |> List.distinct
+        |> List.sortWith cmpOrdinal

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -92,6 +92,7 @@
     <Compile Include="CayleyWeightedSet.Tests.fs" />
     <Compile Include="RayTensor.Tests.fs" />
     <Compile Include="ZetaCli.Tests.fs" />
+    <Compile Include="ZetaGraph.Tests.fs" />
     <Compile Include="ITensor.Tests.fs" />
     <Compile Include="SagaSnapshot.Tests.fs" />
     <Compile Include="DagFs.Tests.fs" />

--- a/tests/Tests.FSharp/ZetaGraph.Tests.fs
+++ b/tests/Tests.FSharp/ZetaGraph.Tests.fs
@@ -1,0 +1,68 @@
+module Zeta.Tests.ZetaGraphTests
+
+open global.Xunit
+open Zeta.Core
+open Zeta.Core.ZetaCli
+
+// node helper: a command keyed by Noun with the given dependson edges (seam/verb irrelevant to ordering)
+let private n noun deps : ZetaCommand = { Seam = None; Verb = "ensure"; Noun = noun; DependsOn = deps }
+let private nouns (cmds: ZetaCommand list) = cmds |> List.map (fun c -> c.Noun)
+
+[<Fact>]
+let ``topoOrder: deps come before dependents (chain a->b->c)`` () =
+    // a dependson b; b dependson c  =>  c, then b, then a
+    let cmds = [ n "a" [ "b" ]; n "b" [ "c" ]; n "c" [] ]
+    match ZetaGraph.topoOrder cmds with
+    | Ok ordered -> Assert.Equal<string list>([ "c"; "b"; "a" ], nouns ordered)
+    | Error e -> failwithf "unexpected cycle: %A" e
+
+[<Fact>]
+let ``topoOrder: order is derived from dependson, NOT input order (shuffle-invariant)`` () =
+    let a, b, c = n "a" [ "b" ], n "b" [ "c" ], n "c" []
+    let r1 = ZetaGraph.topoOrder [ a; b; c ]
+    let r2 = ZetaGraph.topoOrder [ c; a; b ]
+    let r3 = ZetaGraph.topoOrder [ b; c; a ]
+    Assert.Equal<Result<ZetaCommand list, string list>>(r1, r2)
+    Assert.Equal<Result<ZetaCommand list, string list>>(r1, r3)
+
+[<Fact>]
+let ``topoOrder: diamond d->[b,c], b->[a], c->[a] puts a first, d last`` () =
+    let cmds = [ n "d" [ "b"; "c" ]; n "b" [ "a" ]; n "c" [ "a" ]; n "a" [] ]
+    match ZetaGraph.topoOrder cmds with
+    | Ok ordered ->
+        let o = nouns ordered
+        Assert.Equal("a", List.head o)
+        Assert.Equal("d", List.last o)
+        // b and c both after a, both before d
+        let idx x = List.findIndex ((=) x) o
+        Assert.True(idx "a" < idx "b" && idx "a" < idx "c")
+        Assert.True(idx "b" < idx "d" && idx "c" < idx "d")
+    | Error e -> failwithf "unexpected cycle: %A" e
+
+[<Fact>]
+let ``topoOrder: external deps (not in set) are ignored for ordering`` () =
+    // a dependson compiler.rust (external/push-down, not in set) — still orders fine
+    let cmds = [ n "a" [ "compiler.rust"; "b" ]; n "b" [] ]
+    match ZetaGraph.topoOrder cmds with
+    | Ok ordered -> Assert.Equal<string list>([ "b"; "a" ], nouns ordered)
+    | Error e -> failwithf "unexpected cycle: %A" e
+
+[<Fact>]
+let ``topoOrder: a cycle is reported as Error with the cycle's nouns`` () =
+    let cmds = [ n "a" [ "b" ]; n "b" [ "a" ] ]
+    match ZetaGraph.topoOrder cmds with
+    | Ok _ -> failwith "expected a cycle error"
+    | Error c -> Assert.Equal<string list>([ "a"; "b" ], c)
+
+[<Fact>]
+let ``topoOrder: independent nodes ordered deterministically (ordinal tie-break)`` () =
+    let cmds = [ n "z" []; n "a" []; n "m" [] ]
+    match ZetaGraph.topoOrder cmds with
+    | Ok ordered -> Assert.Equal<string list>([ "a"; "m"; "z" ], nouns ordered)
+    | Error e -> failwithf "unexpected cycle: %A" e
+
+[<Fact>]
+let ``directDependents: who depends on a noun`` () =
+    let cmds = [ n "a" [ "lib" ]; n "b" [ "lib" ]; n "c" [ "other" ]; n "lib" [] ]
+    Assert.Equal<string list>([ "a"; "b" ], ZetaGraph.directDependents cmds "lib")
+    Assert.Equal<string list>([], ZetaGraph.directDependents cmds "nobody")


### PR DESCRIPTION
Builds on ZetaCli (#6983): commands form a graph (node=Noun, edges=DependsOn #6971); topoOrder derives execution order from edges (deps first), deterministic + shuffle-invariant (#6975); DFS+cycle detection reports cyclic nouns (Error); external deps (push-down #6977) ignored for in-set ordering. 0 warnings, 7/7 green. The resolver the lazy/JIT lock saga (#6976) walks. 🤖 Generated with [Claude Code](https://claude.com/claude-code)