### PR TITLE
feat(core): SoftDashboard — Rx fitness button-glow on the 4x4 grid + empowerment (no-fitness-needed)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -197,6 +197,7 @@
     <Compile Include="Chip8Cow.fs" />
     <Compile Include="SoftChip8.fs" />
     <Compile Include="SoftController.fs" />
+    <Compile Include="SoftDashboard.fs" />
     <Compile Include="ZetaExec.fs" />
     <Compile Include="DarkHall.fs" />
     <Compile Include="Consent/KskAuthorization.fs" />

--- a/src/Core/SoftDashboard.fs
+++ b/src/Core/SoftDashboard.fs
@@ -1,0 +1,83 @@
+namespace Zeta.Core
+
+/// **`SoftDashboard` — Rx fitness over the soft branches; the 16 buttons glow by future fitness (Aaron 2026-06-08, shadow*).**
+///
+/// Aaron: *"it's content-based addressing — we need an Rx fitness function (easy one: sum of all memory values
+/// goes up), so I can follow the future branches that do this best. Like the observe.ts dashboard where the
+/// buttons glow on which one is the right one to press, on the 4×4 universal action grammar grid."*
+///
+/// The CHIP-8 hex keypad **is** the 4×4 grid (16 keys = the universal action grammar grid). Given a **fitness
+/// function** `Frame → float` (content-based — it scores the resulting *content-state*), the dashboard:
+///   - runs the **soft controller** (`SoftController`) — press each key, follow its future a few steps;
+///   - **scores each branch by the fitness** (the future that maximises it = the branch to follow);
+///   - **glows each button** by its branch's fitness ⇒ the brightest button is the one to press.
+///
+/// This is the `collapseToBest` idea rendered as a UI surface: the fuzzy field (every button's future)
+/// projected onto the 4×4 grid as glow; the locus of now is the input frame; the connection is the fitness.
+///
+/// **Honest scope (peel):** `buttonGlow` holds each key for the `depth`-step lookahead and scores the result —
+/// a *first* fitness probe (a real model would weight by likelihood / search deeper via `SoftController.
+/// bestSequence`, throttled when intractable). Fitness functions are *examples* (`sumMemory`, `litPixels`);
+/// the real fitness is task-specific. Built on `Chip8Cow` (COW ⇒ each probe is cheap). Deterministic (DST §7).
+[<RequireQualifiedAccess>]
+module SoftDashboard =
+
+    /// Rx fitness: the sum of all memory byte values (Aaron's easy one — "goes up"). Content-based.
+    let sumMemory (f: Chip8Cow.Frame) : float =
+        f.Mem |> Map.fold (fun acc _ v -> acc + float v) 0.0
+
+    /// Rx fitness: the number of lit display pixels.
+    let litPixels (f: Chip8Cow.Frame) : float =
+        f.Display |> Map.fold (fun acc _ v -> if v then acc + 1.0 else acc) 0.0
+
+    /// The standard CHIP-8 hex keypad as a 4×4 grid — the universal action grammar grid.
+    /// Layout: `1 2 3 C / 4 5 6 D / 7 8 9 E / A 0 B F`.
+    let keypad: int[][] =
+        [| [| 0x1; 0x2; 0x3; 0xC |]
+           [| 0x4; 0x5; 0x6; 0xD |]
+           [| 0x7; 0x8; 0x9; 0xE |]
+           [| 0xA; 0x0; 0xB; 0xF |] |]
+
+    /// **Button glow:** for each key `0..15`, the fitness of the future if you press it now (hold the key,
+    /// look ahead `depth` steps, score). The 16-element glow array (index = key value). The brightest = the
+    /// best button to press.
+    let buttonGlow (fitness: Chip8Cow.Frame -> float) (depth: int) (f: Chip8Cow.Frame) : float[] =
+        [| for k in 0..15 -> fitness (Chip8Cow.run depth { f with Keys = SoftController.singleKey k }) |]
+
+    /// Which button to press — the brightest (argmax glow).
+    let bestButton (fitness: Chip8Cow.Frame -> float) (depth: int) (f: Chip8Cow.Frame) : int =
+        let g = buttonGlow fitness depth f
+        [ 0..15 ] |> List.maxBy (fun k -> g.[k])
+
+    /// The glow projected onto the 4×4 keypad layout — rows of `(key, glow)` (the dashboard surface).
+    let glowGrid (fitness: Chip8Cow.Frame -> float) (depth: int) (f: Chip8Cow.Frame) : (int * float)[][] =
+        let g = buttonGlow fitness depth f
+        keypad |> Array.map (Array.map (fun k -> k, g.[k]))
+
+    // ── Unsupervised fitness (no external reward given) — Aaron 2026-06-08 ────────────────────────────────
+    //
+    // "What if I didn't give you a fitness function — is there an unsupervised way?" Yes. Without ANY criterion
+    // there is no 'best', but principled INTRINSIC objectives need no external reward. The Zeta-aligned default
+    // is EMPOWERMENT (Klyubin–Polani 2005): prefer states that keep the most future options — a proxy for the
+    // action->future channel capacity. Maximizing it = maximizing AGENCY over the future, which IS the
+    // forward-momentum / identity principle (an identity grows by keeping/expanding what it can control).
+    // (Other families: curiosity / compression-progress (Schmidhuber, Pathak — reward novelty/surprise);
+    // free-energy / active inference (Friston — minimize surprise); max-entropy state coverage; survival /
+    // non-collapse — tie to identity-preservation.)
+
+    /// A cheap content-address of a frame for dedup (PC + registers + I — content-based addressing).
+    let private contentKey (f: Chip8Cow.Frame) : int * int list * int =
+        int f.PC, (f.V |> Array.toList |> List.map int), int f.I
+
+    /// **EMPOWERMENT — the unsupervised fitness:** the count of DISTINCT (content-addressed) states the agent's
+    /// input choices can reach over `depth` (proxy for the action→future channel capacity). No external reward;
+    /// higher = more future control / agency. Use as `fitness` in `buttonGlow`/`bestButton` when none is given.
+    let empowerment (depth: int) (f: Chip8Cow.Frame) : float =
+        let rec reach d fr =
+            if d <= 0 then
+                Set.singleton (contentKey fr)
+            else
+                SoftController.softFork fr
+                |> List.map (fun (fr', _) -> reach (d - 1) fr')
+                |> Set.unionMany
+        reach depth f |> Set.count |> float

--- a/tests/Tests.FSharp/SoftDashboard.Tests.fs
+++ b/tests/Tests.FSharp/SoftDashboard.Tests.fs
@@ -1,0 +1,65 @@
+module Zeta.Tests.SoftDashboardTests
+
+open global.Xunit
+open Zeta.Core
+
+// FX0A waits for a key into V[0] ; I=0x300 ; store V[0] into mem[0x300]. So the pressed key's VALUE lands in
+// memory => sumMemory is highest for the highest key pressed. The dashboard should glow key F (15) brightest.
+let private keyToMem = [| 0xF0uy; 0x0Auy; 0xA3uy; 0x00uy; 0xF0uy; 0x55uy |]
+let private start () = Chip8Cow.create 1UL |> Chip8Cow.loadRom keyToMem
+
+[<Fact>]
+let ``sumMemory fitness rises with the value written; litPixels counts the display`` () =
+    let f = start ()
+    Assert.True(SoftDashboard.sumMemory f > 0.0) // font + ROM bytes present
+    Assert.Equal(0.0, SoftDashboard.litPixels f) // nothing drawn yet
+
+[<Fact>]
+let ``buttonGlow returns 16 fitness values, one per key`` () =
+    let g = SoftDashboard.buttonGlow SoftDashboard.sumMemory 3 (start ())
+    Assert.Equal(16, g.Length)
+
+[<Fact>]
+let ``bestButton glows the key whose future maximises the fitness (press F -> most memory)`` () =
+    // pressing key k writes k into mem[0x300]; higher k => higher sumMemory => key F (15) is brightest.
+    let best = SoftDashboard.bestButton SoftDashboard.sumMemory 3 (start ())
+    Assert.Equal(0xF, best)
+    let g = SoftDashboard.buttonGlow SoftDashboard.sumMemory 3 (start ())
+    Assert.True(g.[0xF] > g.[0x0]) // F brighter than 0
+
+[<Fact>]
+let ``the 4x4 keypad grid is the 16 hex keys`` () =
+    let keys = SoftDashboard.keypad |> Array.collect id |> Array.sort
+    Assert.Equal<int[]>([| 0..15 |], keys)
+    Assert.Equal(4, SoftDashboard.keypad.Length)
+    Assert.True(SoftDashboard.keypad |> Array.forall (fun row -> row.Length = 4))
+
+[<Fact>]
+let ``glowGrid projects the glow onto the 4x4 layout`` () =
+    let grid = SoftDashboard.glowGrid SoftDashboard.sumMemory 3 (start ())
+    Assert.Equal(4, grid.Length)
+    // the (key,glow) for key F should be the brightest cell
+    let allCells = grid |> Array.collect id
+    let brightest = allCells |> Array.maxBy snd |> fst
+    Assert.Equal(0xF, brightest)
+
+[<Fact>]
+let ``deterministic / replayable (DST)`` () =
+    Assert.Equal<float[]>(
+        SoftDashboard.buttonGlow SoftDashboard.sumMemory 3 (start ()),
+        SoftDashboard.buttonGlow SoftDashboard.sumMemory 3 (start ()))
+
+[<Fact>]
+let ``empowerment (unsupervised): a branchy state has more reachable futures than a halt`` () =
+    // branchy: E09E forks the future (input matters) => >1 distinct reachable state.
+    let branchy = Chip8Cow.create 1UL |> Chip8Cow.loadRom [| 0x60uy; 0x00uy; 0xE0uy; 0x9Euy |] |> Chip8Cow.step
+    // halt: 1200 jumps to itself forever => exactly 1 reachable state.
+    let halt = Chip8Cow.create 1UL |> Chip8Cow.loadRom [| 0x12uy; 0x00uy |]
+    Assert.True(SoftDashboard.empowerment 3 branchy > SoftDashboard.empowerment 3 halt)
+    Assert.Equal(1.0, SoftDashboard.empowerment 3 halt) // stuck = zero agency (one reachable state)
+
+[<Fact>]
+let ``empowerment works as a no-supplied-fitness dashboard objective`` () =
+    let f = Chip8Cow.create 1UL |> Chip8Cow.loadRom [| 0x60uy; 0x00uy; 0xE0uy; 0x9Euy |] |> Chip8Cow.step
+    let g = SoftDashboard.buttonGlow (SoftDashboard.empowerment 2) 1 f
+    Assert.Equal(16, g.Length) // glows by intrinsic agency, no external reward needed

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -123,6 +123,7 @@
     <Compile Include="Chip8Cow.Tests.fs" />
     <Compile Include="SoftChip8.Tests.fs" />
     <Compile Include="SoftController.Tests.fs" />
+    <Compile Include="SoftDashboard.Tests.fs" />
     <Compile Include="DarkHall.Tests.fs" />
     <Compile Include="ITensor.Tests.fs" />
     <Compile Include="SagaSnapshot.Tests.fs" />


### PR DESCRIPTION
Aaron: fitness-driven button-glow dashboard (Σmemory etc.) on the 4x4 hex keypad (= universal action grammar grid); AND the unsupervised way (better — no fitness needed). buttonGlow/bestButton/glowGrid + fitness sumMemory/litPixels; EMPOWERMENT (Klyubin-Polani) = distinct reachable content-states = action->future channel capacity = agency = forward-momentum/identity, works with NO supplied fitness. 8/8 tests. Peel: first-probe lookahead; empowerment proxy content-key (PC,V,I); other intrinsic families noted (curiosity/free-energy). 🤖 Generated with [Claude Code](https://claude.com/claude-code)