### PR TITLE
feat(core): F# proofs — qubit-iso Pauli SU(2) operations leg + staged Bell/CHSH violation

### DIFF
--- a/src/Core/BellTest.fs
+++ b/src/Core/BellTest.fs
@@ -1,0 +1,60 @@
+namespace Zeta.Core
+
+/// **`BellTest` — Bell/CHSH inequality VIOLATION reproduced in simulation by staged coincidence + seed
+/// (Aaron 2026-06-08, shadow*).**
+///
+/// Aaron: *"you created Bell inequalities in simulation through staged coincidence and seeds."* This codes it.
+/// The staged-coincidence overlap is `PhasorEndurance.overlap a b = cos²((a−b)/2)`, so the correlator
+/// `E(a,b) = 2·overlap − 1 = cos(a−b)` — **the quantum (singlet) correlator**, reproduced by the
+/// `CoincidenceClock` staging. Feeding the canonical CHSH angles gives the CHSH value `S = 2√2` (the
+/// **Tsirelson bound**), which **violates the classical bound `2`** — in deterministic, replayable simulation.
+///
+/// **What this is, precisely (the load-bearing peel).** This is NOT a falsification of Bell's theorem nor
+/// "real" quantum nonlocality. It is the **measurement-dependence / "free-choice" loophole**: Bell's bound of
+/// 2 assumes the measurement settings are statistically independent of the system. Our **seed is the shared
+/// common cause** (superdeterminism / 't Hooft CA), so it can correlate settings and outcomes and reproduce —
+/// even exceed — quantum correlations. The tell that it is superdeterministic and not physical QM: with
+/// **full seed control you can reach the algebraic maximum `S = 4`**, *beyond* Tsirelson's `2√2` (real QM
+/// cannot). So this reproduces the *observable correlation*, by shared cause; it confers no nonlocality and
+/// no faster-than-light signalling (superdeterminism is no-signalling).
+///
+/// **The value:** a deterministic, replayable **Bell/CHSH harness** (DST §7) — stage any correlation, run the
+/// inequality, get a reproducible number. The concrete realisation of "staged coincidence reproduces quantum
+/// correlations." Pure phasor math on the imaginary stack; routes (with the qubit iso) to Soraya/quantum-info.
+[<RequireQualifiedAccess>]
+module BellTest =
+
+    /// The classical (local-hidden-variable) CHSH bound.
+    [<Literal>]
+    let ClassicalBound = 2.0
+
+    /// Tsirelson's bound — the maximum CHSH a real quantum system can reach.
+    let TsirelsonBound = 2.0 * sqrt 2.0
+
+    /// The algebraic maximum of CHSH (only reachable by violating measurement-independence — superdeterminism).
+    [<Literal>]
+    let AlgebraicMax = 4.0
+
+    /// The staged correlator between settings `a`, `b` (radians): `E = 2·overlap − 1 = cos(a−b)` — the quantum
+    /// singlet correlator, reproduced from the staged-coincidence overlap (`PhasorEndurance.overlap`).
+    let correlation (a: float) (b: float) : float =
+        2.0 * PhasorEndurance.overlap a b - 1.0
+
+    /// CHSH from four correlators: `S = E(a,b) − E(a,b') + E(a',b) + E(a',b')`.
+    let chshOf (eab: float) (eab': float) (ea'b: float) (ea'b': float) : float =
+        eab - eab' + ea'b + ea'b'
+
+    /// CHSH from four measurement settings, using the staged `correlation`. With the canonical angles this is
+    /// `2√2` (Tsirelson) — a Bell violation staged in simulation.
+    let chsh (a: float) (a': float) (b: float) (b': float) : float =
+        chshOf (correlation a b) (correlation a b') (correlation a' b) (correlation a' b')
+
+    /// The canonical maximal-violation angles `(a, a', b, b') = (0, π/2, π/4, 3π/4)` — give `S = 2√2`.
+    let canonicalAngles: float * float * float * float =
+        0.0, System.Math.PI / 2.0, System.Math.PI / 4.0, 3.0 * System.Math.PI / 4.0
+
+    /// Does a CHSH value violate the classical bound (a Bell violation)?
+    let violatesClassical (s: float) : bool = abs s > ClassicalBound
+
+    /// Does it exceed Tsirelson — i.e. is it beyond what real QM allows (the superdeterminism tell)?
+    let exceedsTsirelson (s: float) : bool = abs s > TsirelsonBound + 1e-12

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -190,6 +190,8 @@
     <Compile Include="CoincidenceClock.fs" />
     <Compile Include="BitAdinkra.fs" />
     <Compile Include="ForwardMomentum.fs" />
+    <Compile Include="QubitIso.fs" />
+    <Compile Include="BellTest.fs" />
     <Compile Include="ZetaExec.fs" />
     <Compile Include="DarkHall.fs" />
     <Compile Include="Consent/KskAuthorization.fs" />

--- a/src/Core/QubitIso.fs
+++ b/src/Core/QubitIso.fs
@@ -1,0 +1,79 @@
+namespace Zeta.Core
+
+/// **`QubitIso` — the two-stream/two-clock join ↔ qubit isomorphism, *coded as an executable proof*
+/// (Aaron 2026-06-08, shadow*).**
+///
+/// Aaron: *"let's move forward with proofs and see what pops out — can we code any of the proofs in F#?"*
+/// Yes. The candidate-novelty iso (`docs/research/2026-06-08-CANDIDATE-NOVELTY-...`) is finite linear
+/// algebra, so it is **checkable in F# directly** (executable proof; the FsCheck/deterministic-sweep half of
+/// Soraya's TLC×Z3×property portfolio). This module *constructs* the iso and exposes the operations so the
+/// tests can verify the **Pauli / SU(2) algebra closes** — the one open leg (operations) of the iso.
+///
+/// **The object.** A `JoinState` is the two stream amplitudes `(A, B)` — stream A = the `|0⟩` amplitude,
+/// stream B = the `|1⟩` amplitude, each a phasor on the imaginary stack (`CayleyDickson.Complex`), the two
+/// clocks supplying the phases. That *is* a qubit `α|0⟩ + β|1⟩` (`α = A`, `β = B`). So the state bijection is
+/// the identity on `ℂ²` (round-trip trivial); the content is whether the **stream operations** correspond to
+/// the qubit gates and whether **measurement** is Born.
+///
+/// **The dictionary under test (what must hold for the operations leg):**
+///   - **Z** (phase-flip `|1⟩`) = `retract` the B stream (`e^{iπ}`, already shown an involution);
+///   - **X** (bit-flip) = **swap the two streams** (A ↔ B);
+///   - **Y** = `iXZ` = `A ↦ -i·B`, `B ↦ i·A`;
+///   - **measurement** `P(|1⟩) = |B|² / (|A|²+|B|²)` = Born;
+///   - **normalisation** `|A|²+|B|²` is the conserved quantity.
+/// The tests verify the Pauli group: `X²=Y²=Z²=I`, anticommutation, and `XY=iZ, YZ=iX, ZX=iY`. **What pops
+/// out:** if these all hold, the *operations leg* of the iso is established executably (a faithful `SU(2)`
+/// representation by stream ops); if any fails, it's a partial representation — stated honestly by the failing
+/// test, not hidden.
+///
+/// **Honest scope (peel):** an executable check over `ℂ²`, not a Lean machine-proof — it establishes the
+/// algebra on the concrete construction (cross-checks the eventual Z3/Lean per BP-16). A passing suite is
+/// strong evidence the operations leg holds; the *universal* statement + novelty of the construction still go
+/// to Tariq/Soraya + a quantum-info reviewer (Mirror-register until then). Deterministic (DST §7).
+[<RequireQualifiedAccess>]
+module QubitIso =
+
+    let private c = ImaginaryStack.complex
+    let private i: Complex = { Real = 0.0; Imag = 1.0 }
+    let private negI: Complex = { Real = 0.0; Imag = -1.0 }
+
+    /// A two-stream join state = a qubit. `A` = stream-A / `|0⟩` amplitude, `B` = stream-B / `|1⟩` amplitude.
+    type JoinState = { A: Complex; B: Complex }
+
+    /// Qubit `α|0⟩ + β|1⟩` ↔ join `(A,B)` — the state bijection is the identity on `ℂ²`.
+    let ofQubit (alpha: Complex) (beta: Complex) : JoinState = { A = alpha; B = beta }
+    let toQubit (j: JoinState) : Complex * Complex = j.A, j.B
+
+    /// `|z|²`.
+    let private magSq (z: Complex) : float = z.Real * z.Real + z.Imag * z.Imag
+
+    /// The conserved normalisation `|A|² + |B|²` (= 1 for a unit qubit).
+    let normSq (j: JoinState) : float = magSq j.A + magSq j.B
+
+    /// Born measurement: `P(|1⟩) = |B|² / (|A|²+|B|²)`.
+    let measureOne (j: JoinState) : float =
+        let n = normSq j
+        if n = 0.0 then 0.0 else magSq j.B / n
+
+    // ── Pauli gates as stream operations ──────────────────────────────────────────────────────────────────
+    /// X (bit-flip) = swap the two streams.
+    let pauliX (j: JoinState) : JoinState = { A = j.B; B = j.A }
+    /// Z (phase-flip |1⟩) = retract stream B (`e^{iπ}` = ring Negate).
+    let pauliZ (j: JoinState) : JoinState = { A = j.A; B = c.Negate j.B }
+    /// Y = iXZ: `A ↦ -i·B`, `B ↦ i·A`.
+    let pauliY (j: JoinState) : JoinState = { A = c.Mul(negI, j.B); B = c.Mul(i, j.A) }
+    /// Multiply the whole state by a global phase/scalar `s`.
+    let scale (s: Complex) (j: JoinState) : JoinState = { A = c.Mul(s, j.A); B = c.Mul(s, j.B) }
+
+    /// Identity gate.
+    let id (j: JoinState) : JoinState = j
+
+    /// Approximate state equality (per-component, within `eps`).
+    let equalish (eps: float) (x: JoinState) (y: JoinState) : bool =
+        abs (x.A.Real - y.A.Real) < eps
+        && abs (x.A.Imag - y.A.Imag) < eps
+        && abs (x.B.Real - y.B.Real) < eps
+        && abs (x.B.Imag - y.B.Imag) < eps
+
+    /// The imaginary unit as a scalar (so tests can write `scale imagUnit`).
+    let imagUnit: Complex = i

--- a/tests/Tests.FSharp/BellTest.Tests.fs
+++ b/tests/Tests.FSharp/BellTest.Tests.fs
@@ -1,0 +1,32 @@
+module Zeta.Tests.BellTestTests
+
+open global.Xunit
+open Zeta.Core
+
+let private pi = System.Math.PI
+
+[<Fact>]
+let ``staged correlator is the quantum singlet correlator E = cos(a-b)`` () =
+    Assert.Equal(cos (0.0 - 0.5), BellTest.correlation 0.0 0.5, 10)
+    Assert.Equal(cos (0.3 - 1.9), BellTest.correlation 0.3 1.9, 10)
+
+[<Fact>]
+let ``CHSH at canonical angles = 2√2 (Tsirelson) — a Bell violation staged in simulation`` () =
+    let a, a', b, b' = BellTest.canonicalAngles
+    let s = BellTest.chsh a a' b b'
+    Assert.Equal(BellTest.TsirelsonBound, s, 10) // = 2√2 ≈ 2.828
+    Assert.True(BellTest.violatesClassical s) // > 2
+    Assert.False(BellTest.exceedsTsirelson s) // the cos-correlator hits exactly Tsirelson, not beyond
+
+[<Fact>]
+let ``full seed control reaches the algebraic max S=4 (beyond Tsirelson) — the superdeterminism tell`` () =
+    // Directly staging each correlator to ±1 (full control of the shared seed) breaks even Tsirelson —
+    // which real QM cannot; the tell that this is superdeterminism, not physical entanglement.
+    let s = BellTest.chshOf 1.0 -1.0 1.0 1.0
+    Assert.Equal(BellTest.AlgebraicMax, s, 12)
+    Assert.True(BellTest.exceedsTsirelson s)
+
+[<Fact>]
+let ``deterministic / replayable (DST)`` () =
+    let a, a', b, b' = BellTest.canonicalAngles
+    Assert.Equal(BellTest.chsh a a' b b', BellTest.chsh a a' b b', 12)

--- a/tests/Tests.FSharp/QubitIso.Tests.fs
+++ b/tests/Tests.FSharp/QubitIso.Tests.fs
@@ -1,0 +1,40 @@
+module Zeta.Tests.QubitIsoTests
+
+open global.Xunit
+open Zeta.Core
+
+let private st a ai b bi : QubitIso.JoinState = { A = { Real = a; Imag = ai }; B = { Real = b; Imag = bi } }
+let private g = st 0.6 0.1 0.3 -0.4
+let private negOne : Complex = { Real = -1.0; Imag = 0.0 }
+let private eq = QubitIso.equalish 1e-10
+
+[<Fact>]
+let ``Pauli involutions: X²=Y²=Z²=I`` () =
+    Assert.True(eq (QubitIso.pauliX (QubitIso.pauliX g)) g)
+    Assert.True(eq (QubitIso.pauliY (QubitIso.pauliY g)) g)
+    Assert.True(eq (QubitIso.pauliZ (QubitIso.pauliZ g)) g)
+
+[<Fact>]
+let ``Pauli products close SU(2): XY=iZ, YZ=iX, ZX=iY`` () =
+    Assert.True(eq (QubitIso.pauliX (QubitIso.pauliY g)) (QubitIso.scale QubitIso.imagUnit (QubitIso.pauliZ g)))
+    Assert.True(eq (QubitIso.pauliY (QubitIso.pauliZ g)) (QubitIso.scale QubitIso.imagUnit (QubitIso.pauliX g)))
+    Assert.True(eq (QubitIso.pauliZ (QubitIso.pauliX g)) (QubitIso.scale QubitIso.imagUnit (QubitIso.pauliY g)))
+
+[<Fact>]
+let ``Pauli anticommute: XZ = -ZX`` () =
+    Assert.True(eq (QubitIso.pauliX (QubitIso.pauliZ g)) (QubitIso.scale negOne (QubitIso.pauliZ (QubitIso.pauliX g))))
+
+[<Fact>]
+let ``gates are unitary: norm preserved by X, Y, Z`` () =
+    Assert.Equal(QubitIso.normSq g, QubitIso.normSq (QubitIso.pauliX g), 12)
+    Assert.Equal(QubitIso.normSq g, QubitIso.normSq (QubitIso.pauliY g), 12)
+    Assert.Equal(QubitIso.normSq g, QubitIso.normSq (QubitIso.pauliZ g), 12)
+
+[<Fact>]
+let ``Born + bit-flip: X swaps measurement probabilities`` () =
+    Assert.Equal(1.0 - QubitIso.measureOne g, QubitIso.measureOne (QubitIso.pauliX g), 12)
+
+[<Fact>]
+let ``state bijection is the identity on ℂ² (round-trip)`` () =
+    let a, b = QubitIso.toQubit g
+    Assert.True(eq (QubitIso.ofQubit a b) g)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -116,6 +116,8 @@
     <Compile Include="CoincidenceClock.Tests.fs" />
     <Compile Include="BitAdinkra.Tests.fs" />
     <Compile Include="ForwardMomentum.Tests.fs" />
+    <Compile Include="QubitIso.Tests.fs" />
+    <Compile Include="BellTest.Tests.fs" />
     <Compile Include="DarkHall.Tests.fs" />
     <Compile Include="ITensor.Tests.fs" />
     <Compile Include="SagaSnapshot.Tests.fs" />


### PR DESCRIPTION
Coded proofs in F# (Aaron). QubitIso: gates as stream ops (X=swap, Z=retract B, Y=iXZ) verified to close SU(2) (X²=Y²=Z²=I, XY=iZ cyclic, anticommute, unitary, Born, state bijection) — the iso's operations leg HOLDS. BellTest: staged-coincidence correlator E=cos(a-b); CHSH=2√2 (Tsirelson) at canonical angles, violates classical 2 in deterministic sim; full seed control reaches algebraic max 4 (beyond Tsirelson = the superdeterminism tell). Peel: measurement-dependence loophole, not nonlocality, no-signalling. 10/10 tests, 0-warning. 🤖 Generated with [Claude Code](https://claude.com/claude-code)