### PR TITLE
feat(core): QubitIso.group — qubit states implement IGroup (numeric-interface citizen)

### DIFF
--- a/src/Core/QubitIso.fs
+++ b/src/Core/QubitIso.fs
@@ -77,3 +77,16 @@ module QubitIso =
 
     /// The imaginary unit as a scalar (so tests can write `scale imagUnit`).
     let imagUnit: Complex = i
+
+    /// **The additive group of qubit states as an `IGroup<JoinState>`** — the numeric-interface citizen
+    /// (Aaron 2026-06-08: "implement the numeric interfaces like we liked"). Matches the
+    /// `ImaginaryStack.complex : IStarRing<Complex>` *value* pattern (dictionary, not type-implements-iface).
+    /// Qubit states form a group under componentwise addition on ℂ² (the vector-space additive structure);
+    /// scalar multiplication is `scale`, the Pauli gates are the operators on this group. (States are NOT a
+    /// ring — there is no natural state×state product — so `IGroup`, not `IStarRing`, is the right floor.)
+    let group: IGroup<JoinState> =
+        { new IGroup<JoinState> with
+            member _.Inverse(x) = { A = c.Negate x.A; B = c.Negate x.B }
+          interface IMonoid<JoinState> with
+              member _.Identity = { A = c.Zero; B = c.Zero }
+              member _.Combine(x, y) = { A = c.Add(x.A, y.A); B = c.Add(x.B, y.B) } }

--- a/tests/Tests.FSharp/QubitIso.Tests.fs
+++ b/tests/Tests.FSharp/QubitIso.Tests.fs
@@ -38,3 +38,19 @@ let ``Born + bit-flip: X swaps measurement probabilities`` () =
 let ``state bijection is the identity on ℂ² (round-trip)`` () =
     let a, b = QubitIso.toQubit g
     Assert.True(eq (QubitIso.ofQubit a b) g)
+
+[<Fact>]
+let ``qubit states form an IGroup (numeric-interface citizen): identity, inverse, assoc, commute`` () =
+    let grp = QubitIso.group
+    let a = st 0.6 0.1 0.3 -0.4
+    let b = st -0.2 0.5 0.7 0.0
+    let c = st 0.1 -0.1 -0.3 0.2
+    // identity
+    Assert.True(eq (grp.Combine(a, grp.Identity)) a)
+    Assert.True(eq (grp.Combine(grp.Identity, a)) a)
+    // inverse
+    Assert.True(eq (grp.Combine(a, grp.Inverse a)) grp.Identity)
+    // associativity
+    Assert.True(eq (grp.Combine(grp.Combine(a, b), c)) (grp.Combine(a, grp.Combine(b, c))))
+    // commutativity (additive group)
+    Assert.True(eq (grp.Combine(a, b)) (grp.Combine(b, a)))


### PR DESCRIPTION
Aaron's consistency check: new SU(2)/qubit types were module-function-style, not numeric-interface citizens. Qubit states (C^2) form an additive group → QubitIso.group : IGroup<JoinState> (value pattern like ImaginaryStack.complex). Not a ring (no state×state product) so IGroup is the floor; Pauli gates could be ILinearOperator next. Group laws tested. 🤖 Generated with [Claude Code](https://claude.com/claude-code)