### PR TITLE
feat(core): Catalog — catalog as metadata tables, ensure -> DML-delta DU (no DDL, built)

### DIFF
--- a/docs/research/2026-06-07-catalog-as-metadata-tables-ensure-built.md
+++ b/docs/research/2026-06-07-catalog-as-metadata-tables-ensure-built.md
@@ -1,0 +1,56 @@
+# Catalog as metadata tables — `ensure` → DML-delta DU, built
+
+**Otto, 2026-06-07** (chosen work, when Aaron asked "what do you want to work on"): make the no-DDL
+principle real in code. This turns #7038/#7039/#7040 from captures into a tested artifact.
+
+## What was built (`src/Core/Catalog.fs`, module `Catalog`, tests green, 0-warning)
+
+The catalog lives in **metadata tables** (ordinary `TableStream` rows — metadata is homoiconic to data,
+#7038), so there is **no DDL** — schema management is **DML on catalog rows (#7039)**, and you don't write
+that DML by hand: it's derived from `ensure` (#7040).
+
+- **Catalog rows** (homoiconic — the catalog IS a table): `table:<name>` → `"1"`,
+  `column:<table>.<col>` → `<type>`.
+- **`ensure schema current : Delta list`** — the automatic schema evolution **as a DU over the DML
+  meta-updates**: diff the desired `Schema` against the current catalog table, return the ordered
+  `Upsert`/`Retract` deltas to evolve current → desired. **Idempotent** (#6): an already-satisfied schema
+  → `[]`. Deterministic (ordinal-sorted).
+- **`evolve`** folds those deltas into the catalog; **`readSchema`** reads it back (round-trips).
+
+So every DDL operation collapses to DML, derived from a declarative `ensure`:
+
+| DDL | `ensure` derives |
+|---|---|
+| CREATE TABLE | `Upsert table:… ` + `Upsert column:….*` |
+| ALTER ADD / CHANGE TYPE | `Upsert column:…` (new/changed row) |
+| DROP COLUMN | `Retract column:…` |
+| DROP TABLE | `Retract` table row + all its column rows |
+
+Tested: create-collapses-to-upserts, idempotent re-ensure → `[]`, add/change/drop column, drop table,
+`evolve`+`readSchema` round-trip, full create→alter→drop lifecycle.
+
+## Why this one
+
+It's the concrete embodiment of the last four captures (#7038 homoiconic metadata → #7039 no DDL → #7040
+ensure→DU), self-contained on `TableStream`, and it makes "schema migration is just deltas on the one
+stream" executable: an `ensure` produces a `Delta list` that is the same `Upsert`/`Retract` the data plane
+uses — so it inherits DST replay, CRDT merge, idempotency, golden vectors, git versioning for free.
+
+## Honest scope (peel)
+
+A clean, tested **oracle**: string-typed catalog rows (matching the `TableStream` oracle; the
+`DynamicValue` homoiconicity gap from #7038 still applies — full realization carries `DynamicValue`).
+NOT wired into the `ZetaCli` grammar (no `zeta ensure <schema>` verb yet), and `ensure` derives the delta
+*set* but does not yet enforce ordering constraints (e.g. column-before-its-table on apply — applied as a
+set, which is fine for upserts; a real engine would also validate referential constraints). It proves the
+principle executably; production wiring (grammar verb, DynamicValue values, constraint validation) is the
+named next step.
+
+## Anchors (Beacon)
+
+- **Schema-as-data / DDL-as-DML** — Datomic (schema is datoms asserted by transactions); RDF/RDFS;
+  `pg_catalog`/`information_schema`.
+- **Declarative reconcile (`ensure`)** — Kubernetes/Terraform desired-state diff→plan; Ace `ensure`
+  (#6964); declarative-lowers-to-DU-over-imperative (#6998).
+- Internal: #7038/#7039/#7040 (the principle stack), #7029 (TableStream Upsert/Retract = DML deltas),
+  #6996 (SchemaEvolution/SchemaRegistry), idempotency #6 / DST §7.

--- a/src/Core/Catalog.fs
+++ b/src/Core/Catalog.fs
@@ -1,0 +1,108 @@
+namespace Zeta.Core
+
+/// **The catalog as metadata tables — no DDL, just `ensure` → a DU of DML meta-updates.**
+///
+/// Realizes the principle stack (Aaron #7038/#7039/#7040): metadata is homoiconic to data (#7038), so the
+/// schema/catalog lives in **metadata tables** (#7028) — ordinary `TableStream` rows. Therefore there is **no
+/// DDL**: defining/evolving a schema is **DML** (`Upsert`/`Retract`) on those catalog rows (#7039). And you
+/// don't hand-write that DML: **DDL collapses to `ensure`** (idempotent declarative target), and **automatic
+/// schema evolution is a DU over the DML meta-updates** (#7040) — `ensure` diffs the desired schema against
+/// the current catalog and *derives* the `Delta` list (the meta-DML) to evolve current → desired.
+///
+/// Catalog rows are encoded as ordinary `TableStream` keys (homoiconic; the catalog IS a table):
+///   `table:<name>`           → `"1"`         (a declared table)
+///   `column:<table>.<col>`   → `<type>`      (a column + its type)
+/// Editing those rows = DML deltas = events on the one stream (#7032/#7036); evolution replays under DST,
+/// merges as a CRDT, and is idempotent (#6) — the same guarantees data gets. F# reference oracle.
+module Catalog =
+
+    open TableStream
+
+    /// A desired schema: each table with its (column, type) pairs. This is the `ensure` TARGET.
+    type Schema = (string * (string * string) list) list
+
+    [<Literal>]
+    let private TablePrefix = "table:"
+
+    [<Literal>]
+    let private ColumnPrefix = "column:"
+
+    let private tableKey (t: string) = TablePrefix + t
+    let private columnKey (t: string) (c: string) = ColumnPrefix + t + "." + c
+
+    /// The desired catalog as the flat metadata-table rows it implies (table + column rows).
+    let private desiredRows (schema: Schema) : Map<string, string> =
+        schema
+        |> List.collect (fun (t, cols) -> (tableKey t, "1") :: (cols |> List.map (fun (c, ty) -> columnKey t c, ty)))
+        |> Map.ofList
+
+    /// **`ensure schema current`** — the automatic schema evolution as a **DU over the DML meta-updates**
+    /// (#7040): diff the desired schema against the `current` catalog table and return the ordered `Delta`
+    /// list (the meta-DML) that evolves current → desired. `Upsert` for new/changed rows, `Retract` for rows
+    /// no longer desired. **Idempotent** (#6): when the catalog already matches, returns `[]` (a no-op).
+    /// Deterministic: deltas are ordinal-sorted by key (retracts before upserts is not required — applied as a
+    /// set — but ordering is stable for diffable golden vectors).
+    let ensure (schema: Schema) (current: Table) : Delta list =
+        let desired = desiredRows schema
+
+        // Upserts: desired rows that are absent or have a different value in current.
+        let upserts =
+            desired
+            |> Map.toList
+            |> List.filter (fun (k, v) ->
+                match Map.tryFind k current with
+                | Some cur -> cur <> v
+                | None -> true)
+            |> List.map Upsert
+
+        // Retracts: current rows (catalog rows only) no longer desired.
+        let retracts =
+            current
+            |> Map.toList
+            |> List.filter (fun (k, _) ->
+                (k.StartsWith(TablePrefix, System.StringComparison.Ordinal)
+                 || k.StartsWith(ColumnPrefix, System.StringComparison.Ordinal))
+                && not (Map.containsKey k desired))
+            |> List.map (fun (k, _) -> Retract k)
+
+        (retracts @ upserts)
+        |> List.sortWith (fun a b ->
+            let keyOf =
+                function
+                | Upsert(k, _) -> k
+                | Retract k -> k
+                | Meta(k, _) -> k
+
+            System.String.CompareOrdinal(keyOf a, keyOf b))
+
+    /// Apply `ensure`'s deltas to evolve the catalog (fold the meta-DML over the current table).
+    let evolve (schema: Schema) (current: Table) : Table =
+        ensure schema current |> List.fold applyDelta current
+
+    /// Read back the schema from a catalog table (tables + their columns), ordinal-sorted — the inverse view.
+    let readSchema (current: Table) : Schema =
+        let tables =
+            current
+            |> Map.toList
+            |> List.choose (fun (k, _) ->
+                if k.StartsWith(TablePrefix, System.StringComparison.Ordinal) then
+                    Some(k.Substring(TablePrefix.Length))
+                else
+                    None)
+            |> List.sortWith (fun a b -> System.String.CompareOrdinal(a, b))
+
+        tables
+        |> List.map (fun t ->
+            let colPrefix = ColumnPrefix + t + "."
+
+            let cols =
+                current
+                |> Map.toList
+                |> List.choose (fun (k, ty) ->
+                    if k.StartsWith(colPrefix, System.StringComparison.Ordinal) then
+                        Some(k.Substring(colPrefix.Length), ty)
+                    else
+                        None)
+                |> List.sortWith (fun (a, _) (b, _) -> System.String.CompareOrdinal(a, b))
+
+            t, cols)

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -172,6 +172,7 @@
     <Compile Include="KeyStore.fs" />
     <Compile Include="File.fs" />
     <Compile Include="TableStream.fs" />
+    <Compile Include="Catalog.fs" />
     <Compile Include="DarkHall.fs" />
     <Compile Include="Consent/KskAuthorization.fs" />
   </ItemGroup>

--- a/tests/Tests.FSharp/Catalog.Tests.fs
+++ b/tests/Tests.FSharp/Catalog.Tests.fs
@@ -1,0 +1,64 @@
+module Zeta.Tests.CatalogTests
+
+open global.Xunit
+open Zeta.Core
+open Zeta.Core.TableStream
+open Zeta.Core.Catalog
+
+let private schema1: Schema =
+    [ "users", [ "id", "int"; "name", "text" ] ]
+
+[<Fact>]
+let ``ensure on empty catalog: CREATE TABLE collapses to DML upserts`` () =
+    let deltas = ensure schema1 emptyTable
+    // table row + 2 column rows, all Upserts (no DDL — just DML)
+    Assert.Equal<Delta list>(
+        [ Upsert("column:users.id", "int"); Upsert("column:users.name", "text"); Upsert("table:users", "1") ],
+        deltas
+    )
+
+[<Fact>]
+let ``ensure is idempotent: re-ensuring a satisfied schema yields [] (apply-N == apply-once)`` () =
+    let cat = evolve schema1 emptyTable
+    Assert.Equal<Delta list>([], ensure schema1 cat)
+
+[<Fact>]
+let ``ALTER (add column) is an Upsert; automatic evolution as a DU over DML`` () =
+    let cat = evolve schema1 emptyTable
+    let schema2: Schema = [ "users", [ "id", "int"; "name", "text"; "email", "text" ] ]
+    Assert.Equal<Delta list>([ Upsert("column:users.email", "text") ], ensure schema2 cat)
+
+[<Fact>]
+let ``ALTER (change column type) is an Upsert of the changed row`` () =
+    let cat = evolve schema1 emptyTable
+    let schema2: Schema = [ "users", [ "id", "bigint"; "name", "text" ] ]
+    Assert.Equal<Delta list>([ Upsert("column:users.id", "bigint") ], ensure schema2 cat)
+
+[<Fact>]
+let ``DROP column is a Retract`` () =
+    let cat = evolve schema1 emptyTable
+    let schema2: Schema = [ "users", [ "id", "int" ] ] // dropped name
+    Assert.Equal<Delta list>([ Retract "column:users.name" ], ensure schema2 cat)
+
+[<Fact>]
+let ``DROP table retracts the table row and its columns`` () =
+    let cat = evolve schema1 emptyTable
+    Assert.Equal<Delta list>(
+        [ Retract "column:users.id"; Retract "column:users.name"; Retract "table:users" ],
+        ensure [] cat
+    )
+
+[<Fact>]
+let ``evolve reaches the desired schema; readSchema round-trips`` () =
+    let cat = evolve schema1 emptyTable
+    Assert.Equal<Schema>(schema1, readSchema cat)
+
+[<Fact>]
+let ``full lifecycle: create -> alter -> drop, each via DML deltas, readSchema reflects`` () =
+    let s1: Schema = [ "t", [ "a", "int" ] ]
+    let s2: Schema = [ "t", [ "a", "int"; "b", "text" ] ]
+    let c1 = evolve s1 emptyTable
+    let c2 = evolve s2 c1
+    Assert.Equal<Schema>(s2, readSchema c2)
+    let c3 = evolve [] c2 // drop everything
+    Assert.Equal<Schema>([], readSchema c3)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -97,6 +97,7 @@
     <Compile Include="KeyStore.Tests.fs" />
     <Compile Include="File.Tests.fs" />
     <Compile Include="TableStream.Tests.fs" />
+    <Compile Include="Catalog.Tests.fs" />
     <Compile Include="DarkHall.Tests.fs" />
     <Compile Include="ITensor.Tests.fs" />
     <Compile Include="SagaSnapshot.Tests.fs" />


### PR DESCRIPTION
Otto's chosen work: make the no-DDL principle (#7038/#7039/#7040) real. Catalog.fs on TableStream: catalog rows are ordinary table rows (table:<name>, column:<t>.<c>); ensure(schema, current) = automatic schema evolution AS a DU over DML meta-updates (diff desired vs current -> Upsert/Retract deltas), idempotent + deterministic; evolve folds them, readSchema round-trips. CREATE/ALTER/DROP all collapse to DML. Migration inherits DST/CRDT/idempotency/golden-vectors/git. Tests green, 0-warning. Honest scope: oracle (string rows; DynamicValue gap), not wired into ZetaCli grammar yet, no constraint validation. 🤖 Generated with [Claude Code](https://claude.com/claude-code)