### PR TITLE
feat(core): SoftDrive frame-aware (live) MPC variants

### DIFF
--- a/src/Core/SoftDrive.fs
+++ b/src/Core/SoftDrive.fs
@@ -62,3 +62,31 @@ module SoftDrive =
     /// Convenience: drive toward maximal *empowerment* (the unsupervised objective — agency / forward momentum).
     let driveEmpowerment (lookahead: int) (depth: int) (width: int) (steps: int) (hard: Chip8Cow.Frame) : Chip8Cow.Frame =
         drive (SoftDashboard.empowerment lookahead) depth width steps hard
+
+    // ---- frame-aware (LIVE) variants — the step-based ones above never tick, so they freeze on delay loops ----
+    // (the 2026-06-08 run). These interleave the 60 Hz tick (`Chip8Cow.frameStep` / `SoftEmu.softFrame`) so the
+    // MPC driver actually works on real ROMs. `cyclesPerFrame ≈ 8`. `depth` is now in FRAMES, not CPU steps.
+
+    /// **Frame-aware planner:** best action chosen by a `depth`-FRAME soft rollout (each rollout step a full frame
+    /// with the tick). The live analog of `bestAction`.
+    let bestFrameAction (value: Chip8Cow.Frame -> float) (cyclesPerFrame: int) (depth: int) (width: int) (hard: Chip8Cow.Frame) : bool[] =
+        actions
+        |> List.maxBy (fun keys ->
+            let started = Chip8Cow.frameStep cyclesPerFrame { hard with Keys = keys }
+            let mutable s = SoftEmu.pure1 started
+            for _ in 1 .. max 0 depth do
+                s <- SoftEmu.softFrame cyclesPerFrame s |> SoftEmu.prune width
+            SoftEmu.expect value s)
+
+    /// **One live control step:** plan the best action, commit it to one full `frameStep` (steps + tick). Unlike
+    /// `controlStep` this keeps timers advancing, so delay-wait ROMs don't freeze.
+    let frameControlStep (value: Chip8Cow.Frame -> float) (cyclesPerFrame: int) (depth: int) (width: int) (hard: Chip8Cow.Frame) : Chip8Cow.Frame =
+        let keys = bestFrameAction value cyclesPerFrame depth width hard
+        Chip8Cow.frameStep cyclesPerFrame { hard with Keys = keys }
+
+    /// **Drive the hard emulator for `frames` live control frames** (the live receding-horizon loop). Deterministic.
+    let driveFrames (value: Chip8Cow.Frame -> float) (cyclesPerFrame: int) (depth: int) (width: int) (frames: int) (hard: Chip8Cow.Frame) : Chip8Cow.Frame =
+        let mutable cur = hard
+        for _ in 1 .. max 0 frames do
+            cur <- frameControlStep value cyclesPerFrame depth width cur
+        cur

--- a/tests/Tests.FSharp/SoftDrive.Tests.fs
+++ b/tests/Tests.FSharp/SoftDrive.Tests.fs
@@ -33,3 +33,24 @@ let ``a control step advances exactly one hard step (PC moves once)`` () =
     let after = SoftDrive.controlStep SoftDashboard.sumMemory 2 4 h
     // one Chip8Cow.step from 0x200 over a 2-byte opcode => PC advanced by 2
     Assert.Equal(int h.PC + 2, int after.PC)
+
+// delay-wait ROM: 6305 F315 F207 3200 1206 — step-based drive would freeze; frame-aware keeps it live
+let private delayWait = [| 0x63uy; 0x05uy; 0xF3uy; 0x15uy; 0xF2uy; 0x07uy; 0x32uy; 0x00uy; 0x12uy; 0x06uy |]
+
+[<Fact>]
+let ``frame-aware driveFrames stays LIVE on a delay-wait ROM (ticks the timer down)`` () =
+    let setup = Chip8Cow.run 2 (Chip8Cow.create 1UL |> Chip8Cow.loadRom delayWait) // delay = 5, in wait loop
+    let driven = SoftDrive.driveFrames SoftDashboard.sumMemory 4 1 4 6 setup
+    Assert.True(int driven.Delay < 5) // the tick fired across frames — not frozen
+
+[<Fact>]
+let ``frame-aware drive is deterministic (DST)`` () =
+    let a = SoftDrive.driveFrames SoftDashboard.sumMemory 8 2 4 5 (hard ())
+    let b = SoftDrive.driveFrames SoftDashboard.sumMemory 8 2 4 5 (hard ())
+    Assert.Equal<byte[]>(a.V, b.V)
+    Assert.Equal(int a.PC, int b.PC)
+
+[<Fact>]
+let ``bestFrameAction returns a valid 16-key vector`` () =
+    let keys = SoftDrive.bestFrameAction SoftDashboard.sumMemory 8 2 4 (hard ())
+    Assert.Equal(16, keys.Length)


### PR DESCRIPTION
Makes the MPC recursion live: frame-aware variants (driveFrames/frameControlStep/bestFrameAction) interleave the 60Hz tick so the driver doesn't freeze on delay-wait ROMs (the step-based ones did). 7/7 tests incl. stays-live-on-delay-wait + DST. 🤖 Generated with [Claude Code](https://claude.com/claude-code)