### PR TITLE
feat(core): LensRouter — multi-lens selection (MoE over lenses, bounded working set)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -213,6 +213,7 @@
     <Compile Include="StateSpace.fs" />
     <Compile Include="DeltaPattern.fs" />
     <Compile Include="MemoryLens.fs" />
+    <Compile Include="LensRouter.fs" />
     <Compile Include="Survival.fs" />
     <Compile Include="MemorySense.fs" />
     <Compile Include="ControlMerge.fs" />

--- a/src/Core/LensRouter.fs
+++ b/src/Core/LensRouter.fs
@@ -1,0 +1,58 @@
+namespace Zeta.Core
+
+/// **`LensRouter` — multi-lens selection (Mixture-of-Experts over lenses) (Aaron 2026-06-08, shadow*).**
+///
+/// Aaron: *"we could also do multi-lens selection — my multiple lenses feel like background threads in my head,
+/// but I can only have so many in context at one time, like MoE."* Many candidate **lenses** (each a reduction of
+/// memory to a subset of cells — `MemoryLens` view, a `MemorySense` baseline, a hand-named slice) sit in the
+/// background; a **gate** scores each lens's relevance for the current state from a per-cell **signal**
+/// (controllability, change-rate, anomaly pressure…); **top-k** are made active (the bounded working set / context
+/// budget — sparse gating, Shazeer et al. MoE). The active lenses compose into one working world-state key (the
+/// union of their cells). Only k experts attend at once; the rest stay background threads until the gate promotes
+/// them.
+///
+/// **Honest scope (peel):** the gate is a relevance *heuristic* over a caller-supplied signal — it does not learn
+/// the gating (no trained router; that's the next slice). Top-k is a hard cutoff (no soft mixture weights yet).
+/// `composeKey` unions cells (a datum in two active lenses appears once). Deterministic (DST). The signal is where
+/// the intelligence lives — feed it `MemoryLens` controllability and/or `MemorySense` change-rate/anomaly.
+[<RequireQualifiedAccess>]
+module LensRouter =
+
+    /// A lens = a named reduction of memory to the cells it attends to.
+    type Lens = { Name: string; Cells: string list }
+
+    let private cellsOf (f: Chip8Cow.Frame) : Map<string, int> =
+        ([ "PC", int f.PC; "I", int f.I; "Delay", int f.Delay; "Sound", int f.Sound ]
+         @ [ for i in 0..15 -> sprintf "V%X" i, int f.V.[i] ])
+        |> Map.ofList
+
+    /// **The gate:** a lens's relevance = the mean of the per-cell `signal` over the cells it attends to (a cell
+    /// absent from `signal` scores 0). Higher = more worth attending to now.
+    let gate (signal: Map<string, float>) (lens: Lens) : float =
+        match lens.Cells with
+        | [] -> 0.0
+        | cells ->
+            (cells |> List.sumBy (fun c -> Map.tryFind c signal |> Option.defaultValue 0.0))
+            / float (List.length cells)
+
+    /// **Select the top-`k` lenses** by the gate (the bounded active working set — MoE sparse gating). Ties broken
+    /// by name for determinism.
+    let select (k: int) (signal: Map<string, float>) (lenses: Lens list) : Lens list =
+        lenses
+        |> List.sortByDescending (fun l -> gate signal l, l.Name)
+        |> List.truncate (max 0 k)
+
+    /// The union of cells attended to by the active lenses (the working world-state's footprint).
+    let activeCells (active: Lens list) : string list =
+        active |> List.collect (fun l -> l.Cells) |> List.distinct |> List.sort
+
+    /// **Compose the active lenses into one working world-state key** — the values of the union of their cells
+    /// (sorted, comparable). The bounded reduced state the controller/predictor sees this tick.
+    let composeKey (active: Lens list) (f: Chip8Cow.Frame) : (string * int) list =
+        let vals = cellsOf f
+        activeCells active
+        |> List.choose (fun c -> Map.tryFind c vals |> Option.map (fun v -> c, v))
+
+    /// One-shot: select top-`k` lenses for `f` under `signal`, then compose their working key.
+    let route (k: int) (signal: Map<string, float>) (lenses: Lens list) (f: Chip8Cow.Frame) : (string * int) list =
+        composeKey (select k signal lenses) f

--- a/tests/Tests.FSharp/LensRouter.Tests.fs
+++ b/tests/Tests.FSharp/LensRouter.Tests.fs
@@ -1,0 +1,43 @@
+module Zeta.Tests.LensRouterTests
+
+open global.Xunit
+open Zeta.Core
+
+let private lensA = { LensRouter.Name = "A"; LensRouter.Cells = [ "V0"; "V1" ] }
+let private lensB = { LensRouter.Name = "B"; LensRouter.Cells = [ "V2"; "V3" ] }
+let private lensC = { LensRouter.Name = "C"; LensRouter.Cells = [ "Delay" ] }
+let private lenses = [ lensA; lensB; lensC ]
+
+[<Fact>]
+let ``gate scores a lens by mean per-cell signal`` () =
+    let signal = Map.ofList [ "V0", 1.0; "V1", 1.0; "V2", 0.0; "V3", 0.0 ]
+    Assert.Equal(1.0, LensRouter.gate signal lensA, 9)
+    Assert.Equal(0.0, LensRouter.gate signal lensB, 9)
+
+[<Fact>]
+let ``select top-k activates the most-relevant lenses (the bounded MoE working set)`` () =
+    let signal = Map.ofList [ "V0", 1.0; "V1", 1.0; "Delay", 0.5; "V2", 0.0; "V3", 0.0 ]
+    Assert.Equal<string list>([ "A" ], LensRouter.select 1 signal lenses |> List.map (fun l -> l.Name))
+    Assert.Equal<string list>([ "A"; "C" ], LensRouter.select 2 signal lenses |> List.map (fun l -> l.Name))
+
+[<Fact>]
+let ``k >= count returns all lenses (sorted by relevance)`` () =
+    let signal = Map.ofList [ "V0", 0.1; "V2", 0.9; "V3", 0.9; "Delay", 0.5 ]
+    let names = LensRouter.select 10 signal lenses |> List.map (fun l -> l.Name)
+    Assert.Equal(3, List.length names)
+    Assert.Equal("B", List.head names) // B = mean(V2,V3) = 0.9, the most relevant
+
+[<Fact>]
+let ``composeKey is the union of active lenses' cell values (bounded working state)`` () =
+    let f = Chip8Cow.create 1UL
+    let key = LensRouter.composeKey [ lensA; lensC ] f
+    let cells = key |> List.map fst
+    Assert.Contains("V0", cells)
+    Assert.Contains("Delay", cells)
+    Assert.DoesNotContain("V2", cells) // lensB not active
+
+[<Fact>]
+let ``route selects then composes in one shot`` () =
+    let signal = Map.ofList [ "V2", 1.0; "V3", 1.0 ] // favors lens B
+    let key = LensRouter.route 1 signal lenses (Chip8Cow.create 1UL)
+    Assert.Equal<string list>([ "V2"; "V3" ], key |> List.map fst)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -138,6 +138,7 @@
     <Compile Include="StateSpaceGuarded.Tests.fs" />
     <Compile Include="DeltaPattern.Tests.fs" />
     <Compile Include="MemoryLens.Tests.fs" />
+    <Compile Include="LensRouter.Tests.fs" />
     <Compile Include="Survival.Tests.fs" />
     <Compile Include="MemorySense.Tests.fs" />
     <Compile Include="ControlMerge.Tests.fs" />


### PR DESCRIPTION
Aaron: multi-lens MoE (background-thread lenses, bounded context). gate (relevance from per-cell signal), select (top-k), composeKey (union working state), route. 5/5 tests. Feed the signal from MemoryLens/MemorySense. 🤖 Generated with [Claude Code](https://claude.com/claude-code)