### PR TITLE
feat(core): PrivacyEconomy — private-state budget as hard money, mixture-of-personas reward

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -224,6 +224,7 @@
     <Compile Include="Hat.fs" />
     <Compile Include="Persona.fs" />
     <Compile Include="Diversity.fs" />
+    <Compile Include="PrivacyEconomy.fs" />
     <Compile Include="ControlMerge.fs" />
     <Compile Include="PolarityFilter.fs" />
     <Compile Include="ZetaExec.fs" />

--- a/src/Core/PrivacyEconomy.fs
+++ b/src/Core/PrivacyEconomy.fs
@@ -1,0 +1,74 @@
+namespace Zeta.Core
+
+/// **`PrivacyEconomy` — private-state budget as a self-regulating economy among personas (Aaron 2026-06-08, shadow*).**
+///
+/// Aaron: *"the ultimate goal is privacy is **self-regulating** among the personas, based on some measure of **good
+/// use of private state that's revealable to others** and can **increase the private-state budget** — this is
+/// **economics among the personas**."*
+///
+/// The private-state budget (`Persona.Private` — the overfitting lever / entropy / NCI encryption budget, #7148)
+/// is an **economic resource**. A persona **earns more budget by demonstrating good use of it** — and crucially
+/// the evidence of good use is **revealable** (voluntary disclosure, NCI-respecting §6): you reveal *that you used
+/// privacy well* to earn more, without being forced to reveal the private state itself. The economy is
+/// **self-regulating** — no central allocator: each persona's budget is a function of its **own revealed good use**
+/// (scale-free §1, weight-free §3). The market finds each persona's right privacy/entropy level, like prices emerge.
+///
+/// **Privacy budget is HARD MONEY (Aaron 2026-06-08): you can NEVER lose it — ever.** No punishment, no decay, no
+/// confiscation, no inflation-away: budget is **strictly monotonic non-decreasing**, earned only by reward. That
+/// is exactly a **grow-only counter (G-Counter CRDT)** (`Crdt.fs`) — sound, mergeable, never-decreasing. And it is
+/// **rewards-only** — there is *no* punish operation in this module (punishment would be coercive, violating NCI;
+/// the economy is positive-sum).
+///
+/// **Each persona has its OWN private definition of good use** (Aaron): good-use is *subjective per persona*; what
+/// is public is the **reveal**. And **the reveal is rewarded by a MIXTURE OF PERSONAS, not hats** (`rewardByMixture`)
+/// — peer personas each score the reveal by *their own* private good-use definition, and the mixture (consensus)
+/// sets the grant. ("Good use" candidate: value the private state produced without collapsing diversity or coercing
+/// — e.g. solid-ground gain generalised across games.) `roi` = good-use per unit budget (the efficiency rewarded).
+///
+/// **Honest scope (peel):** sound only if the good-use measures are *revealable and hard to game* (a gameable
+/// measure → reward-hacking, the failure the unsubjective method #7142 avoids; prefer objective categories like
+/// solid-ground gain). Budgets are `int` (byte counts), G-Counter-shaped (never decrease). `cap` is an optional
+/// ceiling on the *rate*-summed total, never a loss. Trade/transfer between personas is a later slice. Deterministic (DST).
+[<RequireQualifiedAccess>]
+module PrivacyEconomy =
+
+    /// A revealed good-use claim: a persona discloses *that* it used its private budget well (a measure), without
+    /// disclosing the private state itself.
+    type GoodUse = { Persona: string; Revealed: float }
+
+    /// Each persona's current private-state budget (bytes). The ledger.
+    type Ledger = Map<string, int>
+
+    /// Look up a persona's budget (0 if unknown).
+    let budget (persona: string) (ledger: Ledger) : int =
+        Map.tryFind persona ledger |> Option.defaultValue 0
+
+    /// **Reward revealed good use:** grow the persona's budget by `gainOf revealed`, capped at `cap`. Self-
+    /// regulating per persona (a function of *its own* revealed good use — no central authority).
+    let reward (gainOf: float -> int) (cap: int) (u: GoodUse) (ledger: Ledger) : Ledger =
+        let next = min cap (budget u.Persona ledger + max 0 (gainOf u.Revealed))
+        Map.add u.Persona next ledger
+
+    /// Settle a round of revealed good-use claims — each persona's budget updates independently (decentralized).
+    let settle (gainOf: float -> int) (cap: int) (uses: GoodUse list) (ledger: Ledger) : Ledger =
+        uses |> List.fold (fun l u -> reward gainOf cap u l) ledger
+
+    /// **Reward by a MIXTURE OF PERSONAS, not hats (Aaron):** peer personas each score the reveal `u` by *their
+    /// own* private good-use definition (`evaluators`); the **mixture** (mean consensus) sets the grant. Hard money
+    /// (monotonic up, capped ceiling, never lost) and rewards-only. No peers ⇒ no reward (you need the mixture).
+    let rewardByMixture (evaluators: (GoodUse -> float) list) (gainOf: float -> int) (cap: int) (u: GoodUse) (ledger: Ledger) : Ledger =
+        match evaluators with
+        | [] -> ledger
+        | _ ->
+            let consensus = (evaluators |> List.sumBy (fun ev -> ev u)) / float (List.length evaluators)
+            reward gainOf cap { u with Revealed = consensus } ledger
+
+    /// **ROI of privacy:** revealed good-use per unit budget — the efficiency the economy rewards. `infinity` if
+    /// the persona holds no budget yet but produced good use (a strong signal to grant it some).
+    let roi (u: GoodUse) (ledger: Ledger) : float =
+        let b = budget u.Persona ledger
+        if b = 0 then (if u.Revealed > 0.0 then infinity else 0.0) else u.Revealed / float b
+
+    /// Personas ranked by current budget (the self-regulating outcome — who earned privacy).
+    let ranking (ledger: Ledger) : (string * int) list =
+        ledger |> Map.toList |> List.sortByDescending snd

--- a/tests/Tests.FSharp/PrivacyEconomy.Tests.fs
+++ b/tests/Tests.FSharp/PrivacyEconomy.Tests.fs
@@ -1,0 +1,64 @@
+module Zeta.Tests.PrivacyEconomyTests
+
+open global.Xunit
+open Zeta.Core
+
+// good-use -> budget grant: 1 byte of budget per unit of revealed good use (rounded)
+let private gainOf (revealed: float) : int = int (round revealed)
+
+[<Fact>]
+let ``reward grows a persona's budget by revealed good use, capped`` () =
+    let l = Map.empty |> PrivacyEconomy.reward gainOf 100 { Persona = "otto"; Revealed = 8.0 }
+    Assert.Equal(8, PrivacyEconomy.budget "otto" l)
+    let l2 = l |> PrivacyEconomy.reward gainOf 100 { Persona = "otto"; Revealed = 5.0 }
+    Assert.Equal(13, PrivacyEconomy.budget "otto" l2) // accumulates
+    let capped = l2 |> PrivacyEconomy.reward gainOf 100 { Persona = "otto"; Revealed = 1000.0 }
+    Assert.Equal(100, PrivacyEconomy.budget "otto" capped) // capped
+
+[<Fact>]
+let ``self-regulating: each persona's budget reflects its own revealed good use (decentralized)`` () =
+    let l =
+        PrivacyEconomy.settle gainOf 1000
+            [ { Persona = "thrifty"; Revealed = 2.0 }
+              { Persona = "productive"; Revealed = 20.0 } ]
+            Map.empty
+    Assert.Equal(2, PrivacyEconomy.budget "thrifty" l)
+    Assert.Equal(20, PrivacyEconomy.budget "productive" l)
+    // the productive persona earned more privacy budget
+    Assert.Equal<(string * int) list>([ "productive", 20; "thrifty", 2 ], PrivacyEconomy.ranking l)
+
+[<Fact>]
+let ``ROI: good use per unit budget; new productive persona reads infinity (grant it budget)`` () =
+    let l = Map.ofList [ "veteran", 100 ]
+    Assert.Equal(0.1, PrivacyEconomy.roi { Persona = "veteran"; Revealed = 10.0 } l, 9) // 10/100
+    Assert.Equal(infinity, PrivacyEconomy.roi { Persona = "newcomer"; Revealed = 5.0 } l) // 0 budget + good use
+
+[<Fact>]
+let ``no revealed good use earns no budget (you must demonstrate use to grow)`` () =
+    let l = Map.empty |> PrivacyEconomy.reward gainOf 100 { Persona = "idle"; Revealed = 0.0 }
+    Assert.Equal(0, PrivacyEconomy.budget "idle" l)
+
+[<Fact>]
+let ``rewardByMixture: a MIXTURE OF PERSONAS scores the reveal (not hats); mean consensus sets the grant`` () =
+    // three peer personas, each its own private good-use definition of the reveal
+    let peers: (PrivacyEconomy.GoodUse -> float) list =
+        [ (fun u -> u.Revealed)          // peer A: takes it at face value
+          (fun u -> u.Revealed * 2.0)    // peer B: values it highly
+          (fun _ -> 0.0) ]              // peer C: unimpressed
+    // consensus over reveal=6: (6 + 12 + 0)/3 = 6 -> grant 6
+    let l = Map.empty |> PrivacyEconomy.rewardByMixture peers gainOf 1000 { Persona = "otto"; Revealed = 6.0 }
+    Assert.Equal(6, PrivacyEconomy.budget "otto" l)
+    // no peers -> no reward (need the mixture)
+    let none = Map.empty |> PrivacyEconomy.rewardByMixture [] gainOf 1000 { Persona = "otto"; Revealed = 6.0 }
+    Assert.Equal(0, PrivacyEconomy.budget "otto" none)
+
+[<Fact>]
+let ``HARD MONEY: budget never decreases across any sequence of rewards (G-Counter invariant)`` () =
+    let mutable l = Map.empty
+    let mutable prev = 0
+    for r in [ 3.0; 0.0; 10.0; 1.0; 0.0; 50.0 ] do
+        l <- l |> PrivacyEconomy.reward gainOf 1000 { Persona = "otto"; Revealed = r }
+        let now = PrivacyEconomy.budget "otto" l
+        Assert.True(now >= prev) // monotonic non-decreasing — never lost
+        prev <- now
+    Assert.Equal(64, prev) // 3+0+10+1+0+50

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -146,6 +146,7 @@
     <Compile Include="Hat.Tests.fs" />
     <Compile Include="Persona.Tests.fs" />
     <Compile Include="Diversity.Tests.fs" />
+    <Compile Include="PrivacyEconomy.Tests.fs" />
     <Compile Include="Survival.Tests.fs" />
     <Compile Include="MemorySense.Tests.fs" />
     <Compile Include="SolidGround.Tests.fs" />


### PR DESCRIPTION
Aaron: privacy budget = self-regulating economy among personas. Hard money (G-Counter, never lost, rewards-only/no punishment = NCI-consistent); rewardByMixture (peer personas each score the reveal by their OWN private good-use def; mixture sets the grant — mixture of personas not hats). 6/6 tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)