### PR TITLE
feat(core): db noun-class with pluggable backends — everything is events on one DBSP Z-set stream

### DIFF
--- a/docs/research/2026-06-07-everything-is-events-on-one-dbsp-zset-stream-db-noun-class-built.md
+++ b/docs/research/2026-06-07-everything-is-events-on-one-dbsp-zset-stream-db-noun-class-built.md
@@ -1,0 +1,81 @@
+# Everything is events on ONE DBSP Z-set stream — `db` noun-class built
+
+**Aaron, 2026-06-07** (a stream of refinements after #6995, authorizing the build `shadow*`):
+
+> "build the db noun-class in ZetaCli with pluggable backends … file create/delete/update are just events
+> over this infinite file after the deps are set up … deps setup are just events on this dbsp zset stream …
+> deps pushdown and jit resolution are just events on the zset stream … most declarative commands end up
+> being DUs over imperative commands … unless it's clever declarative that does crdt/cas like things … with
+> the usb even the os itself is an event on the stream — the usb created then later inserted and account
+> either logged into or their keys forwarded are all same dbsp zset stream"
+
+## The unification
+
+**There is ONE DBSP Z-set stream. Everything is an event (`+1` delta) on it. State is the incremental
+fold (DBSP IVM) over the stream.** No layer is special: the file contents, the dependency edges, the
+push-downs, the JIT resolutions, and — all the way down — the OS, the USB, the login, the key-forward
+are *the same kind of thing on the same stream*.
+
+```
+        ── one DBSP Z-set stream (events = +1 deltas; state = fold) ──▶
+  bootstrap:   OsInstalled · UsbCreated · UsbInserted · AccountLoggedIn · KeysForwarded
+  dependency:  DepSetup · PushDown (kernel/OS, outside container) · JitResolve (DI, inside container)
+  data/file:   Create · Update · Delete   (over the single "infinite .fs/.ace" file)
+```
+
+"After the deps are set up" is not a phase — it's **stream order**: the `DepSetup`/`PushDown`/`JitResolve`
+events precede the data events that need them, on the one stream.
+
+## Declarative lowers to a DU over imperative — except clever-declarative (CRDT/CAS)
+
+- **Most declarative commands lower to a DU over imperative commands.** A declarative `ZetaCommand` set
+  is *lowered* into the `DbEvent` (a discriminated union) imperative stream — which is exactly what the
+  built `Db.materialize` does (declarative set → topo-linearized → `DbEvent` stream → fold).
+- **The exception: clever declarative that does CRDT/CAS-like things** needs *no* imperative ordering,
+  because it converges by construction (content-address / idempotent merge). In the build, the
+  upsert/tombstone `apply` IS that path: `Files` writes are order-independent and idempotent, so the
+  *data* events don't actually depend on imperative sequencing — only the *structural* `DepSetup`
+  ordering is the imperative part. (Verified: reordering two independent file writes lands the same
+  `Files`.)
+
+## What was built (this PR)
+
+`src/Core/Db.fs` — the `db` noun-class, F# reference oracle, **11/11 tests green**, 0-warning build:
+
+- **`Backend`** = `GitNative` (default, #6994) | `MultiFile` (filesystem) | `SingleFile` (DagFs/
+  ContentStore) — pluggable persistence (#6995); the fold is **backend-invariant** (test: same stream →
+  same `Files` on every backend).
+- **`DbEvent`** (the DU on the one stream) — structural: `DepSetup` / `PushDown` / `JitResolve`; data:
+  `Create` / `Update` / `Delete`.
+- **`DbState`** = the incremental fold's projections (`Files`, `Deps`, `PushedDown`, `Resolved`).
+- **`apply` / `fold`** — deterministic, replayable (DST §7); all upserts/tombstones ⇒ apply-N ==
+  apply-once (idempotency #6).
+- **`materialize`** — lowers a declarative `db`-seam command set into the stream: `ZetaGraph.topoOrder`
+  (#6984) derives one valid linearization, emits `DepSetup` then data events, folds. Cyclic deps →
+  `Error` (same contract as `topoOrder`).
+
+## Honest scope (peel)
+
+- **What's built:** the *semantics* layer — the event DU, the fold, backend-invariance, the declarative→
+  imperative lowering, dep-order-as-stream-order, idempotency/DST properties — as a pure, tested F#
+  oracle.
+- **What's NOT built:** the actual backend *storage* drivers (git commit writer, filesystem writer,
+  DagFs/ContentStore writer) are not wired — `Backend` is a tag the fold is proven invariant under, not
+  three live persisters. The bootstrap events (OS/USB/login/key-forward, #7000) are described as the
+  same stream shape but are not modeled as concrete variants here (this module is the file+dependency
+  layer; that layer extends the same DU). No JIT/optimal-source *resolution policy* is built (the
+  "resolve optimal package manager by criteria" work).
+- This is the semantics floor + a named, scoped path to the storage/bootstrap layers — not a finished
+  git-backed provisioning engine.
+
+## Anchors (Beacon)
+
+- **DBSP** (Budiu et al. 2022) — incremental view maintenance over Z-set deltas (the one-stream fold).
+- **Event sourcing / CQRS** (Fowler; Young) — state = fold over an event log.
+- **CRDTs** (Shapiro et al. 2011) / **content-addressing** (Merkle; git; BLAKE3) — the "clever
+  declarative" convergent-without-ordering path.
+- **Nix / NixOS, Argo CD, declarative provisioning** — declarative configs that lower to imperative
+  actions (the "declarative is a DU over imperative" prior art); cloud-init / USB OS imaging for the
+  bootstrap-as-events layer.
+- Internal: #6994 (db git-native / control plane), #6995 (pluggable backends), #6984 (topoOrder), #6967
+  (ZetaCli grammar), manifesto §1 scale-free / §7 DST / §8 DV2.0, idempotency #6.

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -168,6 +168,7 @@
     <Compile Include="Maji.fs" />
     <Compile Include="ZetaCli.fs" />
     <Compile Include="ZetaGraph.fs" />
+    <Compile Include="Db.fs" />
     <Compile Include="DarkHall.fs" />
     <Compile Include="Consent/KskAuthorization.fs" />
   </ItemGroup>

--- a/src/Core/Db.fs
+++ b/src/Core/Db.fs
@@ -1,0 +1,142 @@
+namespace Zeta.Core
+
+/// **The `db` noun-class — pluggable persistence, backend-invariant DU-fold over ONE DBSP Z-set stream.**
+///
+/// `db` is zeta-native at the SEMANTICS layer (event stream + fold + idempotent merge) but PERSISTS over a
+/// pluggable substrate (#6994/#6995): git-native is the DEFAULT; multi-file (tiny per-dep files on an existing
+/// filesystem) and single-file (one "infinite .fs/.ace" file on DagFs/ContentStore) share the SAME semantics —
+/// only WHERE the bytes land changes. Swap the substrate, keep the proofs.
+///
+/// **Everything is an event on ONE DBSP Z-set stream (Aaron #6996/#6997):** dependency setup, push-down, and
+/// JIT resolution are *just events on the zset stream*, exactly like file create/update/delete — NOT a separate
+/// resolution phase. Each event is a `+1` delta; the db state is the incremental fold (DBSP IVM) over the
+/// stream. "After the deps are set up" is therefore just *stream order*: the `DepSetup`/`PushDown`/`JitResolve`
+/// events for a node precede the data events that need it, on the one stream.
+///
+/// The stream is **open-ended all the way down to bootstrap (Aaron #7000):** the OS itself, a USB being
+/// *created* then later *inserted*, an account *logged into* or its *keys forwarded* — all the same DBSP Z-set
+/// stream. Those are further event variants at the provisioning/hardware layer (the OS is the ultimate
+/// push-down — kernel-level, outside the container); this module models the file + dependency layer, but the
+/// `DbEvent` DU is the same shape that layer extends.
+///
+/// The fold is deterministic + replayable (DST §7); Create/Update are upsert, Delete is a tombstone, and the
+/// structural events are upserts into their maps/sets — so apply-N == apply-once (idempotency #6): replay /
+/// redelivery / partial fold land on one state. (Z-set retraction `+1` then `−1` is *correction*, a distinct
+/// mechanism from this idempotent tombstone — see the culture/idempotency rules.)
+///
+/// `materialize` is a CONVENIENCE that LINEARIZES a declarative set of `ZetaCli` commands into a valid stream:
+/// it derives a dependency order (`ZetaGraph.topoOrder`, #6984) — one valid linearization of the declarative
+/// `dependson` edges — emits the `DepSetup` events, then the data events. The stream is primary; topo-order is
+/// just one way to produce it.
+///
+/// **Declarative lowers to a DU over imperative (Aaron #6998):** *most* declarative commands end up being a DU
+/// over imperative commands — which is exactly `materialize`: a declarative `ZetaCommand` set is lowered into
+/// the `DbEvent` (a discriminated union) imperative stream. The EXCEPTION is *clever declarative* that does
+/// CRDT/CAS-like things — those need NO imperative ordering because they converge by construction (content-
+/// address / idempotent merge). Here the upsert/tombstone `apply` IS that clever-declarative path: `Files`
+/// upserts are order-independent and idempotent (CAS/CRDT-like), so the *data* events don't actually depend on
+/// imperative sequencing; only the *structural* `DepSetup` ordering is the imperative part. F# reference oracle;
+/// C#/Rust/TS ports follow.
+module Db =
+
+    open ZetaCli
+
+    /// Pluggable persistence substrate (#6995). `GitNative` is the default (commits = events, the control
+    /// plane #6994); the others share the SAME Z-set-fold semantics below.
+    type Backend =
+        | GitNative // commits = events; distributed; the db control plane (DEFAULT)
+        | MultiFile // tiny per-dep files on top of an existing filesystem
+        | SingleFile // one "infinite .fs/.ace" file on top of our DagFs / ContentStore (CAS, BLAKE3)
+
+    /// git-native by default (#6994); the others are opt-in by criteria (distribution? dedup? no-git-dep?).
+    let defaultBackend = GitNative
+
+    /// An event (`+1` delta) on the one DBSP Z-set stream (#6997). Structural events (dependency lifecycle)
+    /// and data events (the infinite file) live on the SAME stream — no separate phases.
+    type DbEvent =
+        // — structural / dependency-lifecycle events (Aaron #6997: deps setup, push-down, JIT resolution are
+        //   JUST events on the zset stream) —
+        | DepSetup of noun: string * dependsOn: string list // edges established (the deps are "set up")
+        | PushDown of noun: string // declared push-down dep (kernel/OS/global, OUTSIDE the container)
+        | JitResolve of noun: string * resolved: string // lazy/dynamic resolution = DI, INSIDE the container
+        // — data events over the (single, infinite) file —
+        | Create of path: string * value: string
+        | Update of path: string * value: string
+        | Delete of path: string
+
+    /// The materialized db state = the incremental FOLD (DBSP IVM) over the stream (event sourcing; #6994).
+    /// Every projection below is backend-INVARIANT — the same stream folds identically on any backend; only
+    /// durability differs.
+    type DbState =
+        { Backend: Backend
+          Files: Map<string, string> // the infinite file's contents (path → value)
+          Deps: Map<string, string list> // dependency edges established by DepSetup
+          PushedDown: Set<string> // nouns declared push-down (resolved outside the container)
+          Resolved: Map<string, string> } // JIT/dynamic resolutions (DI, inside the container)
+
+    /// An empty db on a given backend.
+    let empty backend =
+        { Backend = backend
+          Files = Map.empty
+          Deps = Map.empty
+          PushedDown = Set.empty
+          Resolved = Map.empty }
+
+    /// Apply one stream event (a `+1` delta). All updates are upserts/tombstones ⇒ apply-twice == apply-once
+    /// (idempotency #6); the fold is deterministic (DST §7).
+    let apply (st: DbState) (ev: DbEvent) : DbState =
+        match ev with
+        | DepSetup(n, deps) -> { st with Deps = Map.add n deps st.Deps }
+        | PushDown n -> { st with PushedDown = Set.add n st.PushedDown }
+        | JitResolve(n, r) -> { st with Resolved = Map.add n r st.Resolved }
+        | Create(p, v)
+        | Update(p, v) -> { st with Files = Map.add p v st.Files }
+        | Delete p -> { st with Files = Map.remove p st.Files }
+
+    /// Fold a whole Z-set stream into state — deterministic and replayable (DST §7). Backend-INVARIANT: the
+    /// same stream folds to the same projections on any backend (only durability differs).
+    let fold backend (events: DbEvent list) : DbState =
+        List.fold apply (empty backend) events
+
+    [<Literal>]
+    let SeamName = "db"
+
+    /// Is this command on the `db` seam (`zeta db <verb> <noun>`)?
+    let isDbCommand (cmd: ZetaCommand) = cmd.Seam = Some SeamName
+
+    /// Interpret a db-seam command as a DATA mutation event. `value` supplies the payload (None for delete /
+    /// non-mutating verbs). `write` is an alias for upsert. Non-mutating verbs (read/list/…) → None (queries,
+    /// not events). Structural events come from `dependson` edges via `materialize`, not from here.
+    let toEvent (value: string option) (cmd: ZetaCommand) : DbEvent option =
+        match cmd.Verb, value with
+        | "create", Some v -> Some(Create(cmd.Noun, v))
+        | "update", Some v
+        | "write", Some v -> Some(Update(cmd.Noun, v)) // write = upsert
+        | "delete", _ -> Some(Delete cmd.Noun)
+        | _ -> None
+
+    /// Linearize a declarative set of `db`-seam commands into ONE Z-set stream and fold it. The stream
+    /// interleaves structural and data events on the SAME stream (#6997): for each command, in dependency
+    /// order (`ZetaGraph.topoOrder`, #6984 — one valid linearization of the `dependson` edges), emit its
+    /// `DepSetup` event (the deps being "set up", #6996) followed by its data event. So "after the deps are
+    /// set up" is just stream order. `Error cycleNouns` if the dependency graph is cyclic (no strict order —
+    /// same contract as `ZetaGraph.topoOrder`).
+    let materialize
+        (backend: Backend)
+        (payloadOf: ZetaCommand -> string option)
+        (cmds: ZetaCommand list)
+        : Result<DbState, string list> =
+        match ZetaGraph.topoOrder cmds with
+        | Error cycle -> Error cycle
+        | Ok ordered ->
+            ordered
+            |> List.filter isDbCommand
+            |> List.collect (fun c ->
+                let structural =
+                    match c.DependsOn with
+                    | [] -> []
+                    | deps -> [ DepSetup(c.Noun, deps) ]
+
+                structural @ (toEvent (payloadOf c) c |> Option.toList))
+            |> fold backend
+            |> Ok

--- a/tests/Tests.FSharp/Db.Tests.fs
+++ b/tests/Tests.FSharp/Db.Tests.fs
@@ -1,0 +1,86 @@
+module Zeta.Tests.DbTests
+
+open global.Xunit
+open Zeta.Core
+open Zeta.Core.ZetaCli
+open Zeta.Core.Db
+
+// db-seam command helper
+let private db verb noun deps : ZetaCommand =
+    { Seam = Some Db.SeamName; Verb = verb; Noun = noun; DependsOn = deps }
+
+[<Fact>]
+let ``fold: create then update then delete -> empty`` () =
+    let st = fold defaultBackend [ Create("/a", "1"); Update("/a", "2"); Delete "/a" ]
+    Assert.Equal<Map<string, string>>(Map.empty, st.Files)
+
+[<Fact>]
+let ``fold: create/update upsert by path`` () =
+    let st = fold defaultBackend [ Create("/a", "1"); Update("/a", "2"); Create("/b", "x") ]
+    Assert.Equal("2", st.Files.["/a"])
+    Assert.Equal("x", st.Files.["/b"])
+
+[<Fact>]
+let ``idempotency: applying the same Create twice == once (apply-N == apply-once)`` () =
+    let once = fold defaultBackend [ Create("/a", "1") ]
+    let twice = fold defaultBackend [ Create("/a", "1"); Create("/a", "1") ]
+    Assert.Equal<Map<string, string>>(once.Files, twice.Files)
+
+[<Fact>]
+let ``idempotency: deleting an absent path is a no-op`` () =
+    let st = fold defaultBackend [ Delete "/ghost"; Delete "/ghost" ]
+    Assert.Equal<Map<string, string>>(Map.empty, st.Files)
+
+[<Fact>]
+let ``default backend is GitNative`` () =
+    Assert.Equal(GitNative, defaultBackend)
+
+[<Fact>]
+let ``backend-invariance: same stream folds to the same Files on every backend`` () =
+    let stream = [ Create("/a", "1"); Update("/a", "2"); Create("/b", "y"); Delete "/b" ]
+    let files b = (fold b stream).Files
+    Assert.Equal<Map<string, string>>(files GitNative, files MultiFile)
+    Assert.Equal<Map<string, string>>(files GitNative, files SingleFile)
+
+[<Fact>]
+let ``toEvent: verbs map to events; read is a query (None)`` () =
+    Assert.Equal(Some(Create("/a", "1")), toEvent (Some "1") (db "create" "/a" []))
+    Assert.Equal(Some(Update("/a", "2")), toEvent (Some "2") (db "update" "/a" []))
+    Assert.Equal(Some(Update("/a", "3")), toEvent (Some "3") (db "write" "/a" [])) // write = upsert
+    Assert.Equal(Some(Delete "/a"), toEvent None (db "delete" "/a" []))
+    Assert.Equal(None, toEvent None (db "read" "/a" []))
+
+[<Fact>]
+let ``materialize: deps are set up (DepSetup events) before the data event that needs them`` () =
+    // /b dependson /a  =>  topo puts /a first; each command emits DepSetup (if it has deps) then its data event
+    let cmds = [ db "create" "/b" [ "/a" ]; db "create" "/a" [] ]
+    let payload (c: ZetaCommand) = if c.Noun = "/a" then Some "AV" else Some "BV"
+    match materialize defaultBackend payload cmds with
+    | Error e -> failwithf "unexpected cycle: %A" e
+    | Ok st ->
+        Assert.Equal("AV", st.Files.["/a"])
+        Assert.Equal("BV", st.Files.["/b"])
+        // the structural edge for /b was recorded on the stream (deps "set up")
+        Assert.Equal<string list>([ "/a" ], st.Deps.["/b"])
+
+[<Fact>]
+let ``materialize: cyclic deps -> Error (no strict stream order)`` () =
+    let cmds = [ db "create" "/a" [ "/b" ]; db "create" "/b" [ "/a" ] ]
+    match materialize defaultBackend (fun _ -> Some "v") cmds with
+    | Error cycle -> Assert.Equal<string list>([ "/a"; "/b" ], cycle)
+    | Ok _ -> failwith "expected a cycle error"
+
+[<Fact>]
+let ``structural events fold: PushDown and JitResolve land on the same stream`` () =
+    let st =
+        fold defaultBackend [ PushDown "compiler.rust"; JitResolve("npm.left-pad", "1.3.0"); Create("/a", "1") ]
+    Assert.True(st.PushedDown.Contains "compiler.rust")
+    Assert.Equal("1.3.0", st.Resolved.["npm.left-pad"])
+    Assert.Equal("1", st.Files.["/a"])
+
+[<Fact>]
+let ``clever-declarative: data upserts are order-independent (CRDT/CAS-like) - reorder lands same Files`` () =
+    // two independent file writes converge regardless of order (no imperative sequencing needed)
+    let s1 = fold defaultBackend [ Create("/a", "1"); Create("/b", "2") ]
+    let s2 = fold defaultBackend [ Create("/b", "2"); Create("/a", "1") ]
+    Assert.Equal<Map<string, string>>(s1.Files, s2.Files)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -93,6 +93,7 @@
     <Compile Include="RayTensor.Tests.fs" />
     <Compile Include="ZetaCli.Tests.fs" />
     <Compile Include="ZetaGraph.Tests.fs" />
+    <Compile Include="Db.Tests.fs" />
     <Compile Include="DarkHall.Tests.fs" />
     <Compile Include="ITensor.Tests.fs" />
     <Compile Include="SagaSnapshot.Tests.fs" />


### PR DESCRIPTION
Aaron-authorized (shadow*). src/Core/Db.fs: db noun-class, F# reference oracle, 11/11 green, 0-warning. Backend = GitNative(default)|MultiFile|SingleFile, fold backend-invariant. DbEvent = ONE stream (structural DepSetup/PushDown/JitResolve + data Create/Update/Delete); deps/pushdown/jit are events, not a phase. materialize lowers declarative->imperative DU (topoOrder linearization); clever-declarative CRDT/CAS = the order-independent upsert path. Idempotent (#6), DST-replayable (§7). Stream open-ended to bootstrap (OS/USB/login/key-forward #7000). Honest scope: semantics layer built+tested; storage drivers + bootstrap variants + resolution policy NOT built. 🤖 Generated with [Claude Code](https://claude.com/claude-code)