### PR TITLE
fix(roms): markdownlint MD032 — blank line before list in roms/chip8/README.md

### DIFF
--- a/roms/chip8/README.md
+++ b/roms/chip8/README.md
@@ -5,6 +5,7 @@ CHIP-8 ROMs that are **either authored by us (CC0) or third-party under a verifi
 in git so unit tests can exercise the emulator against real ROM bytes.
 
 Policy for this folder (maintainer decision, 2026-06-08): a ROM may be committed here **only** if it is
+
 1. **authored by Zeta** (CC0 / public-domain — ours), or
 2. **third-party with an explicitly verified free license** (MIT/CC0/etc.) whose notice travels with it
    (`THIRD-PARTY-LICENSES.md`).


### PR DESCRIPTION
Gate markdownlint failure (MD032, the only failing check; build-and-test green). Blank line before the policy list. Verified clean locally. 🤖 Generated with [Claude Code](https://claude.com/claude-code)