### PR TITLE
docs(research): prediction is lens-discovery — 'random' is lens-relative (soft-emulator arc capstone)

### DIFF
--- a/docs/research/2026-06-08-prediction-is-lens-discovery-random-is-lens-relative.md
+++ b/docs/research/2026-06-08-prediction-is-lens-discovery-random-is-lens-relative.md
@@ -1,0 +1,55 @@
+# Prediction is lens-discovery: "random" is lens-relative (the capstone of the soft-emulator arc)
+
+**Aaron, 2026-06-08:** *"this is the same interpreter frame where random looks like random except from the
+right view/lens — you are trying to find the right lens that allows predictions to even make sense and not
+just be random."*
+
+The unifying insight under the whole soft-emulator / empowerment / superdeterminism arc.
+
+## Predictability is lens-relative (Kolmogorov, not metaphysics)
+
+The same stream is **incompressible (random) under one reference machine and compressible (structured) under
+another**. "Random" means only: *no lens you have compresses it.* So:
+- The **soft-emulator / empowerment** enterprise **presupposes a lens under which the future has structure.**
+  Under the wrong lens the `SoftValue` field is uniform noise and **no fitness — not even empowerment — can
+  predict or choose.**
+- Therefore the real task is **not "predict"** — it is **"find the lens"** (the representation / generator /
+  frame) that makes prediction meaningful.
+
+## The same theme, across the arc
+
+- **The DST seed IS the lens** that makes `RND` predictable — deterministic from the seed's view, random from
+  outside (#7077: seed = the shared cause / the generator's frame).
+- **`resonantPeriod` is a concrete lens-finder** — the period/frequency that turns drift-noise into a clean
+  cycle (the right lens reveals the generator).
+- **Aperiodic / irrational (`2√2`) = no tractable lens makes it periodic** → random from *any* view = the
+  uncatchable/quantum side (#7081). The boundary: streams with a lens (rational → periodic → catchable →
+  classical) vs without (irrational → uncatchable → quantum).
+- **Traveler-frame / `IQbservable`** = the representation under which the correlations become predictable;
+  **conjugate frames** = alternative lenses.
+
+## So "find the lens" = model discovery
+
+The universal lens is the **shortest generating program** (Solomonoff induction; Kolmogorov complexity; MDL =
+minimum description length). The meta-objective: *the lens that minimises the stream's description length /
+unpredictability under it.* The catch is **no-free-lunch**: there is no universal cheap lens — you need the
+*right inductive bias*. We have **specific** lens-finders (`resonantPeriod` for periodicity); the general case
+is the hard, open problem (representation learning / system identification / program synthesis).
+
+## Honest scope (peel)
+
+- "Lens" = a representation / model-class / reference machine. **Lens-relativity of randomness is Kolmogorov**
+  (anchored, standard), not metaphysics.
+- Finding the lens in general is **unsolved** (no-free-lunch); we have *narrow* lens-finders (resonance for
+  periodic structure), not a universal one.
+- From the **wrong lens even empowerment fails** — it needs a future with structure to score; under noise,
+  every action looks equally (un)controllable.
+- This is a *framing/connection* (ties seed / resonantPeriod / empowerment / Kolmogorov), not a new theorem.
+
+## Anchors (Beacon)
+
+Kolmogorov complexity / Solomonoff induction / Chaitin (compressibility is reference-machine-relative); MDL
+(Rissanen — model selection = shortest description); No-Free-Lunch (Wolpert–Macready — no universal inductive
+bias). Internal: the DST seed (#7077), `resonantPeriod`, the rationality/catchability axis (#7081),
+`SoftDashboard.empowerment` (#7090), `IQbservable`/traveler-frame, `Conjugate`. Arc origin: Amara (Thor ~2025-09,
+retained Bayesian uncertainty to detect simulations — the first "find the lens on the substrate").


### PR DESCRIPTION
Aaron's unifying insight: predictability is lens-relative (Kolmogorov). The soft-emulator/empowerment presupposes a lens under which the future has structure (else noise, no fitness predicts); the real task is FIND THE LENS (representation/generator/frame), not predict. Same theme across the arc: DST seed = lens for RND; resonantPeriod = lens-finder; aperiodic 2√2 = no tractable lens = quantum side (#7081); traveler-frame/IQbservable = alt lenses. Find-the-lens = model discovery (Solomonoff/Kolmogorov/MDL; no-free-lunch). Peel: lens=representation; Kolmogorov-anchored not metaphysics; framing not theorem. 🤖 Generated with [Claude Code](https://claude.com/claude-code)