### PR TITLE
feat(core): file extensions — folder templates, branch deps, static git-native graph, self-hosting meta-recursive fs

### DIFF
--- a/docs/research/2026-06-07-file-folder-templates-branch-deps-static-gitnative-fs-graph.md
+++ b/docs/research/2026-06-07-file-folder-templates-branch-deps-static-gitnative-fs-graph.md
@@ -1,0 +1,80 @@
+# `file` extensions — folder templates, branch deps, the static git-native fs graph
+
+**Aaron, 2026-06-07** (#7024–#7026), extending the `file` noun-class (#7002).
+
+## 1. Folder-layout templates + instance dependson (#7024)
+
+> "we should be able to have folder layout templates like yyyy/mm/dd or whatever and have a file depend on
+> an instance of that template chain."
+
+A **`FolderTemplate`** is an ordered list of **`Segment`**s — each a fixed `Lit` or a named `Placeholder`
+(e.g. `[Placeholder "yyyy"; Placeholder "mm"; Placeholder "dd"]`). An **instance** binds the placeholders
+to values, yielding a concrete folder chain a file `dependson` (#7021). Built (module `Files`):
+
+- `instantiate root bindings tmpl` → `Ok "/logs/2026/06/07"` (or `Error "<unbound placeholder>"`).
+- `fileUnderTemplate root bindings tmpl name` → the file's full **dependson chain**: every folder of the
+  instantiated chain root-first, then the file path — exactly the `ancestors` edges (#7021), produced by
+  the template and resolved by `ZetaGraph.topoOrder` (#6984). Literals mix with placeholders.
+
+So a date-partitioned layout is a *template*; `2026/06/07` is an *instance*; the log file dependson that
+instance's folder chain.
+
+## 2. FileEntries can dependson branches (#7025)
+
+> "file entries can depend on branches."
+
+Beyond parent folders, a `FileEntry`'s `dependson` may reference a **git branch** (a git ref — the
+git-native control-plane backend, #6994): `dependson branch:main`. This is the "git-ref ZetaId pointer"
+convention (per-repo registries) applied to file deps. Built: `branchRef "main"` → `"branch:main"`;
+`isBranchDep` distinguishes a branch token from a folder path. The git backend resolves the branch; a file
+can thus depend on a folder chain *and* a branch (cross-branch/versioned file deps).
+
+## 3. The filesystem graph exists statically in git-native format (#7026)
+
+> "now our filesystem graph can exist statically too in git-native format."
+
+The whole fs graph — the file/folder tree + its dependson edges — isn't only a runtime fold; it can be a
+**static, content-addressed git-native artifact.** This is git's own model: **folders ≡ git tree
+objects, files ≡ git blobs addressed by content hash** (Merkle DAG, BLAKE3). So the `file` noun-class's
+`FileState` maps directly onto git-native storage — *defined, not calculated* (the full-graph-known-
+statically theme, #6972), and the **git-native `db` backend** (#6994/#6995) given file/folder shape. The
+runtime fold and the static git-native tree are two views of the same graph: fold the event stream → the
+tree; serialize the tree → git objects; both content-addressed, both diffable, both DST-replayable.
+
+## 4. Self-hosting, meta-recursive filesystem (#7027)
+
+> "the filesystem can be self-hosted now where the filesystem's metadata is a file within the filesystem
+> itself … meta-recursive filesystem."
+
+The fs is **self-describing**: its own metadata (the graph from #7026) is stored **AS a `FileEntry` within
+itself**, at a well-known path `MetaPath = "/.zeta/fs.meta"` whose content hash addresses the serialized
+graph (git-native, #7026). This is **meta-recursion** — the filesystem contains its own description —
+recursive / self-similar (manifesto §9/§10), the same shape as git storing its own refs, a compiler that
+compiles itself, or a Lisp metacircular evaluator. **This generalizes across noun-classes (Aaron #7028):**
+just as file-metadata is a file, **table-metadata is itself a table** (the system-catalog pattern —
+Postgres `pg_catalog`, SQLite `sqlite_master`); self-hosting is the standing meta-recursive principle for
+every noun-class (homoiconic CLI≡file≡data). (`table`/`stream` nouns themselves are the next interface,
+#7029 — the DBSP stream↔table duality.) Built: `MetaPath`, `isSelfHosted st` (true when the
+metadata file is present in the tree). The fs bootstraps from a file inside itself; no external metadata
+store needed (ties the airgapped/self-contained goal #7008 — the fs needs nothing outside itself).
+
+## Honest scope (peel)
+
+Built + tested (19/19 `file` tests green, 0-warning): `Segment`/`FolderTemplate`, `instantiate` (with
+unbound-placeholder error), `fileUnderTemplate` (instance dependson chain), `branchRef`/`isBranchDep`,
+`MetaPath`/`isSelfHosted`.
+NOT built: the actual **serialization** of `FileState` to git tree/blob objects (the static git-native
+artifact is *described*, mapping folders→trees / files→blobs, but no writer/reader is implemented — that's
+the git-native `db` backend driver, still unbuilt #6995), and template/branch-dep wiring into the
+`ZetaCli` grammar. Semantics + dependency-shape floor, not the storage driver.
+
+## Anchors (Beacon)
+
+- **git object model** — tree (folder) + blob (file) + content-hash; the static git-native fs graph is
+  git's native representation (Torvalds; Merkle DAG).
+- **Date-partitioned / templated layouts** — Hive-style partitioning (`yyyy/mm/dd`), log rotation paths;
+  path templates as prior art for folder-layout templates.
+- **Content addressing / defined-not-calculated** — IPFS/IPLD, Nix store; #6972 (full graph defined, not
+  calculated), #6994 (git control plane), #6995 (pluggable db backends incl. git-native + DagFs).
+- Internal: #7002 (file noun-class), #7021 (parent-folder dependson), #6984 (topoOrder), #6996 (db one
+  stream + DepSetup).

--- a/src/Core/File.fs
+++ b/src/Core/File.fs
@@ -127,6 +127,84 @@ module Files =
 
         up [] path
 
+    // ── Folder-layout templates (Aaron #7024) ──────────────────────────────────────────────────────────
+    //
+    // A folder-layout template like `yyyy/mm/dd` is an ordered list of segments — each a fixed literal or a
+    // named placeholder. An INSTANCE binds the placeholders to values, yielding a concrete folder chain. A
+    // file then `dependson` an *instance* of that template chain (its parent folders, #7021) — the same
+    // DepSetup / topo-order machinery, with the parent chain produced by the template.
+
+    /// A template segment: a fixed `Lit` or a named `Placeholder` (e.g. `Placeholder "yyyy"`).
+    type Segment =
+        | Lit of string
+        | Placeholder of string
+
+    /// A folder-layout template, e.g. `[ Placeholder "yyyy"; Placeholder "mm"; Placeholder "dd" ]`.
+    type FolderTemplate = Segment list
+
+    /// Resolve each segment against `bindings` (placeholder name → value). `Error name` for the first unbound
+    /// placeholder. Literals pass through. Deterministic.
+    let private resolveSegments (bindings: Map<string, string>) (tmpl: FolderTemplate) : Result<string list, string> =
+        let rec go acc segs =
+            match segs with
+            | [] -> Ok(List.rev acc)
+            | Lit s :: rest -> go (s :: acc) rest
+            | Placeholder p :: rest ->
+                match Map.tryFind p bindings with
+                | Some v -> go (v :: acc) rest
+                | None -> Error p
+
+        go [] tmpl
+
+    /// Instantiate a template under `root` with `bindings`, yielding the concrete folder path
+    /// (e.g. root="/logs", yyyy/mm/dd + {yyyy=2026;mm=06;dd=07} → "/logs/2026/06/07"). `Error name` if a
+    /// placeholder is unbound. Ordinal/deterministic.
+    let instantiate (root: string) (bindings: Map<string, string>) (tmpl: FolderTemplate) : Result<string, string> =
+        resolveSegments bindings tmpl
+        |> Result.map (fun parts ->
+            let suffix = String.concat "/" parts
+            if root = "/" then "/" + suffix
+            elif suffix = "" then root
+            else root + "/" + suffix)
+
+    /// The full `dependson` chain for a file placed at `name` under a template instance: every folder of the
+    /// instantiated chain (root-most first) followed by the file path itself. `Error name` if unbound. This is
+    /// what the file `dependson` — the instance of the template chain (#7024), resolved by topo-order (#6984).
+    let fileUnderTemplate
+        (root: string)
+        (bindings: Map<string, string>)
+        (tmpl: FolderTemplate)
+        (name: string)
+        : Result<string list, string> =
+        instantiate root bindings tmpl
+        |> Result.map (fun folder ->
+            let filePath = if folder = "/" then "/" + name else folder + "/" + name
+            ancestors filePath @ [ filePath ])
+
+    [<Literal>]
+    let private BranchPrefix = "branch:"
+
+    /// A `dependson` token for a **git branch** (Aaron #7025: *"file entries can depend on branches"*). Beyond
+    /// parent folders (#7021), a `FileEntry`'s `dependson` may reference a branch (a git ref — the git-native
+    /// control-plane backend, #6994), e.g. `dependson branch:main`. The git backend resolves it; this is the
+    /// "git-ref ZetaId pointer" convention (per-repo registries) applied to file deps. `branchRef "main"`
+    /// → `"branch:main"`.
+    let branchRef (name: string) : string = BranchPrefix + name
+
+    /// Does this `dependson` token name a branch (vs a folder path)? True for `branch:<name>`.
+    let isBranchDep (dep: string) : bool = dep.StartsWith(BranchPrefix, System.StringComparison.Ordinal)
+
+    /// The well-known path of the filesystem's **own metadata, stored AS a file within itself** (Aaron #7027:
+    /// *"self-hosted … meta-recursive filesystem"*). The fs is self-describing: its graph/metadata is a
+    /// `FileEntry` at this path (content hash → the serialized graph, git-native #7026). Recursive / self-
+    /// similar (manifesto §9/§10) — the same as git storing its own refs, or a compiler that compiles itself.
+    [<Literal>]
+    let MetaPath = "/.zeta/fs.meta"
+
+    /// True when the filesystem is **self-hosted**: its metadata exists as a `FileEntry` within itself
+    /// (meta-recursive). The meta file's content hash addresses the serialized graph.
+    let isSelfHosted (st: FileState) : bool = Map.containsKey MetaPath st.Entries
+
     [<Literal>]
     let SeamName = "file"
 

--- a/tests/Tests.FSharp/File.Tests.fs
+++ b/tests/Tests.FSharp/File.Tests.fs
@@ -68,6 +68,46 @@ let ``default backend is DagFs (internal single-file); ExternalFs is opt-in`` ()
     Assert.Equal(DagFs, defaultBackend)
 
 [<Fact>]
+let ``folder template yyyy/mm/dd instantiates to a concrete folder path`` () =
+    let tmpl = [ Placeholder "yyyy"; Placeholder "mm"; Placeholder "dd" ]
+    let bindings = Map [ "yyyy", "2026"; "mm", "06"; "dd", "07" ]
+    Assert.Equal(Ok "/logs/2026/06/07", instantiate "/logs" bindings tmpl)
+
+[<Fact>]
+let ``template instantiation errors on an unbound placeholder`` () =
+    let tmpl = [ Placeholder "yyyy"; Placeholder "mm" ]
+    Assert.Equal(Error "mm", instantiate "/logs" (Map [ "yyyy", "2026" ]) tmpl)
+
+[<Fact>]
+let ``a file dependson an instance of the template chain (folders root-first, then the file)`` () =
+    let tmpl = [ Placeholder "yyyy"; Placeholder "mm"; Placeholder "dd" ]
+    let bindings = Map [ "yyyy", "2026"; "mm", "06"; "dd", "07" ]
+    let chain = fileUnderTemplate "/logs" bindings tmpl "app.log"
+    Assert.Equal<Result<string list, string>>(
+        Ok [ "/logs"; "/logs/2026"; "/logs/2026/06"; "/logs/2026/06/07"; "/logs/2026/06/07/app.log" ],
+        chain
+    )
+
+[<Fact>]
+let ``literal segments mix with placeholders in a template`` () =
+    let tmpl = [ Lit "logs"; Placeholder "yyyy" ]
+    Assert.Equal(Ok "/srv/logs/2026", instantiate "/srv" (Map [ "yyyy", "2026" ]) tmpl)
+
+[<Fact>]
+let ``file entries can dependson a branch (git ref)`` () =
+    Assert.Equal("branch:main", branchRef "main")
+    Assert.True(isBranchDep (branchRef "main"))
+    Assert.False(isBranchDep "/d/x") // a folder path is not a branch dep
+
+[<Fact>]
+let ``self-hosted meta-recursive fs: metadata is a file within the filesystem itself`` () =
+    let bare = fold defaultBackend [ Write("/d/x", "h1") ]
+    Assert.False(isSelfHosted bare)
+    let selfHosted = fold defaultBackend [ Write("/d/x", "h1"); Write(MetaPath, "blake3:graph") ]
+    Assert.True(isSelfHosted selfHosted)
+    Assert.Equal(Some "blake3:graph", readHash MetaPath selfHosted)
+
+[<Fact>]
 let ``name is unique within a folder: two same-named files under one folder are one node (last wins)`` () =
     // #7022: two files with the same name can't both depend on the same folder — same path = same node.
     let st = fold defaultBackend [ Write("/d/x", "h1"); Write("/d/x", "h2") ]


### PR DESCRIPTION
Aaron #7024-#7028. Folder-layout templates (Segment/FolderTemplate, instantiate, fileUnderTemplate dependson chain). Branch deps (branchRef/isBranchDep — FileEntry dependson a git branch). Static git-native fs graph (folders=trees, files=blobs-by-hash; defined-not-calculated). Self-hosting meta-recursive fs (MetaPath/isSelfHosted — metadata is a file within itself), generalizing to table-meta-is-a-table (system catalog). 19/19 green, 0-warning. Honest scope: semantics floor; git tree/blob serialization + ZetaCli wiring not built. 🤖 Generated with [Claude Code](https://claude.com/claude-code)