### PR TITLE
feat(core): Optic — Lens + Store comonad (universal pointers #7061) — sequence step 3

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -175,6 +175,7 @@
     <Compile Include="Catalog.fs" />
     <Compile Include="StoredProc.fs" />
     <Compile Include="ReactiveSynth.fs" />
+    <Compile Include="Optic.fs" />
     <Compile Include="ZetaExec.fs" />
     <Compile Include="DarkHall.fs" />
     <Compile Include="Consent/KskAuthorization.fs" />

--- a/src/Core/Optic.fs
+++ b/src/Core/Optic.fs
@@ -1,0 +1,70 @@
+namespace Zeta.Core
+
+/// **Universal pointers — Lens (composable focus) + the Store comonad (close over the host & read).**
+///
+/// Aaron #7061: *"I tied in universal pointers so I can close over the host and replicate its functionality
+/// within our what-remains."* The categorical shapes for that (sequence step 3):
+///
+/// - **`Lens<'s,'a>`** — a *composable* universal pointer into a structure: `Get` (read the focus) + `Set`
+///   (replace the focus). Lenses **compose** (`∘`), so a deep pointer is built from shallow ones. The
+///   "pointer into a structure that composes" (Pickering–Gibbons–Wu profunctor optics; Kmett's `lens`).
+/// - **`Store<'s,'a>`** — the **costate / Store comonad**: `Peek: 's -> 'a` (a way to read) + `Pos: 's` (the
+///   pointer). This is *exactly* "close over the host and replicate its functionality in the what-remains":
+///   `Peek` is the host's functionality captured as a closure (the yin), `Pos` is the current pointer.
+///   `extract = Peek Pos`; `extend`/`map` are the comonad operations. ZetaId is the concrete pointer; this is
+///   its categorical shape (#7061).
+///
+/// Both obey their standard laws (tested): lens get/set, set/get, set/set; comonad extract/extend identities.
+/// F# reference oracle; C#/Rust/TS ports follow.
+module Optic =
+
+    // ── Lens: a composable universal pointer ────────────────────────────────────────────────────────────
+
+    /// A lens focusing an `'a` inside an `'s`. `Get` reads the focus; `Set` replaces it (returning a new `'s`).
+    type Lens<'s, 'a> =
+        { Get: 's -> 'a
+          Set: 'a -> 's -> 's }
+
+    /// Modify the focus by a function (read-modify-write through the lens).
+    let over (l: Lens<'s, 'a>) (f: 'a -> 'a) (s: 's) : 's = l.Set(f (l.Get s)) s
+
+    /// Compose two lenses: focus an `'a` in `'s`, then a `'b` in that `'a`, giving a lens `'s → 'b`.
+    /// `(outer >>> inner)` — a deep pointer from two shallow ones (universal-pointer composition).
+    let compose (outer: Lens<'s, 'a>) (inner: Lens<'a, 'b>) : Lens<'s, 'b> =
+        { Get = outer.Get >> inner.Get
+          Set = fun b s -> outer.Set (inner.Set b (outer.Get s)) s }
+
+    /// The identity lens (focus the whole structure).
+    let id_<'s> : Lens<'s, 's> =
+        { Get = id; Set = fun a _ -> a }
+
+    /// A lens into a `Map` at a given key, with a fallback for the absent case (total `Get`).
+    let mapKey (key: 'k) (fallback: 'v) : Lens<Map<'k, 'v>, 'v> =
+        { Get = fun m -> Map.tryFind key m |> Option.defaultValue fallback
+          Set = fun v m -> Map.add key v m }
+
+    // ── Store comonad: close over the host and read ─────────────────────────────────────────────────────
+
+    /// The **Store (costate) comonad**: a pointer `Pos` into a host plus a reader `Peek` that replicates the
+    /// host's functionality (the captured closure / what-remains, #7061).
+    type Store<'s, 'a> = { Peek: 's -> 'a; Pos: 's }
+
+    /// `extract` — read at the current position (the comonad counit). The host's value *here, now*.
+    let extract (w: Store<'s, 'a>) : 'a = w.Peek w.Pos
+
+    /// `map` — post-transform the read value (functor map).
+    let mapStore (f: 'a -> 'b) (w: Store<'s, 'a>) : Store<'s, 'b> =
+        { Peek = w.Peek >> f; Pos = w.Pos }
+
+    /// `extend` — recompute the whole reader from a function of the *focused store* (the comonad cobind):
+    /// `extend f w` peeks by moving the position and applying `f` to the store there. Enables context-
+    /// dependent reads (e.g. neighbourhood/relative access — the universal-pointer-with-context).
+    let extend (f: Store<'s, 'a> -> 'b) (w: Store<'s, 'a>) : Store<'s, 'b> =
+        { Peek = (fun s -> f { Peek = w.Peek; Pos = s }); Pos = w.Pos }
+
+    /// Move the pointer (seek) without changing the reader — re-aim the universal pointer at another position.
+    let seek (pos: 's) (w: Store<'s, 'a>) : Store<'s, 'a> = { w with Pos = pos }
+
+    /// Build a Store from a host reader and a starting pointer — "close over the host" (`peek`) "and the
+    /// pointer" (`pos`). The yin (`peek`) replicates the host's functionality; the pointer is the address.
+    let store (peek: 's -> 'a) (pos: 's) : Store<'s, 'a> = { Peek = peek; Pos = pos }

--- a/tests/Tests.FSharp/Optic.Tests.fs
+++ b/tests/Tests.FSharp/Optic.Tests.fs
@@ -1,0 +1,79 @@
+module Zeta.Tests.OpticTests
+
+open global.Xunit
+open Zeta.Core
+open Zeta.Core.Optic
+
+// a small nested record to focus into
+type private Addr = { City: string }
+type private Person = { Name: string; Addr: Addr }
+
+let private cityL: Lens<Addr, string> =
+    { Get = (fun a -> a.City); Set = fun c a -> { a with City = c } }
+
+let private addrL: Lens<Person, Addr> =
+    { Get = (fun p -> p.Addr); Set = fun a p -> { p with Addr = a } }
+
+let private p0 = { Name = "Aaron"; Addr = { City = "Rolesville" } }
+
+// ── Lens laws ──
+[<Fact>]
+let ``lens law: get-set (setting what you got changes nothing)`` () =
+    Assert.Equal<Person>(p0, addrL.Set (addrL.Get p0) p0)
+
+[<Fact>]
+let ``lens law: set-get (you get back what you set)`` () =
+    let a = { City = "Henderson" }
+    Assert.Equal<Addr>(a, addrL.Get(addrL.Set a p0))
+
+[<Fact>]
+let ``lens law: set-set (last set wins)`` () =
+    let a1 = { City = "A" }
+    let a2 = { City = "B" }
+    Assert.Equal<Person>(addrL.Set a2 p0, addrL.Set a2 (addrL.Set a1 p0))
+
+[<Fact>]
+let ``compose focuses deep: person -> addr -> city`` () =
+    let cityOfPerson = compose addrL cityL
+    Assert.Equal("Rolesville", cityOfPerson.Get p0)
+    Assert.Equal("Henderson", (cityOfPerson.Set "Henderson" p0).Addr.City)
+
+[<Fact>]
+let ``over modifies through the lens`` () =
+    let cityOfPerson = compose addrL cityL
+    Assert.Equal("ROLESVILLE", (over cityOfPerson (fun (s: string) -> s.ToUpperInvariant()) p0).Addr.City)
+
+[<Fact>]
+let ``mapKey lens reads with fallback and writes`` () =
+    let l = mapKey "k" "default"
+    Assert.Equal("default", l.Get Map.empty)
+    Assert.Equal("v", l.Get(l.Set "v" Map.empty))
+
+// ── Store comonad ──
+let private grid = [| 10; 20; 30; 40 |]
+let private w0: Store<int, int> = store (fun i -> grid.[i]) 1
+
+[<Fact>]
+let ``store extract reads at the current position`` () =
+    Assert.Equal(20, extract w0)
+
+[<Fact>]
+let ``seek re-aims the pointer; extract reads there`` () =
+    Assert.Equal(30, extract (seek 2 w0))
+
+[<Fact>]
+let ``comonad law: extend extract = identity (extract everywhere reproduces the store)`` () =
+    let w' = extend extract w0
+    Assert.Equal(extract w0, extract w')
+    Assert.Equal(extract (seek 3 w0), extract (seek 3 w'))
+
+[<Fact>]
+let ``extend gives context-dependent reads (neighbour sum via seek)`` () =
+    // at each position, read self + left neighbour (clamped) — the universal-pointer-with-context
+    let withLeft (s: Store<int, int>) =
+        let here = extract s
+        let left = if s.Pos > 0 then extract (seek (s.Pos - 1) s) else 0
+        here + left
+    let w' = extend withLeft w0
+    Assert.Equal(20 + 10, extract w') // pos 1: 20 + 10
+    Assert.Equal(40 + 30, extract (seek 3 w')) // pos 3: 40 + 30

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -101,6 +101,7 @@
     <Compile Include="ZetaExec.Tests.fs" />
     <Compile Include="StoredProc.Tests.fs" />
     <Compile Include="ReactiveSynth.Tests.fs" />
+    <Compile Include="Optic.Tests.fs" />
     <Compile Include="DarkHall.Tests.fs" />
     <Compile Include="ITensor.Tests.fs" />
     <Compile Include="SagaSnapshot.Tests.fs" />


### PR DESCRIPTION
Step 3: the universal-pointer shapes (#7061). Lens (Get/Set, compose/over/mapKey; lens laws tested) = composable pointer; Store comonad (Peek/Pos, extract/map/extend/seek) = close over the host & read (Peek=captured host functionality/yin, Pos=pointer; ZetaId is the concrete pointer). 10/10 green, 0-warning. Anchors: profunctor optics, Store/costate comonad. 🤖 Generated with [Claude Code](https://claude.com/claude-code)