### PR TITLE
feat(core): GridBinding — homoiconic 4x4 controller (constant cells, context labels)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -217,6 +217,7 @@
     <Compile Include="Traversal.fs" />
     <Compile Include="MetaController.fs" />
     <Compile Include="Salience.fs" />
+    <Compile Include="GridBinding.fs" />
     <Compile Include="Survival.fs" />
     <Compile Include="MemorySense.fs" />
     <Compile Include="SolidGround.fs" />

--- a/src/Core/GridBinding.fs
+++ b/src/Core/GridBinding.fs
@@ -1,0 +1,76 @@
+namespace Zeta.Core
+
+/// **`GridBinding` — the homoiconic 4×4 controller: constant cells, context-dependent labels (Aaron 2026-06-08, shadow*).**
+///
+/// Aaron: *"our meta-action grammar and our action grammar are **homoiconic** — just like the Xbox dashboard vs
+/// games, they both use the **same controller layout (4×4 grid)** where the **cells have constant meaning but the
+/// labels change**."*
+///
+/// One physical controller, two grammars. The **4×4 grid** (`ActionGrammar` geometry) is the *invariant
+/// structure*; what each of the 16 cells *means* is a **context-dependent label**:
+///   - **game** (object level): cell → a CHIP-8 key (`GridBinding<int>` of key indices);
+///   - **dashboard / meta** (observe.ts): cell → a `MetaController.MetaAction` (a traversal or a map move).
+/// Same `GridBinding<'label>` type both ways. **Where the homoiconicity lives (Aaron):** it is the **index into
+/// the 4×4 grid and its *transforms*** — the `ActionGrammar` grid algebra (`ofGrid`/`toGrid` geometry, the lattice
+/// `join`/`meet`, neighbour/directional moves, the superposition) — that is *identical* in game space and meta/
+/// dashboard space. The same index transforms the same way regardless of what's labelled: "up is up", a cell's
+/// neighbours are its neighbours, whether the label is a game key or a meta-action. **Consistent like an Xbox
+/// controller** (the layout and how you move through it never change; only the labels do). The deeper sameness is
+/// that the index+transforms are shared — homoiconic at the *grammar* level, not just a shared type.
+/// **observe.ts populates the dashboard labels** by binding the **top-k salient** items (`Salience.display`) onto
+/// the cells — so the agent always faces the *same 16-slot controller*, re-labelled per context with what matters
+/// now (`bindSalient`).
+///
+/// **Honest scope (peel):** a fixed 16-cell grid (the CHIP-8 keypad shape); larger action sets must page/scroll
+/// or re-route via salience (top-16). `bind` returns a new grid (immutable copy). Geometry is row-major via
+/// `ActionGrammar.ofGrid`/`toGrid`. Deterministic (DST).
+[<RequireQualifiedAccess>]
+module GridBinding =
+
+    /// The grid is the 4×4 = 16-cell CHIP-8 keypad layout (the invariant structure).
+    [<Literal>]
+    let Size = 16
+
+    /// A binding of the 16 grid cells to labels of type `'label` (None = unbound). Cell index = the
+    /// `ActionGrammar` key index (row-major). Homoiconic: `'label` = key (game) or meta-action (dashboard).
+    type GridBinding<'label> = { Cells: 'label option[] }
+
+    /// The empty binding (no cell labelled).
+    let empty<'label> : GridBinding<'label> = { Cells = Array.create Size None }
+
+    /// Bind one cell to a label (returns a new grid). Out-of-range cell is ignored.
+    let bind (cell: int) (label: 'label) (g: GridBinding<'label>) : GridBinding<'label> =
+        if cell < 0 || cell >= Size then g
+        else
+            let c = Array.copy g.Cells
+            c.[cell] <- Some label
+            { Cells = c }
+
+    /// The label at a cell (None if unbound / out of range).
+    let labelAt (cell: int) (g: GridBinding<'label>) : 'label option =
+        if cell < 0 || cell >= Size then None else g.Cells.[cell]
+
+    /// The label at grid coord (row, col) — the 4×4 view.
+    let atGrid (row: int) (col: int) (g: GridBinding<'label>) : 'label option =
+        labelAt (ActionGrammar.ofGrid row col) g
+
+    /// Bind labels onto cells 0..15 in order (truncated to 16). The general "set the controller's labels".
+    let ofLabels (labels: 'label list) : GridBinding<'label> =
+        let c = Array.create Size None
+        labels |> List.truncate Size |> List.iteri (fun i l -> c.[i] <- Some l)
+        { Cells = c }
+
+    /// The bound cells as (cell, label) pairs.
+    let bound (g: GridBinding<'label>) : (int * 'label) list =
+        [ for i in 0 .. Size - 1 do
+              match g.Cells.[i] with
+              | Some l -> yield i, l
+              | None -> () ]
+
+    /// How many cells are labelled.
+    let count (g: GridBinding<'label>) : int = g.Cells |> Array.sumBy (fun c -> if Option.isSome c then 1 else 0)
+
+    /// **observe.ts populates the dashboard:** bind the top-k salient items (`Salience.display` under the agent's
+    /// `priority`) onto the grid cells — the same 16-slot controller, re-labelled with what matters now.
+    let bindSalient (k: int) (priority: Map<string, float>) (items: Salience.Item<'label> list) : GridBinding<'label> =
+        ofLabels (Salience.display (min k Size) priority items)

--- a/tests/Tests.FSharp/GridBinding.Tests.fs
+++ b/tests/Tests.FSharp/GridBinding.Tests.fs
@@ -1,0 +1,49 @@
+module Zeta.Tests.GridBindingTests
+
+open global.Xunit
+open Zeta.Core
+
+[<Fact>]
+let ``ofLabels binds cells in order; labelAt reads them back`` () =
+    let g = GridBinding.ofLabels [ "a"; "b"; "c" ]
+    Assert.Equal(Some "a", GridBinding.labelAt 0 g)
+    Assert.Equal(Some "b", GridBinding.labelAt 1 g)
+    Assert.Equal(None, GridBinding.labelAt 5 g)
+    Assert.Equal(3, GridBinding.count g)
+
+[<Fact>]
+let ``bind/labelAt roundtrip; out-of-range is ignored`` () =
+    let g = GridBinding.empty |> GridBinding.bind 7 "x" |> GridBinding.bind 99 "ignored"
+    Assert.Equal(Some "x", GridBinding.labelAt 7 g)
+    Assert.Equal(1, GridBinding.count g)
+
+[<Fact>]
+let ``atGrid uses the same 4x4 index transform as ActionGrammar (the homoiconic geometry)`` () =
+    // cell index 6 = grid (row 1, col 2) per ActionGrammar.ofGrid; the transform is shared
+    let g = GridBinding.bind (ActionGrammar.ofGrid 1 2) "here" GridBinding.empty
+    Assert.Equal(Some "here", GridBinding.atGrid 1 2 g)
+
+[<Fact>]
+let ``homoiconic: the SAME grid type/geometry labels game keys OR meta-actions`` () =
+    // game binding: cells -> key indices
+    let game: GridBinding.GridBinding<int> = GridBinding.ofLabels [ 0; 1; 2; 3 ]
+    // dashboard binding: cells -> meta-action labels (strings here) — same type, same index transforms
+    let dash: GridBinding.GridBinding<string> = GridBinding.ofLabels [ "traverse-x"; "move-up" ]
+    // cell 0 transforms identically in both spaces (the index is the invariant)
+    Assert.Equal(Some 0, GridBinding.labelAt 0 game)
+    Assert.Equal(Some "traverse-x", GridBinding.labelAt 0 dash)
+    Assert.Equal(GridBinding.atGrid 0 0 game |> Option.isSome, GridBinding.atGrid 0 0 dash |> Option.isSome)
+
+[<Fact>]
+let ``bindSalient lays the top-k salient items onto the controller (observe.ts dashboard)`` () =
+    let item p objs : Salience.Item<string> = { Payload = p; LivenessCritical = false; Objectives = Map.ofList objs }
+    let items = [ item "low" [ "u", 1.0 ]; item "high" [ "u", 9.0 ]; item "mid" [ "u", 5.0 ] ]
+    let g = GridBinding.bindSalient 2 (Map.ofList [ "u", 1.0 ]) items
+    Assert.Equal(2, GridBinding.count g)
+    Assert.Equal(Some "high", GridBinding.labelAt 0 g) // highest salience on the first cell
+    Assert.Equal(Some "mid", GridBinding.labelAt 1 g)
+
+[<Fact>]
+let ``ofLabels truncates to the 16-cell grid`` () =
+    let g = GridBinding.ofLabels [ for i in 1..30 -> string i ]
+    Assert.Equal(GridBinding.Size, GridBinding.count g)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -142,6 +142,7 @@
     <Compile Include="Traversal.Tests.fs" />
     <Compile Include="MetaController.Tests.fs" />
     <Compile Include="Salience.Tests.fs" />
+    <Compile Include="GridBinding.Tests.fs" />
     <Compile Include="Survival.Tests.fs" />
     <Compile Include="MemorySense.Tests.fs" />
     <Compile Include="SolidGround.Tests.fs" />


### PR DESCRIPTION
Aaron: meta + game grammars are homoiconic via the 4x4 grid index + its transforms (ActionGrammar = the universal controller interface). GridBinding<'label>: same type/index for game keys vs dashboard meta-actions; bindSalient = observe.ts lays the salient top-k on the controller. 6/6 tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)