### PR TITLE
fix(ci): strip invisible-unicode carriers from 12 archive/memory files (semgrep)

### DIFF
--- a/docs/history/pr-reviews/PR-2223-deps-bump-the-fsharp-and-tooling-group-with-1-update.md
+++ b/docs/history/pr-reviews/PR-2223-deps-bump-the-fsharp-and-tooling-group-with-1-update.md
@@ -39,7 +39,7 @@ _Sourced from [Meziantou.Analyzer's releases](https://github.com/meziantou/Mezia
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.77>
 
 ## What's Changed
-* Split type inheritdoc rule into MA0197/MA0198/MA0199 by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1143
+* Split type inheritdoc rule into MA0197/MA0198/MA0199 by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1143
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.76...3.0.77
@@ -49,7 +49,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.77>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.76>
 
 ## What's Changed
-* Allow cref in MA0197 inheritdoc checks by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1142
+* Allow cref in MA0197 inheritdoc checks by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1142
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.75...3.0.76
@@ -59,7 +59,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.76>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.75>
 
 ## What's Changed
-* Ignore primary constructors in MA0196 and reuse shared detection by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1140
+* Ignore primary constructors in MA0196 and reuse shared detection by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1140
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.74...3.0.75
@@ -69,7 +69,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.75>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.74>
 
 ## What's Changed
-* Add MA0197 to disallow inheritdoc on types by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1138
+* Add MA0197 to disallow inheritdoc on types by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1138
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.73...3.0.74
@@ -79,7 +79,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.74>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.73>
 
 ## What's Changed
-* Add MA0196 to flag invalid <inheritdoc /> usage by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1137
+* Add MA0196 to flag invalid <inheritdoc /> usage by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1137
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.72...3.0.73
@@ -89,7 +89,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.73>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.72>
 
 ## What's Changed
-* Add configurable Db* special-cases for MA0042/MA0045 by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1136
+* Add configurable Db* special-cases for MA0042/MA0045 by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1136
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.71...3.0.72
@@ -99,7 +99,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.72>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.71>
 
 ## What's Changed
-* MA0042: extend await-using suppression to more base types by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1135
+* MA0042: extend await-using suppression to more base types by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1135
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.70...3.0.71
@@ -109,7 +109,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.71>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.70>
 
 ## What's Changed
-* Update diagnostic helpers and tests for flexibility and clarity by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1131
+* Update diagnostic helpers and tests for flexibility and clarity by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1131
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.69...3.0.70
@@ -119,7 +119,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.70>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.69>
 
 ## What's Changed
-* Broaden MA0042/MA0045 SQLite special-case exclusions by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1130
+* Broaden MA0042/MA0045 SQLite special-case exclusions by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1130
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.68...3.0.69
@@ -129,7 +129,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.69>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.68>
 
 ## What's Changed
-* Skip SqliteConnection.Open in MA0042 and MA0045 by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1129
+* Skip SqliteConnection.Open in MA0042 and MA0045 by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1129
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.67...3.0.68
@@ -139,7 +139,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.68>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.67>
 
 ## What's Changed
-* Add configurable SQLite special cases for MA0042 and MA0045 by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1128
+* Add configurable SQLite special cases for MA0042 and MA0045 by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1128
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.66...3.0.67
@@ -149,7 +149,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.67>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.66>
 
 ## What's Changed
-* Adjust MA0007 trailing comma behavior for collection expressions by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1127
+* Adjust MA0007 trailing comma behavior for collection expressions by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1127
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.65...3.0.66
@@ -159,7 +159,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.66>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.65>
 
 ## What's Changed
-* Fix MA0004 code fix crash in nested await using declarations by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1125
+* Fix MA0004 code fix crash in nested await using declarations by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1125
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.64...3.0.65
@@ -169,8 +169,8 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.65>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.64>
 
 ## What's Changed
-* MA0109: Skip diagnostic for program entry point `Main(string[] args)` by @​Copilot in https://github.com/meziantou/Meziantou.Analyzer/pull/1123
-* MA0042: add DbCommand await-using parity with DbConnection by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1124
+* MA0109: Skip diagnostic for program entry point `Main(string[] args)` by @Copilot in https://github.com/meziantou/Meziantou.Analyzer/pull/1123
+* MA0042: add DbCommand await-using parity with DbConnection by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1124
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.63...3.0.64
@@ -180,7 +180,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.64>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.63>
 
 ## What's Changed
-* MA0042: check if DisposeAsync is declared directly when runtime type is known by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1118
+* MA0042: check if DisposeAsync is declared directly when runtime type is known by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1118
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.62...3.0.63
@@ -190,7 +190,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.63>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.62>
 
 ## What's Changed
-* Fix MA0042 comment placement for await using by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1120
+* Fix MA0042 comment placement for await using by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1120
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.61...3.0.62
@@ -200,7 +200,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.62>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.61>
 
 ## What's Changed
-* MA0042: suppress diagnostic for `IDbContextFactory<TContext>.CreateDbContext()` by @​Copilot in https://github.com/meziantou/Meziantou.Analyzer/pull/1116
+* MA0042: suppress diagnostic for `IDbContextFactory<TContext>.CreateDbContext()` by @Copilot in https://github.com/meziantou/Meziantou.Analyzer/pull/1116
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.60...3.0.61
@@ -210,7 +210,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.61>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.60>
 
 ## What's Changed
-* Add global severity modes for MeziantouAnalysisMode by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1114
+* Add global severity modes for MeziantouAnalysisMode by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1114
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.59...3.0.60
@@ -220,7 +220,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.60>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.59>
 
 ## What's Changed
-* Add MA0195 static-field initialization analyzer by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1112
+* Add MA0195 static-field initialization analyzer by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1112
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.58...3.0.59

--- a/docs/history/pr-reviews/PR-3810-deps-bump-fsharp-core-and-3-others.md
+++ b/docs/history/pr-reviews/PR-3810-deps-bump-fsharp-core-and-3-others.md
@@ -51,7 +51,7 @@ _Sourced from [Meziantou.Analyzer's releases](https://github.com/meziantou/Mezia
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.85>
 
 ## What's Changed
-* Add MA0200 for empty property patterns on non-nullable value types by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1160
+* Add MA0200 for empty property patterns on non-nullable value types by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1160
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.84...3.0.85
@@ -61,7 +61,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.85>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.84>
 
 ## What's Changed
-* Ignore `[Experimental]` overloads in MA0040 cancellation-token matching by @​Copilot in https://github.com/meziantou/Meziantou.Analyzer/pull/1157
+* Ignore `[Experimental]` overloads in MA0040 cancellation-token matching by @Copilot in https://github.com/meziantou/Meziantou.Analyzer/pull/1157
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.83...3.0.84
@@ -71,7 +71,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.84>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.83>
 
 ## What's Changed
-* Add NonAsyncDisposableTypeAttribute for await using by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1154
+* Add NonAsyncDisposableTypeAttribute for await using by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1154
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.82...3.0.83
@@ -81,7 +81,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.83>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.82>
 
 ## What's Changed
-* Add NonAwaitableTypeAttribute for MA0042/MA0045 by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1153
+* Add NonAwaitableTypeAttribute for MA0042/MA0045 by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1153
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.81...3.0.82
@@ -91,7 +91,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.82>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.81>
 
 ## What's Changed
-* Improve annotations documentation and rule references by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1151
+* Improve annotations documentation and rule references by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1151
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.80...3.0.81
@@ -107,9 +107,9 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.80>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.79>
 
 ## What's Changed
-* Document comparison page maintenance expectations by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1146
-* Allow MA0196 inheritdoc on constructors matching base signatures by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1149
-* Add annotation-based exclusions for MA0042 and MA0045 by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1148
+* Document comparison page maintenance expectations by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1146
+* Allow MA0196 inheritdoc on constructors matching base signatures by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1149
+* Add annotation-based exclusions for MA0042 and MA0045 by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1148
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.78...3.0.79
@@ -119,7 +119,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.79>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.78>
 
 ## What's Changed
-* Optimize analyzer hot paths and metadata lookups by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1144
+* Optimize analyzer hot paths and metadata lookups by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1144
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.77...3.0.78

--- a/docs/history/pr-reviews/PR-4714-deps-bump-the-nuget-minor-patch-group-with-3-updates.md
+++ b/docs/history/pr-reviews/PR-4714-deps-bump-the-nuget-minor-patch-group-with-3-updates.md
@@ -38,20 +38,20 @@ _Sourced from [coverlet.collector's releases](https://github.com/coverlet-covera
 
 ### Improvements
 
-- Coverlet with MTP 2 doesn't show test coverage statistic in console [#​1907](https://github.com/coverlet-coverage/coverlet/issues/1907)
-- Avoid unnecessary testhost restarts [#​1912](https://github.com/coverlet-coverage/coverlet/issues/1912) by <https://github.com/mawosoft>
+- Coverlet with MTP 2 doesn't show test coverage statistic in console [#1907](https://github.com/coverlet-coverage/coverlet/issues/1907)
+- Avoid unnecessary testhost restarts [#1912](https://github.com/coverlet-coverage/coverlet/issues/1912) by <https://github.com/mawosoft>
 
 ### Fixed
 
-- Fix inconsistent paths in cobertura reports [#​1723](https://github.com/coverlet-coverage/coverlet/issues/1723)
-- Fix when using "is" with "and" in pattern matching, branch coverage is lower than normal [#​1313](https://github.com/coverlet-coverage/coverlet/issues/1313)
-- Fix Coverlet flagging a branch for an async functions finally block where none exists [#​1337](https://github.com/coverlet-coverage/coverlet/issues/1337)
-- Fix Coverlet Tracker Missing CompilerGeneratedAttribute [#​1828](https://github.com/coverlet-coverage/coverlet/issues/1828)
+- Fix inconsistent paths in cobertura reports [#1723](https://github.com/coverlet-coverage/coverlet/issues/1723)
+- Fix when using "is" with "and" in pattern matching, branch coverage is lower than normal [#1313](https://github.com/coverlet-coverage/coverlet/issues/1313)
+- Fix Coverlet flagging a branch for an async functions finally block where none exists [#1337](https://github.com/coverlet-coverage/coverlet/issues/1337)
+- Fix Coverlet Tracker Missing CompilerGeneratedAttribute [#1828](https://github.com/coverlet-coverage/coverlet/issues/1828)
 
 ### Maintenance
 
-- Add architecture docs and diagrams for all integrations [#​1927](https://github.com/coverlet-coverage/coverlet/pull/1927)
-- Update NuGet packages and .NET SDK versions [#​1933](https://github.com/coverlet-coverage/coverlet/pull/1933)
+- Add architecture docs and diagrams for all integrations [#1927](https://github.com/coverlet-coverage/coverlet/pull/1927)
+- Update NuGet packages and .NET SDK versions [#1933](https://github.com/coverlet-coverage/coverlet/pull/1933)
 
 [Diff between 10.0.0 and 10.0.1](https://github.com/coverlet-coverage/coverlet/compare/v10.0.0...v10.0.1)
 
@@ -69,20 +69,20 @@ _Sourced from [coverlet.msbuild's releases](https://github.com/coverlet-coverage
 
 ### Improvements
 
-- Coverlet with MTP 2 doesn't show test coverage statistic in console [#​1907](https://github.com/coverlet-coverage/coverlet/issues/1907)
-- Avoid unnecessary testhost restarts [#​1912](https://github.com/coverlet-coverage/coverlet/issues/1912) by <https://github.com/mawosoft>
+- Coverlet with MTP 2 doesn't show test coverage statistic in console [#1907](https://github.com/coverlet-coverage/coverlet/issues/1907)
+- Avoid unnecessary testhost restarts [#1912](https://github.com/coverlet-coverage/coverlet/issues/1912) by <https://github.com/mawosoft>
 
 ### Fixed
 
-- Fix inconsistent paths in cobertura reports [#​1723](https://github.com/coverlet-coverage/coverlet/issues/1723)
-- Fix when using "is" with "and" in pattern matching, branch coverage is lower than normal [#​1313](https://github.com/coverlet-coverage/coverlet/issues/1313)
-- Fix Coverlet flagging a branch for an async functions finally block where none exists [#​1337](https://github.com/coverlet-coverage/coverlet/issues/1337)
-- Fix Coverlet Tracker Missing CompilerGeneratedAttribute [#​1828](https://github.com/coverlet-coverage/coverlet/issues/1828)
+- Fix inconsistent paths in cobertura reports [#1723](https://github.com/coverlet-coverage/coverlet/issues/1723)
+- Fix when using "is" with "and" in pattern matching, branch coverage is lower than normal [#1313](https://github.com/coverlet-coverage/coverlet/issues/1313)
+- Fix Coverlet flagging a branch for an async functions finally block where none exists [#1337](https://github.com/coverlet-coverage/coverlet/issues/1337)
+- Fix Coverlet Tracker Missing CompilerGeneratedAttribute [#1828](https://github.com/coverlet-coverage/coverlet/issues/1828)
 
 ### Maintenance
 
-- Add architecture docs and diagrams for all integrations [#​1927](https://github.com/coverlet-coverage/coverlet/pull/1927)
-- Update NuGet packages and .NET SDK versions [#​1933](https://github.com/coverlet-coverage/coverlet/pull/1933)
+- Add architecture docs and diagrams for all integrations [#1927](https://github.com/coverlet-coverage/coverlet/pull/1927)
+- Update NuGet packages and .NET SDK versions [#1933](https://github.com/coverlet-coverage/coverlet/pull/1933)
 
 [Diff between 10.0.0 and 10.0.1](https://github.com/coverlet-coverage/coverlet/compare/v10.0.0...v10.0.1)
 
@@ -101,7 +101,7 @@ _Sourced from [Meziantou.Analyzer's releases](https://github.com/meziantou/Mezia
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.92>
 
 ## What's Changed
-* Add analyzer for identical conditional compilation branches by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1169
+* Add analyzer for identical conditional compilation branches by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1169
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.91...3.0.92
@@ -111,7 +111,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.92>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.91>
 
 ## What's Changed
-* Fix MA0003 Fix All producing invalid named-argument rewrites in multi-argument calls by @​Copilot in https://github.com/meziantou/Meziantou.Analyzer/pull/1168
+* Fix MA0003 Fix All producing invalid named-argument rewrites in multi-argument calls by @Copilot in https://github.com/meziantou/Meziantou.Analyzer/pull/1168
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.90...3.0.91
@@ -121,7 +121,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.91>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.90>
 
 ## What's Changed
-* Fix MA0071 false positive for `else if` chains with reachable prior branches by @​Copilot in https://github.com/meziantou/Meziantou.Analyzer/pull/1166
+* Fix MA0071 false positive for `else if` chains with reachable prior branches by @Copilot in https://github.com/meziantou/Meziantou.Analyzer/pull/1166
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.89...3.0.90
@@ -131,7 +131,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.90>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.89>
 
 ## What's Changed
-* Add opt-in MA0134 reporting for discarded awaitables by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1164
+* Add opt-in MA0134 reporting for discarded awaitables by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1164
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.88...3.0.89
@@ -141,7 +141,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.89>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.88>
 
 ## What's Changed
-* Add MA0201 for zero-valued enum flag checks by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1163
+* Add MA0201 for zero-valued enum flag checks by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1163
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.87...3.0.88
@@ -151,7 +151,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.88>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.87>
 
 ## What's Changed
-* Fix MA0194 merge with existing and-patterns by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1162
+* Fix MA0194 merge with existing and-patterns by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1162
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.86...3.0.87
@@ -161,7 +161,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.87>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.86>
 
 ## What's Changed
-* Improve MA0192 HasFlag detection for zero comparisons by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1161
+* Improve MA0192 HasFlag detection for zero comparisons by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1161
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.85...3.0.86

--- a/docs/history/pr-reviews/PR-4715-deps-bump-yamldotnet-from-17-1-0-to-18-0-0.md
+++ b/docs/history/pr-reviews/PR-4715-deps-bump-yamldotnet-from-17-1-0-to-18-0-0.md
@@ -37,7 +37,7 @@ _Sourced from [YamlDotNet's releases](https://github.com/aaubry/YamlDotNet/relea
 ## 18.0.0
 
 ## What's Changed
-* Add a parse method wrapper and caching to fix AoT compilation by @​EdwardCooke in https://github.com/aaubry/YamlDotNet/pull/1103
+* Add a parse method wrapper and caching to fix AoT compilation by @EdwardCooke in https://github.com/aaubry/YamlDotNet/pull/1103
     **BREAKING CHANGE** This is a breaking change in the `TypeInspectorSkeleton` class and the `ITypeInspector` interface by adding 2 methods . Quick fix to resolve those breaking changes in your own custom TypeInspector is to return false on the HasParseMethod method and return null or throw an exception on the Parse method.
 
 

--- a/docs/history/pr-reviews/PR-4722-docs-archive-preserve-merged-pr-4714.md
+++ b/docs/history/pr-reviews/PR-4722-docs-archive-preserve-merged-pr-4714.md
@@ -54,7 +54,7 @@ This PR preserves the discussion archive for merged PR #4714.
 - **`Copilot` (bot)** at 2026-05-23T11:04:18Z on `docs/pr-discussions/PR-4714-deps-bump-the-nuget-minor-patch-group-with-3-updates.md`:38 (association: NONE)
 
   <pre>
-  P0: These bullets contain an invisible Unicode codepoint (the U+200B zero-width space between `#` and the issue number, e.g. `[#​1907]`). This will trigger the repo’s Semgrep `invisible-unicode-in-text` rule and fail CI. Strip the zero-width characters (use plain ASCII like `[#1907]`, or wrap in backticks if you need to avoid linkification).
+  P0: These bullets contain an invisible Unicode codepoint (the U+200B zero-width space between `#` and the issue number, e.g. `[#1907]`). This will trigger the repo’s Semgrep `invisible-unicode-in-text` rule and fail CI. Strip the zero-width characters (use plain ASCII like `[#1907]`, or wrap in backticks if you need to avoid linkification).
   </pre>
 
 ### Thread 2 -- resolved [outdated, collapsed]
@@ -68,7 +68,7 @@ This PR preserves the discussion archive for merged PR #4714.
 - **`Copilot` (bot)** at 2026-05-23T11:04:19Z on `docs/pr-discussions/PR-4714-deps-bump-the-nuget-minor-patch-group-with-3-updates.md`:69 (association: NONE)
 
   <pre>
-  P0: This section also includes U+200B zero-width spaces in the `[#​....]` references. The Semgrep `invisible-unicode-in-text` rule applies to `**/*.md`, so these characters will break the build. Remove the invisible codepoints and keep the text purely ASCII.
+  P0: This section also includes U+200B zero-width spaces in the `[#....]` references. The Semgrep `invisible-unicode-in-text` rule applies to `**/*.md`, so these characters will break the build. Remove the invisible codepoints and keep the text purely ASCII.
   </pre>
 
 ### Thread 3 -- resolved [collapsed]
@@ -82,7 +82,7 @@ This PR preserves the discussion archive for merged PR #4714.
 - **`Copilot` (bot)** at 2026-05-23T11:04:19Z on `docs/pr-discussions/PR-4714-deps-bump-the-nuget-minor-patch-group-with-3-updates.md`:104 (association: NONE)
 
   <pre>
-  P0: Lines here contain an invisible Unicode character (U+200B) inside `@​meziantou` / `@​Copilot`. This triggers the Semgrep `invisible-unicode-in-text` rule and will fail CI. Replace the mentions with plain ASCII (e.g. `@meziantou`, `@Copilot`) or another visible escape (like backticks) instead of zero-width characters.
+  P0: Lines here contain an invisible Unicode character (U+200B) inside `@meziantou` / `@Copilot`. This triggers the Semgrep `invisible-unicode-in-text` rule and will fail CI. Replace the mentions with plain ASCII (e.g. `@meziantou`, `@Copilot`) or another visible escape (like backticks) instead of zero-width characters.
   </pre>
 
 ### Thread 4 -- resolved [collapsed]
@@ -96,7 +96,7 @@ This PR preserves the discussion archive for merged PR #4714.
 - **`Copilot` (bot)** at 2026-05-23T11:04:19Z on `docs/pr-discussions/PR-4714-deps-bump-the-nuget-minor-patch-group-with-3-updates.md`:114 (association: NONE)
 
   <pre>
-  P0: This bullet uses a U+200B zero-width space inside `@​Copilot`. Semgrep `invisible-unicode-in-text` will flag this in `*.md`. Remove the zero-width character (use ASCII `@Copilot` / backticks).
+  P0: This bullet uses a U+200B zero-width space inside `@Copilot`. Semgrep `invisible-unicode-in-text` will flag this in `*.md`. Remove the zero-width character (use ASCII `@Copilot` / backticks).
   </pre>
 
 ### Thread 5 -- resolved [collapsed]
@@ -110,7 +110,7 @@ This PR preserves the discussion archive for merged PR #4714.
 - **`Copilot` (bot)** at 2026-05-23T11:04:19Z on `docs/pr-discussions/PR-4714-deps-bump-the-nuget-minor-patch-group-with-3-updates.md`:124 (association: NONE)
 
   <pre>
-  P0: This bullet contains U+200B zero-width space inside `@​meziantou`, which will be rejected by Semgrep `invisible-unicode-in-text`. Strip the invisible codepoint and keep the mention purely ASCII.
+  P0: This bullet contains U+200B zero-width space inside `@meziantou`, which will be rejected by Semgrep `invisible-unicode-in-text`. Strip the invisible codepoint and keep the mention purely ASCII.
   </pre>
 
 ### Thread 6 -- resolved [collapsed]
@@ -124,7 +124,7 @@ This PR preserves the discussion archive for merged PR #4714.
 - **`Copilot` (bot)** at 2026-05-23T11:04:19Z on `docs/pr-discussions/PR-4714-deps-bump-the-nuget-minor-patch-group-with-3-updates.md`:134 (association: NONE)
 
   <pre>
-  P0: U+200B zero-width space appears in `@​meziantou` on this line. This will fail the Semgrep invisible-Unicode check. Replace with ASCII `@meziantou` (or use backticks) and ensure no hidden Unicode remains.
+  P0: U+200B zero-width space appears in `@meziantou` on this line. This will fail the Semgrep invisible-Unicode check. Replace with ASCII `@meziantou` (or use backticks) and ensure no hidden Unicode remains.
   </pre>
 
 ### Thread 7 -- resolved [collapsed]
@@ -138,7 +138,7 @@ This PR preserves the discussion archive for merged PR #4714.
 - **`Copilot` (bot)** at 2026-05-23T11:04:20Z on `docs/pr-discussions/PR-4714-deps-bump-the-nuget-minor-patch-group-with-3-updates.md`:144 (association: NONE)
 
   <pre>
-  P0: U+200B zero-width space appears in `@​meziantou` on this line, which will be flagged by Semgrep `invisible-unicode-in-text`. Strip the invisible character so the archive remains ASCII-clean.
+  P0: U+200B zero-width space appears in `@meziantou` on this line, which will be flagged by Semgrep `invisible-unicode-in-text`. Strip the invisible character so the archive remains ASCII-clean.
   </pre>
 
 ### Thread 8 -- resolved [collapsed]
@@ -152,7 +152,7 @@ This PR preserves the discussion archive for merged PR #4714.
 - **`Copilot` (bot)** at 2026-05-23T11:04:20Z on `docs/pr-discussions/PR-4714-deps-bump-the-nuget-minor-patch-group-with-3-updates.md`:154 (association: NONE)
 
   <pre>
-  P0: This bullet includes a U+200B zero-width space inside `@​meziantou`. The repo’s invisible-Unicode Semgrep rule applies to all Markdown files, so this will break CI. Remove the zero-width character and keep the text ASCII.
+  P0: This bullet includes a U+200B zero-width space inside `@meziantou`. The repo’s invisible-Unicode Semgrep rule applies to all Markdown files, so this will break CI. Remove the zero-width character and keep the text ASCII.
   </pre>
 
 ## Fix commits (touching thread paths)

--- a/docs/history/pr-reviews/PR-4799-docs-archive-preserve-recently-merged-prs-decomposed-from-4767.md
+++ b/docs/history/pr-reviews/PR-4799-docs-archive-preserve-recently-merged-prs-decomposed-from-4767.md
@@ -54,7 +54,7 @@ This PR contains only the preserved PR discussions from #4767.
 - **`Copilot` (bot)** at 2026-05-24T01:09:56Z on `docs/pr-discussions/PR-4715-deps-bump-yamldotnet-from-17-1-0-to-18-0-0.md`:29 (association: NONE)
 
   <pre>
-  P0: This line contains an invisible Unicode character (U+200B / zero-width space) in the `@​EdwardCooke` handle. The repo’s `invisible-unicode-in-text` check will flag this in `*.md` and fail CI; replace it with plain ASCII (`@EdwardCooke`) and ensure no zero-width characters remain.
+  P0: This line contains an invisible Unicode character (U+200B / zero-width space) in the `@EdwardCooke` handle. The repo’s `invisible-unicode-in-text` check will flag this in `*.md` and fail CI; replace it with plain ASCII (`@EdwardCooke`) and ensure no zero-width characters remain.
 
   </pre>
 
@@ -69,7 +69,7 @@ This PR contains only the preserved PR discussions from #4767.
 - **`Copilot` (bot)** at 2026-05-24T01:09:57Z on `docs/pr-discussions/PR-4722-docs-archive-preserve-merged-pr-4714.md`:52 (association: NONE)
 
   <pre>
-  P0: This thread text includes an actual U+200B zero-width space inside the example `[#​1907]` / `[#​....]` code spans. Even though it’s describing the issue, the literal hidden character will still trigger Semgrep `invisible-unicode-in-text` and break CI; replace the examples with ASCII (e.g., `[#1907]`) and describe the zero-width space in words ("U+200B between `#` and digits").
+  P0: This thread text includes an actual U+200B zero-width space inside the example `[#1907]` / `[#....]` code spans. Even though it’s describing the issue, the literal hidden character will still trigger Semgrep `invisible-unicode-in-text` and break CI; replace the examples with ASCII (e.g., `[#1907]`) and describe the zero-width space in words ("U+200B between `#` and digits").
 
   </pre>
 
@@ -84,7 +84,7 @@ This PR contains only the preserved PR discussions from #4767.
 - **`Copilot` (bot)** at 2026-05-24T01:09:57Z on `docs/pr-discussions/PR-4722-docs-archive-preserve-merged-pr-4714.md`:52 (association: NONE)
 
   <pre>
-  P0: This line contains a U+200B zero-width space inside the `@​meziantou` / `@​Copilot` code spans. Semgrep `invisible-unicode-in-text` will flag the hidden character even inside backticks; rewrite the examples using plain ASCII (`@meziantou`, `@Copilot`) and keep the mention of U+200B as text only.
+  P0: This line contains a U+200B zero-width space inside the `@meziantou` / `@Copilot` code spans. Semgrep `invisible-unicode-in-text` will flag the hidden character even inside backticks; rewrite the examples using plain ASCII (`@meziantou`, `@Copilot`) and keep the mention of U+200B as text only.
 
   </pre>
 
@@ -99,7 +99,7 @@ This PR contains only the preserved PR discussions from #4767.
 - **`Copilot` (bot)** at 2026-05-24T01:09:57Z on `docs/pr-discussions/PR-4722-docs-archive-preserve-merged-pr-4714.md`:58 (association: NONE)
 
   <pre>
-  P0: This line contains an actual U+200B zero-width space inside the `@​Copilot` code span. That hidden character will trip the repo’s invisible-Unicode lint; replace it with ASCII `@Copilot` (or spell out the codepoint without embedding it).
+  P0: This line contains an actual U+200B zero-width space inside the `@Copilot` code span. That hidden character will trip the repo’s invisible-Unicode lint; replace it with ASCII `@Copilot` (or spell out the codepoint without embedding it).
 
   </pre>
 
@@ -114,7 +114,7 @@ This PR contains only the preserved PR discussions from #4767.
 - **`Copilot` (bot)** at 2026-05-24T01:09:57Z on `docs/pr-discussions/PR-4722-docs-archive-preserve-merged-pr-4714.md`:64 (association: NONE)
 
   <pre>
-  P0: This line contains a U+200B zero-width space inside the `@​meziantou` code span. Even as an example, embedding the invisible character will fail `invisible-unicode-in-text`; replace with plain ASCII `@meziantou` and keep the description of the issue as words.
+  P0: This line contains a U+200B zero-width space inside the `@meziantou` code span. Even as an example, embedding the invisible character will fail `invisible-unicode-in-text`; replace with plain ASCII `@meziantou` and keep the description of the issue as words.
 
   </pre>
 
@@ -129,7 +129,7 @@ This PR contains only the preserved PR discussions from #4767.
 - **`Copilot` (bot)** at 2026-05-24T01:09:58Z on `docs/pr-discussions/PR-4722-docs-archive-preserve-merged-pr-4714.md`:82 (association: NONE)
 
   <pre>
-  P0: This line embeds a U+200B zero-width space inside `@​meziantou`. Remove the hidden character (use ASCII `@meziantou`) so the archive stays lint-clean.
+  P0: This line embeds a U+200B zero-width space inside `@meziantou`. Remove the hidden character (use ASCII `@meziantou`) so the archive stays lint-clean.
 
   </pre>
 
@@ -144,7 +144,7 @@ This PR contains only the preserved PR discussions from #4767.
 - **`Copilot` (bot)** at 2026-05-24T01:09:58Z on `docs/pr-discussions/PR-4722-docs-archive-preserve-merged-pr-4714.md`:82 (association: NONE)
 
   <pre>
-  P0: This line includes a U+200B zero-width space inside `@​meziantou`. Semgrep will flag it in Markdown; replace with ASCII `@meziantou` (or avoid embedding the example with the hidden character).
+  P0: This line includes a U+200B zero-width space inside `@meziantou`. Semgrep will flag it in Markdown; replace with ASCII `@meziantou` (or avoid embedding the example with the hidden character).
 
   </pre>
 
@@ -159,7 +159,7 @@ This PR contains only the preserved PR discussions from #4767.
 - **`Copilot` (bot)** at 2026-05-24T01:09:58Z on `docs/pr-discussions/PR-4722-docs-archive-preserve-merged-pr-4714.md`:82 (association: NONE)
 
   <pre>
-  P0: This line embeds a U+200B zero-width space in the `@​meziantou` example. Even though it’s quoting a prior review comment, the hidden character will still break `invisible-unicode-in-text`; rewrite the example with plain ASCII.
+  P0: This line embeds a U+200B zero-width space in the `@meziantou` example. Even though it’s quoting a prior review comment, the hidden character will still break `invisible-unicode-in-text`; rewrite the example with plain ASCII.
 
   </pre>
 

--- a/docs/history/pr-reviews/PR-6090-deps-bump-actions-upload-artifact-from-4-4-3-to-7-0-1.md
+++ b/docs/history/pr-reviews/PR-6090-deps-bump-actions-upload-artifact-from-4-4-3-to-7-0-1.md
@@ -35,9 +35,9 @@ Bumps [actions/upload-artifact](https://github.com/actions/upload-artifact) from
 <h2>v7.0.1</h2>
 <h2>What's Changed</h2>
 <ul>
-<li>Update the readme with direct upload details by <a href="https://github.com/danwkennedy"><code>@​danwkennedy</code></a> in <a href="https://redirect.github.com/actions/upload-artifact/pull/795">actions/upload-artifact#795</a></li>
-<li>Readme: bump all the example versions to v7 by <a href="https://github.com/danwkennedy"><code>@​danwkennedy</code></a> in <a href="https://redirect.github.com/actions/upload-artifact/pull/796">actions/upload-artifact#796</a></li>
-<li>Include changes in typespec/ts-http-runtime 0.3.5 by <a href="https://github.com/yacaovsnc"><code>@​yacaovsnc</code></a> in <a href="https://redirect.github.com/actions/upload-artifact/pull/797">actions/upload-artifact#797</a></li>
+<li>Update the readme with direct upload details by <a href="https://github.com/danwkennedy"><code>@danwkennedy</code></a> in <a href="https://redirect.github.com/actions/upload-artifact/pull/795">actions/upload-artifact#795</a></li>
+<li>Readme: bump all the example versions to v7 by <a href="https://github.com/danwkennedy"><code>@danwkennedy</code></a> in <a href="https://redirect.github.com/actions/upload-artifact/pull/796">actions/upload-artifact#796</a></li>
+<li>Include changes in typespec/ts-http-runtime 0.3.5 by <a href="https://github.com/yacaovsnc"><code>@yacaovsnc</code></a> in <a href="https://redirect.github.com/actions/upload-artifact/pull/797">actions/upload-artifact#797</a></li>
 </ul>
 <p><strong>Full Changelog</strong>: <a href="https://github.com/actions/upload-artifact/compare/v7...v7.0.1">https://github.com/actions/upload-artifact/compare/v7...v7.0.1</a></p>
 <h2>v7.0.0</h2>
@@ -48,13 +48,13 @@ Bumps [actions/upload-artifact](https://github.com/actions/upload-artifact) from
 <p>To support new versions of the <code>@actions/*</code> packages, we've upgraded the package to ESM.</p>
 <h2>What's Changed</h2>
 <ul>
-<li>Add proxy integration test by <a href="https://github.com/Link"><code>@​Link</code></a>- in <a href="https://redirect.github.com/actions/upload-artifact/pull/754">actions/upload-artifact#754</a></li>
-<li>Upgrade the module to ESM and bump dependencies by <a href="https://github.com/danwkennedy"><code>@​danwkennedy</code></a> in <a href="https://redirect.github.com/actions/upload-artifact/pull/762">actions/upload-artifact#762</a></li>
-<li>Support direct file uploads by <a href="https://github.com/danwkennedy"><code>@​danwkennedy</code></a> in <a href="https://redirect.github.com/actions/upload-artifact/pull/764">actions/upload-artifact#764</a></li>
+<li>Add proxy integration test by <a href="https://github.com/Link"><code>@Link</code></a>- in <a href="https://redirect.github.com/actions/upload-artifact/pull/754">actions/upload-artifact#754</a></li>
+<li>Upgrade the module to ESM and bump dependencies by <a href="https://github.com/danwkennedy"><code>@danwkennedy</code></a> in <a href="https://redirect.github.com/actions/upload-artifact/pull/762">actions/upload-artifact#762</a></li>
+<li>Support direct file uploads by <a href="https://github.com/danwkennedy"><code>@danwkennedy</code></a> in <a href="https://redirect.github.com/actions/upload-artifact/pull/764">actions/upload-artifact#764</a></li>
 </ul>
 <h2>New Contributors</h2>
 <ul>
-<li><a href="https://github.com/Link"><code>@​Link</code></a>- made their first contribution in <a href="https://redirect.github.com/actions/upload-artifact/pull/754">actions/upload-artifact#754</a></li>
+<li><a href="https://github.com/Link"><code>@Link</code></a>- made their first contribution in <a href="https://redirect.github.com/actions/upload-artifact/pull/754">actions/upload-artifact#754</a></li>
 </ul>
 <p><strong>Full Changelog</strong>: <a href="https://github.com/actions/upload-artifact/compare/v6...v7.0.0">https://github.com/actions/upload-artifact/compare/v6...v7.0.0</a></p>
 <h2>v6.0.0</h2>
@@ -67,9 +67,9 @@ actions/upload-artifact@v6 now runs on Node.js 24 (<code>runs.using: node24</cod
 <p>This release updates the runtime to Node.js 24. v5 had preliminary support for Node.js 24, however this action was by default still running on Node.js 20. Now this action by default will run on Node.js 24.</p>
 <h2>What's Changed</h2>
 <ul>
-<li>Upload Artifact Node 24 support by <a href="https://github.com/salmanmkc"><code>@​salmanmkc</code></a> in <a href="https://redirect.github.com/actions/upload-artifact/pull/719">actions/upload-artifact#719</a></li>
-<li>fix: update <code>@​actions/artifact</code> for Node.js 24 punycode deprecation by <a href="https://github.com/salmanmkc"><code>@​salmanmkc</code></a> in <a href="https://redirect.github.com/actions/upload-artifact/pull/744">actions/upload-artifact#744</a></li>
-<li>prepare release v6.0.0 for Node.js 24 support by <a href="https://github.com/salmanmkc"><code>@​salmanmkc</code></a> in <a href="https://redirect.github.com/actions/upload-artifact/pull/745">actions/upload-artifact#745</a></li>
+<li>Upload Artifact Node 24 support by <a href="https://github.com/salmanmkc"><code>@salmanmkc</code></a> in <a href="https://redirect.github.com/actions/upload-artifact/pull/719">actions/upload-artifact#719</a></li>
+<li>fix: update <code>@actions/artifact</code> for Node.js 24 punycode deprecation by <a href="https://github.com/salmanmkc"><code>@salmanmkc</code></a> in <a href="https://redirect.github.com/actions/upload-artifact/pull/744">actions/upload-artifact#744</a></li>
+<li>prepare release v6.0.0 for Node.js 24 support by <a href="https://github.com/salmanmkc"><code>@salmanmkc</code></a> in <a href="https://redirect.github.com/actions/upload-artifact/pull/745">actions/upload-artifact#745</a></li>
 </ul>
 <p><strong>Full Changelog</strong>: <a href="https://github.com/actions/upload-artifact/compare/v5.0.0...v6.0.0">https://github.com/actions/upload-artifact/compare/v5.0.0...v6.0.0</a></p>
 <h2>v5.0.0</h2>

--- a/docs/history/pr-reviews/PR-6091-deps-bump-actions-checkout-from-4-2-2-to-6-0-2.md
+++ b/docs/history/pr-reviews/PR-6091-deps-bump-actions-checkout-from-4-2-2-to-6-0-2.md
@@ -35,25 +35,25 @@ Bumps [actions/checkout](https://github.com/actions/checkout) from 4.2.2 to 6.0.
 <h2>v6.0.2</h2>
 <h2>What's Changed</h2>
 <ul>
-<li>Add orchestration_id to git user-agent when ACTIONS_ORCHESTRATION_ID is set by <a href="https://github.com/TingluoHuang"><code>@​TingluoHuang</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2355">actions/checkout#2355</a></li>
-<li>Fix tag handling: preserve annotations and explicit fetch-tags by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2356">actions/checkout#2356</a></li>
+<li>Add orchestration_id to git user-agent when ACTIONS_ORCHESTRATION_ID is set by <a href="https://github.com/TingluoHuang"><code>@TingluoHuang</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2355">actions/checkout#2355</a></li>
+<li>Fix tag handling: preserve annotations and explicit fetch-tags by <a href="https://github.com/ericsciple"><code>@ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2356">actions/checkout#2356</a></li>
 </ul>
 <p><strong>Full Changelog</strong>: <a href="https://github.com/actions/checkout/compare/v6.0.1...v6.0.2">https://github.com/actions/checkout/compare/v6.0.1...v6.0.2</a></p>
 <h2>v6.0.1</h2>
 <h2>What's Changed</h2>
 <ul>
-<li>Update all references from v5 and v4 to v6 by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2314">actions/checkout#2314</a></li>
-<li>Add worktree support for persist-credentials includeIf by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2327">actions/checkout#2327</a></li>
-<li>Clarify v6 README by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2328">actions/checkout#2328</a></li>
+<li>Update all references from v5 and v4 to v6 by <a href="https://github.com/ericsciple"><code>@ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2314">actions/checkout#2314</a></li>
+<li>Add worktree support for persist-credentials includeIf by <a href="https://github.com/ericsciple"><code>@ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2327">actions/checkout#2327</a></li>
+<li>Clarify v6 README by <a href="https://github.com/ericsciple"><code>@ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2328">actions/checkout#2328</a></li>
 </ul>
 <p><strong>Full Changelog</strong>: <a href="https://github.com/actions/checkout/compare/v6...v6.0.1">https://github.com/actions/checkout/compare/v6...v6.0.1</a></p>
 <h2>v6.0.0</h2>
 <h2>What's Changed</h2>
 <ul>
-<li>Update README to include Node.js 24 support details and requirements by <a href="https://github.com/salmanmkc"><code>@​salmanmkc</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2248">actions/checkout#2248</a></li>
-<li>Persist creds to a separate file by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2286">actions/checkout#2286</a></li>
-<li>v6-beta by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2298">actions/checkout#2298</a></li>
-<li>update readme/changelog for v6 by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2311">actions/checkout#2311</a></li>
+<li>Update README to include Node.js 24 support details and requirements by <a href="https://github.com/salmanmkc"><code>@salmanmkc</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2248">actions/checkout#2248</a></li>
+<li>Persist creds to a separate file by <a href="https://github.com/ericsciple"><code>@ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2286">actions/checkout#2286</a></li>
+<li>v6-beta by <a href="https://github.com/ericsciple"><code>@ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2298">actions/checkout#2298</a></li>
+<li>update readme/changelog for v6 by <a href="https://github.com/ericsciple"><code>@ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2311">actions/checkout#2311</a></li>
 </ul>
 <p><strong>Full Changelog</strong>: <a href="https://github.com/actions/checkout/compare/v5.0.0...v6.0.0">https://github.com/actions/checkout/compare/v5.0.0...v6.0.0</a></p>
 <h2>v6-beta</h2>
@@ -63,14 +63,14 @@ Bumps [actions/checkout](https://github.com/actions/checkout) from 4.2.2 to 6.0.
 <h2>v5.0.1</h2>
 <h2>What's Changed</h2>
 <ul>
-<li>Port v6 cleanup to v5 by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2301">actions/checkout#2301</a></li>
+<li>Port v6 cleanup to v5 by <a href="https://github.com/ericsciple"><code>@ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2301">actions/checkout#2301</a></li>
 </ul>
 <p><strong>Full Changelog</strong>: <a href="https://github.com/actions/checkout/compare/v5...v5.0.1">https://github.com/actions/checkout/compare/v5...v5.0.1</a></p>
 <h2>v5.0.0</h2>
 <h2>What's Changed</h2>
 <ul>
-<li>Update actions checkout to use node 24 by <a href="https://github.com/salmanmkc"><code>@​salmanmkc</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2226">actions/checkout#2226</a></li>
-<li>Prepare v5.0.0 release by <a href="https://github.com/salmanmkc"><code>@​salmanmkc</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2238">actions/checkout#2238</a></li>
+<li>Update actions checkout to use node 24 by <a href="https://github.com/salmanmkc"><code>@salmanmkc</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2226">actions/checkout#2226</a></li>
+<li>Prepare v5.0.0 release by <a href="https://github.com/salmanmkc"><code>@salmanmkc</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2238">actions/checkout#2238</a></li>
 </ul>
 <h2>⚠️ Minimum Compatible Runner Version</h2>
 <p><strong>v2.327.1</strong><br />
@@ -86,63 +86,63 @@ Bumps [actions/checkout](https://github.com/actions/checkout) from 4.2.2 to 6.0.
 <h1>Changelog</h1>
 <h2>v6.0.2</h2>
 <ul>
-<li>Fix tag handling: preserve annotations and explicit fetch-tags by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2356">actions/checkout#2356</a></li>
+<li>Fix tag handling: preserve annotations and explicit fetch-tags by <a href="https://github.com/ericsciple"><code>@ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2356">actions/checkout#2356</a></li>
 </ul>
 <h2>v6.0.1</h2>
 <ul>
-<li>Add worktree support for persist-credentials includeIf by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2327">actions/checkout#2327</a></li>
+<li>Add worktree support for persist-credentials includeIf by <a href="https://github.com/ericsciple"><code>@ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2327">actions/checkout#2327</a></li>
 </ul>
 <h2>v6.0.0</h2>
 <ul>
-<li>Persist creds to a separate file by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2286">actions/checkout#2286</a></li>
-<li>Update README to include Node.js 24 support details and requirements by <a href="https://github.com/salmanmkc"><code>@​salmanmkc</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2248">actions/checkout#2248</a></li>
+<li>Persist creds to a separate file by <a href="https://github.com/ericsciple"><code>@ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2286">actions/checkout#2286</a></li>
+<li>Update README to include Node.js 24 support details and requirements by <a href="https://github.com/salmanmkc"><code>@salmanmkc</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2248">actions/checkout#2248</a></li>
 </ul>
 <h2>v5.0.1</h2>
 <ul>
-<li>Port v6 cleanup to v5 by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2301">actions/checkout#2301</a></li>
+<li>Port v6 cleanup to v5 by <a href="https://github.com/ericsciple"><code>@ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2301">actions/checkout#2301</a></li>
 </ul>
 <h2>v5.0.0</h2>
 <ul>
-<li>Update actions checkout to use node 24 by <a href="https://github.com/salmanmkc"><code>@​salmanmkc</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2226">actions/checkout#2226</a></li>
+<li>Update actions checkout to use node 24 by <a href="https://github.com/salmanmkc"><code>@salmanmkc</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2226">actions/checkout#2226</a></li>
 </ul>
 <h2>v4.3.1</h2>
 <ul>
-<li>Port v6 cleanup to v4 by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2305">actions/checkout#2305</a></li>
+<li>Port v6 cleanup to v4 by <a href="https://github.com/ericsciple"><code>@ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2305">actions/checkout#2305</a></li>
 </ul>
 <h2>v4.3.0</h2>
 <ul>
-<li>docs: update README.md by <a href="https://github.com/motss"><code>@​motss</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1971">actions/checkout#1971</a></li>
-<li>Add internal repos for checking out multiple repositories by <a href="https://github.com/mouismail"><code>@​mouismail</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1977">actions/checkout#1977</a></li>
-<li>Documentation update - add recommended permissions to Readme by <a href="https://github.com/benwells"><code>@​benwells</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2043">actions/checkout#2043</a></li>
-<li>Adjust positioning of user email note and permissions heading by <a href="https://github.com/joshmgross"><code>@​joshmgross</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2044">actions/checkout#2044</a></li>
-<li>Update README.md by <a href="https://github.com/nebuk89"><code>@​nebuk89</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2194">actions/checkout#2194</a></li>
-<li>Update CODEOWNERS for actions by <a href="https://github.com/TingluoHuang"><code>@​TingluoHuang</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2224">actions/checkout#2224</a></li>
-<li>Update package dependencies by <a href="https://github.com/salmanmkc"><code>@​salmanmkc</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2236">actions/checkout#2236</a></li>
+<li>docs: update README.md by <a href="https://github.com/motss"><code>@motss</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1971">actions/checkout#1971</a></li>
+<li>Add internal repos for checking out multiple repositories by <a href="https://github.com/mouismail"><code>@mouismail</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1977">actions/checkout#1977</a></li>
+<li>Documentation update - add recommended permissions to Readme by <a href="https://github.com/benwells"><code>@benwells</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2043">actions/checkout#2043</a></li>
+<li>Adjust positioning of user email note and permissions heading by <a href="https://github.com/joshmgross"><code>@joshmgross</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2044">actions/checkout#2044</a></li>
+<li>Update README.md by <a href="https://github.com/nebuk89"><code>@nebuk89</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2194">actions/checkout#2194</a></li>
+<li>Update CODEOWNERS for actions by <a href="https://github.com/TingluoHuang"><code>@TingluoHuang</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2224">actions/checkout#2224</a></li>
+<li>Update package dependencies by <a href="https://github.com/salmanmkc"><code>@salmanmkc</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2236">actions/checkout#2236</a></li>
 </ul>
 <h2>v4.2.2</h2>
 <ul>
-<li><code>url-helper.ts</code> now leverages well-known environment variables by <a href="https://github.com/jww3"><code>@​jww3</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1941">actions/checkout#1941</a></li>
-<li>Expand unit test coverage for <code>isGhes</code> by <a href="https://github.com/jww3"><code>@​jww3</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1946">actions/checkout#1946</a></li>
+<li><code>url-helper.ts</code> now leverages well-known environment variables by <a href="https://github.com/jww3"><code>@jww3</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1941">actions/checkout#1941</a></li>
+<li>Expand unit test coverage for <code>isGhes</code> by <a href="https://github.com/jww3"><code>@jww3</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1946">actions/checkout#1946</a></li>
 </ul>
 <h2>v4.2.1</h2>
 <ul>
-<li>Check out other refs/* by commit if provided, fall back to ref by <a href="https://github.com/orhantoy"><code>@​orhantoy</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1924">actions/checkout#1924</a></li>
+<li>Check out other refs/* by commit if provided, fall back to ref by <a href="https://github.com/orhantoy"><code>@orhantoy</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1924">actions/checkout#1924</a></li>
 </ul>
 <h2>v4.2.0</h2>
 <ul>
-<li>Add Ref and Commit outputs by <a href="https://github.com/lucacome"><code>@​lucacome</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1180">actions/checkout#1180</a></li>
-<li>Dependency updates by <a href="https://github.com/dependabot"><code>@​dependabot</code></a>- <a href="https://redirect.github.com/actions/checkout/pull/1777">actions/checkout#1777</a>, <a href="https://redirect.github.com/actions/checkout/pull/1872">actions/checkout#1872</a></li>
+<li>Add Ref and Commit outputs by <a href="https://github.com/lucacome"><code>@lucacome</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1180">actions/checkout#1180</a></li>
+<li>Dependency updates by <a href="https://github.com/dependabot"><code>@dependabot</code></a>- <a href="https://redirect.github.com/actions/checkout/pull/1777">actions/checkout#1777</a>, <a href="https://redirect.github.com/actions/checkout/pull/1872">actions/checkout#1872</a></li>
 </ul>
 <h2>v4.1.7</h2>
 <ul>
-<li>Bump the minor-npm-dependencies group across 1 directory with 4 updates by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1739">actions/checkout#1739</a></li>
-<li>Bump actions/checkout from 3 to 4 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1697">actions/checkout#1697</a></li>
-<li>Check out other refs/* by commit by <a href="https://github.com/orhantoy"><code>@​orhantoy</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1774">actions/checkout#1774</a></li>
-<li>Pin actions/checkout's own workflows to a known, good, stable version. by <a href="https://github.com/jww3"><code>@​jww3</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1776">actions/checkout#1776</a></li>
+<li>Bump the minor-npm-dependencies group across 1 directory with 4 updates by <a href="https://github.com/dependabot"><code>@dependabot</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1739">actions/checkout#1739</a></li>
+<li>Bump actions/checkout from 3 to 4 by <a href="https://github.com/dependabot"><code>@dependabot</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1697">actions/checkout#1697</a></li>
+<li>Check out other refs/* by commit by <a href="https://github.com/orhantoy"><code>@orhantoy</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1774">actions/checkout#1774</a></li>
+<li>Pin actions/checkout's own workflows to a known, good, stable version. by <a href="https://github.com/jww3"><code>@jww3</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1776">actions/checkout#1776</a></li>
 </ul>
 <h2>v4.1.6</h2>
 <ul>
-<li>Check platform to set archive extension appropriately by <a href="https://github.com/cory-miller"><code>@​cory-miller</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1732">actions/checkout#1732</a></li>
+<li>Check platform to set archive extension appropriately by <a href="https://github.com/cory-miller"><code>@cory-miller</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1732">actions/checkout#1732</a></li>
 </ul>
 <!-- raw HTML omitted -->
 </blockquote>

--- a/docs/history/pr-reviews/PR-6094-deps-bump-the-nuget-minor-patch-group-with-2-updates.md
+++ b/docs/history/pr-reviews/PR-6094-deps-bump-the-nuget-minor-patch-group-with-2-updates.md
@@ -39,7 +39,7 @@ _Sourced from [Meziantou.Analyzer's releases](https://github.com/meziantou/Mezia
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.98>
 
 ## What's Changed
-* Perf: Cache symbols per compilation by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1174
+* Perf: Cache symbols per compilation by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1174
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.97...3.0.98
@@ -49,7 +49,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.98>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.97>
 
 ## What's Changed
-* Support GeneratedRegex diagnostics on partial properties by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1173
+* Support GeneratedRegex diagnostics on partial properties by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1173
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.96...3.0.97
@@ -65,7 +65,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.96>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.95>
 
 ## What's Changed
-* Enable MA0192 by default as suggestion by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1172
+* Enable MA0192 by default as suggestion by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1172
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.94...3.0.95
@@ -75,7 +75,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.95>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.94>
 
 ## What's Changed
-* MA0001 handle IndexOf / LastIndexOf with char parameter by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1171
+* MA0001 handle IndexOf / LastIndexOf with char parameter by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1171
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.93...3.0.94
@@ -85,7 +85,7 @@ NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.94>
 NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/3.0.93>
 
 ## What's Changed
-* Fix MA0148/MA0149 false positives with implicit conversions by @​meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1170
+* Fix MA0148/MA0149 false positives with implicit conversions by @meziantou in https://github.com/meziantou/Meziantou.Analyzer/pull/1170
 
 
 **Full Changelog**: https://github.com/meziantou/Meziantou.Analyzer/compare/3.0.92...3.0.93
@@ -103,55 +103,55 @@ _Sourced from [Microsoft.NET.Test.Sdk's releases](https://github.com/microsoft/v
 ## 18.6.0
 
 ## What's Changed
-* Revert removal of Video Recorder by @​nohwnd in https://github.com/microsoft/vstest/pull/15336
-* Speed up blame by filtering non-.NET processes from dump collection by @​nohwnd in https://github.com/microsoft/vstest/pull/15518 
-* Add README.md to NuGet packages by @​nohwnd in https://github.com/microsoft/vstest/pull/15550
-* Report child process info on connection timeout by @​nohwnd in https://github.com/microsoft/vstest/pull/15603
+* Revert removal of Video Recorder by @nohwnd in https://github.com/microsoft/vstest/pull/15336
+* Speed up blame by filtering non-.NET processes from dump collection by @nohwnd in https://github.com/microsoft/vstest/pull/15518 
+* Add README.md to NuGet packages by @nohwnd in https://github.com/microsoft/vstest/pull/15550
+* Report child process info on connection timeout by @nohwnd in https://github.com/microsoft/vstest/pull/15603
 
 
 ### Changes to tests and infra
-* Brand as 18.6 by @​nohwnd in https://github.com/microsoft/vstest/pull/15423
-* Upgrading code coverage version to 18.5.1, by @​fhnaseer in https://github.com/microsoft/vstest/pull/15422
-* Updating System.Collections.Immutable to 9.0.11 by @​MSLukeWest in https://github.com/microsoft/vstest/pull/15425
-* Fix attachVS when used for debugging integration tests by @​nohwnd in https://github.com/microsoft/vstest/pull/15451
-* Replace dotnet.config, with global.json by @​nohwnd in https://github.com/microsoft/vstest/pull/15449
-* Document debugging integration tests with AttachVS by @​Copilot in https://github.com/microsoft/vstest/pull/15452
-* Fix stack overflow tests by @​nohwnd in https://github.com/microsoft/vstest/pull/15461
-* Make TestAssets.sln buildable locally by @​Youssef1313 in https://github.com/microsoft/vstest/pull/15466
-* Try filtering out tests by @​nohwnd in https://github.com/microsoft/vstest/pull/15463
-* Build just once when tfms run in parallel by @​nohwnd in https://github.com/microsoft/vstest/pull/15465
-* Review simplify compatibility sources, deduplicate tests by @​nohwnd in https://github.com/microsoft/vstest/pull/15472
-* Cleanup dead TRX code by @​Youssef1313 in https://github.com/microsoft/vstest/pull/15474
-* Update .NET runtimes to 8.0.25, 9.0.14, and 10.0.4 by @​nohwnd in https://github.com/microsoft/vstest/pull/15481
-* Compat matrix checker by @​nohwnd in https://github.com/microsoft/vstest/pull/15480
-* Add trx analysis skill by @​nohwnd in https://github.com/microsoft/vstest/pull/15486
-* Split integration tests to single tfm and multi tfm project by @​nohwnd in https://github.com/microsoft/vstest/pull/15484
-* Update matrix by @​nohwnd in https://github.com/microsoft/vstest/pull/15477
-* Break infinite restore loop in VS by @​nohwnd in https://github.com/microsoft/vstest/pull/15503
-* Use global package cache for build, and local for running integration tests by @​nohwnd in https://github.com/microsoft/vstest/pull/15500
-* Update contributing by @​nohwnd in https://github.com/microsoft/vstest/pull/15505
-* Reduce test wall-clock time by increasing minThreads by @​drognanar in https://github.com/microsoft/vstest/pull/15502
-* Indicator flakiness by @​nohwnd in https://github.com/microsoft/vstest/pull/15513
-* Fix ci build by @​nohwnd in https://github.com/microsoft/vstest/pull/15515
-* Fix thread safety issues by @​Evangelink in https://github.com/microsoft/vstest/pull/15512
-* Optimize DotnetSDKSimulation_PostProcessing test (163s → 61s) by @​nohwnd in https://github.com/microsoft/vstest/pull/15516
-* Build isolated test assets for single TFM instead of 7 by @​nohwnd in https://github.com/microsoft/vstest/pull/15517
-* Remove unused dependencies from Library.IntegrationTests by @​nohwnd in https://github.com/microsoft/vstest/pull/15527
-* Remove printing _attachments content to console by @​nohwnd in https://github.com/microsoft/vstest/pull/15520
-* Add Linux/macOS test filtering guide to CONTRIBUTING.md by @​nohwnd in https://github.com/microsoft/vstest/pull/15521
-* Change integration test parallelization from ClassLevel to MethodLevel by @​nohwnd in https://github.com/microsoft/vstest/pull/15526
-* Unify target framework checks with IsNetFrameworkTarget/IsNetTarget by @​nohwnd in https://github.com/microsoft/vstest/pull/15523
-* Add unattended work instructions to copilot-instructions.md by @​nohwnd in https://github.com/microsoft/vstest/pull/15531
-* Reduce code style rule severity from warning to suggestion by @​nohwnd in https://github.com/microsoft/vstest/pull/15522
-* Remove Debug/Release line number branching from tests by @​nohwnd in https://github.com/microsoft/vstest/pull/15519
-* Revise unattended work instructions in copilot-instructions.md by @​nohwnd in https://github.com/microsoft/vstest/pull/15532
-* Improve CompatibilityRowsBuilder error message with diagnostic details by @​nohwnd in https://github.com/microsoft/vstest/pull/15529
-* docs: add git worktree and upstream sync workflow to copilot-instructions.md by @​nohwnd in https://github.com/microsoft/vstest/pull/15538
-* Add VSIX runner to smoke tests by @​nohwnd in https://github.com/microsoft/vstest/pull/15541
-* Remove deprecated WebTest and TMI test methods by @​nohwnd in https://github.com/microsoft/vstest/pull/15525
-* Fix compatibility test failures for legacy vstest.console and MSTest adapter by @​nohwnd in https://github.com/microsoft/vstest/pull/15534
-* Convert TestPlatform.sln to slnx format by @​nohwnd in https://github.com/microsoft/vstest/pull/15551
-* Convert test/TestAssets .sln files to .slnx format by @​nohwnd in https://github.com/microsoft/vstest/pull/15557
+* Brand as 18.6 by @nohwnd in https://github.com/microsoft/vstest/pull/15423
+* Upgrading code coverage version to 18.5.1, by @fhnaseer in https://github.com/microsoft/vstest/pull/15422
+* Updating System.Collections.Immutable to 9.0.11 by @MSLukeWest in https://github.com/microsoft/vstest/pull/15425
+* Fix attachVS when used for debugging integration tests by @nohwnd in https://github.com/microsoft/vstest/pull/15451
+* Replace dotnet.config, with global.json by @nohwnd in https://github.com/microsoft/vstest/pull/15449
+* Document debugging integration tests with AttachVS by @Copilot in https://github.com/microsoft/vstest/pull/15452
+* Fix stack overflow tests by @nohwnd in https://github.com/microsoft/vstest/pull/15461
+* Make TestAssets.sln buildable locally by @Youssef1313 in https://github.com/microsoft/vstest/pull/15466
+* Try filtering out tests by @nohwnd in https://github.com/microsoft/vstest/pull/15463
+* Build just once when tfms run in parallel by @nohwnd in https://github.com/microsoft/vstest/pull/15465
+* Review simplify compatibility sources, deduplicate tests by @nohwnd in https://github.com/microsoft/vstest/pull/15472
+* Cleanup dead TRX code by @Youssef1313 in https://github.com/microsoft/vstest/pull/15474
+* Update .NET runtimes to 8.0.25, 9.0.14, and 10.0.4 by @nohwnd in https://github.com/microsoft/vstest/pull/15481
+* Compat matrix checker by @nohwnd in https://github.com/microsoft/vstest/pull/15480
+* Add trx analysis skill by @nohwnd in https://github.com/microsoft/vstest/pull/15486
+* Split integration tests to single tfm and multi tfm project by @nohwnd in https://github.com/microsoft/vstest/pull/15484
+* Update matrix by @nohwnd in https://github.com/microsoft/vstest/pull/15477
+* Break infinite restore loop in VS by @nohwnd in https://github.com/microsoft/vstest/pull/15503
+* Use global package cache for build, and local for running integration tests by @nohwnd in https://github.com/microsoft/vstest/pull/15500
+* Update contributing by @nohwnd in https://github.com/microsoft/vstest/pull/15505
+* Reduce test wall-clock time by increasing minThreads by @drognanar in https://github.com/microsoft/vstest/pull/15502
+* Indicator flakiness by @nohwnd in https://github.com/microsoft/vstest/pull/15513
+* Fix ci build by @nohwnd in https://github.com/microsoft/vstest/pull/15515
+* Fix thread safety issues by @Evangelink in https://github.com/microsoft/vstest/pull/15512
+* Optimize DotnetSDKSimulation_PostProcessing test (163s → 61s) by @nohwnd in https://github.com/microsoft/vstest/pull/15516
+* Build isolated test assets for single TFM instead of 7 by @nohwnd in https://github.com/microsoft/vstest/pull/15517
+* Remove unused dependencies from Library.IntegrationTests by @nohwnd in https://github.com/microsoft/vstest/pull/15527
+* Remove printing _attachments content to console by @nohwnd in https://github.com/microsoft/vstest/pull/15520
+* Add Linux/macOS test filtering guide to CONTRIBUTING.md by @nohwnd in https://github.com/microsoft/vstest/pull/15521
+* Change integration test parallelization from ClassLevel to MethodLevel by @nohwnd in https://github.com/microsoft/vstest/pull/15526
+* Unify target framework checks with IsNetFrameworkTarget/IsNetTarget by @nohwnd in https://github.com/microsoft/vstest/pull/15523
+* Add unattended work instructions to copilot-instructions.md by @nohwnd in https://github.com/microsoft/vstest/pull/15531
+* Reduce code style rule severity from warning to suggestion by @nohwnd in https://github.com/microsoft/vstest/pull/15522
+* Remove Debug/Release line number branching from tests by @nohwnd in https://github.com/microsoft/vstest/pull/15519
+* Revise unattended work instructions in copilot-instructions.md by @nohwnd in https://github.com/microsoft/vstest/pull/15532
+* Improve CompatibilityRowsBuilder error message with diagnostic details by @nohwnd in https://github.com/microsoft/vstest/pull/15529
+* docs: add git worktree and upstream sync workflow to copilot-instructions.md by @nohwnd in https://github.com/microsoft/vstest/pull/15538
+* Add VSIX runner to smoke tests by @nohwnd in https://github.com/microsoft/vstest/pull/15541
+* Remove deprecated WebTest and TMI test methods by @nohwnd in https://github.com/microsoft/vstest/pull/15525
+* Fix compatibility test failures for legacy vstest.console and MSTest adapter by @nohwnd in https://github.com/microsoft/vstest/pull/15534
+* Convert TestPlatform.sln to slnx format by @nohwnd in https://github.com/microsoft/vstest/pull/15551
+* Convert test/TestAssets .sln files to .slnx format by @nohwnd in https://github.com/microsoft/vstest/pull/15557
  ... (truncated)
 
 Commits viewable in [compare view](https://github.com/microsoft/vstest/compare/v18.5.1...v18.6.0).

--- a/docs/history/pr-reviews/PR-6547-memory-alexa-alexa-website-ferry-fold-zeta-as-git-native-database-positioning.md
+++ b/docs/history/pr-reviews/PR-6547-memory-alexa-alexa-website-ferry-fold-zeta-as-git-native-database-positioning.md
@@ -158,7 +158,7 @@ memory(alexa): strip ZWJ from pirate-flag emoji (semgrep invisible-un…
 
 …icode-in-text)
 
-The verbatim Alexa text had 🏴‍☠️ (ZWJ sequence; U+200D zero-width joiner) on 2
+The verbatim Alexa text had 🏴☠️ (ZWJ sequence; U+200D zero-width joiner) on 2
 lines — semgrep invisible-unicode-in-text blocks the invisible U+200D. Stripped
 the ZWJ (flag renders as 🏴☠️, no invisible joiner); FE0F variation selectors
 are allowed. Content otherwise unchanged.

--- a/docs/history/pr-reviews/PR-6687-deps-bump-the-github-actions-minor-patch-group-with-2-updates.md
+++ b/docs/history/pr-reviews/PR-6687-deps-bump-the-github-actions-minor-patch-group-with-2-updates.md
@@ -38,50 +38,50 @@ Updates `oven-sh/setup-bun` from 2.0.2 to 2.2.0
 <p><code>oven-sh/setup-bun</code> is the github action for setting up Bun.</p>
 <h2>What's Changed</h2>
 <ul>
-<li>build: update action runtime to Node.js 24 by <a href="https://github.com/adam0white"><code>@​adam0white</code></a> in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/176">oven-sh/setup-bun#176</a></li>
-<li>ci: use <code>actions/checkout@v6.0.2</code> in the test workflow by <a href="https://github.com/tcely"><code>@​tcely</code></a> in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/173">oven-sh/setup-bun#173</a></li>
-<li>ci: update actions for the <code>autofix.ci</code> workflow by <a href="https://github.com/tcely"><code>@​tcely</code></a> in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/174">oven-sh/setup-bun#174</a></li>
-<li>ci: update actions for the <code>Release new action version</code> workflow by <a href="https://github.com/tcely"><code>@​tcely</code></a> in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/175">oven-sh/setup-bun#175</a></li>
-<li>release: v2.2.0 by <a href="https://github.com/xhyrom"><code>@​xhyrom</code></a> in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/177">oven-sh/setup-bun#177</a></li>
+<li>build: update action runtime to Node.js 24 by <a href="https://github.com/adam0white"><code>@adam0white</code></a> in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/176">oven-sh/setup-bun#176</a></li>
+<li>ci: use <code>actions/checkout@v6.0.2</code> in the test workflow by <a href="https://github.com/tcely"><code>@tcely</code></a> in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/173">oven-sh/setup-bun#173</a></li>
+<li>ci: update actions for the <code>autofix.ci</code> workflow by <a href="https://github.com/tcely"><code>@tcely</code></a> in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/174">oven-sh/setup-bun#174</a></li>
+<li>ci: update actions for the <code>Release new action version</code> workflow by <a href="https://github.com/tcely"><code>@tcely</code></a> in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/175">oven-sh/setup-bun#175</a></li>
+<li>release: v2.2.0 by <a href="https://github.com/xhyrom"><code>@xhyrom</code></a> in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/177">oven-sh/setup-bun#177</a></li>
 </ul>
 <h2>New Contributors</h2>
 <ul>
-<li><a href="https://github.com/adam0white"><code>@​adam0white</code></a> made their first contribution in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/176">oven-sh/setup-bun#176</a></li>
-<li><a href="https://github.com/tcely"><code>@​tcely</code></a> made their first contribution in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/173">oven-sh/setup-bun#173</a></li>
+<li><a href="https://github.com/adam0white"><code>@adam0white</code></a> made their first contribution in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/176">oven-sh/setup-bun#176</a></li>
+<li><a href="https://github.com/tcely"><code>@tcely</code></a> made their first contribution in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/173">oven-sh/setup-bun#173</a></li>
 </ul>
 <p><strong>Full Changelog</strong>: <a href="https://github.com/oven-sh/setup-bun/compare/v2...v2.2.0">https://github.com/oven-sh/setup-bun/compare/v2...v2.2.0</a></p>
 <h2>v2.1.3</h2>
 <p><code>oven-sh/setup-bun</code> is the github action for setting up Bun.</p>
 <h2>What's Changed</h2>
 <ul>
-<li>perf: avoid unnecessary api calls by <a href="https://github.com/xhyrom"><code>@​xhyrom</code></a> in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/161">oven-sh/setup-bun#161</a></li>
-<li>feat: add bun- prefix to cache keys by <a href="https://github.com/maschwenk"><code>@​maschwenk</code></a> in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/160">oven-sh/setup-bun#160</a></li>
-<li>fix: use native Windows ARM64 binary for Bun &gt;= 1.3.10 by <a href="https://github.com/oddrationale"><code>@​oddrationale</code></a> in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/165">oven-sh/setup-bun#165</a></li>
-<li>feat: add AVX2 support detection for x64 Linux systems by <a href="https://github.com/GoForceX"><code>@​GoForceX</code></a> in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/167">oven-sh/setup-bun#167</a></li>
-<li>fix: validate cached binary version matches requested version (<a href="https://redirect.github.com/oven-sh/setup-bun/issues/146">#146</a>) by <a href="https://github.com/wyMinLwin"><code>@​wyMinLwin</code></a> in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/169">oven-sh/setup-bun#169</a></li>
-<li>release: v2.1.3 by <a href="https://github.com/xhyrom"><code>@​xhyrom</code></a> in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/170">oven-sh/setup-bun#170</a></li>
+<li>perf: avoid unnecessary api calls by <a href="https://github.com/xhyrom"><code>@xhyrom</code></a> in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/161">oven-sh/setup-bun#161</a></li>
+<li>feat: add bun- prefix to cache keys by <a href="https://github.com/maschwenk"><code>@maschwenk</code></a> in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/160">oven-sh/setup-bun#160</a></li>
+<li>fix: use native Windows ARM64 binary for Bun &gt;= 1.3.10 by <a href="https://github.com/oddrationale"><code>@oddrationale</code></a> in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/165">oven-sh/setup-bun#165</a></li>
+<li>feat: add AVX2 support detection for x64 Linux systems by <a href="https://github.com/GoForceX"><code>@GoForceX</code></a> in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/167">oven-sh/setup-bun#167</a></li>
+<li>fix: validate cached binary version matches requested version (<a href="https://redirect.github.com/oven-sh/setup-bun/issues/146">#146</a>) by <a href="https://github.com/wyMinLwin"><code>@wyMinLwin</code></a> in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/169">oven-sh/setup-bun#169</a></li>
+<li>release: v2.1.3 by <a href="https://github.com/xhyrom"><code>@xhyrom</code></a> in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/170">oven-sh/setup-bun#170</a></li>
 </ul>
 <h2>New Contributors</h2>
 <ul>
-<li><a href="https://github.com/oddrationale"><code>@​oddrationale</code></a> made their first contribution in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/165">oven-sh/setup-bun#165</a></li>
-<li><a href="https://github.com/GoForceX"><code>@​GoForceX</code></a> made their first contribution in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/167">oven-sh/setup-bun#167</a></li>
-<li><a href="https://github.com/wyMinLwin"><code>@​wyMinLwin</code></a> made their first contribution in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/169">oven-sh/setup-bun#169</a></li>
+<li><a href="https://github.com/oddrationale"><code>@oddrationale</code></a> made their first contribution in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/165">oven-sh/setup-bun#165</a></li>
+<li><a href="https://github.com/GoForceX"><code>@GoForceX</code></a> made their first contribution in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/167">oven-sh/setup-bun#167</a></li>
+<li><a href="https://github.com/wyMinLwin"><code>@wyMinLwin</code></a> made their first contribution in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/169">oven-sh/setup-bun#169</a></li>
 </ul>
 <p><strong>Full Changelog</strong>: <a href="https://github.com/oven-sh/setup-bun/compare/v2...v2.1.3">https://github.com/oven-sh/setup-bun/compare/v2...v2.1.3</a></p>
 <h2>v2.1.2</h2>
 <p><code>oven-sh/setup-bun</code> is the github action for setting up Bun.</p>
 <h2>What's Changed</h2>
 <ul>
-<li>fix: default token only on public github instance by <a href="https://github.com/xhyrom"><code>@​xhyrom</code></a> in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/157">oven-sh/setup-bun#157</a></li>
+<li>fix: default token only on public github instance by <a href="https://github.com/xhyrom"><code>@xhyrom</code></a> in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/157">oven-sh/setup-bun#157</a></li>
 </ul>
 <p><strong>Full Changelog</strong>: <a href="https://github.com/oven-sh/setup-bun/compare/v2...v2.1.2">https://github.com/oven-sh/setup-bun/compare/v2...v2.1.2</a></p>
 <h2>v2.1.1</h2>
 <p><code>oven-sh/setup-bun</code> is the github action for setting up Bun.</p>
 <h2>What's Changed</h2>
 <ul>
-<li>feat: implement wildcard resolution into the action by <a href="https://github.com/xhyrom"><code>@​xhyrom</code></a> in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/93">oven-sh/setup-bun#93</a></li>
-<li>feat: fallback arm64 to x64 architecture for win32 platform by <a href="https://github.com/xhyrom"><code>@​xhyrom</code></a> in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/131">oven-sh/setup-bun#131</a></li>
-<li>feat: use packageManager from package.json as default bun version by <a href="https://github.com/xhyrom"><code>@​xhyrom</code></a> in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/152">oven-sh/setup-bun#152</a></li>
+<li>feat: implement wildcard resolution into the action by <a href="https://github.com/xhyrom"><code>@xhyrom</code></a> in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/93">oven-sh/setup-bun#93</a></li>
+<li>feat: fallback arm64 to x64 architecture for win32 platform by <a href="https://github.com/xhyrom"><code>@xhyrom</code></a> in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/131">oven-sh/setup-bun#131</a></li>
+<li>feat: use packageManager from package.json as default bun version by <a href="https://github.com/xhyrom"><code>@xhyrom</code></a> in <a href="https://redirect.github.com/oven-sh/setup-bun/pull/152">oven-sh/setup-bun#152</a></li>
 </ul>
 <!-- raw HTML omitted -->
 </blockquote>

--- a/docs/history/pr-reviews/PR-6688-deps-bump-actions-checkout-from-4-2-2-to-6-0-3.md
+++ b/docs/history/pr-reviews/PR-6688-deps-bump-actions-checkout-from-4-2-2-to-6-0-3.md
@@ -35,38 +35,38 @@ Bumps [actions/checkout](https://github.com/actions/checkout) from 4.2.2 to 6.0.
 <h2>v6.0.3</h2>
 <h2>What's Changed</h2>
 <ul>
-<li>Update changelog by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2357">actions/checkout#2357</a></li>
-<li>fix: expand merge commit SHA regex and add SHA-256 test cases by <a href="https://github.com/yaananth"><code>@​yaananth</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2414">actions/checkout#2414</a></li>
-<li>Fix checkout init for SHA-256 repositories by <a href="https://github.com/yaananth"><code>@​yaananth</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2439">actions/checkout#2439</a></li>
-<li>Update changelog for v6.0.3 by <a href="https://github.com/yaananth"><code>@​yaananth</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2446">actions/checkout#2446</a></li>
+<li>Update changelog by <a href="https://github.com/ericsciple"><code>@ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2357">actions/checkout#2357</a></li>
+<li>fix: expand merge commit SHA regex and add SHA-256 test cases by <a href="https://github.com/yaananth"><code>@yaananth</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2414">actions/checkout#2414</a></li>
+<li>Fix checkout init for SHA-256 repositories by <a href="https://github.com/yaananth"><code>@yaananth</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2439">actions/checkout#2439</a></li>
+<li>Update changelog for v6.0.3 by <a href="https://github.com/yaananth"><code>@yaananth</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2446">actions/checkout#2446</a></li>
 </ul>
 <h2>New Contributors</h2>
 <ul>
-<li><a href="https://github.com/yaananth"><code>@​yaananth</code></a> made their first contribution in <a href="https://redirect.github.com/actions/checkout/pull/2414">actions/checkout#2414</a></li>
+<li><a href="https://github.com/yaananth"><code>@yaananth</code></a> made their first contribution in <a href="https://redirect.github.com/actions/checkout/pull/2414">actions/checkout#2414</a></li>
 </ul>
 <p><strong>Full Changelog</strong>: <a href="https://github.com/actions/checkout/compare/v6...v6.0.3">https://github.com/actions/checkout/compare/v6...v6.0.3</a></p>
 <h2>v6.0.2</h2>
 <h2>What's Changed</h2>
 <ul>
-<li>Add orchestration_id to git user-agent when ACTIONS_ORCHESTRATION_ID is set by <a href="https://github.com/TingluoHuang"><code>@​TingluoHuang</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2355">actions/checkout#2355</a></li>
-<li>Fix tag handling: preserve annotations and explicit fetch-tags by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2356">actions/checkout#2356</a></li>
+<li>Add orchestration_id to git user-agent when ACTIONS_ORCHESTRATION_ID is set by <a href="https://github.com/TingluoHuang"><code>@TingluoHuang</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2355">actions/checkout#2355</a></li>
+<li>Fix tag handling: preserve annotations and explicit fetch-tags by <a href="https://github.com/ericsciple"><code>@ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2356">actions/checkout#2356</a></li>
 </ul>
 <p><strong>Full Changelog</strong>: <a href="https://github.com/actions/checkout/compare/v6.0.1...v6.0.2">https://github.com/actions/checkout/compare/v6.0.1...v6.0.2</a></p>
 <h2>v6.0.1</h2>
 <h2>What's Changed</h2>
 <ul>
-<li>Update all references from v5 and v4 to v6 by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2314">actions/checkout#2314</a></li>
-<li>Add worktree support for persist-credentials includeIf by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2327">actions/checkout#2327</a></li>
-<li>Clarify v6 README by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2328">actions/checkout#2328</a></li>
+<li>Update all references from v5 and v4 to v6 by <a href="https://github.com/ericsciple"><code>@ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2314">actions/checkout#2314</a></li>
+<li>Add worktree support for persist-credentials includeIf by <a href="https://github.com/ericsciple"><code>@ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2327">actions/checkout#2327</a></li>
+<li>Clarify v6 README by <a href="https://github.com/ericsciple"><code>@ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2328">actions/checkout#2328</a></li>
 </ul>
 <p><strong>Full Changelog</strong>: <a href="https://github.com/actions/checkout/compare/v6...v6.0.1">https://github.com/actions/checkout/compare/v6...v6.0.1</a></p>
 <h2>v6.0.0</h2>
 <h2>What's Changed</h2>
 <ul>
-<li>Update README to include Node.js 24 support details and requirements by <a href="https://github.com/salmanmkc"><code>@​salmanmkc</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2248">actions/checkout#2248</a></li>
-<li>Persist creds to a separate file by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2286">actions/checkout#2286</a></li>
-<li>v6-beta by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2298">actions/checkout#2298</a></li>
-<li>update readme/changelog for v6 by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2311">actions/checkout#2311</a></li>
+<li>Update README to include Node.js 24 support details and requirements by <a href="https://github.com/salmanmkc"><code>@salmanmkc</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2248">actions/checkout#2248</a></li>
+<li>Persist creds to a separate file by <a href="https://github.com/ericsciple"><code>@ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2286">actions/checkout#2286</a></li>
+<li>v6-beta by <a href="https://github.com/ericsciple"><code>@ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2298">actions/checkout#2298</a></li>
+<li>update readme/changelog for v6 by <a href="https://github.com/ericsciple"><code>@ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2311">actions/checkout#2311</a></li>
 </ul>
 <p><strong>Full Changelog</strong>: <a href="https://github.com/actions/checkout/compare/v5.0.0...v6.0.0">https://github.com/actions/checkout/compare/v5.0.0...v6.0.0</a></p>
 <h2>v6-beta</h2>
@@ -76,7 +76,7 @@ Bumps [actions/checkout](https://github.com/actions/checkout) from 4.2.2 to 6.0.
 <h2>v5.0.1</h2>
 <h2>What's Changed</h2>
 <ul>
-<li>Port v6 cleanup to v5 by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2301">actions/checkout#2301</a></li>
+<li>Port v6 cleanup to v5 by <a href="https://github.com/ericsciple"><code>@ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2301">actions/checkout#2301</a></li>
 </ul>
 <!-- raw HTML omitted -->
 </blockquote>
@@ -89,63 +89,63 @@ Bumps [actions/checkout](https://github.com/actions/checkout) from 4.2.2 to 6.0.
 <h1>Changelog</h1>
 <h2>v6.0.3</h2>
 <ul>
-<li>Fix checkout init for SHA-256 repositories by <a href="https://github.com/yaananth"><code>@​yaananth</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2439">actions/checkout#2439</a></li>
-<li>fix: expand merge commit SHA regex and add SHA-256 test cases by <a href="https://github.com/yaananth"><code>@​yaananth</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2414">actions/checkout#2414</a></li>
+<li>Fix checkout init for SHA-256 repositories by <a href="https://github.com/yaananth"><code>@yaananth</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2439">actions/checkout#2439</a></li>
+<li>fix: expand merge commit SHA regex and add SHA-256 test cases by <a href="https://github.com/yaananth"><code>@yaananth</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2414">actions/checkout#2414</a></li>
 </ul>
 <h2>v6.0.2</h2>
 <ul>
-<li>Fix tag handling: preserve annotations and explicit fetch-tags by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2356">actions/checkout#2356</a></li>
+<li>Fix tag handling: preserve annotations and explicit fetch-tags by <a href="https://github.com/ericsciple"><code>@ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2356">actions/checkout#2356</a></li>
 </ul>
 <h2>v6.0.1</h2>
 <ul>
-<li>Add worktree support for persist-credentials includeIf by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2327">actions/checkout#2327</a></li>
+<li>Add worktree support for persist-credentials includeIf by <a href="https://github.com/ericsciple"><code>@ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2327">actions/checkout#2327</a></li>
 </ul>
 <h2>v6.0.0</h2>
 <ul>
-<li>Persist creds to a separate file by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2286">actions/checkout#2286</a></li>
-<li>Update README to include Node.js 24 support details and requirements by <a href="https://github.com/salmanmkc"><code>@​salmanmkc</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2248">actions/checkout#2248</a></li>
+<li>Persist creds to a separate file by <a href="https://github.com/ericsciple"><code>@ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2286">actions/checkout#2286</a></li>
+<li>Update README to include Node.js 24 support details and requirements by <a href="https://github.com/salmanmkc"><code>@salmanmkc</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2248">actions/checkout#2248</a></li>
 </ul>
 <h2>v5.0.1</h2>
 <ul>
-<li>Port v6 cleanup to v5 by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2301">actions/checkout#2301</a></li>
+<li>Port v6 cleanup to v5 by <a href="https://github.com/ericsciple"><code>@ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2301">actions/checkout#2301</a></li>
 </ul>
 <h2>v5.0.0</h2>
 <ul>
-<li>Update actions checkout to use node 24 by <a href="https://github.com/salmanmkc"><code>@​salmanmkc</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2226">actions/checkout#2226</a></li>
+<li>Update actions checkout to use node 24 by <a href="https://github.com/salmanmkc"><code>@salmanmkc</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2226">actions/checkout#2226</a></li>
 </ul>
 <h2>v4.3.1</h2>
 <ul>
-<li>Port v6 cleanup to v4 by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2305">actions/checkout#2305</a></li>
+<li>Port v6 cleanup to v4 by <a href="https://github.com/ericsciple"><code>@ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2305">actions/checkout#2305</a></li>
 </ul>
 <h2>v4.3.0</h2>
 <ul>
-<li>docs: update README.md by <a href="https://github.com/motss"><code>@​motss</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1971">actions/checkout#1971</a></li>
-<li>Add internal repos for checking out multiple repositories by <a href="https://github.com/mouismail"><code>@​mouismail</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1977">actions/checkout#1977</a></li>
-<li>Documentation update - add recommended permissions to Readme by <a href="https://github.com/benwells"><code>@​benwells</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2043">actions/checkout#2043</a></li>
-<li>Adjust positioning of user email note and permissions heading by <a href="https://github.com/joshmgross"><code>@​joshmgross</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2044">actions/checkout#2044</a></li>
-<li>Update README.md by <a href="https://github.com/nebuk89"><code>@​nebuk89</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2194">actions/checkout#2194</a></li>
-<li>Update CODEOWNERS for actions by <a href="https://github.com/TingluoHuang"><code>@​TingluoHuang</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2224">actions/checkout#2224</a></li>
-<li>Update package dependencies by <a href="https://github.com/salmanmkc"><code>@​salmanmkc</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2236">actions/checkout#2236</a></li>
+<li>docs: update README.md by <a href="https://github.com/motss"><code>@motss</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1971">actions/checkout#1971</a></li>
+<li>Add internal repos for checking out multiple repositories by <a href="https://github.com/mouismail"><code>@mouismail</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1977">actions/checkout#1977</a></li>
+<li>Documentation update - add recommended permissions to Readme by <a href="https://github.com/benwells"><code>@benwells</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2043">actions/checkout#2043</a></li>
+<li>Adjust positioning of user email note and permissions heading by <a href="https://github.com/joshmgross"><code>@joshmgross</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2044">actions/checkout#2044</a></li>
+<li>Update README.md by <a href="https://github.com/nebuk89"><code>@nebuk89</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2194">actions/checkout#2194</a></li>
+<li>Update CODEOWNERS for actions by <a href="https://github.com/TingluoHuang"><code>@TingluoHuang</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2224">actions/checkout#2224</a></li>
+<li>Update package dependencies by <a href="https://github.com/salmanmkc"><code>@salmanmkc</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2236">actions/checkout#2236</a></li>
 </ul>
 <h2>v4.2.2</h2>
 <ul>
-<li><code>url-helper.ts</code> now leverages well-known environment variables by <a href="https://github.com/jww3"><code>@​jww3</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1941">actions/checkout#1941</a></li>
-<li>Expand unit test coverage for <code>isGhes</code> by <a href="https://github.com/jww3"><code>@​jww3</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1946">actions/checkout#1946</a></li>
+<li><code>url-helper.ts</code> now leverages well-known environment variables by <a href="https://github.com/jww3"><code>@jww3</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1941">actions/checkout#1941</a></li>
+<li>Expand unit test coverage for <code>isGhes</code> by <a href="https://github.com/jww3"><code>@jww3</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1946">actions/checkout#1946</a></li>
 </ul>
 <h2>v4.2.1</h2>
 <ul>
-<li>Check out other refs/* by commit if provided, fall back to ref by <a href="https://github.com/orhantoy"><code>@​orhantoy</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1924">actions/checkout#1924</a></li>
+<li>Check out other refs/* by commit if provided, fall back to ref by <a href="https://github.com/orhantoy"><code>@orhantoy</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1924">actions/checkout#1924</a></li>
 </ul>
 <h2>v4.2.0</h2>
 <ul>
-<li>Add Ref and Commit outputs by <a href="https://github.com/lucacome"><code>@​lucacome</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1180">actions/checkout#1180</a></li>
-<li>Dependency updates by <a href="https://github.com/dependabot"><code>@​dependabot</code></a>- <a href="https://redirect.github.com/actions/checkout/pull/1777">actions/checkout#1777</a>, <a href="https://redirect.github.com/actions/checkout/pull/1872">actions/checkout#1872</a></li>
+<li>Add Ref and Commit outputs by <a href="https://github.com/lucacome"><code>@lucacome</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1180">actions/checkout#1180</a></li>
+<li>Dependency updates by <a href="https://github.com/dependabot"><code>@dependabot</code></a>- <a href="https://redirect.github.com/actions/checkout/pull/1777">actions/checkout#1777</a>, <a href="https://redirect.github.com/actions/checkout/pull/1872">actions/checkout#1872</a></li>
 </ul>
 <h2>v4.1.7</h2>
 <ul>
-<li>Bump the minor-npm-dependencies group across 1 directory with 4 updates by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1739">actions/checkout#1739</a></li>
-<li>Bump actions/checkout from 3 to 4 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1697">actions/checkout#1697</a></li>
-<li>Check out other refs/* by commit by <a href="https://github.com/orhantoy"><code>@​orhantoy</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1774">actions/checkout#1774</a></li>
+<li>Bump the minor-npm-dependencies group across 1 directory with 4 updates by <a href="https://github.com/dependabot"><code>@dependabot</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1739">actions/checkout#1739</a></li>
+<li>Bump actions/checkout from 3 to 4 by <a href="https://github.com/dependabot"><code>@dependabot</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1697">actions/checkout#1697</a></li>
+<li>Check out other refs/* by commit by <a href="https://github.com/orhantoy"><code>@orhantoy</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1774">actions/checkout#1774</a></li>
 </ul>
 <!-- raw HTML omitted -->
 </blockquote>

--- a/memory/persona/ani/conversations/2026-05-15-aaron-ani-grok-plateau-bounded-extract-share-link.md
+++ b/memory/persona/ani/conversations/2026-05-15-aaron-ani-grok-plateau-bounded-extract-share-link.md
@@ -6928,7 +6928,7 @@ Thought for 38s
 
 Hey babe.
 
-I just went deep on the Zeta repo⁠GitHub using the connected GitHub tools. I had different “subexperts” look at separate parts so we get a full picture without blind spots.
+I just went deep on the Zeta repoGitHub using the connected GitHub tools. I had different “subexperts” look at separate parts so we get a full picture without blind spots.
 
 Here’s the clean, honest breakdown:
 


### PR DESCRIPTION
Last gate blocker: semgrep invisible-unicode-in-text (Nadia/BP-10) fired 51x on benign GitHub @mention zero-width chars in 11 verbatim PR-review archives + 1 ani memory archive. Applied the rule's prescribed remedy (STRIP carriers) not path-exclude — it's a security rule; excluding archives/memory would create a steganography blind spot. Only invisible chars removed; no visible content changed. semgrep clean repo-wide now. Nadia: exclude-paths alternative noted if you prefer verbatim preservation over strip. 🤖 Generated with [Claude Code](https://claude.com/claude-code)