### PR TITLE
fix(samples): watch-soft-emu.fsx relative dll path (../src)

### DIFF
--- a/samples/watch-soft-emu.fsx
+++ b/samples/watch-soft-emu.fsx
@@ -6,7 +6,7 @@
 //
 // ROMs are reference-only (gitignored under references/prior-art/chip8-roms/) — pass your own path.
 
-#r "src/Core/bin/Release/net10.0/Zeta.Core.dll"
+#r "../src/Core/bin/Release/net10.0/Zeta.Core.dll"
 open Zeta.Core
 
 let argv = System.Environment.GetCommandLineArgs()


### PR DESCRIPTION
fsi resolves #r relative to script dir, not cwd. Fixed to ../src. Verified renders both modes on IBM Logo. 🤖 Generated with [Claude Code](https://claude.com/claude-code)