### PR TITLE
feat(core): AmplitudeEmu — complex-amplitude soft emulator, merge IS interference (Born rule)

### DIFF
--- a/src/Core/AmplitudeEmu.fs
+++ b/src/Core/AmplitudeEmu.fs
@@ -1,0 +1,102 @@
+namespace Zeta.Core
+
+/// **`AmplitudeEmu` — the soft emulator with COMPLEX amplitudes, so it actually *interferes* (Aaron 2026-06-08, shadow*).**
+///
+/// Aaron caught the real sloppiness: *"we had complex amplitudes on our qubit — the rotations of the unit
+/// circle. Why can't we construct a generator that hits this? Does merging make the wave phase cancel?"* —
+/// **yes, it does, and this is where.** `SoftEmu` (#7095) used *real* weights (a classical probability
+/// mixture: no phase ⇒ no interference). This module is the same ensemble with **complex-amplitude weights**
+/// (the `QubitIso`/`ImaginaryStack.Complex` phasor — `e^{iθ}`, unit-circle rotations). The single change that
+/// turns a classical mixture into a quantum-like amplitude is the **merge**:
+///
+///   - **`merge` sums the amplitudes of identical frames** — and complex amplitudes with opposite phase
+///     *cancel* (destructive) while equal phase *reinforce* (constructive). **That is interference**, in code.
+///     It is exactly the CAS-dedup-merge `SoftEmu` deliberately dropped: drop the merge *and* use real weights
+///     ⇒ no interference; restore the merge *with* complex weights ⇒ the two-slit falls out.
+///   - **`bornProb` measures by `|amplitude|²`** (the Born rule) — the only place amplitudes become
+///     probabilities, normalized over the ensemble intensity.
+///
+/// **Honest scope (peel) — read before believing this "simulates qubits":**
+///   - **Interference is real here; the entanglement exponential is NOT escaped.** This is cheap only while the
+///     number of *distinct* frames stays small (low entanglement / few reconverging paths). General
+///     high-entanglement state needs `4ⁿ` reals — the merge does not reduce that count; it only collapses paths
+///     that *reconverge to the identical frame*. `support` growing un-merged IS the exponential, logged not hidden.
+///   - **CHIP-8 opcodes introduce no phase.** Genuine interference needs a *phase source* (a quantum-gate
+///     opcode, or driving amplitudes through the `QubitIso` layer); plain CHIP-8 steps keep amplitudes real, so
+///     `softStep` here is the *substrate* for interference, demonstrated directly by `merge` (the two-path test),
+///     not produced by the ROM. This is the bridge layer `SoftEmu` lacked, not a quantum CPU.
+///   - **Bell still bounds the *correlations* at S=2 for a local generator** (`SoftEmu` doc / FeedbackThrottle):
+///     complex amplitudes buy *interference*, not non-locality. 2√2 still needs the feedback/superdeterminism
+///     channel. Amplitudes ≠ entanglement ≠ signalling — three separate resources.
+///
+/// So: this answers "does merging make the phase cancel?" with runnable code (yes), while holding that
+/// interference, the 4ⁿ entanglement wall, and the Bell S=2 bound are three distinct things.
+[<RequireQualifiedAccess>]
+module AmplitudeEmu =
+
+    let private c = ImaginaryStack.complex
+
+    /// The whole emulator as an *amplitude* ensemble: each joint frame carries a complex amplitude (not a real
+    /// probability). The superposition is the list; the physics is in how amplitudes combine under `merge`.
+    type Amp = (Chip8Cow.Frame * Complex) list
+
+    let private EPS = 1e-12
+
+    /// Born intensity of one amplitude: `|z|²`.
+    let private magSq (z: Complex) : float = z.Real * z.Real + z.Imag * z.Imag
+
+    /// A real amplitude (phase 0).
+    let private real (r: float) : Complex = { Real = r; Imag = 0.0 }
+
+    /// **The interference step:** sum the amplitudes of *identical* frames. Opposite-phase amplitudes cancel
+    /// (destructive), equal-phase reinforce (constructive) — this is where the wave phase cancels. Frames use
+    /// structural equality (persistent `Map` + arrays). Drops amplitudes that cancel to ≈0 (a fully destroyed path).
+    let merge (a: Amp) : Amp =
+        a
+        |> List.groupBy fst
+        |> List.choose (fun (f, group) ->
+            let summed = group |> List.fold (fun acc (_, z) -> c.Add(acc, z)) c.Zero
+            if magSq summed <= EPS then None else Some(f, summed))
+
+    /// A point mass — amplitude 1 at one frame.
+    let pure1 (f: Chip8Cow.Frame) : Amp = [ f, c.One ]
+
+    /// Lift a classical `SoftEmu.Soft` (real weights) into amplitudes (phase 0) — `√weight` so that
+    /// `|amp|² = weight` (amplitude, not probability). The classical mixture as a phase-0 amplitude state.
+    let ofSoft (s: SoftEmu.Soft) : Amp =
+        s |> List.map (fun (f, w) -> f, real (sqrt (max 0.0 w)))
+
+    /// Total Born intensity `Σ|z|²` (the norm² before normalization).
+    let intensity (a: Amp) : float = a |> List.sumBy (fun (_, z) -> magSq z)
+
+    /// Normalize so `Σ|z|² = 1` (divide every amplitude by the norm). Empty / zero ⇒ empty (no fabricated norm).
+    let normalize (a: Amp) : Amp =
+        let norm = sqrt (intensity a)
+        if norm <= EPS then []
+        else a |> List.map (fun (f, z) -> f, c.Mul(z, real (1.0 / norm)))
+
+    /// **Born-rule measurement:** the probability distribution over frames = `|amp|² / Σ|amp|²`. The one place
+    /// amplitudes become probabilities. (Always real, non-negative, sums to 1.)
+    let bornProb (a: Amp) : (Chip8Cow.Frame * float) list =
+        let total = intensity a
+        if total <= EPS then []
+        else a |> List.map (fun (f, z) -> f, magSq z / total)
+
+    /// Number of distinct-after-merge branches (the ensemble width; un-merged growth = the entanglement cost).
+    let support (a: Amp) : int = a |> merge |> List.length
+
+    /// **Soft amplitude step:** advance every branch (reusing `SoftChip8.forkOnInput`, real fork weights folded
+    /// in as amplitudes via `√`), then `merge` (interference on any reconverged frames). NB: CHIP-8 opcodes add
+    /// no phase, so phase must come from a quantum-gate layer / `QubitIso`; this carries amplitudes faithfully.
+    let softStep (a: Amp) : Amp =
+        a
+        |> List.collect (fun (f, z) ->
+            SoftChip8.forkOnInput f
+            |> List.map (fun (f', p) -> f', c.Mul(z, real (sqrt p))))
+        |> merge
+
+    /// Collapse to the most-probable frame under the Born rule (the one legitimate definite choice). `None` if empty.
+    let measure (a: Amp) : Chip8Cow.Frame option =
+        match bornProb a with
+        | [] -> None
+        | ps -> ps |> List.maxBy snd |> fst |> Some

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -199,6 +199,7 @@
     <Compile Include="SoftController.fs" />
     <Compile Include="SoftDashboard.fs" />
     <Compile Include="SoftEmu.fs" />
+    <Compile Include="AmplitudeEmu.fs" />
     <Compile Include="PolarityFilter.fs" />
     <Compile Include="ZetaExec.fs" />
     <Compile Include="DarkHall.fs" />

--- a/tests/Tests.FSharp/AmplitudeEmu.Tests.fs
+++ b/tests/Tests.FSharp/AmplitudeEmu.Tests.fs
@@ -1,0 +1,58 @@
+module Zeta.Tests.AmplitudeEmuTests
+
+open System
+open global.Xunit
+open Zeta.Core
+
+let private frame () = Chip8Cow.create 7UL |> Chip8Cow.loadRom [| 0x60uy; 0x01uy |]
+
+// amplitude with magnitude 1 at phase θ
+let private phasor (theta: float) : Complex = { Real = cos theta; Imag = sin theta }
+
+[<Fact>]
+let ``DESTRUCTIVE interference: two equal frames, opposite phase, cancel to nothing`` () =
+    let f = frame ()
+    // amplitude +1 and amplitude -1 (phase π apart) on the SAME frame
+    let a: AmplitudeEmu.Amp = [ f, phasor 0.0; f, phasor Math.PI ]
+    let merged = AmplitudeEmu.merge a
+    Assert.Empty(merged) // the path cancelled — wave phase cancellation, in code
+
+[<Fact>]
+let ``CONSTRUCTIVE interference: two equal frames, same phase, reinforce (intensity 4×)`` () =
+    let f = frame ()
+    let a: AmplitudeEmu.Amp = [ f, phasor 0.0; f, phasor 0.0 ] // 1 + 1 = 2 amplitude
+    let merged = AmplitudeEmu.merge a
+    Assert.Equal(1, AmplitudeEmu.support merged)
+    // |1+1|² = 4 (vs |1|²+|1|² = 2 for a classical mixture) — the interference signature
+    Assert.Equal(4.0, AmplitudeEmu.intensity merged, 9)
+
+[<Fact>]
+let ``partial interference: 90 degrees apart adds in quadrature (intensity 2, not 4 or 0)`` () =
+    let f = frame ()
+    let a: AmplitudeEmu.Amp = [ f, phasor 0.0; f, phasor (Math.PI / 2.0) ] // 1 + i, |1+i|² = 2
+    Assert.Equal(2.0, AmplitudeEmu.intensity (AmplitudeEmu.merge a), 9)
+
+[<Fact>]
+let ``bornProb is a normalized probability distribution`` () =
+    let f1 = frame ()
+    let f2 = Chip8Cow.create 9UL |> Chip8Cow.loadRom [| 0x60uy; 0x02uy |]
+    let a: AmplitudeEmu.Amp = [ f1, phasor 0.0; f2, phasor 1.0 ]
+    let ps = AmplitudeEmu.bornProb a
+    Assert.Equal(1.0, ps |> List.sumBy snd, 9)
+    Assert.All(ps, fun (_, p) -> Assert.True(p >= 0.0 && p <= 1.0))
+
+[<Fact>]
+let ``ofSoft lifts a classical mixture to phase-0 amplitudes (|amp|² = weight)`` () =
+    let soft = SoftEmu.softRun 1 (Chip8Cow.create 7UL |> Chip8Cow.loadRom [| 0x60uy; 0x01uy |] |> SoftEmu.pure1)
+    let amp = AmplitudeEmu.ofSoft soft
+    // phase-0 lift: Born probabilities equal the original real weights
+    let born = AmplitudeEmu.bornProb amp |> List.sortBy (fun (f, _) -> int f.PC) |> List.map snd
+    let orig = soft |> List.sortBy (fun (f, _) -> int f.PC) |> List.map snd
+    Assert.Equal(orig.Length, born.Length)
+    List.zip orig born |> List.iter (fun (o, b) -> Assert.Equal(o, b, 9))
+
+[<Fact>]
+let ``normalize makes total intensity 1`` () =
+    let f = frame ()
+    let a: AmplitudeEmu.Amp = [ f, { Real = 3.0; Imag = 4.0 } ] // |z|=5
+    Assert.Equal(1.0, AmplitudeEmu.intensity (AmplitudeEmu.normalize a), 9)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -126,6 +126,7 @@
     <Compile Include="SoftController.Tests.fs" />
     <Compile Include="SoftDashboard.Tests.fs" />
     <Compile Include="SoftEmu.Tests.fs" />
+    <Compile Include="AmplitudeEmu.Tests.fs" />
     <Compile Include="PolarityFilter.Tests.fs" />
     <Compile Include="DarkHall.Tests.fs" />
     <Compile Include="ITensor.Tests.fs" />


### PR DESCRIPTION
Answers Aaron's 'does merging make the phase cancel?' with runnable code: complex amplitudes + merge-by-summing = interference (destructive |+1,-1|->empty; constructive |1+1|²=4). Born-rule measurement. 6/6 tests. HONEST: interference real, but 4^n entanglement wall NOT escaped (merge only collapses reconverged frames); CHIP-8 adds no phase (substrate not quantum CPU); Bell S=2 still bounds correlations (amplitudes ≠ entanglement ≠ signalling). 🤖 Generated with [Claude Code](https://claude.com/claude-code)