### PR TITLE
docs: ensure stored-proc is total — no-DU/CRDT encodes as the symmetric form

### DIFF
--- a/docs/research/2026-06-08-ensure-declarative-nouns-protect-a-resource-yin-yang-stored-proc.md
+++ b/docs/research/2026-06-08-ensure-declarative-nouns-protect-a-resource-yin-yang-stored-proc.md
@@ -42,6 +42,23 @@ special construct. Aaron calls it a **yin/yang stored proc**:
 So: `ensure = { protects: resource-ref; target: DynamicValue (desired); evolution: DU-of-deltas | merge/CAS }`
 — a homoiconic yin/yang stored proc.
 
+### The representation is total: no-DU still encodes, as the SYMMETRIC form (#7048)
+
+Aaron: *"even if you don't need the DU and it's just CRDTs, that will be encoded in the symmetric
+DynamicValue/SoftValue/yin/yang stored proc."* The CRDT/CAS case is **not an absence** of representation —
+it's the **symmetric** encoding of the same stored proc:
+
+- **Asymmetric form (DU):** an *ordered* saga of deltas — sequence matters, applied in order (the
+  imperative lowering, #6998). Used when ops aren't natively idempotent.
+- **Symmetric form (CRDT/CAS):** a *commutative / associative / idempotent merge* — order doesn't matter,
+  convergence is free (#7029). Used when ops are idempotent by construction.
+
+Both are **encoded in the one yin/yang stored-proc value** (`DynamicValue`/`SoftValue`). The `evolution`
+field isn't "a DU or nothing" — it's "asymmetric (DU) **or** symmetric (merge)", both *present* as data.
+So the representation is **total**: every `ensure` carries its evolution explicitly, and "no DU needed"
+means "the symmetric variant," never an unencoded special case. (This mirrors the manifesto's symmetry/
+self-similarity: the value tells you which algebra applies — ordered saga vs commutative merge — in-band.)
+
 ## Honest scope (peel)
 
 Design capture generalizing #7040; the concrete instance exists (`Catalog.ensure` — resource = catalog


### PR DESCRIPTION
Aaron #7048 refines #7046: the CRDT/no-DU case isn't an absence — it's the SYMMETRIC encoding of the same yin/yang stored proc. evolution = asymmetric (ordered DU saga, #6998) OR symmetric (commutative/idempotent merge, #7029), both present as data in the one DynamicValue/SoftValue value. Representation is total; the value says in-band which algebra applies. 🤖 Generated with [Claude Code](https://claude.com/claude-code)