### PR TITLE
feat(core): table & stream nouns (DBSP duality, meta-events in-band); interface-vs-noun rule; block-storage requirement

### DIFF
--- a/docs/research/2026-06-07-block-storage-primitive-requirement-hitchhiker-trees-out-of-band.md
+++ b/docs/research/2026-06-07-block-storage-primitive-requirement-hitchhiker-trees-out-of-band.md
@@ -1,0 +1,64 @@
+# Block-storage primitive — requirement & scope (hitchhiker trees, out-of-band blocks)
+
+**Aaron, 2026-06-07 (#7035)** — a requirement-capture, NOT a build (this is a large primitive needing the
+full Zeta protocol):
+
+> "we prob need some hitchhiker trees or something to support large files, or some non-table-based files
+> too, or out-of-band block storage; we likely need block-storage algebra and code and tests and tearing
+> and seed treaty and 4-lang and 4-serializer and such."
+
+## Why it's needed (where it sits)
+
+The layering is `stream → table → file` (#7034): tables/files are folds of the one event stream, with
+content referenced by hash (reference-not-copy, #7002). That works for *structured/small* content, but:
+
+- **Large files** don't belong inline in the event stream (no-binary-in-proof-lineage; the stream stays
+  text/diffable). They need **out-of-band block storage** — the bytes live in blocks addressed by hash;
+  the stream/table/file holds only the pointer (already the `File of contentHash` shape, #7002).
+- **Non-table-based / opaque files** (media, binaries) aren't naturally rows — they're block sequences.
+- **Big mutable structures** need a persistent, log-structured, copy-on-write index — **hitchhiker
+  trees** (a B-tree / append-log hybrid: batches writes in-node then flushes, giving good write amplitude
+  + structural sharing; used by Datomic / Datahike) are the named candidate.
+
+So block storage is the layer **under `stream`** for large/opaque content: `block` = an out-of-band,
+content-addressed byte range; `file`/`table` reference blocks by hash; a hitchhiker tree indexes them.
+
+## Scope — this is a full primitive, needs the standard protocol
+
+Aaron named the full treatment, which is exactly the Zeta primitive-development protocol (NOT a single
+tick):
+
+- **Block-storage algebra** — the operations + laws (content-address, split/chunk, concat, dedup, GC;
+  likely a monoid/semilattice over blocks; chunking via FastCDC, already in-repo).
+- **Code** — the F# reference implementation (+ hitchhiker-tree index for large mutable structures).
+- **Tests + tearing** — property tests + **DST tearing** (fault/partial-write injection; "tearing" =
+  torn-write / crash-mid-block fault classes — the durability story).
+- **Seed treaty** — the canonical golden-vector seed (hex-in-JSON, no-binary-in-proof-lineage) that the
+  oracles agree on.
+- **4-lang oracle** — F# (reference) + C# + Rust + TS conformance.
+- **4-serializer** — CBOR / Arrow / protobuf / (JSON) byte-locked golden vectors.
+
+This is multi-PR work and should be a **backlog item**, routed through the primitive registry + likely
+Soraya (formal coverage: which properties get TLA+/Z3/FsCheck) and Naledi (perf: block size, write
+amplification). It is explicitly **not built here** — this doc records the requirement, the placement
+(under `stream`, out-of-band), the prior art, and the protocol it must follow.
+
+## Honest scope (peel)
+
+Requirement + scoping only. No block-storage code, algebra, tests, seed, oracle, or serializer exists yet.
+The `File of contentHash` pointer (#7002) and `ContentStore`/`CasStore`/`DagFs`/`FastCdc` already in-repo
+are the substrate this would build on (content-addressing + chunking are present; the block-storage
+*algebra* + hitchhiker-tree index + the full 4×4 protocol are the gap). Next step: file a backlog item and
+route to the primitive process — do not let this capture read as "done."
+
+## Anchors (Beacon)
+
+- **Hitchhiker trees** — David Greenberg (Datomic/Datahike); fractal/Bε-trees (Bender et al.); the
+  write-batching B-tree + structural-sharing design.
+- **Content-addressed block storage** — IPFS/IPLD, Git packfiles, restic/borg chunk stores, ZFS blocks;
+  **FastCDC** content-defined chunking (Xia et al. 2016 — already `FastCdc.fs`).
+- **Out-of-band large objects** — Postgres TOAST/large objects, S3 multipart, Git LFS.
+- **Torn-write / tearing durability** — power-loss/atomicity testing; DST fault injection (`ChaosEnv`).
+- Internal: #7002 (`File of contentHash`), #6995 (pluggable backends incl. DagFs), #7034 (stream→table→
+  file layering), `ContentStore.fs`/`CasStore.fs`/`DagFs.fs`/`FastCdc.fs`, no-binary-in-proof-lineage,
+  seed-treaty / 4-lang / 4-serializer disciplines.

--- a/docs/research/2026-06-07-table-stream-nouns-duality-meta-events-in-band-interface-vs-noun.md
+++ b/docs/research/2026-06-07-table-stream-nouns-duality-meta-events-in-band-interface-vs-noun.md
@@ -1,0 +1,88 @@
+# `table` & `stream` nouns — the duality, meta-events in-band, and interface-vs-noun
+
+**Aaron, 2026-06-07** (#7029–#7032), plus the design question "how to decide what's an interface vs a noun."
+
+## `table` & `stream` — one or the other (#7029), built
+
+`src/Core/TableStream.fs` (module `TableStream`, 5/5 tests green, 0-warning). The **stream is the
+primitive** (the ordered changelog of deltas = the one DBSP Z-set stream #6997); a **table is its fold**
+(materialized current state). "One or the other" = two views of the same data:
+
+- `toTable stream` — fold the changelog → current state.
+- `toStream table` — the `Upsert` deltas that reconstruct the table (ordinal-sorted).
+- Duality: `toTable (toStream t) = t` (tested). Kafka KStream/KTable; DBSP; CQRS event-log vs read-model.
+
+`db` (#6996), `file` (#7002), `key` (#6998) are all this one pattern — a table/tree/keyring folded from a
+stream.
+
+## Stream-metadata is a meta event in-band (#7031/#7032)
+
+Aaron's sharpening: stream-metadata isn't a *separate* stream — it's **an event within the same stream as
+the data**: there are `Meta` events interleaved over the one stream (in-band self-description).
+
+- `Delta = Upsert | Retract | Meta(key, value)` — data events and `Meta` events on the SAME stream.
+- `toTable` folds the data events → the table; `toMeta` folds the `Meta` events → the metadata. Two
+  projections over ONE stream (tested). The self-hosting meta-recursion (#7027/#7028: file-meta is a file,
+  table-meta is a table) **bottoms out here**: both are folds of a stream, and stream-meta is just more
+  events on that stream — nothing more primitive, no separate meta-stream.
+- **Prior art (Aaron #7033):** **CloudEvents** (envelope metadata carried with the event) and the
+  **Debezium CDC** stream protocol (each change event carries schema + payload + source metadata) — both
+  already in the repo (`CloudEvents.fs`, `DebeziumCdc.fs`). Meta-in-band is exactly their shape.
+
+## Interface vs noun — the decision rule (#7030)
+
+> "I'm not sure how to decide what's an interface vs a noun."
+
+The grammar is `[seam] verb noun [dependson]`. The cut:
+
+- **Interface (= seam = "noun-class")** — a **port**: it has its own **verb set** + **pluggable backends**
+  (adapters). It *classifies a family* of things and defines the operations + where they persist. Examples:
+  `db`, `file`, `key`, `table`, `stream`, `container`, `cell`, `research`, `sim`. (In code: a `SeamName` +
+  `is<X>Command` + a `Backend` DU.)
+- **Noun** — an addressable **instance** the interface's verbs act on: a **ZetaId / unique-in-scope name**,
+  with **no verbs or backends of its own**. Examples: `users:42`, `/logs/app.log`, `branch:main`,
+  `compiler.rust`.
+
+**Decision test:**
+1. Does it have a *verb set* and *pluggable backends* (ports & adapters)? → **interface/seam.**
+2. Is it a *specific thing* those verbs operate on, named by ZetaId / unique-in-scope? → **noun.**
+3. Write the command: in `zeta <X> <verb> <Y>`, `<X>` (the integration plane + its verbs/backends) is the
+   **interface**; `<Y>` (the instance) is the **noun**.
+
+So what we've loosely called "noun-classes" (db/file/key/table/stream) are precisely **interfaces (seams)**
+— each *classifies* a family of nouns. The **noun is the instance**; the **interface is the noun-class**.
+Corollary (hexagonal, #7019): a thing earns interface status by having a port (verbs) + adapters
+(backends); if it has neither and is just an addressed instance, it's a noun. `table`/`stream` are dual
+*views* of the one stream substrate — they can be one interface with two projections rather than two rival
+seams.
+
+## Layering: streams under tables under files (#7034)
+
+Aaron: *"streams under tables and tables under files."* The composition stack:
+
+```
+stream  (deltas / the primitive event log)
+  └─ table   = fold(stream)            — materialized rows
+       └─ file = a table (+folders)    — the file/folder tree (#7002) is a table view with hierarchy
+```
+
+A **table is a fold of a stream**; a **file (tree) is a table** with path hierarchy + folders. So `file`
+sits on `table` sits on `stream` — each a higher-level view of the one substrate. (Block storage —
+captured separately — is what sits *under* stream for large/opaque content, out-of-band.)
+
+## Honest scope (peel)
+
+Built + tested: `TableStream` (Delta incl. `Meta`, `toTable`/`toStream` duality, `toMeta` in-band metadata,
+seam predicates), 5/5 green, 0-warning. The interface-vs-noun rule is a **taxonomy clarification** (no
+code) — it names what the existing `SeamName`/`Backend` pattern already encodes. NOT built: `table`/`stream`
+verbs in the `ZetaCli` grammar; whether `table`+`stream` collapse to one seam with two views is left open.
+
+## Anchors (Beacon)
+
+- **Stream↔table duality:** Kafka Streams (KStream/KTable), DBSP (Budiu 2022), CQRS/event sourcing
+  (Fowler/Young), Materialize/ksqlDB.
+- **Meta-in-band:** CloudEvents spec; Debezium CDC change-event envelope (schema+payload+source); Kafka
+  record headers. (`CloudEvents.fs`, `DebeziumCdc.fs`.)
+- **Ports & adapters (hexagonal):** Cockburn — the interface-as-port / backend-as-adapter cut.
+- Internal: #6996 (db one stream), #7002 (file), #6998 (key), #7027/#7028 (self-hosting meta-recursion),
+  #7019 (pluggable/hexagonal), #6997/#7000 (everything-is-events on one stream).

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -171,6 +171,7 @@
     <Compile Include="Db.fs" />
     <Compile Include="KeyStore.fs" />
     <Compile Include="File.fs" />
+    <Compile Include="TableStream.fs" />
     <Compile Include="DarkHall.fs" />
     <Compile Include="Consent/KskAuthorization.fs" />
   </ItemGroup>

--- a/src/Core/TableStream.fs
+++ b/src/Core/TableStream.fs
@@ -1,0 +1,84 @@
+namespace Zeta.Core
+
+/// **The `table` and `stream` noun-classes — the DBSP table↔stream duality.**
+///
+/// Aaron #7029: *"we should have a table and stream nouns/interfaces — one or the other too."* #7031: *"stream
+/// metadata is just a stream too; this is the ultimate base of table-meta-as-table and file-meta-as-file."*
+///
+/// The **stream is the primitive** — the ordered changelog of deltas, i.e. the one DBSP Z-set stream
+/// (#6997/#7000). A **table is its fold** — the materialized current state. They are "one or the other": two
+/// views of the same data (Kafka KStream/KTable; DBSP; CQRS read-model vs event-log):
+///   - `table = toTable stream`  (fold the changelog → current state)
+///   - `stream = toStream table` (the upsert deltas that reconstruct the table)
+/// with the duality `toTable (toStream t) = t`.
+///
+/// **`db` (#6996), `file` (#7002), `key` (#6998) are all this pattern** — a table/tree/keyring folded from a
+/// stream. So `stream` is the ULTIMATE BASE of the self-hosting meta-recursion (#7027/#7028): file-meta is a
+/// file and table-meta is a table because both are folds of a stream — and (Aaron #7032) **stream-metadata is
+/// just an event WITHIN THE SAME STREAM as the data**: there are `Meta` events interleaved over the stream,
+/// in-band. The recursion bottoms out here — the stream describes itself with its own events; nothing more
+/// primitive, and no *separate* meta-stream. Fold the data events → the table; fold the `Meta` events → the
+/// metadata; both from the ONE stream.
+///
+/// Idempotency (#6): `Upsert`/`Retract`/`Meta` are upsert/tombstone ⇒ apply-N == apply-once; the fold is
+/// deterministic + replayable (DST §7). F# reference oracle; C#/Rust/TS ports follow.
+module TableStream =
+
+    open ZetaCli
+
+    /// A stream delta (DBSP Z-set style). Data events (`Upsert`/`Retract`) AND **`Meta` events live on the
+    /// SAME stream** (Aaron #7032: stream-metadata is an event within the same stream as the data — in-band).
+    type Delta =
+        | Upsert of key: string * value: string // data: set a keyed row
+        | Retract of key: string // data: remove a keyed row
+        | Meta of key: string * value: string // META: describes the stream itself, in-band, same stream
+
+    /// The `stream` noun: the ordered changelog of deltas (the primitive).
+    type Stream = Delta list
+
+    /// The `table` noun: materialized current state (the fold of a stream).
+    type Table = Map<string, string>
+
+    let emptyTable: Table = Map.empty
+
+    /// Apply one delta to the DATA table. Upsert = set; Retract = remove (idempotent, #6). `Meta` events do
+    /// NOT affect the data table (they fold into the metadata view instead — `toMeta`).
+    let applyDelta (t: Table) (d: Delta) : Table =
+        match d with
+        | Upsert(k, v) -> Map.add k v t
+        | Retract k -> Map.remove k t
+        | Meta _ -> t
+
+    /// `table = fold(data events of stream)` — the materialized view (deterministic, replayable; DST §7).
+    let toTable (s: Stream) : Table = List.fold applyDelta emptyTable s
+
+    /// The metadata view = fold of the **`Meta` events on the same stream** (#7032). Stream-metadata is in-band;
+    /// this is just a second projection over the one stream — no separate meta-stream.
+    let toMeta (s: Stream) : Table =
+        s
+        |> List.fold
+            (fun (m: Table) d ->
+                match d with
+                | Meta(k, v) -> Map.add k v m
+                | _ -> m)
+            emptyTable
+
+    /// `stream = changelog(table)` — the `Upsert` deltas that reconstruct the table, keys ordinal-sorted for
+    /// determinism. Round-trips: `toTable (toStream t) = t` (the duality).
+    let toStream (t: Table) : Stream =
+        t
+        |> Map.toList
+        |> List.sortWith (fun (a, _) (b, _) -> System.String.CompareOrdinal(a, b))
+        |> List.map Upsert
+
+    [<Literal>]
+    let StreamSeamName = "stream"
+
+    [<Literal>]
+    let TableSeamName = "table"
+
+    /// Is this command on the `stream` seam (`zeta stream <verb> <noun>`)?
+    let isStreamCommand (cmd: ZetaCommand) = cmd.Seam = Some StreamSeamName
+
+    /// Is this command on the `table` seam (`zeta table <verb> <noun>`)?
+    let isTableCommand (cmd: ZetaCommand) = cmd.Seam = Some TableSeamName

--- a/tests/Tests.FSharp/TableStream.Tests.fs
+++ b/tests/Tests.FSharp/TableStream.Tests.fs
@@ -1,0 +1,39 @@
+module Zeta.Tests.TableStreamTests
+
+open global.Xunit
+open Zeta.Core
+open Zeta.Core.TableStream
+
+[<Fact>]
+let ``table = fold(stream): deltas materialize to current state`` () =
+    let s = [ Upsert("a", "1"); Upsert("b", "2"); Upsert("a", "3"); Retract "b" ]
+    let t = toTable s
+    Assert.Equal("3", t.["a"])
+    Assert.False(t.ContainsKey "b")
+
+[<Fact>]
+let ``duality: toTable (toStream t) = t`` () =
+    let t = Map [ "a", "1"; "b", "2"; "c", "3" ]
+    Assert.Equal<Table>(t, toTable (toStream t))
+
+[<Fact>]
+let ``toStream is deterministic: keys ordinal-sorted`` () =
+    let t = Map [ "b", "2"; "a", "1" ]
+    Assert.Equal<Stream>([ Upsert("a", "1"); Upsert("b", "2") ], toStream t)
+
+[<Fact>]
+let ``idempotency: applying the same upsert twice == once`` () =
+    Assert.Equal<Table>(toTable [ Upsert("a", "1") ], toTable [ Upsert("a", "1"); Upsert("a", "1") ])
+
+[<Fact>]
+let ``meta events live on the SAME stream as data; toMeta folds only them`` () =
+    // #7032: stream-metadata is an event within the same stream as the data (in-band).
+    let s = [ Upsert("a", "1"); Meta("schema", "v2"); Upsert("b", "2"); Meta("owner", "aaron") ]
+    let data = toTable s
+    let meta = toMeta s
+    // data view sees only data events
+    Assert.Equal<string list>([ "a"; "b" ], data |> Map.toList |> List.map fst)
+    // meta view sees only meta events — same one stream
+    Assert.Equal("v2", meta.["schema"])
+    Assert.Equal("aaron", meta.["owner"])
+    Assert.False(meta.ContainsKey "a")

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -96,6 +96,7 @@
     <Compile Include="Db.Tests.fs" />
     <Compile Include="KeyStore.Tests.fs" />
     <Compile Include="File.Tests.fs" />
+    <Compile Include="TableStream.Tests.fs" />
     <Compile Include="DarkHall.Tests.fs" />
     <Compile Include="ITensor.Tests.fs" />
     <Compile Include="SagaSnapshot.Tests.fs" />


### PR DESCRIPTION
Aaron #7029-#7035. TableStream.fs: table & stream = DBSP duality (toTable/toStream, round-trip proven); Meta events IN-BAND on the same stream (toTable folds data, toMeta folds meta) — self-hosting recursion bottoms out here; prior art CloudEvents/Debezium. Docs: interface-vs-noun decision rule (interface=port w/ verbs+backends; noun=instance); stream->table->file layering; block-storage requirement (hitchhiker trees, out-of-band, UNDER stream) scoped as a full primitive (algebra/4-lang/4-serializer/seed/tearing) — requirement-only, NOT built, file a backlog item. 5/5 green, 0-warning. 🤖 Generated with [Claude Code](https://claude.com/claude-code)