### PR TITLE
feat(core): SoftSession — end-to-end autonomous soft-play capstone

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -207,6 +207,7 @@
     <Compile Include="SoftMem.fs" />
     <Compile Include="SoftDrive.fs" />
     <Compile Include="SoftScope.fs" />
+    <Compile Include="SoftSession.fs" />
     <Compile Include="PolarityFilter.fs" />
     <Compile Include="ZetaExec.fs" />
     <Compile Include="DarkHall.fs" />

--- a/src/Core/SoftSession.fs
+++ b/src/Core/SoftSession.fs
@@ -1,0 +1,83 @@
+namespace Zeta.Core
+
+/// **`SoftSession` — the end-to-end autonomous soft-play session (Aaron 2026-06-08, shadow*).**
+///
+/// The capstone that ties the live soft stack into one runnable call: load a ROM, then drive it by **empowerment**
+/// (the unsupervised objective — agency) through the **frame-aware** MPC loop, capturing a watchable **trace** of
+/// observables per frame. No external state; deterministic (DST §7) — same `seed`+`rom` ⇒ same trace, byte-for-byte.
+///
+/// Pipeline per frame: `SoftDrive.bestFrameAction (empowerment)` (plan in soft probability space) → commit one
+/// `Chip8Cow.frameStep` (the live hard step + 60 Hz tick) → record `Tick`. This is `Chip8Cow` + `SoftEmu`
+/// (`softFrame`) + `SoftDrive` (frame-aware) + `SoftDashboard` (empowerment / litPixels) composed.
+///
+/// **Honest scope (peel):** greedy first-action search over the 17 actions (`none`+16 keys), not full tree
+/// search; `empowerment` horizon (`lookahead`) must be deep enough to see input value or the driver idles
+/// (the 2026-06-08 finding — what you watch is right, the horizon is the knob). The `Tick` trace is the
+/// observable summary; for the full ghost-screen heatmap use `SoftScope.render` on `SoftEmu.pure1 frame`.
+/// Cost scales as `frames · actions · width · depth` soft frames — keep them modest for interactive runs.
+[<RequireQualifiedAccess>]
+module SoftSession =
+
+    /// One frame of the autonomous play: the frame index, the committed `PC`, the key pressed (`-1` = none), the
+    /// expected lit-pixel count, and the empowerment (reachable-futures / agency) at that frame.
+    type Tick =
+        { Frame: int
+          PC: int
+          Key: int
+          LitPixels: float
+          Empowerment: float }
+
+    /// **Play `frames` autonomous frames**, driving by empowerment through the live frame-aware loop. Returns the
+    /// per-frame `Tick` trace. Deterministic for a given `seed`/`rom`.
+    let play
+        (cyclesPerFrame: int)
+        (lookahead: int)
+        (depth: int)
+        (width: int)
+        (frames: int)
+        (seed: uint64)
+        (rom: byte[])
+        : Tick list =
+        let value = SoftDashboard.empowerment lookahead
+        let mutable cur = Chip8Cow.create seed |> Chip8Cow.loadRom rom
+        [ for i in 1 .. max 0 frames do
+              let keys = SoftDrive.bestFrameAction value cyclesPerFrame depth width cur
+              let k = keys |> Array.tryFindIndex id |> Option.defaultValue -1
+              cur <- Chip8Cow.frameStep cyclesPerFrame { cur with Keys = keys }
+              { Frame = i
+                PC = int cur.PC
+                Key = k
+                LitPixels = SoftDashboard.litPixels cur
+                Empowerment = value cur } ]
+
+    /// Play and return the final hard frame (e.g. to render its ghost via `SoftScope.render (SoftEmu.pure1 f)`).
+    let playToFrame
+        (cyclesPerFrame: int)
+        (lookahead: int)
+        (depth: int)
+        (width: int)
+        (frames: int)
+        (seed: uint64)
+        (rom: byte[])
+        : Chip8Cow.Frame =
+        let value = SoftDashboard.empowerment lookahead
+        let mutable cur = Chip8Cow.create seed |> Chip8Cow.loadRom rom
+        for _ in 1 .. max 0 frames do
+            let keys = SoftDrive.bestFrameAction value cyclesPerFrame depth width cur
+            cur <- Chip8Cow.frameStep cyclesPerFrame { cur with Keys = keys }
+        cur
+
+    /// A compact one-line digest of a trace (last frame's observables) — for logging an autonomous run.
+    let digest (trace: Tick list) : string =
+        match List.tryLast trace with
+        | None -> "empty session"
+        | Some t ->
+            System.String.Format(
+                System.Globalization.CultureInfo.InvariantCulture,
+                "frames={0} final PC=0x{1:X3} lastKey={2} E[lit]={3:F1} empowerment={4:F0}",
+                List.length trace,
+                t.PC,
+                t.Key,
+                t.LitPixels,
+                t.Empowerment
+            )

--- a/tests/Tests.FSharp/SoftSession.Tests.fs
+++ b/tests/Tests.FSharp/SoftSession.Tests.fs
@@ -1,0 +1,38 @@
+module Zeta.Tests.SoftSessionTests
+
+open global.Xunit
+open Zeta.Core
+
+// deterministic arithmetic ROM (no input opcodes) — drives without freezing, control inert
+let private arith = [| 0x6Auy; 0x05uy; 0x7Auy; 0x03uy; 0x60uy; 0x02uy; 0x8Auy; 0x04uy; 0x12uy; 0x00uy |]
+
+[<Fact>]
+let ``play returns a Tick per frame`` () =
+    let trace = SoftSession.play 8 2 2 4 6 42UL arith
+    Assert.Equal(6, List.length trace)
+    Assert.Equal<int list>([ 1; 2; 3; 4; 5; 6 ], trace |> List.map (fun t -> t.Frame))
+
+[<Fact>]
+let ``play is deterministic (DST): same seed+rom -> identical trace`` () =
+    let a = SoftSession.play 8 2 2 4 5 7UL arith
+    let b = SoftSession.play 8 2 2 4 5 7UL arith
+    Assert.Equal<int list>(a |> List.map (fun t -> t.PC), b |> List.map (fun t -> t.PC))
+    Assert.Equal<int list>(a |> List.map (fun t -> t.Key), b |> List.map (fun t -> t.Key))
+
+[<Fact>]
+let ``playToFrame agrees with the last Tick's PC`` () =
+    let trace = SoftSession.play 8 2 2 4 5 7UL arith
+    let final = SoftSession.playToFrame 8 2 2 4 5 7UL arith
+    Assert.Equal((List.last trace).PC, int final.PC)
+
+[<Fact>]
+let ``digest summarizes a run and handles empty`` () =
+    Assert.Equal("empty session", SoftSession.digest [])
+    let d = SoftSession.digest (SoftSession.play 8 2 2 4 3 7UL arith)
+    Assert.Contains("frames=3", d)
+    Assert.Contains("PC=0x", d)
+
+[<Fact>]
+let ``empowerment is reported non-negative across the trace`` () =
+    let trace = SoftSession.play 8 2 2 4 4 7UL arith
+    Assert.All(trace, fun t -> Assert.True(t.Empowerment >= 0.0))

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -131,6 +131,7 @@
     <Compile Include="SoftMem.Tests.fs" />
     <Compile Include="SoftDrive.Tests.fs" />
     <Compile Include="SoftScope.Tests.fs" />
+    <Compile Include="SoftSession.Tests.fs" />
     <Compile Include="SoftEmu.Tests.fs" />
     <Compile Include="SoftStationary.Tests.fs" />
     <Compile Include="SoftFrame.Tests.fs" />


### PR DESCRIPTION
The capstone: load ROM -> drive by empowerment through the frame-aware MPC loop -> watchable Tick trace. Deterministic. Composes the whole live soft stack. 5/5 tests. Verified on Brix (40 frames, screen fills, replayable; idles during deterministic intro = correct, empowerment=1 there). 🤖 Generated with [Claude Code](https://claude.com/claude-code)