### PR TITLE
feat(core): SolidGround — navigable landmarks (constants+monotonic) + solid-ground gain as lens quality

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -216,6 +216,7 @@
     <Compile Include="LensRouter.fs" />
     <Compile Include="Survival.fs" />
     <Compile Include="MemorySense.fs" />
+    <Compile Include="SolidGround.fs" />
     <Compile Include="ControlMerge.fs" />
     <Compile Include="PolarityFilter.fs" />
     <Compile Include="ZetaExec.fs" />

--- a/src/Core/SolidGround.fs
+++ b/src/Core/SolidGround.fs
@@ -1,0 +1,86 @@
+namespace Zeta.Core
+
+/// **`SolidGround` — the navigable landmarks in memory: constants + monotonic cells (Aaron 2026-06-08, shadow*).**
+///
+/// Aaron: *"without a map and navigation of recurrence, everything looks like random noise in memory other than
+/// the **monotonically increasing digits** — we should keep track of those, they're like **solid ground**… also
+/// some memory **never changes ever** — these are solid **constants**, another type of solid ground… solid ground
+/// is often used as **input to lens parameters**."*
+///
+/// Where `MemoryLens` asks "is it controllable?" and drops the rest as nuisance, `SolidGround` rescues the
+/// *reliable* part of that "rest": a cell whose value series is **constant** (never changes) or **monotonic** (a
+/// counter/clock/odometer — always up, or always down) is **solid ground** — a dependable landmark you can
+/// navigate by even when everything else is noise. The remainder (non-monotonic drift) is **erratic** (RNG-like
+/// noise). Solid ground is the **coordinate frame**: constants are fixed reference points; monotonic cells are the
+/// clock/odometer that tells you *where you are in the trajectory*. Both feed **lens parameters** (a constant base
+/// address configures a lens; a monotonic frame-counter indexes/phases it).
+///
+/// **Honest scope (peel):** classification is over the *sampled* series (a cell monotonic in the window may not be
+/// globally; a constant may change off-sample). Monotonic = pairwise diffs all ≥0 or all ≤0 (and ≥1 change);
+/// "noise vs monotonic" is the navigable/non-navigable cut, not a proof of RNG. Deterministic (DST). Complements
+/// `MemoryLens` (controllable) and `MemorySense` (ranges/seasons/anomaly) — this is the *stable* substrate they
+/// build on. Anchors: dead-reckoning / odometry (navigate by a monotonic count); fixed landmarks; loop invariants.
+[<RequireQualifiedAccess>]
+module SolidGround =
+
+    /// What kind of solid ground (if any) a cell's value series is.
+    type Ground =
+        | Constant of int // never changes — a fixed reference point
+        | Monotonic of int // always moves one way: +1 = up (counter), -1 = down (countdown clock)
+        | Erratic // non-monotonic drift — noise, not navigable
+
+    /// Classify a cell's value series.
+    let classifySeries (vals: int list) : Ground =
+        match vals with
+        | [] -> Constant 0
+        | [ v ] -> Constant v
+        | first :: _ ->
+            let diffs = vals |> List.pairwise |> List.map (fun (a, b) -> b - a)
+            if diffs |> List.forall ((=) 0) then Constant first
+            elif diffs |> List.forall (fun d -> d >= 0) then Monotonic 1
+            elif diffs |> List.forall (fun d -> d <= 0) then Monotonic -1
+            else Erratic
+
+    /// Is this ground solid (navigable) — a constant or a monotonic landmark?
+    let isSolid (g: Ground) : bool =
+        match g with
+        | Constant _
+        | Monotonic _ -> true
+        | Erratic -> false
+
+    /// Classify every cell of a series map (e.g. from `MemorySense.series`).
+    let classify (s: Map<string, int list>) : Map<string, Ground> = s |> Map.map (fun _ vals -> classifySeries vals)
+
+    /// The solid-ground cells (constants + monotonic) — the navigable landmarks / lens-parameter inputs.
+    let solidCells (s: Map<string, int list>) : (string * Ground) list =
+        classify s |> Map.toList |> List.filter (fun (_, g) -> isSolid g)
+
+    /// Just the constant cells (fixed reference points).
+    let constants (s: Map<string, int list>) : (string * int) list =
+        solidCells s
+        |> List.choose (fun (n, g) ->
+            match g with
+            | Constant v -> Some(n, v)
+            | _ -> None)
+
+    /// Just the monotonic cells with direction (+1 up / -1 down) — the clocks/odometers to navigate by.
+    let monotonic (s: Map<string, int list>) : (string * int) list =
+        solidCells s
+        |> List.choose (fun (n, g) ->
+            match g with
+            | Monotonic dir -> Some(n, dir)
+            | _ -> None)
+
+    /// The amount of solid ground: count of navigable (constant/monotonic) cells.
+    let solidCount (s: Map<string, int list>) : int = solidCells s |> List.length
+
+    /// The solid-ground fraction (navigable cells / all cells) — how much of memory is dependable.
+    let solidFraction (s: Map<string, int list>) : float =
+        if Map.isEmpty s then 0.0 else float (solidCount s) / float (Map.count s)
+
+    /// **Solid-ground GAIN of a transform/lens** (Aaron 2026-06-08): solid cells *after* minus *before*. Positive
+    /// = the lens turned noise into navigable landmarks. **This is how you judge a lens** other than the stay-alive
+    /// one — by how much new solid ground it produces (a compression / predictability gain; the bootstrap where
+    /// lenses + solid ground produce more solid ground). The `LensRouter` gate signal for non-survival lenses.
+    let gain (before: Map<string, int list>) (after: Map<string, int list>) : int =
+        solidCount after - solidCount before

--- a/tests/Tests.FSharp/SolidGround.Tests.fs
+++ b/tests/Tests.FSharp/SolidGround.Tests.fs
@@ -1,0 +1,43 @@
+module Zeta.Tests.SolidGroundTests
+
+open global.Xunit
+open Zeta.Core
+
+[<Fact>]
+let ``classifySeries: constant / monotonic-up / monotonic-down / erratic`` () =
+    Assert.Equal(SolidGround.Constant 5, SolidGround.classifySeries [ 5; 5; 5 ])
+    Assert.Equal(SolidGround.Monotonic 1, SolidGround.classifySeries [ 0; 4; 8; 12 ])
+    Assert.Equal(SolidGround.Monotonic -1, SolidGround.classifySeries [ 9; 6; 3; 0 ])
+    Assert.Equal(SolidGround.Erratic, SolidGround.classifySeries [ 3; 1; 4; 1; 5 ])
+
+[<Fact>]
+let ``isSolid: constants and monotonics are solid ground, erratic is not`` () =
+    Assert.True(SolidGround.isSolid (SolidGround.Constant 0))
+    Assert.True(SolidGround.isSolid (SolidGround.Monotonic 1))
+    Assert.False(SolidGround.isSolid SolidGround.Erratic)
+
+[<Fact>]
+let ``solidCells / constants / monotonic partition a series map`` () =
+    let s =
+        Map.ofList
+            [ "base", [ 512; 512; 512 ] // constant
+              "clock", [ 0; 1; 2; 3 ] // monotonic up
+              "timer", [ 60; 59; 58 ] // monotonic down
+              "rng", [ 7; 2; 9; 1 ] ] // erratic noise
+    Assert.Equal(3, SolidGround.solidCount s) // base + clock + timer
+    Assert.Equal<(string * int) list>([ "base", 512 ], SolidGround.constants s)
+    let mono = SolidGround.monotonic s |> List.sortBy fst
+    Assert.Equal<(string * int) list>([ "clock", 1; "timer", -1 ], mono)
+
+[<Fact>]
+let ``solid-ground GAIN: a lens that turns noise into a landmark scores positive (how you judge a lens)`` () =
+    let before = Map.ofList [ "x", [ 7; 2; 9; 1 ] ] // erratic -> 0 solid
+    // a lens deriving x mod 8's cumulative count, say, that comes out monotonic -> +1 solid
+    let after = Map.ofList [ "x", [ 7; 2; 9; 1 ]; "lensed", [ 0; 1; 2; 3 ] ]
+    Assert.Equal(1, SolidGround.gain before after) // the lens produced one unit of solid ground
+    Assert.Equal(0, SolidGround.solidCount before)
+
+[<Fact>]
+let ``solidFraction is navigable cells over all cells`` () =
+    let s = Map.ofList [ "a", [ 1; 1; 1 ]; "b", [ 3; 1; 4; 1 ] ] // a solid, b erratic
+    Assert.Equal(0.5, SolidGround.solidFraction s, 9)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -141,6 +141,7 @@
     <Compile Include="LensRouter.Tests.fs" />
     <Compile Include="Survival.Tests.fs" />
     <Compile Include="MemorySense.Tests.fs" />
+    <Compile Include="SolidGround.Tests.fs" />
     <Compile Include="ControlMerge.Tests.fs" />
     <Compile Include="RomFixtures.Tests.fs" />
     <Compile Include="SoftEmu.Tests.fs" />


### PR DESCRIPTION
Aaron: monotonic + constant cells = solid ground (navigable landmarks / lens parameters); judge a lens by how much new solid ground it produces. classifySeries (Constant/Monotonic/Erratic), solidCells/constants/monotonic, solidCount/fraction, gain (lens-quality metric). 5/5 tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)