### PR TITLE
feat(core): SybilBftProgress — observe consensus progress per sim tick

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -183,6 +183,7 @@
     <Compile Include="SybilBft.fs" />
     <Compile Include="SybilBftProtocol.fs" />
     <Compile Include="SybilBftLiveness.fs" />
+    <Compile Include="SybilBftProgress.fs" />
     <Compile Include="ZetaExec.fs" />
     <Compile Include="DarkHall.fs" />
     <Compile Include="Consent/KskAuthorization.fs" />

--- a/src/Core/SybilBftProgress.fs
+++ b/src/Core/SybilBftProgress.fs
@@ -1,0 +1,107 @@
+namespace Zeta.Core
+
+/// **`SybilBftProgress` — observe consensus progress per sim tick (Aaron 2026-06-08, shadow*).**
+///
+/// The BFT runs on deterministic logical ticks (`SybilBftLiveness`, DST §7), so progress toward a decision is
+/// **observable and replayable at every tick**. This module exposes that observation: a per-tick `Progress`
+/// snapshot and a `fraction` in `[0,1]` that is the **liveness variant function** — the monotone rank a
+/// liveness proof (Soraya's TLA+ `◇commit` obligation) needs, made concrete and watchable in the sim.
+///
+/// **What "progress" is:** how close the leading value is to the distinct-source quorum, or `1.0` once
+/// committed. It rises as distinct sources report and resets only across a view-change (new leader, new round)
+/// — exactly the rank that must strictly improve on productive steps for liveness to hold. A run where the
+/// fraction stays flat without committing is a **stall / livelock** — `isStalled` flags it.
+///
+/// **Honest scope (peel):** an *observation* layer over the shipped reducer — pure, deterministic, no new
+/// protocol behaviour. `fraction` is monotone *within a view* but legitimately *drops* on a view-change
+/// (progress in the failed view is abandoned); so `isStalled` judges over a window, not a single step, and
+/// only flags flat-without-commit. Inherits the safety/liveness scope of `SybilBftProtocol`/`Liveness`.
+module SybilBftProgress =
+
+    open SybilBft
+    open SybilBftLiveness
+
+    /// A per-tick progress observation. Deterministic given the view (DST-replayable).
+    type Progress<'v when 'v: comparison> =
+        { Tick: Tick
+          ViewNum: int
+          /// Distinct entropy sources whose votes are in (Sybil-collapsed).
+          DistinctSources: int
+          /// Max distinct-source votes for any single value (the leader in the tally).
+          LeadingVotes: int
+          /// The fixed `2f+1` quorum for the membership.
+          Quorum: int
+          Committed: 'v option }
+
+    /// Observe the live view's progress at its current tick.
+    let observe (lv: LiveView<'v>) : Progress<'v> =
+        let votes = lv.Safety.Heard |> Map.toList |> List.map snd
+        let t = tally lv.Safety.Threshold votes
+        let leading =
+            if Map.isEmpty t.VotesByValue then 0
+            else t.VotesByValue |> Map.toList |> List.map snd |> List.max
+        { Tick = lv.Now
+          ViewNum = lv.ViewNum
+          DistinctSources = t.DistinctSources
+          LeadingVotes = leading
+          Quorum = SybilBftProtocol.quorum lv.Safety
+          Committed = committed lv }
+
+    /// Progress fraction in `[0,1]`: `1.0` once committed, else `leadingVotes / quorum` (clamped). The liveness
+    /// variant — watch it per tick to see the round close in.
+    let fraction (p: Progress<'v>) : float =
+        match p.Committed with
+        | Some _ -> 1.0
+        | None -> if p.Quorum <= 0 then 0.0 else min 1.0 (float p.LeadingVotes / float p.Quorum)
+
+    /// True once a decision is reached (terminal — idempotent, #6).
+    let isDecided (p: Progress<'v>) : bool = Option.isSome p.Committed
+
+    /// **Stall / livelock detector** over a tick-ordered window. Stalled iff the window is non-trivial, ends
+    /// undecided, stays in ONE view (no view-change happened — a view-change is legitimate progress), and the
+    /// leading-vote count never improved across it. (A flat fraction *with* a view-change is not a stall — the
+    /// system is trying to recover.)
+    let isStalled (window: Progress<'v> list) : bool =
+        match window with
+        | []
+        | [ _ ] -> false
+        | first :: _ ->
+            let last = List.last window
+            let sameView = window |> List.forall (fun p -> p.ViewNum = first.ViewNum)
+            let noImprovement =
+                (window |> List.map (fun p -> p.LeadingVotes) |> List.max) <= first.LeadingVotes
+            Option.isNone last.Committed && sameView && noImprovement
+
+    /// Convenience: observe progress, then advance the live view one sim tick (deliver `msgs`, then `onTick`).
+    /// Returns the post-step view, the post-step progress observation, and any outbound messages. The per-tick
+    /// driver you fold over a schedule to get a full progress trace.
+    let stepObserve
+        (lv: LiveView<'v>)
+        (tick: Tick)
+        (msgs: LiveMessage<'v> list)
+        (selfClaim: int)
+        (selfStream: int list)
+        : LiveView<'v> * Progress<'v> * LiveMessage<'v> list =
+        let mutable v = lv
+        let out = ResizeArray<LiveMessage<'v>>()
+        for m in msgs do
+            let v', o = receive v m
+            v <- v'
+            out.AddRange o
+        let v', tickOut = onTick v tick selfClaim selfStream
+        out.AddRange tickOut
+        v', observe v', List.ofSeq out
+
+    /// Fold a tick schedule `(tick, messages)` into a **progress trace** — one `Progress` per sim tick, in
+    /// order. This is "observe progress per sim tick" (Aaron): deterministic, replayable, watchable.
+    let trace
+        (lv0: LiveView<'v>)
+        (selfClaim: int)
+        (selfStream: int list)
+        (schedule: (Tick * LiveMessage<'v> list) list)
+        : Progress<'v> list =
+        let mutable v = lv0
+        [ for (tick, msgs) in schedule do
+              let v', p, _ = stepObserve v tick msgs selfClaim selfStream
+              v <- v'
+              yield p ]

--- a/tests/Tests.FSharp/SybilBftProgress.Tests.fs
+++ b/tests/Tests.FSharp/SybilBftProgress.Tests.fs
@@ -1,0 +1,77 @@
+module Zeta.Tests.SybilBftProgressTests
+
+open global.Xunit
+open Zeta.Core
+open Zeta.Core.SybilBftLiveness
+open Zeta.Core.SybilBftProgress
+
+let private bits (seed: int) (n: int) : int list =
+    let mutable s = uint64 seed * 2862933555777941757UL + 3037000493UL
+    [ for _ in 1 .. n ->
+          s <- s * 6364136223846793005UL + 1442695040888963407UL
+          int ((s >>> 33) &&& 1UL) ]
+
+let private ballot v id = Safety(SybilBftProtocol.ballot id (bits id 200) v)
+
+[<Fact>]
+let ``empty view: progress fraction is 0, not decided`` () =
+    let p = observe (init 4 0.5 10 : LiveView<string>)
+    Assert.Equal(0.0, fraction p)
+    Assert.False(isDecided p)
+    Assert.Equal(3, p.Quorum) // 2f+1 for 4 members, f=1
+
+[<Fact>]
+let ``fraction climbs as distinct sources report, hits 1.0 at commit`` () =
+    let lv = init 4 0.5 10
+    let lv = fst (receive lv (ballot "go" 0))
+    let p1 = observe lv
+    let lv = fst (receive lv (ballot "go" 1))
+    let p2 = observe lv
+    let lv = fst (receive lv (ballot "go" 2)) // 3rd distinct = quorum
+    let p3 = observe lv
+    Assert.True(fraction p1 < fraction p2)
+    Assert.True(fraction p2 < fraction p3)
+    Assert.Equal(1.0, fraction p3)
+    Assert.True(isDecided p3)
+    Assert.Equal(Some "go", p3.Committed)
+
+[<Fact>]
+let ``trace yields one progress observation per sim tick, converging to commit`` () =
+    let schedule =
+        [ (1, [ ballot "v" 0 ])
+          (2, [ ballot "v" 1 ])
+          (3, [ ballot "v" 2 ]) ] // quorum reached
+    let tr = trace (init 4 0.5 100) 9 (bits 9 200) schedule
+    Assert.Equal(3, List.length tr)
+    Assert.Equal<int list>([ 1; 2; 3 ], tr |> List.map (fun p -> p.Tick))
+    // Monotone non-decreasing progress, ending decided.
+    Assert.True(fraction tr.[0] <= fraction tr.[1])
+    Assert.True(fraction tr.[1] <= fraction tr.[2])
+    Assert.True(isDecided (List.last tr))
+
+[<Fact>]
+let ``isStalled flags a flat, undecided, single-view window`` () =
+    // Two distinct votes then nothing more: leading stays at 2, never reaches quorum 3, no view-change.
+    let lv = init 4 0.5 1000
+    let lv = fst (receive lv (ballot "x" 0))
+    let lv = fst (receive lv (ballot "x" 1))
+    // Observe the same stuck state across several ticks (no new votes).
+    let window = [ { observe lv with Tick = 10 }; { observe lv with Tick = 11 }; { observe lv with Tick = 12 } ]
+    Assert.True(isStalled window)
+
+[<Fact>]
+let ``isStalled is false when progress improves or a decision lands`` () =
+    let lv0 = init 4 0.5 1000
+    let lv1 = fst (receive lv0 (ballot "x" 0))
+    let lv2 = fst (receive lv1 (ballot "x" 1))
+    // Improving window: 1 then 2 leading votes.
+    Assert.False(isStalled [ observe lv1; observe lv2 ])
+    // Committed window is never a stall.
+    let lv3 = fst (receive lv2 (ballot "x" 2))
+    Assert.False(isStalled [ observe lv2; observe lv3 ])
+
+[<Fact>]
+let ``deterministic / replayable (DST): same schedule, same trace`` () =
+    let schedule = [ (1, [ ballot "a" 0 ]); (2, [ ballot "a" 1 ]) ]
+    let run () = trace (init 4 0.5 100) 9 (bits 9 200) schedule |> List.map fraction
+    Assert.Equal<float list>(run (), run ())

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -109,6 +109,7 @@
     <Compile Include="SybilBft.Tests.fs" />
     <Compile Include="SybilBftProtocol.Tests.fs" />
     <Compile Include="SybilBftLiveness.Tests.fs" />
+    <Compile Include="SybilBftProgress.Tests.fs" />
     <Compile Include="DarkHall.Tests.fs" />
     <Compile Include="ITensor.Tests.fs" />
     <Compile Include="SagaSnapshot.Tests.fs" />


### PR DESCRIPTION
Aaron: 'observe progress per sim tick'. Per-tick Progress observation = the liveness variant function (monotone rank for TLA+ <>commit), DST-replayable. fraction in [0,1], isDecided, isStalled (livelock detector), trace (one Progress per tick over a schedule). Sets up the forger-side race certificate next (prove attacker can't forge a distinct-passing quorum before honest commit). 6/6 tests, 0-warning. 🤖 Generated with [Claude Code](https://claude.com/claude-code)