### PR TITLE
feat(zflash): save WiFi + install-answers (diagnosed gap); 3-level install mode; erase-preserve; boot=heartbeat-to-git->k8s->argocd

### DIFF
--- a/docs/research/2026-06-07-zflash-credential-persistence-wifi-install-answers-three-level-erase-preserve-trace-continuity.md
+++ b/docs/research/2026-06-07-zflash-credential-persistence-wifi-install-answers-three-level-erase-preserve-trace-continuity.md
@@ -1,0 +1,119 @@
+# zflash credential persistence — WiFi + install-answers, 3-level erase/preserve, trace continuity
+
+**Aaron, 2026-06-07** (a diagnostic + design stream on `zflash` credential saving, #7006–#7011).
+
+## The diagnosed bug (root cause)
+
+> "the password saving didn't work last time in either direction (outwards/down to hardware, or
+> outwards/backwards to USB) … or it's not password — I don't think it's credentials saving — it should
+> **also save my WiFi credentials too** … and also **save the answers to my install questions** from
+> previous installs unless there are new questions or I choose to reanswer/reformat."
+
+**Root cause for WiFi:** the credential manifest (`tools/installer/zeta-creds-manifest.ts`) + handlers
+(`tools/installer/zeta-cred-handlers.ts`) only declared `gh-cli`, `claude`, `gemini`, `codex`,
+`ssh-host-keys`, `ssh-operator-pubkey`. **There was no `wifi` entry at all** — so WiFi creds could never
+save "in either direction": nothing captured them. Per the subsystem's own discipline (Aaron 2026-05-27:
+*"declare each credential we need… adding a new credential type = manifest edit, NOT a code change"*),
+the fix is a manifest + handler entry, not new flow code.
+
+### Fixed (this PR, B-0852; TS, 92/92 installer tests green)
+
+- **`wifi`** — manifest entry `paths: ["/etc/NetworkManager/system-connections"]`, `personaScoped:false`,
+  `required:false`. `WIFI_HANDLER` accepts JSON `{ssid, psk}` or `.nmconnection`/`wpa_supplicant` text;
+  **requires an SSID reference**; **never echoes the PSK** in error messages (P0 redaction discipline).
+- **`install-answers`** — manifest entry `paths: ["/etc/zeta/install-answers.json"]`, optional;
+  `INSTALL_ANSWERS_HANDLER` (JSON object). Saved answers are **reused** so previously-answered questions
+  aren't re-asked — *unless* a new question appears or the operator reanswers / chooses a fresh reformat.
+
+## Install mode — three levels (corrected, #7004/#7009/#7010)
+
+Aaron corrected the model twice; the final shape (F# `KeyStore.InstallMode`, 13/13 Core tests green):
+
+| mode | meaning |
+|---|---|
+| **`Live`** *(default)* | non-destructive boot; host untouched (erase-by-default is too aggressive) |
+| **`ErasePreserveConfig`** | erase OS/data but **preserve config/secrets first** — to **hardware first, USB fallback** if no enclave (`preserveTargets`) — before erasing; secrets survive |
+| **`EraseWipeConfig`** | also erase the preserved config/secrets — fully **fresh** (the only path that destroys the keyring) |
+
+### The erase-preserve round-trip (`erasePreserveFlow`, #7010)
+
+```
+preserve → use-before-format → format → repersist
+```
+
+Preserve config/secrets BEFORE format; **use** them during install so there's **no re-login / re-auth /
+re-config**; **re-persist** them to USB/hardware AFTER format. A **saga** (each phase fenced/idempotent;
+DurableSaga + discipline #6) so a crash mid-flow replays without losing or double-applying secrets.
+
+## Governing principles (#7011) — over the whole flow
+
+> "just always try to do the right thing at every timestep to preserve continuity — the span/trace id
+> from the USB event trigger — and don't recompute secrets/config that's already been computed."
+
+1. **Trace continuity.** The span/trace id is rooted at the **USB event trigger** and propagates through
+   every timestep of the flow (one distributed trace across preserve→use→format→repersist). Continuity
+   of identity/trace is the invariant; every event on the stream carries the trigger's trace id.
+2. **Don't recompute.** Secrets/config already computed are **reused, not recomputed** — idempotency
+   (#6) + content-addressing (CAS): compute-once, address-by-content, reuse on replay. This is exactly
+   why the erase-preserve flow *preserves and reuses* rather than re-deriving (no re-login/reauth).
+
+Both are already load-bearing disciplines (idempotency #6, DST §7, content-addressing); this names them
+as the explicit governing rule for the zflash install flow.
+
+## Boot sequence: heartbeat to git → k8s → ArgoCD → charts (#7012/#7013)
+
+> "when USB boots it should start heartbeating to git … after booting k8s and argocd and the charts."
+
+The booted USB node's startup sequence, each step an event on the one stream (#6997/#7000):
+
+```
+OsInstalled → first-heartbeat-to-git → k8s up → ArgoCD up → charts reconciled
+```
+
+1. **Heartbeat to git** — the node joins the fleet via the heartbeat-via-commit pattern (`CLAUDE.md`:
+   heartbeat = a commit to `origin/main`, the externalized idle counter + AgencySignature trailer). git
+   is the **db control plane** (#6994), so boot → emit heartbeat commits = register liveness on the same
+   shared event stream every other node folds.
+2. **k8s → ArgoCD → charts** — bring up Kubernetes, then ArgoCD, then the charts. This is **GitOps**:
+   ArgoCD's reconcile loop pulls desired state from **git** — the same control plane (#6994, "reconcile =
+   fold git → desired state"). The charts are declarative state in git; ArgoCD is the reconciler. (Cf.
+   #6994: CRDT + single-repo DUs *can* replace operators, but the concrete boot stack here is real
+   k8s+ArgoCD reconciling from git.)
+- **Continuity (#7011):** every step carries the trace id rooted at the USB trigger; one trace across
+  boot → heartbeat → k8s → ArgoCD → charts.
+- **Offline/airgapped:** heartbeats + chart state land in **local git**, **ferried** later (USB-ferry
+  vision below) — same stream, deferred transport.
+
+## Future / deferred (Aaron #7008/#7011) — captured, not built
+
+- **Always a reformat, retention is the axis** — the 3-level mode above is the realization.
+- **USB ferries for airgapped update (offline self-contained):** eventually the USB is **fully
+  self-contained — no internet needed to start a cluster**, and an **airgapped PC is updated purely via
+  USB ferries** (sneakernet transport of substrate DU events; ties the "ferries preserve memory" theme +
+  `FerryThrottler`). The install/update stream is the same DBSP Z-set stream (#6997/#7000), carried by
+  USB instead of network.
+- **Incremental updates / self-healing on the USB** — explicitly **not now** (deferred); the current
+  model is reformat-with-retention, not in-place incremental.
+
+## Honest scope (peel)
+
+- **Built + tested:** the `wifi` + `install-answers` manifest/handler entries (the diagnosed WiFi gap),
+  the 3-level `InstallMode`, `preserveTargets` (hardware-first/USB-fallback), `erasePreserveFlow` phase
+  order. TS 92/92, F# Core 13/13, 0-warning.
+- **NOT built:** the actual capture/restore *wiring* of WiFi/install-answers through the live install
+  (the manifest declares them; the persist/restore code iterates the manifest — verify it picks the new
+  entries up end-to-end in the QEMU harness before claiming the round-trip works). Trace-id propagation
+  and the saga fencing are *named/encoded as order*, not yet threaded through the live zflash flow.
+  Airgapped-ferry + offline-self-contained + incremental-healing are future. The original "didn't save in
+  either direction" runtime failure for non-WiFi creds still needs the failing run's logs to confirm
+  whether the WiFi gap was the whole story or there's a second write-path bug.
+
+## Anchors (Beacon)
+
+- NetworkManager `.nmconnection` / `wpa_supplicant` (WiFi cred formats); GNOME Keyring / macOS Keychain.
+- Distributed tracing — W3C Trace Context, OpenTelemetry span/trace ids (the continuity principle).
+- Idempotency / content-addressing — discipline #6, CAS/Merkle/BLAKE3 (don't-recompute).
+- Sagas — Garcia-Molina & Salem 1987 (`DurableSaga`; the fenced preserve→format→repersist flow).
+- Sneakernet / air-gapped update transport (USB ferries).
+- Internal: B-0852 (zflash cred substrate), B-0891 (QEMU 5-scenario matrix incl. reformat-with-retention
+  / reformat-from-scratch), #6996/#6998 (db + key noun-classes, one stream), #7000 (OS/USB/login events).

--- a/src/Core/KeyStore.fs
+++ b/src/Core/KeyStore.fs
@@ -112,16 +112,35 @@ module KeyStore =
         |> Seq.choose (fun ((i, acct), r) -> if i = identity then Some(acct, r) else None)
         |> Map.ofSeq
 
-    /// Install mode (#7004). `Live` = non-destructive (boot without wiping the host) — the **DEFAULT**, since
-    /// erase-by-default is too aggressive. `Erase` = wipe-and-install, opt-in only (must be explicitly chosen).
-    /// Orthogonal to the credential push below (a Live boot still pushes/binds keys); it governs whether the
-    /// host is wiped.
+    /// Install mode — three levels (Aaron #7004/#7009), increasingly destructive:
+    ///   `Live`                = non-destructive boot, host untouched — the **DEFAULT** (erase-by-default is
+    ///                           too aggressive).
+    ///   `ErasePreserveConfig` = erase OS/data, but **preserve config/secrets first** — to hardware, falling
+    ///                           back to the USB if no hardware enclave exists — BEFORE erasing. Secrets survive.
+    ///   `EraseWipeConfig`     = erase including the preserved config/secrets — fully **fresh** (opt-in on top
+    ///                           of erase; the only path that destroys the keyring).
     type InstallMode =
         | Live // non-destructive — DEFAULT
-        | Erase // destructive — opt-in only
+        | ErasePreserveConfig // erase OS/data; preserve config/secrets first (hardware, USB fallback)
+        | EraseWipeConfig // also erase config/secrets — fully fresh
 
-    /// Live by default (#7004): never wipe the host unless `Erase` is explicitly chosen.
+    /// Live by default (#7004): never wipe the host unless an `Erase*` mode is explicitly chosen.
     let defaultInstallMode = Live
+
+    /// Where `ErasePreserveConfig` saves config/secrets before erasing (#7009): **hardware first, USB fallback
+    /// if no hardware enclave exists.** Returns the ordered preserve targets for the given host capability.
+    let preserveTargets (hasHardwareEnclave: bool) : string list =
+        if hasHardwareEnclave then [ PcHardware ] else [ UsbHardware ]
+
+    /// The `ErasePreserveConfig` round-trip (Aaron #7010), in order. Preserve config/secrets BEFORE format,
+    /// **use** them during install so there's no re-login / re-auth / re-config, then **re-persist** them to
+    /// USB/hardware AFTER format. A saga (each phase fenced/idempotent; #6/DurableSaga) so a crash mid-flow
+    /// replays without losing or double-applying secrets.
+    let erasePreserveFlow: string list =
+        [ "preserve" // save config/secrets → hardware (USB fallback) before erasing
+          "use-before-format" // reuse them during install: no relogin / reauth / reconfig
+          "format" // erase OS/data
+          "repersist" ] // write config/secrets back to USB/hardware after format
 
     /// Install-from-medium (#7002/#7003): push the credential DOWN to the host PC's hardware, and — ONLY if the
     /// boot medium is **writable** (a USB, not a read-only ISO) — back into the medium's own hardware too. A

--- a/tests/Tests.FSharp/KeyStore.Tests.fs
+++ b/tests/Tests.FSharp/KeyStore.Tests.fs
@@ -66,6 +66,15 @@ let ``install mode defaults to Live (non-destructive) — erase is opt-in`` () =
     Assert.Equal(Live, defaultInstallMode)
 
 [<Fact>]
+let ``erase preserves config to hardware first, USB fallback when no enclave`` () =
+    Assert.Equal<string list>([ PcHardware ], preserveTargets true)
+    Assert.Equal<string list>([ UsbHardware ], preserveTargets false)
+
+[<Fact>]
+let ``erase-preserve flow is preserve -> use-before-format -> format -> repersist`` () =
+    Assert.Equal<string list>([ "preserve"; "use-before-format"; "format"; "repersist" ], erasePreserveFlow)
+
+[<Fact>]
 let ``GitHub secret scopes cascade most-specific to broadest`` () =
     Assert.Equal<string list>([ "environment"; "repo"; "org"; "enterprise" ], gitHubSecretScopes)
 

--- a/tools/installer/zeta-cred-handlers.test.ts
+++ b/tools/installer/zeta-cred-handlers.test.ts
@@ -16,8 +16,10 @@ import {
   DEFAULT_HANDLERS,
   GEMINI_HANDLER,
   GH_CLI_HANDLER,
+  INSTALL_ANSWERS_HANDLER,
   SSH_HOST_KEYS_HANDLER,
   SSH_OPERATOR_PUBKEY_HANDLER,
+  WIFI_HANDLER,
   parseBakeCredArg,
   resolveBakeCred,
   resolveValueSource,
@@ -232,9 +234,18 @@ describe("SSH_HOST_KEYS_HANDLER (Phase 1 deferred)", () => {
 });
 
 describe("DEFAULT_HANDLERS registry", () => {
-  it("registers all 6 default manifest entries", () => {
+  it("registers all 8 default manifest entries", () => {
     expect(Object.keys(DEFAULT_HANDLERS).sort()).toEqual(
-      ["claude", "codex", "gemini", "gh-cli", "ssh-host-keys", "ssh-operator-pubkey"].sort(),
+      [
+        "claude",
+        "codex",
+        "gemini",
+        "gh-cli",
+        "install-answers",
+        "ssh-host-keys",
+        "ssh-operator-pubkey",
+        "wifi",
+      ].sort(),
     );
   });
 });
@@ -299,5 +310,53 @@ describe("resolveBakeCred — full pipeline", () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
+  });
+});
+
+describe("WIFI_HANDLER", () => {
+  it("is registered in DEFAULT_HANDLERS", () => {
+    expect(DEFAULT_HANDLERS["wifi"]).toBe(WIFI_HANDLER);
+  });
+
+  it("accepts JSON with an ssid field", () => {
+    expect(WIFI_HANDLER.validateValue(Buffer.from(JSON.stringify({ ssid: "home-net", psk: "secret" })))).toBeNull();
+  });
+
+  it("accepts .nmconnection-style text with an ssid= line", () => {
+    expect(WIFI_HANDLER.validateValue(Buffer.from("[wifi]\nssid=home-net\n[wifi-security]\npsk=secret\n"))).toBeNull();
+  });
+
+  it("rejects empty value", () => {
+    expect(WIFI_HANDLER.validateValue(Buffer.from(""))).not.toBeNull();
+  });
+
+  it("rejects JSON object without an ssid", () => {
+    expect(WIFI_HANDLER.validateValue(Buffer.from(JSON.stringify({ psk: "secret" })))).not.toBeNull();
+  });
+
+  it("rejects text with no ssid reference", () => {
+    expect(WIFI_HANDLER.validateValue(Buffer.from("just some bytes"))).not.toBeNull();
+  });
+
+  it("never echoes the value (PSK) in its error message", () => {
+    const err = WIFI_HANDLER.validateValue(Buffer.from("top-secret-psk-no-ssid"));
+    expect(err).not.toBeNull();
+    expect(err!).not.toContain("top-secret-psk");
+  });
+});
+
+describe("INSTALL_ANSWERS_HANDLER", () => {
+  it("is registered in DEFAULT_HANDLERS", () => {
+    expect(DEFAULT_HANDLERS["install-answers"]).toBe(INSTALL_ANSWERS_HANDLER);
+  });
+
+  it("accepts a JSON object of saved answers", () => {
+    expect(
+      INSTALL_ANSWERS_HANDLER.validateValue(Buffer.from(JSON.stringify({ hostname: "node-1", timezone: "UTC" }))),
+    ).toBeNull();
+  });
+
+  it("rejects non-JSON", () => {
+    expect(INSTALL_ANSWERS_HANDLER.validateValue(Buffer.from("not json"))).not.toBeNull();
   });
 });

--- a/tools/installer/zeta-cred-handlers.ts
+++ b/tools/installer/zeta-cred-handlers.ts
@@ -117,6 +117,43 @@ export const SSH_HOST_KEYS_HANDLER: CredHandler = {
   },
 };
 
+/**
+ * Handler for wifi — NetworkManager .nmconnection content (SSID + PSK). Aaron 2026-06-07: zflash should also
+ * save WiFi credentials. Accept either a JSON object `{ssid, psk}` or raw .nmconnection / wpa_supplicant text;
+ * require that it references an SSID so we don't silently bake junk. SECURITY: never echo the value (the PSK)
+ * in error messages — reference the id only.
+ */
+export const WIFI_HANDLER: CredHandler = {
+  id: "wifi",
+  supportedSources: ["literal", "file", "env"],
+  validateValue(value) {
+    if (value.length === 0) return "wifi value must be non-empty";
+    const s = value.toString("utf8");
+    if (s.trim().length === 0) return "wifi value must be non-whitespace";
+    // JSON form: must be an object carrying an ssid. Text form: must mention an SSID (.nmconnection has
+    // `ssid=` under [wifi]; wpa_supplicant has `ssid="..."`). Either way require an SSID reference.
+    try {
+      const parsed = JSON.parse(s);
+      if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+        return "wifi JSON value must be an object with at least an 'ssid' field";
+      }
+      if (typeof (parsed as Record<string, unknown>).ssid !== "string") {
+        return "wifi JSON value must include a string 'ssid' field";
+      }
+      return null;
+    } catch {
+      // Not JSON — accept as raw connection text iff it references an SSID.
+      if (!/(^|\n)\s*ssid\s*=/i.test(s)) {
+        return "wifi text value must be a .nmconnection / wpa_supplicant blob containing an 'ssid=' line (or JSON with an 'ssid' field)";
+      }
+      return null;
+    }
+  },
+};
+
+/** Handler for install-answers — saved answers to install prompts; JSON object (Aaron 2026-06-07). */
+export const INSTALL_ANSWERS_HANDLER = makeJsonHandler("install-answers");
+
 /** Default registry of handlers, keyed by manifest id. */
 export const DEFAULT_HANDLERS: Readonly<Record<string, CredHandler>> = {
   "gh-cli": GH_CLI_HANDLER,
@@ -125,6 +162,8 @@ export const DEFAULT_HANDLERS: Readonly<Record<string, CredHandler>> = {
   codex: CODEX_HANDLER,
   "ssh-operator-pubkey": SSH_OPERATOR_PUBKEY_HANDLER,
   "ssh-host-keys": SSH_HOST_KEYS_HANDLER,
+  wifi: WIFI_HANDLER,
+  "install-answers": INSTALL_ANSWERS_HANDLER,
 };
 
 /**

--- a/tools/installer/zeta-creds-manifest.test.ts
+++ b/tools/installer/zeta-creds-manifest.test.ts
@@ -55,6 +55,19 @@ describe("DEFAULT_MANIFEST", () => {
       expect(entry.paths.length).toBeGreaterThan(0);
     }
   });
+
+  it("declares wifi as optional, host-level (Aaron 2026-06-07: save WiFi creds too)", () => {
+    const entry = DEFAULT_MANIFEST.credentials.find((c) => c.id === "wifi");
+    expect(entry).toBeDefined();
+    expect(entry!.required).toBe(false);
+    expect(entry!.personaScoped).toBe(false);
+  });
+
+  it("declares install-answers as optional (reused unless new questions / fresh reformat)", () => {
+    const entry = DEFAULT_MANIFEST.credentials.find((c) => c.id === "install-answers");
+    expect(entry).toBeDefined();
+    expect(entry!.required).toBe(false);
+  });
 });
 
 describe("validateManifest — accepts well-formed input", () => {

--- a/tools/installer/zeta-creds-manifest.ts
+++ b/tools/installer/zeta-creds-manifest.ts
@@ -96,6 +96,27 @@ export const DEFAULT_MANIFEST: Manifest = {
       required: true,
       notes: "Operator's SSH pubkey injected by iter-4.2 ESP write. Composes with that channel.",
     },
+    {
+      id: "wifi",
+      paths: ["/etc/NetworkManager/system-connections"],
+      personaScoped: false,
+      required: false,
+      notes:
+        "WiFi credentials (Aaron 2026-06-07): NetworkManager .nmconnection files (SSID + PSK under [wifi]/" +
+        "[wifi-security]). Host-level network config, not per-AI. Optional (re-enter acceptable), but persisting " +
+        "means you don't re-type WiFi every install. Reformat-from-scratch ('fresh') re-enters.",
+    },
+    {
+      id: "install-answers",
+      paths: ["/etc/zeta/install-answers.json"],
+      personaScoped: false,
+      required: false,
+      notes:
+        "Saved answers to install prompts (Aaron 2026-06-07): reused across installs so previously-answered " +
+        "questions are NOT re-asked — UNLESS a new question appears, or the operator chooses to reanswer / a " +
+        "'fresh' reformat-from-scratch is selected (B-0891 scenario). Retention ties to install mode: " +
+        "Live/retain reuses; fresh/Erase re-prompts.",
+    },
   ],
 };
 


### PR DESCRIPTION
Diagnosed: WiFi 'didn't save in either direction' because there was NO wifi manifest entry (only gh/claude/gemini/codex/ssh). Fixed additively per subsystem discipline (cred type = manifest edit): wifi + install-answers manifest entries + handlers (WIFI requires ssid, never echoes PSK; install-answers JSON, reused unless new question/fresh). 3-level InstallMode: Live(default)|ErasePreserveConfig(preserve to hardware-first/USB-fallback before erase)|EraseWipeConfig(fully fresh); erasePreserveFlow preserve->use-before-format->format->repersist (saga). Principles: trace continuity (span/trace from USB trigger) + don't-recompute (idempotency/CAS). Boot: heartbeat-to-git (git=control plane #6994) -> k8s -> ArgoCD -> charts (GitOps). TS 92/92, Core 13/13, 0-warning. Honest scope: entries+mode built; live capture/restore wiring not yet verified in QEMU; original non-wifi failure needs logs. 🤖 Generated with [Claude Code](https://claude.com/claude-code)