### PR TITLE
feat(core): DynamicValue homoiconicity (table/stream/catalog); dep model (qualifiers + criteria + canonical name/policy)

### DIFF
--- a/docs/research/2026-06-08-dynamicvalue-homoiconicity-realized-table-stream-catalog.md
+++ b/docs/research/2026-06-08-dynamicvalue-homoiconicity-realized-table-stream-catalog.md
@@ -1,0 +1,39 @@
+# DynamicValue homoiconicity realized — table/stream/catalog carry DynamicValue
+
+**Otto, 2026-06-08** (Aaron's chosen direction: "DynamicValue homoiconicity"). Closes the gap flagged in
+#7038: the noun-class oracles carried `string` values; now the table/stream/catalog vertical carries
+`DynamicValue` — metadata and data genuinely share **one representation**.
+
+## What changed (tests green, 0-warning)
+
+- **`TableStream`** (#7041): `Delta.Upsert`/`Meta` and `Table` now carry **`DynamicValue`** values, not
+  `string`. Data values and `Meta` values are the *same* `DynamicValue` shape — homoiconicity made literal
+  (a count is `DynamicValue.Int 42`, a name is `DynamicValue.String "zeta"`, on the same stream). The fold
+  (`applyDelta`/`toTable`/`toMeta`/`toStream`) was already value-type-agnostic, so only the type changed.
+- **`Catalog`**: catalog rows are now homoiconic `DynamicValue` — a table row is `Bool true`, a column row
+  is `String <type>`. So the **catalog is data in the same value model as the data it describes** (#7028
+  table-meta-is-a-table, now byte-for-byte the same value type). `readSchema` extracts the type back.
+
+## Design note: keys stay `string` (deliberately, #7042)
+
+`DynamicValue` is `[<NoComparison>]` (its `Object` is order-significant, `Float` has NaN, etc.), so it
+**cannot be a Map key** — only a value. So **keys remain `string`**. This is not a limitation but the
+right call for long-term flexibility (Aaron's steer): a string key is free to carry **version / namespace
+/ scope** qualification later (e.g. `users@v2`, `ns:prod/users`, `scope:cell-7/users`) — match with or
+without the qualifier — without fighting a `NoComparison` key type. Values are homoiconic `DynamicValue`;
+keys are flexible qualified strings. (The eventual key-qualification grammar is future work, #7043.)
+
+## Honest scope (peel)
+
+Done for the **table/stream/catalog** vertical (the freshest, most coupled). `Db`, `File` (contentHash is
+already a hash *pointer* string — arguably stays a ref), and `KeyStore` (KeyRef is a pointer) still carry
+their original value/pointer types; converting `Db`'s `Create`/`Update` values to `DynamicValue` is the
+same one-line-per-case change and is the obvious follow-on. The 4-lang/4-serializer parity for these
+noun-classes (C#/Rust/TS oracles + golden vectors) remains the separate, larger discipline gap.
+
+## Anchors (Beacon)
+
+- **Homoiconicity / self-describing values** — `DynamicValue` (the universal CBOR/msgpack/JSON/YAML core),
+  Lisp S-expressions, RDF, Datomic.
+- Internal: #7038 (metadata homoiconic to data), #7028 (table-meta-is-a-table), #7029 (table/stream
+  duality), #7032 (meta-in-band), #7010 (Catalog), `DynamicValue.fs`.

--- a/docs/research/2026-06-08-each-dep-is-qualified-by-os-pkgmgr-namespace-scope-and-exposes-criteria-metadata.md
+++ b/docs/research/2026-06-08-each-dep-is-qualified-by-os-pkgmgr-namespace-scope-and-exposes-criteria-metadata.md
@@ -1,0 +1,89 @@
+# Each dep is qualified by (OS, package-manager, namespace, scope) and exposes criteria metadata
+
+**Aaron, 2026-06-08 (#7043):**
+
+> "some of the commands would have other things other than namespace and scope, or maybe it's some
+> combination — no, I got it: each dep is written for what OS, package manager, namespace, and scope it's
+> for, and what metadata it exposes, like best for security, stability, recency."
+
+This sharpens the optimal-source resolution model (the "resolve optimal package manager / source by
+criteria" thread, #6972, and the key-flexibility note #7042). A dependency carries **two metadata
+groups**:
+
+## 1. Qualifiers — *what this dep is FOR* (the match dimensions)
+
+Each dep declares the context it applies to, so the resolver can pick the right variant:
+
+- **OS** — linux / macOS / windows / nixos …
+- **package manager** — apt / brew / nix / npm / cargo / dotnet …
+- **namespace** — the registry/source namespace (e.g. `npm[privaterepo].bar`, an org/registry)
+- **scope** — system / user-global / cell-local / environment (the push-down level, #6996/#7005)
+
+So a single logical dep (`compiler.rust`) has multiple *qualified* variants, one per (OS × pkgmgr ×
+namespace × scope) it's written for. Resolution = **match the current context against these qualifiers**
+(match with or without a given qualifier — the "match with and without versions/namespace/scope"
+flexibility, #7042). This is why **keys stay flexible qualified strings** (#7042): the qualifier tuple
+lives in/with the key, matched partially.
+
+## 2. Exposed criteria metadata — *how GOOD this dep is* (the ranking dimensions)
+
+Each dep also **exposes metadata** the resolver ranks on when multiple variants match:
+
+- **security** (best-for-security)
+- **stability** (best-for-stability)
+- **recency** (most up-to-date)
+
+These are exactly the SoftValue / Pareto criteria from the optimal-source cut (#6972): when several
+qualified variants are eligible, pick by the operator's weighting over (security, stability, recency) —
+a Pareto frontier, not a single total order (you may prefer the most-secure-but-older, or the newest, per
+policy).
+
+## Canonical name groups variants; policy chooses; default is conservative (#7044)
+
+Aaron: *"some deps have the same canonical name and different IDs in different package managers / OSes /
+namespaces / scopes — they share a canonical name, and policy chooses which one when there are multiple;
+if no policy you get security or stability by default."*
+
+- **Canonical name = the shared grouping identity.** Many *variants* (each a distinct **ID**, qualified
+  per pkgmgr × OS × namespace × scope) share **one canonical name** (e.g. canonical `rust-compiler` →
+  `nix:rustc`, `brew:rust`, `apt:rustc`, … each a different ID). The canonical name is what you *depend
+  on*; the ID is the concrete resolved variant.
+- **Policy chooses among same-canonical-name variants.** When more than one variant matches the context,
+  the operator's **policy** (the SoftValue weighting) selects.
+- **Default (no policy) = security or stability — NOT recency.** Conservative by default: absent an
+  explicit policy, prefer the most-secure / most-stable variant, never silently the newest. Recency is
+  **opt-in**. (Safety-first default; the operator must *choose* to live on the edge.)
+
+## Shape
+
+```
+dep <canonical-name>                                          # what you depend on (the grouping identity)
+  variants:                                                   # many, sharing the canonical name
+    - id: <variant-id>
+      qualified-for: { os, packageManager, namespace, scope } # match dimensions (partial-match OK)
+      exposes:        { security, stability, recency, … }     # rank dimensions (SoftValue/Pareto)
+resolution: filter variants by qualifier-match → rank by policy
+            (default policy = security/stability, NOT recency)
+```
+
+Resolution: **filter** variants by qualifier-match against the current context, then **rank** the
+survivors by the exposed criteria under the operator's weighting. The qualifiers narrow; the criteria
+choose.
+
+## Honest scope (peel)
+
+Design/model capture — names the two metadata groups (qualifiers vs exposed criteria) and how resolution
+uses them (filter-then-rank). No code: no qualifier schema, no resolver. It refines #6972 (optimal-source
+by criteria) + #7042 (flexible qualified keys) into a concrete dep-metadata shape. Realization would carry
+these as homoiconic `DynamicValue` metadata (#7041) on the dep's `Meta` events (#7032), and route the
+Pareto/weighting to the SoftValue machinery already in-repo.
+
+## Anchors (Beacon)
+
+- **Qualified/conditional dependencies** — Nix (per-system attrsets), Cargo target/cfg-gated deps, npm
+  `os`/`cpu` fields, Maven classifiers/profiles, Bazel `select()` — deps written per (OS/arch/context).
+- **Criteria ranking / Pareto** — SoftValue (in-repo), multi-criteria decision (security/stability/
+  recency); package-manager resolvers (apt pinning, npm semver + audit).
+- Internal: #6972 (resolve optimal source by criteria), #7042 (flexible qualified keys), #7005 (push-down
+  vs JIT graphs — scope/push-down level), #6996/#7005 (scope levels), #7041 (DynamicValue metadata),
+  `SoftValue.fs`.

--- a/src/Core/Catalog.fs
+++ b/src/Core/Catalog.fs
@@ -30,10 +30,13 @@ module Catalog =
     let private tableKey (t: string) = TablePrefix + t
     let private columnKey (t: string) (c: string) = ColumnPrefix + t + "." + c
 
-    /// The desired catalog as the flat metadata-table rows it implies (table + column rows).
-    let private desiredRows (schema: Schema) : Map<string, string> =
+    /// The desired catalog as the flat metadata-table rows it implies (table + column rows). Values are
+    /// `DynamicValue` (homoiconic, #7038): a table row is `Bool true` (exists); a column row is `String <type>`.
+    let private desiredRows (schema: Schema) : Map<string, DynamicValue> =
         schema
-        |> List.collect (fun (t, cols) -> (tableKey t, "1") :: (cols |> List.map (fun (c, ty) -> columnKey t c, ty)))
+        |> List.collect (fun (t, cols) ->
+            (tableKey t, DynamicValue.Bool true)
+            :: (cols |> List.map (fun (c, ty) -> columnKey t c, DynamicValue.String ty)))
         |> Map.ofList
 
     /// **`ensure schema current`** — the automatic schema evolution as a **DU over the DML meta-updates**
@@ -98,8 +101,14 @@ module Catalog =
             let cols =
                 current
                 |> Map.toList
-                |> List.choose (fun (k, ty) ->
+                |> List.choose (fun (k, v) ->
                     if k.StartsWith(colPrefix, System.StringComparison.Ordinal) then
+                        // column value is a homoiconic DynamicValue.String <type>; extract the type name
+                        let ty =
+                            match v with
+                            | DynamicValue.String s -> s
+                            | other -> string other
+
                         Some(k.Substring(colPrefix.Length), ty)
                     else
                         None)

--- a/src/Core/TableStream.fs
+++ b/src/Core/TableStream.fs
@@ -22,22 +22,28 @@ namespace Zeta.Core
 ///
 /// Idempotency (#6): `Upsert`/`Retract`/`Meta` are upsert/tombstone ⇒ apply-N == apply-once; the fold is
 /// deterministic + replayable (DST §7). F# reference oracle; C#/Rust/TS ports follow.
+///
+/// **Homoiconic values (Aaron #7038/#7041):** values are `DynamicValue`, not `string` — so metadata and data
+/// share ONE representation (#7038). `DynamicValue` is `NoComparison`, so it can only be a Map *value*, not a
+/// key; **keys stay `string`** (which also keeps the key free to carry version/namespace/scope qualification
+/// later, #7042). Data values and `Meta` values are the same `DynamicValue` shape — homoiconicity made literal.
 module TableStream =
 
     open ZetaCli
 
     /// A stream delta (DBSP Z-set style). Data events (`Upsert`/`Retract`) AND **`Meta` events live on the
     /// SAME stream** (Aaron #7032: stream-metadata is an event within the same stream as the data — in-band).
+    /// Values are `DynamicValue` (homoiconic, #7038); keys stay `string`.
     type Delta =
-        | Upsert of key: string * value: string // data: set a keyed row
+        | Upsert of key: string * value: DynamicValue // data: set a keyed row
         | Retract of key: string // data: remove a keyed row
-        | Meta of key: string * value: string // META: describes the stream itself, in-band, same stream
+        | Meta of key: string * value: DynamicValue // META: describes the stream itself, in-band, same stream
 
     /// The `stream` noun: the ordered changelog of deltas (the primitive).
     type Stream = Delta list
 
-    /// The `table` noun: materialized current state (the fold of a stream).
-    type Table = Map<string, string>
+    /// The `table` noun: materialized current state (the fold of a stream). Values are `DynamicValue` (#7038).
+    type Table = Map<string, DynamicValue>
 
     let emptyTable: Table = Map.empty
 

--- a/tests/Tests.FSharp/Catalog.Tests.fs
+++ b/tests/Tests.FSharp/Catalog.Tests.fs
@@ -5,6 +5,10 @@ open Zeta.Core
 open Zeta.Core.TableStream
 open Zeta.Core.Catalog
 
+// homoiconic catalog values (#7038): table row = Bool true; column row = String <type>
+let private tbl = DynamicValue.Bool true
+let private ty (s: string) = DynamicValue.String s
+
 let private schema1: Schema =
     [ "users", [ "id", "int"; "name", "text" ] ]
 
@@ -13,7 +17,9 @@ let ``ensure on empty catalog: CREATE TABLE collapses to DML upserts`` () =
     let deltas = ensure schema1 emptyTable
     // table row + 2 column rows, all Upserts (no DDL — just DML)
     Assert.Equal<Delta list>(
-        [ Upsert("column:users.id", "int"); Upsert("column:users.name", "text"); Upsert("table:users", "1") ],
+        [ Upsert("column:users.id", ty "int")
+          Upsert("column:users.name", ty "text")
+          Upsert("table:users", tbl) ],
         deltas
     )
 
@@ -26,13 +32,13 @@ let ``ensure is idempotent: re-ensuring a satisfied schema yields [] (apply-N ==
 let ``ALTER (add column) is an Upsert; automatic evolution as a DU over DML`` () =
     let cat = evolve schema1 emptyTable
     let schema2: Schema = [ "users", [ "id", "int"; "name", "text"; "email", "text" ] ]
-    Assert.Equal<Delta list>([ Upsert("column:users.email", "text") ], ensure schema2 cat)
+    Assert.Equal<Delta list>([ Upsert("column:users.email", ty "text") ], ensure schema2 cat)
 
 [<Fact>]
 let ``ALTER (change column type) is an Upsert of the changed row`` () =
     let cat = evolve schema1 emptyTable
     let schema2: Schema = [ "users", [ "id", "bigint"; "name", "text" ] ]
-    Assert.Equal<Delta list>([ Upsert("column:users.id", "bigint") ], ensure schema2 cat)
+    Assert.Equal<Delta list>([ Upsert("column:users.id", ty "bigint") ], ensure schema2 cat)
 
 [<Fact>]
 let ``DROP column is a Retract`` () =

--- a/tests/Tests.FSharp/TableStream.Tests.fs
+++ b/tests/Tests.FSharp/TableStream.Tests.fs
@@ -4,36 +4,48 @@ open global.Xunit
 open Zeta.Core
 open Zeta.Core.TableStream
 
+// homoiconic value helper: a DynamicValue.String (#7038 — values are DynamicValue, not string)
+let private dv (s: string) = DynamicValue.String s
+
 [<Fact>]
 let ``table = fold(stream): deltas materialize to current state`` () =
-    let s = [ Upsert("a", "1"); Upsert("b", "2"); Upsert("a", "3"); Retract "b" ]
+    let s = [ Upsert("a", dv "1"); Upsert("b", dv "2"); Upsert("a", dv "3"); Retract "b" ]
     let t = toTable s
-    Assert.Equal("3", t.["a"])
+    Assert.Equal(dv "3", t.["a"])
     Assert.False(t.ContainsKey "b")
 
 [<Fact>]
 let ``duality: toTable (toStream t) = t`` () =
-    let t = Map [ "a", "1"; "b", "2"; "c", "3" ]
+    let t = Map [ "a", dv "1"; "b", dv "2"; "c", dv "3" ]
     Assert.Equal<Table>(t, toTable (toStream t))
 
 [<Fact>]
 let ``toStream is deterministic: keys ordinal-sorted`` () =
-    let t = Map [ "b", "2"; "a", "1" ]
-    Assert.Equal<Stream>([ Upsert("a", "1"); Upsert("b", "2") ], toStream t)
+    let t = Map [ "b", dv "2"; "a", dv "1" ]
+    Assert.Equal<Stream>([ Upsert("a", dv "1"); Upsert("b", dv "2") ], toStream t)
 
 [<Fact>]
 let ``idempotency: applying the same upsert twice == once`` () =
-    Assert.Equal<Table>(toTable [ Upsert("a", "1") ], toTable [ Upsert("a", "1"); Upsert("a", "1") ])
+    Assert.Equal<Table>(toTable [ Upsert("a", dv "1") ], toTable [ Upsert("a", dv "1"); Upsert("a", dv "1") ])
+
+[<Fact>]
+let ``values are homoiconic DynamicValue: int and string coexist on the same stream`` () =
+    // #7038/#7041: a value is any DynamicValue (Int, String, ...), not just a string.
+    let s = [ Upsert("count", DynamicValue.Int 42L); Upsert("name", dv "zeta") ]
+    let t = toTable s
+    Assert.Equal(DynamicValue.Int 42L, t.["count"])
+    Assert.Equal(dv "zeta", t.["name"])
 
 [<Fact>]
 let ``meta events live on the SAME stream as data; toMeta folds only them`` () =
     // #7032: stream-metadata is an event within the same stream as the data (in-band).
-    let s = [ Upsert("a", "1"); Meta("schema", "v2"); Upsert("b", "2"); Meta("owner", "aaron") ]
+    // #7038: meta values are the SAME DynamicValue shape as data values (homoiconic).
+    let s = [ Upsert("a", dv "1"); Meta("schema", dv "v2"); Upsert("b", dv "2"); Meta("owner", dv "aaron") ]
     let data = toTable s
     let meta = toMeta s
     // data view sees only data events
     Assert.Equal<string list>([ "a"; "b" ], data |> Map.toList |> List.map fst)
-    // meta view sees only meta events — same one stream
-    Assert.Equal("v2", meta.["schema"])
-    Assert.Equal("aaron", meta.["owner"])
+    // meta view sees only meta events — same one stream, same value shape
+    Assert.Equal(dv "v2", meta.["schema"])
+    Assert.Equal(dv "aaron", meta.["owner"])
     Assert.False(meta.ContainsKey "a")


### PR DESCRIPTION
Aaron's chosen direction + dep-resolution model. CODE: TableStream + Catalog now carry DynamicValue values (closes #7038 string gap); data & meta values share one DynamicValue shape; catalog rows homoiconic (table=Bool true, column=String type). Keys stay string (NoComparison; also keeps them free for version/namespace/scope qualifiers #7042). DOCS: dep model #7043/#7044 — qualifiers (os/pkgmgr/namespace/scope, match) + exposed criteria (security/stability/recency, rank); variants share a CANONICAL NAME, distinct IDs; policy chooses, default=security/stability NOT recency (conservative). Tests green, 0-warning. Honest scope: table/stream/catalog vertical done (Db/File follow); dep model is design, no resolver. 🤖 Generated with [Claude Code](https://claude.com/claude-code)