### PR TITLE
feat(core): SoftScope — watch the soft emulator (ghost-screen heatmap + observables)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -206,6 +206,7 @@
     <Compile Include="AmplitudeEmu.fs" />
     <Compile Include="SoftMem.fs" />
     <Compile Include="SoftDrive.fs" />
+    <Compile Include="SoftScope.fs" />
     <Compile Include="PolarityFilter.fs" />
     <Compile Include="ZetaExec.fs" />
     <Compile Include="DarkHall.fs" />

--- a/src/Core/SoftScope.fs
+++ b/src/Core/SoftScope.fs
@@ -1,0 +1,56 @@
+namespace Zeta.Core
+
+/// **`SoftScope` — watch the soft emulator: render the ghost-screen + the soft observables (Aaron 2026-06-08, shadow*).**
+///
+/// "What do you watch when you run the soft version?" — you watch *soft observables*, because the state is a
+/// distribution, not one screen. This renders them:
+///   - **the ghost screen** — `SoftEmu.probLitGrid` (P(pixel lit) over the whole superposition) as an ASCII
+///     intensity heatmap (the soft analog of the display: intensity = probability, not a bitmap);
+///   - **the observable line** — `support` (ensemble width), `entropy` (nats), and `E[lit pixels]` (the expected
+///     number of lit pixels = Σ probLit). Pair with empowerment (`SoftDashboard.empowerment`) as the agency watch.
+///
+/// Pure string rendering (DST-clean, no clock/RNG). ASCII ramp (no unicode — keeps the source byte-clean per
+/// the culture-invariant / no-invisible-unicode disciplines).
+///
+/// **Honest scope (peel):** the ghost screen is the *marginal* P(lit) per pixel — it does NOT show inter-pixel
+/// correlations (two pixels each at 0.5 could be perfectly correlated or anti-correlated; the heatmap can't tell).
+/// That's the same marginal-vs-joint limit as factored memory; for the joint you'd inspect the ensemble members.
+/// 8-level ramp (coarse). 64×32 is a large block of text — a viewer, not a compact log line.
+[<RequireQualifiedAccess>]
+module SoftScope =
+
+    /// 8-level intensity ramp, dark→bright (ASCII only). Index 0 = ~0 probability, last = ~1.
+    let private ramp = [| ' '; '.'; ':'; '-'; '+'; '*'; '#'; '@' |]
+
+    /// Map a probability in [0,1] to an intensity glyph.
+    let intensityChar (p: float) : char =
+        let n = ramp.Length
+        let idx = int (p * float n) |> max 0 |> min (n - 1)
+        ramp.[idx]
+
+    /// Render the ghost screen (`probLitGrid`) as a `DisplayH`-line ASCII heatmap, each line `DisplayW` wide.
+    let renderGhost (s: SoftEmu.Soft) : string =
+        SoftEmu.probLitGrid s
+        |> Array.map (fun row -> System.String(row |> Array.map intensityChar))
+        |> String.concat "\n"
+
+    /// The expected number of lit pixels over the superposition (Σ P(lit)).
+    let expectedLitPixels (s: SoftEmu.Soft) : float =
+        let mutable total = 0.0
+        for y in 0 .. Chip8.DisplayH - 1 do
+            for x in 0 .. Chip8.DisplayW - 1 do
+                total <- total + SoftEmu.probLit x y s
+        total
+
+    /// One-line soft observables summary (the dashboard header).
+    let observables (s: SoftEmu.Soft) : string =
+        System.String.Format(
+            System.Globalization.CultureInfo.InvariantCulture,
+            "support={0} entropy={1:F3} E[lit]={2:F1}",
+            SoftEmu.support s,
+            SoftEmu.entropy s,
+            expectedLitPixels s
+        )
+
+    /// The full scope frame: the observable line, then the ghost-screen heatmap.
+    let render (s: SoftEmu.Soft) : string = observables s + "\n" + renderGhost s

--- a/tests/Tests.FSharp/SoftScope.Tests.fs
+++ b/tests/Tests.FSharp/SoftScope.Tests.fs
@@ -1,0 +1,38 @@
+module Zeta.Tests.SoftScopeTests
+
+open global.Xunit
+open Zeta.Core
+
+let private blank () = Chip8Cow.create 1UL |> SoftEmu.pure1
+
+[<Fact>]
+let ``intensityChar maps 0 to blank and 1 to the brightest glyph, monotonically`` () =
+    Assert.Equal(' ', SoftScope.intensityChar 0.0)
+    Assert.Equal('@', SoftScope.intensityChar 1.0)
+    Assert.True(SoftScope.intensityChar 0.1 <= SoftScope.intensityChar 0.9) // brighter for higher p (ASCII order)
+
+[<Fact>]
+let ``renderGhost is DisplayH lines each DisplayW wide`` () =
+    let lines = (SoftScope.renderGhost (blank ())).Split('\n')
+    Assert.Equal(Chip8.DisplayH, lines.Length)
+    Assert.All(lines, fun l -> Assert.Equal(Chip8.DisplayW, l.Length))
+
+[<Fact>]
+let ``a blank display renders all spaces (E[lit] = 0)`` () =
+    let s = blank ()
+    Assert.Equal(0.0, SoftScope.expectedLitPixels s, 9)
+    Assert.True((SoftScope.renderGhost s) |> Seq.forall (fun c -> c = ' ' || c = '\n'))
+
+[<Fact>]
+let ``observables reports support and is culture-invariant (uses a dot decimal)`` () =
+    let o = SoftScope.observables (blank ())
+    Assert.Contains("support=1", o)
+    Assert.Contains("entropy=0.000", o) // invariant culture -> dot, not comma
+
+[<Fact>]
+let ``a lit pixel shows up bright in the ghost (drawn sprite -> nonzero intensity)`` () =
+    // ROM: A200 (I=0x200) D005 draws 5-row sprite at (V0,V1)=(0,0) using bytes at I (the ROM's own bytes)
+    let rom = [| 0xA2uy; 0x00uy; 0xD0uy; 0x05uy |]
+    let drawn = Chip8Cow.create 1UL |> Chip8Cow.loadRom rom |> Chip8Cow.run 2 |> SoftEmu.pure1
+    Assert.True(SoftScope.expectedLitPixels drawn > 0.0) // something got drawn
+    Assert.Contains("@", SoftScope.renderGhost drawn) // a definite (p=1) lit pixel renders brightest

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -130,6 +130,7 @@
     <Compile Include="Orbit.Tests.fs" />
     <Compile Include="SoftMem.Tests.fs" />
     <Compile Include="SoftDrive.Tests.fs" />
+    <Compile Include="SoftScope.Tests.fs" />
     <Compile Include="SoftEmu.Tests.fs" />
     <Compile Include="SoftFrame.Tests.fs" />
     <Compile Include="ActionGrammar.Tests.fs" />


### PR DESCRIPTION
Makes the soft emulator watchable: renderGhost = probLitGrid as an ASCII intensity heatmap (P(lit) per pixel), observables line (support/entropy/E[lit]). The 'what do you watch' thread, made into a viewer. 5/5 tests incl. a drawn sprite rendering '@'. Honest: ghost = marginal P(lit), not inter-pixel correlations. 🤖 Generated with [Claude Code](https://claude.com/claude-code)