### PR TITLE
feat(core): BitAdinkra — generate adinkra doubly-even codewords from the 1-bit identity stream

### DIFF
--- a/src/Core/BitAdinkra.fs
+++ b/src/Core/BitAdinkra.fs
@@ -1,0 +1,53 @@
+namespace Zeta.Core
+
+/// **`BitAdinkra` — layer the Adinkra doubly-even code over the 1-bit identity stream (Aaron 2026-06-08, shadow*).**
+///
+/// Aaron: *"we should be able to bit like adinkras on top of our 1-bit, or use our 1-bit to generate with
+/// adinkras."* The 1-bit identity stream (drift / `BitGan` / the phasor-qubit, the irreducible identity bit of
+/// the anti-Sybil arc) is grouped into 4-bit messages and encoded by `AdinkraCode` (the published Gates
+/// adinkra ↔ **doubly-even binary code** correspondence; the canonical N=4 generator = the [8,4] extended
+/// Hamming code, doubly-even + self-dual). Each 4 identity bits → an 8-bit **doubly-even codeword** — an
+/// **error-correcting layer over identity** generated *from* the 1-bit.
+///
+/// **Why this is more than cute:** Gates et al. famously found **doubly-even error-correcting codes embedded
+/// in the SUSY (adinkra) equations** — the result that fuelled the "is reality a simulation?" discussion. Our
+/// 1-bit identity is the irreducible bit of the *sim-detection* arc (clock-drift = identity; "am I in a sim?",
+/// #7096). Encoding identity through the adinkra code carries the *same code structure* Gates linked to
+/// simulation, on our own substrate — error-correctable identity, anchored to the published correspondence.
+///
+/// **Honest scope (peel):** this LAYERS the *published* adinkra/doubly-even code (`AdinkraCode`, already
+/// proven doubly-even + distance-4) over our bit stream — a real, useful construction (error-correcting
+/// identity). It is NOT a claim that we discovered the SUSY code, nor that our `CayleyDickson` stack *induces*
+/// this exact generator — that deeper claim is **open in `docs/FROZEN-CORE-AND-CONJECTURE-REGISTER.md` §B**
+/// (Vera's construction specifics). The Gates simulation framing is the Beacon anchor, not our result.
+/// Deterministic (DST §7); pure GF(2) over the existing `AdinkraCode`.
+[<RequireQualifiedAccess>]
+module BitAdinkra =
+
+    /// Group a 1-bit identity stream into `AdinkraCode.dimension`-bit (4-bit) messages, zero-padding a final
+    /// short group (so a partial group of identity bits still encodes). Deterministic.
+    let toMessages (bits: int list) : int[] list =
+        bits
+        |> List.map (fun b -> if b <> 0 then 1 else 0)
+        |> List.chunkBySize AdinkraCode.dimension
+        |> List.map (fun chunk ->
+            let m = Array.zeroCreate AdinkraCode.dimension
+            chunk |> List.iteri (fun i b -> m.[i] <- b)
+            m)
+
+    /// Encode the 1-bit identity stream into Adinkra codewords: each 4 identity bits → an 8-bit doubly-even
+    /// codeword (error-correcting identity). "Use our 1-bit to generate with adinkras."
+    let encodeIdentity (bits: int list) : int[] list =
+        toMessages bits |> List.map AdinkraCode.encode
+
+    /// Every codeword the identity stream generates is **doubly-even** (Hamming weight ≡ 0 mod 4) — the Gates
+    /// adinkra/SUSY code property, carried by identity. (Holds by construction; this checks it.)
+    let allDoublyEven (codewords: int[] list) : bool =
+        codewords |> List.forall (fun c -> AdinkraCode.weight c % 4 = 0)
+
+    /// One step: 4 identity bits → the single adinkra codeword (the atomic "generate with adinkras" op).
+    let encodeNibble (b0: int) (b1: int) (b2: int) (b3: int) : int[] =
+        AdinkraCode.encode [| (if b0 <> 0 then 1 else 0)
+                              (if b1 <> 0 then 1 else 0)
+                              (if b2 <> 0 then 1 else 0)
+                              (if b3 <> 0 then 1 else 0) |]

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -188,6 +188,7 @@
     <Compile Include="SymmetricEndurance.fs" />
     <Compile Include="PhasorEndurance.fs" />
     <Compile Include="CoincidenceClock.fs" />
+    <Compile Include="BitAdinkra.fs" />
     <Compile Include="ZetaExec.fs" />
     <Compile Include="DarkHall.fs" />
     <Compile Include="Consent/KskAuthorization.fs" />

--- a/tests/Tests.FSharp/BitAdinkra.Tests.fs
+++ b/tests/Tests.FSharp/BitAdinkra.Tests.fs
@@ -1,0 +1,36 @@
+module Zeta.Tests.BitAdinkraTests
+
+open global.Xunit
+open Zeta.Core
+
+[<Fact>]
+let ``identity bits generate doubly-even adinkra codewords (Gates SUSY code property)`` () =
+    let bits = [ 1; 0; 1; 1; 0; 0; 1; 0; 1; 1; 1; 0 ] // 12 identity bits → 3 nibbles
+    let codewords = BitAdinkra.encodeIdentity bits
+    Assert.Equal(3, List.length codewords)
+    Assert.True(BitAdinkra.allDoublyEven codewords) // every codeword weight ≡ 0 mod 4
+    Assert.True(codewords |> List.forall (fun c -> Array.length c = AdinkraCode.length)) // 8-bit codewords
+
+[<Fact>]
+let ``encodeNibble matches AdinkraCode.encode and is weight-4-multiple`` () =
+    let cw = BitAdinkra.encodeNibble 1 0 1 0
+    Assert.Equal<int[]>(AdinkraCode.encode [| 1; 0; 1; 0 |], cw)
+    Assert.Equal(0, AdinkraCode.weight cw % 4)
+
+[<Fact>]
+let ``short final group is zero-padded so partial identity still encodes`` () =
+    let bits = [ 1; 1 ] // only 2 bits → one padded nibble [1;1;0;0]
+    let msgs = BitAdinkra.toMessages bits
+    Assert.Equal(1, List.length msgs)
+    Assert.Equal<int[]>([| 1; 1; 0; 0 |], msgs.[0])
+    Assert.True(BitAdinkra.allDoublyEven (BitAdinkra.encodeIdentity bits))
+
+[<Fact>]
+let ``non-0/1 bit inputs are normalised to 0/1`` () =
+    let msgs = BitAdinkra.toMessages [ 5; 0; -3; 0 ] // 5,-3 → 1; 0 → 0
+    Assert.Equal<int[]>([| 1; 0; 1; 0 |], msgs.[0])
+
+[<Fact>]
+let ``deterministic / replayable (DST)`` () =
+    let bits = [ 1; 0; 0; 1; 1; 1; 0; 1 ]
+    Assert.Equal<int[] list>(BitAdinkra.encodeIdentity bits, BitAdinkra.encodeIdentity bits)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -114,6 +114,7 @@
     <Compile Include="SymmetricEndurance.Tests.fs" />
     <Compile Include="PhasorEndurance.Tests.fs" />
     <Compile Include="CoincidenceClock.Tests.fs" />
+    <Compile Include="BitAdinkra.Tests.fs" />
     <Compile Include="DarkHall.Tests.fs" />
     <Compile Include="ITensor.Tests.fs" />
     <Compile Include="SagaSnapshot.Tests.fs" />


### PR DESCRIPTION
Bridges the 1-bit identity stream to AdinkraCode (Gates adinkra<->doubly-even-code; [8,4] ext. Hamming). 4 identity bits -> 8-bit doubly-even codeword = error-correcting layer over identity. Anchor: Gates found doubly-even ECC in SUSY equations (the simulation-hypothesis result) — same code structure carried by our sim-detection-arc identity bit. Peel: layers the published+proven AdinkraCode; CayleyDickson-induces-this-generator stays open (FROZEN-CORE §B). 5/5 tests, 0-warning. 🤖 Generated with [Claude Code](https://claude.com/claude-code)