### PR TITLE
feat(core): interface in DynamicValue via object expression (native vs interpreted, one port); design: interface from joined/zipped stream queries

### DIFF
--- a/docs/research/2026-06-08-interface-from-dynamicvalue-object-expression-and-from-joined-zipped-stream-queries.md
+++ b/docs/research/2026-06-08-interface-from-dynamicvalue-object-expression-and-from-joined-zipped-stream-queries.md
@@ -1,0 +1,66 @@
+# Implementing an interface from DynamicValue — and from joined/zipped banana-split stream queries
+
+**Aaron, 2026-06-08 (#7051/#7052).** Two steps toward "the interface is synthesized from the stream."
+
+## 1. Implement the interface in DynamicValue via an F# object expression (#7051, built)
+
+> "should be able to implement the interface in DynamicValue in F# — you can return `new Interface with {}`
+> or something like that."
+
+F# **object expressions** (`{ new IInterface with member … }`) let a `DynamicValue`-backed interpreter
+*satisfy the same interface* as the native fold. So native and interpreted are **interchangeable behind
+one interface** (hexagonal port, #7019), and the differential test (#7049) compares two implementations of
+the *same* interface.
+
+Built (`src/Core/StoredProc.fs`, 6/6 tests green, 0-warning):
+- `ITableProc` — the port: `abstract Apply: Table -> Table`.
+- `nativeProc d` — native impl (`{ new ITableProc with Apply t = applyDelta t d }`).
+- `dynamicProc sp` — the **DynamicValue-backed** impl via object expression: validates the stored-proc once
+  (`decodeDelta`), then `Apply` runs the independent interpreter (`interpretApply`). `Error` if malformed.
+- Differential test: `nativeProc d` and `dynamicProc (encodeDelta d)` agree behind `ITableProc`.
+
+## 2. Synthesize the interface from joined/zipped banana-split stream queries (#7052, design)
+
+> "I want to take 1 stream and implement one interface from multiple banana-split RX queries joined and/or
+> zipped, and then `new` the interface from the intersection."
+
+The next step: an interface implementation isn't hand-written — it's **synthesized from one stream**:
+
+```
+            ┌─ query₁ (banana/fold over the stream) ─┐
+ one stream ┼─ query₂ (banana/fold) ─────────────────┼─ join / zip ─→ new IInterface { ... }
+            └─ query₃ (banana/fold) ─────────────────┘     (intersection)
+```
+
+- **One stream** — the DBSP Z-set event stream (#6997); the single source.
+- **Multiple banana-split queries** — each interface *member* is a **catamorphism / fold** (a "banana",
+  #7050) over the stream: a reactive query projecting the member's value. "Banana-split" = decompose the
+  interface into N independent fold-queries.
+- **Join and/or zip** — combine the per-member queries: **zip** (align by position/tick — same-index
+  combine) or **join** (align by key) — the Rx/Bonsai combinators (`Rx.fs`, `Bonsai.fs`). The combined
+  reactive value is the **intersection** of the queries (the tuple/record of all members, live).
+- **`new` the interface from the intersection** — an object expression (#7051) whose members read from the
+  joined/zipped reactive value: `{ new IInterface with member _.A = q1.Value; member _.B = q2.Value; … }`.
+  The interface is *born from the stream*, reactive by construction (the forced-RX nature, #7050).
+
+So an interface = **a bundle of fold-queries over one stream, joined/zipped, new'd into an object**. This
+unifies: the noun-class interface (#7051), the table↔stream fold (#7029), the forced-RX observation
+(#7050), and the everything-is-edges graph (#7036 — joins/zips are graph edges between queries).
+
+## Honest scope (peel)
+
+#7051 is **built + differential-tested** (`ITableProc`, `nativeProc`, `dynamicProc` via object expression).
+#7052 is **design** — the shape of interface-synthesis-from-joined-stream-queries; NOT built: no
+`synthesize`/`new-from-queries` combinator wiring `Rx.fs`/`Bonsai.fs` join/zip into an object expression
+yet (that's the reactive-interface builder — the next step, on the Bonsai/Rx substrate already in-repo).
+Recorded as the target shape.
+
+## Anchors (Beacon)
+
+- **F# object expressions** — `{ new I with … }` (the language feature Aaron named).
+- **Rx join/zip / reactive combinators** — `Rx.fs`, ReactiveX `zip`/`combineLatest`/`join`; Bonsai
+  incremental joins.
+- **Catamorphisms ("bananas") / recursion schemes** — Meijer et al. 1991 (each query is a fold).
+- **Hexagonal ports & adapters** — Cockburn (#7019); native vs interpreted vs synthesized, one interface.
+- Internal: #7049 (native-vs-interpreted differential), #7050 (forced RX / bananas), #7029 (table/stream
+  fold), #7036 (everything-is-edges; join/zip = edges), #7019 (pluggable/hexagonal), `StoredProc.fs`.

--- a/src/Core/StoredProc.fs
+++ b/src/Core/StoredProc.fs
@@ -81,3 +81,29 @@ module StoredProc =
             | Some(DynamicValue.String op) -> Error(sprintf "unknown op '%s'" op)
             | _ -> Error "missing 'op'"
         | _ -> Error "stored-proc must be a DynamicValue.Object"
+
+    /// A table operation as an **interface** — the hexagonal port (#7019) both the native fold and the
+    /// DynamicValue-backed interpreter satisfy. Native and interpreted are then *interchangeable behind one
+    /// interface*, and the differential test (#7049) compares two implementations of the SAME interface.
+    type ITableProc =
+        abstract member Apply: Table -> Table
+
+    /// The **native** implementation of the interface (the F# fold).
+    let nativeProc (d: Delta) : ITableProc =
+        { new ITableProc with
+            member _.Apply(t) = applyDelta t d }
+
+    /// The **interpreted** implementation of the SAME interface, backed by a `DynamicValue` stored-proc via an
+    /// F# **object expression** (Aaron #7051: *"implement the interface in DynamicValue in F# — return a
+    /// `{ new Interface with … }`"*). Validates the proc once (`decodeDelta`); `Apply` then runs the
+    /// independent interpreter (`interpretApply`). `Error` if the stored-proc is malformed.
+    let dynamicProc (sp: DynamicValue) : Result<ITableProc, string> =
+        match decodeDelta sp with
+        | Error e -> Error e
+        | Ok _ ->
+            Ok
+                { new ITableProc with
+                    member _.Apply(t) =
+                        match interpretApply t sp with
+                        | Ok r -> r
+                        | Error e -> failwithf "validated stored-proc failed at Apply: %s" e }

--- a/tests/Tests.FSharp/StoredProc.Tests.fs
+++ b/tests/Tests.FSharp/StoredProc.Tests.fs
@@ -37,6 +37,28 @@ let ``DIFFERENTIAL: native applyDelta == interpreted stored-proc (the per-test, 
             Assert.Equal<Table>(native, interpreted)
 
 [<Fact>]
+let ``DIFFERENTIAL via interface: nativeProc and dynamicProc agree behind ITableProc (#7051)`` () =
+    // Both implement the SAME interface (the DynamicValue one via an F# object expression); they agree.
+    let tables = [ emptyTable; Map [ "a", dv "old" ] ]
+
+    for t in tables do
+        for d in deltas do
+            let native: ITableProc = nativeProc d
+            let dyn: ITableProc =
+                match dynamicProc (encodeDelta d) with
+                | Ok p -> p
+                | Error e -> failwithf "dynamicProc failed: %s" e
+            Assert.Equal<Table>(native.Apply t, dyn.Apply t)
+
+[<Fact>]
+let ``dynamicProc rejects a malformed stored-proc up front`` () =
+    Assert.True(
+        match dynamicProc (DynamicValue.String "nope") with
+        | Error _ -> true
+        | Ok _ -> false
+    )
+
+[<Fact>]
 let ``interpret surfaces a malformed stored-proc as Error (no silent failure)`` () =
     Assert.True(
         match interpretApply emptyTable (DynamicValue.String "not-an-object") with


### PR DESCRIPTION
Aaron #7051/#7052. #7051 built: ITableProc with nativeProc (fold) + dynamicProc (DynamicValue-backed via F# object expression) — two impls of ONE interface, differential-tested to agree; malformed proc rejected. #7052 design: synthesize an interface from one stream — members = banana-split fold-queries, join/zip them, new the interface from the intersection (reactive by construction, forced-RX #7050). 6/6 green, 0-warning. Honest scope: #7051 built+tested; #7052 is the target shape (the Rx/Bonsai synthesize combinator is next). 🤖 Generated with [Claude Code](https://claude.com/claude-code)