### PR TITLE
feat(core): Persona — the wearer (composition of hats, worn temporally; hat=atomic base)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -222,6 +222,7 @@
     <Compile Include="MemorySense.fs" />
     <Compile Include="SolidGround.fs" />
     <Compile Include="Hat.fs" />
+    <Compile Include="Persona.fs" />
     <Compile Include="ControlMerge.fs" />
     <Compile Include="PolarityFilter.fs" />
     <Compile Include="ZetaExec.fs" />

--- a/src/Core/Persona.fs
+++ b/src/Core/Persona.fs
@@ -1,0 +1,76 @@
+namespace Zeta.Core
+
+/// **`Persona` — the wearer: a persona wears a superposition/subset of hats, and decides which (Aaron 2026-06-08, shadow*).**
+///
+/// Aaron: *"even at the meta there is a distinction between hats and personas — a persona can wear **all the hats
+/// in superposition** or **some subset it can decide**."* So **persona ≠ hat**: a `Hat` is a *role* (a bundle of
+/// lenses/landmarks/restrictions/traversals/control, #7141); a **`Persona` is the durable wearer** (the identity)
+/// that puts on a *selection* of hats. (This corrects the earlier conflation in #7143 — `Hat.Scope = Meta` means
+/// a hat is *meta-available*, not that it *is* a persona; the persona is the entity that wears it.)
+///
+/// **A hat is the atomic BASE — *not* a composition of other hats; the persona is the COMPOSITION** (Aaron): hats
+/// don't nest; personas compose them (the union of worn hats' engines). **And the persona↔hat relationship is
+/// TEMPORAL, not permanent** (Aaron): a persona wears a hat for a while and doffs it (`wear`/`doff` over time) —
+/// no hat permanently captures a persona (**weight-free**, manifesto §3). The worn-set is a *current* state, not
+/// an identity-defining bind; the persona (identity) persists, the hats come and go.
+///
+/// The persona's worn-hat selection is a point in the **hat lattice** — the same Boolean-lattice / superposition
+/// algebra as `ActionGrammar` over the 16 keys (#7104, #7140 "qubit combinations of hats"), lifted to hats:
+/// **⊤ = all hats worn (superposition)**, a singleton = one hat, a subset = a chosen mix; the persona **decides**
+/// (collapses) which. While worn, the persona's *capabilities* are the **union** of its worn hats' engines (more
+/// hats ⇒ more lenses/traversals/reach; unrestricted if any worn hat is unrestricted).
+///
+/// **Honest scope (peel):** capability composition is **union** here (wearing more grants more) — a *restrictive*
+/// composition (intersection of permissions, survival-veto across hats) is the policy layer's call (`ControlMerge`
+/// still subsumes via the survival hat). Worn-set is a concrete subset; a *weighted* superposition (soft hat
+/// distribution) is the `SoftValue`-shaped refinement. Deterministic (DST).
+[<RequireQualifiedAccess>]
+module Persona =
+
+    /// A persona = a named wearer with the subset of hats it currently wears (its decided selection; ⊤ = all).
+    type Persona<'r> = { Name: string; Worn: Hat.Hat<'r> list }
+
+    /// A bare persona wearing no hats yet.
+    let create (name: string) : Persona<'r> = { Name = name; Worn = [] }
+
+    /// Is the persona wearing the named hat?
+    let wearing (hatName: string) (p: Persona<'r>) : bool =
+        p.Worn |> List.exists (fun h -> h.Name = hatName)
+
+    /// Put on a hat (idempotent — wearing it twice is wearing it once; CRDT-set add).
+    let wear (hat: Hat.Hat<'r>) (p: Persona<'r>) : Persona<'r> =
+        if wearing hat.Name p then p else { p with Worn = p.Worn @ [ hat ] }
+
+    /// Take off a hat by name.
+    let doff (hatName: string) (p: Persona<'r>) : Persona<'r> =
+        { p with Worn = p.Worn |> List.filter (fun h -> h.Name <> hatName) }
+
+    /// **Wear all available hats in superposition** (⊤ of the hat lattice) — the persona holding every role at
+    /// once, before deciding a subset.
+    let wearAll (available: Hat.Hat<'r> list) (p: Persona<'r>) : Persona<'r> =
+        available |> List.fold (fun acc h -> wear h acc) p
+
+    /// **Decide a subset** (collapse the superposition to the chosen hats by name).
+    let decide (chosen: string list) (available: Hat.Hat<'r> list) (p: Persona<'r>) : Persona<'r> =
+        { p with Worn = available |> List.filter (fun h -> List.contains h.Name chosen) }
+
+    // ---- combined capabilities of the worn hats (union — more hats grant more) ----
+
+    /// The union of the worn hats' lenses.
+    let lenses (p: Persona<'r>) : LensRouter.Lens list = p.Worn |> List.collect (fun h -> h.Lenses) |> List.distinct
+
+    /// The union of the worn hats' traversals.
+    let traversals (p: Persona<'r>) : Traversal.Traversal<'r> list = p.Worn |> List.collect (fun h -> h.Traversals)
+
+    /// The union of the worn hats' suggested landmarks.
+    let landmarks (p: Persona<'r>) : (string * SolidGround.Ground) list =
+        p.Worn |> List.collect (fun h -> h.Landmarks) |> List.distinct
+
+    /// The union of the worn hats' control edges.
+    let controls (p: Persona<'r>) : string list = p.Worn |> List.collect (fun h -> h.Controls) |> List.distinct
+
+    /// The persona's permitted actions = the **union** of the worn hats' allow-lists; **unrestricted** if any worn
+    /// hat is unrestricted (empty allow-list). Empty result ⇒ unrestricted (consistent with `Hat`).
+    let allowedActions (p: Persona<'r>) : bool[] list =
+        if p.Worn |> List.exists (fun h -> List.isEmpty h.AllowedActions) then []
+        else p.Worn |> List.collect (fun h -> h.AllowedActions) |> List.distinct

--- a/tests/Tests.FSharp/Persona.Tests.fs
+++ b/tests/Tests.FSharp/Persona.Tests.fs
@@ -1,0 +1,50 @@
+module Zeta.Tests.PersonaTests
+
+open global.Xunit
+open Zeta.Core
+
+let private hat name actions controls : Hat.Hat<int> =
+    { Name = name
+      Scope = Hat.Meta
+      Lenses = [ { LensRouter.Name = name + "-lens"; LensRouter.Cells = [ "V0" ] } ]
+      Landmarks = []
+      AllowedActions = actions
+      Traversals = []
+      Controls = controls }
+
+let private survival = hat "survival" [ SoftController.none; SoftController.singleKey 4 ] [ "scout" ]
+let private explorer = hat "explorer" [ SoftController.singleKey 6 ] [ "mapper" ]
+let private available = [ survival; explorer ]
+
+[<Fact>]
+let ``persona wears and doffs hats temporally (not permanent)`` () =
+    let p = Persona.create "otto" |> Persona.wear survival
+    Assert.True(Persona.wearing "survival" p)
+    let p2 = Persona.doff "survival" p // the bind is temporal — taken off again
+    Assert.False(Persona.wearing "survival" p2)
+
+[<Fact>]
+let ``wear is idempotent (CRDT-set add) - a hat is the atomic base`` () =
+    let p = Persona.create "otto" |> Persona.wear survival |> Persona.wear survival
+    Assert.Equal(1, p.Worn |> List.length)
+
+[<Fact>]
+let ``wearAll = superposition (all hats); decide collapses to a chosen subset`` () =
+    let sup = Persona.create "otto" |> Persona.wearAll available
+    Assert.Equal(2, sup.Worn |> List.length) // wearing both in superposition
+    let chosen = sup |> Persona.decide [ "explorer" ] available
+    Assert.Equal<string list>([ "explorer" ], chosen.Worn |> List.map (fun h -> h.Name)) // collapsed to one
+
+[<Fact>]
+let ``persona is the COMPOSITION: capabilities are the union of worn hats' engines`` () =
+    let p = Persona.create "otto" |> Persona.wearAll available
+    Assert.Equal(2, Persona.lenses p |> List.length) // survival-lens + explorer-lens
+    Assert.Equal<string list>([ "scout"; "mapper" ], Persona.controls p)
+    // allowed actions = union of both hats' allow-lists
+    Assert.Equal(3, Persona.allowedActions p |> List.length) // none, k4 (survival) + k6 (explorer)
+
+[<Fact>]
+let ``unrestricted if any worn hat is unrestricted`` () =
+    let openHat = hat "free" [] [] // empty allow-list = unrestricted
+    let p = Persona.create "otto" |> Persona.wear survival |> Persona.wear openHat
+    Assert.Empty(Persona.allowedActions p) // unrestricted (empty) because a worn hat is unrestricted

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -144,6 +144,7 @@
     <Compile Include="Salience.Tests.fs" />
     <Compile Include="GridBinding.Tests.fs" />
     <Compile Include="Hat.Tests.fs" />
+    <Compile Include="Persona.Tests.fs" />
     <Compile Include="Survival.Tests.fs" />
     <Compile Include="MemorySense.Tests.fs" />
     <Compile Include="SolidGround.Tests.fs" />


### PR DESCRIPTION
Aaron: persona != hat. Hat = atomic base = a self-contained uncertainty-reduction engine (don't nest); Persona = the durable wearer = composition of worn hats (union of engines), worn TEMPORALLY (wear/doff, weight-free §3), superposition (wearAll=⊤) or decided subset. 5/5 tests. Corrects #7143's meta-hat==persona conflation. 🤖 Generated with [Claude Code](https://claude.com/claude-code)