### PR TITLE
feat(core): Salience — observe.ts objective-integration + display reduction (window -> top-k)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -216,6 +216,7 @@
     <Compile Include="LensRouter.fs" />
     <Compile Include="Traversal.fs" />
     <Compile Include="MetaController.fs" />
+    <Compile Include="Salience.fs" />
     <Compile Include="Survival.fs" />
     <Compile Include="MemorySense.fs" />
     <Compile Include="SolidGround.fs" />

--- a/src/Core/Salience.fs
+++ b/src/Core/Salience.fs
@@ -1,0 +1,52 @@
+namespace Zeta.Core
+
+/// **`Salience` — observe.ts: where objectives come together, the agent chooses priority, and the window reduces to top-k (Aaron 2026-06-08, shadow*).**
+///
+/// Aaron: *"observe.ts is never the base buttons — it's the meta-level navigation, so it's simple for the agent.
+/// observe.ts has access to the entire context window so it can decide what to display and reduce it down to top-k
+/// most important to liveness, empowerment, uncertainty-reduction, etc… observe.ts is the place where different
+/// objectives come together and the agent chooses priority, among other things."*
+///
+/// So observe.ts is the **objective-integration + display-reduction** point. Each context item (a solid-ground
+/// fact, a lens, a `Traversal`, a map move, an anomaly) carries a **vector of per-objective relevances**
+/// (`Objectives : objective → relevance`); the **agent chooses the priority** as a weight vector
+/// (`priority : objective → weight`); the salience score is their dot product; the window reduces to the **top-k**
+/// the agent then steers (a salience-filtered `MetaController` menu). **Liveness keeps display priority** —
+/// liveness-critical items surface first regardless of score (subsumption, `ControlMerge`). The objective set is
+/// **open** ("etc.", "among other things"): liveness, empowerment, uncertainty-reduction/solid-ground-gain, score,
+/// and whatever future intrinsic ladders are added — they all come together here under the agent's chosen priority.
+///
+/// **Honest scope (peel):** the priority weights are *agent-chosen* (the point), not learned; score is a linear
+/// (dot-product) integration, not a learned combiner. Liveness is a hard priority tier (boolean `LivenessCritical`)
+/// — the strict "final say"; a graded survival-risk weight is a refinement. Deterministic (DST). Generalizes
+/// `LensRouter` (top-k lenses) to rank *all* heterogeneous context items under an open objective set.
+[<RequireQualifiedAccess>]
+module Salience =
+
+    /// A candidate context item with its per-objective relevances. `Payload` is what gets displayed/steered.
+    type Item<'a> =
+        { Payload: 'a
+          /// Liveness-critical items always surface first (subsumption — liveness has final say).
+          LivenessCritical: bool
+          /// objective name → this item's relevance to that objective (the open objective set).
+          Objectives: Map<string, float> }
+
+    /// The salience score = ⟨priority, objectives⟩ (dot product). The agent's chosen `priority` weights integrate
+    /// the open objective set; missing objectives score 0.
+    let score (priority: Map<string, float>) (item: Item<'a>) : float =
+        priority
+        |> Map.toSeq
+        |> Seq.sumBy (fun (obj, w) -> w * (Map.tryFind obj item.Objectives |> Option.defaultValue 0.0))
+
+    /// **Display reduction:** the whole context → the top-`k` payloads to show the agent, under the agent's chosen
+    /// `priority`. Liveness-critical items surface first (sorted among themselves by score), then the rest by
+    /// score; truncated to `k`. This is what observe.ts decides to display — the simple curated menu.
+    let display (k: int) (priority: Map<string, float>) (items: Item<'a> list) : 'a list =
+        let scored = items |> List.map (fun it -> it, score priority it)
+        let critical = scored |> List.filter (fst >> fun it -> it.LivenessCritical) |> List.sortByDescending snd
+        let rest = scored |> List.filter (fst >> fun it -> not it.LivenessCritical) |> List.sortByDescending snd
+        (critical @ rest) |> List.truncate (max 0 k) |> List.map (fun (it, _) -> it.Payload)
+
+    /// The full ranked order (liveness-critical first, then by score), no truncation — diagnostics.
+    let ranked (priority: Map<string, float>) (items: Item<'a> list) : 'a list =
+        display System.Int32.MaxValue priority items

--- a/tests/Tests.FSharp/Salience.Tests.fs
+++ b/tests/Tests.FSharp/Salience.Tests.fs
@@ -1,0 +1,42 @@
+module Zeta.Tests.SalienceTests
+
+open global.Xunit
+open Zeta.Core
+
+let private item name critical objs : Salience.Item<string> =
+    { Payload = name; LivenessCritical = critical; Objectives = Map.ofList objs }
+
+[<Fact>]
+let ``score is the dot product of agent priority and item objectives`` () =
+    let it = item "x" false [ "empowerment", 2.0; "uncertainty", 3.0 ]
+    let priority = Map.ofList [ "empowerment", 1.0; "uncertainty", 10.0 ] // agent prioritizes uncertainty
+    Assert.Equal(2.0 * 1.0 + 3.0 * 10.0, Salience.score priority it, 9)
+
+[<Fact>]
+let ``the agent's chosen priority changes what ranks highest`` () =
+    let a = item "a" false [ "empowerment", 10.0; "uncertainty", 0.0 ]
+    let b = item "b" false [ "empowerment", 0.0; "uncertainty", 10.0 ]
+    let empFirst = Salience.display 1 (Map.ofList [ "empowerment", 1.0 ]) [ a; b ]
+    let uncFirst = Salience.display 1 (Map.ofList [ "uncertainty", 1.0 ]) [ a; b ]
+    Assert.Equal<string list>([ "a" ], empFirst) // prioritize empowerment -> a
+    Assert.Equal<string list>([ "b" ], uncFirst) // prioritize uncertainty -> b
+
+[<Fact>]
+let ``liveness-critical items surface first regardless of score (subsumption)`` () =
+    let danger = item "danger" true [ "empowerment", 0.0; "uncertainty", 0.0 ] // low score but liveness-critical
+    let shiny = item "shiny" false [ "empowerment", 100.0; "uncertainty", 100.0 ] // high score, not critical
+    let top = Salience.display 1 (Map.ofList [ "empowerment", 1.0; "uncertainty", 1.0 ]) [ shiny; danger ]
+    Assert.Equal<string list>([ "danger" ], top) // liveness wins the display slot
+
+[<Fact>]
+let ``display reduces the whole window to top-k`` () =
+    let items = [ for i in 1..10 -> item (string i) false [ "u", float i ] ]
+    let top3 = Salience.display 3 (Map.ofList [ "u", 1.0 ]) items
+    Assert.Equal<string list>([ "10"; "9"; "8" ], top3)
+
+[<Fact>]
+let ``an open objective set: a new objective just adds a priority weight`` () =
+    let it = item "x" false [ "empowerment", 1.0; "score", 5.0; "novelty", 2.0 ]
+    // agent adds a 'novelty' ladder with weight 3 — integrates with no code change
+    let priority = Map.ofList [ "empowerment", 1.0; "score", 1.0; "novelty", 3.0 ]
+    Assert.Equal(1.0 + 5.0 + 6.0, Salience.score priority it, 9)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -141,6 +141,7 @@
     <Compile Include="LensRouter.Tests.fs" />
     <Compile Include="Traversal.Tests.fs" />
     <Compile Include="MetaController.Tests.fs" />
+    <Compile Include="Salience.Tests.fs" />
     <Compile Include="Survival.Tests.fs" />
     <Compile Include="MemorySense.Tests.fs" />
     <Compile Include="SolidGround.Tests.fs" />


### PR DESCRIPTION
Aaron: observe.ts = where objectives come together + agent chooses priority + reduce window to top-k. Salience: open objective vector per item, agent priority weights, dot-product score, top-k display, liveness-critical surfaces first (subsumption). 5/5 tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)