### PR TITLE
feat(platform): foundation — Headlamp console, Cilium LB-IPAM, GMod base test

### DIFF
--- a/full-ai-cluster/k8s/applications/cilium-lb-ipam/Application.yaml
+++ b/full-ai-cluster/k8s/applications/cilium-lb-ipam/Application.yaml
@@ -1,0 +1,26 @@
+# Cilium LB-IPAM + L2 announcement — gives `Service type=LoadBalancer` real
+# external IPs on bare metal. This is the MetalLB slot, done the Cilium-native
+# way (servicelb is disabled so Cilium owns L2-L4; MetalLB would fight it).
+# Prereq for game-server / VM external ports. See PLATFORM-ARCHITECTURE.md §4.1.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-10"   # before workloads that need LB IPs
+  name: cilium-lb-ipam
+  namespace: argocd
+  finalizers: [ resources-finalizer.argocd.argoproj.io ]
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Lucent-Financial-Group/Zeta
+    targetRevision: main
+    path: full-ai-cluster/k8s/applications/cilium-lb-ipam
+    directory:
+      include: '{ip-pool,l2-policy}.yaml'
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  syncPolicy:
+    automated: { prune: false, selfHeal: true }
+    syncOptions: [ ServerSideApply=true ]

--- a/full-ai-cluster/k8s/applications/cilium-lb-ipam/ip-pool.yaml
+++ b/full-ai-cluster/k8s/applications/cilium-lb-ipam/ip-pool.yaml
@@ -1,0 +1,14 @@
+# Pool of external IPs Cilium hands out to `type: LoadBalancer` Services.
+#
+# ⚠️ ADJUST TO YOUR NETWORK. These must be free IPs on the node's LAN that are
+# NOT in the router's DHCP range. The test node is 192.168.1.74/24 (router
+# .254); this reserves .240–.250 for LoadBalancer Services. Change the block to
+# match your subnet / a routed public range before relying on it.
+apiVersion: cilium.io/v2alpha1
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: zeta-lb-pool
+spec:
+  blocks:
+    - start: "192.168.1.240"
+      stop: "192.168.1.250"

--- a/full-ai-cluster/k8s/applications/cilium-lb-ipam/l2-policy.yaml
+++ b/full-ai-cluster/k8s/applications/cilium-lb-ipam/l2-policy.yaml
@@ -1,0 +1,18 @@
+# Announce LoadBalancer IPs on the LAN via L2 (ARP/NDP), so traffic to a
+# pool IP reaches this node. (Use BGP instead if you peer with a router.)
+#
+# `interfaces` are regexes — adjust if your NIC names differ (the test node's
+# external NIC is enp172s0; en*/eth* covers the common cases).
+apiVersion: cilium.io/v2alpha1
+kind: CiliumL2AnnouncementPolicy
+metadata:
+  name: zeta-l2-announce
+spec:
+  loadBalancerIPs: true
+  interfaces:
+    - "^en[ops].*"
+    - "^eth[0-9]+"
+  nodeSelector:
+    matchExpressions:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists

--- a/full-ai-cluster/k8s/applications/game-hosting/gmod/Application.yaml
+++ b/full-ai-cluster/k8s/applications/game-hosting/gmod/Application.yaml
@@ -1,0 +1,30 @@
+# Garry's Mod base-test game server (PLATFORM-ARCHITECTURE.md §3.2). The
+# App-of-Apps root picks up this Application.yaml; it reconciles the namespace +
+# statefulset + service in this directory. This single hand-written instance
+# becomes the template the `GameServer` controller stamps out per server.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"   # after longhorn + cilium-lb-ipam
+  name: gmod
+  namespace: argocd
+  finalizers: [ resources-finalizer.argocd.argoproj.io ]
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Lucent-Financial-Group/Zeta
+    targetRevision: main
+    path: full-ai-cluster/k8s/applications/game-hosting/gmod
+    directory:
+      include: '{namespace,statefulset,service}.yaml'
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: game-hosting
+  syncPolicy:
+    automated:
+      prune: false      # never auto-delete a game server + its world volume
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/full-ai-cluster/k8s/applications/game-hosting/gmod/namespace.yaml
+++ b/full-ai-cluster/k8s/applications/game-hosting/gmod/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: game-hosting
+  labels:
+    app.kubernetes.io/part-of: zeta-game-hosting
+    # gatekeeper-exempt so a policy outage can't block game workloads
+    admission.gatekeeper.sh/ignore: "true"

--- a/full-ai-cluster/k8s/applications/game-hosting/gmod/service.yaml
+++ b/full-ai-cluster/k8s/applications/game-hosting/gmod/service.yaml
@@ -1,0 +1,34 @@
+# External entry point for the GMod server. type=LoadBalancer → Cilium LB-IPAM
+# assigns an IP from the pool (needs the cilium-lb-ipam app). Players connect to
+# <LB-IP>:27015. (Public-internet reachability is a separate physical layer —
+# see PLATFORM-ARCHITECTURE.md §4.1: a home/NAT IP won't serve public players.)
+apiVersion: v1
+kind: Service
+metadata:
+  name: gmod
+  namespace: game-hosting
+  labels:
+    app.kubernetes.io/name: gmod
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local   # preserve client IP; keep traffic on this node
+  selector:
+    app.kubernetes.io/name: gmod
+  ports:
+    - { name: game-udp, port: 27015, targetPort: 27015, protocol: UDP }
+    - { name: game-tcp, port: 27015, targetPort: 27015, protocol: TCP }
+---
+# Separate Service for SFTP (different IP/port lifecycle from the game port).
+apiVersion: v1
+kind: Service
+metadata:
+  name: gmod-sftp
+  namespace: game-hosting
+  labels:
+    app.kubernetes.io/name: gmod
+spec:
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: gmod
+  ports:
+    - { name: sftp, port: 2222, targetPort: 22, protocol: TCP }

--- a/full-ai-cluster/k8s/applications/game-hosting/gmod/statefulset.yaml
+++ b/full-ai-cluster/k8s/applications/game-hosting/gmod/statefulset.yaml
@@ -1,0 +1,96 @@
+# Garry's Mod dedicated server — the base test for the game-hosting product.
+# The k8s-native shape (StatefulSet + Longhorn PVC + sidecars) that the
+# GameServer CRD will template per server (PLATFORM-ARCHITECTURE.md §3.2).
+#
+# Status: SCAFFOLD — schema-valid; needs live validation on a healthy cluster
+# (the GMod image install + srcds 32-bit runtime + sidecar permissions are the
+# runtime unknowns). Single instance — game servers are pets, not cattle.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: gmod
+  namespace: game-hosting
+  labels:
+    app.kubernetes.io/name: gmod
+spec:
+  serviceName: gmod
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: gmod
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: gmod
+    spec:
+      securityContext:
+        fsGroup: 1000          # shared group so game + sftp can both write /data
+      initContainers:
+        # Install / update Garry's Mod dedicated server (Steam app 4020) into
+        # the persistent Longhorn volume. First run is slow; subsequent restarts
+        # validate-only (fast) since the files persist.
+        - name: install
+          image: cm2network/steamcmd:root
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              set -eu
+              mkdir -p /data/gmod
+              /home/steam/steamcmd/steamcmd.sh \
+                +force_install_dir /data/gmod \
+                +login anonymous \
+                +app_update 4020 validate \
+                +quit
+          volumeMounts:
+            - { name: data, mountPath: /data }
+      containers:
+        - name: gmod
+          image: cm2network/steamcmd:root
+          workingDir: /data/gmod
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              set -eu
+              # Runtime-generated RCON password persisted to the volume — no
+              # secret in git. Panel/agents read it via `kubectl exec ... cat`.
+              RCONF=/data/.rcon_password
+              [ -s "$RCONF" ] || head -c 32 /dev/urandom | base64 | tr -dc 'A-Za-z0-9' | head -c 24 > "$RCONF"
+              RCON=$(cat "$RCONF")
+              echo "GMod starting; RCON password persisted at /data/.rcon_password"
+              exec ./srcds_run -game garrysmod -console -norestart \
+                -port 27015 +ip 0.0.0.0 \
+                +gamemode sandbox +map gm_construct +maxplayers 16 \
+                +rcon_password "$RCON"
+          ports:
+            - { name: game-udp, containerPort: 27015, protocol: UDP }
+            - { name: game-tcp, containerPort: 27015, protocol: TCP }   # query + RCON
+          volumeMounts:
+            - { name: data, mountPath: /data }
+          resources:
+            requests: { cpu: "1", memory: "2Gi" }
+            limits:   { cpu: "2", memory: "4Gi" }
+        # SFTP sidecar — FTP access to the same game files (the FTP root IS the
+        # Longhorn PVC). Key-based auth: drop operator/tenant pubkeys into the
+        # `gmod-sftp-keys` ConfigMap (the controller injects them per tenant).
+        - name: sftp
+          image: atmoz/sftp:alpine
+          args: ["gmod::1000:1000"]   # user gmod, key-only (no password)
+          ports:
+            - { name: sftp, containerPort: 22, protocol: TCP }
+          volumeMounts:
+            - { name: data, mountPath: /home/gmod/data }
+            - { name: sftp-keys, mountPath: /home/gmod/.ssh/keys, readOnly: true }
+      volumes:
+        - name: sftp-keys
+          configMap:
+            name: gmod-sftp-keys
+            optional: true
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: longhorn
+        resources:
+          requests:
+            storage: 20Gi

--- a/full-ai-cluster/k8s/applications/headlamp/Application.yaml
+++ b/full-ai-cluster/k8s/applications/headlamp/Application.yaml
@@ -1,0 +1,41 @@
+# Headlamp — the top-down cluster console (the "see everything we have" UI).
+#
+# CNCF, plugin-extensible web dashboard: namespaces, workloads, pods, PVCs,
+# services, CRDs (incl. our GameServer / KubeVirt VirtualMachine once those
+# land), with live logs + exec. This is the near-term Zeta Portal per
+# PLATFORM-ARCHITECTURE.md §3.3 — instant visibility while the bespoke portal
+# is built; Headlamp plugins bridge our CRDs in the meantime.
+#
+# Auth: ships with token/OIDC login. For now reach it via
+#   kubectl -n headlamp port-forward svc/headlamp 8080:80
+# and a service-account token. Wire OIDC (Authentik/Keycloak or Forgejo) +
+# a Cilium Gateway HTTPRoute when the IdP decision (§8) is made.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"   # after CRDs/storage exist
+  name: headlamp
+  namespace: argocd
+  finalizers: [ resources-finalizer.argocd.argoproj.io ]
+spec:
+  project: default
+  source:
+    repoURL: https://kubernetes-sigs.github.io/headlamp/
+    chart: headlamp
+    targetRevision: 0.30.1   # bump as upstream publishes
+    helm:
+      releaseName: headlamp
+      valuesObject:
+        replicaCount: 1
+        # Read-broad by default; actions gated by the caller's RBAC token.
+        config:
+          watchNamespaces: ""   # all namespaces (cluster-wide view)
+        service:
+          type: ClusterIP        # exposed via port-forward / Gateway later
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: headlamp
+  syncPolicy:
+    automated: { prune: true, selfHeal: true }
+    syncOptions: [ CreateNamespace=true, ServerSideApply=true ]


### PR DESCRIPTION
First build executing **PLATFORM-ARCHITECTURE.md §7** — Headlamp (visibility), Cilium LB-IPAM (external IPs), and the GMod base test. All ArgoCD apps under `k8s/applications/`. **All 8 manifests pass schema validation** — the Cilium CRs were validated *server-side* against the deployed CRDs.

### `headlamp/`
CNCF top-down cluster console — the near-term **Zeta Portal**: pods / PVCs / services / CRDs cluster-wide, logs + exec. `ClusterIP` for now (`kubectl port-forward`); OIDC + Cilium Gateway later.

### `cilium-lb-ipam/`
`CiliumLoadBalancerIPPool` + `CiliumL2AnnouncementPolicy` so `Service type=LoadBalancer` gets a real external IP — **the MetalLB slot, done the Cilium-native way** (servicelb is disabled; MetalLB would fight Cilium). Pool `192.168.1.240–.250` + `en*/eth*` L2 announce — **⚠️ adjust to the real network**.

### `game-hosting/gmod/` — Garry's Mod base test
StatefulSet (SteamCMD app **4020** install → `srcds`) + **Longhorn PVC** (world/addons = the FTP root) + **SFTP sidecar** (key-based) + **LoadBalancer Service on 27015**. RCON password is **runtime-generated into the volume** (no secret in git). This single hand-written instance is the template the `GameServer` CRD will stamp out per server.

> **Scaffold note:** schema-valid, but the GMod image / `srcds` 32-bit runtime / sidecar permissions need **live validation on a healthy cluster** (post-reinstall).

### Next (per the plan)
KubeVirt (operator + CDI + `nixos/modules/kubevirt-node.nix`) and the `GameServer` CRD + controller (templating this GMod instance per tenant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
