### PR TITLE
feat(core): SoftDrive — soft drives hard via control interface (recursive MPC)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -202,6 +202,7 @@
     <Compile Include="SoftEmu.fs" />
     <Compile Include="AmplitudeEmu.fs" />
     <Compile Include="SoftMem.fs" />
+    <Compile Include="SoftDrive.fs" />
     <Compile Include="PolarityFilter.fs" />
     <Compile Include="ZetaExec.fs" />
     <Compile Include="DarkHall.fs" />

--- a/src/Core/SoftDrive.fs
+++ b/src/Core/SoftDrive.fs
@@ -1,0 +1,64 @@
+namespace Zeta.Core
+
+/// **`SoftDrive` — the soft layer drives the hard emulator via the control interface (Aaron 2026-06-08, shadow*).**
+///
+/// Aaron: *"can the soft version drive the hard DynamicValue version via the control interface, so it's kind of
+/// recursive?"* — yes, and this is it. The pattern has a name: **Model Predictive Control** (receding-horizon).
+/// Each `controlStep`:
+///   1. **plan (soft):** for each candidate immediate control input, roll out `SoftEmu` `depth` steps (throttled
+///      to `width`) and score the rollout by `value` (a fitness / empowerment objective);
+///   2. **commit (hard):** apply the *best* first action to ONE real `Chip8Cow.step` (the hard deterministic plant);
+///   3. **re-plan** from the new hard state.
+///
+/// **Why it's recursive (three senses):**
+///   - **plan→act→replan** — the MPC loop itself.
+///   - **self-similar** (manifesto §9/§10) — the soft model *is* the hard `Chip8Cow.step` lifted to a distribution
+///     (`SoftEmu`); the **control interface is the collapse boundary** where soft becomes hard — exactly
+///     `SoftValue.resolve → DynamicValue`, lifted to the whole machine.
+///   - **stackable** — soft can drive soft can drive hard; same interface at every level.
+///
+/// **The honest good property:** unlike a *learned* world model (Dreamer/MuZero), the soft model here is the
+/// *exact* emulator lifted, so **MPC has zero model-mismatch** — the only cost is rollout width (`prune`/`width`).
+/// Think expensively (soft, throttled), act cheaply (hard, one step). Deterministic (DST §7): same seed ⇒ same
+/// driven trajectory, byte-for-byte replayable.
+///
+/// **Honest scope (peel):** the candidate action set is `none` + each single hex key (17 actions) — a greedy
+/// first-action search, not full tree search (MCTS would deepen it). `value` defaults to `SoftDashboard.sumMemory`
+/// (a toy objective; `SoftDashboard.empowerment` is the unsupervised one). On a no-input ROM the control is inert
+/// (keys only matter at input opcodes), so `drive` degenerates to `Chip8Cow.run` — the correct degenerate case.
+[<RequireQualifiedAccess>]
+module SoftDrive =
+
+    /// The candidate immediate actions: do-nothing plus each single hex key held (17 total).
+    let private actions: bool[] list =
+        SoftController.none :: [ for k in 0..15 -> SoftController.singleKey k ]
+
+    /// **The planner:** the best immediate control input from the hard state `hard`, chosen by soft rollout.
+    /// For each candidate action, commit it once, roll out `depth` soft steps (capped to `width`), and take the
+    /// expected `value` over the resulting ensemble; return the action whose rollout scores highest.
+    let bestAction (value: Chip8Cow.Frame -> float) (depth: int) (width: int) (hard: Chip8Cow.Frame) : bool[] =
+        actions
+        |> List.maxBy (fun keys ->
+            let started = Chip8Cow.step { hard with Keys = keys }
+            SoftEmu.pure1 started |> SoftEmu.softRun depth |> SoftEmu.prune width |> SoftEmu.expect value)
+
+    /// **One control step:** plan the best action (soft), then commit it to ONE hard `Chip8Cow.step`. The soft
+    /// layer drives the hard plant through the key (control) interface.
+    let controlStep (value: Chip8Cow.Frame -> float) (depth: int) (width: int) (hard: Chip8Cow.Frame) : Chip8Cow.Frame =
+        let keys = bestAction value depth width hard
+        Chip8Cow.step { hard with Keys = keys }
+
+    /// **Drive the hard emulator for `steps` control steps** (the receding-horizon loop). Deterministic.
+    let drive (value: Chip8Cow.Frame -> float) (depth: int) (width: int) (steps: int) (hard: Chip8Cow.Frame) : Chip8Cow.Frame =
+        let mutable cur = hard
+        for _ in 1 .. max 0 steps do
+            cur <- controlStep value depth width cur
+        cur
+
+    /// Convenience: drive toward maximal memory sum (the toy objective).
+    let driveSumMemory (depth: int) (width: int) (steps: int) (hard: Chip8Cow.Frame) : Chip8Cow.Frame =
+        drive SoftDashboard.sumMemory depth width steps hard
+
+    /// Convenience: drive toward maximal *empowerment* (the unsupervised objective — agency / forward momentum).
+    let driveEmpowerment (lookahead: int) (depth: int) (width: int) (steps: int) (hard: Chip8Cow.Frame) : Chip8Cow.Frame =
+        drive (SoftDashboard.empowerment lookahead) depth width steps hard

--- a/tests/Tests.FSharp/SoftDrive.Tests.fs
+++ b/tests/Tests.FSharp/SoftDrive.Tests.fs
@@ -1,0 +1,35 @@
+module Zeta.Tests.SoftDriveTests
+
+open global.Xunit
+open Zeta.Core
+
+// deterministic, no-input ROM: 6A05 7A03 6002 8A04 (build up memory, no key opcodes)
+let private arith = [| 0x6Auy; 0x05uy; 0x7Auy; 0x03uy; 0x60uy; 0x02uy; 0x8Auy; 0x04uy |]
+let private hard () = Chip8Cow.create 7UL |> Chip8Cow.loadRom arith
+
+[<Fact>]
+let ``bestAction returns a valid 16-key control vector`` () =
+    let keys = SoftDrive.bestAction SoftDashboard.sumMemory 3 8 (hard ())
+    Assert.Equal(16, keys.Length)
+
+[<Fact>]
+let ``on a no-input ROM, driving degenerates to the plain hard run (control is inert)`` () =
+    let driven = SoftDrive.driveSumMemory 3 8 4 (hard ())
+    let plain = Chip8Cow.run 4 (hard ())
+    // keys never read (no input opcodes) => identical trajectory
+    Assert.Equal<byte[]>(plain.V, driven.V)
+    Assert.Equal(int plain.PC, int driven.PC)
+
+[<Fact>]
+let ``drive is deterministic (DST): same seed, same driven trajectory`` () =
+    let a = SoftDrive.driveSumMemory 2 6 5 (hard ())
+    let b = SoftDrive.driveSumMemory 2 6 5 (hard ())
+    Assert.Equal<byte[]>(a.V, b.V)
+    Assert.Equal(int a.PC, int b.PC)
+
+[<Fact>]
+let ``a control step advances exactly one hard step (PC moves once)`` () =
+    let h = hard ()
+    let after = SoftDrive.controlStep SoftDashboard.sumMemory 2 4 h
+    // one Chip8Cow.step from 0x200 over a 2-byte opcode => PC advanced by 2
+    Assert.Equal(int h.PC + 2, int after.PC)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -127,6 +127,7 @@
     <Compile Include="SoftDashboard.Tests.fs" />
     <Compile Include="Cl3.Tests.fs" />
     <Compile Include="SoftMem.Tests.fs" />
+    <Compile Include="SoftDrive.Tests.fs" />
     <Compile Include="SoftEmu.Tests.fs" />
     <Compile Include="AmplitudeEmu.Tests.fs" />
     <Compile Include="PolarityFilter.Tests.fs" />


### PR DESCRIPTION
Aaron's recursion, made runnable: soft plans (SoftEmu rollout scored by empowerment/fitness), hard commits one Chip8Cow.step via the key interface, re-plan. = Model Predictive Control; recursive (plan-act-replan / self-similar = SoftValue.resolve->DynamicValue at machine scale / stackable). 4/4 tests. Zero model-mismatch (soft model = exact emulator lifted). 🤖 Generated with [Claude Code](https://claude.com/claude-code)