### PR TITLE
feat(core): StateSpace.exploreGuarded (invariant guard) + planTo (goal-directed)

### DIFF
--- a/src/Core/StateSpace.fs
+++ b/src/Core/StateSpace.fs
@@ -98,6 +98,56 @@ module StateSpace =
     /// Was any cycle detected (a transposition/revisit or a self-loop)? — branching converges/loops in soft mode.
     let hasCycle (g: Graph) : bool = g.Revisits > 0 || g.SelfLoops > 0
 
+    /// **Guarded explore — the invariant constraint** (the don't-die ≡ no-downtime guard, #7119). Same BFS as
+    /// `explore`, but a child that **violates `invariant`** is *never entered* (not indexed, not expanded) — it's
+    /// a forbidden state, pruned (dropped, not indexed). `Revisits`/`SelfLoops`/`Truncated` carry their usual
+    /// meaning over the *safe* subspace. The resulting `Graph` therefore contains **only invariant-satisfying
+    /// states** — every path through it is safe by construction (a winning game line that never dies / a deploy
+    /// sequence that never goes down).
+    let exploreGuarded (invariant: Chip8Cow.Frame -> bool) (cyclesPerFrame: int) (maxStates: int) (actions: bool[] list) (f0: Chip8Cow.Frame) : Graph =
+        let index = Dictionary<_, int>(HashIdentity.Structural)
+        let frames = ResizeArray<Chip8Cow.Frame>()
+        let edges = ResizeArray<int * bool[] * int>()
+        let queue = Queue<int>()
+        let mutable revisits = 0
+        let mutable selfLoops = 0
+        let mutable truncated = false
+
+        let addNew (f: Chip8Cow.Frame) =
+            let id = frames.Count
+            frames.Add f
+            index.[contentKey f] <- id
+            queue.Enqueue id
+            id
+
+        // The root must itself be safe; if not, the safe subspace is empty.
+        if invariant f0 then
+            addNew f0 |> ignore
+
+        while queue.Count > 0 do
+            let fromId = queue.Dequeue()
+            let parent = frames.[fromId]
+            let pk = contentKey parent
+            for a in actions do
+                let child = Chip8Cow.frameStep cyclesPerFrame { parent with Keys = a }
+                if invariant child then // forbidden states are pruned (don't-die / no-downtime)
+                    let ck = contentKey child
+                    if ck = pk then selfLoops <- selfLoops + 1
+                    match index.TryGetValue ck with
+                    | true, toId ->
+                        revisits <- revisits + 1
+                        edges.Add(fromId, a, toId)
+                    | false, _ ->
+                        if frames.Count >= maxStates then truncated <- true
+                        else edges.Add(fromId, a, addNew child)
+
+        { Frames = frames.ToArray()
+          Edges = List.ofSeq edges
+          Revisits = revisits
+          SelfLoops = selfLoops
+          Truncated = truncated }
+
+
     /// **Backward plan recovery:** the shortest input sequence from state 0 to `goal`, by BFS over the edges
     /// (the `(parent,input)` back-trace). `None` if `goal` is unreachable from the root in the explored graph.
     let recoverPlan (goal: int) (g: Graph) : (bool[] list) option =
@@ -128,3 +178,11 @@ module StateSpace =
                         let p, input = pred.[node]
                         back p (input :: acc)
                 Some(back goal [])
+
+    /// **Goal-directed plan:** the shortest input sequence from the root to *any* explored state satisfying
+    /// `goal` (a winning/deployed predicate), by BFS over the edges. `None` if no explored state satisfies it.
+    /// Compose with `exploreGuarded` so the recovered plan is safe by construction (every step held the invariant).
+    let planTo (goal: Chip8Cow.Frame -> bool) (g: Graph) : (bool[] list) option =
+        match g.Frames |> Array.tryFindIndex goal with
+        | None -> None
+        | Some t -> recoverPlan t g

--- a/tests/Tests.FSharp/StateSpaceGuarded.Tests.fs
+++ b/tests/Tests.FSharp/StateSpaceGuarded.Tests.fs
@@ -1,0 +1,44 @@
+module Zeta.Tests.StateSpaceGuardedTests
+
+open global.Xunit
+open Zeta.Core
+
+let private none = [ SoftController.none ]
+let private counter = [| 0x70uy; 0x01uy; 0x12uy; 0x00uy |] // 7001;1200: V0 grows ~4/frame
+let private mk rom = Chip8Cow.create 1UL |> Chip8Cow.loadRom rom
+
+[<Fact>]
+let ``exploreGuarded prunes states violating the invariant (the don't-die / no-downtime guard)`` () =
+    // invariant: V0 stays below 20 -> states past that are forbidden, never entered
+    let inv (f: Chip8Cow.Frame) = int f.V.[0] < 20
+    let g = StateSpace.exploreGuarded inv 8 1000 none (mk counter)
+    Assert.All(g.Frames, fun f -> Assert.True(int f.V.[0] < 20)) // every explored state is safe by construction
+    Assert.True(g.StateCount > 0)
+
+[<Fact>]
+let ``a root that violates the invariant yields an empty safe subspace`` () =
+    let inv (_: Chip8Cow.Frame) = false // nothing is safe
+    let g = StateSpace.exploreGuarded inv 8 100 none (mk counter)
+    Assert.Equal(0, g.StateCount)
+
+[<Fact>]
+let ``planTo finds a safe path to a goal predicate and replaying it satisfies the goal`` () =
+    let inv (f: Chip8Cow.Frame) = int f.V.[0] < 100
+    let goal (f: Chip8Cow.Frame) = int f.V.[0] >= 12
+    let f0 = mk counter
+    let g = StateSpace.exploreGuarded inv 8 200 none f0
+    match StateSpace.planTo goal g with
+    | Some plan ->
+        let mutable f = f0
+        for a in plan do
+            f <- Chip8Cow.frameStep 8 { f with Keys = a }
+        Assert.True(goal f) // replaying the recovered plan reaches a goal state
+        Assert.True(inv f) // ...and it stayed safe (invariant held)
+    | None -> Assert.True(false, "goal V0>=12 should be reachable safely")
+
+[<Fact>]
+let ``planTo returns None when no explored state meets the goal`` () =
+    let inv (f: Chip8Cow.Frame) = int f.V.[0] < 5 // safe subspace caps V0 below 5
+    let goal (f: Chip8Cow.Frame) = int f.V.[0] >= 50 // unreachable within the safe subspace
+    let g = StateSpace.exploreGuarded inv 8 200 none (mk counter)
+    Assert.Equal(None, StateSpace.planTo goal g)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -135,6 +135,7 @@
     <Compile Include="SoftActionController.Tests.fs" />
     <Compile Include="SoftEvolution.Tests.fs" />
     <Compile Include="StateSpace.Tests.fs" />
+    <Compile Include="StateSpaceGuarded.Tests.fs" />
     <Compile Include="RomFixtures.Tests.fs" />
     <Compile Include="SoftEmu.Tests.fs" />
     <Compile Include="SoftStationary.Tests.fs" />


### PR DESCRIPTION
The don't-die/no-downtime invariant guard: exploreGuarded prunes forbidden states -> safe-by-construction graph; planTo = shortest safe path to a goal predicate. 4/4 tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)