### PR TITLE
feat(core): PrivacyEconomy good/bad asymmetry — Verdict = Good | Unknown (never Bad)

### DIFF
--- a/src/Core/PrivacyEconomy.fs
+++ b/src/Core/PrivacyEconomy.fs
@@ -72,3 +72,25 @@ module PrivacyEconomy =
     /// Personas ranked by current budget (the self-regulating outcome — who earned privacy).
     let ranking (ledger: Ledger) : (string * int) list =
         ledger |> Map.toList |> List.sortByDescending snd
+
+    /// **The good/bad asymmetry (Aaron 2026-06-08): `Bad` does NOT exist — "not good" ≠ "bad".** A reveal is either
+    /// confirmed **`Good`** (the mixture's confidence ≥ threshold) or **`Unknown`** — *never* "bad". We can only
+    /// confirm good (with a confidence threshold), never confirm bad; the absence of confirmation is held as
+    /// Unknown, not flipped to a negative. This is the `SoftValue`/`Predicate3`/`TriBoolean.N` never-falsely-certain
+    /// discipline applied to *good*: the middle never collapses. It is **why the economy is rewards-only** — good is
+    /// confirmable (reward it), bad is not (so never punish).
+    type Verdict =
+        | Good // confidence ≥ threshold
+        | Unknown // below threshold — NOT bad, just unconfirmed (there is no Bad case)
+
+    /// Confirm good only above a confidence threshold; otherwise `Unknown` (never `Bad`).
+    let verdict (threshold: float) (confidence: float) : Verdict =
+        if confidence >= threshold then Good else Unknown
+
+    /// **Reward only on a confirmed-`Good` verdict** (mixture `confidence` ≥ `threshold`); `Unknown` ⇒ ledger
+    /// unchanged — **no reward and no punishment** (held). Hard money preserved; the rewards-only / good-is-the-only-
+    /// confirmable-thing invariant in one function.
+    let rewardIfGood (threshold: float) (confidence: float) (gainOf: float -> int) (cap: int) (u: GoodUse) (ledger: Ledger) : Ledger =
+        match verdict threshold confidence with
+        | Good -> reward gainOf cap u ledger
+        | Unknown -> ledger

--- a/tests/Tests.FSharp/PrivacyEconomy.Tests.fs
+++ b/tests/Tests.FSharp/PrivacyEconomy.Tests.fs
@@ -62,3 +62,16 @@ let ``HARD MONEY: budget never decreases across any sequence of rewards (G-Count
         Assert.True(now >= prev) // monotonic non-decreasing — never lost
         prev <- now
     Assert.Equal(64, prev) // 3+0+10+1+0+50
+
+[<Fact>]
+let ``good/bad asymmetry: verdict is Good (>= threshold) or Unknown — there is NO Bad`` () =
+    Assert.Equal(PrivacyEconomy.Good, PrivacyEconomy.verdict 0.7 0.8)
+    Assert.Equal(PrivacyEconomy.Unknown, PrivacyEconomy.verdict 0.7 0.5) // below threshold = Unknown, NOT bad
+
+[<Fact>]
+let ``rewardIfGood: rewards confirmed good, HOLDS on Unknown (no reward, no punishment)`` () =
+    let start = Map.ofList [ "otto", 10 ]
+    let confirmed = start |> PrivacyEconomy.rewardIfGood 0.7 0.9 gainOf 1000 { Persona = "otto"; Revealed = 5.0 }
+    Assert.Equal(15, PrivacyEconomy.budget "otto" confirmed) // confidence 0.9 >= 0.7 -> rewarded
+    let held = start |> PrivacyEconomy.rewardIfGood 0.7 0.4 gainOf 1000 { Persona = "otto"; Revealed = 5.0 }
+    Assert.Equal(10, PrivacyEconomy.budget "otto" held) // Unknown -> unchanged (held, NOT punished -> still 10)


### PR DESCRIPTION
Aaron: bad != not-good; only good is confirmable (confidence threshold). Verdict = Good | Unknown (no Bad) = never-falsely-certain (SoftValue/Predicate3) applied to good; rewardIfGood rewards confirmed good, holds on Unknown (no punishment) = why the economy is rewards-only. 8/8 tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)