### PR TITLE
feat(core): SoftDashboard.streamLength — gameable survival metric; empowerment robust to its cheat

### DIFF
--- a/src/Core/SoftDashboard.fs
+++ b/src/Core/SoftDashboard.fs
@@ -81,3 +81,23 @@ module SoftDashboard =
                 |> List.map (fun (fr', _) -> reach (d - 1) fr')
                 |> Set.unionMany
         reach depth f |> Set.count |> float
+
+    /// **`streamLength` — a common cross-game fitness, but GAMEABLE (Aaron 2026-06-08):** steps survived before
+    /// a self-halt (a `1NNN` jump to its own address), capped at `budget`. Common ("survive longest"), but
+    /// **easy to game (Goodhart's law / reward hacking):** a do-nothing loop that never self-halts maxes it
+    /// without playing (cf. the Tetris-pause bot, the CoastRunners boat looping for points; Krakovna's
+    /// specification-gaming list). Contrast `empowerment`, which a do-nothing loop *minimises* (no agency) — so
+    /// empowerment is robust to exactly this cheat. Kept here to demonstrate the gameability, not as the default.
+    let streamLength (budget: int) (f0: Chip8Cow.Frame) : float =
+        let isHalt (f: Chip8Cow.Frame) =
+            let pc = int f.PC
+            let op =
+                (int (Map.tryFind pc f.Mem |> Option.defaultValue 0uy) <<< 8)
+                ||| int (Map.tryFind (pc + 1) f.Mem |> Option.defaultValue 0uy)
+            (op &&& 0xF000 = 0x1000) && (op &&& 0x0FFF = pc) // jump-to-self = halt
+        let mutable f = f0
+        let mutable n = 0
+        while n < budget && not (isHalt f) do
+            f <- Chip8Cow.step f
+            n <- n + 1
+        float n

--- a/tests/Tests.FSharp/SoftDashboard.Tests.fs
+++ b/tests/Tests.FSharp/SoftDashboard.Tests.fs
@@ -63,3 +63,14 @@ let ``empowerment works as a no-supplied-fitness dashboard objective`` () =
     let f = Chip8Cow.create 1UL |> Chip8Cow.loadRom [| 0x60uy; 0x00uy; 0xE0uy; 0x9Euy |] |> Chip8Cow.step
     let g = SoftDashboard.buttonGlow (SoftDashboard.empowerment 2) 1 f
     Assert.Equal(16, g.Length) // glows by intrinsic agency, no external reward needed
+
+[<Fact>]
+let ``streamLength is gameable; empowerment is robust to the do-nothing-loop cheat`` () =
+    // counter loop: 6000 V0=0 ; 7001 V0+=1 ; 1202 jump 0x202 — runs FOREVER, plays nothing.
+    let cheat = Chip8Cow.create 1UL |> Chip8Cow.loadRom [| 0x60uy; 0x00uy; 0x70uy; 0x01uy; 0x12uy; 0x02uy |]
+    // self-halt: 1200 at 0x200 jumps to its own address.
+    let halted = Chip8Cow.create 1UL |> Chip8Cow.loadRom [| 0x12uy; 0x00uy |]
+    Assert.Equal(50.0, SoftDashboard.streamLength 50 cheat) // GAMED: maxes the survival metric doing nothing
+    Assert.Equal(0.0, SoftDashboard.streamLength 50 halted) // a program that finishes scores low
+    // empowerment is NOT fooled: the do-nothing loop has no agency (your inputs don't change the future).
+    Assert.Equal(1.0, SoftDashboard.empowerment 4 cheat) // 1 reachable state regardless of action = zero agency


### PR DESCRIPTION
Aaron: stream-length is common but gameable. streamLength (steps-to-halt, capped) = the survival metric; test shows a do-nothing counter-loop MAXES it (Goodhart/reward-hacking) while empowerment=1 (zero agency) — empowerment is robust to exactly the cheat. Kept to demonstrate gameability, not as default. 9/9 tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)