### PR TITLE
feat(core): Traversal — uncertainty-reduction unit (cost + relevant lenses + control loop), scheduled by VOI

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -214,6 +214,7 @@
     <Compile Include="DeltaPattern.fs" />
     <Compile Include="MemoryLens.fs" />
     <Compile Include="LensRouter.fs" />
+    <Compile Include="Traversal.fs" />
     <Compile Include="Survival.fs" />
     <Compile Include="MemorySense.fs" />
     <Compile Include="SolidGround.fs" />

--- a/src/Core/Traversal.fs
+++ b/src/Core/Traversal.fs
@@ -1,0 +1,65 @@
+namespace Zeta.Core
+
+/// **`Traversal` — an uncertainty-reduction unit: cost + control loop + its relevant lenses (Aaron 2026-06-08, shadow*).**
+///
+/// Aaron: *"the window = solid ground + pointers to the traversals that reduce uncertainty of stuff outside the
+/// context window… those traversals will have a **cost** and a **control loop** attached, along with several
+/// **top-k lenses** that are most relevant to that uncertainty-reduction loop."*
+///
+/// A `Traversal` is the first-class thing a context-window *pointer* (#7135) points at: a packaged way to resolve
+/// some out-of-window uncertainty. It carries
+///   - **`Cost`** — the resources to run it (the caching cost-tier, #7134: ambient ≈ 0, expensive = traversal +
+///     oscillation);
+///   - **`Lenses`** — the top-k lenses (`LensRouter`) most relevant to *this* uncertainty-reduction loop (each
+///     traversal has its own bounded relevant set, not the global one);
+///   - **`ExpectedReduction`** — how much uncertainty it's expected to remove (entropy drop / solid-ground gain);
+///   - **`Run`** — the control loop itself (e.g. a `ControlMerge`/`SoftDrive`/`Fixpoint` oscillation that settles
+///     to the resolved clarity).
+///
+/// You don't run them all — you **schedule by value-of-information** (`voi = reduction / cost`) under a budget:
+/// run the traversal whose uncertainty-reduction most exceeds its cost (active sensing). That is how a bounded
+/// agent decides which out-of-window clarity is worth fetching now.
+///
+/// **Honest scope (peel):** `ExpectedReduction`/`Cost` are *estimates* the scheduler trusts (mis-estimates ⇒
+/// wrong priority — calibrate against realized reduction). `schedule` is greedy-by-VOI under an additive cost
+/// budget (a knapsack heuristic, not optimal). `Run` is generic `'r` (the resolved value). Deterministic (DST).
+/// Anchors: value-of-information / active sensing; the cost-tier caching (#7134); `LensRouter` (the relevant set).
+[<RequireQualifiedAccess>]
+module Traversal =
+
+    /// A packaged uncertainty-reduction traversal (what a context-window pointer points at).
+    type Traversal<'r> =
+        { Name: string
+          /// What out-of-window uncertainty this resolves (a cell / region label).
+          Target: string
+          /// Resource cost to run the loop.
+          Cost: float
+          /// The top-k lenses most relevant to this uncertainty-reduction loop.
+          Lenses: LensRouter.Lens list
+          /// Expected uncertainty removed (entropy drop / solid-ground gain).
+          ExpectedReduction: float
+          /// The control loop that resolves the clarity (oscillation/settle) — invoked on demand.
+          Run: Chip8Cow.Frame -> 'r }
+
+    /// **Value of information:** expected uncertainty reduced per unit cost. Free (`Cost ≤ 0`) ⇒ `infinity`
+    /// (ambient solid ground — always worth "running"). The priority signal for scheduling.
+    let voi (t: Traversal<'r>) : float =
+        if t.Cost <= 0.0 then infinity else t.ExpectedReduction / t.Cost
+
+    /// Is this traversal worth running (its VOI clears `threshold`)?
+    let worth (threshold: float) (t: Traversal<'r>) : bool = voi t >= threshold
+
+    /// **Schedule under a cost `budget`:** greedily take traversals by descending VOI while the cumulative cost
+    /// fits — the active-sensing decision of which out-of-window clarities to fetch now.
+    let schedule (budget: float) (ts: Traversal<'r> list) : Traversal<'r> list =
+        ts
+        |> List.sortByDescending voi
+        |> List.fold
+            (fun (spent, chosen) t ->
+                if spent + t.Cost <= budget then (spent + t.Cost, chosen @ [ t ]) else (spent, chosen))
+            (0.0, [])
+        |> snd
+
+    /// Run the scheduled traversals from a state, returning each resolved clarity (with its target label).
+    let runScheduled (budget: float) (f: Chip8Cow.Frame) (ts: Traversal<'r> list) : (string * 'r) list =
+        schedule budget ts |> List.map (fun t -> t.Target, t.Run f)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -139,6 +139,7 @@
     <Compile Include="DeltaPattern.Tests.fs" />
     <Compile Include="MemoryLens.Tests.fs" />
     <Compile Include="LensRouter.Tests.fs" />
+    <Compile Include="Traversal.Tests.fs" />
     <Compile Include="Survival.Tests.fs" />
     <Compile Include="MemorySense.Tests.fs" />
     <Compile Include="SolidGround.Tests.fs" />

--- a/tests/Tests.FSharp/Traversal.Tests.fs
+++ b/tests/Tests.FSharp/Traversal.Tests.fs
@@ -1,0 +1,46 @@
+module Zeta.Tests.TraversalTests
+
+open global.Xunit
+open Zeta.Core
+
+let private lens name cells = { LensRouter.Name = name; LensRouter.Cells = cells }
+
+let private mk name cost reduction lenses : Traversal.Traversal<int> =
+    { Name = name
+      Target = name
+      Cost = cost
+      Lenses = lenses
+      ExpectedReduction = reduction
+      Run = fun _ -> 0 }
+
+[<Fact>]
+let ``voi = expected reduction / cost; free traversals are infinity`` () =
+    Assert.Equal(2.0, Traversal.voi (mk "a" 5.0 10.0 []), 9)
+    Assert.Equal(infinity, Traversal.voi (mk "ambient" 0.0 1.0 []))
+
+[<Fact>]
+let ``worth gates on a VOI threshold`` () =
+    Assert.True(Traversal.worth 1.5 (mk "a" 5.0 10.0 [])) // voi 2.0 >= 1.5
+    Assert.False(Traversal.worth 3.0 (mk "a" 5.0 10.0 [])) // voi 2.0 < 3.0
+
+[<Fact>]
+let ``schedule takes highest-VOI traversals within the cost budget`` () =
+    let hi = mk "hi" 2.0 10.0 [] // voi 5
+    let mid = mk "mid" 3.0 6.0 [] // voi 2
+    let lo = mk "lo" 5.0 2.0 [] // voi 0.4
+    let chosen = Traversal.schedule 5.0 [ lo; mid; hi ] |> List.map (fun t -> t.Name)
+    Assert.Equal<string list>([ "hi"; "mid" ], chosen) // hi(2)+mid(3)=5 fits; lo would overflow
+
+[<Fact>]
+let ``schedule with zero budget runs only the free (ambient) traversals`` () =
+    let ambient = mk "ambient" 0.0 1.0 []
+    let costly = mk "costly" 1.0 5.0 []
+    let chosen = Traversal.schedule 0.0 [ costly; ambient ] |> List.map (fun t -> t.Name)
+    Assert.Equal<string list>([ "ambient" ], chosen)
+
+[<Fact>]
+let ``a traversal carries its relevant lenses and resolves via Run`` () =
+    let t = { (mk "resolve-x" 1.0 1.0 [ lens "L" [ "V0" ] ]) with Run = fun f -> int f.V.[0] }
+    Assert.Equal<string list>([ "L" ], t.Lenses |> List.map (fun l -> l.Name))
+    let f = Chip8Cow.create 1UL |> Chip8Cow.loadRom [| 0x60uy; 0x07uy |] |> Chip8Cow.run 1
+    Assert.Equal(7, t.Run f) // the control loop resolved V0=7


### PR DESCRIPTION
Aaron: traversals have cost + a control loop + top-k relevant lenses. Traversal<'r> = what a context-window pointer points at: Cost/Lenses/ExpectedReduction/Run. voi=reduction/cost (ambient=inf), worth, schedule (greedy-VOI under budget = active sensing), runScheduled. 5/5 tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)