### PR TITLE
feat(core): SoftActionController (soft value AS controller) + screen renderer + viewer

### DIFF
--- a/samples/watch-soft-emu.fsx
+++ b/samples/watch-soft-emu.fsx
@@ -1,0 +1,38 @@
+// Watch the soft emulator play — both modes (hard screen + ghost heatmap).
+//
+// Prereq:  dotnet build src/Core/Core.fsproj -c Release
+// Usage (from the repo root):
+//   dotnet fsi samples/watch-soft-emu.fsx <path-to-rom.ch8> [frames] [snapshotEvery]
+//
+// ROMs are reference-only (gitignored under references/prior-art/chip8-roms/) — pass your own path.
+
+#r "src/Core/bin/Release/net10.0/Zeta.Core.dll"
+open Zeta.Core
+
+let argv = System.Environment.GetCommandLineArgs()
+let romPath =
+    if argv.Length > 2 then argv.[2]
+    else failwith "usage: dotnet fsi samples/watch-soft-emu.fsx <rom.ch8> [frames] [snapshotEvery]"
+let frames = if argv.Length > 3 then int argv.[3] else 60
+let every = if argv.Length > 4 then int argv.[4] else 15
+
+let rom = System.IO.File.ReadAllBytes romPath
+let cyc = 8
+let value = SoftDashboard.empowerment 3
+
+printfn "Playing %s for %d frames (snapshot every %d)\n" (System.IO.Path.GetFileName romPath) frames every
+
+let mutable cur = Chip8Cow.create 42UL |> Chip8Cow.loadRom rom
+for i in 1..frames do
+    // calibrated soft controller: resolve the soft value to an action (holds when not confident)
+    let keys = SoftActionController.resolve 0.30 0.5 value cyc 3 6 cur
+    cur <- Chip8Cow.frameStep cyc { cur with Keys = keys }
+    if i % every = 0 then
+        let k = keys |> Array.tryFindIndex id |> Option.defaultValue -1
+        // HARD MODE: the actual screen
+        printfn "%s" (SoftScope.renderFrameCaptioned (sprintf "frame %d  PC=0x%03X  key=%d  [HARD screen]" i (int cur.PC) k) cur)
+        // GHOST MODE: P(lit) over a short soft look-ahead from here
+        let mutable ghost = SoftEmu.pure1 cur
+        for _ in 1..4 do ghost <- SoftEmu.softFrame cyc ghost |> SoftEmu.prune 16
+        printfn "[GHOST heatmap — %s]" (SoftScope.observables ghost)
+        printfn "%s\n" (SoftScope.renderGhost ghost)

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -208,6 +208,7 @@
     <Compile Include="SoftDrive.fs" />
     <Compile Include="SoftScope.fs" />
     <Compile Include="SoftSession.fs" />
+    <Compile Include="SoftActionController.fs" />
     <Compile Include="PolarityFilter.fs" />
     <Compile Include="ZetaExec.fs" />
     <Compile Include="DarkHall.fs" />

--- a/src/Core/SoftActionController.fs
+++ b/src/Core/SoftActionController.fs
@@ -1,0 +1,100 @@
+namespace Zeta.Core
+
+/// **`SoftActionController` — the soft value AS the controller for the hard (DynamicValue) emulator (Aaron 2026-06-08, shadow*).**
+///
+/// Aaron: *"can we make the DynamicValue version that uses the soft value as a controller?"* — this is it. The
+/// **hard `Chip8Cow` emulator is the DynamicValue version** (concrete frames = resolved definite values); the
+/// **controller is a `SoftValue` over actions** — a calibrated distribution that is *resolved* each frame to the
+/// concrete key that drives the hard step. This applies the [[SoftValue]] **never-falsely-certain** discipline to
+/// *control*: score each candidate action by its soft empowerment/value rollout → softmax into a distribution
+/// (the soft controller) → **commit the top action only when confidence ≥ threshold, else HOLD** (do nothing).
+///
+/// **Why this is the right shape:** the idling the earlier runs showed isn't a bug — it's *calibration*. When no
+/// action discriminates (a deterministic phase, all rollouts tie), the action distribution is ~uniform,
+/// confidence is low, and the controller correctly **holds** rather than acting on noise. It acts exactly when
+/// the soft value is *confident* one action opens more future than the others. Soft plans → resolves → hard acts:
+/// `SoftValue.resolve → DynamicValue`, lifted to the control loop (the recursion, #7100, made calibrated).
+///
+/// **Honest scope (peel):** greedy first-action search over 17 actions (`none`+16 keys), not full tree search;
+/// the empowerment horizon (`depth`) must be deep enough to discriminate or it holds forever (the weak-player
+/// caveat — calibration makes idling *honest*, not *good*). Softmax `temperature` and `threshold` are knobs, not
+/// derived. Deterministic (DST §7). Cost ~ `actions · depth · width` soft frames per decision.
+[<RequireQualifiedAccess>]
+module SoftActionController =
+
+    let private actions: bool[] list =
+        SoftController.none :: [ for k in 0..15 -> SoftController.singleKey k ]
+
+    /// Score each candidate action by the expected `value` over its `depth`-frame soft rollout (frame-aware).
+    let actionScores
+        (value: Chip8Cow.Frame -> float)
+        (cyclesPerFrame: int)
+        (depth: int)
+        (width: int)
+        (hard: Chip8Cow.Frame)
+        : (bool[] * float) list =
+        actions
+        |> List.map (fun keys ->
+            let started = Chip8Cow.frameStep cyclesPerFrame { hard with Keys = keys }
+            let mutable s = SoftEmu.pure1 started
+            for _ in 1 .. max 0 depth do
+                s <- SoftEmu.softFrame cyclesPerFrame s |> SoftEmu.prune width
+            keys, SoftEmu.expect value s)
+
+    /// **The soft controller = a `SoftValue` over actions:** softmax the rollout scores into a normalized
+    /// distribution over the candidate actions (stabilized; `temperature → 0` sharpens to argmax, `→ ∞` uniform).
+    let actionDistribution
+        (temperature: float)
+        (value: Chip8Cow.Frame -> float)
+        (cyclesPerFrame: int)
+        (depth: int)
+        (width: int)
+        (hard: Chip8Cow.Frame)
+        : (bool[] * float) list =
+        let scores = actionScores value cyclesPerFrame depth width hard
+        let t = max 1e-9 temperature
+        let m = scores |> List.map snd |> List.max
+        let exps = scores |> List.map (fun (k, s) -> k, exp ((s - m) / t))
+        let z = exps |> List.sumBy snd
+        if z <= 1e-12 then scores |> List.map (fun (k, _) -> k, 1.0 / float (List.length scores))
+        else exps |> List.map (fun (k, e) -> k, e / z)
+
+    /// Confidence = the probability mass on the most-likely action (1.0 = a point mass; `1/17` = uniform/no idea).
+    let confidence (dist: (bool[] * float) list) : float =
+        match dist with
+        | [] -> 0.0
+        | _ -> dist |> List.map snd |> List.max
+
+    /// **Resolve the soft controller to a concrete action (the calibrated collapse):** commit the top action iff
+    /// its confidence ≥ `threshold`; otherwise **HOLD** (`none`) — never act on an uncertain distribution. This is
+    /// `SoftValue.resolve` for control: the only place the soft value becomes a definite (DynamicValue) action.
+    let resolve
+        (threshold: float)
+        (temperature: float)
+        (value: Chip8Cow.Frame -> float)
+        (cyclesPerFrame: int)
+        (depth: int)
+        (width: int)
+        (hard: Chip8Cow.Frame)
+        : bool[] =
+        let dist = actionDistribution temperature value cyclesPerFrame depth width hard
+        let best, _ = dist |> List.maxBy snd
+        if confidence dist >= threshold then best else SoftController.none
+
+    /// **Drive the hard (DynamicValue) emulator with the soft value as controller:** each frame, resolve the soft
+    /// action and commit one live `frameStep`. Holds when not confident. Deterministic.
+    let drive
+        (threshold: float)
+        (temperature: float)
+        (value: Chip8Cow.Frame -> float)
+        (cyclesPerFrame: int)
+        (depth: int)
+        (width: int)
+        (frames: int)
+        (hard: Chip8Cow.Frame)
+        : Chip8Cow.Frame =
+        let mutable cur = hard
+        for _ in 1 .. max 0 frames do
+            let keys = resolve threshold temperature value cyclesPerFrame depth width cur
+            cur <- Chip8Cow.frameStep cyclesPerFrame { cur with Keys = keys }
+        cur

--- a/src/Core/SoftScope.fs
+++ b/src/Core/SoftScope.fs
@@ -54,3 +54,18 @@ module SoftScope =
 
     /// The full scope frame: the observable line, then the ghost-screen heatmap.
     let render (s: SoftEmu.Soft) : string = observables s + "\n" + renderGhost s
+
+    /// **Render a concrete (hard) frame's actual display** — `#` for a lit pixel, space for unlit, as a
+    /// `DisplayH`-line `DisplayW`-wide screen. This is the *definite* screen (what the emulator is really showing),
+    /// vs `renderGhost`'s probability heatmap. Use to *watch* a `SoftSession` / `SoftActionController` play.
+    let renderFrame (f: Chip8Cow.Frame) : string =
+        [ for y in 0 .. Chip8.DisplayH - 1 ->
+              System.String(
+                  [| for x in 0 .. Chip8.DisplayW - 1 -> if Chip8Cow.pixel x y f then '#' else ' ' |]
+              ) ]
+        |> String.concat "\n"
+
+    /// A bordered screen with a caption line above it (for a labelled filmstrip frame).
+    let renderFrameCaptioned (caption: string) (f: Chip8Cow.Frame) : string =
+        let bar = System.String('-', Chip8.DisplayW)
+        caption + "\n" + bar + "\n" + renderFrame f + "\n" + bar

--- a/tests/Tests.FSharp/SoftActionController.Tests.fs
+++ b/tests/Tests.FSharp/SoftActionController.Tests.fs
@@ -1,0 +1,46 @@
+module Zeta.Tests.SoftActionControllerTests
+
+open global.Xunit
+open Zeta.Core
+
+// deterministic arithmetic+loop ROM (no input opcodes) -> all actions tie -> calibrated controller should HOLD
+let private arith = [| 0x6Auy; 0x05uy; 0x7Auy; 0x03uy; 0x60uy; 0x02uy; 0x8Auy; 0x04uy; 0x12uy; 0x00uy |]
+let private hard () = Chip8Cow.create 7UL |> Chip8Cow.loadRom arith
+
+[<Fact>]
+let ``actionDistribution is a normalized distribution over actions`` () =
+    let dist = SoftActionController.actionDistribution 1.0 SoftDashboard.sumMemory 8 2 4 (hard ())
+    Assert.Equal(1.0, dist |> List.sumBy snd, 6)
+    Assert.All(dist, fun (_, p) -> Assert.True(p >= 0.0 && p <= 1.0))
+
+[<Fact>]
+let ``on a no-input ROM the controller HOLDS (calibrated: not confident -> none)`` () =
+    // all actions tie (input inert) -> ~uniform (conf ~ 1/17) -> below a 0.5 threshold -> hold
+    let keys = SoftActionController.resolve 0.5 1.0 SoftDashboard.sumMemory 8 2 4 (hard ())
+    Assert.Equal<bool[]>(SoftController.none, keys)
+
+[<Fact>]
+let ``a low threshold lets it commit (always acts) - returns a valid 16-key vector`` () =
+    let keys = SoftActionController.resolve 0.0 1.0 SoftDashboard.sumMemory 8 2 4 (hard ())
+    Assert.Equal(16, keys.Length)
+
+[<Fact>]
+let ``confidence is in [0,1] and 1/17-ish for a flat distribution`` () =
+    let dist = SoftActionController.actionDistribution 1.0 SoftDashboard.sumMemory 8 2 4 (hard ())
+    let c = SoftActionController.confidence dist
+    Assert.True(c >= 0.0 && c <= 1.0)
+
+[<Fact>]
+let ``drive is deterministic (DST)`` () =
+    let a = SoftActionController.drive 0.5 1.0 SoftDashboard.sumMemory 8 2 4 5 (hard ())
+    let b = SoftActionController.drive 0.5 1.0 SoftDashboard.sumMemory 8 2 4 5 (hard ())
+    Assert.Equal<byte[]>(a.V, b.V)
+    Assert.Equal(int a.PC, int b.PC)
+
+[<Fact>]
+let ``renderFrame is a DisplayH x DisplayW screen of # and space`` () =
+    let f = hard ()
+    let lines = (SoftScope.renderFrame f).Split('\n')
+    Assert.Equal(Chip8.DisplayH, lines.Length)
+    Assert.All(lines, fun l -> Assert.Equal(Chip8.DisplayW, l.Length))
+    Assert.All(lines, fun l -> Assert.All(l, fun c -> Assert.True(c = '#' || c = ' ')))

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -132,6 +132,7 @@
     <Compile Include="SoftDrive.Tests.fs" />
     <Compile Include="SoftScope.Tests.fs" />
     <Compile Include="SoftSession.Tests.fs" />
+    <Compile Include="SoftActionController.Tests.fs" />
     <Compile Include="SoftEmu.Tests.fs" />
     <Compile Include="SoftStationary.Tests.fs" />
     <Compile Include="SoftFrame.Tests.fs" />


### PR DESCRIPTION
Aaron: DynamicValue version driven by the soft value as controller + 'i want to see it' (both modes). SoftActionController = a SoftValue over actions, resolved (commit iff confident else HOLD) to drive the hard emu (calibrated control; idling now principled). SoftScope.renderFrame = the HARD screen; renderGhost = the P(lit) heatmap. samples/watch-soft-emu.fsx = runnable viewer (both modes). 6/6 tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)