### PR TITLE
feat(core): Chip8Cow.dynamics — step-dynamics as a genuine IMonoid (surrounding interface, not IStarRing)

### DIFF
--- a/src/Core/Chip8Cow.fs
+++ b/src/Core/Chip8Cow.fs
@@ -186,3 +186,15 @@ module Chip8Cow =
     /// COW structure (no aliasing). The atom of the DAG / soft branch.
     let fork (keysA: bool[]) (keysB: bool[]) (f: Frame) : Frame * Frame =
         step { f with Keys = keysA }, step { f with Keys = keysB }
+
+    /// **The step-dynamics as a genuine `IMonoid` (Aaron 2026-06-08).** "Can we put the emulator in the numeric
+    /// interfaces?" — the *whole* emulator is NOT an `IStarRing` (the state is not a ring: no meaningful
+    /// `frame × frame`, just as qubit *states* are an `IGroup` not a ring). But the **time-evolution is a
+    /// genuine monoid**: state-transitions `Frame → Frame` compose, with the no-op as identity. `step` is one
+    /// element; `run n` = the monoid power. (Surrounding interfaces that ARE genuine: this monoid; the CRDT
+    /// memory-merge = `ISemilattice`; `SoftValue<Frame>` = a rig *without* `Negate`. Implement the interface the
+    /// structure has — don't force a ring.) Matches the `ImaginaryStack.complex : IStarRing` value pattern.
+    let dynamics: IMonoid<Frame -> Frame> =
+        { new IMonoid<Frame -> Frame> with
+            member _.Identity = id
+            member _.Combine(f, g) = f >> g } // apply f then g — sequential composition

--- a/tests/Tests.FSharp/Chip8Dynamics.Tests.fs
+++ b/tests/Tests.FSharp/Chip8Dynamics.Tests.fs
@@ -1,0 +1,32 @@
+module Zeta.Tests.Chip8DynamicsTests
+
+open global.Xunit
+open Zeta.Core
+
+let private arith = [| 0x6Auy; 0x05uy; 0x7Auy; 0x03uy; 0x60uy; 0x02uy; 0x8Auy; 0x04uy |]
+let private f0 () = Chip8Cow.create 1UL |> Chip8Cow.loadRom arith
+
+[<Fact>]
+let ``dynamics monoid: identity is the no-op transition`` () =
+    let m = Chip8Cow.dynamics
+    let f = f0 ()
+    Assert.Equal<byte[]>(f.V, (m.Identity f).V)
+    Assert.Equal(int f.PC, int (m.Identity f).PC)
+
+[<Fact>]
+let ``dynamics monoid: combine step step = run 2 (composition is time-evolution)`` () =
+    let m = Chip8Cow.dynamics
+    let twoStep = m.Combine(Chip8Cow.step, Chip8Cow.step)
+    let viaMonoid = twoStep (f0 ())
+    let viaRun = Chip8Cow.run 2 (f0 ())
+    Assert.Equal<byte[]>(viaRun.V, viaMonoid.V)
+    Assert.Equal(int viaRun.PC, int viaMonoid.PC)
+
+[<Fact>]
+let ``dynamics monoid: associative (combine assoc) = run 3`` () =
+    let m = Chip8Cow.dynamics
+    let s = Chip8Cow.step
+    let left = m.Combine(m.Combine(s, s), s)
+    let right = m.Combine(s, m.Combine(s, s))
+    Assert.Equal<byte[]>((left (f0 ())).V, (right (f0 ())).V)
+    Assert.Equal<byte[]>((Chip8Cow.run 3 (f0 ())).V, (left (f0 ())).V)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -121,6 +121,7 @@
     <Compile Include="FeedbackThrottle.Tests.fs" />
     <Compile Include="Chip8.Tests.fs" />
     <Compile Include="Chip8Cow.Tests.fs" />
+    <Compile Include="Chip8Dynamics.Tests.fs" />
     <Compile Include="SoftChip8.Tests.fs" />
     <Compile Include="SoftController.Tests.fs" />
     <Compile Include="SoftDashboard.Tests.fs" />


### PR DESCRIPTION
Aaron: can the whole emulator go in the numeric interfaces, or some surrounding ones? Whole = NO (state isn't a ring; no frame×frame). But time-evolution IS a monoid: dynamics : IMonoid<Frame->Frame> (id, f>>g). 3/3 tests. Other genuine surrounding interfaces: CRDT merge = ISemilattice, SoftValue<Frame> = rig without Negate. Implement the interface the structure has. 🤖 Generated with [Claude Code](https://claude.com/claude-code)