### PR TITLE
feat(core): FeedbackThrottle TsirelsonLatency=√2 + latencyFor inverse + regimeOf classifier

### DIFF
--- a/src/Core/FeedbackThrottle.fs
+++ b/src/Core/FeedbackThrottle.fs
@@ -59,3 +59,36 @@ module FeedbackThrottle =
 
     /// Does this latency still beat the classical bound at all (any quantum-like correlation maintainable)?
     let canExceedClassical (latency: float) : bool = maxChsh latency > ClassicalBound + 1e-12
+
+    /// **The latency that sets `maxChsh` to exactly `2√2` (Tsirelson) — it is `√2`** (Aaron 2026-06-08).
+    /// Solve `2 + 2/(1+L) = 2√2` ⇒ `1+L = 1/(√2−1) = √2+1` ⇒ `L = √2`. **Honest caveat:** this clean `√2`
+    /// is *contingent on the `1/(1+latency)` attenuation modeling choice* (see `attenuation` — flagged a
+    /// modeling choice, not derived). A different attenuation form gives a different Tsirelson-crossing latency,
+    /// so `√2` is "the Tsirelson point *of this model*", an artifact of the chosen curve — elegant, not fundamental.
+    let TsirelsonLatency = sqrt 2.0
+
+    /// Invert the model: the latency at which `maxChsh = targetChsh`, for `2 < target < 4`. `L = 2/(target−2) − 1`.
+    /// `None` outside the achievable open interval `(2, 4)` (classical floor / algebraic ceiling are limits, not hit).
+    let latencyFor (targetChsh: float) : float option =
+        if targetChsh <= ClassicalBound + 1e-12 || targetChsh >= AlgebraicMax - 1e-12 then None
+        else Some(2.0 / (targetChsh - ClassicalBound) - 1.0)
+
+    /// The correlation regime a channel of this `latency` sits in (given the model's attenuation):
+    /// **Classical** (`maxChsh ≤ 2`, e.g. git-over-commits — high latency), **Quantum** (`2 < maxChsh ≤ 2√2`,
+    /// the physical no-signalling band), **Signalling** (`maxChsh > 2√2`, super-quantum / PR-box — the channel
+    /// is effectively communicating). The honest read of a measured S: which band the channel's speed allows.
+    type Regime =
+        | Classical
+        | Quantum
+        | Signalling
+
+    /// Classical band tolerance: `maxChsh` asymptotes to 2 but never hits it (finite latency), so "Classical"
+    /// means "within `ClassicalEps` of 2" — practically indistinguishable from shared-randomness.
+    [<Literal>]
+    let ClassicalEps = 1e-5
+
+    let regimeOf (latency: float) : Regime =
+        let s = maxChsh latency
+        if s <= ClassicalBound + ClassicalEps then Classical
+        elif s <= Tsirelson + 1e-9 then Quantum
+        else Signalling

--- a/tests/Tests.FSharp/FeedbackThrottle.Tests.fs
+++ b/tests/Tests.FSharp/FeedbackThrottle.Tests.fs
@@ -31,3 +31,27 @@ let ``2√2 is crossed at a finite latency — a real transport drops below the 
 [<Fact>]
 let ``deterministic / replayable (DST)`` () =
     Assert.Equal(FeedbackThrottle.maxChsh 1.5, FeedbackThrottle.maxChsh 1.5, 12)
+
+[<Fact>]
+let ``TsirelsonLatency = sqrt 2 and it sets maxChsh to exactly 2 root 2`` () =
+    Assert.Equal(sqrt 2.0, FeedbackThrottle.TsirelsonLatency, 12)
+    Assert.Equal(FeedbackThrottle.Tsirelson, FeedbackThrottle.maxChsh FeedbackThrottle.TsirelsonLatency, 9)
+
+[<Fact>]
+let ``latencyFor inverts maxChsh (round-trip) and rejects out-of-band targets`` () =
+    let t = 2.6
+    match FeedbackThrottle.latencyFor t with
+    | Some l -> Assert.Equal(t, FeedbackThrottle.maxChsh l, 9)
+    | None -> Assert.True(false, "should be achievable")
+    Assert.Equal(None, FeedbackThrottle.latencyFor 2.0) // classical floor not hit
+    Assert.Equal(None, FeedbackThrottle.latencyFor 4.0) // algebraic ceiling not hit
+    match FeedbackThrottle.latencyFor FeedbackThrottle.Tsirelson with
+    | Some l -> Assert.Equal(sqrt 2.0, l, 9) // latencyFor 2√2 = √2
+    | None -> Assert.True(false, "2√2 is achievable")
+
+[<Fact>]
+let ``regimeOf classifies channels by latency (git-slow=Classical, instant=Signalling, sqrt2=Quantum)`` () =
+    Assert.Equal(FeedbackThrottle.Classical, FeedbackThrottle.regimeOf 1e6) // git-over-commits: huge latency
+    Assert.Equal(FeedbackThrottle.Signalling, FeedbackThrottle.regimeOf 0.0) // instant feedback: S=4
+    Assert.Equal(FeedbackThrottle.Quantum, FeedbackThrottle.regimeOf (sqrt 2.0)) // exactly at 2√2 -> Quantum band
+    Assert.Equal(FeedbackThrottle.Quantum, FeedbackThrottle.regimeOf 2.0) // slower than √2, still > classical


### PR DESCRIPTION
Aaron: pick the latency that sets the number to 2√2 -> L=√2 (solve 2+2/(1+L)=2√2). TsirelsonLatency, latencyFor (inverse), regimeOf (Classical/Quantum/Signalling; git-slow=Classical, instant=Signalling, √2=Quantum). 8/8 tests. Honest: √2 is contingent on the 1/(1+latency) attenuation modeling choice — Tsirelson point OF THIS MODEL, not fundamental. 🤖 Generated with [Claude Code](https://claude.com/claude-code)