### PR TITLE
feat(core): SoftEmu.stationary — the t0=t∞ fixed point on the soft ensemble

### DIFF
--- a/src/Core/SoftEmu.fs
+++ b/src/Core/SoftEmu.fs
@@ -119,3 +119,38 @@ module SoftEmu =
     /// empowerment.
     let probLitGrid (s: Soft) : float[][] =
         [| for y in 0 .. Chip8.DisplayH - 1 -> [| for x in 0 .. Chip8.DisplayW - 1 -> probLit x y s |] |]
+
+    /// A fully-comparable content key for a frame (for distribution distance / dedup — `Frame` itself isn't
+    /// comparable because of its `byte[]` fields).
+    let private frameKey (f: Chip8Cow.Frame) =
+        (int f.PC,
+         [ for v in f.V -> int v ],
+         int f.I,
+         Map.toList f.Mem,
+         Map.toList f.Display,
+         f.Stack,
+         int f.Delay,
+         int f.Sound,
+         [ for k in f.Keys -> k ],
+         f.Rng)
+
+    /// **Total-variation distance** between two soft ensembles: `½ Σ |p_a(f) − p_b(f)|` over all frames. 0 =
+    /// identical distributions, 1 = disjoint support. The metric for the `t0=t∞` self-consistency search.
+    let softDistance (a: Soft) (b: Soft) : float =
+        let tally (s: Soft) =
+            s
+            |> List.fold (fun m (f, w) -> let k = frameKey f in Map.add k (w + (Map.tryFind k m |> Option.defaultValue 0.0)) m) Map.empty
+        let ma, mb = tally a, tally b
+        let keys = Set.union (ma |> Map.toSeq |> Seq.map fst |> Set.ofSeq) (mb |> Map.toSeq |> Seq.map fst |> Set.ofSeq)
+        0.5
+        * (keys
+           |> Seq.sumBy (fun k ->
+               abs ((Map.tryFind k ma |> Option.defaultValue 0.0) - (Map.tryFind k mb |> Option.defaultValue 0.0))))
+
+    /// **The `t0=t∞` stationary soft state:** iterate the (caller-supplied, bounded) soft step to its
+    /// self-consistent fixed point `s = step s` under `softDistance` — the closed-time-loop state of the soft
+    /// emulator (Aaron's t0=t∞ on the ensemble; the soft analog of `Fixpoint`/`Orbit`). Use a *pruned* step
+    /// (e.g. `fun s -> softFrame cyc s |> prune width`) so the ensemble stays bounded and a fixed point can exist.
+    /// Returns the `Fixpoint.FixResult` (state + whether it converged + residual + iterations).
+    let stationary (step: Soft -> Soft) (tol: float) (maxIter: int) (s0: Soft) : Fixpoint.FixResult<Soft> =
+        Fixpoint.solve softDistance step tol maxIter s0

--- a/tests/Tests.FSharp/SoftStationary.Tests.fs
+++ b/tests/Tests.FSharp/SoftStationary.Tests.fs
@@ -1,0 +1,37 @@
+module Zeta.Tests.SoftStationaryTests
+
+open global.Xunit
+open Zeta.Core
+
+// 1200: jump to 0x200 (itself) forever — a self-looping frame (PC stays, mem unchanged) = a fixed point.
+let private selfLoop = [| 0x12uy; 0x00uy |]
+let private loopStart () = Chip8Cow.create 1UL |> Chip8Cow.loadRom selfLoop |> SoftEmu.pure1
+
+[<Fact>]
+let ``softDistance: identical distributions = 0, disjoint = 1`` () =
+    let a = loopStart ()
+    Assert.Equal(0.0, SoftEmu.softDistance a a, 9)
+    let b = Chip8Cow.create 99UL |> Chip8Cow.loadRom [| 0x60uy; 0x07uy |] |> Chip8Cow.run 1 |> SoftEmu.pure1
+    Assert.Equal(1.0, SoftEmu.softDistance a b, 9) // different frames, disjoint support
+
+[<Fact>]
+let ``softDistance is symmetric`` () =
+    let a = loopStart ()
+    let b = SoftEmu.softFrame 4 a
+    Assert.Equal(SoftEmu.softDistance a b, SoftEmu.softDistance b a, 9)
+
+[<Fact>]
+let ``stationary converges on a self-looping ROM (t0=t-infinity fixed point reached)`` () =
+    let step s = SoftEmu.softFrame 8 s |> SoftEmu.prune 8
+    let r = SoftEmu.stationary step 1e-9 64 (loopStart ())
+    Assert.True(r.Converged) // the closed-loop self-consistent state exists and is found
+    Assert.True(r.Residual < 1e-9)
+
+[<Fact>]
+let ``stationary reports non-convergence honestly when no fixed point in budget`` () =
+    // a counter ROM: 7001 (V0 += 1) then 1200 loop -> V0 changes every loop, never self-consistent
+    let counter = [| 0x70uy; 0x01uy; 0x12uy; 0x00uy |]
+    let s0 = Chip8Cow.create 1UL |> Chip8Cow.loadRom counter |> SoftEmu.pure1
+    let step s = SoftEmu.softFrame 8 s |> SoftEmu.prune 8
+    let r = SoftEmu.stationary step 1e-9 12 s0
+    Assert.False(r.Converged) // V0 keeps incrementing -> no fixed point; reported, not faked

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -132,6 +132,7 @@
     <Compile Include="SoftDrive.Tests.fs" />
     <Compile Include="SoftScope.Tests.fs" />
     <Compile Include="SoftEmu.Tests.fs" />
+    <Compile Include="SoftStationary.Tests.fs" />
     <Compile Include="SoftFrame.Tests.fs" />
     <Compile Include="ActionGrammar.Tests.fs" />
     <Compile Include="AmplitudeEmu.Tests.fs" />


### PR DESCRIPTION
Closes Fixpoint+SoftEmu: softDistance (total-variation between ensembles) + stationary (iterate a pruned soft step to s=step s = the closed-time self-consistent state). 4/4 tests incl. converges on a self-loop ROM + honest non-convergence on a counter ROM. 🤖 Generated with [Claude Code](https://claude.com/claude-code)