### PR TITLE
feat(core): DarkHall — the cell that hosts a deterministic emulator (the arcade runs the games)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -168,6 +168,7 @@
     <Compile Include="Maji.fs" />
     <Compile Include="ZetaCli.fs" />
     <Compile Include="ZetaGraph.fs" />
+    <Compile Include="DarkHall.fs" />
     <Compile Include="Consent/KskAuthorization.fs" />
   </ItemGroup>
 

--- a/src/Core/DarkHall.fs
+++ b/src/Core/DarkHall.fs
@@ -1,0 +1,83 @@
+namespace Zeta.Core
+
+/// **The Dark Hall cell — host of a deterministic emulator (the arcade hosting the arcade games).**
+///
+/// The "Dark Hall" (Aaron's childhood neon arcade) is a Zeta cell metaphor (#6985): a hidden-door, glows-on-
+/// entry, liminal space. Here it hosts an **emulator** — poetic-becomes-literal (the arcade runs the games).
+///
+/// This is a **clean-room, minimal CHIP-8-SUBSET CPU** (public opcode conventions; original implementation, NO
+/// ROMs / no copyrighted content) — a *deterministic* stepper proving the load-bearing property: **a cell hosts
+/// an emulator whose execution is a pure function of (program, budget) ⇒ DST-replayable** (the test seam,
+/// #6958; the ARC-AGI chip8/atari DBSP-replay curriculum). NOT a full Atari 2600 / not CHIP-8 display, timers,
+/// input, or self-modifying memory — just the deterministic CPU core, the vertical slice. F# reference oracle.
+module DarkHall =
+
+    open ZetaCli
+
+    /// Emulator CPU state. Immutable (functional step) ⇒ every run replays identically.
+    type EmuState =
+        { V: int[]      // 16 registers, byte-valued (0..255); VF is the carry/flag register
+          I: int        // index register
+          PC: int       // program counter (byte offset into the program)
+          Halted: bool
+          Steps: int }
+
+    /// Fresh CPU: registers zeroed, PC at program start (offset 0 — this slice's convention).
+    let init () : EmuState =
+        { V = Array.zeroCreate 16; I = 0; PC = 0; Halted = false; Steps = 0 }
+
+    /// One deterministic step over the program memory (read-only; this subset has no self-modifying writes).
+    /// Supported opcodes (clean-room CHIP-8 subset): `0000` halt · `1NNN` jump · `3XNN` skip-if-Vx=NN ·
+    /// `6XNN` Vx=NN · `7XNN` Vx+=NN (byte-wrap) · `ANNN` I=NNN · `8XY0` Vx=Vy · `8XY4` Vx+=Vy (VF=carry).
+    /// Unknown opcodes halt safely. Out-of-range PC halts.
+    let step (mem: byte[]) (s: EmuState) : EmuState =
+        if s.Halted || s.PC < 0 || s.PC + 1 >= mem.Length then
+            { s with Halted = true }
+        else
+            let op = (int mem.[s.PC] <<< 8) ||| int mem.[s.PC + 1]
+            let x = (op >>> 8) &&& 0xF
+            let y = (op >>> 4) &&& 0xF
+            let nn = op &&& 0xFF
+            let nnn = op &&& 0xFFF
+            let advanced = { s with PC = s.PC + 2; Steps = s.Steps + 1 }
+            let withV (f: int[] -> unit) =
+                let v = Array.copy s.V in f v
+                { advanced with V = v }
+
+            match op >>> 12, op &&& 0xF with
+            | _ when op = 0x0000 -> { s with Halted = true }                 // 0000 halt
+            | 0x1, _ -> { advanced with PC = nnn }                            // 1NNN jump
+            | 0x3, _ -> if s.V.[x] = nn then { advanced with PC = s.PC + 4 } else advanced // 3XNN skip-if-eq
+            | 0x6, _ -> withV (fun v -> v.[x] <- nn)                          // 6XNN Vx=NN
+            | 0x7, _ -> withV (fun v -> v.[x] <- (s.V.[x] + nn) &&& 0xFF)     // 7XNN Vx+=NN
+            | 0xA, _ -> { advanced with I = nnn }                             // ANNN I=NNN
+            | 0x8, 0x0 -> withV (fun v -> v.[x] <- s.V.[y])                   // 8XY0 Vx=Vy
+            | 0x8, 0x4 ->                                                     // 8XY4 Vx+=Vy, VF=carry
+                withV (fun v ->
+                    let sum = s.V.[x] + s.V.[y]
+                    v.[0xF] <- (if sum > 0xFF then 1 else 0)
+                    v.[x] <- sum &&& 0xFF)
+            | _ -> { s with Halted = true }                                  // unknown ⇒ halt safely
+
+    /// Run a program in the Dark Hall to halt or `budget` steps. Pure ⇒ deterministic ⇒ DST-replayable.
+    let run (mem: byte[]) (budget: int) : EmuState =
+        let rec loop s n = if s.Halted || n <= 0 then s else loop (step mem s) (n - 1)
+        loop (init ()) budget
+
+    /// The full execution trace (state after each step, including the start). Identical across runs (replay).
+    let trace (mem: byte[]) (budget: int) : EmuState list =
+        let rec loop s n acc =
+            if s.Halted || n <= 0 then List.rev (s :: acc) else loop (step mem s) (n - 1) (s :: acc)
+        loop (init ()) budget []
+
+    // ── Cell wiring (#6957/#6985): the Dark Hall is addressed as a cell via the ZetaCli grammar ──
+
+    /// The ZetaCli noun this cell hosts under: `zeta run dark-hall`.
+    [<Literal>]
+    let CellName = "dark-hall"
+
+    /// True when a parsed command addresses the Dark Hall cell to run (`zeta run dark-hall`).
+    let isAddressed (cmd: ZetaCommand) : bool = cmd.Verb = "run" && cmd.Noun = CellName
+
+    /// Host a program in the Dark Hall cell (the verb "run" on this cell). Deterministic.
+    let host (program: byte[]) (budget: int) : EmuState = run program budget

--- a/tests/Tests.FSharp/DarkHall.Tests.fs
+++ b/tests/Tests.FSharp/DarkHall.Tests.fs
@@ -1,0 +1,63 @@
+module Zeta.Tests.DarkHallTests
+
+open global.Xunit
+open Zeta.Core
+open Zeta.Core.DarkHall
+
+// Programs are clean-room CHIP-8-subset byte arrays (no ROMs). Load at offset 0, PC starts at 0.
+
+[<Fact>]
+let ``set + add + halt: V0 = 5; V0 += 3 -> 8`` () =
+    // 6005 (V0=5)  7003 (V0+=3)  0000 (halt)
+    let prog = [| 0x60uy; 0x05uy; 0x70uy; 0x03uy; 0x00uy; 0x00uy |]
+    let s = run prog 100
+    Assert.True s.Halted
+    Assert.Equal(8, s.V.[0])
+
+[<Fact>]
+let ``1NNN jump skips an instruction`` () =
+    // 0: 1004 jump->4 | 2: 6063 V0=99 (skipped) | 4: 6007 V0=7 | 6: 0000 halt
+    let prog = [| 0x10uy; 0x04uy; 0x60uy; 0x63uy; 0x60uy; 0x07uy; 0x00uy; 0x00uy |]
+    let s = run prog 100
+    Assert.Equal(7, s.V.[0]) // not 99 — the jump skipped index 2
+
+[<Fact>]
+let ``3XNN skips next instruction when Vx = NN`` () =
+    // 0: 6005 V0=5 | 2: 3005 skip-if V0=5 (yes -> PC=6) | 4: 6063 V0=99 (skipped) | 6: 0000 halt
+    let prog = [| 0x60uy; 0x05uy; 0x30uy; 0x05uy; 0x60uy; 0x63uy; 0x00uy; 0x00uy |]
+    let s = run prog 100
+    Assert.Equal(5, s.V.[0]) // stayed 5; the V0=99 was skipped
+
+[<Fact>]
+let ``8XY4 adds with carry into VF (byte wrap)`` () =
+    // 0: 60C8 V0=200 | 2: 6164 V1=100 | 4: 8014 V0+=V1 | 6: 0000 halt
+    let prog = [| 0x60uy; 0xC8uy; 0x61uy; 0x64uy; 0x80uy; 0x14uy; 0x00uy; 0x00uy |]
+    let s = run prog 100
+    Assert.Equal(44, s.V.[0]) // (200+100) & 0xFF
+    Assert.Equal(1, s.V.[0xF]) // carry set
+
+[<Fact>]
+let ``DST: the Dark Hall is deterministic — same program ⇒ identical final state and trace`` () =
+    let prog = [| 0x60uy; 0x05uy; 0x70uy; 0x03uy; 0x80uy; 0x04uy; 0x00uy; 0x00uy |]
+    Assert.Equal<EmuState>(run prog 100, run prog 100)
+    Assert.Equal<EmuState list>(trace prog 100, trace prog 100)
+
+[<Fact>]
+let ``budget bounds a non-halting program (jump-to-self)`` () =
+    // 1000 = jump to 0 forever
+    let prog = [| 0x10uy; 0x00uy |]
+    let s = run prog 10
+    Assert.False s.Halted
+    Assert.Equal(10, s.Steps)
+
+[<Fact>]
+let ``cell wiring: zeta run dark-hall addresses the Dark Hall cell`` () =
+    match ZetaCli.parse "zeta run dark-hall" with
+    | Ok cmd ->
+        Assert.True(isAddressed cmd)
+        Assert.Equal(CellName, cmd.Noun)
+    | Error e -> failwith e
+    // a different noun does not address it
+    match ZetaCli.parse "zeta run cell" with
+    | Ok cmd -> Assert.False(isAddressed cmd)
+    | Error e -> failwith e

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -93,6 +93,7 @@
     <Compile Include="RayTensor.Tests.fs" />
     <Compile Include="ZetaCli.Tests.fs" />
     <Compile Include="ZetaGraph.Tests.fs" />
+    <Compile Include="DarkHall.Tests.fs" />
     <Compile Include="ITensor.Tests.fs" />
     <Compile Include="SagaSnapshot.Tests.fs" />
     <Compile Include="DagFs.Tests.fs" />


### PR DESCRIPTION
Wires the Dark Hall cell (#6985) to host an emulator: clean-room minimal CHIP-8-subset CPU (no ROMs), pure functional step => DST-replayable (test seam #6958); addressed via ZetaCli 'zeta run dark-hall' (#6983). Vertical slice proving 'a cell hosts a deterministic, replayable emulator' — not a full Atari 2600. 0 warnings, 7/7 green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)