### PR TITLE
feat(core): Diversity — math of the NCI keystone (coercion collapse vs private-state preservation)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -223,6 +223,7 @@
     <Compile Include="SolidGround.fs" />
     <Compile Include="Hat.fs" />
     <Compile Include="Persona.fs" />
+    <Compile Include="Diversity.fs" />
     <Compile Include="ControlMerge.fs" />
     <Compile Include="PolarityFilter.fs" />
     <Compile Include="ZetaExec.fs" />

--- a/src/Core/Diversity.fs
+++ b/src/Core/Diversity.fs
@@ -1,0 +1,59 @@
+namespace Zeta.Core
+
+/// **`Diversity` — the math of the NCI keystone: coercion collapses diversity to one; private state preserves it (Aaron 2026-06-08, shadow*).**
+///
+/// Makes #7146 *provable*. The claim: uncertainty-reduction *without* non-coercion is objectively pathological
+/// because **mutual coercive observability collapses a population to one** (monoculture) — which crushes learning
+/// (no new solid ground anyone lacks ⇒ gain → 0). Private state (the NCI encryption budget) is the independent
+/// variation that **keeps the population distinct**. This module is the measures + the dynamics that show it.
+///
+/// Measures: `distinct` (how many states survive) and `entropy` (Shannon, nats — the information-theoretic
+/// diversity). Dynamics: `coerciveStep` (every agent copies the majority public state — one homogenizing round
+/// under full observability) drives both to their floor (distinct → 1, entropy → 0). `combinedDistinct` shows
+/// that with a retained **private** component, agents stay distinguishable even after their *public* state has
+/// fully converged — diversity preserved by NCI.
+///
+/// **Honest scope (peel):** `coerciveStep` is the strongest homogenizer (copy-the-majority) — a clean upper bound
+/// on collapse, not a model of every convergence dynamic. Entropy is over the empirical distribution of exactly-
+/// equal states (a coarse, exact-match diversity); a metric/feature diversity is a refinement. Generic over any
+/// state with equality. Deterministic (DST).
+[<RequireQualifiedAccess>]
+module Diversity =
+
+    /// Number of distinct states in the population (the coarsest diversity — 1 = collapsed).
+    let distinct (xs: 'a list) : int = xs |> List.distinct |> List.length
+
+    /// **Shannon entropy** (nats) of the population's empirical state distribution — 0 = all identical (collapsed),
+    /// higher = more diverse. The information-theoretic diversity measure.
+    let entropy (xs: 'a list) : float =
+        match xs with
+        | [] -> 0.0
+        | _ ->
+            let n = float (List.length xs)
+            xs
+            |> List.countBy id
+            |> List.sumBy (fun (_, c) ->
+                let p = float c / n
+                if p <= 0.0 then 0.0 else -p * log p)
+
+    /// **One coercive homogenizing round:** under full (coerced) observability every agent copies the *majority*
+    /// public state. The strongest collapse step.
+    let coerciveStep (xs: 'a list) : 'a list =
+        match xs with
+        | [] -> []
+        | _ ->
+            let majority = xs |> List.countBy id |> List.maxBy snd |> fst
+            xs |> List.map (fun _ -> majority)
+
+    /// Run `rounds` coercive rounds — the population collapses toward a single state (monoculture).
+    let coerciveConverge (rounds: int) (xs: 'a list) : 'a list =
+        let mutable cur = xs
+        for _ in 1 .. max 0 rounds do
+            cur <- coerciveStep cur
+        cur
+
+    /// **Diversity surviving when each agent keeps a private component:** distinct count of the *combined*
+    /// (public, private) states. Even if `publics` have fully converged, distinct `privates` keep agents
+    /// distinguishable — NCI's encryption budget preserving diversity. Lists must be the same length.
+    let combinedDistinct (publics: 'a list) (privates: 'b list) : int =
+        List.zip publics privates |> List.distinct |> List.length

--- a/tests/Tests.FSharp/Diversity.Tests.fs
+++ b/tests/Tests.FSharp/Diversity.Tests.fs
@@ -1,0 +1,35 @@
+module Zeta.Tests.DiversityTests
+
+open System
+open global.Xunit
+open Zeta.Core
+
+[<Fact>]
+let ``distinct and entropy: uniform is max diversity, all-equal is zero`` () =
+    Assert.Equal(3, Diversity.distinct [ "a"; "b"; "c" ])
+    Assert.Equal(1, Diversity.distinct [ "a"; "a"; "a" ])
+    Assert.Equal(0.0, Diversity.entropy [ "a"; "a"; "a" ], 9) // collapsed -> 0
+    Assert.Equal(log 3.0, Diversity.entropy [ "a"; "b"; "c" ], 9) // uniform over 3 -> ln 3
+
+[<Fact>]
+let ``coercive observability collapses the population to ONE (entropy -> 0)`` () =
+    let pop = [ "a"; "a"; "b"; "c" ] // majority a
+    let collapsed = Diversity.coerciveConverge 1 pop
+    Assert.Equal(1, Diversity.distinct collapsed) // one round of copy-the-majority -> monoculture
+    Assert.Equal(0.0, Diversity.entropy collapsed, 9)
+    Assert.True(Diversity.entropy pop > Diversity.entropy collapsed) // diversity strictly destroyed
+
+[<Fact>]
+let ``private state preserves diversity even after public state fully converges (NCI)`` () =
+    // publics collapse to one; privates stay distinct -> combined population stays diverse
+    let publics = Diversity.coerciveConverge 5 [ "x"; "y"; "z" ] // -> all the same public
+    Assert.Equal(1, Diversity.distinct publics)
+    let privates = [ 1; 2; 3 ] // each agent's private encryption budget — distinct
+    Assert.Equal(3, Diversity.combinedDistinct publics privates) // diversity preserved by NCI
+    Assert.True(Diversity.combinedDistinct publics privates > Diversity.distinct publics)
+
+[<Fact>]
+let ``without private state, combined distinct = public distinct (collapse stands)`` () =
+    let publics = [ "a"; "a"; "a" ]
+    let noPrivate = [ (); (); () ] // no distinguishing private component
+    Assert.Equal(1, Diversity.combinedDistinct publics noPrivate) // still collapsed

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -145,6 +145,7 @@
     <Compile Include="GridBinding.Tests.fs" />
     <Compile Include="Hat.Tests.fs" />
     <Compile Include="Persona.Tests.fs" />
+    <Compile Include="Diversity.Tests.fs" />
     <Compile Include="Survival.Tests.fs" />
     <Compile Include="MemorySense.Tests.fs" />
     <Compile Include="SolidGround.Tests.fs" />


### PR DESCRIPTION
Makes #7146 provable: distinct/entropy measures; coerciveStep/coerciveConverge collapse to one (entropy->0); combinedDistinct shows private state preserves diversity after public convergence (NCI). 4/4 tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)