### PR TITLE
feat(core): MetaController — the agent's controller (traversals + map moves) = meta universal action grammar

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -215,6 +215,7 @@
     <Compile Include="MemoryLens.fs" />
     <Compile Include="LensRouter.fs" />
     <Compile Include="Traversal.fs" />
+    <Compile Include="MetaController.fs" />
     <Compile Include="Survival.fs" />
     <Compile Include="MemorySense.fs" />
     <Compile Include="SolidGround.fs" />

--- a/src/Core/MetaController.fs
+++ b/src/Core/MetaController.fs
@@ -1,0 +1,51 @@
+namespace Zeta.Core
+
+/// **`MetaController` — the agent's own controller: traversals + map moves = the meta universal action grammar (Aaron 2026-06-08, shadow*).**
+///
+/// Aaron: *"traversals + some sort of navigable map = our Xbox controller — **not the actual game buttons** but
+/// our **universal action grammar**. So you have top-k traversals available to you based on the current context
+/// window and can move directionally within some map."*
+///
+/// There are **two** action grammars:
+///   - the **game's** (object level) — the 16 CHIP-8 keys (`ActionGrammar`); and
+///   - the **agent's** (meta level, *this*) — what the agent actually steers: **`Traverse`** (run an uncertainty-
+///     reduction traversal = *sense*, resolve out-of-window clarity) or **`Move`** (a directional move in the map
+///     = *act*, transition between attractors via a game-action). The agent's "Xbox controller" is this menu, and
+///     **its available buttons are context-dependent**: the top-k *affordable* traversals (`Traversal.schedule`
+///     by VOI under the budget) plus the directional moves available from the current map node (`StateSpace`
+///     edges / `planTo` directions). Same algebra as `ActionGrammar`, lifted to the cognitive layer.
+///
+/// So the agent navigates its own **world-state map** (`observe.ts`, #7129): pick a `Traverse` to sharpen where
+/// it's murky, or a `Move` to go toward a desired attractor — within liveness (survival subsumes, `ControlMerge`).
+///
+/// **Honest scope (peel):** `available` just assembles the menu (scheduled traversals + supplied map moves) — the
+/// *choice* among them is the policy layer (`ControlMerge`/`SoftDrive` + the intrinsic objective). `Move` is a
+/// raw game-action here; a higher-level "move toward attractor X" compiles to an action *sequence* via
+/// `StateSpace.recoverPlan` (a future slice). Deterministic (DST).
+[<RequireQualifiedAccess>]
+module MetaController =
+
+    /// A meta-action — the agent's own controller button: sense (a traversal) or act (a directional map move).
+    type MetaAction<'r> =
+        | Traverse of Traversal.Traversal<'r> // reduce out-of-window uncertainty (sense)
+        | Move of bool[] // a directional move in the map (act / transition)
+
+    /// **The agent's currently-available controller menu:** the top-k *affordable* traversals (scheduled by VOI
+    /// under `budget`) plus the directional `mapMoves` available from the current node. Context-dependent buttons.
+    let available (budget: float) (traversals: Traversal.Traversal<'r> list) (mapMoves: bool[] list) : MetaAction<'r> list =
+        (Traversal.schedule budget traversals |> List.map Traverse)
+        @ (mapMoves |> List.map Move)
+
+    /// The traversal (sense) options in a menu.
+    let senses (menu: MetaAction<'r> list) : Traversal.Traversal<'r> list =
+        menu
+        |> List.choose (function
+            | Traverse t -> Some t
+            | Move _ -> None)
+
+    /// The directional move (act) options in a menu.
+    let moves (menu: MetaAction<'r> list) : bool[] list =
+        menu
+        |> List.choose (function
+            | Move m -> Some m
+            | Traverse _ -> None)

--- a/tests/Tests.FSharp/MetaController.Tests.fs
+++ b/tests/Tests.FSharp/MetaController.Tests.fs
@@ -1,0 +1,37 @@
+module Zeta.Tests.MetaControllerTests
+
+open global.Xunit
+open Zeta.Core
+
+let private trav name cost reduction : Traversal.Traversal<int> =
+    { Name = name; Target = name; Cost = cost; Lenses = []; ExpectedReduction = reduction; Run = fun _ -> 0 }
+
+let private moves = [ SoftController.none; SoftController.singleKey 6 ]
+
+[<Fact>]
+let ``available assembles affordable traversals (by VOI) + the map moves`` () =
+    let cheap = trav "cheap" 2.0 10.0 // voi 5, fits budget 3
+    let costly = trav "costly" 5.0 5.0 // voi 1, would overflow budget 3
+    let menu = MetaController.available 3.0 [ costly; cheap ] moves
+    Assert.Equal(1, MetaController.senses menu |> List.length) // only the affordable traversal
+    Assert.Equal("cheap", (MetaController.senses menu |> List.head).Name)
+    Assert.Equal(2, MetaController.moves menu |> List.length) // both directional moves available
+
+[<Fact>]
+let ``senses and moves partition the menu`` () =
+    let menu = MetaController.available 100.0 [ trav "t" 1.0 1.0 ] moves
+    Assert.Equal(1, MetaController.senses menu |> List.length)
+    Assert.Equal(2, MetaController.moves menu |> List.length)
+    Assert.Equal(3, List.length menu) // 1 traverse + 2 moves
+
+[<Fact>]
+let ``zero budget -> only ambient (free) traversals, still all moves`` () =
+    let ambient = trav "ambient" 0.0 1.0
+    let costly = trav "costly" 1.0 5.0
+    let menu = MetaController.available 0.0 [ costly; ambient ] moves
+    Assert.Equal<string list>([ "ambient" ], MetaController.senses menu |> List.map (fun t -> t.Name))
+    Assert.Equal(2, MetaController.moves menu |> List.length)
+
+[<Fact>]
+let ``no traversals and no moves -> empty menu`` () =
+    Assert.Empty(MetaController.available 10.0 ([]: Traversal.Traversal<int> list) [])

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -140,6 +140,7 @@
     <Compile Include="MemoryLens.Tests.fs" />
     <Compile Include="LensRouter.Tests.fs" />
     <Compile Include="Traversal.Tests.fs" />
+    <Compile Include="MetaController.Tests.fs" />
     <Compile Include="Survival.Tests.fs" />
     <Compile Include="MemorySense.Tests.fs" />
     <Compile Include="SolidGround.Tests.fs" />


### PR DESCRIPTION
Aaron: the agent's Xbox controller = traversals + navigable map (not game buttons). MetaAction = Traverse (sense) | Move (act); available = top-k affordable traversals (VOI) + directional map moves = the context-dependent controller menu. 4/4 tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)