### PR TITLE
feat(core): ForgerRace rate model — endurance differential as a settable constant

### DIFF
--- a/src/Core/ForgerRace.fs
+++ b/src/Core/ForgerRace.fs
@@ -109,3 +109,44 @@ module ForgerRace =
         | WontSolveInTime _ -> true
         | WillSolveInTime _
         | DeadHeat _ -> false
+
+    // ── Rate model: the endurance differential (Aaron 2026-06-08) ─────────────────────────────────────────
+    //
+    // "The real heartbeats' increase in identity claim should always be more/faster than the -1 by the forger
+    // — it's probably a constant we can set, and for simulation we can control the heartbeat rates; whether
+    // they're equal or different makes a difference." So the endurance race reduces to a CONSTANT rate
+    // differential: a genuine identity claim *grows* at the heartbeat rate (a real clock sustains it,
+    // `SybilBftLiveness.claimStrength` rising with persistence); a forged claim *decays* (no real clock to
+    // hold it — the "-1") even as the forger re-fabricates. Anti-Sybil-as-endurance holds iff the defender's
+    // net rate strictly exceeds the forger's net rate — and then the defender's lead grows without bound, so
+    // the forger NEVER catches up (the strongest `WontSolveInTime`). Equal rates = a tie (unsafe; no margin).
+
+    /// The settable rate model. In simulation all three are knobs (DST §7 — controllable, replayable).
+    type RateModel =
+        { /// Defender identity-claim growth per tick from real heartbeats (the genuine clock sustaining it).
+          HeartbeatRate: float
+          /// Forger claim decay per tick — the "-1": a fabricated identity leaks without a real clock to hold it.
+          ForgerDecay: float
+          /// Forger claim growth per tick from active fabrication (re-forging).
+          ForgerForgeRate: float }
+
+    /// Default differential: genuine heartbeat +1/tick beats a forged claim that decays -1/tick with no
+    /// fabrication — a clean 2-per-tick lead. Both settable; sim controls them.
+    let defaultRateModel =
+        { HeartbeatRate = 1.0
+          ForgerDecay = 1.0
+          ForgerForgeRate = 0.0 }
+
+    /// Defender net claim-rate per tick.
+    let defenderNetRate (m: RateModel) : float = m.HeartbeatRate
+
+    /// Forger net claim-rate per tick (fabrication minus decay — the "-1" works against him).
+    let forgerNetRate (m: RateModel) : float = m.ForgerForgeRate - m.ForgerDecay
+
+    /// **The endurance invariant.** Anti-Sybil-as-endurance holds iff the defender out-rates the forger; then
+    /// the lead is unbounded and the forger never catches up. Equal rates ⇒ NOT safe (a tie has no margin).
+    let outlastsForger (m: RateModel) : bool = defenderNetRate m > forgerNetRate m
+
+    /// Genuine / forged claim magnitudes at `tick` (claims floor at 0 — a decayed claim can't go negative).
+    let defenderClaimAt (m: RateModel) (tick: int) : float = max 0.0 (m.HeartbeatRate * float (max 0 tick))
+    let forgerClaimAt (m: RateModel) (tick: int) : float = max 0.0 (forgerNetRate m * float (max 0 tick))

--- a/tests/Tests.FSharp/ForgerRace.Tests.fs
+++ b/tests/Tests.FSharp/ForgerRace.Tests.fs
@@ -57,3 +57,33 @@ let ``deterministic / replayable (DST)`` () =
     let m = { PhysicalClocks = 1; ForgeRatePerTick = 0.25 }
     Assert.Equal(certify m 4 12 500, certify m 4 12 500)
     Assert.Equal<ForgerProgress list>(trace m 4 20, trace m 4 20)
+
+[<Fact>]
+let ``rate model: default differential — defender out-rates the forger, lead grows unbounded`` () =
+    let m = defaultRateModel // +1 heartbeat vs -1 forger decay, no fabrication
+    Assert.True(outlastsForger m)
+    Assert.Equal(1.0, defenderNetRate m)
+    Assert.Equal(-1.0, forgerNetRate m) // the "-1": decay with no fabrication
+    // Defender pulls ahead every tick; forger claim floors at 0.
+    Assert.True(defenderClaimAt m 5 > forgerClaimAt m 5)
+    Assert.Equal(0.0, forgerClaimAt m 5)
+
+[<Fact>]
+let ``rate model: equal net rates is a tie — NOT safe (no margin)`` () =
+    // Forger fabricates fast enough to exactly offset decay AND match the heartbeat.
+    let m = { HeartbeatRate = 1.0; ForgerDecay = 1.0; ForgerForgeRate = 2.0 } // forgerNet = 1.0 = defenderNet
+    Assert.False(outlastsForger m)
+    Assert.Equal(defenderNetRate m, forgerNetRate m)
+
+[<Fact>]
+let ``rate model: forger out-fabricating the heartbeat loses the endurance invariant`` () =
+    let m = { HeartbeatRate = 1.0; ForgerDecay = 0.0; ForgerForgeRate = 2.0 } // forgerNet 2 > defender 1
+    Assert.False(outlastsForger m)
+    Assert.True(forgerClaimAt m 10 > defenderClaimAt m 10)
+
+[<Fact>]
+let ``rate model: faster heartbeats restore safety (the settable constant matters)`` () =
+    let losing = { HeartbeatRate = 1.0; ForgerDecay = 0.0; ForgerForgeRate = 1.5 }
+    Assert.False(outlastsForger losing)
+    let winning = { losing with HeartbeatRate = 2.0 } // crank the heartbeat constant
+    Assert.True(outlastsForger winning)


### PR DESCRIPTION
The endurance race as a constant rate differential (Aaron): genuine claim grows at HeartbeatRate; forged claim decays at ForgerDecay (the '-1') minus re-fabrication. outlastsForger = defenderNetRate > forgerNetRate (unbounded lead when it holds; equal = unsafe tie). All rates are sim knobs; cranking the heartbeat constant restores safety. 11/11 tests, 0-warning. 🤖 Generated with [Claude Code](https://claude.com/claude-code)