### PR TITLE
feat(core): StoredProc — native vs interpreted verb-noun (differential-tested); the forced-RX nature

### DIFF
--- a/docs/research/2026-06-08-stored-procs-native-vs-interpreted-and-forced-rx-bonsai-bananas.md
+++ b/docs/research/2026-06-08-stored-procs-native-vs-interpreted-and-forced-rx-bonsai-bananas.md
@@ -1,0 +1,75 @@
+# Stored-procs: native vs interpreted (differential-tested) + the forced-RX nature
+
+**Aaron, 2026-06-08 (#7049/#7050).** Two linked things: a built pattern, and the delight that the
+architecture *forces* reactivity.
+
+## 1. Native vs interpreted stored-procs, differential-tested (#7049, built)
+
+> "anywhere we have interfaces and nouns we should implement the verb-noun with plugins and DynamicValue /
+> SoftValue / yin-yang stored procs; we just need to per-test the F#-native versions vs our interpreted."
+
+Every noun-class op gets **two** implementations, and a test asserts they agree:
+
+- **native** — the F# fold (`TableStream.applyDelta`, …) — fast, the oracle.
+- **interpreted** — the op as a homoiconic **stored-proc** (`DynamicValue`, #7041) run by an *independent*
+  interpreter (the yin/yang stored proc, #7046/#7048) — pluggable, serializable, ship-anywhere.
+- **differential test** — `native ≡ interpreted` for the same input (a cross-check oracle, BP-16: two
+  implementations that must agree, so a bug in either is caught).
+
+Built (`src/Core/StoredProc.fs`, reference instance for `table`, 4/4 tests green, 0-warning):
+`encodeDelta`/`decodeDelta` (homoiconic `DynamicValue.Object` ⇄ `Delta`, round-trips) + `interpretApply`
+(a genuinely separate code path: reads the `DynamicValue` fields and mutates the `Table` directly, no
+`Delta` round-trip). The **DIFFERENTIAL** test runs every op across several tables and asserts
+`applyDelta t d == interpretApply t (encodeDelta d)`. Malformed procs / unknown ops → explicit `Error`
+(no silent failure). Generalizes to `db`/`file`/`catalog` — the per-test discipline is the deliverable.
+
+## 2. The forced-RX nature (#7050) — "I love this forced nature"
+
+> "the yin/yang version is fun — you only get observable over streams basically, because of Bonsai, so
+> everything HAS to be RX. I love this forced nature. It makes parallelism easy, and banana-split a
+> survival imperative. Algebras should be easy too."
+
+The yin/yang stored proc, executed through **Bonsai** (the in-repo incremental/reactive engine), means
+**state is only observable over streams** — there's no non-reactive read escape hatch. So **everything is
+forced to be RX** (`Rx.fs`): you don't *read* state, you *observe* the stream (#6997 everything-is-events,
+now as the observation API). Aaron's joy is in the forcing function — the architecture won't *let* you be
+non-reactive.
+
+Consequences he names:
+
+- **Parallelism is easy.** Observe-over-streams + idempotent/commutative folds (CRDT/symmetric #7048) means
+  work parallelizes with no special cases (scale-free §1, DoP-knob ferry): a commutative fold over a
+  stream runs at DoP=1 deterministically or DoP=N concurrently, same code path.
+- **Banana-split is a survival imperative.** "Bananas" = **catamorphisms / folds** (Meijer et al.,
+  *Bananas, Lenses, Envelopes & Barbed Wire*, 1991 — banana brackets `⦇ ⦈` = fold). When the only way to
+  observe is to fold a stream, you *must* express computation as a fold (a banana) — it's not optional, it's
+  how you survive in a stream-only world. (Ties Aaron's earlier 4-tree "banana split" universal
+  representation: decompose-to-fold-over-a-tree.)
+- **Algebras are easy.** A fold needs an **algebra** (the carrier + combine op — semiring/monoid/
+  semilattice, the `Algebra.fs`/`Semiring.fs` floor). Because everything is a stream-fold, the algebra is
+  the *natural* unit: you bring a (zero, combine) and the stream-fold does the rest. Idempotent/commutative
+  algebras (the symmetric form #7048) are exactly the ones that parallelize — so "easy parallelism" and
+  "easy algebras" are the same fact.
+
+So the chain: **yin/yang + Bonsai ⇒ observe-only-over-streams ⇒ forced RX ⇒ fold-everything (bananas) ⇒
+algebras are the natural unit ⇒ commutative algebras parallelize for free.** The constraint *is* the
+feature.
+
+## Honest scope (peel)
+
+`StoredProc` (#7049) is built + differential-tested for `table` (db/file/catalog follow the same pattern).
+The forced-RX section (#7050) is an **observation** about the existing substrate (Bonsai + Rx + yin/yang +
+the algebra floor) — no code; it names why the architecture forces reactivity and how that makes
+parallelism/algebras easy. No claim that the stored-procs run *through Bonsai* yet — wiring the interpreted
+stored-proc into Bonsai's reactive loop (so it's observed-over-streams in practice) is the named next step.
+
+## Anchors (Beacon)
+
+- **Recursion schemes / catamorphisms ("bananas")** — Meijer, Fokkinga & Paterson 1991; folds as the
+  universal stream consumer.
+- **F-algebras / fold algebras** — `Algebra.fs`, `Semiring.fs`, monoid/semilattice (the carrier+combine).
+- **Reactive / incremental computation** — Bonsai (`Bonsai.fs`, in-repo), Rx (`Rx.fs`); observe-over-streams.
+- **Differential / cross-check testing** — BP-16; property-based + two-implementation agreement.
+- Internal: #7041 (DynamicValue homoiconic), #7046/#7048 (yin/yang stored proc; symmetric/CRDT form),
+  #6997 (everything-is-events), #7029 (table/stream fold), manifesto §1 scale-free (DoP-knob ferry),
+  idempotency #6.

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -173,6 +173,7 @@
     <Compile Include="File.fs" />
     <Compile Include="TableStream.fs" />
     <Compile Include="Catalog.fs" />
+    <Compile Include="StoredProc.fs" />
     <Compile Include="ZetaExec.fs" />
     <Compile Include="DarkHall.fs" />
     <Compile Include="Consent/KskAuthorization.fs" />

--- a/src/Core/StoredProc.fs
+++ b/src/Core/StoredProc.fs
@@ -1,0 +1,83 @@
+namespace Zeta.Core
+
+/// **Interpreted stored-procs — verb-noun ops as homoiconic `DynamicValue`, differential-tested vs native.**
+///
+/// Aaron #7049: *"anywhere we have interfaces and nouns we should implement the verb-noun with plugins and
+/// DynamicValue / SoftValue / yin-yang stored procs; we just need to per-test the F#-native versions vs our
+/// interpreted."* So every noun-class op gets **two** implementations:
+///   1. **native** — the F# fold (`TableStream.applyDelta`, `Db.apply`, `Files.apply`, …) — fast, the oracle.
+///   2. **interpreted** — the op encoded as a homoiconic **stored-proc** (`DynamicValue`, #7041) and executed
+///      by an *independent* interpreter (a different code path) — the pluggable, serializable, ship-anywhere
+///      form (the yin/yang stored proc, #7046/#7048).
+/// A **differential test** then asserts `native ≡ interpreted` for the same input — a cross-check oracle
+/// (BP-16): two implementations that must agree, so a bug in either is caught.
+///
+/// This module is the REFERENCE instance for the `table` noun-class (#7029). Same pattern generalizes to
+/// `db`/`file`/`catalog`; the per-test discipline (native vs interpreted) is the deliverable. F# reference
+/// oracle; C#/Rust/TS ports follow.
+module StoredProc =
+
+    open TableStream
+
+    [<Literal>]
+    let private OpKey = "op"
+
+    [<Literal>]
+    let private KeyKey = "key"
+
+    [<Literal>]
+    let private ValKey = "value"
+
+    /// Encode a table delta as a homoiconic stored-proc (`DynamicValue.Object`). The value rides as-is (it is
+    /// already a `DynamicValue`, #7041) — the op is data describing data.
+    let encodeDelta (d: Delta) : DynamicValue =
+        match d with
+        | Upsert(k, v) ->
+            DynamicValue.Object [ OpKey, DynamicValue.String "upsert"; KeyKey, DynamicValue.String k; ValKey, v ]
+        | Retract k -> DynamicValue.Object [ OpKey, DynamicValue.String "retract"; KeyKey, DynamicValue.String k ]
+        | Meta(k, v) ->
+            DynamicValue.Object [ OpKey, DynamicValue.String "meta"; KeyKey, DynamicValue.String k; ValKey, v ]
+
+    /// Decode a stored-proc back to a `Delta` (round-trips with `encodeDelta`). `Error` on a malformed proc.
+    let decodeDelta (sp: DynamicValue) : Result<Delta, string> =
+        match sp with
+        | DynamicValue.Object fields ->
+            let get k =
+                fields |> List.tryPick (fun (fk, fv) -> if fk = k then Some fv else None)
+
+            match get OpKey, get KeyKey with
+            | Some(DynamicValue.String "upsert"), Some(DynamicValue.String k) ->
+                match get ValKey with
+                | Some v -> Ok(Upsert(k, v))
+                | None -> Error "upsert stored-proc missing 'value'"
+            | Some(DynamicValue.String "retract"), Some(DynamicValue.String k) -> Ok(Retract k)
+            | Some(DynamicValue.String "meta"), Some(DynamicValue.String k) ->
+                match get ValKey with
+                | Some v -> Ok(Meta(k, v))
+                | None -> Error "meta stored-proc missing 'value'"
+            | Some(DynamicValue.String op), _ -> Error(sprintf "unknown op '%s'" op)
+            | _ -> Error "stored-proc missing 'op'/'key'"
+        | _ -> Error "stored-proc must be a DynamicValue.Object"
+
+    /// **Interpret** a stored-proc against a table — an INDEPENDENT code path from `TableStream.applyDelta`:
+    /// it reads the `DynamicValue` fields and mutates the `Table` directly (no `Delta` round-trip), so it is a
+    /// genuine second implementation for the differential test to compare against the native fold.
+    let interpretApply (t: Table) (sp: DynamicValue) : Result<Table, string> =
+        match sp with
+        | DynamicValue.Object fields ->
+            let get k =
+                fields |> List.tryPick (fun (fk, fv) -> if fk = k then Some fv else None)
+
+            match get OpKey with
+            | Some(DynamicValue.String "upsert") ->
+                match get KeyKey, get ValKey with
+                | Some(DynamicValue.String k), Some v -> Ok(Map.add k v t)
+                | _ -> Error "upsert requires key:String and value"
+            | Some(DynamicValue.String "retract") ->
+                match get KeyKey with
+                | Some(DynamicValue.String k) -> Ok(Map.remove k t)
+                | _ -> Error "retract requires key:String"
+            | Some(DynamicValue.String "meta") -> Ok t // meta does not change the data table (mirrors applyDelta)
+            | Some(DynamicValue.String op) -> Error(sprintf "unknown op '%s'" op)
+            | _ -> Error "missing 'op'"
+        | _ -> Error "stored-proc must be a DynamicValue.Object"

--- a/tests/Tests.FSharp/StoredProc.Tests.fs
+++ b/tests/Tests.FSharp/StoredProc.Tests.fs
@@ -1,0 +1,58 @@
+module Zeta.Tests.StoredProcTests
+
+open global.Xunit
+open Zeta.Core
+open Zeta.Core.TableStream
+open Zeta.Core.StoredProc
+
+let private dv (s: string) = DynamicValue.String s
+
+// the deltas exercised by the differential check (data + meta + non-string value)
+let private deltas =
+    [ Upsert("a", dv "1")
+      Upsert("count", DynamicValue.Int 42L)
+      Retract "a"
+      Meta("schema", dv "v2") ]
+
+[<Fact>]
+let ``encode/decode round-trips every delta`` () =
+    for d in deltas do
+        Assert.Equal<Result<Delta, string>>(Ok d, decodeDelta (encodeDelta d))
+
+[<Fact>]
+let ``DIFFERENTIAL: native applyDelta == interpreted stored-proc (the per-test, #7049)`` () =
+    // Across several starting tables and every op, the F#-native fold and the independent interpreter agree.
+    let tables =
+        [ emptyTable
+          Map [ "a", dv "old" ]
+          Map [ "a", dv "x"; "count", DynamicValue.Int 1L ] ]
+
+    for t in tables do
+        for d in deltas do
+            let native = applyDelta t d
+            let interpreted =
+                match interpretApply t (encodeDelta d) with
+                | Ok r -> r
+                | Error e -> failwithf "interpret failed: %s" e
+            Assert.Equal<Table>(native, interpreted)
+
+[<Fact>]
+let ``interpret surfaces a malformed stored-proc as Error (no silent failure)`` () =
+    Assert.True(
+        match interpretApply emptyTable (DynamicValue.String "not-an-object") with
+        | Error _ -> true
+        | Ok _ -> false
+    )
+    Assert.True(
+        match interpretApply emptyTable (DynamicValue.Object [ "op", DynamicValue.String "frob" ]) with
+        | Error _ -> true
+        | Ok _ -> false
+    )
+
+[<Fact>]
+let ``decode rejects an unknown op`` () =
+    Assert.True(
+        match decodeDelta (DynamicValue.Object [ "op", DynamicValue.String "frob"; "key", dv "k" ]) with
+        | Error _ -> true
+        | Ok _ -> false
+    )

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -99,6 +99,7 @@
     <Compile Include="TableStream.Tests.fs" />
     <Compile Include="Catalog.Tests.fs" />
     <Compile Include="ZetaExec.Tests.fs" />
+    <Compile Include="StoredProc.Tests.fs" />
     <Compile Include="DarkHall.Tests.fs" />
     <Compile Include="ITensor.Tests.fs" />
     <Compile Include="SagaSnapshot.Tests.fs" />


### PR DESCRIPTION
Aaron #7049/#7050. StoredProc.fs (table reference, 4/4 green): every op has native (F# fold) + interpreted (homoiconic DynamicValue stored-proc, independent interpreter); DIFFERENTIAL test asserts applyDelta == interpretApply(encode) across ops/tables (cross-check oracle BP-16). Doc: the forced-RX nature — yin/yang+Bonsai => observe-only-over-streams => everything RX; parallelism easy, banana-split (catamorphisms/folds, Meijer 1991) a survival imperative, algebras easy (fold needs an algebra; commutative ones parallelize). Honest scope: built for table (others follow); forced-RX is observation, wiring through Bonsai is next. 🤖 Generated with [Claude Code](https://claude.com/claude-code)