### PR TITLE
feat(core): file noun-class — files & folders as events on the one stream; pluggable/hexagonal backends (ExternalFs|DagFs|S3)

### DIFF
--- a/docs/research/2026-06-07-file-noun-class-files-folders-events-on-the-one-stream.md
+++ b/docs/research/2026-06-07-file-noun-class-files-folders-events-on-the-one-stream.md
@@ -1,0 +1,77 @@
+# The `file` noun-class — files & folders as events on the one stream
+
+**Aaron, 2026-06-07** (#7016–#7018):
+
+> "we need a zeta fs or zeta file for working with files … I like `file` better than `fs` (F# uses `fs`) …
+> we likely need file, folder, and entry — the generic word for file-or-folder … `entry` seems too generic
+> for a global namespace noun; it's not obvious it's file-related."
+
+## What was built (`src/Core/File.fs`, module `Files`, 9/9 tests green, 0-warning)
+
+Another interface (#6992) on the universal grammar — same shape as `Db` (#6996) / `KeyStore` (#6998):
+operations are events on the ONE DBSP Z-set stream (#6997/#7000), folded into a tree; deterministic +
+replayable (DST §7). Over `db`'s flat key/value, the `file` noun-class adds **folders** and **move/copy**
+(subtree-aware) and **content-by-hash**.
+
+- **Seam: `file`** (not `fs` — collides with F#/`fsharp`). `SeamName = "file"`, `isFileCommand`.
+- **`FileEntry`** — the file-or-folder type: `File of contentHash | Folder`. Named **`FileEntry`**, not
+  bare `Entry` (#7018: a global noun must be obviously file-related).
+- **`FileEvent`** on the stream: `Write(path, contentHash)` · `MkFolder path` · `Remove path`
+  (prefix-cascade) · `Move(src,dst)` · `Copy(src,dst)`.
+- **`fold` / `apply`** → `FileState { Entries: Map<path, FileEntry> }`; plus `readHash`, `listFolder`
+  (immediate children, ordinal-sorted).
+
+## Pluggable backends + hexagonal (Aaron #7019/#7020)
+
+`file` has pluggable backends like `db` (#6995) — **`ExternalFs`** (real OS multi-file paths) ·
+**`DagFs`** (internal single-file content-addressed; the default) · **`ObjectStore`** (S3 / MinIO / any
+S3-compatible). The fold is **backend-invariant** (same stream → same tree on all three; tested). And the
+governing principle Aaron stated: **every interface should be pluggable and hexagonal (ports & adapters)
+across all the CLIs** — the noun-class is the *port*; each backend is an *adapter*; the semantics
+(event-fold) live in the port, swappable underneath. (`db`, `key`, `file` all follow this; it's the
+standing rule for new noun-classes.)
+
+## Entries depend on their parent folders (#7021/#7022/#7023)
+
+> "in our fs a file just depends on its parent folders … more accurately, two FileEntries with the same
+> name can't depend on the same folder."
+
+- **Parent-folder dependson.** A `FileEntry` (file *or* folder) **dependson** its parent folder — the
+  dependency edge of the file tree, identical to `Db`'s `DepSetup` (#6996): the parent must be "set up"
+  (exist) before the child. `parent path` / `ancestors path` give those edges; `ZetaGraph.topoOrder`
+  (#6984) sequences parent folders before children on the one stream. So `file write /d/x dependson /d`.
+- **Name unique within a folder — at the *FileEntry* level.** Because the full path is the key, two
+  **FileEntries** (file or folder, #7023) with the same name can't both depend on the same parent folder —
+  they are the **same node** (last write wins; can't coexist). This is the ZetaCli "**unique-in-scope
+  noun**" rule, scope = parent folder; validates `FileEntry` + `Map<path, FileEntry>`. (Tested.)
+
+## Load-bearing disciplines
+
+- **Reference-not-copy / no-binary-in-proof-lineage.** A `Write` carries a **content HASH** (BLAKE3 CAS
+  pointer into `ContentStore`/`DagFs`), NEVER the bytes. The stream stays text + diffable; bytes live in
+  the content store (dedup + verify for free). This is the single-file/DagFs backend of `db` (#6995)
+  given proper file/folder semantics. `readHash` returns the pointer; the caller resolves bytes.
+- **Idempotency (#6), named honestly.** `Write` / `MkFolder` are upserts; `Remove` is a prefix-cascade
+  tombstone ⇒ apply-N == apply-once. `Move` / `Copy` are **transformations, NOT idempotent** (re-applying
+  after the source moved nets a different effect) — named per the discipline; treat like Z-set
+  corrections, not dedup-guarded upserts. (Tested: write/upsert, remove-cascade, move file + subtree,
+  copy-keeps-source, listFolder one-level, fold determinism.)
+- **Culture-invariant.** All path comparison/sort is `Ordinal` (subtree prefix checks, `listFolder` sort).
+
+## Honest scope (peel)
+
+Semantics layer built + tested as a pure F# oracle: the event DU, the tree fold, files/folders, move/copy
+subtree relocation, content-by-hash, listing. NOT built: the live bridge to a real filesystem or to
+`ContentStore`/`DagFs` (it traffics in hash *strings* — wiring `Write` to actually store bytes in the CAS
+and `readHash` to fetch them is the named next step), and the `file` verbs in `ZetaCli`'s grammar (a `file`
+seam command → `FileEvent`). It's the file/folder semantics floor, sharing the one stream + the `db`
+pluggable backends (#6995).
+
+## Anchors (Beacon)
+
+- **Content-addressed filesystems / Merkle trees** — git tree objects, IPFS/IPLD, our `DagFs`/
+  `ContentStore` (BLAKE3); content-by-hash is the prior art for reference-not-copy file storage.
+- **Event-sourced / log-structured filesystems** — the fold-over-events tree (cf. `db` #6994).
+- **POSIX file/dir + move/rename semantics** — the operation vocabulary (file/folder/move/copy).
+- Internal: #6996 (db one-stream + backends), #6998 (KeyStore parallel), #6995 (single-file/DagFs
+  backend), #6992 ("another interface"), manifesto §7 DST / §8 DV2.0, idempotency #6, culture-invariant rule.

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -170,6 +170,7 @@
     <Compile Include="ZetaGraph.fs" />
     <Compile Include="Db.fs" />
     <Compile Include="KeyStore.fs" />
+    <Compile Include="File.fs" />
     <Compile Include="DarkHall.fs" />
     <Compile Include="Consent/KskAuthorization.fs" />
   </ItemGroup>

--- a/src/Core/File.fs
+++ b/src/Core/File.fs
@@ -1,0 +1,134 @@
+namespace Zeta.Core
+
+/// **The `file` noun-class — files & folders as events on the one stream.**
+///
+/// Aaron #7016/#7017: *"we need a zeta file for working with files … I like `file` better than `fs` (fsharp
+/// uses fs); we likely need file, folder, and entry — the generic word for file-or-folder."* So: the seam is
+/// **`file`**; an **`Entry`** is the generic (a **`File`** addressed by content hash, or a **`Folder`**).
+///
+/// Same shape as `Db` (#6996) / `KeyStore` (#6998): operations are events on the ONE DBSP Z-set stream
+/// (#6997/#7000), folded into a tree; deterministic + replayable (DST §7). Over `db`'s flat key/value, the
+/// `file` noun-class adds **folders** and **move/copy** (subtree-aware), and **content-by-hash**.
+///
+/// **Reference-not-copy / no-binary-in-proof-lineage:** a `Write` carries a **content HASH** (a CAS pointer —
+/// BLAKE3, the `ContentStore`/`DagFs` address), NEVER the file bytes. The stream stays text + diffable; the
+/// bytes live in the content store (dedup + verify for free). This is the single-file/DagFs backend of `db`
+/// (#6995) given proper file/folder semantics.
+///
+/// Idempotency (#6): `Write` / `MkFolder` are upserts and `Remove` is a prefix-cascade tombstone ⇒ apply-N ==
+/// apply-once. `Move` / `Copy` are **transformations, NOT idempotent** (re-applying after the source moved is a
+/// no-op with a different net effect) — named here per the discipline; treat them like Z-set corrections, not
+/// dedup-guarded upserts. F# reference oracle; C#/Rust/TS ports follow.
+module Files =
+
+    open ZetaCli
+
+    /// A file-or-folder (Aaron #7017): a `File` (content addressed by hash) or a `Folder`. Named `FileEntry`
+    /// (not bare `Entry`) so the global noun is obviously file-related (#7018).
+    type FileEntry =
+        | File of contentHash: string // CAS pointer (BLAKE3) into ContentStore/DagFs — NOT the bytes
+        | Folder
+
+    /// An event (`+1` delta) on the one stream. Paths are the keys; `Write` carries a content HASH, not bytes.
+    type FileEvent =
+        | Write of path: string * contentHash: string // upsert a file at path with the given content hash
+        | MkFolder of path: string // upsert a folder at path
+        | Remove of path: string // remove path and all descendants (prefix cascade)
+        | Move of src: string * dst: string // move a file/subtree (NOT idempotent)
+        | Copy of src: string * dst: string // copy a file/subtree (NOT idempotent)
+
+    /// Pluggable backend (Aaron #7019, mirrors `Db.Backend` #6995): an **external** OS filesystem (real
+    /// multi-file paths) or our **internal single-file content-addressed `DagFs`**. The fold is backend-
+    /// INVARIANT — the same stream folds to the same tree on either; only WHERE entries + content durably land
+    /// differs (external: real files; DagFs: one content-addressed file).
+    type Backend =
+        | ExternalFs // an existing OS filesystem (multi-file, real paths)
+        | DagFs // internal single-file content-addressed filesystem (our DagFs/ContentStore)
+        | ObjectStore // S3 / MinIO / any S3-compatible object store (#7020)
+
+    /// DagFs by default: self-contained + content-addressed (zeta-native); `ExternalFs` is opt-in.
+    let defaultBackend = DagFs
+
+    /// The materialized tree = fold over the stream. `path → FileEntry`. `Backend` records where entries +
+    /// content durably land (it does not change the fold result — see `Backend`).
+    type FileState =
+        { Backend: Backend
+          Entries: Map<string, FileEntry> }
+
+    let empty backend = { Backend = backend; Entries = Map.empty }
+
+    /// True when `path` is `prefix` itself or lies under `prefix/` (subtree membership).
+    let private isUnderOrEqual (prefix: string) (path: string) : bool =
+        path = prefix || path.StartsWith(prefix + "/", System.StringComparison.Ordinal)
+
+    /// Re-key a path from under `src` to under `dst` (subtree relocation).
+    let private reKey (src: string) (dst: string) (path: string) : string =
+        dst + path.Substring(src.Length)
+
+    /// Apply one stream event. Deterministic; ordinal throughout (culture-invariant).
+    let apply (st: FileState) (ev: FileEvent) : FileState =
+        match ev with
+        | Write(p, h) -> { st with Entries = Map.add p (File h) st.Entries }
+        | MkFolder p -> { st with Entries = Map.add p Folder st.Entries }
+        | Remove p ->
+            { st with Entries = st.Entries |> Map.filter (fun k _ -> not (isUnderOrEqual p k)) }
+        | Move(src, dst) ->
+            let moved =
+                st.Entries |> Map.toList |> List.filter (fun (k, _) -> isUnderOrEqual src k)
+            let without =
+                st.Entries |> Map.filter (fun k _ -> not (isUnderOrEqual src k))
+            let relocated =
+                moved |> List.fold (fun (m: Map<string, FileEntry>) (k, v) -> Map.add (reKey src dst k) v m) without
+            { st with Entries = relocated }
+        | Copy(src, dst) ->
+            let copied =
+                st.Entries |> Map.toList |> List.filter (fun (k, _) -> isUnderOrEqual src k)
+            let withCopy =
+                copied |> List.fold (fun (m: Map<string, FileEntry>) (k, v) -> Map.add (reKey src dst k) v m) st.Entries
+            { st with Entries = withCopy }
+
+    /// Fold a whole stream into a tree on a backend — deterministic, replayable (DST §7), backend-INVARIANT.
+    let fold backend (events: FileEvent list) : FileState = List.fold apply (empty backend) events
+
+    /// Read a file's content hash at `path` (None if absent or a folder). The caller resolves the hash against
+    /// the ContentStore/DagFs to get the bytes (reference-not-copy).
+    let readHash (path: string) (st: FileState) : string option =
+        match Map.tryFind path st.Entries with
+        | Some(File h) -> Some h
+        | _ -> None
+
+    /// List the immediate children of a folder `path` (one level), sorted ordinal for determinism.
+    let listFolder (path: string) (st: FileState) : string list =
+        let prefix = if path = "/" then "/" else path + "/"
+        st.Entries
+        |> Map.toList
+        |> List.map fst
+        |> List.filter (fun k -> k <> path && k.StartsWith(prefix, System.StringComparison.Ordinal))
+        // immediate children only: no further "/" after the prefix
+        |> List.filter (fun k -> not (k.Substring(prefix.Length).Contains "/"))
+        |> List.sortWith (fun a b -> System.String.CompareOrdinal(a, b))
+
+    /// A path's **parent folder** — the dependson edge of the file tree (Aaron #7021: *"a file just depends on
+    /// its parent folders"*). `None` for a top-level path (`/x`) or root (`/`). The parent must be "set up"
+    /// (exist) before the child, exactly like `Db`'s `DepSetup` (#6996); topo-order over these edges
+    /// (`ZetaGraph.topoOrder`, #6984) sequences parent folders before their children on the one stream.
+    let parent (path: string) : string option =
+        match path.LastIndexOf '/' with
+        | i when i > 0 -> Some(path.Substring(0, i))
+        | _ -> None
+
+    /// All ancestor folders of a path, ordered shallowest → deepest (root-most first). These are the file's
+    /// `dependson` chain: each must precede the next, and all precede the path itself.
+    let ancestors (path: string) : string list =
+        let rec up acc p =
+            match parent p with
+            | Some par -> up (par :: acc) par
+            | None -> acc
+
+        up [] path
+
+    [<Literal>]
+    let SeamName = "file"
+
+    /// Is this command on the `file` seam (`zeta file <verb> <noun>`)?
+    let isFileCommand (cmd: ZetaCommand) = cmd.Seam = Some SeamName

--- a/tests/Tests.FSharp/File.Tests.fs
+++ b/tests/Tests.FSharp/File.Tests.fs
@@ -1,0 +1,88 @@
+module Zeta.Tests.FileTests
+
+open global.Xunit
+open Zeta.Core
+open Zeta.Core.Files
+
+[<Fact>]
+let ``write then read returns the content hash (reference-not-copy: hash, not bytes)`` () =
+    let st = fold defaultBackend [ Write("/a.txt", "blake3:abc") ]
+    Assert.Equal(Some "blake3:abc", readHash "/a.txt" st)
+
+[<Fact>]
+let ``write is upsert; idempotent by path`` () =
+    let once = fold defaultBackend [ Write("/a", "h1") ]
+    let twice = fold defaultBackend [ Write("/a", "h1"); Write("/a", "h1") ]
+    Assert.Equal<Map<string, FileEntry>>(once.Entries, twice.Entries)
+
+[<Fact>]
+let ``remove cascades over a folder subtree`` () =
+    let st =
+        fold defaultBackend
+            [ MkFolder "/d"
+              Write("/d/x", "h1")
+              Write("/d/sub/y", "h2")
+              Write("/keep", "h3")
+              Remove "/d" ]
+    Assert.False(st.Entries.ContainsKey "/d")
+    Assert.False(st.Entries.ContainsKey "/d/x")
+    Assert.False(st.Entries.ContainsKey "/d/sub/y")
+    Assert.True(st.Entries.ContainsKey "/keep")
+
+[<Fact>]
+let ``remove of an absent path is a no-op (idempotent)`` () =
+    let st = fold defaultBackend [ Remove "/ghost"; Remove "/ghost" ]
+    Assert.Equal<Map<string, FileEntry>>(Map.empty, st.Entries)
+
+[<Fact>]
+let ``move relocates a file`` () =
+    let st = fold defaultBackend [ Write("/a", "h1"); Move("/a", "/b") ]
+    Assert.False(st.Entries.ContainsKey "/a")
+    Assert.Equal(Some "h1", readHash "/b" st)
+
+[<Fact>]
+let ``move relocates a whole subtree`` () =
+    let st = fold defaultBackend [ Write("/d/x", "h1"); Write("/d/sub/y", "h2"); Move("/d", "/e") ]
+    Assert.False(st.Entries.ContainsKey "/d/x")
+    Assert.Equal(Some "h1", readHash "/e/x" st)
+    Assert.Equal(Some "h2", readHash "/e/sub/y" st)
+
+[<Fact>]
+let ``copy duplicates a subtree, keeping the source`` () =
+    let st = fold defaultBackend [ Write("/d/x", "h1"); Copy("/d", "/e") ]
+    Assert.Equal(Some "h1", readHash "/d/x" st) // source kept
+    Assert.Equal(Some "h1", readHash "/e/x" st) // copy made
+
+[<Fact>]
+let ``listFolder returns immediate children only, sorted ordinal`` () =
+    let st = fold defaultBackend [ Write("/d/b", "h"); Write("/d/a", "h"); Write("/d/sub/deep", "h"); MkFolder "/d/sub" ]
+    Assert.Equal<string list>([ "/d/a"; "/d/b"; "/d/sub" ], listFolder "/d" st)
+
+[<Fact>]
+let ``fold is deterministic / replayable: same stream, same tree`` () =
+    let stream = [ Write("/a", "h1"); MkFolder "/d"; Write("/d/x", "h2"); Move("/a", "/d/a") ]
+    Assert.Equal<Map<string, FileEntry>>((fold defaultBackend stream).Entries, (fold defaultBackend stream).Entries)
+
+[<Fact>]
+let ``default backend is DagFs (internal single-file); ExternalFs is opt-in`` () =
+    Assert.Equal(DagFs, defaultBackend)
+
+[<Fact>]
+let ``name is unique within a folder: two same-named files under one folder are one node (last wins)`` () =
+    // #7022: two files with the same name can't both depend on the same folder — same path = same node.
+    let st = fold defaultBackend [ Write("/d/x", "h1"); Write("/d/x", "h2") ]
+    Assert.Equal(Some "h2", readHash "/d/x" st) // last write wins
+    Assert.Equal<string list>([ "/d/x" ], listFolder "/d" st) // one child, not two
+
+[<Fact>]
+let ``a file dependson its parent folder; ancestors are the dependson chain root-first`` () =
+    Assert.Equal(Some "/d/sub", parent "/d/sub/x")
+    Assert.Equal(None, parent "/x") // top-level: no folder dep
+    Assert.Equal(None, parent "/") // root
+    Assert.Equal<string list>([ "/d"; "/d/sub" ], ancestors "/d/sub/x")
+
+[<Fact>]
+let ``backend-invariance: same stream folds to the same tree on external fs and DagFs`` () =
+    let stream = [ Write("/a", "h1"); MkFolder "/d"; Write("/d/x", "h2"); Move("/a", "/d/a") ]
+    Assert.Equal<Map<string, FileEntry>>((fold ExternalFs stream).Entries, (fold DagFs stream).Entries)
+    Assert.Equal<Map<string, FileEntry>>((fold ExternalFs stream).Entries, (fold ObjectStore stream).Entries)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -95,6 +95,7 @@
     <Compile Include="ZetaGraph.Tests.fs" />
     <Compile Include="Db.Tests.fs" />
     <Compile Include="KeyStore.Tests.fs" />
+    <Compile Include="File.Tests.fs" />
     <Compile Include="DarkHall.Tests.fs" />
     <Compile Include="ITensor.Tests.fs" />
     <Compile Include="SagaSnapshot.Tests.fs" />


### PR DESCRIPTION
Aaron #7016-#7023. module Files (seam 'file', not fs). FileEntry = File of contentHash | Folder. FileEvent on the one stream (Write/MkFolder/Remove-cascade/Move/Copy, subtree-aware). Reference-not-copy (content HASH, never bytes). Pluggable+hexagonal backends ExternalFs|DagFs(default)|ObjectStore(S3/MinIO), backend-invariant fold — the standing rule: every interface = port, backend = adapter. Parent-folder dependson (= Db DepSetup; parent/ancestors + topoOrder); name unique within a folder at the FileEntry level (file OR folder; same path = same node = unique-in-scope noun). Idempotency named (Move/Copy are transformations, not idempotent). 13/13 green, 0-warning. Honest scope: semantics floor; live FS/DagFs/S3 bridge + ZetaCli file verbs not built. 🤖 Generated with [Claude Code](https://claude.com/claude-code)