### PR TITLE
feat(core): SybilBft — BFT quorum over distinct sources, not claimed identities

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -179,6 +179,7 @@
     <Compile Include="Conjugate.fs" />
     <Compile Include="BitGan.fs" />
     <Compile Include="AntiSybil.fs" />
+    <Compile Include="SybilBft.fs" />
     <Compile Include="ZetaExec.fs" />
     <Compile Include="DarkHall.fs" />
     <Compile Include="Consent/KskAuthorization.fs" />

--- a/src/Core/SybilBft.fs
+++ b/src/Core/SybilBft.fs
@@ -1,0 +1,99 @@
+namespace Zeta.Core
+
+/// **`SybilBft` — Byzantine fault tolerance whose quorum counts *distinct sources*, not *claimed identities*
+/// (Aaron 2026-06-08: "the start of a unique BFT").**
+///
+/// Classical BFT (PBFT, HotStuff) assumes `n` participants are *already distinct* and needs `n ≥ 3f+1`,
+/// quorum `2f+1`. The unhandled attack underneath that assumption is **Sybil**: one Byzantine node forging
+/// `k` identities votes `k` times, inflating `n` and breaking the `f < n/3` bound. Permissionless chains
+/// patch this *economically* (PoW/PoS make each identity expensive). This module patches it **physically**:
+/// the quorum is taken over the **distinct entropy sources** found by `AntiSybil` (non-fungible drift, #7091),
+/// so forged identities collapse to the one clock that produced them *before* votes are counted.
+///
+/// **Anti-Sybil comes first, then voting** — that ordering is the novelty (the prior-art search 2026-06-08
+/// found PoW/PoS-gated committees and "consensus on the honest identity set," but none deriving the quorum
+/// from a physical proof-of-distinctness). The classical bound is recovered exactly, but on `d` = distinct
+/// sources rather than `k` = claims: safety needs `d ≥ 3f+1`, quorum `2f+1` distinct sources.
+///
+/// **Honest scope (peel):** inherits `AntiSybil`'s scope — sound against *exact* identity-replay; noisy
+/// forgeries sit on the detection/length curve. An **equivocating** source (same clock, conflicting votes
+/// across its claims) is detected and excluded — it cannot have its conflicting votes both counted, which is
+/// the other half of Byzantine behaviour. This is a *reference model*, not a wire protocol: no network,
+/// timeouts, view-change, or leader election yet. Route the adversary model to Aminata/Mateo; do not claim
+/// "a new BFT" outward before naming-expert + Ilyana + human review.
+module SybilBft =
+
+    /// A vote: a *claimed* identity, the drift bit-stream that is supposed to certify its distinctness, and
+    /// the value it votes for.
+    type Vote<'v when 'v: comparison> =
+        { Claimed: int
+          Stream: int list
+          Value: 'v }
+
+    /// How a distinct source voted after collapsing its claims.
+    type SourceVote<'v when 'v: comparison> =
+        | Agreed of 'v // all of this source's claims voted the same value — one honest-shaped vote
+        | Equivocated // this source's claims disagree — detected Byzantine equivocation, excluded from quorum
+
+    /// Result of tallying votes by distinct source.
+    type Tally<'v when 'v: comparison> =
+        { /// Distinct entropy sources detected (`AntiSybil.DistinctCount`) — the *real* `n` for the BFT bound.
+          DistinctSources: int
+          /// Source id → how it voted (agreed value, or equivocated).
+          BySource: Map<int, SourceVote<'v>>
+          /// Value → number of **distinct, non-equivocating** sources that voted for it.
+          VotesByValue: Map<'v, int>
+          /// Distinct sources caught equivocating (Byzantine).
+          Equivocators: int }
+
+    /// Tally `votes` by distinct source: collapse Sybil-correlated claims via `AntiSybil` (`threshold`), then
+    /// give **one** vote per distinct source — `Agreed v` if all its claims voted `v`, else `Equivocated`.
+    /// This is the anti-Sybil-first step: vote-stuffing collapses before counting.
+    let tally (threshold: float) (votes: Vote<'v> list) : Tally<'v> =
+        let streams = votes |> List.map (fun v -> v.Stream)
+        let verdict = AntiSybil.antiSybil threshold streams
+        // Group claim indices by their detected source.
+        let bySource =
+            votes
+            |> List.mapi (fun i v -> verdict.SourceOf.[i], v.Value)
+            |> List.groupBy fst
+            |> List.map (fun (src, pairs) ->
+                let values = pairs |> List.map snd |> List.distinct
+                let sv = match values with [ v ] -> Agreed v | _ -> Equivocated
+                src, sv)
+            |> Map.ofList
+
+        let votesByValue =
+            bySource
+            |> Map.toList
+            |> List.choose (fun (_, sv) -> match sv with Agreed v -> Some v | Equivocated -> None)
+            |> List.countBy id
+            |> Map.ofList
+
+        let equivocators =
+            bySource |> Map.toList |> List.sumBy (fun (_, sv) -> match sv with Equivocated -> 1 | _ -> 0)
+
+        { DistinctSources = verdict.DistinctCount
+          BySource = bySource
+          VotesByValue = votesByValue
+          Equivocators = equivocators }
+
+    /// The Byzantine quorum size for `f` tolerated faulty sources: `2f+1`.
+    let quorumSize (f: int) : int = 2 * (max 0 f) + 1
+
+    /// The max faulty sources the classical bound tolerates given `d` distinct sources: `⌊(d-1)/3⌋`.
+    let maxFaults (distinctSources: int) : int = (max 0 distinctSources - 1) / 3
+
+    /// Does `value` have a `2f+1` quorum of **distinct** sources? (Sybil inflation already collapsed.)
+    let hasQuorum (f: int) (value: 'v) (t: Tally<'v>) : bool =
+        (t.VotesByValue |> Map.tryFind value |> Option.defaultValue 0) >= quorumSize f
+
+    /// The decided value, if any single value holds a `2f+1` distinct-source quorum. `f` is derived from the
+    /// distinct-source count (`maxFaults`), so the bound tracks *real* participants, not claimed ones.
+    let decide (t: Tally<'v>) : 'v option =
+        let f = maxFaults t.DistinctSources
+        let q = quorumSize f
+        t.VotesByValue
+        |> Map.toList
+        |> List.tryFind (fun (_, n) -> n >= q)
+        |> Option.map fst

--- a/tests/Tests.FSharp/SybilBft.Tests.fs
+++ b/tests/Tests.FSharp/SybilBft.Tests.fs
@@ -1,0 +1,71 @@
+module Zeta.Tests.SybilBftTests
+
+open global.Xunit
+open Zeta.Core
+open Zeta.Core.SybilBft
+
+// Deterministic pseudo-random bit stream (DST §7) — same generator as AntiSybil tests.
+let private bits (seed: int) (n: int) : int list =
+    let mutable s = uint64 seed * 2862933555777941757UL + 3037000493UL
+    [ for _ in 1 .. n ->
+          s <- s * 6364136223846793005UL + 1442695040888963407UL
+          int ((s >>> 33) &&& 1UL) ]
+
+let private vote claimed seed value =
+    { Claimed = claimed; Stream = bits seed 500; Value = value }
+
+[<Fact>]
+let ``quorum/maxFaults track the classical BFT bound`` () =
+    Assert.Equal(1, quorumSize 0)
+    Assert.Equal(3, quorumSize 1)
+    Assert.Equal(7, quorumSize 3)
+    Assert.Equal(0, maxFaults 1)
+    Assert.Equal(1, maxFaults 4) // 3f+1 = 4 ⇒ f = 1
+    Assert.Equal(2, maxFaults 7)
+
+[<Fact>]
+let ``honest 4-source agreement decides the value (d=4, f=1, quorum=3)`` () =
+    let votes =
+        [ vote 0 1 "commit"; vote 1 2 "commit"; vote 2 3 "commit"; vote 3 4 "commit" ]
+    let t = tally 0.5 votes
+    Assert.Equal(4, t.DistinctSources)
+    Assert.Equal(Some "commit", decide t)
+
+[<Fact>]
+let ``THE GUARANTEE: one Byzantine clock forging 5 identities cannot reach quorum`` () =
+    // Attacker has ONE clock (seed 9), claims 5 identities all voting "evil".
+    // 3 honest distinct sources vote "good".
+    let evil = bits 9 500
+    let votes =
+        [ { Claimed = 0; Stream = evil; Value = "evil" }
+          { Claimed = 1; Stream = evil; Value = "evil" }
+          { Claimed = 2; Stream = evil; Value = "evil" }
+          { Claimed = 3; Stream = evil; Value = "evil" }
+          { Claimed = 4; Stream = evil; Value = "evil" }
+          vote 5 1 "good"; vote 6 2 "good"; vote 7 3 "good" ]
+    let t = tally 0.5 votes
+    // 5 forged claims collapse to 1 source; 3 honest = 4 distinct sources total.
+    Assert.Equal(4, t.DistinctSources)
+    Assert.Equal(1, t.VotesByValue.["evil"]) // NOT 5 — Sybil inflation defeated before counting
+    Assert.Equal(3, t.VotesByValue.["good"])
+    // f = maxFaults 4 = 1, quorum = 3: "good" wins, "evil" never had the votes.
+    Assert.Equal(Some "good", decide t)
+    Assert.False(hasQuorum 1 "evil" t)
+
+[<Fact>]
+let ``equivocating source (same clock, conflicting votes) is detected and excluded`` () =
+    let clk = bits 11 500
+    let votes =
+        [ { Claimed = 0; Stream = clk; Value = "A" }
+          { Claimed = 1; Stream = clk; Value = "B" } // same clock, different vote ⇒ equivocation
+          vote 2 1 "A"; vote 3 2 "A" ]
+    let t = tally 0.5 votes
+    Assert.Equal(3, t.DistinctSources)
+    Assert.Equal(1, t.Equivocators)
+    Assert.Equal(2, t.VotesByValue.["A"]) // only the two honest sources; equivocator excluded
+    Assert.False(t.VotesByValue.ContainsKey "B")
+
+[<Fact>]
+let ``deterministic / replayable (DST)`` () =
+    let votes = [ vote 0 1 "x"; vote 1 2 "x"; vote 2 3 "y" ]
+    Assert.Equal(decide (tally 0.5 votes), decide (tally 0.5 votes))

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -105,6 +105,7 @@
     <Compile Include="Conjugate.Tests.fs" />
     <Compile Include="BitGan.Tests.fs" />
     <Compile Include="AntiSybil.Tests.fs" />
+    <Compile Include="SybilBft.Tests.fs" />
     <Compile Include="DarkHall.Tests.fs" />
     <Compile Include="ITensor.Tests.fs" />
     <Compile Include="SagaSnapshot.Tests.fs" />


### PR DESCRIPTION
Aaron: 'the start of a unique BFT.' Quorum counts DISTINCT entropy sources (AntiSybil) not claimed identities, so Sybil vote-stuffing collapses before counting — anti-Sybil first, then voting. Recovers the classical bound (d>=3f+1, quorum 2f+1) on d=distinct sources. Tested guarantee: one clock forging 5 identities = 1 vote, cannot reach quorum; equivocation detected+excluded. Prior-art search found PoW/PoS-gated committees but none deriving quorum from a physical proof-of-distinctness — the slot is open. Peel: reference model not a wire protocol (no net/timeout/view-change); -> Aminata/Mateo. 5/5 tests, 0-warning. 🤖 Generated with [Claude Code](https://claude.com/claude-code)