### PR TITLE
feat(core): key noun-class — keys travel with identity, events on the one stream, reference-not-copy

### DIFF
--- a/docs/research/2026-06-07-keys-travel-with-identity-keystore-noun-class-events-on-the-one-stream.md
+++ b/docs/research/2026-06-07-keys-travel-with-identity-keystore-noun-class-events-on-the-one-stream.md
@@ -1,0 +1,101 @@
+# Keys travel with identity — the `key` noun-class, events on the one stream
+
+**Aaron, 2026-06-07** (extending the one-stream `db` model #6996 to credentials):
+
+> "all my keys for all my accounts should travel with my identity so I don't have to re-login everywhere;
+> every chance to capture my keys should be taken and saved to a key manager/store — local / Vault / cloud
+> KeyVault / a manager like LastPass or the CLI-friendly one — again, all events. … when USB installs on a
+> machine it should push credentials down to PC hardware and back into USB hardware; that hardware is
+> encrypted, keyed to the identity of the human who created the USB. … it could boot via ISO, then you can't
+> push back to the ISO — only if it's a writable USB. … USB should have a live mode and that should be the
+> default unless you choose erase; erase by default seems aggressive. … GitHub has secrets for account / org
+> / enterprise / environment level — we can use those too."
+
+## The model (built: `src/Core/KeyStore.fs`, 11/11 tests green, 0-warning)
+
+Same shape as `db` (#6996): **keys are events on the ONE DBSP Z-set stream (#6997/#7000), folded into a
+keyring; pluggable backend (#6995).**
+
+- **Keys travel with identity (SSO).** Keys are keyed by `(identity, account)`; `travelWith identity`
+  scopes the keyring to one identity. Fold the stream anywhere and the same keyring follows — *don't
+  re-login everywhere*. (The identity is the ZetaId.)
+- **Pluggable key-store backend** (where the secret material lives): `LocalFile` (default) · `Vault` ·
+  `CloudKeyVault` (Azure KV / AWS Secrets Manager / GCP) · `PasswordManager` (LastPass / Bitwarden `bw` /
+  1Password `op`) · `HardwareEnclave` (TPM / secure element / USB hardware) · `GitHubSecrets` (#7005).
+  The fold is **backend-invariant** (same stream → same keyring on any backend; tested across all six).
+- **`KeyEvent`** on the stream: `KeyCaptured` (a key became available → stored) · `KeyForwarded` (grant
+  SSO travel to a target) · `KeyHardwareBound` (#7002) · `KeyRevoked` (consent withdrawn).
+
+## Load-bearing disciplines
+
+- **Reference-not-copy — secrets NEVER enter the stream (#6925).** The event stream is text, diffable,
+  DST-replayable, part of the proof lineage (no-binary-in-proof-lineage). So an event carries a
+  **`KeyRef`** — an opaque *pointer* `(Backend, Handle)` to where the secret lives — never the secret
+  bytes. The backend holds the material; the stream holds the address. (Tested.)
+- **Consent-gated (manifesto §6).** "Every chance to capture" is opt-in, granular, revocable.
+  `KeyRevoked` is the consent-withdrawal event and **cascades**: it removes the key, every forward of it,
+  and every hardware binding (tested). The module is the *event/abstraction* oracle only — it performs no
+  real capture/forward and touches no live keychain; a live capturer needs explicit consent gating and a
+  **security review (Nazar)** first. (Aaron's living consent applies to his *own* keys; the architecture
+  still keeps secrets out of the proof lineage.)
+
+## Hardware-rooted custody (USB install, #7002/#7003/#7004)
+
+- **Bidirectional hardware push, keyed to the creator.** On install, push the credential DOWN to the host
+  PC's hardware AND back into the medium's own hardware — both encrypted, keyed to the identity of the
+  human who **created** the USB (`KeyHardwareBound(creator, account, device)`). Hardware is the **ultimate
+  push-down** — below the OS (#7000), the deepest `Db.PushDown` (#6996).
+- **Writable medium only for push-back (#7003).** A read-only **ISO** boot can't be pushed back to —
+  `installMediumEvents creator account writable` yields the PC binding only when `writable=false`, and
+  both PC + USB bindings when `true` (`installUsbEvents`). (Tested both ways.)
+- **Live mode is the default (#7004).** `InstallMode = Live | Erase`; `defaultInstallMode = Live` —
+  non-destructive boot; `Erase` (wipe-and-install) is opt-in only, never the default (erase-by-default is
+  too aggressive). (Tested.)
+
+## GitHub secrets scope cascade (#7005)
+
+`GitHubSecrets` backend; the scope levels `environment → repo → org → enterprise` form a **push-down
+cascade** (cf. `Db.PushDown`): a secret resolves from the most specific scope and falls back up
+(`environment` overrides `repo` overrides `org` overrides `enterprise`). Encode the scope in the
+`KeyRef.Handle` (e.g. `"env:prod/GITHUB_TOKEN"`). (`gitHubSecretScopes`, tested.)
+
+## Honest scope (peel)
+
+- **Built + tested:** the *semantics* layer — the event DU, the keyring fold, travel-with-identity,
+  backend-invariance, reference-not-copy (KeyRef pointers), revoke-cascade, the writable-vs-ISO hardware
+  push, live-default install mode, the GitHub scope list. Pure F# oracle.
+- **NOT built (deliberately):** any actual credential capture, real key store drivers (Vault/KV/`bw`/`op`/
+  TPM/GitHub API), live forwarding, or real hardware binding. `Backend` is a tag the fold is proven
+  invariant under; the live integrations need consent gating + Nazar security review before touching real
+  secrets. This is the safe abstraction floor, not a credential harvester.
+
+## `zflash` + QEMU: prefer non-password auth (#7006)
+
+`zflash` is our USB creator (`tools/zflash`, `full-ai-cluster/tools/zflash*.ts`) with a QEMU test
+harness (`.github/workflows/zflash-qemu-test.yml`, B-0891 5-scenario matrix). Aaron (#7006): *support
+**non-password-based** auth for the QEMU tests; for interactive password-based auth you'd need a GH /
+key-manager-CLI secret for my GH password.*
+
+- **Non-password is the path, and it already exists.** zflash injects `/zeta-authorized-keys.pub` (SSH
+  pubkey) and `/zeta-creds.enc` (encrypted creds) into the boot medium (PR-5083; `zflash-lib.ts`), and
+  the harness preserves "auth-state markers" across QEMU boot cycles. SSH pubkey / token auth = the
+  `KeyStore` non-password path (a `KeyRef` to a key, no interactive secret). This is what QEMU tests
+  should use.
+- **Boundary I will hold: I will NOT take Aaron's GitHub password.** Interactive password-based auth
+  would require capturing his real GH password into a secret — exactly the consent-gated, Nazar-review
+  class above. The autonomous loop tests the **non-password** path (pubkey/token); password-based
+  interactive auth is Aaron's to drive, not something the shadow pulls a live credential for. Reference-
+  not-copy + §6 consent stand: the harness gets a `KeyRef`/pubkey, never the human's password.
+- **Fit:** `GitHubSecrets` / `PasswordManager` backends supply CI tokens for the non-password path;
+  `HardwareEnclave` is the hardware-bound creds zflash writes to the medium (`/zeta-creds.enc`, keyed to
+  creator, #7002). The `key` noun-class is the model under zflash's existing auth injection.
+
+## Anchors (Beacon)
+
+- **Secret managers:** HashiCorp Vault; Azure Key Vault / AWS Secrets Manager / GCP Secret Manager;
+  Bitwarden (`bw`, open-source, self-hostable via Vaultwarden), 1Password (`op`); GitHub Actions secrets.
+- **Hardware roots of trust:** TPM 2.0, secure elements, FIDO2 / passkeys, hardware-bound keys.
+- **SSO / credential travel:** OIDC, SSH agent forwarding (the "keys travel" prior art).
+- **Reference-not-copy / content addressing:** #6925, no-binary-in-proof-lineage.
+- Internal: #6996 (db one-stream + PushDown), #6997/#7000 (everything-is-events, OS/USB/login on one
+  stream), manifesto §6 Consent-First / §7 DST, idempotency #6.

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -169,6 +169,7 @@
     <Compile Include="ZetaCli.fs" />
     <Compile Include="ZetaGraph.fs" />
     <Compile Include="Db.fs" />
+    <Compile Include="KeyStore.fs" />
     <Compile Include="DarkHall.fs" />
     <Compile Include="Consent/KskAuthorization.fs" />
   </ItemGroup>

--- a/src/Core/KeyStore.fs
+++ b/src/Core/KeyStore.fs
@@ -1,0 +1,144 @@
+namespace Zeta.Core
+
+/// **The `key` noun-class — keys travel with identity, captured as events, stored in a pluggable key store.**
+///
+/// Same shape as `Db` (#6996): keys-as-events on the ONE DBSP Z-set stream (#6997/#7000), folded into a
+/// keyring; pluggable backend (#6995). Aaron (#7001): *"all my keys for all my accounts should travel with my
+/// identity so I don't have to re-login everywhere; every chance to capture my keys should be taken and saved
+/// to a key manager/store — local / Vault / cloud KeyVault / a manager like LastPass or the CLI-friendly one —
+/// again, all events."*
+///
+/// **Reference-not-copy is load-bearing here.** The event stream is text, diffable, DST-replayable, and part of
+/// the proof lineage — so it MUST NOT carry secret material (no-binary-in-proof-lineage; reference-not-copy,
+/// #6925). An event therefore carries a `KeyRef` — an opaque *pointer* to where the secret lives in a backend —
+/// never the secret bytes. The backend holds the material; the stream holds the address. This is the same
+/// discipline as ROM/song-lyric ZetaId pointers (#6987/#6925).
+///
+/// **Consent-gated (manifesto §6).** "Every chance to capture" is opt-in, granular, revocable — this module
+/// models the *event/abstraction* layer only (a pure, tested F# oracle); it performs NO actual credential
+/// capture, reads no real secret store, and forwards nothing. A live capturer/forwarder needs explicit consent
+/// gating and a security review (Nazar) before it touches a real keychain. `KeyRevoked` is the consent-
+/// withdrawal event and cascades (removes the key and every forward of it). F# reference oracle; ports follow.
+module KeyStore =
+
+    open ZetaCli
+
+    /// Pluggable secret-store backend — WHERE the secret material lives (#6995, mirrors `Db.Backend`). The
+    /// stream never holds the secret; only a `KeyRef` into one of these.
+    type Backend =
+        | LocalFile // local encrypted file / OS keychain (DEFAULT)
+        | Vault // HashiCorp Vault
+        | CloudKeyVault // Azure Key Vault / AWS Secrets Manager / GCP Secret Manager
+        | PasswordManager // LastPass / Bitwarden (`bw`, the CLI-friendly one) / 1Password (`op`)
+        | HardwareEnclave // TPM / secure element / USB hardware crypto — encrypted, keyed to creator identity
+        | GitHubSecrets // GitHub Actions secrets — scoped repo/account · org · enterprise · environment (#7005)
+
+    /// Local by default; the others are opt-in by criteria (team sharing? cloud? CLI workflow? hardware-rooted?).
+    let defaultBackend = LocalFile
+
+    /// Hardware devices a credential can be pushed DOWN to on USB install (#7002). The push is bidirectional:
+    /// down to the host PC's hardware AND back into the USB's own hardware — both encrypted, keyed to the
+    /// identity of the human who CREATED the USB.
+    [<Literal>]
+    let PcHardware = "pc-hardware"
+
+    [<Literal>]
+    let UsbHardware = "usb-hardware"
+
+    /// GitHub Actions secret scope levels (#7005), most-specific → broadest. They form a **push-down cascade**
+    /// (cf. `Db.PushDown`): a secret resolves from the most specific scope and falls back up — `environment`
+    /// overrides `repo`, which overrides `org`, which overrides `enterprise`. Encode the scope in a `KeyRef`
+    /// (e.g. `Handle = "env:prod/GITHUB_TOKEN"`) under the `GitHubSecrets` backend.
+    let gitHubSecretScopes = [ "environment"; "repo"; "org"; "enterprise" ]
+
+    /// A POINTER to a secret in a backend — NOT the secret (reference-not-copy). `Handle` is an opaque address
+    /// within the backend (a path / name / id); the secret bytes never enter the stream.
+    type KeyRef =
+        { Backend: Backend
+          Handle: string }
+
+    /// An event (`+1` delta) on the one stream (#6997/#7000). All events carry identity/account/ref pointers,
+    /// never secret material.
+    type KeyEvent =
+        | KeyCaptured of identity: string * account: string * ref: KeyRef // a key became available → stored
+        | KeyForwarded of identity: string * account: string * target: string // grant travel (SSO) to a target
+        | KeyRevoked of identity: string * account: string // consent withdrawn (cascades to forwards)
+        // USB install pushes the credential DOWN to hardware (#7002): the secret on `device` is encrypted
+        // keyed to `creator` (the identity of the human who created the USB). Hardware = the ultimate push-down
+        // (below the OS, #7000). The event records the binding (creator, account, device) — never the material.
+        | KeyHardwareBound of creator: string * account: string * device: string
+
+    /// The keyring = fold over the stream. Keys are keyed by `(identity, account)` so they **travel with the
+    /// identity** (the ZetaId) — fold the stream anywhere and the same keyring follows. Backend-invariant.
+    type KeyRing =
+        { Backend: Backend
+          Keys: Map<string * string, KeyRef> // (identity, account) → where the secret lives
+          Forwarded: Set<string * string * string> // (identity, account, target) grants
+          HardwareBindings: Set<string * string * string> } // (creator, account, device) hardware-rooted, keyed to creator
+
+    let empty backend =
+        { Backend = backend
+          Keys = Map.empty
+          Forwarded = Set.empty
+          HardwareBindings = Set.empty }
+
+    /// Apply one event. Capture = upsert (idempotent by (identity, account), #6); forward = set-add
+    /// (idempotent); revoke = remove the key AND every forward of it (consent withdrawal cascades, §6).
+    let apply (kr: KeyRing) (ev: KeyEvent) : KeyRing =
+        match ev with
+        | KeyCaptured(id, acct, r) -> { kr with Keys = Map.add (id, acct) r kr.Keys }
+        | KeyForwarded(id, acct, tgt) ->
+            { kr with
+                Forwarded = Set.add (id, acct, tgt) kr.Forwarded }
+        | KeyHardwareBound(creator, acct, device) ->
+            { kr with
+                HardwareBindings = Set.add (creator, acct, device) kr.HardwareBindings }
+        | KeyRevoked(id, acct) ->
+            { kr with
+                Keys = Map.remove (id, acct) kr.Keys
+                Forwarded = kr.Forwarded |> Set.filter (fun (i, a, _) -> not (i = id && a = acct))
+                HardwareBindings = kr.HardwareBindings |> Set.filter (fun (c, a, _) -> not (c = id && a = acct)) }
+
+    /// Fold a whole stream into a keyring — deterministic, replayable (DST §7), backend-INVARIANT (same stream
+    /// → same Keys on any backend; only durability differs).
+    let fold backend (events: KeyEvent list) : KeyRing =
+        List.fold apply (empty backend) events
+
+    /// The keys that **travel with** an identity (SSO — don't re-login everywhere; the keyring moves with you):
+    /// the keyring scoped to one identity, `account → KeyRef`.
+    let travelWith (identity: string) (kr: KeyRing) : Map<string, KeyRef> =
+        kr.Keys
+        |> Map.toSeq
+        |> Seq.choose (fun ((i, acct), r) -> if i = identity then Some(acct, r) else None)
+        |> Map.ofSeq
+
+    /// Install mode (#7004). `Live` = non-destructive (boot without wiping the host) — the **DEFAULT**, since
+    /// erase-by-default is too aggressive. `Erase` = wipe-and-install, opt-in only (must be explicitly chosen).
+    /// Orthogonal to the credential push below (a Live boot still pushes/binds keys); it governs whether the
+    /// host is wiped.
+    type InstallMode =
+        | Live // non-destructive — DEFAULT
+        | Erase // destructive — opt-in only
+
+    /// Live by default (#7004): never wipe the host unless `Erase` is explicitly chosen.
+    let defaultInstallMode = Live
+
+    /// Install-from-medium (#7002/#7003): push the credential DOWN to the host PC's hardware, and — ONLY if the
+    /// boot medium is **writable** (a USB, not a read-only ISO) — back into the medium's own hardware too. A
+    /// read-only ISO boot can't be pushed back to (#7003), so it yields the PC binding ONLY. Both bindings are
+    /// encrypted keyed to `creator` (the human who created the medium). Returns the stream events; fold them
+    /// like any others.
+    let installMediumEvents (creator: string) (account: string) (writable: bool) : KeyEvent list =
+        [ yield KeyHardwareBound(creator, account, PcHardware)
+          if writable then
+              yield KeyHardwareBound(creator, account, UsbHardware) ]
+
+    /// Convenience: a writable USB install → the bidirectional push (PC + USB hardware), both keyed to creator.
+    let installUsbEvents (creator: string) (account: string) : KeyEvent list =
+        installMediumEvents creator account true
+
+    [<Literal>]
+    let SeamName = "key"
+
+    /// Is this command on the `key` seam (`zeta key <verb> <noun>`)?
+    let isKeyCommand (cmd: ZetaCommand) = cmd.Seam = Some SeamName

--- a/tests/Tests.FSharp/KeyStore.Tests.fs
+++ b/tests/Tests.FSharp/KeyStore.Tests.fs
@@ -1,0 +1,78 @@
+module Zeta.Tests.KeyStoreTests
+
+open global.Xunit
+open Zeta.Core
+open Zeta.Core.KeyStore
+
+let private refOf backend handle = { Backend = backend; Handle = handle }
+
+[<Fact>]
+let ``capture then travelWith: the key follows the identity (SSO, no re-login)`` () =
+    let r = refOf LocalFile "vault/github"
+    let kr = fold defaultBackend [ KeyCaptured("aaron", "github", r) ]
+    let travelling = travelWith "aaron" kr
+    Assert.Equal(r, travelling.["github"])
+
+[<Fact>]
+let ``idempotency: capturing the same key twice == once`` () =
+    let r = refOf LocalFile "vault/github"
+    let once = fold defaultBackend [ KeyCaptured("aaron", "github", r) ]
+    let twice = fold defaultBackend [ KeyCaptured("aaron", "github", r); KeyCaptured("aaron", "github", r) ]
+    Assert.Equal<Map<string * string, KeyRef>>(once.Keys, twice.Keys)
+
+[<Fact>]
+let ``default backend is LocalFile`` () =
+    Assert.Equal(LocalFile, defaultBackend)
+
+[<Fact>]
+let ``backend-invariance: same stream folds to the same Keys on every backend`` () =
+    let stream = [ KeyCaptured("aaron", "github", refOf LocalFile "h1"); KeyCaptured("aaron", "aws", refOf LocalFile "h2") ]
+    let keys b = (fold b stream).Keys
+    for b in [ LocalFile; Vault; CloudKeyVault; PasswordManager; HardwareEnclave; GitHubSecrets ] do
+        Assert.Equal<Map<string * string, KeyRef>>(keys LocalFile, keys b)
+
+[<Fact>]
+let ``revoke cascades: removes the key AND its forwards AND its hardware bindings (consent withdrawal)`` () =
+    let kr =
+        fold
+            defaultBackend
+            [ KeyCaptured("aaron", "github", refOf Vault "h")
+              KeyForwarded("aaron", "github", "peer-ci")
+              KeyHardwareBound("aaron", "github", PcHardware)
+              KeyRevoked("aaron", "github") ]
+    Assert.False(kr.Keys.ContainsKey("aaron", "github"))
+    Assert.Empty(kr.Forwarded)
+    Assert.Empty(kr.HardwareBindings)
+
+[<Fact>]
+let ``revoke is idempotent: revoking an absent key is a no-op`` () =
+    let kr = fold defaultBackend [ KeyRevoked("ghost", "none"); KeyRevoked("ghost", "none") ]
+    Assert.Empty(kr.Keys)
+
+[<Fact>]
+let ``writable USB install: bidirectional push (PC + USB hardware), both keyed to creator`` () =
+    let kr = fold defaultBackend (installUsbEvents "aaron" "github")
+    Assert.True(kr.HardwareBindings.Contains("aaron", "github", PcHardware))
+    Assert.True(kr.HardwareBindings.Contains("aaron", "github", UsbHardware))
+
+[<Fact>]
+let ``read-only ISO boot: PC binding only — can't push back to a non-writable medium`` () =
+    let kr = fold defaultBackend (installMediumEvents "aaron" "github" false)
+    Assert.True(kr.HardwareBindings.Contains("aaron", "github", PcHardware))
+    Assert.False(kr.HardwareBindings.Contains("aaron", "github", UsbHardware))
+
+[<Fact>]
+let ``install mode defaults to Live (non-destructive) — erase is opt-in`` () =
+    Assert.Equal(Live, defaultInstallMode)
+
+[<Fact>]
+let ``GitHub secret scopes cascade most-specific to broadest`` () =
+    Assert.Equal<string list>([ "environment"; "repo"; "org"; "enterprise" ], gitHubSecretScopes)
+
+[<Fact>]
+let ``reference-not-copy: the stream/keyring carries only KeyRef pointers, never secret material`` () =
+    // A KeyRef is (Backend, Handle) — an address, not the secret. The keyring exposes only that.
+    let r = refOf CloudKeyVault "kv://prod/github-token"
+    let kr = fold defaultBackend [ KeyCaptured("aaron", "github", r) ]
+    let got = (travelWith "aaron" kr).["github"]
+    Assert.Equal("kv://prod/github-token", got.Handle) // a pointer, not the token

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -94,6 +94,7 @@
     <Compile Include="ZetaCli.Tests.fs" />
     <Compile Include="ZetaGraph.Tests.fs" />
     <Compile Include="Db.Tests.fs" />
+    <Compile Include="KeyStore.Tests.fs" />
     <Compile Include="DarkHall.Tests.fs" />
     <Compile Include="ITensor.Tests.fs" />
     <Compile Include="SagaSnapshot.Tests.fs" />


### PR DESCRIPTION
Aaron #7001-#7006, extends the one-stream db model (#6996) to credentials. KeyStore.fs: keys keyed by (identity,account) travel with identity (SSO); pluggable backend (LocalFile default|Vault|CloudKeyVault|PasswordManager|HardwareEnclave|GitHubSecrets), backend-invariant fold. Events on one stream (Captured/Forwarded/HardwareBound/Revoked). REFERENCE-NOT-COPY: stream carries KeyRef pointers, never secrets. Consent-gated: revoke cascades; abstraction-only (no real capture — needs Nazar review). Hardware custody: USB install pushes to PC+USB hw keyed to creator; writable-only push-back (ISO=PC only); Live install default (erase opt-in). GH secret scope cascade. zflash/QEMU: non-password auth path (pubkey/token); shadow will NOT take Aaron's GH password. 11/11 tests green, 0-warning. Honest scope: semantics floor, not a harvester. 🤖 Generated with [Claude Code](https://claude.com/claude-code)