### PR TITLE
feat(core): SybilBftLiveness — heartbeat + timeout + view-change over the distinct-source quorum

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -181,6 +181,7 @@
     <Compile Include="AntiSybil.fs" />
     <Compile Include="SybilBft.fs" />
     <Compile Include="SybilBftProtocol.fs" />
+    <Compile Include="SybilBftLiveness.fs" />
     <Compile Include="ZetaExec.fs" />
     <Compile Include="DarkHall.fs" />
     <Compile Include="Consent/KskAuthorization.fs" />

--- a/src/Core/SybilBftLiveness.fs
+++ b/src/Core/SybilBftLiveness.fs
@@ -1,0 +1,192 @@
+namespace Zeta.Core
+
+/// **`SybilBftLiveness` — the liveness layer over the distinct-source quorum (Aaron 2026-06-08, shadow*).**
+///
+/// `SybilBftProtocol` (#7048) gives *safety* (no two honest views commit different values) but not
+/// *liveness*: if the leader is silent, nothing forces progress. This layer adds the standard BFT liveness
+/// mechanisms — **heartbeats**, **timeout-driven suspicion**, and **view-change** (leader rotation) — but
+/// reuses the anti-Sybil discipline so the liveness path is itself Sybil-resistant.
+///
+/// **Aaron's design inputs, made concrete:**
+/// - **Heartbeats are the timeout mechanism.** A leader that keeps beating holds the view; silence past a
+///   `Timeout` (in *logical ticks* — DST §7, no wall clock) makes a replica suspect it and call a view-change.
+/// - **Persistence-over-time increases the identity claim.** A source that sustains a *consistent* drift
+///   signature accrues a stronger claim than a fresh one — a forger can fake a moment, not a long regular
+///   history. `claimStrength` rewards sustained beats and penalizes jitter (variance).
+/// - **Harmonic resonance finds the clock generator efficiently.** `resonantPeriod` locks onto the
+///   generator's period via an **autocorrelation peak** on the beat train (O(n·maxLag), not a brute scan of
+///   candidate generators). Anchor: autocorrelation pitch detection (Rabiner & Schafer); a real clock's beat
+///   train resonates at one dominant lag, a forged/irregular one does not.
+///
+/// **The BFT-critical bit — view-change is ALSO counted over distinct sources.** A naive view-change lets one
+/// Byzantine node spam suspicions and stall the system forever (a liveness attack). Here a view-change
+/// installs only on a `2f+1` quorum of **distinct sources** (via `SybilBft.tally`), so a forger's many
+/// claimed ids collapse to one vote and cannot force rotation alone.
+///
+/// **Honest scope (peel):** logical-tick model (the caller drives `onTick`); single-shot agreement per view
+/// (composes `SybilBftProtocol`, not multi-slot). `resonantPeriod` is a standard signal-processing estimator,
+/// not a novel transform — its role here is the *efficient generator-finder*, and it inherits the
+/// detection/length limits of any finite-sample autocorrelation. Inherits `AntiSybil`'s exact-replay
+/// soundness. Reference model; the gated transport (B-1002) and wall-clock binding live in the adapter.
+module SybilBftLiveness =
+
+    open SybilBft
+
+    /// A logical tick (DST — advanced explicitly by the caller, never read from a wall clock).
+    type Tick = int
+
+    /// A per-member identity claim that accrues with persistence over time. `RecentBeats` is the bounded
+    /// recent history of heartbeat ticks (for resonance + jitter).
+    type IdentityClaim =
+        { FirstTick: Tick
+          LastTick: Tick
+          Beats: int
+          RecentBeats: Tick list }
+
+    /// How many recent beats to retain for resonance/jitter analysis.
+    [<Literal>]
+    let HistoryLen = 32
+
+    let private intervalsOf (beats: Tick list) : int list =
+        match List.sort beats with
+        | [] | [ _ ] -> []
+        | sorted -> List.pairwise sorted |> List.map (fun (a, b) -> b - a)
+
+    let private variance (xs: float list) : float =
+        match xs with
+        | [] | [ _ ] -> 0.0
+        | _ ->
+            let n = float (List.length xs)
+            let mean = List.sum xs / n
+            (xs |> List.sumBy (fun x -> (x - mean) * (x - mean))) / n
+
+    /// Claim strength: grows with **persistence** (sustained beats) and is dampened by **jitter** (interval
+    /// variance). A long, regular history ⇒ strong claim; a short or erratic one ⇒ weak. (Aaron: "persistence
+    /// over time increases the identity claim.")
+    let claimStrength (c: IdentityClaim) : float =
+        let jitter = c.RecentBeats |> intervalsOf |> List.map float |> variance
+        float c.Beats / (1.0 + jitter)
+
+    /// Record a heartbeat at `tick` into an (optional) existing claim.
+    let private beat (existing: IdentityClaim option) (tick: Tick) : IdentityClaim =
+        match existing with
+        | None ->
+            { FirstTick = tick
+              LastTick = tick
+              Beats = 1
+              RecentBeats = [ tick ] }
+        | Some c ->
+            { c with
+                LastTick = max c.LastTick tick
+                Beats = c.Beats + 1
+                RecentBeats = (tick :: c.RecentBeats) |> List.truncate HistoryLen }
+
+    /// **Resonant period** of a beat train via autocorrelation peak — the efficient way to find the clock
+    /// generator's period (Aaron: "harmonic oscillation / resonance frequency is how you find the clock
+    /// generator efficiently"). Reconstruct a 0/1 train over `[min..max]` beat ticks and return the positive
+    /// lag in `[1..maxLag]` maximizing self-overlap. `None` if fewer than two beats. A regular clock peaks
+    /// sharply at its period; an irregular/forged train does not.
+    let resonantPeriod (beats: Tick list) : Tick option =
+        match List.sort (List.distinct beats) with
+        | [] | [ _ ] -> None
+        | sorted ->
+            let lo = List.head sorted
+            let span = List.last sorted - lo
+            if span < 1 then
+                None
+            else
+                let present = sorted |> List.map (fun t -> t - lo) |> Set.ofList
+                let maxLag = span
+                let score lag =
+                    present |> Set.fold (fun acc t -> if present.Contains(t + lag) then acc + 1 else acc) 0
+                let best =
+                    [ 1..maxLag ]
+                    |> List.maxBy (fun lag -> (score lag, -lag)) // ties → smallest period (fundamental, not harmonic)
+                Some best
+
+    /// A liveness-layer message (composes the safety-layer `SybilBftProtocol.Message`).
+    type LiveMessage<'v when 'v: comparison> =
+        | Safety of SybilBftProtocol.Message<'v>
+        | Heartbeat of leaderClaim: int * stream: int list * tick: Tick
+        | ViewChangeVote of newView: int * voter: int * stream: int list
+
+    /// The liveness view, wrapping the safety-layer `View`.
+    type LiveView<'v when 'v: comparison> =
+        { Safety: SybilBftProtocol.View<'v>
+          ViewNum: int
+          Now: Tick
+          Timeout: Tick
+          LastLeaderBeat: Tick
+          Claims: Map<int, IdentityClaim>
+          /// Accumulated view-change votes: keyed by claimed voter id → the new view it voted for + its
+          /// drift stream (so the install quorum is counted over *distinct sources*).
+          ViewChangeVotes: Map<int, int * int list> }
+
+    /// The current leader's claimed id = `ViewNum mod Members` (round-robin rotation).
+    let leader (lv: LiveView<'v>) : int =
+        if lv.Safety.Members <= 0 then 0 else lv.ViewNum % lv.Safety.Members
+
+    /// A fresh liveness view at view 0, logical time 0, with the given suspicion `timeout`.
+    let init (members: int) (threshold: float) (timeout: Tick) : LiveView<'v> =
+        { Safety = SybilBftProtocol.init members threshold
+          ViewNum = 0
+          Now = 0
+          Timeout = timeout
+          LastLeaderBeat = 0
+          Claims = Map.empty
+          ViewChangeVotes = Map.empty }
+
+    /// Record a heartbeat: accrue the sender's identity claim, and if it is the current leader, reset the
+    /// suspicion timer.
+    let onHeartbeat (lv: LiveView<'v>) (claimed: int) (stream: int list) (tick: Tick) : LiveView<'v> =
+        let claims = Map.add claimed (beat (Map.tryFind claimed lv.Claims) tick) lv.Claims
+        let lastLeaderBeat = if claimed = leader lv then max lv.LastLeaderBeat tick else lv.LastLeaderBeat
+        { lv with
+            Claims = claims
+            Now = max lv.Now tick
+            LastLeaderBeat = lastLeaderBeat }
+
+    /// Advance the logical clock to `tick`. If the leader has been silent for longer than `Timeout`, emit a
+    /// `ViewChangeVote` for the next view (suspicion). Deterministic — no wall clock.
+    let onTick (lv: LiveView<'v>) (tick: Tick) (selfClaim: int) (selfStream: int list) : LiveView<'v> * LiveMessage<'v> list =
+        let lv = { lv with Now = max lv.Now tick }
+        if lv.Now - lv.LastLeaderBeat > lv.Timeout then
+            lv, [ ViewChangeVote(lv.ViewNum + 1, selfClaim, selfStream) ]
+        else
+            lv, []
+
+    /// Fold a `ViewChangeVote` into the view. A new view installs only when `2f+1` **distinct sources** have
+    /// voted for it (Sybil-resistant view-change). On install: bump `ViewNum`, reset the suspicion timer, and
+    /// clear the accumulated votes.
+    let onViewChangeVote (lv: LiveView<'v>) (newView: int) (voter: int) (stream: int list) : LiveView<'v> =
+        let votes = Map.add voter (newView, stream) lv.ViewChangeVotes
+        // Count only votes for this candidate view, over distinct sources.
+        let forThis =
+            votes
+            |> Map.toList
+            |> List.choose (fun (claimed, (v, s)) ->
+                if v = newView then Some { Claimed = claimed; Stream = s; Value = newView } else None)
+        let t = tally lv.Safety.Threshold forThis
+        let q = SybilBftProtocol.quorum lv.Safety
+        let installed =
+            t.VotesByValue |> Map.tryFind newView |> Option.defaultValue 0 >= q
+        if installed && newView > lv.ViewNum then
+            { lv with
+                ViewNum = newView
+                LastLeaderBeat = lv.Now // give the new leader a fresh window
+                ViewChangeVotes = Map.empty }
+        else
+            { lv with ViewChangeVotes = votes }
+
+    /// Route a liveness message. Safety messages defer to `SybilBftProtocol.receive` (and any safety outbound
+    /// is re-wrapped); heartbeats and view-change votes are handled here.
+    let receive (lv: LiveView<'v>) (m: LiveMessage<'v>) : LiveView<'v> * LiveMessage<'v> list =
+        match m with
+        | Safety sm ->
+            let sv, out = SybilBftProtocol.receive lv.Safety sm
+            { lv with Safety = sv }, (out |> List.map Safety)
+        | Heartbeat(claimed, stream, tick) -> onHeartbeat lv claimed stream tick, []
+        | ViewChangeVote(newView, voter, stream) -> onViewChangeVote lv newView voter stream, []
+
+    /// The committed value of the underlying safety view, if any.
+    let committed (lv: LiveView<'v>) : 'v option = SybilBftProtocol.committed lv.Safety

--- a/tests/Tests.FSharp/SybilBftLiveness.Tests.fs
+++ b/tests/Tests.FSharp/SybilBftLiveness.Tests.fs
@@ -1,0 +1,87 @@
+module Zeta.Tests.SybilBftLivenessTests
+
+open global.Xunit
+open Zeta.Core
+open Zeta.Core.SybilBftLiveness
+
+let private bits (seed: int) (n: int) : int list =
+    let mutable s = uint64 seed * 2862933555777941757UL + 3037000493UL
+    [ for _ in 1 .. n ->
+          s <- s * 6364136223846793005UL + 1442695040888963407UL
+          int ((s >>> 33) &&& 1UL) ]
+
+[<Fact>]
+let ``leader rotates with the view number (round-robin)`` () =
+    let lv = init 4 0.5 10
+    Assert.Equal(0, leader lv)
+    Assert.Equal(1, leader { lv with ViewNum = 1 })
+    Assert.Equal(0, leader { lv with ViewNum = 4 })
+
+[<Fact>]
+let ``heartbeat from the leader resets the suspicion timer; silence past timeout triggers a view-change vote`` () =
+    let lv = init 4 0.5 10
+    // Leader (id 0) beats at tick 5.
+    let lv = onHeartbeat lv 0 (bits 0 200) 5
+    // At tick 12, only 7 ticks of silence (<=10): no suspicion.
+    let lv', out1 = onTick lv 12 1 (bits 1 200)
+    Assert.True(List.isEmpty out1)
+    // At tick 20, 15 ticks since the last leader beat (>10): suspect → vote for view 1.
+    let _, out2 = onTick lv' 20 1 (bits 1 200)
+    Assert.Equal<LiveMessage<string> list>([ ViewChangeVote(1, 1, bits 1 200) ], out2)
+
+[<Fact>]
+let ``THE LIVENESS GUARANTEE: one clock forging view-change votes cannot force rotation alone`` () =
+    let lv = init 4 0.5 10
+    let evil = bits 9 200
+    // Attacker spams 5 forged ids all voting to move to view 1.
+    let lv =
+        [ 0..4 ]
+        |> List.fold (fun acc i -> onViewChangeVote acc 1 i evil) lv
+    Assert.Equal(0, lv.ViewNum) // 5 forged votes collapse to 1 distinct source < quorum 3 — NOT installed
+
+[<Fact>]
+let ``view-change installs on a 2f+1 distinct-source quorum`` () =
+    let lv = init 4 0.5 10
+    let lv = onViewChangeVote lv 1 0 (bits 0 200)
+    let lv = onViewChangeVote lv 1 1 (bits 1 200)
+    Assert.Equal(0, lv.ViewNum) // only 2 distinct < quorum 3
+    let lv = onViewChangeVote lv 1 2 (bits 2 200)
+    Assert.Equal(1, lv.ViewNum) // 3 distinct sources ≥ quorum 3 → installed
+    Assert.Equal(1, leader lv) // new leader
+
+[<Fact>]
+let ``persistence increases the identity claim; jitter weakens it`` () =
+    // Regular beats every 4 ticks, 8 of them.
+    let regular =
+        [ 0..7 ] |> List.fold (fun acc i -> onHeartbeat acc 0 (bits 0 200) (i * 4)) (init 4 0.5 10)
+    // Sparse: only 2 beats.
+    let sparse = onHeartbeat (onHeartbeat (init 4 0.5 10) 0 (bits 0 200) 0) 0 (bits 0 200) 4
+    let sReg = claimStrength regular.Claims.[0]
+    let sSparse = claimStrength sparse.Claims.[0]
+    Assert.True(sReg > sSparse) // sustained > sparse
+    // Regular train (low jitter) beats an erratic one with the same beat count.
+    let erratic =
+        [ 0; 1; 2; 30; 31; 60; 90; 91 ]
+        |> List.fold (fun acc t -> onHeartbeat acc 0 (bits 0 200) t) (init 4 0.5 10)
+    Assert.True(claimStrength regular.Claims.[0] > claimStrength erratic.Claims.[0])
+
+[<Fact>]
+let ``resonantPeriod finds the generator period of a regular beat train`` () =
+    // Beats at 0,5,10,15,20 → fundamental period 5.
+    Assert.Equal(Some 5, resonantPeriod [ 0; 5; 10; 15; 20 ])
+    // Period 3.
+    Assert.Equal(Some 3, resonantPeriod [ 0; 3; 6; 9; 12 ])
+    // Fewer than two beats → no period.
+    Assert.Equal(None, resonantPeriod [ 7 ])
+
+[<Fact>]
+let ``deterministic / replayable (DST)`` () =
+    let run () =
+        let lv = init 4 0.5 10
+        let lv = onHeartbeat lv 0 (bits 0 200) 5
+        let lv, _ = onTick lv 20 1 (bits 1 200)
+        let lv = onViewChangeVote lv 1 0 (bits 0 200)
+        let lv = onViewChangeVote lv 1 1 (bits 1 200)
+        let lv = onViewChangeVote lv 1 2 (bits 2 200)
+        lv.ViewNum
+    Assert.Equal(run (), run ())

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -107,6 +107,7 @@
     <Compile Include="AntiSybil.Tests.fs" />
     <Compile Include="SybilBft.Tests.fs" />
     <Compile Include="SybilBftProtocol.Tests.fs" />
+    <Compile Include="SybilBftLiveness.Tests.fs" />
     <Compile Include="DarkHall.Tests.fs" />
     <Compile Include="ITensor.Tests.fs" />
     <Compile Include="SagaSnapshot.Tests.fs" />


### PR DESCRIPTION
Liveness layer over SybilBftProtocol (#7048). Heartbeats = timeout mechanism (logical ticks, DST); persistence-over-time accrues identity claim (claimStrength rewards sustained low-jitter beats); resonantPeriod (autocorrelation peak) = efficient clock-generator finder. BFT-critical: view-change counted over DISTINCT SOURCES — tested that one clock forging 5 view-change votes can't force rotation; real 2f+1 distinct quorum installs. Peel: logical-tick reference model, single-shot per view, resonantPeriod a standard estimator. 7/7 tests, 0-warning. Next per Aaron: TLA+ proof (Soraya), gated transport, crypto noun. 🤖 Generated with [Claude Code](https://claude.com/claude-code)