### PR TITLE
docs(platform): architecture + expansion plan (portal, game hosting, KubeVirt, DBaaS)

### DIFF
--- a/full-ai-cluster/PLATFORM-ARCHITECTURE.md
+++ b/full-ai-cluster/PLATFORM-ARCHITECTURE.md
@@ -98,6 +98,7 @@ packaged; we assemble `NixOS + k3s + Longhorn + KubeVirt` declaratively, keeping
 our OS, our k8s, our GitOps.
 
 **Components (all ArgoCD apps, sync-wave after Longhorn):**
+
 - **KubeVirt operator** → installs `virt-controller`, `virt-handler` (DaemonSet),
   `virt-api`. VMs run as `virt-launcher` pods wrapping QEMU.
 - **CDI** (Containerized Data Importer) → imports disk images (qcow2/iso/raw)
@@ -105,6 +106,7 @@ our OS, our k8s, our GitOps.
 
 **NixOS node enablement** (`nixos/modules/kubevirt-node.nix`, imported by hosts
 that run VMs):
+
 - `boot.kernelModules = [ "kvm-intel" /* or kvm-amd */ ]`, ensure `/dev/kvm`.
 - packages: `swtpm` (vTPM), `virtiofsd` (fs passthrough), `qemu` (already present
   on `worker-gpu`).
@@ -208,6 +210,7 @@ The management plane. Mental model maps cleanly:
 ```
 
 **Build vs adopt:**
+
 - **Now (days):** drop in **Headlamp** (CNCF, plugin-extensible) as an ArgoCD app
   → instant top-down visibility into pods/clusters/PVCs/DBs/(VMs once KubeVirt).
   *(Rancher is also NixOS-safe — it's an app, unlike Harvester — but heavier.)*
@@ -279,21 +282,25 @@ tenant owns lives in its namespace(s). We already run all five mechanisms — mo
 platforms don't.
 
 ### 4.3 Storage
+
 Longhorn for all stateful state: game saves, VM disks, DB data, agent memory.
 Single replica on one node (set in the hardening PR); 2–3 as workers join.
 Object storage (MinIO/SeaweedFS) added for backups, images, large blobs.
 
 ### 4.4 Security
+
 Per-tenant: gatekeeper policy, Vault creds, SPIRE workload identity,
 cert-manager TLS. Tenant workloads image-scanned before admission. The portal
 authenticates via OIDC (IdP decision below) → k8s RBAC.
 
 ### 4.5 Observability & billing
+
 Grafana stack already collects metrics/logs/traces → the portal's per-resource
 blades read from it. **OpenCost** (later) turns Prometheus usage into per-tenant
 cost → billing/metering.
 
 ### 4.6 The agent layer (the differentiator)
+
 otto/lior/vera run as systemd units **outside** k8s ("control plane outside the
 control plane"), so they can repair the cluster from outside its failure domain.
 They drive the **same CRs** the portal does: provision, scale, repair, configure,

--- a/full-ai-cluster/PLATFORM-ARCHITECTURE.md
+++ b/full-ai-cluster/PLATFORM-ARCHITECTURE.md
@@ -1,0 +1,358 @@
+# Zeta Platform Architecture & Expansion Plan
+
+> How we turn the Zeta cluster into a self-hostable cloud platform: an
+> Azure-style management console, game-server hosting (GMod first), general VM
+> compute (KubeVirt), and databases — all on the substrate we already run, all
+> driven by one pattern (**everything is a Custom Resource**), with the **AI
+> agents threaded through as the ops layer**.
+
+Status: design. Companion to `README.md`, `PROVISIONING.md`, `INJECTION-POINTS.md`.
+
+---
+
+## 0. Thesis
+
+A cloud platform is three things: **(1) a provisioning API, (2) a console to
+drive it, (3) resource types you can provision.** We already own the hard
+substrate. We add resource types (VMs, game servers, databases), one console
+(Zeta Portal), and use the agents as the automation/ops layer — the thing no
+Azure Portal or Pterodactyl has.
+
+The unifying rule: **every provisionable thing is a Kubernetes Custom Resource.**
+The portal creates CRs. The agents create the same CRs. ArgoCD reconciles the
+platform itself. One API, three ways to drive it (human UI, agent, GitOps).
+
+```
+        ┌──────────────────── Zeta Portal (Azure-style console) ───────────────────┐
+        │   top-down view + actions over EVERY resource type + embedded agent chat  │
+        └───────┬──────────────────────┬───────────────────────┬───────────────────┘
+                │ k8s API + CRDs        │ (agents drive          │ FTP / console
+                │                       │  the SAME CRs)          │ gateways
+   ┌────────────┼───────────────────────┼───────────────────────┼──────────────┐
+   │  Tenant    │  GameServer  │  VirtualMachine  │  Database  │  App (ArgoCD)   │  ← resource types (CRDs)
+   └────────────┴───────────────────────┴───────────────────────┴──────────────┘
+   ┌──────────────────────────── substrate we already run ───────────────────────┐
+   │  k3s · Cilium (CNI+LB+Gateway) · Longhorn · Vault/SPIRE/gatekeeper/cert-mgr  │
+   │  ArgoCD/Argo-Rollouts/Workflows · CockroachDB/Redis/NATS/Weaviate ·          │
+   │  Prometheus/Loki/Mimir/Tempo/Alloy(Grafana) · Forgejo/GitLab · vLLM/Ollama   │
+   └──────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 1. What we already have (the substrate)
+
+This is the inventory every section below builds on. Nothing here is new.
+
+| Concern | We already run | Used by |
+|---|---|---|
+| Orchestration | **k3s** (single CP today; multi-node wired-but-TODO) | everything |
+| CNI / networking | **Cilium** 1.16.5 — kube-proxy replacement, **Gateway API**, ingress, Hubble, **LB-IPAM capable** | all traffic |
+| Storage | **Longhorn** (distributed block; RWO + RWX-over-NFS) | all stateful: game saves, VM disks, DB data, agent memory |
+| GitOps | **ArgoCD** (app-of-apps), Argo Rollouts, Argo Workflows | platform reconciliation |
+| Databases | **CockroachDB** (distributed SQL), **Redis**, **NATS**, **Weaviate** (vector) | apps, DBaaS |
+| Secrets / identity / policy | **Vault**, **SPIRE**, **cert-manager**, **external-secrets**, **sealed-secrets**, **OPA/gatekeeper**, **trust-manager** | per-tenant creds, isolation, policy |
+| Observability | **kube-prometheus-stack** + **Loki/Mimir/Tempo/Alloy** (Grafana) | portal metrics, billing source |
+| Compute runtimes | **Orleans**, **Dapr**, **Temporal** | platform services |
+| AI | **vLLM**, **Ollama**, deepseek/qwen-coder, **hindsight** (semantic memory), **agent-memory** (file memory) | the agent layer |
+| Git / CI | **Forgejo**, **GitLab** | source, can be OIDC IdP |
+| Virtualization base | NixOS `virtualisation.libvirtd` + `qemu_kvm` + **VFIO/GPU-passthrough** on `worker-gpu` | KubeVirt foundation |
+
+**Gaps to close for "platform":** (a) VMs aren't in k8s yet, (b) no
+service-LB/external-IP wired (servicelb disabled in favour of Cilium), (c) no
+file/FTP layer, (d) no management console, (e) no tenant/provisioning CRDs.
+
+---
+
+## 2. Architectural spine (the pattern everything follows)
+
+Five layers, bottom-up. Each ask in §3 plugs into these.
+
+```
+ ┌─ Surfaces ─────────────────────────────────────────────────────────────┐
+ │  Zeta Portal (human) │ Agents (otto/lior/vera) │ GitOps (ArgoCD)         │
+ ├─ Control plane (one API) ───────────────────────────────────────────────┤
+ │  k8s API + CRDs + controllers   (later: Crossplane compositions)         │
+ ├─ Resource types (CRDs) ─────────────────────────────────────────────────┤
+ │  Tenant · App · GameServer · VirtualMachine · Database · Volume · FTP     │
+ ├─ Platform services ─────────────────────────────────────────────────────┤
+ │  Cilium LB/Gateway · Longhorn · Vault/SPIRE/gatekeeper · Grafana stack    │
+ ├─ Substrate ─────────────────────────────────────────────────────────────┤
+ │  NixOS nodes · k3s · KVM/QEMU                                             │
+ └──────────────────────────────────────────────────────────────────────────┘
+```
+
+**Why CRD-first:** the portal and the agents both just `create`/`patch` CRs;
+controllers do the work; ArgoCD/git is the audit log. A "deploy a GMod server"
+button and an agent saying "spin up a GMod server" are the **same API call**.
+
+---
+
+## 3. The asks — each with full architecture
+
+### 3.1 KubeVirt — general VM compute (NOT game-specific)
+
+VMs become a first-class resource the portal lists next to pods. KubeVirt is the
+**un-appliance'd Harvester**: Harvester = `SLE-Micro + RKE2 + KubeVirt + Longhorn`
+packaged; we assemble `NixOS + k3s + Longhorn + KubeVirt` declaratively, keeping
+our OS, our k8s, our GitOps.
+
+**Components (all ArgoCD apps, sync-wave after Longhorn):**
+- **KubeVirt operator** → installs `virt-controller`, `virt-handler` (DaemonSet),
+  `virt-api`. VMs run as `virt-launcher` pods wrapping QEMU.
+- **CDI** (Containerized Data Importer) → imports disk images (qcow2/iso/raw)
+  into **Longhorn PVCs** as `DataVolume`s. A VM disk *is* a Longhorn volume.
+
+**NixOS node enablement** (`nixos/modules/kubevirt-node.nix`, imported by hosts
+that run VMs):
+- `boot.kernelModules = [ "kvm-intel" /* or kvm-amd */ ]`, ensure `/dev/kvm`.
+- packages: `swtpm` (vTPM), `virtiofsd` (fs passthrough), `qemu` (already present
+  on `worker-gpu`).
+- KubeVirt device plugins expose `/dev/kvm` to launcher pods. Known NixOS wrinkle:
+  `virt-handler` wants a couple of writable host paths — pinned via the module.
+
+**Networking:** VM gets a Cilium pod IP by default (masquerade binding); exposed
+externally exactly like a pod (§4.1). For VMs needing their own L2 (a "real
+server" NIC), add **Multus** + a bridge/macvlan attachment.
+
+**Storage / HA:** RWO Longhorn PVC per VM disk; **live migration** later needs
+**RWX** (Longhorn-over-NFS — enabled by the `nfs-utils` in `longhorn-prereqs.nix`).
+
+**GPU:** the existing **VFIO passthrough** composes — KubeVirt supports
+`GPU`/host-device passthrough → GPU VMs on `worker-gpu`.
+
+```
+ VirtualMachine CR ──> virt-controller ──> virt-launcher pod (QEMU)
+        │                                      │ disk: Longhorn PVC (via CDI DataVolume)
+        │                                      │ net : Cilium pod IP (+ Multus optional)
+        └─ runStrategy/resources/gpu           │ gpu : VFIO host-device (worker-gpu)
+                                               └─ console/VNC via virtctl / portal
+```
+
+**Phases:** deploy operator+CDI → first cloud-image VM → VM templates → GPU VMs →
+live migration (multi-node).
+
+---
+
+### 3.2 Game-server hosting — GMod as the base test
+
+A rented game server = a persistent, single-instance stateful workload + a panel.
+**No Pterodactyl runtime** (it's Docker-daemon based and fights k8s); we reuse the
+*idea* (and optionally its game "egg" specs) but build k8s-native — the **same
+pattern as the `agent-memory` StatefulSet** already shipped.
+
+**`GameServer` CRD** (new) → a controller materializes, per server:
+
+```
+ GameServer { game: gmod, gamemode: sandbox, map: gm_construct,
+              maxPlayers: 16, mem: 4Gi, runtime: pod, ftp: true,
+              workshopCollection: "<id>" }
+        │  (controller — start as ArgoCD ApplicationSet+Helm, graduate to kubebuilder)
+        ▼   namespace: tenant-<id>
+ ┌──────────────────────────────────────────────────────────────────────────┐
+ │ StatefulSet(1)  steamcmd image → srcds            (the GMod process)       │
+ │ PVC (longhorn)  /home/steam/gmod  ← server+addons+workshop+saves (FTP root)│
+ │ Service (LB)    27015/udp game · 27015/tcp query+rcon   (Cilium LB-IPAM)   │
+ │ SFTP sidecar    atmoz/sftp → same PVC, creds from Vault     (FTP)          │
+ │ console gateway RCON(tcp) ⇄ websocket → portal             (web console)   │
+ │ (agents)        k8s exec into the pod, RBAC-scoped         (AI/SSH)        │
+ └──────────────────────────────────────────────────────────────────────────┘
+```
+
+**GMod specifics (the base test):** Source dedicated server via **SteamCMD app
+`4020`**; start `srcds_run -game garrysmod +gamemode sandbox +map gm_construct
++maxplayers 16 -port 27015 +rcon_password <vault>`; workshop content via
+`+host_workshop_collection`; ~2 vCPU / 2–4 GiB per server; single instance
+(no autoscaling — these are pets, not cattle).
+
+**Each sub-ask, mapped:**
+
+| Sub-ask | Architecture |
+|---|---|
+| **Panel** | UI over the k8s API + `GameServer` CR: list/create/start(scale 0↔1)/stop/delete, resource graphs from Prometheus. **Console** = a small in-cluster **RCON⇄WebSocket gateway** (Source RCON over TCP, password from Vault) + log tail via the k8s API — the job Pterodactyl "wings" does, but over the cluster API. |
+| **FTP** | Per-server **SFTP sidecar** (`atmoz/sftp`) mounting the game's Longhorn PVC; per-server credentials issued by **Vault**; exposed on a Cilium LB IP/port. Add **Filebrowser** for a web file manager over the same PVC. |
+| **AI / SSH** | Agents reach a server via **k8s `exec`** into the pod, with an RBAC Role scoped to the tenant's namespace (`pods/exec` on game pods) — no sshd, minimal attack surface. Portal gets an **"ask the AI"** action → an agent task execs in to install addons, fix a crash loop, tune `garrysmod/cfg/server.cfg`, read logs. *(Optional real SSH for users: an sshd sidecar with the user's pubkey — the same ESP key-injection pattern we use for nodes.)* **This is the differentiator Pterodactyl/Azure can't do.** |
+| **Provision** | User picks game + size → portal writes a `GameServer` CR → controller materializes the objects → live in seconds. **Agents provision identically** (same CR). |
+
+**Pod vs VM:** **pods by default** (lighter, k8s-native; covers GMod and most
+Source/SteamCMD games). `runtime: vm` (KubeVirt) only for games needing a full OS
+/ kernel anti-cheat / Windows — same panel, same CR, different backend.
+
+**Phases:** GMod MVP (pod+PVC+ports+SFTP+RCON) → agent-exec admin → more games
+(import Pterodactyl egg specs as `GameSpec`s) → web file manager → tenant
+accounts/quotas/billing → VM-backed games via KubeVirt.
+
+---
+
+### 3.3 Zeta Portal — the Azure-style top-down console
+
+The management plane. Mental model maps cleanly:
+
+| Azure | Zeta Portal |
+|---|---|
+| Subscription / Resource Group | **Tenant** (one or more namespaces) |
+| Resource (VM, DB, App Service…) | any k8s object **incl. our CRDs** (GameServer, VirtualMachine, Database) |
+| Resource blade (metrics/config/actions) | per-resource view: status, **Grafana** panels, YAML, actions |
+| Activity log | k8s events + ArgoCD history + git |
+| Cloud Shell / Copilot | **embedded agent chat** (acts through the same API) |
+
+**Architecture:**
+```
+ Browser ──> Zeta Portal frontend
+                │  ├─ k8s API (read all resources + CRDs; actions = create/patch CR)
+                │  ├─ Prometheus/Loki/Tempo  (metrics/logs/traces per resource)
+                │  ├─ OpenCost (later)        (cost/metering blade)
+                │  └─ agent chat endpoint     (NL → agent → same k8s API)
+                └─ OIDC login ──> IdP (decision: Authentik/Keycloak, or Forgejo/GitLab OIDC)
+                                    └─ maps user → tenant namespaces + k8s RBAC
+```
+
+**Build vs adopt:**
+- **Now (days):** drop in **Headlamp** (CNCF, plugin-extensible) as an ArgoCD app
+  → instant top-down visibility into pods/clusters/PVCs/DBs/(VMs once KubeVirt).
+  *(Rancher is also NixOS-safe — it's an app, unlike Harvester — but heavier.)*
+- **Then:** **Zeta Portal** — a thin custom console rendering a **resource graph**
+  over k8s built-ins **+ our CRDs**, with metrics from the Grafana stack, actions
+  that write CRs, the agent chat, and tenant-scoped RBAC views. Headlamp can be
+  extended with plugins for the CRDs as a bridge before a bespoke UI.
+
+**Phases:** Headlamp visibility → Zeta Portal v1 (resources + actions) →
+metrics/quota/cost blades → multi-tenant views → marketplace (one-click
+app/game/DB/VM).
+
+---
+
+### 3.4 Databases-as-a-service
+
+| | |
+|---|---|
+| Have | CockroachDB, Redis, NATS, Weaviate (as platform singletons today) |
+| Add | a **`Database` CRD** + DB **operators** (CloudNativePG for Postgres, the CockroachDB operator) so "create a database" = a CR that provisions an instance/logical DB + a Vault-issued credential + a Longhorn PVC |
+| Admin UI | Adminer/pgAdmin behind the portal; connection strings from Vault |
+| Backups | scheduled dumps/snapshots to Longhorn + object storage (MinIO/SeaweedFS — a later add) |
+
+---
+
+### 3.5 Agent memory (shipped)
+
+Already done as the reference for the whole pattern: `agent-memory` StatefulSet →
+`volumeClaimTemplates` → Longhorn PVC (durable per-persona memory across restarts).
+Semantic memory = `hindsight` (also Longhorn-backed). Every resource type in this
+doc follows that same StatefulSet/CR + Longhorn shape.
+
+---
+
+## 4. Cross-cutting architecture
+
+### 4.1 Networking — the layered truth (corrects the earlier MetalLB note)
+
+Three distinct layers; don't conflate them:
+
+```
+ 1. CNI / pod & VM IPs ........ Cilium (already)           — east-west
+ 2. Service external IP ....... Cilium LB-IPAM + L2/BGP    — the MetalLB slot
+       CiliumLoadBalancerIPPool  (hands out IPs)
+       CiliumL2AnnouncementPolicy / BGP (announces them)
+    HTTP/L7 apps ............... Cilium Gateway API (already enabled)
+ 3. Public reachability ....... routable public IP / colo / port-forward / BGP
+                                upstream  — about WHERE the box sits, not k8s
+```
+
+- **Use Cilium LB-IPAM, NOT MetalLB.** servicelb was deliberately disabled so
+  Cilium owns L2-L4; MetalLB would fight it. Cilium does the same job natively.
+- **Game/VM ports** (UDP for srcds) → `Service type=LoadBalancer` gets a Cilium
+  LB IP. On a single public IP, allocate a **port range per server** (27015,
+  27016, …) — a port-allocation field on `GameServer`. With an IP pool, one IP
+  per server.
+- **Public reachability is a separate, physical decision.** A home/AT&T NAT
+  connection cannot host public game servers reliably (NAT, dynamic IP, UDP,
+  upstream filtering). Productizing needs a public-IP host / colo / cloud node.
+  *(This is the single biggest external dependency in the whole plan.)*
+
+### 4.2 Multi-tenancy — a `Tenant` CRD (we have every primitive)
+
+`Tenant` → controller provisions: **namespace(s)** + **RBAC** (tenant role) +
+**ResourceQuota/LimitRange** (sold CPU/RAM/storage caps) + **Cilium
+NetworkPolicy** (tenants can't see each other) + **Vault path** (per-tenant
+secrets) + **gatekeeper** binding (what the tenant may create). Everything a
+tenant owns lives in its namespace(s). We already run all five mechanisms — most
+platforms don't.
+
+### 4.3 Storage
+Longhorn for all stateful state: game saves, VM disks, DB data, agent memory.
+Single replica on one node (set in the hardening PR); 2–3 as workers join.
+Object storage (MinIO/SeaweedFS) added for backups, images, large blobs.
+
+### 4.4 Security
+Per-tenant: gatekeeper policy, Vault creds, SPIRE workload identity,
+cert-manager TLS. Tenant workloads image-scanned before admission. The portal
+authenticates via OIDC (IdP decision below) → k8s RBAC.
+
+### 4.5 Observability & billing
+Grafana stack already collects metrics/logs/traces → the portal's per-resource
+blades read from it. **OpenCost** (later) turns Prometheus usage into per-tenant
+cost → billing/metering.
+
+### 4.6 The agent layer (the differentiator)
+otto/lior/vera run as systemd units **outside** k8s ("control plane outside the
+control plane"), so they can repair the cluster from outside its failure domain.
+They drive the **same CRs** the portal does: provision, scale, repair, configure,
+and answer support — across VMs, game servers, DBs, apps. The portal's chat is a
+front-end to them.
+
+---
+
+## 5. Provisioning control plane & resource taxonomy
+
+Start with **CRD + controller** per type (fast, explicit); graduate to
+**Crossplane** if/when one composition API over app+DB+VM+game+bucket is worth it.
+
+```
+ Tenant
+   ├─ App            (ArgoCD Application — deploy arbitrary workloads)
+   ├─ GameServer     (gmod, …)            → StatefulSet+PVC+Svc+SFTP+console
+   ├─ VirtualMachine (KubeVirt)           → virt-launcher + Longhorn disk
+   ├─ Database       (operator-backed)    → instance + Vault cred
+   ├─ Volume         (Longhorn PVC)       → standalone storage
+   └─ FTPEndpoint    (SFTP into a Volume) → atmoz/sftp + Vault cred
+```
+
+---
+
+## 6. Roadmap
+
+| Phase | KubeVirt | Game hosting (GMod) | Portal | Platform / cross-cutting |
+|---|---|---|---|---|
+| **0 — now** | operator+CDI app; `kubevirt-node.nix` | `GameServer` CRD + **GMod MVP** (pod+PVC+ports+SFTP+RCON) | **Headlamp** for visibility | Cilium **LB-IPAM** turned on |
+| **1** | first VM templates | agent-exec admin; web console | **Zeta Portal v1** (resources+actions) | `Tenant` CRD draft; OIDC IdP chosen |
+| **2** | GPU VMs | more games (egg import); Filebrowser | metrics/quota/cost blades | multi-tenancy (NetworkPolicy+quota); object storage |
+| **3** | live migration (multi-node) | self-service signup; **billing (OpenCost)** | marketplace | **public-IP / colo** host; backups |
+| **4** | — | VM-backed/anti-cheat games | agent-ops console | HA, autoscale, agent self-healing |
+
+---
+
+## 7. Immediate next steps (first PRs, dependency order)
+
+1. **Headlamp** — `k8s/applications/headlamp/` ArgoCD app → instant top-down view.
+2. **Cilium LB-IPAM** — a `CiliumLoadBalancerIPPool` + `CiliumL2AnnouncementPolicy`
+   (or BGP) so `type: LoadBalancer` works (prereq for game/VM external ports).
+3. **KubeVirt** — `k8s/applications/kubevirt/` (operator) + `.../cdi/` + a
+   `nixos/modules/kubevirt-node.nix`.
+4. **GameServer + GMod** — `k8s/applications/game-hosting/`: the CRD, a
+   template-based controller, and a GMod instance (StatefulSet + Longhorn PVC +
+   LB Service + SFTP sidecar + RCON gateway), plus the agent-exec admin path.
+
+---
+
+## 8. Open decisions (need a call before/while building)
+
+1. **Public reachability** — where do production game/VM servers live? (home NAT
+   is a non-starter for public hosting; need public IP / colo / cloud node.)
+2. **Portal: adopt vs build** — Headlamp-extended vs Rancher vs a bespoke Zeta
+   Portal (recommend Headlamp now, bespoke later).
+3. **Human auth / IdP** — Authentik/Keycloak vs Forgejo/GitLab OIDC for portal
+   + tenant login.
+4. **Single-tenant ops vs multi-tenant product** — gates how much of §4.2 we
+   build now.
+5. **Provisioning API** — CRD+controllers now; adopt Crossplane later? (recommend
+   CRD-first.)

--- a/full-ai-cluster/k8s/applications/agent-memory/Application.yaml
+++ b/full-ai-cluster/k8s/applications/agent-memory/Application.yaml
@@ -1,0 +1,42 @@
+# Agent memory — per-persona durable, Longhorn-backed memory volumes.
+#
+# A StatefulSet whose volumeClaimTemplates bind one `longhorn` PVC per
+# replica, giving AI-agent memory that survives pod restart, reschedule, and
+# node failure. The App-of-Apps root (k8s/bootstrap/root-application.yaml)
+# picks up this Application.yaml; this Application then reconciles the
+# namespace + service + statefulset in this directory.
+#
+# Complements the `hindsight` Application (semantic/vector memory service,
+# also Longhorn-backed). This one is the raw file-memory substrate.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    # After longhorn (sync-wave -15) so the `longhorn` StorageClass exists
+    # before these PVCs are created.
+    argocd.argoproj.io/sync-wave: "10"
+  name: agent-memory
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Lucent-Financial-Group/Zeta
+    targetRevision: main
+    path: full-ai-cluster/k8s/applications/agent-memory
+    directory:
+      # Apply the manifests, NOT this Application.yaml itself (no recursion).
+      include: '{namespace,service,statefulset}.yaml'
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: agent-memory
+  syncPolicy:
+    automated:
+      # NEVER prune persistent memory — losing the PVC means losing the
+      # agent's memory. Manual delete only.
+      prune: false
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/full-ai-cluster/k8s/applications/agent-memory/namespace.yaml
+++ b/full-ai-cluster/k8s/applications/agent-memory/namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: agent-memory
+  labels:
+    app.kubernetes.io/part-of: zeta-agents
+    # Exempt from gatekeeper admission so a policy outage can never block
+    # the agents' own memory substrate (matches open-policy-agent exemptions).
+    admission.gatekeeper.sh/ignore: "true"

--- a/full-ai-cluster/k8s/applications/agent-memory/service.yaml
+++ b/full-ai-cluster/k8s/applications/agent-memory/service.yaml
@@ -1,0 +1,20 @@
+# Headless service — gives each StatefulSet replica a stable DNS name
+# (agent-memory-0.agent-memory.agent-memory.svc.cluster.local), so an
+# agent's memory endpoint is addressable per-persona and stable across
+# restarts. No load balancing (clusterIP: None) — identity, not spread.
+apiVersion: v1
+kind: Service
+metadata:
+  name: agent-memory
+  namespace: agent-memory
+  labels:
+    app.kubernetes.io/name: agent-memory
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: agent-memory
+  ports:
+    # Placeholder port; the real agent-runtime image exposes its own here.
+    - name: runtime
+      port: 8080
+      targetPort: 8080

--- a/full-ai-cluster/k8s/applications/agent-memory/statefulset.yaml
+++ b/full-ai-cluster/k8s/applications/agent-memory/statefulset.yaml
@@ -1,0 +1,75 @@
+# Persistent agent memory — the canonical StatefulSet + volumeClaimTemplates
+# (PVC) -> `longhorn` StorageClass pattern, realised for AI-agent memory.
+#
+# WHY a StatefulSet (not a Deployment): each replica gets a STABLE identity
+# (agent-memory-0, -1, …) AND its OWN PersistentVolumeClaim that is re-bound
+# to the same Longhorn volume across pod restart, reschedule, and node
+# failure. That is exactly "persistent agent memory across pods and
+# restarts" — a Deployment with a shared PVC cannot give per-replica stable
+# storage, and emptyDir/hostPath do not survive reschedule.
+#
+# WHERE this fits: Zeta's three personas (otto/lior/vera) currently run as
+# systemd units on the host with file/git-based memory. This is the
+# in-cluster substrate for that memory: one durable, Longhorn-replicated
+# volume per persona, mounted at /memory. The `memory-keeper` container is a
+# functional placeholder that PROVES the volume persists (it appends a boot
+# record every start and survives restarts); replace its image with the real
+# agent-runtime image (claude/codex/gemini CLI) when agents move in-cluster.
+# Semantic/vector memory is a separate, complementary service (see the
+# `hindsight` Application — also Longhorn-backed).
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: agent-memory
+  namespace: agent-memory
+spec:
+  serviceName: agent-memory
+  # One replica == one persona's durable memory. Start at 1 (single node);
+  # bump to match the number of enabled personas (otto/lior/vera => 3) — each
+  # new ordinal automatically gets its own Longhorn PVC from the template.
+  replicas: 1
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: agent-memory
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: agent-memory
+    spec:
+      securityContext:
+        # Let the (non-root) agent runtime own its memory volume.
+        fsGroup: 1000
+      containers:
+        - name: memory-keeper
+          image: busybox:1.36
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              MEM=/memory
+              mkdir -p "$MEM/projects"
+              echo "$(date -u +%FT%TZ) boot pod=$(hostname)" >> "$MEM/boot-log.txt"
+              BOOTS=$(grep -c boot "$MEM/boot-log.txt" 2>/dev/null || echo 0)
+              echo "agent-memory ready on $(hostname): ${BOOTS} boot(s) on this PERSISTENT volume"
+              echo "(volume survives pod restart / reschedule / node failure via Longhorn)"
+              # Keep the volume mounted + the pod alive. The real agent-runtime
+              # image mounts /memory at ~/.claude + the repo memory/ dir here.
+              exec tail -f "$MEM/boot-log.txt"
+          volumeMounts:
+            - name: memory
+              mountPath: /memory
+          resources:
+            requests: { cpu: "50m", memory: "64Mi" }
+            limits:   { cpu: "500m", memory: "256Mi" }
+  # The PVC template — one Longhorn-backed volume per replica. THIS is the
+  # "PVC for the StatefulSet that points to the storage class".
+  volumeClaimTemplates:
+    - metadata:
+        name: memory
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: longhorn
+        resources:
+          requests:
+            storage: 10Gi

--- a/full-ai-cluster/k8s/applications/longhorn/Application.yaml
+++ b/full-ai-cluster/k8s/applications/longhorn/Application.yaml
@@ -21,10 +21,15 @@ spec:
       valuesObject:
         defaultSettings:
           defaultDataPath: /var/lib/longhorn
-          defaultReplicaCount: 2   # bump to 3 once 3+ workers exist
+          # Single control-plane node today. A replica count > the number of
+          # schedulable nodes leaves every volume permanently "Degraded"
+          # (Longhorn can't place the extra replicas), which surfaces as
+          # unhappy PVCs on a fresh single-node install. Keep this == node
+          # count; bump to 2 (then 3) as workers join for real HA.
+          defaultReplicaCount: 1
         persistence:
           defaultClass: false
-          defaultClassReplicaCount: 2
+          defaultClassReplicaCount: 1   # match defaultReplicaCount (single-node)
           reclaimPolicy: Retain
         ingress:
           enabled: false   # turn on after cert-manager + ingress-nginx

--- a/full-ai-cluster/k8s/applications/open-policy-agent/Application.yaml
+++ b/full-ai-cluster/k8s/applications/open-policy-agent/Application.yaml
@@ -17,11 +17,32 @@ spec:
     helm:
       releaseName: gatekeeper
       valuesObject:
-        replicas: 3
+        replicas: 1   # single control-plane node; bump for HA once workers exist
         controllerManager:
           metricsPort: 8888
-        validatingWebhookFailurePolicy: Fail
-        mutatingWebhookFailurePolicy: Ignore   # safer default while iterating
+          # Never let admission control touch system/infra namespaces — these
+          # carry the control plane, CNI, storage and GitOps that gatekeeper
+          # itself depends on. Defence-in-depth alongside the fail-open policy.
+          exemptNamespaces:
+            - kube-system
+            - kube-node-lease
+            - kube-public
+            - gatekeeper-system
+            - cilium
+            - longhorn-system
+            - argocd
+        # FAIL-OPEN, not fail-closed. With failurePolicy: Fail the validating
+        # webhook intercepts EVERY write cluster-wide — including k3s's own
+        # cluster-scoped CRD updates (e.g. addons.k3s.cattle.io). If gatekeeper
+        # has no ready endpoints (pods still starting, or any outage) those
+        # writes are rejected and k3s aborts controller startup → the whole
+        # control plane crash-loops. Observed on node-09485d (2026-06-07): 41
+        # k3s restarts in 10 min, API permanently 503, cluster bricked. A
+        # policy engine must never be able to take down the API server, so it
+        # fails OPEN (admit when the engine is unreachable). Namespaced policy
+        # enforcement still applies whenever gatekeeper is up (the normal case).
+        validatingWebhookFailurePolicy: Ignore
+        mutatingWebhookFailurePolicy: Ignore
   destination:
     server: https://kubernetes.default.svc
     namespace: gatekeeper-system

--- a/full-ai-cluster/nixos/modules/common.nix
+++ b/full-ai-cluster/nixos/modules/common.nix
@@ -14,6 +14,10 @@
   imports = [
     ./injected-hostname.nix
     ./login-banner.nix
+    # Longhorn node prerequisites (open-iscsi + nfs). Without these every
+    # `longhorn` PVC stays Pending and the whole stateful layer is dead.
+    # Imported here so control-plane AND workers get them uniformly.
+    ./longhorn-prereqs.nix
     # iter-5.4.0 (B-0794 homelab-mode): operator SSH pubkeys captured
     # via `gh ssh-key list` during zeta-install.sh Step 6.8. Composes
     # additively with iter-4.2 static maintainer keys.

--- a/full-ai-cluster/nixos/modules/k3s-agent.nix
+++ b/full-ai-cluster/nixos/modules/k3s-agent.nix
@@ -35,6 +35,12 @@
       8472
     ];
     trustedInterfaces = [ "cilium_host" "cilium_net" "cni0" "lxc+" ];
+
+    # Cilium REQUIRES reverse-path filtering OFF — NixOS' default
+    # `checkReversePath` rpfilter (mangle PREROUTING) drops Cilium's
+    # asymmetric pod->host traffic before conntrack, black-holing every
+    # pod->node packet. Same fix + rationale as k3s-server.nix.
+    checkReversePath = false;
   };
 
   systemd.tmpfiles.rules = [

--- a/full-ai-cluster/nixos/modules/k3s-server.nix
+++ b/full-ai-cluster/nixos/modules/k3s-server.nix
@@ -62,6 +62,15 @@
       "--disable=servicelb"
       "--disable=traefik"
 
+      # Disable the bundled local-path-provisioner. local-storage.nix
+      # re-declares it as `zeta-local-path` (the single default class) with
+      # a fixed path; leaving k3s' built-in enabled creates a SECOND
+      # StorageClass *also* marked default (`local-path (default)` AND
+      # `zeta-local-path (default)`), which is an invalid/ambiguous config —
+      # a class-less PVC then binds non-deterministically. Observed on
+      # node-09485d (2026-06-07). Keep exactly one default.
+      "--disable=local-storage"
+
       # Cluster CIDR — give Cilium a /16 to work with.
       "--cluster-cidr=10.42.0.0/16"
       "--service-cidr=10.43.0.0/16"

--- a/full-ai-cluster/nixos/modules/k3s-server.nix
+++ b/full-ai-cluster/nixos/modules/k3s-server.nix
@@ -159,6 +159,23 @@
       8472    # VXLAN (Cilium can also run native-routing)
     ];
     trustedInterfaces = [ "cilium_host" "cilium_net" "cni0" "lxc+" ];
+
+    # Cilium REQUIRES reverse-path filtering OFF. NixOS' default
+    # `checkReversePath` installs an iptables `-m rpfilter` DROP in the
+    # mangle PREROUTING chain (`nixos-fw-rpfilter`). Cilium's eBPF datapath
+    # delivers pod->host traffic on an asymmetric path that this rpfilter
+    # marks as failing and DROPS *before conntrack* — so every pod->node
+    # packet (pod->apiserver via the kubernetes ClusterIP, kubelet, etc.)
+    # vanishes with no conntrack entry and no counter. Symptom: node goes
+    # Ready, Cilium is healthy, pod->internet and pod->pod work, but CoreDNS
+    # can't reach 10.43.0.1 -> in-cluster DNS dies -> every helm/app chart
+    # CrashLoops on DNS. The sysctl `net.ipv4.conf.*.rp_filter` being loose
+    # is NOT enough; the iptables rpfilter module is separate and must be
+    # disabled. Confirmed on node-09485d (2026-06-07): inserting a RETURN for
+    # the pod/service CIDR ahead of the rpfilter DROP immediately restored
+    # pod->apiserver and the whole cluster recovered.
+    # See Cilium docs: "rp_filter must be disabled".
+    checkReversePath = false;
   };
 
   environment.variables = {

--- a/full-ai-cluster/nixos/modules/longhorn-prereqs.nix
+++ b/full-ai-cluster/nixos/modules/longhorn-prereqs.nix
@@ -1,0 +1,43 @@
+# full-ai-cluster/nixos/modules/longhorn-prereqs.nix
+#
+# Node-level prerequisites for Longhorn distributed storage. Imported by
+# common.nix so EVERY cluster node (control-plane + workers) has them.
+#
+# Longhorn's engine attaches each volume to its consumer pod over a
+# host-local iSCSI target, so open-iscsi (iscsid + the iscsiadm binary +
+# the iscsi_tcp kernel module) MUST be present and running on every node.
+# Without it, longhorn-manager cannot create working volumes, so every
+# PVC bound to the `longhorn` StorageClass stays Pending forever and all
+# stateful workloads (vault, spire, kube-prometheus-stack, nats, weaviate,
+# and any agent StatefulSet for persistent memory) never schedule.
+#
+# Observed on node-09485d (2026-06-07): open-iscsi was configured nowhere,
+# Longhorn never provisioned, and vault-0 was stuck on an unbound PVC. This
+# module is the storage analog of the checkReversePath/rpfilter fix — a
+# missing node prerequisite that silently breaks the whole stateful layer.
+#
+# nfs-utils + the NFS client are needed for Longhorn RWX (ReadWriteMany)
+# volumes, which are exported over NFSv4. RWO volumes need only iSCSI.
+{ config, pkgs, lib, ... }:
+
+{
+  # iSCSI initiator — Longhorn's volume-attach transport. Requires a
+  # globally-unique initiator name per node (derived from the hostname).
+  services.openiscsi = {
+    enable = true;
+    name = "iqn.2026-06.dev.zeta:${config.networking.hostName}";
+  };
+  boot.kernelModules = [ "iscsi_tcp" ];
+
+  # RWX (ReadWriteMany) Longhorn volumes are served over NFSv4; the
+  # node needs the userspace tools + client to mount them.
+  environment.systemPackages = [ pkgs.nfs-utils ];
+
+  # Longhorn's default data path. On real installs zeta-install.sh mounts a
+  # dedicated partition under /var/lib/longhorn-disk1; this just guarantees
+  # the default directory exists so longhorn-manager can start cleanly even
+  # on a single-disk / minimal install.
+  systemd.tmpfiles.rules = [
+    "d /var/lib/longhorn 0700 root root - -"
+  ];
+}

--- a/full-ai-cluster/tools/fat-inspect.ts
+++ b/full-ai-cluster/tools/fat-inspect.ts
@@ -1,0 +1,131 @@
+#!/usr/bin/env bun
+/**
+ * fat-inspect.ts — read-only inspector for a flashed USB's EFI System
+ * Partition (FAT12). Reads the BPB, geometry, root directory, and free
+ * cluster count directly from the raw physical drive — no mount required.
+ *
+ * Companion / verifier for flash-and-inject.ts: confirms the ESP layout and
+ * that the operator pubkey (`zeta-authorized-keys.pub`, 8.3 alias
+ * `ZETA-A~1PUB`) actually landed on the FAT, independently of the flasher's
+ * own read-back. Run from an ELEVATED shell (raw physical-drive read).
+ *
+ * argv: <device> <partByteOffset> <log>
+ */
+import { closeSync, openSync, readSync, appendFileSync } from "node:fs";
+
+const device = process.argv[2] ?? "\\\\.\\PhysicalDrive3";
+const partOffset = Number(process.argv[3] ?? 141312);
+const log = process.argv[4] ?? "D:\\Zeta\\.fat-inspect.log";
+const SS = 512;
+
+function W(s: string): void {
+  appendFileSync(log, s + "\n");
+  process.stdout.write(s + "\n");
+}
+function readAligned(fd: number, byteOffset: number, byteLen: number): Buffer {
+  const start = Math.floor(byteOffset / SS) * SS;
+  const end = Math.ceil((byteOffset + byteLen) / SS) * SS;
+  const buf = Buffer.allocUnsafe(end - start);
+  let got = 0;
+  while (got < buf.length) {
+    const n = readSync(fd, buf, got, buf.length - got, start + got);
+    if (n <= 0) break;
+    got += n;
+  }
+  return buf.subarray(byteOffset - start, byteOffset - start + byteLen);
+}
+
+const fd = openSync(device, "r");
+try {
+  W(`=== fat-inspect ${device} partOffset=${partOffset} ===`);
+  const bpb = readAligned(fd, partOffset, SS);
+  const u16 = (o: number) => bpb.readUInt16LE(o);
+  const u8 = (o: number) => bpb.readUInt8(o);
+  const u32 = (o: number) => bpb.readUInt32LE(o);
+
+  const bytesPerSector = u16(0x0b);
+  const secPerClus = u8(0x0d);
+  const reserved = u16(0x0e);
+  const numFATs = u8(0x10);
+  const rootEntCnt = u16(0x11);
+  const totSec16 = u16(0x13);
+  const media = u8(0x15);
+  const fatSz16 = u16(0x16);
+  const totSec32 = u32(0x20);
+  const oem = bpb.subarray(0x03, 0x0b).toString("latin1");
+  const fsType = bpb.subarray(0x36, 0x3e).toString("latin1");
+  const sig = u16(0x1fe);
+
+  const totSec = totSec16 !== 0 ? totSec16 : totSec32;
+  const rootDirSectors = Math.ceil((rootEntCnt * 32) / bytesPerSector);
+  const firstRootDirSec = reserved + numFATs * fatSz16;
+  const firstDataSec = reserved + numFATs * fatSz16 + rootDirSectors;
+  const dataSec = totSec - firstDataSec;
+  const countOfClusters = Math.floor(dataSec / secPerClus);
+  const fatTypeName = countOfClusters < 4085 ? "FAT12" : countOfClusters < 65525 ? "FAT16" : "FAT32";
+
+  W(`OEM='${oem}' fsTypeLabel='${fsType}' bootSig=0x${sig.toString(16)}`);
+  W(`bytesPerSector=${bytesPerSector} secPerClus=${secPerClus} reserved=${reserved} numFATs=${numFATs}`);
+  W(`rootEntCnt=${rootEntCnt} totSec=${totSec} media=0x${media.toString(16)} fatSz16=${fatSz16}`);
+  W(`rootDirSectors=${rootDirSectors} firstRootDirSec=${firstRootDirSec} firstDataSec=${firstDataSec}`);
+  W(`dataSec=${dataSec} countOfClusters=${countOfClusters} => ${fatTypeName}`);
+  W(`clusterSizeBytes=${secPerClus * bytesPerSector}`);
+  W(`BPB[0..63] hex: ${bpb.subarray(0, 64).toString("hex")}`);
+
+  // Root directory: list existing 8.3 entries + count free slots.
+  const rootBytes = readAligned(fd, partOffset + firstRootDirSec * bytesPerSector, rootDirSectors * bytesPerSector);
+  let used = 0,
+    free = 0,
+    lfn = 0,
+    endSeen = false;
+  const names: string[] = [];
+  for (let i = 0; i < rootEntCnt; i++) {
+    const e = rootBytes.subarray(i * 32, i * 32 + 32);
+    const first = e[0];
+    if (first === 0x00) {
+      free++;
+      endSeen = true;
+      continue;
+    }
+    if (first === 0xe5) {
+      free++;
+      continue;
+    }
+    const attr = e[11];
+    if (attr === 0x0f) {
+      lfn++;
+      continue;
+    }
+    used++;
+    const nm = e.subarray(0, 11).toString("latin1");
+    const clus = e.readUInt16LE(0x1a);
+    const sz = e.readUInt32LE(0x1c);
+    names.push(`'${nm}' attr=0x${attr.toString(16)} clus=${clus} size=${sz}`);
+  }
+  W(`root entries: used=${used} lfn=${lfn} free(approx)=${free} endSeen=${endSeen}`);
+  for (const n of names) W(`  ${n}`);
+
+  // Count free clusters in FAT copy #0.
+  const fatStart = partOffset + reserved * bytesPerSector;
+  const fatBytes = readAligned(fd, fatStart, fatSz16 * bytesPerSector);
+  let freeClusters = 0;
+  let firstFree = -1;
+  for (let c = 2; c < countOfClusters + 2; c++) {
+    let val: number;
+    if (fatTypeName === "FAT12") {
+      const off = Math.floor((c * 3) / 2);
+      const pair = fatBytes[off] | (fatBytes[off + 1] << 8);
+      val = c & 1 ? pair >> 4 : pair & 0x0fff;
+    } else {
+      val = fatBytes.readUInt16LE(c * 2);
+    }
+    if (val === 0) {
+      freeClusters++;
+      if (firstFree < 0) firstFree = c;
+    }
+  }
+  W(`FAT: freeClusters=${freeClusters} firstFreeCluster=${firstFree} fatStartByte=${fatStart}`);
+  W(`=== inspect done ===`);
+} finally {
+  closeSync(fd);
+}

--- a/full-ai-cluster/tools/flash-and-inject.ts
+++ b/full-ai-cluster/tools/flash-and-inject.ts
@@ -1,0 +1,388 @@
+#!/usr/bin/env bun
+/**
+ * flash-and-inject.ts — flash the AI-cluster installer ISO to a Windows USB
+ * AND inject the operator SSH pubkey, for the REMOVABLE-MEDIA case that
+ * flash-usb-windows.ts cannot handle.
+ *
+ * Why a separate path from flash-usb-windows.ts: that tool takes the disk
+ * offline (Set-Disk -IsOffline) and injects the key by MOUNTING the ESP.
+ * Neither works on removable USB sticks flashed with an isohybrid ISO:
+ *   - Set-Disk -IsOffline => "Removable media cannot be set to offline".
+ *   - Windows mounts the flashed ISO9660 read-only (CDFS), so the ESP mounts
+ *     write-protected ("The media is write protected") and the key write
+ *     fails — leaving a bootable-but-KEYLESS USB.
+ * (Both confirmed on a PNY USB 3.2.1 FD, 2026-06-07.)
+ *
+ * One elevated process instead:
+ *   1. mountvol /R + /N (purge stale registrations + disable auto-mount) then
+ *      Clear-Disk (force-dismount + blank) so no volume locks the disk.
+ *   2. Raw-write the installer ISO to \\.\PhysicalDriveN on a single handle.
+ *   3. Inject the pubkey into the FAT12 ESP via RAW SECTOR I/O (no mount): the
+ *      inject geometry is computed from the ISO's in-memory head (zero device
+ *      reads between the ISO write and the FAT writes) so the writes land
+ *      before Windows can auto-mount + re-lock the ESP (the cause of EBADF).
+ *   4. fsync, rescan, re-enable auto-mount, read-back verify (incl. LFN
+ *      reconstruction so the installer reads "zeta-authorized-keys.pub").
+ *
+ * Reuses the shared, unit-tested pure helpers from flash-usb-windows.ts
+ * (autoDiscoverIso / validateIso / human). Must run from an ELEVATED shell.
+ *
+ * argv: <device> <keyFile> <log>   (ISO auto-discovered from Downloads)
+ */
+import {
+  appendFileSync,
+  closeSync,
+  fstatSync,
+  fsyncSync,
+  openSync,
+  readFileSync,
+  readSync,
+  writeSync,
+} from "node:fs";
+import { execFileSync } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { autoDiscoverIso, human, validateIso } from "./flash-usb-windows.ts";
+
+const device = process.argv[2] ?? "\\\\.\\PhysicalDrive3";
+const keyFile = process.argv[3]!;
+const log = process.argv[4] ?? "D:\\Zeta\\.flash-inject.log";
+const diskNum = Number((device.match(/PhysicalDrive(\d+)/) ?? [])[1] ?? 3);
+const ESP_NAME = "zeta-authorized-keys.pub";
+const SHORT = "ZETA-A~1PUB";
+
+function W(s: string): void {
+  appendFileSync(log, s + "\n");
+  process.stdout.write(s + "\n");
+}
+function fail(m: string): never {
+  W(`RESULT:FAIL-${m}`);
+  process.exit(1);
+}
+function ps(s: string): string {
+  return execFileSync("powershell", ["-NoProfile", "-NonInteractive", "-Command", s], {
+    encoding: "utf8",
+    maxBuffer: 8 * 1024 * 1024,
+  });
+}
+
+// ── raw aligned device IO ────────────────────────────────────────────
+function readRegion(fd: number, off: number, len: number): Buffer {
+  if (off % 512 || len % 512) throw new Error(`unaligned read off=${off} len=${len}`);
+  const buf = Buffer.allocUnsafe(len);
+  let got = 0;
+  while (got < len) {
+    const n = readSync(fd, buf, got, len - got, off + got);
+    if (n <= 0) break;
+    got += n;
+  }
+  if (got !== len) throw new Error(`short read ${got}/${len}@${off}`);
+  return buf;
+}
+function writeRegion(fd: number, off: number, buf: Buffer): void {
+  if (off % 512 || buf.length % 512) throw new Error(`unaligned write off=${off} len=${buf.length}`);
+  let put = 0;
+  while (put < buf.length) {
+    const n = writeSync(fd, buf, put, buf.length - put, off + put);
+    if (n <= 0) break;
+    put += n;
+  }
+  if (put !== buf.length) throw new Error(`short write ${put}/${buf.length}@${off}`);
+}
+
+// ── FAT12 helpers ────────────────────────────────────────────────────
+function fat12Get(fat: Buffer, c: number): number {
+  const o = Math.floor((c * 3) / 2);
+  const pair = fat[o]! | (fat[o + 1]! << 8);
+  return c & 1 ? pair >> 4 : pair & 0x0fff;
+}
+function fat12Set(fat: Buffer, c: number, v: number): void {
+  const o = Math.floor((c * 3) / 2);
+  if (c & 1) {
+    fat[o] = (fat[o]! & 0x0f) | ((v << 4) & 0xf0);
+    fat[o + 1] = (v >> 4) & 0xff;
+  } else {
+    fat[o] = v & 0xff;
+    fat[o + 1] = (fat[o + 1]! & 0xf0) | ((v >> 8) & 0x0f);
+  }
+}
+function lfnChecksum(s11: Buffer): number {
+  let sum = 0;
+  for (let i = 0; i < 11; i++) sum = ((((sum & 1) << 7) | (sum >> 1)) + s11[i]!) & 0xff;
+  return sum;
+}
+const LFN_SLOTS = [1, 3, 5, 7, 9, 14, 16, 18, 20, 22, 24, 28, 30];
+function lfnEntry(name: string, base: number, seqByte: number, cksum: number): Buffer {
+  const e = Buffer.alloc(32, 0);
+  e[0] = seqByte;
+  e[11] = 0x0f;
+  e[13] = cksum;
+  for (let p = 0; p < 13; p++) {
+    const g = base + p;
+    const code = g < name.length ? name.charCodeAt(g) : g === name.length ? 0 : 0xffff;
+    e.writeUInt16LE(code, LFN_SLOTS[p]!);
+  }
+  return e;
+}
+
+// ── 1. resolve ISO + key ─────────────────────────────────────────────
+const isoPath = autoDiscoverIso(join(homedir(), "Downloads"));
+if (!isoPath) fail("no-iso");
+const isoFd0 = openSync(isoPath, "r");
+const isoSize = fstatSync(isoFd0).size;
+closeSync(isoFd0);
+const v = validateIso(isoPath, isoSize, true);
+if (!v.ok) fail(`iso-${v.message}`);
+const body = Buffer.from(readFileSync(keyFile, "utf8").replace(/\r\n/g, "\n").replace(/\n+$/, "") + "\n", "utf8");
+W(`=== flash-and-inject device=${device} iso=${isoPath} (${human(isoSize)}) key=${keyFile} (${body.length}B) ===`);
+
+// ── 1b. disable auto-mount of NEW volumes for the whole operation, so the
+// freshly-flashed ISO9660 never gets mounted (and thus never locks the disk
+// against our raw FAT writes). Re-enabled at the end.
+try {
+  // Purge stale MountMgr volume registrations first. After repeated flashes
+  // Windows caches this USB's prior volume GUIDs and auto-mounts the new
+  // ISO9660 by GUID *despite* /N — which re-locks the ESP region mid-inject
+  // (EBADF). /R clears those so /N actually takes effect.
+  execFileSync("mountvol", ["/R"], { encoding: "utf8" });
+  W(`stale mount registrations purged (mountvol /R)`);
+} catch (e) {
+  W(`mountvol /R skipped: ${e instanceof Error ? e.message.split("\n")[0] : e}`);
+}
+try {
+  execFileSync("mountvol", ["/N"], { encoding: "utf8" });
+  W(`automount disabled (mountvol /N)`);
+} catch (e) {
+  W(`mountvol /N failed (continuing): ${e instanceof Error ? e.message.split("\n")[0] : e}`);
+}
+
+// ── 2. force-dismount + blank the disk (Clear-Disk; diskpart fallback) ─
+try {
+  ps(`Set-Disk -Number ${diskNum} -IsReadOnly $false -ErrorAction SilentlyContinue`);
+} catch {
+  /* ignore */
+}
+try {
+  ps(`Clear-Disk -Number ${diskNum} -RemoveData -RemoveOEM -Confirm:$false -ErrorAction Stop`);
+  W(`Clear-Disk ok`);
+} catch (e) {
+  W(`Clear-Disk failed (${e instanceof Error ? e.message.split("\n")[0] : e}); trying diskpart clean`);
+  try {
+    const t = join(process.env.TEMP ?? "C:\\Windows\\Temp", `zclean-${process.pid}.txt`);
+    require("node:fs").writeFileSync(t, `select disk ${diskNum}\r\nclean\r\n`, "ascii");
+    W(execFileSync("diskpart", ["/s", t], { encoding: "utf8" }).trim());
+  } catch (e2) {
+    fail(`cannot-blank-disk ${e2 instanceof Error ? e2.message.split("\n")[0] : e2}`);
+  }
+}
+
+// ── 3+4. open ONE handle; write ISO then inject; never rescan first ───
+const SECTOR = 4096; // pad unit (works for 512 & 4096 drives)
+const ISO_HEAD = 256 * 1024; // covers MBR + the whole FAT12 ESP metadata
+let isoHead = Buffer.alloc(0); // in-memory copy of the ISO head (set after write)
+const fd = openSync(device, "r+");
+try {
+ try {
+  // 3. raw ISO copy, sector-padded.
+  W(`writing ISO -> ${device} ...`);
+  const isoFd = openSync(isoPath, "r");
+  try {
+    const chunk = 4 * 1024 * 1024;
+    const buf = Buffer.allocUnsafe(chunk);
+    let written = 0;
+    let srcPos = 0;
+    let lastBucket = -1;
+    while (srcPos < isoSize) {
+      const n = readSync(isoFd, buf, 0, chunk, srcPos);
+      if (n <= 0) break;
+      let len = n;
+      if (len % SECTOR !== 0) {
+        const padded = Math.ceil(len / SECTOR) * SECTOR;
+        buf.fill(0, len, padded);
+        len = padded;
+      }
+      writeSync(fd, buf, 0, len, written);
+      written += len;
+      srcPos += n;
+      const bucket = Math.floor((srcPos / isoSize) * 10);
+      if (bucket !== lastBucket) {
+        lastBucket = bucket;
+        W(`  ${Math.floor((srcPos / isoSize) * 100)}% (${human(Math.min(srcPos, isoSize))}/${human(isoSize)})`);
+      }
+    }
+    // Capture the ISO's first 256 KiB (MBR + the whole FAT12 ESP metadata)
+    // from the SOURCE FILE so the key-inject computes from this in-memory copy
+    // and performs ZERO device reads between the ISO write and the FAT writes.
+    // Those intervening device reads were the gap in which Windows auto-mounts
+    // and locks the ESP (write -> EBADF). Also defer fsync to the very end so
+    // we go straight from the last ISO byte to the FAT writes.
+    isoHead = Buffer.alloc(ISO_HEAD);
+    readSync(isoFd, isoHead, 0, ISO_HEAD, 0);
+    W(`ISO write complete (${human(written)}); captured ${ISO_HEAD >> 10}KiB head for inject`);
+  } finally {
+    closeSync(isoFd);
+  }
+
+  // 4. find the EFI System Partition (type 0xEF) by scanning all 4 MBR slots
+  //    of the IN-MEMORY ISO head (no device read).
+  const mbr = isoHead.subarray(0, 512);
+  let partOffset = 0;
+  let espLBA = 0;
+  for (let p = 0; p < 4; p++) {
+    const o = 0x1be + p * 16;
+    const type = mbr[o + 4]!;
+    const lba = mbr.readUInt32LE(o + 8);
+    const cnt = mbr.readUInt32LE(o + 12);
+    W(`MBR[${p}]: type=0x${type.toString(16)} startLBA=${lba} sectors=${cnt}`);
+    if (type === 0xef && lba > 0) {
+      espLBA = lba;
+      partOffset = lba * 512;
+    }
+  }
+  // Fallback: this ISO's ESP is deterministically at LBA 276 (offset 141312).
+  if (!partOffset) {
+    partOffset = 141312;
+    W(`no 0xEF entry found; falling back to known ESP offset ${partOffset}`);
+  }
+  W(`ESP at offset ${partOffset} (LBA ${espLBA || partOffset / 512})`);
+  // Confirm it's a FAT BPB before trusting it (from the in-memory head).
+  {
+    const probe = isoHead.subarray(partOffset, partOffset + 512);
+    const fsLabel = probe.subarray(0x36, 0x3b).toString("latin1");
+    if (probe.readUInt16LE(0x1fe) !== 0xaa55 || !fsLabel.startsWith("FAT")) {
+      fail(`esp-not-fat probeLabel='${fsLabel}' sig=0x${probe.readUInt16LE(0x1fe).toString(16)}`);
+    }
+  }
+
+  // BPB / geometry (from the in-memory head).
+  const bpb = isoHead.subarray(partOffset, partOffset + 512);
+  const bps = bpb.readUInt16LE(0x0b);
+  const spc = bpb.readUInt8(0x0d);
+  const reserved = bpb.readUInt16LE(0x0e);
+  const numFATs = bpb.readUInt8(0x10);
+  const rootEntCnt = bpb.readUInt16LE(0x11);
+  const fatSz16 = bpb.readUInt16LE(0x16);
+  const totSec = bpb.readUInt16LE(0x13) || bpb.readUInt32LE(0x20);
+  const rootDirSectors = Math.ceil((rootEntCnt * 32) / bps);
+  const countOfClusters = Math.floor((totSec - (reserved + numFATs * fatSz16 + rootDirSectors)) / spc);
+  if (countOfClusters >= 4085) fail(`not-FAT12 clusters=${countOfClusters}`);
+  const clusterBytes = spc * bps;
+  if (body.length > clusterBytes) fail(`key-too-big ${body.length}>${clusterBytes}`);
+  const fat0Off = partOffset + reserved * bps;
+  const fatLen = fatSz16 * bps;
+  const rootOff = partOffset + (reserved + numFATs * fatSz16) * bps;
+  const rootLen = rootDirSectors * bps;
+  const dataOff = partOffset + (reserved + numFATs * fatSz16 + rootDirSectors) * bps;
+  const clusOff = (c: number) => dataOff + (c - 2) * clusterBytes;
+
+  // Writable COPIES of root dir + FAT from the in-memory ISO head (modified
+  // then written back to the device). No device read.
+  const root = Buffer.from(isoHead.subarray(rootOff, rootOff + rootLen));
+  const fat0 = Buffer.from(isoHead.subarray(fat0Off, fat0Off + fatLen));
+  let cluster = -1;
+  for (let c = 2; c < countOfClusters + 2; c++)
+    if (fat12Get(fat0, c) === 0) {
+      cluster = c;
+      break;
+    }
+  if (cluster < 0) fail("no-free-cluster");
+  let slot = -1;
+  for (let i = 0; i + 2 < rootEntCnt; i++) {
+    const f = (k: number) => root[k * 32] === 0x00 || root[k * 32] === 0xe5;
+    if (f(i) && f(i + 1) && f(i + 2)) {
+      slot = i;
+      break;
+    }
+  }
+  if (slot < 0) fail("no-free-dir-slot");
+  W(`inject: cluster=${cluster} dirSlot=${slot} clusterBytes=${clusterBytes}`);
+
+  // write body cluster
+  const cb = Buffer.alloc(clusterBytes, 0);
+  body.copy(cb);
+  writeRegion(fd, clusOff(cluster), cb);
+  // EOC in every FAT copy
+  for (let f = 0; f < numFATs; f++) {
+    const fOff = partOffset + (reserved + f * fatSz16) * bps;
+    const fb = f === 0 ? fat0 : Buffer.from(isoHead.subarray(fOff, fOff + fatLen));
+    fat12Set(fb, cluster, 0xfff);
+    writeRegion(fd, fOff, fb);
+  }
+  // directory entries
+  const s11 = Buffer.from(SHORT, "latin1");
+  const cks = lfnChecksum(s11);
+  const lfnCount = Math.ceil(ESP_NAME.length / 13);
+  const se = Buffer.alloc(32, 0);
+  s11.copy(se, 0);
+  se[11] = 0x20;
+  se.writeUInt16LE(0x5c21, 0x10);
+  se.writeUInt16LE(0x5c21, 0x12);
+  se.writeUInt16LE(0x5c21, 0x18);
+  se.writeUInt16LE(cluster, 0x1a);
+  se.writeUInt32LE(body.length, 0x1c);
+  const ents: Buffer[] = [];
+  for (let seq = lfnCount; seq >= 1; seq--) ents.push(lfnEntry(ESP_NAME, (seq - 1) * 13, (seq === lfnCount ? 0x40 : 0) | seq, cks));
+  ents.push(se);
+  for (let k = 0; k < ents.length; k++) ents[k]!.copy(root, (slot + k) * 32);
+  writeRegion(fd, rootOff, root);
+  fsyncSync(fd);
+  W(`wrote dir entries (short='${SHORT}', lfn='${ESP_NAME}', cksum=0x${cks.toString(16)})`);
+
+  // read-back verify with LFN reconstruction
+  const root2 = readRegion(fd, rootOff, rootLen);
+  let ok = false;
+  let pend: { ord: number; ch: number[] }[] = [];
+  for (let i = 0; i < rootEntCnt; i++) {
+    const e = root2.subarray(i * 32, i * 32 + 32);
+    if (e[0] === 0x00) break;
+    if (e[0] === 0xe5) {
+      pend = [];
+      continue;
+    }
+    if (e[11] === 0x0f) {
+      pend.push({ ord: e[0]! & 0x1f, ch: LFN_SLOTS.map((s) => e.readUInt16LE(s)) });
+      continue;
+    }
+    if (e.subarray(0, 11).toString("latin1") === SHORT) {
+      const maxOrd = pend.reduce((m, p) => Math.max(m, p.ord), 0);
+      const arr = new Array(maxOrd * 13).fill(0xffff);
+      for (const p of pend) for (let k = 0; k < 13; k++) arr[(p.ord - 1) * 13 + k] = p.ch[k]!;
+      let ln = "";
+      for (const c of arr) {
+        if (c === 0 || c === 0xffff) break;
+        ln += String.fromCharCode(c);
+      }
+      const clus = e.readUInt16LE(0x1a);
+      const sz = e.readUInt32LE(0x1c);
+      const data = readRegion(fd, clusOff(clus), clusterBytes).subarray(0, sz);
+      ok = ln === ESP_NAME && sz === body.length && data.equals(body);
+      W(`verify: reconstructedLFN='${ln}' size=${sz} contentOk=${data.equals(body)} -> ${ok}`);
+      break;
+    }
+    pend = [];
+  }
+  if (!ok) fail("readback-mismatch");
+ } catch (e) {
+   W(`EXCEPTION: ${e instanceof Error ? `${e.message}\n${e.stack ?? ""}` : String(e)}`);
+   try { execFileSync("mountvol", ["/E"], { encoding: "utf8" }); } catch {}
+   fail("exception");
+ }
+} finally {
+  closeSync(fd);
+}
+
+// ── 5. re-enable auto-mount + rescan so the table is re-read for removal ─
+try {
+  execFileSync("mountvol", ["/E"], { encoding: "utf8" });
+  W(`automount re-enabled (mountvol /E)`);
+} catch {
+  /* best effort */
+}
+try {
+  const t = join(process.env.TEMP ?? "C:\\Windows\\Temp", `zrescan-${process.pid}.txt`);
+  require("node:fs").writeFileSync(t, "rescan\r\n", "ascii");
+  execFileSync("diskpart", ["/s", t], { encoding: "utf8" });
+} catch {
+  /* best effort */
+}
+W("RESULT:OK");


### PR DESCRIPTION
Full platform architecture & expansion plan, grounded in the stack we already run, written after the design discussion (portal + game hosting + KubeVirt + DBs).

One pattern throughout: **every provisionable thing is a CRD; the portal AND the agents drive the same CRs**; ArgoCD reconciles the platform.

Sections (each with full architecture mapped to existing components):
- **KubeVirt** — general VM compute, the un-appliance'd Harvester (NixOS+k3s+Longhorn+KubeVirt); CDI on Longhorn; VFIO GPU passthrough composes.
- **Game hosting** — `GameServer` CRD; **GMod** (SteamCMD app 4020) as the base test; panel / FTP / AI-SSH / provision each mapped (SFTP sidecar, RCON↔WebSocket console, agent k8s-exec).
- **Zeta Portal** — Azure-style top-down console; Headlamp now → bespoke later; resource graph over k8s built-ins + CRDs, Grafana metrics, embedded agent chat.
- **DBaaS** + the shipped **agent-memory** reference pattern.
- **Cross-cutting** — networking layers (**Cilium LB-IPAM, not MetalLB**; public-IP is a separate physical layer), `Tenant` CRD multi-tenancy, storage, security, observability/billing, the agent ops layer.
- **Roadmap** + first PRs (Headlamp → Cilium LB-IPAM → KubeVirt → GameServer/GMod) + open decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)