### PR TITLE
fix(ci): unblock lint(tsc tools) — 5 TS errors in full-ai-cluster/tools (gate red 7h)

### DIFF
--- a/full-ai-cluster/tools/fat-inspect.ts
+++ b/full-ai-cluster/tools/fat-inspect.ts
@@ -91,7 +91,7 @@ try {
       free++;
       continue;
     }
-    const attr = e[11];
+    const attr = e[11] ?? 0;
     if (attr === 0x0f) {
       lfn++;
       continue;
@@ -114,7 +114,7 @@ try {
     let val: number;
     if (fatTypeName === "FAT12") {
       const off = Math.floor((c * 3) / 2);
-      const pair = fatBytes[off] | (fatBytes[off + 1] << 8);
+      const pair = (fatBytes[off] ?? 0) | ((fatBytes[off + 1] ?? 0) << 8);
       val = c & 1 ? pair >> 4 : pair & 0x0fff;
     } else {
       val = fatBytes.readUInt16LE(c * 2);

--- a/full-ai-cluster/tools/fat12-lib.test.ts
+++ b/full-ai-cluster/tools/fat12-lib.test.ts
@@ -11,7 +11,6 @@ import {
   fat12Get,
   fat12Set,
   lfnChecksum,
-  buildLfnEntry,
   buildDirEntries,
   reconstructLongName,
   firstFreeCluster,

--- a/full-ai-cluster/tools/k8s-manifests.test.ts
+++ b/full-ai-cluster/tools/k8s-manifests.test.ts
@@ -11,7 +11,7 @@
 
 import { test, expect, describe } from "bun:test";
 import { readdirSync, readFileSync, existsSync, statSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { join } from "node:path";
 
 const REPO = join(import.meta.dir, "..", ".."); // .../full-ai-cluster/..  (repo root)
 const K8S = join(REPO, "full-ai-cluster", "k8s");


### PR DESCRIPTION
Main gate red 7+ hours on lint(tsc tools): 5 strict-mode TS errors in full-ai-cluster/tools (maximdolphin, ~6-7h ago; not merge-required so it kept merging). Minimal behavior-preserving fix: ?? 0 guards for noUncheckedIndexedAccess (fat-inspect.ts TS18048/TS2532; JS already coerced undefined→0), drop 2 unused imports (TS6133). tsc --noEmit clean locally; no logic changed. Unblocks the fleet's gate. 🤖 Generated with [Claude Code](https://claude.com/claude-code)