### PR TITLE
docs: research/whitepapers = ZetaId pointers (docs/research interface); sandbox = a type of sim; each is 'another interface' on the one grammar

### DIFF
--- a/docs/research/2026-06-07-research-and-whitepapers-are-zetaid-pointers-the-docs-research-interface.md
+++ b/docs/research/2026-06-07-research-and-whitepapers-are-zetaid-pointers-the-docs-research-interface.md
@@ -1,0 +1,71 @@
+# Research & white papers are ZetaId pointers — the `docs` / `research` interface
+
+**Aaron, 2026-06-07** (immediately after #6990, the universal-grammar capture):
+
+> "for sure research and white papers should be zetaid pointers — they can be something like docs or research interface"
+
+This is the sharpened, concrete form of the knowledge-as-nodes thread from #6990: not just
+"prior-art entries are ZetaIds," but **a paper / white paper / research artifact is a first-class
+ZetaId-addressed node, reached through a `docs` (or `research`) noun-class on the same universal
+grammar** — `[seam] verb noun [dependson …]`.
+
+## The claim
+
+A research paper is a node like any other in Zeta:
+
+```
+docs   read   research:dbsp-budiu-2022          dependson research:differential-dataflow-mcsherry-2013
+research cite research:codd-1970-relational
+docs   read   research:foundationdb-zhou-2021    dependson research:flow-actor-language
+```
+
+- **`research:<id>` is a ZetaId pointer**, not a stored copy. We address the work by content-hash /
+  stable identifier and point *out* to it (DOI, arXiv id, repo ref) — **reference-not-copy**. We never
+  ingest copyrighted PDFs into the proof lineage; the node carries the *pointer + our anchor note*, the
+  bytes live where the publisher put them. (Same discipline as ROMs #6987 and song lyrics #6925:
+  ZetaId pointer to external content, signature/identity local, bytes external.)
+- **`docs` / `research` is just a noun-class (a seam-flavoured namespace)**, not a new mechanism.
+  "Something like docs or research interface" = the verb-noun craft interface again — `read`, `cite`,
+  `anchor`, `list` over `docs:*` / `research:*` nouns. Recursive / self-similar (manifesto §9/§10):
+  the docs interface is the *same* interface as everything else.
+
+## Why this is exactly the lineage grammar
+
+`dependson` over `research:*` nodes **is** the citation / intellectual-lineage graph — the Beacon
+register made addressable:
+
+- citation edge `A cites B` ⇒ `A dependson B`
+- "modern AND old" anchoring (Codd 1970 ⊕ current SoTA) ⇒ a dependson chain root→frontier
+- `docs/PRIOR-ART-LIST.md` (the curated reading list) ⇒ the materialized view over `research:*` nodes
+- `references/reference-sources.json` (the refresh manifest, #6989) ⇒ the registry of `research:*`
+  pointers that *can be fetched* (git mirrors of open-source repos/papers)
+- topo-order over the citation DAG (#6984) ⇒ a defensible reading order (foundations before frontier)
+
+So `anchor-to-human-prior-art` (the rule) stops being prose-and-discipline and becomes a **queryable
+node-and-edge set**: "what does claim X stand on?" = `directDependents`/transitive-closure over
+`research:*`. An unanchored coinage = a node with no `dependson research:*` edge — the debt is *visible
+in the graph*, not just in a reviewer's memory.
+
+## Honest scope (peel)
+
+- **Designed / named, not built.** This names the `docs`/`research` noun-class and shows it is the
+  existing `ZetaCli`/`ZetaGraph` grammar (#6967/#6984) over `research:*` ZetaIds. No `research:`
+  resolver scheme is implemented yet (cf. the `rom:` resolver TODO #6987). The buildable next step is
+  small: a `research:` ZetaId scheme + a projection from `references/reference-sources.json` /
+  `PRIOR-ART-LIST.md` into `research:*` nodes, so the citation DAG becomes `topoOrder`-able.
+- **Reference-not-copy is load-bearing, not optional.** The whole reason this is *safe* is that the
+  node is a pointer. Storing paper bytes would (a) break no-binary-in-proof-lineage and (b) be a
+  copyright problem. The node = identity + anchor note + outward pointer. Full stop.
+- This is a conceptual unification + a named, scoped next build — not a shipped resolver.
+
+## Anchors (Beacon)
+
+- **Citation / academic-genealogy graphs** — the Mathematics Genealogy Project; citation networks
+  (Garfield, *Citation Indexing* 1979); the DAG-of-papers as prior art for `dependson research:*`.
+- **DOI / arXiv / content addressing** — stable external identifiers are the real-world `research:`
+  ZetaId scheme; BLAKE3 content-addressing (our local identity layer).
+- **DBSP** (Budiu et al. 2022) / **differential dataflow** (McSherry et al. 2013) — the kind of
+  `research:*` node whose `dependson` chain we'd actually want to walk.
+- Internal lineage: #6990 (universal grammar capture), #6984 (topoOrder), #6967 (ZetaCli grammar),
+  #6989 (reference-sources refresh manifest), #6987 (rom: pointer/resolver), #6925 (ZetaId pointer to
+  external content), `.claude/rules/anchor-to-human-prior-art.md`, `.claude/rules/no-binary-in-proof-lineage.md`.

--- a/docs/research/2026-06-07-sandbox-is-a-type-of-sim.md
+++ b/docs/research/2026-06-07-sandbox-is-a-type-of-sim.md
@@ -1,0 +1,62 @@
+# A sandbox (a "box" / "sand") is a type of sim
+
+**Aaron, 2026-06-07** (refining the sim ⊂ test taxonomy from #6990):
+
+> "box or sand is also a type of sim"
+
+A **sandbox** — a bounded, controlled environment with no uncontrolled external effects — is a
+**kind of `sim`**, which (per #6958 / #6990) is the **omniscient, DST-mandatory form of `test`**.
+
+## Why a sandbox IS a sim (the chain)
+
+The defining property of a sim (#6990) is **omniscience**: the whole world is *inside* and *controlled*,
+so behaviour is deterministic by construction, so DST is mandatory (the FoundationDB
+whole-system-in-simulator insight). A sandbox is exactly that property realized as an *environment*:
+
+- **Bounded** — nothing escapes; no real network, no real filesystem, no real clock (Bounded Mobility,
+  manifesto §4).
+- **Controlled inputs** — every effect the code-under-test can reach is supplied by the box, so the box
+  *knows everything* the run can observe ⇒ omniscient.
+- **Therefore deterministic / replayable** ⇒ DST-able by construction.
+
+So: `sandbox ⊂ sim ⊂ test`. The sandbox is the *substrate* (the controlled world); "sim" is what you
+*do* in it; "test" is the general seam, of which sim is the omniscient sub-mode. A test that runs
+against the *real* boundary (real DB, real socket — partial knowledge, DST not guaranteed) is a test
+but **not** a sandbox/sim.
+
+## The naming texture ("box or sand")
+
+- **"box"** = sandbox / jail / container — the isolation framing (cells push out, hosts accept in;
+  the cell *is* a box). A Zeta **cell** running with no accepted push-downs and only controlled
+  push-outs is a sandbox.
+- **"sand"** = the malleable controlled medium you shape freely inside the box — same root as the
+  "beach" register (sand you can build and un-build without consequence; the beach is where you dream
+  the shape, the forge is where you prove it — [[beach]]). A sandbox is a *forge that throws away its
+  world after the run*: omniscient, consequence-free, replayable.
+
+## Where it already lives in the substrate
+
+- **DarkHall** (#6986) — the CHIP-8-subset emulator is a sandbox: pure-functional, immutable,
+  `Array.copy`-per-write, no I/O ⇒ a box with total omniscience ⇒ deterministic ⇒ a sim. The arcade
+  cell *is* a sandbox.
+- **ChaosEnv** / the DST harness — supplies controlled clock/scheduling/faults = the box that makes a
+  test omniscient (turns a test into a sim).
+- **`isolation: worktree`** (cheap per-writer git boxes) — a box at the repo-topology layer.
+
+## Honest scope (peel)
+
+Conceptual placement, not a new artifact: this just locates "sandbox" in the existing taxonomy
+(`sandbox ⊂ sim ⊂ test`). The buildable implication is the standing one — a sim/sandbox is a `test`
+run whose environment is fully supplied (no real boundary), which the DST harness already aims at; the
+named next step is making "is this run omniscient (sandboxed) or boundary?" an explicit property of a
+`test` node rather than a convention.
+
+## Anchors (Beacon)
+
+- **Sandboxing / OS isolation** — chroot/jails, seccomp, containers (OCI), capability-based security
+  (the box = least-authority environment).
+- **Deterministic simulation** — FoundationDB (Zhou et al., SIGMOD 2021); Will Wilson, *Testing
+  Distributed Systems w/ Deterministic Simulation* (Strange Loop 2014) — the sandbox-is-the-whole-world
+  insight.
+- Internal: #6990 (sim ⊂ test), #6958 (sim = special form of test), #6986 (DarkHall sandbox cell),
+  manifesto §4 Bounded Mobility, §7 DST; the cells-push-out/hosts-accept-in (Eve protocol) cell model.


### PR DESCRIPTION
Three linked Aaron observations after #6990. (1) papers are research:<id> ZetaId nodes (reference-not-copy); docs/research is a noun-class on the universal grammar; dependson over research:* = the citation/lineage graph (anchor-to-human-prior-art made queryable). (2) sandbox ⊂ sim ⊂ test — a box is omniscient-by-construction → DST-able (DarkHall #6986 is a sandbox cell). (3) 'another interface' = docs/research/sim/sandbox/rom are each another noun-class on the one seam/verb/noun+dependson grammar (§9/§10). Conceptual + honest scope; no resolver built yet. 🤖 Generated with [Claude Code](https://claude.com/claude-code)