### PR TITLE
feat(core): Hat.Scope — personas (meta-surviving, all games) vs game-specific hats

### DIFF
--- a/src/Core/Hat.fs
+++ b/src/Core/Hat.fs
@@ -26,9 +26,18 @@ namespace Zeta.Core
 [<RequireQualifiedAccess>]
 module Hat =
 
-    /// A role/persona bundle: lenses + landmarks + action restrictions + traversals + control edges.
+    /// A hat's scope (Aaron 2026-06-08): most hats are **game-specific** (scoped to one game/task); some **survive
+    /// into the meta** — those are **personas**: general, cross-game, can play *all* games. Personas = the
+    /// meta-surviving hats; game-specific hats are ephemeral, scoped to their game.
+    type Scope =
+        | GameSpecific // scoped to one game/task (many hats)
+        | Meta // survives into the meta = a persona (plays all games)
+
+    /// A role/persona bundle: lenses + landmarks + action restrictions + traversals + control edges + scope.
     type Hat<'r> =
         { Name: string
+          /// Game-specific, or Meta (a persona that survives into the meta and plays all games).
+          Scope: Scope
           Lenses: LensRouter.Lens list
           /// Suggested solid-ground landmarks for lens parameters (cell → its ground kind).
           Landmarks: (string * SolidGround.Ground) list
@@ -38,6 +47,16 @@ module Hat =
           Traversals: Traversal.Traversal<'r> list
           /// Names of other hats/agents this hat controls/coordinates.
           Controls: string list }
+
+    /// Is this hat a **persona** — meta-surviving, plays all games?
+    let isPersona (hat: Hat<'r>) : bool = hat.Scope = Meta
+
+    /// The personas (meta-surviving hats) among a set.
+    let personas (hats: Hat<'r> list) : Hat<'r> list = hats |> List.filter isPersona
+
+    /// The game-specific hats among a set.
+    let gameSpecific (hats: Hat<'r> list) : Hat<'r> list =
+        hats |> List.filter (fun h -> h.Scope = GameSpecific)
 
     /// Does this hat permit `action`? (Empty `AllowedActions` ⇒ unrestricted ⇒ always true.)
     let permits (action: bool[]) (hat: Hat<'r>) : bool =

--- a/tests/Tests.FSharp/Hat.Tests.fs
+++ b/tests/Tests.FSharp/Hat.Tests.fs
@@ -7,11 +7,20 @@ let private k n = SoftController.singleKey n
 
 let private survivalHat: Hat.Hat<int> =
     { Name = "survival"
+      Scope = Hat.Meta // survival is a persona — it plays all games
       Lenses = [ { LensRouter.Name = "pos"; LensRouter.Cells = [ "V0"; "V1" ] } ]
       Landmarks = [ "I", SolidGround.Constant 512; "frame", SolidGround.Monotonic 1 ]
       AllowedActions = [ SoftController.none; k 4; k 6 ] // may only idle / move L / move R
       Traversals = []
       Controls = [ "scout" ] }
+
+[<Fact>]
+let ``personas are meta-surviving hats (play all games); game-specific hats are scoped`` () =
+    let scout = { survivalHat with Name = "brick-scout"; Scope = Hat.GameSpecific } // a one-game hat
+    Assert.True(Hat.isPersona survivalHat) // survival survives into the meta
+    Assert.False(Hat.isPersona scout) // game-specific
+    Assert.Equal<string list>([ "survival" ], Hat.personas [ survivalHat; scout ] |> List.map (fun h -> h.Name))
+    Assert.Equal<string list>([ "brick-scout" ], Hat.gameSpecific [ survivalHat; scout ] |> List.map (fun h -> h.Name))
 
 [<Fact>]
 let ``permits honors the action restriction (allow-list)`` () =


### PR DESCRIPTION
Aaron: personas = meta-surviving hats (play all games); many hats are game-specific, some promote to meta. Hat.Scope = GameSpecific | Meta; isPersona/personas/gameSpecific. 6/6 tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)