### PR TITLE
feat(core): frame-aware step (60Hz tick interleave) + ghost-screen — make the soft emu live

### DIFF
--- a/src/Core/Chip8Cow.fs
+++ b/src/Core/Chip8Cow.fs
@@ -198,3 +198,15 @@ module Chip8Cow =
         { new IMonoid<Frame -> Frame> with
             member _.Identity = id
             member _.Combine(f, g) = f >> g } // apply f then g — sequential composition
+
+    /// **One frame = `cyclesPerFrame` CPU steps, then the 60 Hz `tick` (the interrupt).** This is the *live*
+    /// unit of execution. `step`/`run` alone never `tick`, so a ROM that waits on the delay timer (set `FX15`,
+    /// loop on `FX07`/`3XNN` until it hits 0 — a very common pattern) **spins forever** because the timer never
+    /// decrements. Empirically (the `SoftEmu` run, 2026-06-08) a step-only soft run froze at one reachable state
+    /// (empowerment collapsed to 1); interleaving `tick` released it and the game animated. `cyclesPerFrame ≈ 8`
+    /// matches the classic ~500 Hz CPU / 60 Hz timer ratio. The keys held are whatever is on the frame.
+    let frameStep (cyclesPerFrame: int) (f: Frame) : Frame =
+        let mutable s = f
+        for _ in 1 .. max 1 cyclesPerFrame do
+            s <- step s
+        tick s

--- a/src/Core/SoftEmu.fs
+++ b/src/Core/SoftEmu.fs
@@ -104,3 +104,18 @@ module SoftEmu =
     /// The expected value of any frame-observable over the ensemble (⟨value⟩ — the soft expectation).
     let expect (value: Chip8Cow.Frame -> float) (s: Soft) : float =
         s |> List.sumBy (fun (f, w) -> value f * w)
+
+    /// **The live soft frame-step:** advance every branch a full frame — `cyclesPerFrame` soft steps (forking on
+    /// input), then `tick` every branch (the 60 Hz interrupt). Plain `softStep`/`softRun` never `tick`, so a ROM
+    /// waiting on the delay timer freezes the whole ensemble at one reachable state (empowerment → 1, the bug the
+    /// 2026-06-08 run exposed). This is the unit that keeps the soft emulator *live*. Renormalized.
+    let softFrame (cyclesPerFrame: int) (s: Soft) : Soft =
+        let stepped = [ 1 .. max 1 cyclesPerFrame ] |> List.fold (fun acc _ -> softStep acc) s
+        stepped |> List.map (fun (f, w) -> Chip8Cow.tick f, w) |> normalize
+
+    /// **The ghost screen:** `P(pixel lit)` for every cell as a `DisplayH × DisplayW` float grid — the expected
+    /// display over the whole superposition (intensity = probability). The soft analog of "watching the screen":
+    /// a heatmap, not a bitmap. What you watch when you run the soft version, alongside `support`/`entropy`/
+    /// empowerment.
+    let probLitGrid (s: Soft) : float[][] =
+        [| for y in 0 .. Chip8.DisplayH - 1 -> [| for x in 0 .. Chip8.DisplayW - 1 -> probLit x y s |] |]

--- a/tests/Tests.FSharp/SoftFrame.Tests.fs
+++ b/tests/Tests.FSharp/SoftFrame.Tests.fs
@@ -1,0 +1,43 @@
+module Zeta.Tests.SoftFrameTests
+
+open global.Xunit
+open Zeta.Core
+
+// FX15 set delay = VX, then a wait loop on FX07/3X00 would spin without tick.
+// 6305 F315 F207 3200 1206 : V3=5; delay=V3; loop: V2=delay; if V2==0 skip; jump back
+let private delayWait = [| 0x63uy; 0x05uy; 0xF3uy; 0x15uy; 0xF2uy; 0x07uy; 0x32uy; 0x00uy; 0x12uy; 0x06uy |]
+let private start () = Chip8Cow.create 1UL |> Chip8Cow.loadRom delayWait
+
+[<Fact>]
+let ``frameStep decrements the delay timer (the 60Hz interrupt fires)`` () =
+    let f = Chip8Cow.create 1UL |> Chip8Cow.loadRom delayWait
+    // set the delay to 5 first (run the two setup opcodes), then a frameStep must tick it down
+    let setup = Chip8Cow.run 2 f // 6305, F315 -> delay = 5
+    Assert.Equal(5, int setup.Delay)
+    let afterFrame = Chip8Cow.frameStep 4 setup
+    Assert.Equal(4, int afterFrame.Delay) // ticked once per frame
+
+[<Fact>]
+let ``step-only freezes on a delay wait, frameStep makes progress (the live-by-construction fix)`` () =
+    let setup = Chip8Cow.run 2 (start ()) // delay = 5, now in the wait loop
+    let stepOnly = Chip8Cow.run 50 setup
+    Assert.Equal(5, int stepOnly.Delay) // timer never decrements -> frozen
+    let mutable s = setup
+    for _ in 1..6 do
+        s <- Chip8Cow.frameStep 4 s
+    Assert.True(int s.Delay < 5) // the interrupt freed it
+
+[<Fact>]
+let ``softFrame ticks the whole ensemble (delay decrements across the superposition)`` () =
+    let setup = Chip8Cow.run 2 (start ()) |> SoftEmu.pure1
+    let after = SoftEmu.softFrame 4 setup
+    Assert.Equal(1.0, after |> List.sumBy snd, 9) // normalized
+    Assert.All(after, fun (f, _) -> Assert.True(int f.Delay < 5)) // every branch ticked
+
+[<Fact>]
+let ``probLitGrid is a DisplayH x DisplayW grid of probabilities in [0,1]`` () =
+    let s = SoftEmu.pure1 (start ())
+    let grid = SoftEmu.probLitGrid s
+    Assert.Equal(Chip8.DisplayH, grid.Length)
+    Assert.Equal(Chip8.DisplayW, grid.[0].Length)
+    Assert.All(grid, fun row -> Assert.All(row, fun p -> Assert.True(p >= 0.0 && p <= 1.0)))

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -131,6 +131,7 @@
     <Compile Include="SoftMem.Tests.fs" />
     <Compile Include="SoftDrive.Tests.fs" />
     <Compile Include="SoftEmu.Tests.fs" />
+    <Compile Include="SoftFrame.Tests.fs" />
     <Compile Include="AmplitudeEmu.Tests.fs" />
     <Compile Include="PolarityFilter.Tests.fs" />
     <Compile Include="DarkHall.Tests.fs" />


### PR DESCRIPTION
Running the soft stack on a real ROM exposed a freeze: step-only never ticks, so delay-wait loops spin forever (empowerment=1 caught it). Fix: Chip8Cow.frameStep + SoftEmu.softFrame (steps + 60Hz tick = the live unit; the game animates with it). Plus SoftEmu.probLitGrid = the ghost screen (P(lit) heatmap = the soft 'watch the screen' dashboard observable). 4/4 tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)