### PR TITLE
feat(core): StateSpace — indexed reachable-state search; content hash detects cycles + backward plan recovery

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -210,6 +210,7 @@
     <Compile Include="SoftSession.fs" />
     <Compile Include="SoftActionController.fs" />
     <Compile Include="SoftEvolution.fs" />
+    <Compile Include="StateSpace.fs" />
     <Compile Include="PolarityFilter.fs" />
     <Compile Include="ZetaExec.fs" />
     <Compile Include="DarkHall.fs" />

--- a/src/Core/StateSpace.fs
+++ b/src/Core/StateSpace.fs
@@ -1,0 +1,130 @@
+namespace Zeta.Core
+
+open System.Collections.Generic
+
+/// **`StateSpace` — indexed reachable-state search; the content hash detects cycles (Aaron 2026-06-08, shadow*).**
+///
+/// Aaron: *"our whole game eventually becomes indexing state-space search, so one of our two content hashes can
+/// detect cycles in branching when we run in soft mode."* This is that index. Soft mode forks on input (RND is
+/// seed-deterministic → input is the only branching); we BFS the reachable frames and key each by its **content
+/// hash** (`contentKey`) in a **transposition table** (`Dictionary<key,id>`). A revisit of an existing key is a
+/// **transposition** (a different input path reaching the same state — merge the edge, don't re-expand); a child
+/// whose key equals its parent's is a **self-loop** (a fixed-point cycle). This is exactly a chess engine's
+/// Zobrist transposition table + cycle detection, and it is what bounds the DAG (reconverging paths dedup) and
+/// makes the search the *omniscient ground-truth solve* while the state space is small enough to exhaust.
+///
+/// **The two hashes (Aaron):** (1) the **state-content hash** here = identity → cycle/transposition detection +
+/// dedup; (2) a **path/Merkle hash** over the `(parent,input)` edges = backward plan recovery + verifiable
+/// provenance (the edges are recorded here; the Merkle layer is a later slice).
+///
+/// **Honest scope (peel):** `Revisits` counts *all* re-encounters of an indexed state (transpositions, which
+/// include cycles); `SelfLoops` is the strict fixed-point case (child key = parent key). True back-edge cycle
+/// detection (revisit of an *ancestor on the current path*, vs a sideways transposition) needs path tracking —
+/// not done here; `Revisits` is the superset. `maxStates` bounds the search (`Truncated` reports when hit) — for
+/// a small ROM the full space fits (omniscient); for a large one this is a *bounded* frontier, not exhaustive.
+/// Deterministic (DST). `contentKey` is structural (the index key); a hex/Merkle *hash* of it is the verifiable form.
+[<RequireQualifiedAccess>]
+module StateSpace =
+
+    /// The content key of a frame = its identity for indexing (the "content hash", structural form). `Frame`
+    /// itself isn't comparable (byte[] fields), so this projects to a fully-comparable, hashable tuple.
+    let contentKey (f: Chip8Cow.Frame) =
+        (int f.PC,
+         [ for v in f.V -> int v ],
+         int f.I,
+         Map.toList f.Mem,
+         Map.toList f.Display,
+         f.Stack,
+         int f.Delay,
+         int f.Sound,
+         [ for k in f.Keys -> k ],
+         f.Rng)
+
+    /// The reachable-state graph: `Frames.[id]` is the state, `Edges` are `(fromId, input, toId)`.
+    type Graph =
+        { Frames: Chip8Cow.Frame[]
+          Edges: (int * bool[] * int) list
+          /// Transpositions: edges that re-reached an already-indexed state (includes cycles).
+          Revisits: int
+          /// Self-loops: a child whose content equals its parent's (a fixed-point cycle).
+          SelfLoops: int
+          /// Hit `maxStates` before the space was exhausted.
+          Truncated: bool }
+
+        member g.StateCount = g.Frames.Length
+
+    /// **Explore the reachable state space** from `f0` by BFS, forking over `actions` each frame
+    /// (`Chip8Cow.frameStep cyclesPerFrame`), indexing states by `contentKey`. Bounded by `maxStates`.
+    let explore (cyclesPerFrame: int) (maxStates: int) (actions: bool[] list) (f0: Chip8Cow.Frame) : Graph =
+        let index = Dictionary<_, int>(HashIdentity.Structural)
+        let frames = ResizeArray<Chip8Cow.Frame>()
+        let edges = ResizeArray<int * bool[] * int>()
+        let queue = Queue<int>()
+        let mutable revisits = 0
+        let mutable selfLoops = 0
+        let mutable truncated = false
+
+        let addNew (f: Chip8Cow.Frame) =
+            let id = frames.Count
+            frames.Add f
+            index.[contentKey f] <- id
+            queue.Enqueue id
+            id
+
+        addNew f0 |> ignore
+
+        while queue.Count > 0 do
+            let fromId = queue.Dequeue()
+            let parent = frames.[fromId]
+            let pk = contentKey parent
+            for a in actions do
+                let child = Chip8Cow.frameStep cyclesPerFrame { parent with Keys = a }
+                let ck = contentKey child
+                if ck = pk then selfLoops <- selfLoops + 1
+                match index.TryGetValue ck with
+                | true, toId ->
+                    revisits <- revisits + 1
+                    edges.Add(fromId, a, toId)
+                | false, _ ->
+                    if frames.Count >= maxStates then truncated <- true
+                    else edges.Add(fromId, a, addNew child)
+
+        { Frames = frames.ToArray()
+          Edges = List.ofSeq edges
+          Revisits = revisits
+          SelfLoops = selfLoops
+          Truncated = truncated }
+
+    /// Was any cycle detected (a transposition/revisit or a self-loop)? — branching converges/loops in soft mode.
+    let hasCycle (g: Graph) : bool = g.Revisits > 0 || g.SelfLoops > 0
+
+    /// **Backward plan recovery:** the shortest input sequence from state 0 to `goal`, by BFS over the edges
+    /// (the `(parent,input)` back-trace). `None` if `goal` is unreachable from the root in the explored graph.
+    let recoverPlan (goal: int) (g: Graph) : (bool[] list) option =
+        if goal < 0 || goal >= g.StateCount then None
+        elif goal = 0 then Some []
+        else
+            // BFS from 0, recording the (predecessor, input) that first reaches each state.
+            let pred = Dictionary<int, int * bool[]>()
+            let seen = HashSet<int>([ 0 ])
+            let q = Queue<int>([ 0 ])
+            let adj = g.Edges |> List.groupBy (fun (f, _, _) -> f) |> dict
+            let mutable found = false
+            while q.Count > 0 && not found do
+                let u = q.Dequeue()
+                match adj.TryGetValue u with
+                | true, outs ->
+                    for (_, input, v) in outs do
+                        if seen.Add v then
+                            pred.[v] <- (u, input)
+                            if v = goal then found <- true
+                            q.Enqueue v
+                | _ -> ()
+            if not (pred.ContainsKey goal) then None
+            else
+                let rec back (node: int) (acc: bool[] list) =
+                    if node = 0 then acc
+                    else
+                        let p, input = pred.[node]
+                        back p (input :: acc)
+                Some(back goal [])

--- a/tests/Tests.FSharp/StateSpace.Tests.fs
+++ b/tests/Tests.FSharp/StateSpace.Tests.fs
@@ -1,0 +1,48 @@
+module Zeta.Tests.StateSpaceTests
+
+open global.Xunit
+open Zeta.Core
+
+let private none = [ SoftController.none ]
+let private selfLoop = [| 0x12uy; 0x00uy |] // 1200 jump-to-self
+let private counter = [| 0x70uy; 0x01uy; 0x12uy; 0x00uy |] // 7001;1200: V0 grows forever (no cycle)
+
+let private mk rom = Chip8Cow.create 1UL |> Chip8Cow.loadRom rom
+
+[<Fact>]
+let ``self-loop ROM = one state, cycle detected (the content hash catches the loop)`` () =
+    let g = StateSpace.explore 8 50 none (mk selfLoop)
+    Assert.Equal(1, g.StateCount) // dedup: the loop collapses to one indexed state
+    Assert.True(g.SelfLoops > 0)
+    Assert.True(StateSpace.hasCycle g)
+
+[<Fact>]
+let ``counter ROM never cycles -> bounded search truncates at maxStates`` () =
+    let g = StateSpace.explore 8 10 none (mk counter)
+    Assert.Equal(10, g.StateCount)
+    Assert.True(g.Truncated)
+    Assert.False(StateSpace.hasCycle g) // every state distinct (V0 keeps growing)
+
+[<Fact>]
+let ``recoverPlan reproduces the path: replaying recovered inputs reaches the goal state`` () =
+    let f0 = mk counter
+    let g = StateSpace.explore 8 12 none f0
+    match StateSpace.recoverPlan 5 g with
+    | Some plan ->
+        Assert.Equal(5, List.length plan) // 5 frame-steps from state 0 to state 5
+        let mutable f = f0
+        for a in plan do
+            f <- Chip8Cow.frameStep 8 { f with Keys = a }
+        Assert.Equal(StateSpace.contentKey g.Frames.[5], StateSpace.contentKey f)
+    | None -> Assert.True(false, "state 5 should be reachable")
+
+[<Fact>]
+let ``recoverPlan to the root is the empty plan; unreachable id is None`` () =
+    let g = StateSpace.explore 8 6 none (mk counter)
+    Assert.Equal(Some [], StateSpace.recoverPlan 0 g)
+    Assert.Equal(None, StateSpace.recoverPlan 999 g)
+
+[<Fact>]
+let ``contentKey is stable: same frame -> same key (the index relies on it)`` () =
+    let f = mk counter |> Chip8Cow.run 3
+    Assert.Equal(StateSpace.contentKey f, StateSpace.contentKey f)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -134,6 +134,7 @@
     <Compile Include="SoftSession.Tests.fs" />
     <Compile Include="SoftActionController.Tests.fs" />
     <Compile Include="SoftEvolution.Tests.fs" />
+    <Compile Include="StateSpace.Tests.fs" />
     <Compile Include="RomFixtures.Tests.fs" />
     <Compile Include="SoftEmu.Tests.fs" />
     <Compile Include="SoftStationary.Tests.fs" />


### PR DESCRIPTION
Aaron: indexed state-space search; content hash detects cycles. BFS + transposition table (Zobrist-style) keyed on contentKey; Revisits (transpositions/cycles), SelfLoops (fixed-point). Two hashes: state-content (cycle detection) + path (recoverPlan/provenance). recoverPlan = backward plan recovery (shortest input seq via edge BFS). 5/5 tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)