### PR TITLE
feat(core): ControlMerge — subsumption (survival veto + CRDT-join of optimization loops)

### DIFF
--- a/src/Core/ControlMerge.fs
+++ b/src/Core/ControlMerge.fs
@@ -1,0 +1,64 @@
+namespace Zeta.Core
+
+/// **`ControlMerge` — subsumption: survival vetoes, optimization loops CRDT-join within the safe set (Aaron 2026-06-08, shadow*).**
+///
+/// Aaron: *"the control loops we find become control-structure DUs, CRDT joins and consensus of the different
+/// optimizations — there will be more than the one stay-alive one, but that one has final say… stay-alive is our
+/// heartbeat."* This is that combinator. Each optimization is a **`Loop`** (it scores candidate actions from a
+/// state). **Stay-alive subsumes** them all (Brooks 1986): the survival invariant is a **hard veto** — only
+/// actions that keep the next frame alive are eligible; among those, the optimization loops' scores are
+/// **CRDT-joined** (summed — commutative/associative/order-independent) and the best is chosen. Survival has final
+/// say; everything else optimizes *within* the safe set (`exploreGuarded`/`planTo` are the search-time form; this
+/// is the per-step form). No safe action ⇒ `None` = the heartbeat fails (the agent's "I commit therefore I am"
+/// can no longer commit — death).
+///
+/// **Honest scope (peel):** one-step (greedy) survival veto — it prunes actions whose *immediate* next frame dies,
+/// not actions that doom you k steps later (use `Survival`/`exploreGuarded` for horizon-safe). CRDT-join here is a
+/// plain score *sum*; a real consensus (weighted vote / lexicographic priority across loops) is a richer merge —
+/// `decideLexicographic` gives the strict-priority variant. Action equality is structural over the 16-bool vector.
+/// Deterministic (DST).
+[<RequireQualifiedAccess>]
+module ControlMerge =
+
+    /// An optimization loop: from a state, its scored preferences over candidate actions.
+    type Loop = Chip8Cow.Frame -> (bool[] * float) list
+
+    /// **The survival veto:** the actions whose next frame still satisfies `alive` (one frame ahead). The hard
+    /// constraint stay-alive imposes on every other loop.
+    let safeActions (alive: Chip8Cow.Frame -> bool) (cyclesPerFrame: int) (actions: bool[] list) (f: Chip8Cow.Frame) : bool[] list =
+        actions |> List.filter (fun a -> alive (Chip8Cow.frameStep cyclesPerFrame { f with Keys = a }))
+
+    let private scoreFor (loops: Loop list) (f: Chip8Cow.Frame) (a: bool[]) : float =
+        // CRDT join of the loops' scores for action `a` (sum = commutative/associative/order-independent).
+        loops
+        |> List.sumBy (fun loop ->
+            loop f |> List.tryPick (fun (a', s) -> if a' = a then Some s else None) |> Option.defaultValue 0.0)
+
+    /// **Decide (subsumption):** among the survival-safe actions, pick the one maximizing the CRDT-joined score
+    /// across `loops`. `None` if no action is safe (the heartbeat fails). Survival has final say.
+    let decide
+        (alive: Chip8Cow.Frame -> bool)
+        (cyclesPerFrame: int)
+        (actions: bool[] list)
+        (loops: Loop list)
+        (f: Chip8Cow.Frame)
+        : bool[] option =
+        match safeActions alive cyclesPerFrame actions f with
+        | [] -> None
+        | safe -> safe |> List.maxBy (scoreFor loops f) |> Some
+
+    /// **Lexicographic decide:** among survival-safe actions, prefer the first `loops` entry's best, breaking ties
+    /// by the next loop, and so on (strict priority instead of a summed join — for when loops must not trade off).
+    let decideLexicographic
+        (alive: Chip8Cow.Frame -> bool)
+        (cyclesPerFrame: int)
+        (actions: bool[] list)
+        (loops: Loop list)
+        (f: Chip8Cow.Frame)
+        : bool[] option =
+        match safeActions alive cyclesPerFrame actions f with
+        | [] -> None
+        | safe ->
+            let key (a: bool[]) =
+                loops |> List.map (fun loop -> loop f |> List.tryPick (fun (a', s) -> if a' = a then Some s else None) |> Option.defaultValue 0.0)
+            safe |> List.maxBy key |> Some // F# compares the score list lexicographically

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -215,6 +215,7 @@
     <Compile Include="MemoryLens.fs" />
     <Compile Include="Survival.fs" />
     <Compile Include="MemorySense.fs" />
+    <Compile Include="ControlMerge.fs" />
     <Compile Include="PolarityFilter.fs" />
     <Compile Include="ZetaExec.fs" />
     <Compile Include="DarkHall.fs" />

--- a/tests/Tests.FSharp/ControlMerge.Tests.fs
+++ b/tests/Tests.FSharp/ControlMerge.Tests.fs
@@ -1,0 +1,49 @@
+module Zeta.Tests.ControlMergeTests
+
+open global.Xunit
+open Zeta.Core
+
+let private none = SoftController.none
+let private key0 = SoftController.singleKey 0
+let private actions = [ none; key0 ]
+
+// 6000 (V0=0); E09E skip-if-key0-down; 6005 (V0=5); 1206 loop
+//   key0 held -> skip the V0=5 -> V0 stays 0 (SAFE under V0<3)
+//   none       -> V0=5 (UNSAFE under V0<3)
+let private inputRom = [| 0x60uy; 0x00uy; 0xE0uy; 0x9Euy; 0x60uy; 0x05uy; 0x12uy; 0x06uy |]
+let private f0 () = Chip8Cow.create 1UL |> Chip8Cow.loadRom inputRom
+let private alive (f: Chip8Cow.Frame) = int f.V.[0] < 3
+
+[<Fact>]
+let ``safeActions applies the survival veto (only the alive-preserving action)`` () =
+    let safe = ControlMerge.safeActions alive 8 actions (f0 ())
+    Assert.Equal<bool[] list>([ key0 ], safe) // none -> V0=5 dies; key0 -> V0=0 safe
+
+[<Fact>]
+let ``survival has FINAL SAY: a loop preferring a lethal action is overridden`` () =
+    // the optimization loop strongly prefers `none` (score 10) over key0 (score 1) — but `none` is lethal
+    let greedy: ControlMerge.Loop = fun _ -> [ none, 10.0; key0, 1.0 ]
+    let chosen = ControlMerge.decide alive 8 actions [ greedy ] (f0 ())
+    Assert.Equal(Some key0, chosen) // survival vetoes `none` despite its higher score
+
+[<Fact>]
+let ``with no survival pressure, the joined score wins (CRDT sum of loops)`` () =
+    let permissive (_: Chip8Cow.Frame) = true // nothing is lethal
+    let a: ControlMerge.Loop = fun _ -> [ none, 3.0; key0, 1.0 ]
+    let b: ControlMerge.Loop = fun _ -> [ none, 0.0; key0, 5.0 ] // none=3, key0=6 after join
+    let chosen = ControlMerge.decide permissive 8 actions [ a; b ] (f0 ())
+    Assert.Equal(Some key0, chosen) // 1+5 > 3+0
+
+[<Fact>]
+let ``no safe action -> None (the heartbeat fails)`` () =
+    let doomed (_: Chip8Cow.Frame) = false // nothing is ever safe
+    let chosen = ControlMerge.decide doomed 8 actions [ (fun _ -> [ none, 1.0 ]) ] (f0 ())
+    Assert.Equal(None, chosen)
+
+[<Fact>]
+let ``lexicographic decide respects strict loop priority within the safe set`` () =
+    let permissive (_: Chip8Cow.Frame) = true
+    let primary: ControlMerge.Loop = fun _ -> [ none, 1.0; key0, 1.0 ] // tie
+    let tiebreak: ControlMerge.Loop = fun _ -> [ none, 0.0; key0, 9.0 ] // key0 wins the tiebreak
+    let chosen = ControlMerge.decideLexicographic permissive 8 actions [ primary; tiebreak ] (f0 ())
+    Assert.Equal(Some key0, chosen)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -140,6 +140,7 @@
     <Compile Include="MemoryLens.Tests.fs" />
     <Compile Include="Survival.Tests.fs" />
     <Compile Include="MemorySense.Tests.fs" />
+    <Compile Include="ControlMerge.Tests.fs" />
     <Compile Include="RomFixtures.Tests.fs" />
     <Compile Include="SoftEmu.Tests.fs" />
     <Compile Include="SoftStationary.Tests.fs" />


### PR DESCRIPTION
Aaron's keystone in code: control loops CRDT-join, stay-alive has final say. safeActions (survival veto), decide (argmax CRDT-joined score within safe set), decideLexicographic (strict priority). None = heartbeat fails. 5/5 tests incl. survival overriding a lethal high-score action. 🤖 Generated with [Claude Code](https://claude.com/claude-code)