### PR TITLE
docs(research): NCI is objectively required — coercion collapses diversity, crushing learning

### DIFF
--- a/docs/research/2026-06-08-non-coercion-invariant-bounds-the-uncertainty-reduction-engine.md
+++ b/docs/research/2026-06-08-non-coercion-invariant-bounds-the-uncertainty-reduction-engine.md
@@ -43,6 +43,34 @@ the engine stays the same; NCI is the guard on *cross-agent* traversals. (Altern
 budget even within one machine's memory — a region invisible to outside observers, incl. the DST harness's
 omniscient view, #7125 — which would also bound the *test-time omniscient observer*. Undecided.)
 
+## Why the pathology is *objective*: it collapses diversity, which crushes learning (Aaron 2026-06-08)
+
+Aaron: *"it's pathological from a **diversity** perspective — without it **all hats and personas collapse to one**,
+over time… so this pathological definition is **objective**, based on it **crushing the thing we are trying to do —
+learn**."*
+
+The argument, and it needs no morality:
+
+1. **Without NCI, diversity collapses to one.** Mutual *coercive* observability lets every agent reduce its
+   uncertainty about every other; over time all converge to the same state/knowledge/behaviour — **all hats and
+   personas collapse to a single one** (monoculture). Private state (the encryption budget) is the independent
+   variation that keeps personas *distinct*; remove it and the variation drains out.
+2. **Collapsed diversity crushes learning.** The climb is **solid-ground gain** (#7132/#7142) — turning what's
+   unknown into navigable structure. When everyone has collapsed to one, there is **no new solid ground anyone
+   doesn't already hold**: gain → 0, the redundant lens-towers (#7132 "if one crumbles others hold") have nothing
+   left to differ on, and **learning stops**. Monoculture is a learning dead-end.
+3. **Therefore NCI is *objectively* required — derived, not imposed.** The pathology is defined *unsubjectively*:
+   it is bad because it **destroys the system's own function (learning)**, not because a human disapproves. So
+   **non-coercion is instrumentally necessary for continued learning** — the agent must respect others' private
+   state *to keep itself able to learn*. The safety constraint falls out of the objective (the #7142 method applied
+   to safety itself): you don't bolt on "don't coerce" as a rule; coercion is self-defeating.
+
+This is the alignment keystone of the arc: **the agent has an *intrinsic, unsubjective* reason not to coerce** —
+coercion collapses the diversity that is the fuel of its own learning. Anchors: weight-free §3 (no capture →
+no collapse), scale-free §1 (no central monoculture), ensemble/population diversity (variation requires
+isolation; panmixia homogenizes), information-theoretic distinguishability (private state = the independent
+entropy that keeps agents distinct).
+
 ## The cohered safety statement
 
 The unsubjective objective (liveness + empowerment + solid-ground gain) is safe **iff** bounded by **NCI**:


### PR DESCRIPTION
Aaron: the pathology is objective — coercion collapses hats/personas to one (monoculture), which crushes learning (no new solid ground = gain->0). So NCI is DERIVED not imposed: non-coercion is instrumentally necessary for the agent's own continued learning (the #7142 method applied to safety). The alignment keystone. 🤖 Generated with [Claude Code](https://claude.com/claude-code)