### PR TITLE
feat(core): Hat — role-scoped bundle of the clarity engine (lenses/landmarks/restrictions/traversals/control)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -221,6 +221,7 @@
     <Compile Include="Survival.fs" />
     <Compile Include="MemorySense.fs" />
     <Compile Include="SolidGround.fs" />
+    <Compile Include="Hat.fs" />
     <Compile Include="ControlMerge.fs" />
     <Compile Include="PolarityFilter.fs" />
     <Compile Include="ZetaExec.fs" />

--- a/src/Core/Hat.fs
+++ b/src/Core/Hat.fs
@@ -1,0 +1,55 @@
+namespace Zeta.Core
+
+/// **`Hat` — a role-scoped bundle of the whole clarity engine (Aaron 2026-06-08, shadow*).**
+///
+/// Aaron: *"hats have **lenses**, **suggested landmarks for lens parameters**, **action restrictions**,
+/// **uncertainty-reduction traversals**, and **control of other hats/agents wearing those hats**."* A hat (a
+/// persona/role) is the engine, scoped to a role — every piece we built, packaged:
+///   - **`Lenses`** — the role's `LensRouter` views (what this role attends to);
+///   - **`Landmarks`** — suggested **solid ground** (`SolidGround`) the hat's lenses are parameterized by (the
+///     role's constants/clocks to navigate by);
+///   - **`AllowedActions`** — **action restrictions**: the permitted `ActionGrammar` subset (the role's
+///     authority/permissions; empty = unrestricted). Ties to standing-authorization / gated-classes governance;
+///   - **`Traversals`** — the role's uncertainty-reduction repertoire (`Traversal`s it can run);
+///   - **`Controls`** — names of other hats/agents this hat **controls/coordinates** (the architect-hat-orchestrates
+///     / delegation pattern; the meta-control edge).
+///
+/// Hats **compose** (qubit combinations of hats, #7140): a multi-agent fleet's joint state is the tensor of its
+/// agents' worn hats; a hat's `Controls` is the coordination edge between them. So the world-state clarity engine,
+/// the meta-controller, and the fleet are the same machinery viewed at the role layer.
+///
+/// **Honest scope (peel):** a hat is a *declarative bundle* — it says what the role attends to / may do / can run
+/// / controls; the *policy* (which lens/traversal/action to pick) is `Salience`/`MetaController`/`ControlMerge`
+/// under the intrinsic objective. `AllowedActions` is a structural allow-list (empty = unrestricted), not a proof
+/// of authority — real authorization stays the human-gated governance model. `Controls` is a name edge, not an
+/// enforcement mechanism. Deterministic (DST).
+[<RequireQualifiedAccess>]
+module Hat =
+
+    /// A role/persona bundle: lenses + landmarks + action restrictions + traversals + control edges.
+    type Hat<'r> =
+        { Name: string
+          Lenses: LensRouter.Lens list
+          /// Suggested solid-ground landmarks for lens parameters (cell → its ground kind).
+          Landmarks: (string * SolidGround.Ground) list
+          /// The permitted action subset (action restriction). Empty = unrestricted.
+          AllowedActions: bool[] list
+          /// The role's uncertainty-reduction traversals.
+          Traversals: Traversal.Traversal<'r> list
+          /// Names of other hats/agents this hat controls/coordinates.
+          Controls: string list }
+
+    /// Does this hat permit `action`? (Empty `AllowedActions` ⇒ unrestricted ⇒ always true.)
+    let permits (action: bool[]) (hat: Hat<'r>) : bool =
+        List.isEmpty hat.AllowedActions || List.contains action hat.AllowedActions
+
+    /// Filter a candidate action list to those this hat permits (the role's action restriction applied).
+    let restrict (actions: bool[] list) (hat: Hat<'r>) : bool[] list =
+        if List.isEmpty hat.AllowedActions then actions
+        else actions |> List.filter (fun a -> List.contains a hat.AllowedActions)
+
+    /// Does this hat control the named other hat/agent?
+    let controls (other: string) (hat: Hat<'r>) : bool = List.contains other hat.Controls
+
+    /// The solid-ground landmark cells this hat suggests as lens parameters (just the names).
+    let landmarkCells (hat: Hat<'r>) : string list = hat.Landmarks |> List.map fst

--- a/tests/Tests.FSharp/Hat.Tests.fs
+++ b/tests/Tests.FSharp/Hat.Tests.fs
@@ -1,0 +1,42 @@
+module Zeta.Tests.HatTests
+
+open global.Xunit
+open Zeta.Core
+
+let private k n = SoftController.singleKey n
+
+let private survivalHat: Hat.Hat<int> =
+    { Name = "survival"
+      Lenses = [ { LensRouter.Name = "pos"; LensRouter.Cells = [ "V0"; "V1" ] } ]
+      Landmarks = [ "I", SolidGround.Constant 512; "frame", SolidGround.Monotonic 1 ]
+      AllowedActions = [ SoftController.none; k 4; k 6 ] // may only idle / move L / move R
+      Traversals = []
+      Controls = [ "scout" ] }
+
+[<Fact>]
+let ``permits honors the action restriction (allow-list)`` () =
+    Assert.True(Hat.permits (k 4) survivalHat)
+    Assert.True(Hat.permits SoftController.none survivalHat)
+    Assert.False(Hat.permits (k 9) survivalHat) // not in the allow-list
+
+[<Fact>]
+let ``an empty allow-list is unrestricted`` () =
+    let open' = { survivalHat with AllowedActions = [] }
+    Assert.True(Hat.permits (k 9) open')
+
+[<Fact>]
+let ``restrict filters candidate actions to the permitted subset`` () =
+    let candidates = [ SoftController.none; k 4; k 6; k 9; k 2 ]
+    let allowed = Hat.restrict candidates survivalHat
+    Assert.Equal(3, List.length allowed) // none, k4, k6
+    Assert.DoesNotContain(k 9, allowed)
+
+[<Fact>]
+let ``controls is the coordination edge to other hats/agents`` () =
+    Assert.True(Hat.controls "scout" survivalHat)
+    Assert.False(Hat.controls "auditor" survivalHat)
+
+[<Fact>]
+let ``a hat bundles lenses + landmarks (the role-scoped engine)`` () =
+    Assert.Equal<string list>([ "pos" ], survivalHat.Lenses |> List.map (fun l -> l.Name))
+    Assert.Equal<string list>([ "I"; "frame" ], Hat.landmarkCells survivalHat)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -143,6 +143,7 @@
     <Compile Include="MetaController.Tests.fs" />
     <Compile Include="Salience.Tests.fs" />
     <Compile Include="GridBinding.Tests.fs" />
+    <Compile Include="Hat.Tests.fs" />
     <Compile Include="Survival.Tests.fs" />
     <Compile Include="MemorySense.Tests.fs" />
     <Compile Include="SolidGround.Tests.fs" />


### PR DESCRIPTION
Aaron: hats = lenses + landmark lens-params + action restrictions + uncertainty-reduction traversals + control of other hats. Hat<'r> bundles the role-scoped engine; permits/restrict/controls/landmarkCells. 5/5 tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)