### PR TITLE
feat(core): Persona private state + MoE-over-hats + flags-enum identity + overfitting lever

### DIFF
--- a/src/Core/Persona.fs
+++ b/src/Core/Persona.fs
@@ -27,11 +27,20 @@ namespace Zeta.Core
 [<RequireQualifiedAccess>]
 module Persona =
 
-    /// A persona = a named wearer with the subset of hats it currently wears (its decided selection; ⊤ = all).
-    type Persona<'r> = { Name: string; Worn: Hat.Hat<'r> list }
+    /// A persona = a named wearer with the subset of hats it currently wears (its decided selection; ⊤ = all),
+    /// plus its **private state** (the NCI encryption budget). **Only personas carry private state** (Aaron
+    /// 2026-06-08): a `Hat` is a *public, shareable* atomic engine (many personas can wear the same hat — sharing
+    /// engines collapses nothing); it is the **personas (identities)** that must stay distinct to keep entropy in
+    /// the system (#7147), so the entropy-preserving private state lives here, not on the hat. `Private` is opaque
+    /// bytes (encrypt via `Crypto.fs`; temporal/erasable/voluntary per §6) — the independent variation that keeps
+    /// this persona distinguishable from others even when worn hats coincide.
+    type Persona<'r> = { Name: string; Worn: Hat.Hat<'r> list; Private: byte[] }
 
-    /// A bare persona wearing no hats yet.
-    let create (name: string) : Persona<'r> = { Name = name; Worn = [] }
+    /// A bare persona wearing no hats and holding no private state yet.
+    let create (name: string) : Persona<'r> = { Name = name; Worn = []; Private = [||] }
+
+    /// Set the persona's private state (the entropy budget). Erasable (pass `[||]`) per §6.
+    let withPrivate (priv: byte[]) (p: Persona<'r>) : Persona<'r> = { p with Private = priv }
 
     /// Is the persona wearing the named hat?
     let wearing (hatName: string) (p: Persona<'r>) : bool =
@@ -69,8 +78,28 @@ module Persona =
     /// The union of the worn hats' control edges.
     let controls (p: Persona<'r>) : string list = p.Worn |> List.collect (fun h -> h.Controls) |> List.distinct
 
+    /// **MoE is over HATS, not personas (Aaron):** the experts are *hats* (atomic engines); the persona is the
+    /// *gated composition* of selected hats. `route` is that gate — score each available hat by `relevance` and
+    /// wear the **top-k** (the sparse MoE gate over hats). "MoE personas" is the incomplete definition; the mixture
+    /// is over hats, and a persona is the result of the gate. Ties to `LensRouter` (MoE over lenses), one level up.
+    let route (relevance: Hat.Hat<'r> -> float) (k: int) (available: Hat.Hat<'r> list) (p: Persona<'r>) : Persona<'r> =
+        { p with Worn = available |> List.sortByDescending (fun h -> relevance h, h.Name) |> List.truncate (max 0 k) }
+
     /// The persona's permitted actions = the **union** of the worn hats' allow-lists; **unrestricted** if any worn
     /// hat is unrestricted (empty allow-list). Empty result ⇒ unrestricted (consistent with `Hat`).
     let allowedActions (p: Persona<'r>) : bool[] list =
         if p.Worn |> List.exists (fun h -> List.isEmpty h.AllowedActions) then []
         else p.Worn |> List.collect (fun h -> h.AllowedActions) |> List.distinct
+
+    /// **The flags-enum identity (Aaron):** the worn hats as a bitset over the `universe` (bit i set ⇔ wearing
+    /// `universe.[i]`). *Without private state, a persona's identity is limited to this* — the **combinatorial of
+    /// hat-wearing, `2^N` values, like a `[Flags]` enum** — finite and collapsible. **Private state breaks identity
+    /// out of that finite combinatorial** into the unbounded. (≤ 31 hats fits an `int`.)
+    let hatFlags (universe: Hat.Hat<'r> list) (p: Persona<'r>) : int =
+        universe |> List.mapi (fun i h -> if wearing h.Name p then 1 <<< i else 0) |> List.sum
+
+    /// **Private state is the overfitting lever (Aaron):** *more* private state ⇒ *less* overfitting + *more*
+    /// entropy (the persona generalizes across games — entropy = regularization); *less* private state ⇒ *more*
+    /// overfitting to a specific game (identity collapses toward that game's `hatFlags`). This returns the size of
+    /// the private budget — a proxy for the regularization strength (0 = pure flags-enum identity = max overfit).
+    let regularization (p: Persona<'r>) : int = p.Private.Length

--- a/tests/Tests.FSharp/Persona.Tests.fs
+++ b/tests/Tests.FSharp/Persona.Tests.fs
@@ -44,7 +44,43 @@ let ``persona is the COMPOSITION: capabilities are the union of worn hats' engin
     Assert.Equal(3, Persona.allowedActions p |> List.length) // none, k4 (survival) + k6 (explorer)
 
 [<Fact>]
+let ``only personas carry private state (the entropy budget); it is erasable`` () =
+    let p = Persona.create "otto" |> Persona.withPrivate [| 1uy; 2uy; 3uy |]
+    Assert.Equal<byte[]>([| 1uy; 2uy; 3uy |], p.Private)
+    let erased = Persona.withPrivate [||] p // erasable per §6
+    Assert.Empty(erased.Private)
+
+[<Fact>]
+let ``route is MoE over HATS: wears the top-k most relevant hats (experts = hats)`` () =
+    // relevance favors explorer
+    let relevance (h: Hat.Hat<int>) = if h.Name = "explorer" then 10.0 else 1.0
+    let p = Persona.create "otto" |> Persona.route relevance 1 available
+    Assert.Equal<string list>([ "explorer" ], p.Worn |> List.map (fun h -> h.Name))
+
+[<Fact>]
 let ``unrestricted if any worn hat is unrestricted`` () =
     let openHat = hat "free" [] [] // empty allow-list = unrestricted
     let p = Persona.create "otto" |> Persona.wear survival |> Persona.wear openHat
     Assert.Empty(Persona.allowedActions p) // unrestricted (empty) because a worn hat is unrestricted
+
+[<Fact>]
+let ``hatFlags is the combinatorial (flags-enum) identity over the hat universe`` () =
+    // wearing only explorer (index 1 in [survival; explorer]) -> bit 1 set -> flags = 2
+    let p = Persona.create "otto" |> Persona.wear explorer
+    Assert.Equal(2, Persona.hatFlags available p)
+    let both = Persona.create "otto" |> Persona.wearAll available
+    Assert.Equal(3, Persona.hatFlags available both) // bits 0 and 1
+
+[<Fact>]
+let ``same hatFlags + different private = same combinatorial identity but distinct via private (anti-collapse)`` () =
+    let a = Persona.create "a" |> Persona.wearAll available |> Persona.withPrivate [| 1uy |]
+    let b = Persona.create "b" |> Persona.wearAll available |> Persona.withPrivate [| 2uy |]
+    Assert.Equal(Persona.hatFlags available a, Persona.hatFlags available b) // identical flags-enum identity
+    Assert.NotEqual<byte[]>(a.Private, b.Private) // ...yet distinct — private state breaks the combinatorial limit
+
+[<Fact>]
+let ``regularization (overfitting lever) = size of the private budget; 0 = pure flags-enum (max overfit)`` () =
+    let plain = Persona.create "otto"
+    let reg = plain |> Persona.withPrivate [| 1uy; 2uy; 3uy |]
+    Assert.Equal(0, Persona.regularization plain) // no private state -> max overfit to the game
+    Assert.Equal(3, Persona.regularization reg) // more private state -> more regularization / entropy


### PR DESCRIPTION
Aaron: only personas carry private state (hats are public/shareable); MoE is over HATS (route = gate, experts=hats); without private state identity = flags-enum (2^N hat combos); private state = the overfitting lever (entropy=regularization). 10/10 tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)