### PR TITLE
feat(core): wire the grammar to the noun-classes — ZetaExec (run/converge) + named fields

### DIFF
--- a/docs/research/2026-06-08-ensure-declarative-nouns-protect-a-resource-yin-yang-stored-proc.md
+++ b/docs/research/2026-06-08-ensure-declarative-nouns-protect-a-resource-yin-yang-stored-proc.md
@@ -1,0 +1,64 @@
+# `ensure`/declarative nouns protect a resource — a yin/yang stored proc (DynamicValue/SoftValue)
+
+**Aaron, 2026-06-08 (#7046):**
+
+> "ensure-like declarative nouns are almost always protecting a resource and need a file to save the
+> resource and a DU to wrap the imperative commands — unless there are clever merge/CAS techniques for
+> idempotency to avoid the DU. ensures should be able to be represented as DynamicValue or SoftValue
+> yin/yang stored proc."
+
+This generalizes the no-DDL `ensure` model (#7039/#7040, realized in `Catalog` #7010): every `ensure`-like
+declarative noun has the same anatomy.
+
+## Anatomy of an `ensure`
+
+A declarative `ensure` **protects a resource** (the thing it keeps in the desired state) and needs:
+
+1. **A file to save the resource** — the resource's persisted state (the current value `ensure` diffs
+   against). For `Catalog` this is the catalog table; in general it's a `file`/`table`/`db` row (#7002/
+   #7029) — the homoiconic store of the protected resource.
+2. **A DU to wrap the imperative commands** — the lowering (#6998): `ensure(desired)` diffs vs the saved
+   state and emits a **DU of imperative deltas** (the `Upsert`/`Retract` meta-DML in `Catalog.ensure`).
+   This is the "automatic schema evolution as a DU over DML" (#7040), generalized to any resource.
+   - **Exception (no DU needed): clever merge/CAS.** When the resource's writes are **idempotent by
+     construction** — CRDT merge, content-address/CAS, compare-and-swap — there's no need to *compute* an
+     imperative DU: convergence is free (the "clever declarative" path, #6998/#7029). `ensure` then just
+     merges/CASes the desired value; the DU is only needed when the operations aren't natively idempotent.
+
+## `ensure` is itself a homoiconic value — a yin/yang stored proc
+
+An `ensure` is **representable as a `DynamicValue` or `SoftValue`** (homoiconic, #7041): it's data, not a
+special construct. Aaron calls it a **yin/yang stored proc**:
+
+- **yin/yang** (the engine of change — what-acts / what-remains): `ensure` carries both the **desired
+  target** (what remains / the invariant it protects) and the **imperative DU** it derives (what acts /
+  the change) — the yin/yang pair as one value.
+- **stored proc**: the imperative DU is a *stored, replayable program* (a saga of deltas) attached to the
+  declarative target — like a database stored procedure, but **as data** (a `DynamicValue`/`SoftValue`
+  tree), so it serializes, diffs, merges, and replays (DST §7) like everything else.
+- **SoftValue** when the resolution is criteria-ranked (the dep-policy cut #7044: security/stability/
+  recency Pareto) — `ensure` over multiple eligible variants is a *soft* choice, so it's a `SoftValue`.
+
+So: `ensure = { protects: resource-ref; target: DynamicValue (desired); evolution: DU-of-deltas | merge/CAS }`
+— a homoiconic yin/yang stored proc.
+
+## Honest scope (peel)
+
+Design capture generalizing #7040; the concrete instance exists (`Catalog.ensure` — resource = catalog
+table, DU = DML deltas, idempotent). NOT built: a generic `Ensure` value type carrying
+`{resource, target, evolution}` as a `DynamicValue`/`SoftValue`; the CAS/merge-vs-DU auto-selection; an
+`ensure` verb in the grammar routing to a resource's protector (the executor wires the *data-plane* verbs
+today, #7045 — `ensure` is the declarative follow-on). Records the anatomy + the yin/yang-stored-proc
+representation as the target shape.
+
+## Anchors (Beacon)
+
+- **Declarative reconcile protecting a resource** — Kubernetes controllers (a controller protects a
+  resource toward `spec`), Terraform (state file + plan/DU), `ensure` (Ace #6964).
+- **Stored procedures as data / sagas** — `DurableSaga` (#6996); event-sourced stored procedures.
+- **Idempotent-by-construction (no DU)** — CRDTs (Shapiro 2011), CAS, content-addressing (#7029 clever
+  declarative).
+- **yin/yang** — the engine-of-change primitive (`YinYang.fs`); **SoftValue** (`SoftValue.fs`, Pareto/
+  criteria #7044); **DynamicValue** (#7041 homoiconic).
+- Internal: #7039/#7040 (no DDL, ensure→DU), #7010 (Catalog), #6998 (declarative→DU-over-imperative + CAS
+  exception), #7041 (homoiconic values), #7044 (policy/SoftValue), #7045 (grammar wiring).

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -173,6 +173,7 @@
     <Compile Include="File.fs" />
     <Compile Include="TableStream.fs" />
     <Compile Include="Catalog.fs" />
+    <Compile Include="ZetaExec.fs" />
     <Compile Include="DarkHall.fs" />
     <Compile Include="Consent/KskAuthorization.fs" />
   </ItemGroup>

--- a/src/Core/ZetaCli.fs
+++ b/src/Core/ZetaCli.fs
@@ -7,23 +7,31 @@ namespace Zeta.Core
 /// the `zs` (interpreter) and `zc` (durable CLI) front-ends thin-wrap over the data-plane verbs (`Command.fs`
 /// `DbCommand`). F# is the reference; C#/Rust/TS ports follow (Vera/Lior).
 ///
-/// Grammar (#6957/#6971/#6975):
+/// Grammar (#6957/#6971/#6975/#7045):
 ///   `zeta <seam> <verb> <noun>`            — explicit seam (the integration plane)
 ///   `zeta <verb> <noun>`                   — implicit seam (filled from Context)
 ///   `ace <verb> <noun>`                    — the `ace` seam (#6959)
 ///   `zs` / `zc`                            — shorthands for `zeta run shell` / `zeta run cell`
+///   `… <key>=<value> …`                    — named FIELDS (#7045): the value/payload + qualifiers
 ///   `… dependson <noun> <noun> …`          — trailing dependency clause (the graph edges, #6971)
 /// seam = integration plane (None = implicit, filled by Context); verb = action; noun = ZetaId / unique-in-
 /// scope name (e.g. `npm[www.privaterepo.com].bar`, `compiler.rust`, `cell`); dependson = the deps this node
 /// requires (edges). A statement is a NODE; `dependson` are its EDGES (#6971) — the infinite assembly's graph.
+///
+/// **Named fields (`k=v`, #7045)** are the long-term-flexible value/qualifier slot (Aaron's steer: "match with
+/// and without versions/namespace/scope"): `value=` carries the payload (the thing the verb writes), and
+/// `version=` / `ns=` / `scope=` / `os=` / `pm=` carry the dep qualifiers (#7043) — each present-or-absent,
+/// matched partially. Any token containing `=` is a field; positional tokens (no `=`) stay seam/verb/noun.
+/// Backward-compatible: a line with no `=` tokens parses exactly as before (empty `Fields`).
 module ZetaCli =
 
-    /// A parsed command: a node (`[seam] verb noun`) plus its outgoing dependency edges (`DependsOn`, #6971).
-    /// `Seam = None` means implicit (resolved from `Context`).
+    /// A parsed command: a node (`[seam] verb noun`) plus named `Fields` (#7045) and its outgoing dependency
+    /// edges (`DependsOn`, #6971). `Seam = None` means implicit (resolved from `Context`).
     type ZetaCommand =
         { Seam: string option
           Verb: string
           Noun: string
+          Fields: Map<string, string>
           DependsOn: string list }
 
     /// The resolution context that fills the "short, context-aware" omissions (#6971): the implicit seam and
@@ -42,27 +50,50 @@ module ZetaCli =
     let private isBare (noun: string) : bool =
         not (noun.Contains "." || noun.Contains "[" || noun.Contains "/" || noun.Contains ":")
 
-    /// Parse already-split argv (a `dependson` clause may trail) into a `ZetaCommand`.
+    /// A token is a named field iff it contains `=` (e.g. `value=blake3:abc`, `version=2`). Nouns/verbs/seams
+    /// never contain `=`. Split on the FIRST `=` so values may themselves contain `=`.
+    let private parseField (tok: string) : Result<string * string, string> =
+        match tok.IndexOf '=' with
+        | i when i > 0 -> Ok(tok.Substring(0, i), tok.Substring(i + 1))
+        | _ -> Error(sprintf "malformed field '%s' (expected key=value with a non-empty key)" tok)
+
+    /// Parse already-split argv (named `k=v` fields and a trailing `dependson` clause may appear) into a
+    /// `ZetaCommand`.
     let parseArgs (argv: string list) : Result<ZetaCommand, string> =
         // Split off a trailing `dependson <noun…>` clause, if present.
-        let baseTokens, deps =
+        let beforeDeps, deps =
             match List.tryFindIndex (fun t -> t = DependsOnKw) argv with
             | Some i -> List.truncate i argv, List.skip (i + 1) argv
             | None -> argv, []
 
-        let withDeps (cmd: ZetaCommand) = { cmd with DependsOn = deps }
+        // Partition the remaining tokens into positional (seam/verb/noun) and named fields (contain `=`).
+        let positional, fieldToks = beforeDeps |> List.partition (fun t -> not (t.Contains "="))
 
-        match baseTokens with
-        | [] -> Error "empty command"
-        | "zs" :: _ -> Ok(withDeps { Seam = None; Verb = "run"; Noun = "shell"; DependsOn = [] })
-        | "zc" :: _ -> Ok(withDeps { Seam = None; Verb = "run"; Noun = "cell"; DependsOn = [] })
-        | "ace" :: [ verb; noun ] -> Ok(withDeps { Seam = Some "ace"; Verb = verb; Noun = noun; DependsOn = [] })
-        | "ace" :: _ -> Error "ace requires: ace <verb> <noun> [dependson …]"
-        | "zeta" :: [ verb; noun ] -> Ok(withDeps { Seam = None; Verb = verb; Noun = noun; DependsOn = [] })
-        | "zeta" :: [ seam; verb; noun ] ->
-            Ok(withDeps { Seam = Some seam; Verb = verb; Noun = noun; DependsOn = [] })
-        | "zeta" :: _ -> Error "zeta requires: zeta [<seam>] <verb> <noun> [dependson …]"
-        | other :: _ -> Error(sprintf "unknown program '%s' (expected zeta|ace|zs|zc)" other)
+        // Parse the field tokens into a map (first error wins).
+        let fieldsResult =
+            (Ok Map.empty, fieldToks)
+            ||> List.fold (fun acc tok ->
+                match acc, parseField tok with
+                | Error e, _ -> Error e
+                | Ok m, Ok(k, v) -> Ok(Map.add k v m)
+                | Ok _, Error e -> Error e)
+
+        match fieldsResult with
+        | Error e -> Error e
+        | Ok fields ->
+            let mk seam verb noun =
+                { Seam = seam; Verb = verb; Noun = noun; Fields = fields; DependsOn = deps }
+
+            match positional with
+            | [] -> Error "empty command"
+            | "zs" :: _ -> Ok(mk None "run" "shell")
+            | "zc" :: _ -> Ok(mk None "run" "cell")
+            | "ace" :: [ verb; noun ] -> Ok(mk (Some "ace") verb noun)
+            | "ace" :: _ -> Error "ace requires: ace <verb> <noun> [fields…] [dependson …]"
+            | "zeta" :: [ verb; noun ] -> Ok(mk None verb noun)
+            | "zeta" :: [ seam; verb; noun ] -> Ok(mk (Some seam) verb noun)
+            | "zeta" :: _ -> Error "zeta requires: zeta [<seam>] <verb> <noun> [fields…] [dependson …]"
+            | other :: _ -> Error(sprintf "unknown program '%s' (expected zeta|ace|zs|zc)" other)
 
     /// Parse a whitespace-delimited command line.
     let parse (line: string) : Result<ZetaCommand, string> =
@@ -86,14 +117,28 @@ module ZetaCli =
             Noun = qualify cmd.Noun
             DependsOn = cmd.DependsOn |> List.map qualify }
 
-    /// Render a command back to its canonical `zeta [<seam>] <verb> <noun> [dependson …]` form (homoiconic
-    /// round-trip: `parse (render c) = Ok c`).
+    /// Render a command back to its canonical `zeta [<seam>] <verb> <noun> [<k>=<v>…] [dependson …]` form
+    /// (homoiconic round-trip: `parse (render c) = Ok c`). Fields are emitted ordinal-sorted by key for
+    /// deterministic, diffable output.
     let render (cmd: ZetaCommand) : string =
         let head =
             match cmd.Seam with
             | None -> sprintf "zeta %s %s" cmd.Verb cmd.Noun
             | Some s -> sprintf "zeta %s %s %s" s cmd.Verb cmd.Noun
 
+        let withFields =
+            if Map.isEmpty cmd.Fields then
+                head
+            else
+                let fs =
+                    cmd.Fields
+                    |> Map.toList
+                    |> List.sortWith (fun (a, _) (b, _) -> System.String.CompareOrdinal(a, b))
+                    |> List.map (fun (k, v) -> sprintf "%s=%s" k v)
+                    |> String.concat " "
+
+                sprintf "%s %s" head fs
+
         match cmd.DependsOn with
-        | [] -> head
-        | deps -> sprintf "%s %s %s" head DependsOnKw (String.concat " " deps)
+        | [] -> withFields
+        | deps -> sprintf "%s %s %s" withFields DependsOnKw (String.concat " " deps)

--- a/src/Core/ZetaExec.fs
+++ b/src/Core/ZetaExec.fs
@@ -1,0 +1,103 @@
+namespace Zeta.Core
+
+/// **The executor — wires the `ZetaCli` grammar to the noun-classes (Aaron #7045, shadow*).**
+///
+/// Closes the loop the whole grammar assumed: a parsed `ZetaCommand` (`[seam] verb noun k=v… [dependson …]`)
+/// is *routed by seam* to the matching noun-class, turned into that class's event, and folded into a unified
+/// `Workspace`. Order comes from `dependson` (`ZetaGraph.topoOrder`, #6984) — deps before dependents — so a
+/// list of commands assembles deterministically (DST §7), idempotently (#6).
+///
+/// **The value/payload lives in the `value=` field (#7045)** — the long-term-flexible slot (Aaron's steer):
+/// `zeta table upsert users.42 value=alice`, `zeta file write /a value=blake3:abc`. Qualifiers (`version=`,
+/// `ns=`, `scope=`, `os=`, `pm=`, #7043) ride the same field map, matched with-or-without. Verbs that need no
+/// payload (mkfolder/remove/move/copy/delete/retract) take none; `move`/`copy` take `to=`.
+///
+/// Routed seams: `table`/`stream` (#7029), `db` (#6996), `file` (#7002). Each is a thin map command→event;
+/// the noun-class folds do the work. F# reference oracle; C#/Rust/TS ports follow.
+module ZetaExec =
+
+    open ZetaCli
+
+    /// The unified state a command stream folds into — one materialized view per routed noun-class.
+    type Workspace =
+        { Table: TableStream.Table
+          Db: Db.DbState
+          Files: Files.FileState }
+
+    let empty =
+        { Table = TableStream.emptyTable
+          Db = Db.empty Db.defaultBackend
+          Files = Files.empty Files.defaultBackend }
+
+    let private field k (cmd: ZetaCommand) = Map.tryFind k cmd.Fields
+    let private valueOf cmd = field "value" cmd
+
+    /// Apply one resolved command to the workspace, routing by seam. Unknown seam/verb is a no-op-with-reason
+    /// `Error` so a bad line is surfaced, never silently dropped (BP: no silent failure).
+    let applyCommand (ws: Workspace) (cmd: ZetaCommand) : Result<Workspace, string> =
+        let needValue f =
+            match valueOf cmd with
+            | Some v -> Ok(f v)
+            | None -> Error(sprintf "%s %s requires value=<…>" cmd.Verb cmd.Noun)
+
+        let needTo f =
+            match field "to" cmd with
+            | Some d -> Ok(f d)
+            | None -> Error(sprintf "%s %s requires to=<dest>" cmd.Verb cmd.Noun)
+
+        match cmd.Seam with
+        | Some s when s = TableStream.TableSeamName || s = TableStream.StreamSeamName ->
+            match cmd.Verb with
+            | "upsert"
+            | "write"
+            | "set" ->
+                needValue (fun v ->
+                    { ws with
+                        Table = TableStream.applyDelta ws.Table (TableStream.Upsert(cmd.Noun, DynamicValue.String v)) })
+            | "retract"
+            | "delete"
+            | "remove" -> Ok { ws with Table = TableStream.applyDelta ws.Table (TableStream.Retract cmd.Noun) }
+            | v -> Error(sprintf "table: unknown verb '%s'" v)
+
+        | Some s when s = Db.SeamName ->
+            match Db.toEvent (valueOf cmd) cmd with
+            | Some ev -> Ok { ws with Db = Db.apply ws.Db ev }
+            | None -> Error(sprintf "db: verb '%s' is not a mutation (or missing value=)" cmd.Verb)
+
+        | Some s when s = Files.SeamName ->
+            match cmd.Verb with
+            | "write" -> needValue (fun h -> { ws with Files = Files.apply ws.Files (Files.Write(cmd.Noun, h)) })
+            | "mkfolder"
+            | "mkdir" -> Ok { ws with Files = Files.apply ws.Files (Files.MkFolder cmd.Noun) }
+            | "remove"
+            | "rm" -> Ok { ws with Files = Files.apply ws.Files (Files.Remove cmd.Noun) }
+            | "move"
+            | "mv" -> needTo (fun d -> { ws with Files = Files.apply ws.Files (Files.Move(cmd.Noun, d)) })
+            | "copy"
+            | "cp" -> needTo (fun d -> { ws with Files = Files.apply ws.Files (Files.Copy(cmd.Noun, d)) })
+            | v -> Error(sprintf "file: unknown verb '%s'" v)
+
+        | Some s -> Error(sprintf "no executor wired for seam '%s'" s)
+        | None -> Error(sprintf "command '%s %s' has no seam (resolve it first)" cmd.Verb cmd.Noun)
+
+    /// Fold a list of commands into a workspace **in input order** — the imperative command stream (a stream is
+    /// ordered, #6997; declarative lowers to this imperative sequence, #6998). The same noun may recur (e.g.
+    /// `write /a` then `move /a`); order is the truth. `Error` on the first command that fails to apply.
+    let run (cmds: ZetaCommand list) : Result<Workspace, string> =
+        (Ok empty, cmds)
+        ||> List.fold (fun acc cmd ->
+            match acc with
+            | Error e -> Error e
+            | Ok ws -> applyCommand ws cmd)
+
+    /// **`converge`** (#7047) — the DECLARATIVE counterpart to `run`: order the commands by `dependson`
+    /// (topo-sort, #6984) FIRST, then `run` them, driving the workspace to the desired state the command set
+    /// describes. Idempotent reconcile (Aaron's intuition: "like a thread join if it's already running" — if
+    /// the desired state already holds, converging is a no-op, the way joining an already-finished thread
+    /// returns immediately). For unordered command sets whose order comes from `dependson` (the within-stream
+    /// push-down graph, #7005), NOT for imperative sequences (topo-order keys by noun, so a repeated noun is a
+    /// declarative error). `Error` on a dependency cycle (the cycle nouns) or the first failing command.
+    let converge (cmds: ZetaCommand list) : Result<Workspace, string> =
+        match ZetaGraph.topoOrder cmds with
+        | Error cycle -> Error(sprintf "dependency cycle: %s" (String.concat ", " cycle))
+        | Ok ordered -> run ordered

--- a/tests/Tests.FSharp/Db.Tests.fs
+++ b/tests/Tests.FSharp/Db.Tests.fs
@@ -7,7 +7,7 @@ open Zeta.Core.Db
 
 // db-seam command helper
 let private db verb noun deps : ZetaCommand =
-    { Seam = Some Db.SeamName; Verb = verb; Noun = noun; DependsOn = deps }
+    { Seam = Some Db.SeamName; Verb = verb; Noun = noun; Fields = Map.empty; DependsOn = deps }
 
 [<Fact>]
 let ``fold: create then update then delete -> empty`` () =

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -98,6 +98,7 @@
     <Compile Include="File.Tests.fs" />
     <Compile Include="TableStream.Tests.fs" />
     <Compile Include="Catalog.Tests.fs" />
+    <Compile Include="ZetaExec.Tests.fs" />
     <Compile Include="DarkHall.Tests.fs" />
     <Compile Include="ITensor.Tests.fs" />
     <Compile Include="SagaSnapshot.Tests.fs" />

--- a/tests/Tests.FSharp/ZetaCli.Tests.fs
+++ b/tests/Tests.FSharp/ZetaCli.Tests.fs
@@ -4,7 +4,12 @@ open global.Xunit
 open Zeta.Core
 open Zeta.Core.ZetaCli
 
-let private cmd seam verb noun deps = { Seam = seam; Verb = verb; Noun = noun; DependsOn = deps }
+let private cmd seam verb noun deps =
+    { Seam = seam; Verb = verb; Noun = noun; Fields = Map.empty; DependsOn = deps }
+
+/// Like `cmd` but with named fields (#7045).
+let private cmdF seam verb noun fields deps =
+    { Seam = seam; Verb = verb; Noun = noun; Fields = Map.ofList fields; DependsOn = deps }
 
 [<Fact>]
 let ``zeta explicit seam: zeta git clone <noun>`` () =
@@ -55,6 +60,37 @@ let ``homoiconic round-trip: parse (render c) = Ok c (with deps)`` () =
           cmd (Some "ace") "ensure" "npm[r].bar" [ "compiler.rust" ]
           cmd (Some "test") "message" "otto-cli1" [ "a"; "b"; "c" ] ] do
         Assert.Equal<Result<ZetaCommand, string>>(Ok c, parse (render c))
+
+[<Fact>]
+let ``fields: k=v tokens parse into Fields; positional stays seam/verb/noun`` () =
+    Assert.Equal<Result<ZetaCommand, string>>(
+        Ok(cmdF (Some "table") "upsert" "users.42" [ "value", "alice" ] []),
+        parse "zeta table upsert users.42 value=alice"
+    )
+
+[<Fact>]
+let ``fields: multiple fields incl. qualifiers, with dependson`` () =
+    Assert.Equal<Result<ZetaCommand, string>>(
+        Ok(cmdF (Some "file") "write" "/a" [ "value", "blake3:abc"; "scope", "cell-7" ] [ "/d" ]),
+        parse "zeta file write /a value=blake3:abc scope=cell-7 dependson /d"
+    )
+
+[<Fact>]
+let ``fields: value may contain = (split on first only)`` () =
+    match parse "zeta db write k value=a=b=c" with
+    | Ok c -> Assert.Equal("a=b=c", c.Fields.["value"])
+    | Error e -> failwith e
+
+[<Fact>]
+let ``fields: round-trip parse (render c) = Ok c with fields (sorted)`` () =
+    for c in
+        [ cmdF (Some "table") "upsert" "u.1" [ "value", "x" ] []
+          cmdF (Some "file") "write" "/a" [ "value", "h"; "scope", "s"; "version", "2" ] [ "/d" ] ] do
+        Assert.Equal<Result<ZetaCommand, string>>(Ok c, parse (render c))
+
+[<Fact>]
+let ``fields: no = tokens parse exactly as before (empty Fields, backward-compatible)`` () =
+    Assert.Equal<Result<ZetaCommand, string>>(Ok(cmd (Some "git") "clone" "abc" []), parse "zeta git clone abc")
 
 [<Fact>]
 let ``shorthands canonicalize: render (parse zc) = zeta run cell`` () =

--- a/tests/Tests.FSharp/ZetaExec.Tests.fs
+++ b/tests/Tests.FSharp/ZetaExec.Tests.fs
@@ -1,0 +1,67 @@
+module Zeta.Tests.ZetaExecTests
+
+open global.Xunit
+open Zeta.Core
+open Zeta.Core.ZetaCli
+open Zeta.Core.ZetaExec
+
+// parse-or-fail helper
+let private p (line: string) =
+    match parse line with
+    | Ok c -> c
+    | Error e -> failwithf "parse failed: %s" e
+
+[<Fact>]
+let ``table upsert via grammar: value= field becomes a DynamicValue row`` () =
+    match run [ p "zeta table upsert users.42 value=alice" ] with
+    | Ok ws -> Assert.Equal(DynamicValue.String "alice", ws.Table.["users.42"])
+    | Error e -> failwith e
+
+[<Fact>]
+let ``file write via grammar: value= is the content hash`` () =
+    match run [ p "zeta file write /a value=blake3:abc" ] with
+    | Ok ws -> Assert.Equal(Some "blake3:abc", Files.readHash "/a" ws.Files)
+    | Error e -> failwith e
+
+[<Fact>]
+let ``file move via grammar: to= field is the destination`` () =
+    match run [ p "zeta file write /a value=h"; p "zeta file move /a to=/b" ] with
+    | Ok ws ->
+        Assert.Equal(Some "h", Files.readHash "/b" ws.Files)
+        Assert.False(ws.Files.Entries.ContainsKey "/a")
+    | Error e -> failwith e
+
+[<Fact>]
+let ``db create via grammar routes to the db state`` () =
+    match run [ p "zeta db create users.1 value=v" ] with
+    | Ok ws -> Assert.Equal("v", ws.Db.Files.["users.1"])
+    | Error e -> failwith e
+
+[<Fact>]
+let ``dependson orders execution: parent folder before the file that needs it`` () =
+    // /d/x depends on /d; topo-order ensures /d's mkfolder runs first
+    let cmds =
+        [ p "zeta file write /d/x value=h dependson /d"; p "zeta file mkfolder /d" ]
+    match converge cmds with
+    | Ok ws ->
+        Assert.Equal(Some "h", Files.readHash "/d/x" ws.Files)
+        Assert.Equal(Some Files.Folder, Map.tryFind "/d" ws.Files.Entries)
+    | Error e -> failwith e
+
+[<Fact>]
+let ``missing value= is surfaced as an error, never silently dropped`` () =
+    match run [ p "zeta table upsert k" ] with
+    | Ok _ -> failwith "expected an error for missing value="
+    | Error e -> Assert.Contains("value=", e)
+
+[<Fact>]
+let ``unwired seam is an explicit error`` () =
+    match run [ p "zeta bogus frob x" ] with
+    | Ok _ -> failwith "expected an error for unwired seam"
+    | Error e -> Assert.Contains("bogus", e)
+
+[<Fact>]
+let ``retract removes a table row`` () =
+    match run [ p "zeta table upsert k value=v"; p "zeta table retract k" ] with
+    | Ok ws -> Assert.False(ws.Table.ContainsKey "k")
+    | Error e -> failwith e

--- a/tests/Tests.FSharp/ZetaGraph.Tests.fs
+++ b/tests/Tests.FSharp/ZetaGraph.Tests.fs
@@ -5,7 +5,8 @@ open Zeta.Core
 open Zeta.Core.ZetaCli
 
 // node helper: a command keyed by Noun with the given dependson edges (seam/verb irrelevant to ordering)
-let private n noun deps : ZetaCommand = { Seam = None; Verb = "ensure"; Noun = noun; DependsOn = deps }
+let private n noun deps : ZetaCommand =
+    { Seam = None; Verb = "ensure"; Noun = noun; Fields = Map.empty; DependsOn = deps }
 let private nouns (cmds: ZetaCommand list) = cmds |> List.map (fun c -> c.Noun)
 
 [<Fact>]


### PR DESCRIPTION
Aaron-authorized (shadow*). ZetaCommand gains Fields (k=v): the flexible value/qualifier slot (value= payload; version/ns/scope/os/pm qualifiers #7043), backward-compatible, round-trip preserved. ZetaExec routes parsed commands by seam to the noun-class folds (table/db/file) into a unified Workspace; run = imperative input-order, converge = declarative topo-order-then-run (idempotent reconcile; Aaron's 'thread-join-if-already-running' intuition; renamed from runDeclarative #7047). Missing value=/unwired seam = explicit Error. Doc: ensure protects a resource (state file + DU, or CAS/merge) = a yin/yang stored proc as DynamicValue/SoftValue (#7046). Full suite green (2134), 0-warning. Honest scope: data-plane verbs wired; ensure verb is the follow-on. 🤖 Generated with [Claude Code](https://claude.com/claude-code)