### PR TITLE
docs(research): the method — unsubjective categorization of real intelligent systems (DevOps as ground truth)

### DIFF
--- a/docs/research/2026-06-08-method-unsubjective-categorization-of-real-intelligent-systems-devops-as-ground-truth.md
+++ b/docs/research/2026-06-08-method-unsubjective-categorization-of-real-intelligent-systems-devops-as-ground-truth.md
@@ -1,0 +1,52 @@
+# Method: unsubjective categorization of what exists in real intelligent systems (DevOps as ground truth)
+
+*Captured 2026-06-08 from Aaron (shadow*). The epistemic frame behind the whole soft-emulator → clarity-engine →
+DevOps-hat arc (#7086–#7141). Read every research doc in that arc through this lens.*
+
+## The method
+
+Aaron: *"we have all this **without any objectives yet** — I'm trying to **leave subjectiveness out of it** and
+just **categorize things that exist that are obviously there in real intelligent systems** like DevOps, because
+**that is frontier for me, it's my job**."*
+
+The work is **descriptive, not prescriptive**. It does not impose a chosen objective/reward and optimize it; it
+**names the categories that already exist** in any system that stays alive and clarifies its world:
+
+- liveness / heartbeat · lenses · solid ground (constants + monotonic landmarks) · coincidence · traversals ·
+  attractors + reachability · observability (ranges/seasons/anomaly) · the controller · hats · priority/salience.
+
+Even the "intrinsic objective" (liveness + empowerment + solid-ground gain) is **not a subjective goal** — it is
+the *structure that is already there*, named. That is why the arc cohered **without a game or a score**: the
+categories stand on their own.
+
+## Why DevOps is the ground truth
+
+DevOps is a **real, operating intelligent system** — people + tools keeping complex systems alive under
+uncertainty — and it is **Aaron's frontier / his job**, so it is the reality check he cannot fool himself about.
+The test of a category: **if it does not appear in real DevOps, it is suspect; if it does, it is grounded.** Every
+category we named appears there (uptime, dashboards, alerts, incident probes, personas, DORA), so the emulator and
+DevOps are **two instances of the same objective categories** — each cross-validates the other.
+
+## Why this is the right discipline (and what it buys)
+
+- **It is the honest-registers / anchor-to-human-prior-art discipline made into a method:** a coined term does not
+  stand unless it names something demonstrably present (Mirror→Beacon; proven vs conjecture; cite the human + the
+  prior art; peel the hype). "Leave subjectiveness out" = exactly that gate.
+- **Taxonomy before objective; structure before reward.** Categorize what exists *first*; only then (optionally)
+  choose an objective over those categories. The objective is a later, separable, agent-chosen layer (`Salience`
+  priority), never baked into the substrate.
+- **Alignment-relevant:** an *unsubjective category* cannot be Goodharted the way a *chosen reward* can — there is
+  no human-preference proxy in the substrate to game. (Route to Sova alongside the intrinsic-objective doc.)
+
+## How to read the arc
+
+Treat the research docs (#7093–#7141: clarity engine, observe.ts, the intrinsic objective, controller-qubit,
+hats, the DevOps-hat-testbed) as **a taxonomy of real intelligent-system categories, validated against DevOps and
+made provable on a one-hand machine (CHIP-8)** — not as a proposed reward function. The emulator is the taxonomy
+*demonstrated*; DevOps is the taxonomy *in the wild*.
+
+## Pointers
+
+- The whole arc's docs (`docs/research/2026-06-08-*`), esp. the intrinsic-objective doc (the categories as an
+  objective only *if* an agent chooses to), the DevOps-hat mapping, and `Hat.fs`/`Salience.fs` (objective as a
+  separable agent-chosen layer). `docs/ALIGNMENT.md` (unsubjective-category angle → Sova).


### PR DESCRIPTION
Aaron's epistemic frame for the whole arc: descriptive not prescriptive — categorize what objectively exists in real intelligent systems (DevOps = ground truth + his frontier), no imposed reward. Taxonomy before objective; the intrinsic objective is structure already there, named. The honest-registers discipline as method; alignment-relevant (unsubjective categories can't be Goodharted). 🤖 Generated with [Claude Code](https://claude.com/claude-code)