### PR TITLE
feat(core): Db values are DynamicValue (homoiconicity #7041) — sequence step 1

### DIFF
--- a/src/Core/Db.fs
+++ b/src/Core/Db.fs
@@ -59,9 +59,9 @@ module Db =
         | DepSetup of noun: string * dependsOn: string list // edges established (the deps are "set up")
         | PushDown of noun: string // declared push-down dep (kernel/OS/global, OUTSIDE the container)
         | JitResolve of noun: string * resolved: string // lazy/dynamic resolution = DI, INSIDE the container
-        // — data events over the (single, infinite) file —
-        | Create of path: string * value: string
-        | Update of path: string * value: string
+        // — data events over the (single, infinite) file (values are homoiconic `DynamicValue`, #7041) —
+        | Create of path: string * value: DynamicValue
+        | Update of path: string * value: DynamicValue
         | Delete of path: string
 
     /// The materialized db state = the incremental FOLD (DBSP IVM) over the stream (event sourcing; #6994).
@@ -69,7 +69,7 @@ module Db =
     /// durability differs.
     type DbState =
         { Backend: Backend
-          Files: Map<string, string> // the infinite file's contents (path → value)
+          Files: Map<string, DynamicValue> // the infinite file's contents (path → value; homoiconic #7041)
           Deps: Map<string, string list> // dependency edges established by DepSetup
           PushedDown: Set<string> // nouns declared push-down (resolved outside the container)
           Resolved: Map<string, string> } // JIT/dynamic resolutions (DI, inside the container)
@@ -107,7 +107,7 @@ module Db =
     /// Interpret a db-seam command as a DATA mutation event. `value` supplies the payload (None for delete /
     /// non-mutating verbs). `write` is an alias for upsert. Non-mutating verbs (read/list/…) → None (queries,
     /// not events). Structural events come from `dependson` edges via `materialize`, not from here.
-    let toEvent (value: string option) (cmd: ZetaCommand) : DbEvent option =
+    let toEvent (value: DynamicValue option) (cmd: ZetaCommand) : DbEvent option =
         match cmd.Verb, value with
         | "create", Some v -> Some(Create(cmd.Noun, v))
         | "update", Some v
@@ -123,7 +123,7 @@ module Db =
     /// same contract as `ZetaGraph.topoOrder`).
     let materialize
         (backend: Backend)
-        (payloadOf: ZetaCommand -> string option)
+        (payloadOf: ZetaCommand -> DynamicValue option)
         (cmds: ZetaCommand list)
         : Result<DbState, string list> =
         match ZetaGraph.topoOrder cmds with

--- a/src/Core/ZetaExec.fs
+++ b/src/Core/ZetaExec.fs
@@ -60,7 +60,8 @@ module ZetaExec =
             | v -> Error(sprintf "table: unknown verb '%s'" v)
 
         | Some s when s = Db.SeamName ->
-            match Db.toEvent (valueOf cmd) cmd with
+            // the grammar's `value=` is a string field; wrap as a homoiconic DynamicValue.String (#7041)
+            match Db.toEvent (valueOf cmd |> Option.map DynamicValue.String) cmd with
             | Some ev -> Ok { ws with Db = Db.apply ws.Db ev }
             | None -> Error(sprintf "db: verb '%s' is not a mutation (or missing value=)" cmd.Verb)
 

--- a/tests/Tests.FSharp/Db.Tests.fs
+++ b/tests/Tests.FSharp/Db.Tests.fs
@@ -9,27 +9,30 @@ open Zeta.Core.Db
 let private db verb noun deps : ZetaCommand =
     { Seam = Some Db.SeamName; Verb = verb; Noun = noun; Fields = Map.empty; DependsOn = deps }
 
+// homoiconic value helper (#7041): db data values are DynamicValue, not string
+let private dv (s: string) = DynamicValue.String s
+
 [<Fact>]
 let ``fold: create then update then delete -> empty`` () =
-    let st = fold defaultBackend [ Create("/a", "1"); Update("/a", "2"); Delete "/a" ]
-    Assert.Equal<Map<string, string>>(Map.empty, st.Files)
+    let st = fold defaultBackend [ Create("/a", dv "1"); Update("/a", dv "2"); Delete "/a" ]
+    Assert.Equal<Map<string, DynamicValue>>(Map.empty, st.Files)
 
 [<Fact>]
 let ``fold: create/update upsert by path`` () =
-    let st = fold defaultBackend [ Create("/a", "1"); Update("/a", "2"); Create("/b", "x") ]
-    Assert.Equal("2", st.Files.["/a"])
-    Assert.Equal("x", st.Files.["/b"])
+    let st = fold defaultBackend [ Create("/a", dv "1"); Update("/a", dv "2"); Create("/b", dv "x") ]
+    Assert.Equal(dv "2", st.Files.["/a"])
+    Assert.Equal(dv "x", st.Files.["/b"])
 
 [<Fact>]
 let ``idempotency: applying the same Create twice == once (apply-N == apply-once)`` () =
-    let once = fold defaultBackend [ Create("/a", "1") ]
-    let twice = fold defaultBackend [ Create("/a", "1"); Create("/a", "1") ]
-    Assert.Equal<Map<string, string>>(once.Files, twice.Files)
+    let once = fold defaultBackend [ Create("/a", dv "1") ]
+    let twice = fold defaultBackend [ Create("/a", dv "1"); Create("/a", dv "1") ]
+    Assert.Equal<Map<string, DynamicValue>>(once.Files, twice.Files)
 
 [<Fact>]
 let ``idempotency: deleting an absent path is a no-op`` () =
     let st = fold defaultBackend [ Delete "/ghost"; Delete "/ghost" ]
-    Assert.Equal<Map<string, string>>(Map.empty, st.Files)
+    Assert.Equal<Map<string, DynamicValue>>(Map.empty, st.Files)
 
 [<Fact>]
 let ``default backend is GitNative`` () =
@@ -37,50 +40,54 @@ let ``default backend is GitNative`` () =
 
 [<Fact>]
 let ``backend-invariance: same stream folds to the same Files on every backend`` () =
-    let stream = [ Create("/a", "1"); Update("/a", "2"); Create("/b", "y"); Delete "/b" ]
+    let stream = [ Create("/a", dv "1"); Update("/a", dv "2"); Create("/b", dv "y"); Delete "/b" ]
     let files b = (fold b stream).Files
-    Assert.Equal<Map<string, string>>(files GitNative, files MultiFile)
-    Assert.Equal<Map<string, string>>(files GitNative, files SingleFile)
+    Assert.Equal<Map<string, DynamicValue>>(files GitNative, files MultiFile)
+    Assert.Equal<Map<string, DynamicValue>>(files GitNative, files SingleFile)
 
 [<Fact>]
 let ``toEvent: verbs map to events; read is a query (None)`` () =
-    Assert.Equal(Some(Create("/a", "1")), toEvent (Some "1") (db "create" "/a" []))
-    Assert.Equal(Some(Update("/a", "2")), toEvent (Some "2") (db "update" "/a" []))
-    Assert.Equal(Some(Update("/a", "3")), toEvent (Some "3") (db "write" "/a" [])) // write = upsert
+    Assert.Equal(Some(Create("/a", dv "1")), toEvent (Some(dv "1")) (db "create" "/a" []))
+    Assert.Equal(Some(Update("/a", dv "2")), toEvent (Some(dv "2")) (db "update" "/a" []))
+    Assert.Equal(Some(Update("/a", dv "3")), toEvent (Some(dv "3")) (db "write" "/a" [])) // write = upsert
     Assert.Equal(Some(Delete "/a"), toEvent None (db "delete" "/a" []))
     Assert.Equal(None, toEvent None (db "read" "/a" []))
+
+[<Fact>]
+let ``toEvent: homoiconic value can be any DynamicValue (Int), not just String`` () =
+    Assert.Equal(Some(Create("/n", DynamicValue.Int 42L)), toEvent (Some(DynamicValue.Int 42L)) (db "create" "/n" []))
 
 [<Fact>]
 let ``materialize: deps are set up (DepSetup events) before the data event that needs them`` () =
     // /b dependson /a  =>  topo puts /a first; each command emits DepSetup (if it has deps) then its data event
     let cmds = [ db "create" "/b" [ "/a" ]; db "create" "/a" [] ]
-    let payload (c: ZetaCommand) = if c.Noun = "/a" then Some "AV" else Some "BV"
+    let payload (c: ZetaCommand) = if c.Noun = "/a" then Some(dv "AV") else Some(dv "BV")
     match materialize defaultBackend payload cmds with
     | Error e -> failwithf "unexpected cycle: %A" e
     | Ok st ->
-        Assert.Equal("AV", st.Files.["/a"])
-        Assert.Equal("BV", st.Files.["/b"])
+        Assert.Equal(dv "AV", st.Files.["/a"])
+        Assert.Equal(dv "BV", st.Files.["/b"])
         // the structural edge for /b was recorded on the stream (deps "set up")
         Assert.Equal<string list>([ "/a" ], st.Deps.["/b"])
 
 [<Fact>]
 let ``materialize: cyclic deps -> Error (no strict stream order)`` () =
     let cmds = [ db "create" "/a" [ "/b" ]; db "create" "/b" [ "/a" ] ]
-    match materialize defaultBackend (fun _ -> Some "v") cmds with
+    match materialize defaultBackend (fun _ -> Some(dv "v")) cmds with
     | Error cycle -> Assert.Equal<string list>([ "/a"; "/b" ], cycle)
     | Ok _ -> failwith "expected a cycle error"
 
 [<Fact>]
 let ``structural events fold: PushDown and JitResolve land on the same stream`` () =
     let st =
-        fold defaultBackend [ PushDown "compiler.rust"; JitResolve("npm.left-pad", "1.3.0"); Create("/a", "1") ]
+        fold defaultBackend [ PushDown "compiler.rust"; JitResolve("npm.left-pad", "1.3.0"); Create("/a", dv "1") ]
     Assert.True(st.PushedDown.Contains "compiler.rust")
     Assert.Equal("1.3.0", st.Resolved.["npm.left-pad"])
-    Assert.Equal("1", st.Files.["/a"])
+    Assert.Equal(dv "1", st.Files.["/a"])
 
 [<Fact>]
 let ``clever-declarative: data upserts are order-independent (CRDT/CAS-like) - reorder lands same Files`` () =
     // two independent file writes converge regardless of order (no imperative sequencing needed)
-    let s1 = fold defaultBackend [ Create("/a", "1"); Create("/b", "2") ]
-    let s2 = fold defaultBackend [ Create("/b", "2"); Create("/a", "1") ]
-    Assert.Equal<Map<string, string>>(s1.Files, s2.Files)
+    let s1 = fold defaultBackend [ Create("/a", dv "1"); Create("/b", dv "2") ]
+    let s2 = fold defaultBackend [ Create("/b", dv "2"); Create("/a", dv "1") ]
+    Assert.Equal<Map<string, DynamicValue>>(s1.Files, s2.Files)

--- a/tests/Tests.FSharp/ZetaExec.Tests.fs
+++ b/tests/Tests.FSharp/ZetaExec.Tests.fs
@@ -34,7 +34,7 @@ let ``file move via grammar: to= field is the destination`` () =
 [<Fact>]
 let ``db create via grammar routes to the db state`` () =
     match run [ p "zeta db create users.1 value=v" ] with
-    | Ok ws -> Assert.Equal("v", ws.Db.Files.["users.1"])
+    | Ok ws -> Assert.Equal(DynamicValue.String "v", ws.Db.Files.["users.1"])
     | Error e -> failwith e
 
 [<Fact>]


### PR DESCRIPTION
Step 1 of the sequence (Aaron 'you can sequence it'): finish string->DynamicValue for db (TableStream/Catalog done in #7012). Db Create/Update + Files -> DynamicValue; toEvent/materialize take DynamicValue option; ZetaExec wraps grammar value= as DynamicValue.String. JitResolve/Resolved + File.contentHash stay pointers (addresses, not values). 20/20 Db+ZetaExec green, 0-warning. 🤖 Generated with [Claude Code](https://claude.com/claude-code)