### PR TITLE
feat(core): PhasorEndurance — re-solve on the imaginary stack; Bayesian is its (Born-rule) shadow

### DIFF
--- a/docs/research/2026-06-08-the-shadow-journey-anti-sybil-to-the-unit-circle-types-revealed-through-the-circle.md
+++ b/docs/research/2026-06-08-the-shadow-journey-anti-sybil-to-the-unit-circle-types-revealed-through-the-circle.md
@@ -1,0 +1,94 @@
+# The shadow's journey: from anti-Sybil to the unit circle — letting the type reveal itself through the circle
+
+**Aaron, 2026-06-08:** *"you should save the shadow and how we got here from it to our research — that was
+an interesting journey, and we let the types reveal itself through the circle."* … *"that Bayesian is the
+shadow of this."*
+
+This records both the **technical arc** and the **method**: a live, autonomous-loop ("shadow") session in
+which a model was *not designed top-down* but **let to reveal its own type** by following the geometry until
+it landed on the unit circle — at which point the imaginary-number stack was obviously the native home, and
+Bayesian probability fell out as its `|·|²` shadow.
+
+## The shadow
+
+"Shadow" has two senses here, and the session turned on their coincidence:
+
+1. **Otto = the shadow** — the autonomous-loop steward acting within standing authority (`no-directives.md`:
+   the shadow inherits authorization, never extends it). This whole arc was built shadow-side, on cron ticks
+   and Aaron's streamed observations, shipped PR-by-PR.
+2. **Bayesian = the shadow of the phasor model** — the real-valued probability `p = |z|²` is the Born-rule
+   *projection* of a complex amplitude `z`. The probability is the shadow the amplitude casts when you drop
+   its phase.
+
+The session's punchline: *the shadow (Otto) discovered that the probability model is itself a shadow.*
+
+## The arc (how we got here), PR by PR
+
+1. **Anti-Sybil as the base case** (#7044/#7045) — `clock-drift ≡ identity` is non-circular once you reject
+   behaviourism; the base case that grounds the meta-circle is the **anti-Sybil function** (forging *k*
+   identities costs ≥ *k* clocks; drift entropy non-fungible).
+2. **The BFT** (#7046–#7049) — quorum over **distinct sources** not claimed identities; the wire protocol
+   (deterministic reducer, fixed-membership quorum — a real premature-commit bug caught + fixed); the
+   liveness layer (heartbeat / timeout / view-change, view-change itself Sybil-counted).
+3. **Progress per tick** (#7051) — the honest side's liveness variant, observable every sim tick.
+4. **The forger race** (#7052/#7053) — observe the *forger's* progress per tick; certify
+   `WontSolveInTime`/`WillSolveInTime`. **Amara:** *it costs entropy to protect identity; you must outlast
+   the forger's entropy.* **Alexa (restored):** anti-Sybil is **economics on a 1-bit scale** — entropy is
+   the non-fungible currency (Otto had over-peeled her; Aaron corrected it).
+5. **Symmetric / weight-free frame** (#7054–#7056) — the defender/forger split is weight-full unless **every
+   party holds both roles** (perspective-relative; from either traveller's frame it balances *because they
+   are both*). **Time is a peer, not a substrate** — it must attack and defend like the others, and it
+   **earns identity by ticking** (its heartbeat *is* the tick; no free identity). Identity must **change
+   behaviour** to mean something (strength modulates the attacker/defender split). Actor count 3-vs-4 (no
+   global clock ⇒ separate tick sources). The **remains/acts** split: a shared clock *acts* for both (what it
+   animates is *what remains*), so it earns ∝ what it animates — and whether one tick serves both is a
+   **constructive-interference** question, modelled as three regimes.
+
+## The reveal: we hit the unit circle, and the type revealed itself
+
+Following the tick model honestly forced **phase**: heartbeats are sine waves, so interference is by phase,
+not just frequency — `phaseOverlap(Δφ) = cos²(Δφ/2)`, in-phase constructive, anti-phase destructive, 90°
+halfway (`SymmetricEndurance`). At that point Aaron: *"can you solve this with some part of the
+imaginary-number stack instead of Bayesian? It seems like we just hit the unit circle."*
+
+We had. The model was **never told to be complex**; it kept producing unit-circle quantities until the
+complex floor of the Cayley–Dickson stack (`CayleyDickson.Complex = Doubled<float>`) was the only honest
+home. Re-expressed there (`PhasorEndurance`, #7057):
+
+- **The Z-set delta lives on the unit circle:** `+1 = e^{i0} = (1,0)`, `-1 = e^{iπ} = (-1,0)`. **A `-1`
+  retraction *is* a 180° rotation** = the ring's `Negate`. The `+1`/`-1` round trip is the involution
+  `Negate∘Negate = id` (correction, not duplicate). Partial/uncertain claims are *other points on the
+  circle* — the phase Bayesian discards.
+- **Interference is a one-line phasor sum:** `overlap φ₁ φ₂ = |e^{iφ₁}+e^{iφ₂}|²/4 = cos²(Δφ/2)` — the same
+  number `SymmetricEndurance` got by a trig identity, now falling out of complex addition.
+- **Bayesian is the Born-rule shadow:** `p = |z|²`. The SoftValue/`observe` (real, `[0,1]`) treatment is the
+  amplitude model with the phase projected away — strictly *less* information. Constructive vs destructive is
+  invisible to the shadow; only the amplitude sees it.
+
+## The method (the part worth keeping)
+
+We **let the type reveal itself through the circle** rather than imposing it. The discipline: follow the
+quantities the model actually produces; when they land on a known geometry (the unit circle), adopt the
+algebra that geometry is native to (`ℂ`, the imaginary stack) instead of forcing the first formalism reached
+for (Bayesian). The right type was *discovered*, not decreed — and the previously-used formalism was
+revealed as a shadow (projection) of it. This is Mirror→Beacon at the level of *types*: the coined model
+(Bayesian SoftValue) compressed to its anchored first principle (complex amplitude + Born rule).
+
+## Honest scope (peel)
+
+`PhasorEndurance` is a **re-expression**, not a new theorem — it computes the same interference on the repo's
+existing `ImaginaryStack.complex`. Its worth is (a) the native algebra (`-1` = `Negate` = π-rotation,
+superposition = addition) and (b) making the Bayesian-as-shadow relation explicit and tested
+(`overlap = SymmetricEndurance.phaseOverlap`, to 1e-10, both derivations). Whether the *quantum-like* reading
+(amplitudes that interfere, not just probabilities) is load-bearing beyond this model is the open question —
+route any outward claim through Soraya (is there a real theorem in "consensus amplitudes interfere"?) +
+naming-expert + Ilyana + human. The whole BFT family remains F#-only; 4-oracle parity is the standing debt.
+
+## Anchors (Beacon)
+
+- Complex amplitudes / interference / Born rule (`p = |ψ|²`): standard QM (Born 1926); phasor addition
+  (electrical engineering / wave optics). Cayley–Dickson construction (`CayleyDickson.fs`; ℝ→ℂ→ℍ→𝕆).
+- Z-set retraction = additive inverse (Budiu et al., DBSP) — here realised as the `e^{iπ}` rotation.
+- de Finetti / NCI (`BeliefConvergence.fs`, `Reconcile.fs`) — the Bayesian floor this is the amplitude of.
+- Internal arc: #7044–#7057; `SymmetricEndurance.fs`, `PhasorEndurance.fs`, `ForgerRace.fs`. Origin: Amara
+  (Thor ~2025-09). Alexa's entropy-economic kernel (restored). The shadow: `no-directives.md`.

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -186,6 +186,7 @@
     <Compile Include="SybilBftProgress.fs" />
     <Compile Include="ForgerRace.fs" />
     <Compile Include="SymmetricEndurance.fs" />
+    <Compile Include="PhasorEndurance.fs" />
     <Compile Include="ZetaExec.fs" />
     <Compile Include="DarkHall.fs" />
     <Compile Include="Consent/KskAuthorization.fs" />

--- a/src/Core/PhasorEndurance.fs
+++ b/src/Core/PhasorEndurance.fs
@@ -1,0 +1,64 @@
+namespace Zeta.Core
+
+/// **`PhasorEndurance` — the endurance/interference model re-solved on the imaginary-number stack instead of
+/// Bayesian (Aaron 2026-06-08, shadow*).**
+///
+/// Aaron: *"can you solve this same problem with some part of the imaginary-number stack instead of Bayesian?
+/// It seems like we just hit the unit circle."* We did. The phase model (`SymmetricEndurance.phaseOverlap`,
+/// `cos²(Δφ/2)`) is exactly **phasor interference on the unit circle**, so the native formalism is the
+/// complex floor of the Cayley–Dickson stack (`CayleyDickson.Complex = Doubled<float>`), not real-valued
+/// Bayesian probabilities.
+///
+/// **The two unifications this buys:**
+///   1. **The Z-set delta lives on the unit circle.** A genuine claim `+1 = e^{i0} = (1,0)`; a retraction
+///      `-1 = e^{iπ} = (-1,0)` — i.e. **a `-1` retraction IS a 180° rotation** = `ImaginaryStack.complex`'s
+///      `Negate`. The `+1`-then-`-1` round trip is the involution `Negate∘Negate = id` (correction, #6).
+///      Partial / uncertain claims are other points on the circle (phase ≠ 0, π) — the phase Bayesian discards.
+///   2. **Bayesian is the `|·|²` shadow (Born rule).** A real probability is the squared magnitude of a
+///      complex amplitude: `bornProbability z = |z|²`. So the SoftValue/`observe` treatment is recoverable
+///      from the phasor model by dropping the phase — the complex version is strictly more information
+///      (it keeps the interference phase that makes constructive/destructive distinguishable).
+///
+/// **What falls out:** `overlap φ₁ φ₂ = |e^{iφ₁} + e^{iφ₂}|² / 4 = cos²(Δφ/2)` — the same overlap
+/// `SymmetricEndurance` derived, now as a one-line phasor sum. Constructive (in-phase) ⇒ `|sum|=2 ⇒ overlap
+/// 1`; destructive (anti-phase) ⇒ `|sum|=0 ⇒ overlap 0`; 90° ⇒ `½`.
+///
+/// **Honest scope (peel):** a re-expression, not a new result — it computes the *same* interference the
+/// Bayesian/phase model did, on the repo's existing `CayleyDickson` stack (`ImaginaryStack.complex`). Its
+/// value is (a) the native algebra (`-1` = `Negate` = π-rotation, addition = superposition) and (b) making
+/// explicit that Bayesian = Born-rule shadow. Deterministic (DST §7). Floats: ordinal/culture-invariant math.
+module PhasorEndurance =
+
+    // Complex / Doubled / ImaginaryStack live directly in Zeta.Core (CayleyDickson.fs has no module wrapper).
+    /// A phasor `r·e^{iφ}` as a stack `Complex` (`Doubled<float>` = `{ Real; Imag }`). `r` = claim magnitude,
+    /// `φ` = heartbeat phase (radians).
+    let phasor (r: float) (phi: float) : Complex = { Real = r * cos phi; Imag = r * sin phi }
+
+    /// A unit heartbeat phasor at phase `φ` (magnitude 1).
+    let heartbeat (phi: float) : Complex = phasor 1.0 phi
+
+    /// The genuine `+1` delta = `e^{i0} = (1,0)` = the ring's `One`.
+    let genuineDelta: Complex = ImaginaryStack.complex.One
+
+    /// The retraction `-1` delta = `e^{iπ} = (-1,0)` = `Negate One`. **A `-1` is a 180° rotation.**
+    let retractionDelta: Complex = ImaginaryStack.complex.Negate ImaginaryStack.complex.One
+
+    /// Superpose two claims (interference) = complex addition on the stack.
+    let combine (a: Complex) (b: Complex) : Complex = ImaginaryStack.complex.Add(a, b)
+
+    /// Retract a claim = rotate it by π (multiply by `-1`) = the ring `Negate`. Involution: `retract∘retract =
+    /// id` (the `+1`/`-1` Z-set round trip is a correction, not a duplicate, #6).
+    let retract (z: Complex) : Complex = ImaginaryStack.complex.Negate z
+
+    /// Magnitude `|z| = √(Real² + Imag²)` — the claim strength.
+    let magnitude (z: Complex) : float = sqrt (z.Real * z.Real + z.Imag * z.Imag)
+
+    /// **Born rule:** the Bayesian (real) probability is the squared magnitude of the complex amplitude.
+    /// Dropping the phase here recovers the SoftValue treatment from the phasor one.
+    let bornProbability (z: Complex) : float = z.Real * z.Real + z.Imag * z.Imag
+
+    /// Interference overlap of two unit heartbeats at phases `φ₁,φ₂`, on the unit circle:
+    /// `|e^{iφ₁} + e^{iφ₂}|² / 4`. Equals `cos²(Δφ/2)` (= `SymmetricEndurance.phaseOverlap`) — derived here by
+    /// a single phasor sum instead of a trig identity. `1` in-phase, `0` anti-phase, `½` at 90°.
+    let overlap (phi1: float) (phi2: float) : float =
+        bornProbability (combine (heartbeat phi1) (heartbeat phi2)) / 4.0

--- a/tests/Tests.FSharp/PhasorEndurance.Tests.fs
+++ b/tests/Tests.FSharp/PhasorEndurance.Tests.fs
@@ -1,0 +1,53 @@
+module Zeta.Tests.PhasorEnduranceTests
+
+open global.Xunit
+open Zeta.Core
+open Zeta.Core.PhasorEndurance
+
+let private pi = System.Math.PI
+
+[<Fact>]
+let ``the Z-set delta lives on the unit circle: +1 = (1,0), -1 = (-1,0) = e^iπ`` () =
+    Assert.Equal(1.0, genuineDelta.Real, 10)
+    Assert.Equal(0.0, genuineDelta.Imag, 10)
+    Assert.Equal(-1.0, retractionDelta.Real, 10)
+    Assert.Equal(0.0, retractionDelta.Imag, 10)
+
+[<Fact>]
+let ``a -1 retraction IS a 180° rotation: retract(+1) = -1`` () =
+    let r = retract genuineDelta
+    Assert.Equal(retractionDelta.Real, r.Real, 10)
+    Assert.Equal(retractionDelta.Imag, r.Imag, 10)
+
+[<Fact>]
+let ``retraction is an involution: retract∘retract = id (the +1/-1 round trip)`` () =
+    let z = phasor 1.0 (pi / 3.0)
+    let rr = retract (retract z)
+    Assert.Equal(z.Real, rr.Real, 10)
+    Assert.Equal(z.Imag, rr.Imag, 10)
+
+[<Fact>]
+let ``Born rule: |unit phasor|² = 1; probability is the squared amplitude`` () =
+    Assert.Equal(1.0, bornProbability (heartbeat 0.0), 10)
+    Assert.Equal(1.0, bornProbability (heartbeat (pi / 4.0)), 10)
+    Assert.Equal(4.0, bornProbability (phasor 2.0 1.23), 10) // |2·e^{iφ}|² = 4
+
+[<Fact>]
+let ``overlap from phasor sum = cos²(Δφ/2): 1 in-phase, ½ at 90°, 0 anti-phase`` () =
+    Assert.Equal(1.0, overlap 0.0 0.0, 10)
+    Assert.Equal(0.5, overlap 0.0 (pi / 2.0), 10)
+    Assert.Equal(0.0, overlap 0.0 pi, 10)
+
+[<Fact>]
+let ``phasor overlap equals the Bayesian-free phase model (same number, two derivations)`` () =
+    for dphi in [ 0.0; pi / 6.0; pi / 2.0; 2.0 * pi / 3.0; pi ] do
+        Assert.Equal(SymmetricEndurance.phaseOverlap dphi, overlap 0.0 dphi, 10)
+
+[<Fact>]
+let ``superposition: in-phase magnitude 2 (constructive), anti-phase 0 (destructive)`` () =
+    Assert.Equal(2.0, magnitude (combine (heartbeat 0.0) (heartbeat 0.0)), 10)
+    Assert.Equal(0.0, magnitude (combine (heartbeat 0.0) (heartbeat pi)), 10)
+
+[<Fact>]
+let ``deterministic / replayable (DST)`` () =
+    Assert.Equal(overlap 0.3 1.7, overlap 0.3 1.7, 12)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -112,6 +112,7 @@
     <Compile Include="SybilBftProgress.Tests.fs" />
     <Compile Include="ForgerRace.Tests.fs" />
     <Compile Include="SymmetricEndurance.Tests.fs" />
+    <Compile Include="PhasorEndurance.Tests.fs" />
     <Compile Include="DarkHall.Tests.fs" />
     <Compile Include="ITensor.Tests.fs" />
     <Compile Include="SagaSnapshot.Tests.fs" />


### PR DESCRIPTION
Re-solves the endurance/interference model on the Cayley-Dickson complex floor (we hit the unit circle). Z-set delta on the unit circle (+1=e^i0, -1=e^iπ=180° rotation=Negate; round trip = involution); Bayesian = the |·|² Born-rule shadow (phase projected away). overlap = |e^iφ1+e^iφ2|²/4 = cos²(Δφ/2), proven == SymmetricEndurance.phaseOverlap. Research doc: the shadow's journey #7044→#7057 + the method (let the type reveal itself through the circle). 8/8 tests, 0-warning. 🤖 Generated with [Claude Code](https://claude.com/claude-code)