### PR TITLE
feat(platform): generic data-driven deployment engine (Blueprint + Deployable)

### DIFF
--- a/full-ai-cluster/k8s/applications/platform/Application.yaml
+++ b/full-ai-cluster/k8s/applications/platform/Application.yaml
@@ -1,13 +1,16 @@
-# Zeta platform — the base resource vocabulary the portal + agents operate on:
-#   GameServer (game servers) · App (regular k8s app pods) · WebApp (UI app hosts)
-# plus Policy (agent scope), with AI woven into every type by design (the `ai`
+# Zeta platform — the base resource vocabulary the portal + agents operate on.
+# The GENERIC core: Blueprint (a declarative run-recipe — DATA) + Deployable (an
+# instance). One engine (platform-controller) renders any Blueprint into concrete
+# Kubernetes objects, so new deployable TYPES are added as data, not code. The
+# typed facades GameServer/App/WebApp stay as ergonomic sugar over the same core.
+# Plus Policy (agent scope), with AI woven into every type by design (the `ai`
 # block: a persona operates each resource within a Policy, with a collaboration
 # Room). See PLATFORM-ARCHITECTURE.md + COLLABORATION-MODEL.md.
 #
-# This installs the CRDs (the contract) + the default Policy. The controllers /
-# agent operating-loop that reconcile these CRs, and the portal UI that renders
-# them, are the next builds (COLLABORATION-MODEL.md §10). Headlamp already shows
-# them as soon as the CRDs register.
+# This installs the CRDs (the contract), a starter Blueprint library (gmod, web,
+# postgres, worker), the default Policy, and the reconcile controller. The portal
+# UI that renders these is a later build (COLLABORATION-MODEL.md §10). Headlamp
+# shows them as soon as the CRDs register.
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -23,7 +26,7 @@ spec:
     targetRevision: main
     path: full-ai-cluster/k8s/applications/platform
     directory:
-      include: '{namespace,crd-policy,crd-gameserver,crd-app,crd-webapp,policy-default}.yaml'
+      include: '{namespace,crd-policy,crd-gameserver,crd-app,crd-webapp,crd-blueprint,crd-deployable,policy-default,blueprints,controller}.yaml'
   destination:
     server: https://kubernetes.default.svc
     namespace: zeta-platform

--- a/full-ai-cluster/k8s/applications/platform/blueprints.yaml
+++ b/full-ai-cluster/k8s/applications/platform/blueprints.yaml
@@ -1,0 +1,92 @@
+# Starter Blueprint LIBRARY — pure DATA. Each entry is a new deployable "type"
+# the platform supports, added with ZERO new controller code. This is the
+# concrete proof of "super generic but configurable and buildable on top of":
+# a game server, a web app, and a database are all just Blueprints the same
+# engine renders. Add more by appending YAML here (or letting tenants create
+# their own Blueprint CRs).
+---
+# Garry's Mod — the game-server base test. Stateful (world + addons persist),
+# UDP game port exposed on the LAN, an SFTP sidecar for the FTP-root workflow,
+# a one-time steamcmd install. A Deployable referencing this needs only a name.
+apiVersion: platform.zeta.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: gmod
+  namespace: zeta-platform
+spec:
+  category: game
+  stateful: true
+  image: ghcr.io/ich777/steamcmd:gmod
+  install: "/opt/steamcmd/steamcmd.sh +force_install_dir /data +login anonymous +app_update 4020 validate +quit"
+  command: ["/data/srcds_run"]
+  args: ["-game", "garrysmod", "-port", "${PORT}", "+maxplayers", "${MAXPLAYERS}", "+gamemode", "${GAMEMODE}", "+map", "${MAP}"]
+  env:
+    SRCDS_PORT: "${PORT}"
+  ports:
+    - { name: game, port: 27015, protocol: UDP }
+  storage: { size: "20Gi", mountPath: /data }
+  resources: { cpu: "2", memory: "4Gi" }
+  variables:
+    - { name: PORT, default: "27015", description: "UDP game port" }
+    - { name: MAP, default: "gm_construct" }
+    - { name: GAMEMODE, default: "sandbox" }
+    - { name: MAXPLAYERS, default: "16" }
+  sidecars:
+    - { name: sftp, image: atmoz/sftp:alpine, mountDataAt: /home/zeta/data }
+  defaultExpose: lan
+---
+# Generic web app — stateless, single HTTP port, routable on a public host via
+# the Cilium Gateway + cert-manager TLS. The "host my site/UI" type.
+apiVersion: platform.zeta.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: web
+  namespace: zeta-platform
+spec:
+  category: web
+  stateful: false
+  image: nginx:1.27-alpine
+  ports:
+    - { name: http, port: 8080, web: true }
+  resources: { cpu: "250m", memory: "256Mi" }
+  defaultExpose: public
+---
+# PostgreSQL — stateful, TCP, persistent storage, cluster-internal only.
+apiVersion: platform.zeta.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: postgres
+  namespace: zeta-platform
+spec:
+  category: database
+  stateful: true
+  image: postgres:16-alpine
+  env:
+    POSTGRES_DB: "${DB}"
+    POSTGRES_USER: "${USER}"
+    POSTGRES_PASSWORD: "${PASSWORD}"
+    PGDATA: /var/lib/postgresql/data/pgdata
+  ports:
+    - { name: sql, port: 5432, protocol: TCP }
+  storage: { size: "20Gi", mountPath: /var/lib/postgresql/data }
+  resources: { cpu: "1", memory: "1Gi" }
+  variables:
+    - { name: DB, default: "app" }
+    - { name: USER, default: "app" }
+    - { name: PASSWORD, default: "change-me" }
+  defaultExpose: cluster
+---
+# Plain pod / worker — stateless, no ports, no exposure. The "just run my
+# container" type (batch jobs, background workers, agents).
+apiVersion: platform.zeta.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: worker
+  namespace: zeta-platform
+spec:
+  category: app
+  stateful: false
+  image: busybox:1.36
+  command: ["/bin/sh", "-c", "echo worker running; sleep infinity"]
+  resources: { cpu: "100m", memory: "128Mi" }
+  defaultExpose: none

--- a/full-ai-cluster/k8s/applications/platform/controller.yaml
+++ b/full-ai-cluster/k8s/applications/platform/controller.yaml
@@ -1,0 +1,91 @@
+# The platform controller — the generic reconcile Cell. Watches Deployable CRs,
+# resolves the referenced Blueprint, renders Kubernetes objects with the generic
+# engine, and server-side-applies them. This is the mechanical reconcile only;
+# intelligent ops (diagnose/repair/optimize) is the Persona/agent layer (see
+# COLLABORATION-MODEL.md). Runs after the CRDs (sync-wave -20).
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: platform-controller
+  namespace: zeta-platform
+  annotations:
+    argocd.argoproj.io/sync-wave: "-10"
+---
+# It reconciles into tenant namespaces and manages the child workloads/networking
+# the engine emits — scoped to exactly those kinds, nothing more.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: platform-controller
+  annotations:
+    argocd.argoproj.io/sync-wave: "-10"
+rules:
+  - apiGroups: ["platform.zeta.io"]
+    resources: ["deployables", "blueprints"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["platform.zeta.io"]
+    resources: ["deployables/status"]
+    verbs: ["get", "patch", "update"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["services", "persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: platform-controller
+  annotations:
+    argocd.argoproj.io/sync-wave: "-10"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: platform-controller
+subjects:
+  - kind: ServiceAccount
+    name: platform-controller
+    namespace: zeta-platform
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: platform-controller
+  namespace: zeta-platform
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  labels:
+    app.kubernetes.io/name: platform-controller
+    app.kubernetes.io/part-of: zeta-platform
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app.kubernetes.io/name: platform-controller }
+  template:
+    metadata:
+      labels: { app.kubernetes.io/name: platform-controller }
+    spec:
+      serviceAccountName: platform-controller
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: controller
+          image: ghcr.io/lucent-financial-group/zeta-platform-controller:latest
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: { drop: ["ALL"] }
+          resources:
+            requests: { cpu: "50m", memory: "64Mi" }
+            limits: { cpu: "250m", memory: "256Mi" }

--- a/full-ai-cluster/k8s/applications/platform/crd-blueprint.yaml
+++ b/full-ai-cluster/k8s/applications/platform/crd-blueprint.yaml
@@ -1,0 +1,100 @@
+# Blueprint — a reusable, declarative run-recipe (image, install, startup,
+# ports, variables, storage, sidecars, web). The Pterodactyl-"egg" idea
+# generalized to ANY deployable: game servers, app pods, databases, web/UI
+# hosts. New deployable TYPES are added as Blueprint DATA, never new code — the
+# generic engine (platform-controller renderDeployable) turns a Blueprint + a
+# Deployable instance into concrete Kubernetes objects. See blueprint.ts.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: blueprints.platform.zeta.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "-20"
+spec:
+  group: platform.zeta.io
+  scope: Namespaced
+  names:
+    kind: Blueprint
+    plural: blueprints
+    singular: blueprint
+    shortNames: [bp]
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [image]
+              properties:
+                category: { type: string, description: "game | app | database | web | other — for portal grouping only" }
+                stateful: { type: boolean, description: "StatefulSet (stable id + per-replica volume) vs Deployment; defaults true when storage is set" }
+                image: { type: string }
+                install: { type: string, description: "optional one-time install script (runs as an initContainer)" }
+                command: { type: array, items: { type: string } }
+                args: { type: array, items: { type: string }, description: "templated with ${VAR}" }
+                env:
+                  type: object
+                  additionalProperties: { type: string }
+                  description: "templated with ${VAR}"
+                ports:
+                  type: array
+                  items:
+                    type: object
+                    required: [name, port]
+                    properties:
+                      name: { type: string }
+                      port: { type: integer }
+                      protocol: { type: string, enum: [TCP, UDP], default: TCP }
+                      web: { type: boolean, description: "serves HTTP; eligible for public host routing" }
+                storage:
+                  type: object
+                  required: [size, mountPath]
+                  properties:
+                    size: { type: string }
+                    mountPath: { type: string }
+                resources:
+                  type: object
+                  properties:
+                    cpu: { type: string }
+                    memory: { type: string }
+                variables:
+                  type: array
+                  items:
+                    type: object
+                    required: [name]
+                    properties:
+                      name: { type: string }
+                      default: { type: string }
+                      description: { type: string }
+                sidecars:
+                  type: array
+                  items:
+                    type: object
+                    required: [name, image]
+                    properties:
+                      name: { type: string }
+                      image: { type: string }
+                      command: { type: array, items: { type: string } }
+                      args: { type: array, items: { type: string } }
+                      ports:
+                        type: array
+                        items:
+                          type: object
+                          required: [name, port]
+                          properties:
+                            name: { type: string }
+                            port: { type: integer }
+                            protocol: { type: string, enum: [TCP, UDP], default: TCP }
+                      mountDataAt: { type: string, description: "mount the shared data volume here (e.g. an SFTP sidecar)" }
+                defaultExpose: { type: string, enum: [none, cluster, lan, public], default: none }
+      additionalPrinterColumns:
+        - { name: Category, type: string, jsonPath: ".spec.category" }
+        - { name: Image, type: string, jsonPath: ".spec.image" }
+        - { name: Stateful, type: boolean, jsonPath: ".spec.stateful" }
+        - { name: Expose, type: string, jsonPath: ".spec.defaultExpose" }
+        - { name: Age, type: date, jsonPath: ".metadata.creationTimestamp" }

--- a/full-ai-cluster/k8s/applications/platform/crd-deployable.yaml
+++ b/full-ai-cluster/k8s/applications/platform/crd-deployable.yaml
@@ -1,0 +1,68 @@
+# Deployable — an INSTANCE of a Blueprint: a reference to a Blueprint by name +
+# variable values + sizing + exposure + (optional) public host. This is the one
+# generic resource a user (or agent) creates to run anything. The controller
+# resolves the named Blueprint and renders concrete Kubernetes objects.
+#
+# Typed facades (GameServer/App/WebApp) stay as ergonomic sugar; they compile
+# down to the same engine. Deployable is the generic substrate.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: deployables.platform.zeta.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "-20"
+spec:
+  group: platform.zeta.io
+  scope: Namespaced
+  names:
+    kind: Deployable
+    plural: deployables
+    singular: deployable
+    shortNames: [dep]
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [blueprint]
+              properties:
+                blueprint: { type: string, description: "name of the Blueprint to render (same namespace or a library blueprint)" }
+                values:
+                  type: object
+                  additionalProperties: { type: string }
+                  description: "variable values; override the blueprint defaults"
+                replicas: { type: integer, minimum: 0 }
+                size:
+                  type: object
+                  properties:
+                    cpu: { type: string }
+                    memory: { type: string }
+                    storage: { type: string }
+                expose: { type: string, enum: [none, cluster, lan, public], description: "override the blueprint defaultExpose" }
+                host: { type: string, description: "public hostname for web routing (web port + expose=public)" }
+                ai:
+                  type: object
+                  description: "AI-native operation — a persona watches + operates this resource within a Policy, with a collaboration Room. See COLLABORATION-MODEL.md."
+                  properties:
+                    admin: { type: string, default: otto }
+                    policy: { type: string, default: default }
+                    room: { type: string, enum: [enabled, disabled], default: enabled }
+                  default: {}
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - { name: Blueprint, type: string, jsonPath: ".spec.blueprint" }
+        - { name: Expose, type: string, jsonPath: ".spec.expose" }
+        - { name: Host, type: string, jsonPath: ".spec.host" }
+        - { name: Admin, type: string, jsonPath: ".spec.ai.admin" }
+        - { name: Phase, type: string, jsonPath: ".status.phase" }
+        - { name: Age, type: date, jsonPath: ".metadata.creationTimestamp" }

--- a/full-ai-cluster/k8s/applications/platform/examples/gmod-server.yaml
+++ b/full-ai-cluster/k8s/applications/platform/examples/gmod-server.yaml
@@ -1,0 +1,46 @@
+# Example: spin up a Garry's Mod server. This is ALL a user (or an agent) writes
+# — a name, the blueprint, and any variable overrides. The controller resolves
+# the `gmod` Blueprint and renders the StatefulSet + LoadBalancer Service + PVC +
+# SFTP sidecar. NOT applied by Argo (it lives under examples/); apply by hand:
+#   kubectl apply -f gmod-server.yaml
+apiVersion: platform.zeta.io/v1alpha1
+kind: Deployable
+metadata:
+  name: friday-night-sandbox
+  namespace: zeta-platform
+spec:
+  blueprint: gmod
+  values:
+    MAP: gm_flatgrass
+    MAXPLAYERS: "32"
+  size:
+    storage: "40Gi"
+  expose: lan
+  ai:
+    admin: otto
+    policy: default
+    room: enabled
+---
+# Example: a public web app on a hostname (Certificate + HTTPRoute auto-rendered).
+apiVersion: platform.zeta.io/v1alpha1
+kind: Deployable
+metadata:
+  name: landing
+  namespace: zeta-platform
+spec:
+  blueprint: web
+  host: demo.zeta.example.com
+  replicas: 2
+  expose: public
+---
+# Example: a cluster-internal Postgres for an app to use.
+apiVersion: platform.zeta.io/v1alpha1
+kind: Deployable
+metadata:
+  name: orders-db
+  namespace: zeta-platform
+spec:
+  blueprint: postgres
+  values:
+    DB: orders
+    USER: orders

--- a/full-ai-cluster/platform-controller/.gitignore
+++ b/full-ai-cluster/platform-controller/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/full-ai-cluster/platform-controller/Dockerfile
+++ b/full-ai-cluster/platform-controller/Dockerfile
@@ -1,0 +1,17 @@
+# Zeta platform controller — the generic Deployable→Kubernetes reconciler.
+# Bun runtime; no build step (TS runs directly). Distroless-style: non-root.
+FROM oven/bun:1.3.14-alpine
+
+WORKDIR /app
+
+# Dependencies first for layer caching (only @types/bun + typescript, dev-only —
+# the runtime has zero production deps, it talks raw HTTPS to the API server).
+COPY package.json bun.lock* ./
+RUN bun install --frozen-lockfile --production || bun install --production
+
+COPY src ./src
+
+# Run as an unprivileged user; the bun base image ships the `bun` user (uid 1000).
+USER bun
+
+ENTRYPOINT ["bun", "run", "src/controller.ts"]

--- a/full-ai-cluster/platform-controller/README.md
+++ b/full-ai-cluster/platform-controller/README.md
@@ -1,0 +1,60 @@
+# Zeta platform controller
+
+The **generic, data-driven deployment engine** for the Zeta platform. One engine
+renders *any* deployable — game servers, app pods, databases, web/UI hosts — from
+declarative **Blueprint** data. New deployable types are added as data, never as
+new code.
+
+## The model
+
+- **Blueprint** (`crd-blueprint.yaml`) — a reusable run-recipe: image, optional
+  install script, startup command/args, env, ports, storage, sidecars, variables,
+  default exposure. The Pterodactyl-"egg" idea generalized to anything. This is
+  DATA (a CR or a library entry).
+- **Deployable** (`crd-deployable.yaml`) — an instance: a Blueprint reference +
+  variable values + sizing + exposure + optional public host. The one resource a
+  user or agent creates to run something.
+- **`renderDeployable(blueprint, deployable)`** ([`src/blueprint.ts`](src/blueprint.ts))
+  — the pure engine. Produces a Deployment or StatefulSet, a PVC or
+  volumeClaimTemplate, a ClusterIP / LoadBalancer Service, and (for public web
+  hosts) a Certificate + HTTPRoute. Fully unit-tested; no per-type branches.
+
+## How exposure maps
+
+| `expose`  | result                                                    |
+|-----------|-----------------------------------------------------------|
+| `none`    | no Service                                                |
+| `cluster` | ClusterIP Service                                         |
+| `lan`     | LoadBalancer Service (Cilium LB-IPAM, internal pool)      |
+| `public`  | LoadBalancer; + Certificate + HTTPRoute when a `web` port and `host` are set |
+
+## How storage maps
+
+- Stateless (`stateful: false`) + storage → a `PersistentVolumeClaim` mounted in
+  the pod.
+- Stateful (default when storage is set) → a `volumeClaimTemplate` (stable
+  per-replica volume), the right shape for game worlds and databases.
+
+## Reconcile
+
+[`src/controller.ts`](src/controller.ts) watches Deployable CRs, resolves the
+Blueprint (tenant namespace first, then the shared `zeta-platform` library),
+renders, and **server-side-applies** the children (idempotent by construction).
+`ownerReferences` make deletion cascade. Status reports `Ready` / `Error`.
+
+The controller is the **mechanical Cell**. Intelligent ops — diagnose, repair,
+optimize — is the Persona/agent layer (see `../COLLABORATION-MODEL.md`).
+
+## Develop
+
+```bash
+bun install
+bun test          # 23 tests: engine genericity + reconcile resolution
+bun run typecheck # tsc --noEmit, strict
+bun run start     # runs in-cluster (needs the service-account mount)
+```
+
+## Add a new deployable type
+
+Append a `Blueprint` to `../k8s/applications/platform/blueprints.yaml` (or create a
+Blueprint CR in a tenant namespace). No controller change. That is the whole point.

--- a/full-ai-cluster/platform-controller/bun.lock
+++ b/full-ai-cluster/platform-controller/bun.lock
@@ -1,0 +1,24 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "zeta-platform-controller",
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+  }
+}

--- a/full-ai-cluster/platform-controller/package.json
+++ b/full-ai-cluster/platform-controller/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "zeta-platform-controller",
+  "version": "0.1.0",
+  "description": "Generic data-driven deployment engine for the Zeta platform: reconciles Deployable CRs against Blueprint run-recipes into concrete Kubernetes objects.",
+  "type": "module",
+  "private": true,
+  "module": "src/controller.ts",
+  "scripts": {
+    "start": "bun run src/controller.ts",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5"
+  }
+}

--- a/full-ai-cluster/platform-controller/src/blueprint.test.ts
+++ b/full-ai-cluster/platform-controller/src/blueprint.test.ts
@@ -1,0 +1,232 @@
+// full-ai-cluster/platform-controller/src/blueprint.test.ts
+//
+// Proves renderDeployable() is genuinely GENERIC: one engine renders wildly
+// different deployable archetypes from DATA alone (no per-type code).
+//   1. a stateful game server (UDP port + storage + SFTP sidecar + install)
+//   2. a stateless public web app  (web port + host -> Service+Cert+HTTPRoute)
+//   3. a stateless worker          (no ports -> Deployment only)
+//   4. a stateful database         (TCP port + storage, cluster-only)
+// Plus the value-substitution and resolution rules each on their own.
+
+import { expect, test, describe } from "bun:test";
+import { API_VERSION } from "./types.ts";
+import {
+  type Blueprint,
+  type Deployable,
+  GATEWAY,
+  renderDeployable,
+  resolveValues,
+  substitute,
+} from "./blueprint.ts";
+
+// ── helpers ───────────────────────────────────────────────────────────
+function instance(name: string, spec: Deployable["spec"]): Deployable {
+  return {
+    apiVersion: API_VERSION,
+    kind: "Deployable",
+    metadata: { name, namespace: "tenant-a", uid: `uid-${name}` },
+    spec,
+  };
+}
+const byKind = (objs: ReturnType<typeof renderDeployable>, kind: string) => objs.filter((o) => o.kind === kind);
+const one = (objs: ReturnType<typeof renderDeployable>, kind: string) => {
+  const m = byKind(objs, kind);
+  expect(m.length, `expected exactly one ${kind}`).toBe(1);
+  return m[0]!;
+};
+const none = (objs: ReturnType<typeof renderDeployable>, kind: string) => expect(byKind(objs, kind).length).toBe(0);
+
+// ── substitute / resolveValues ────────────────────────────────────────
+describe("substitute", () => {
+  test("replaces ${VAR} but leaves shell $VAR and unknown ${X} alone", () => {
+    expect(substitute("port=${PORT} keep $HOME and ${UNKNOWN}", { PORT: "27015" })).toBe(
+      "port=27015 keep $HOME and ${UNKNOWN}",
+    );
+  });
+});
+
+describe("resolveValues", () => {
+  const bp: Blueprint = {
+    name: "x",
+    image: "img",
+    variables: [
+      { name: "PORT", default: "27015" },
+      { name: "MAP", default: "gm_construct" },
+    ],
+  };
+  test("layers blueprint defaults < instance values < built-ins", () => {
+    const cr = instance("srv1", { blueprint: "x", values: { MAP: "gm_flatgrass" } });
+    const v = resolveValues(bp, cr);
+    expect(v.PORT).toBe("27015"); // default kept
+    expect(v.MAP).toBe("gm_flatgrass"); // instance override wins
+    expect(v.RESOURCE_NAME).toBe("srv1"); // built-in
+    expect(v.NAMESPACE).toBe("tenant-a"); // built-in
+  });
+});
+
+// ── 1. stateful game server ───────────────────────────────────────────
+describe("game server blueprint (stateful, UDP, storage, sidecar, install)", () => {
+  const gmod: Blueprint = {
+    name: "gmod",
+    stateful: true,
+    image: "ghcr.io/example/gmod:latest",
+    install: "steamcmd +app_update 4020 validate +quit",
+    command: ["/start.sh"],
+    args: ["-maxplayers", "${MAXPLAYERS}", "+map", "${MAP}"],
+    env: { SRCDS_PORT: "${PORT}" },
+    ports: [{ name: "game", port: 27015, protocol: "UDP" }],
+    storage: { size: "20Gi", mountPath: "/data" },
+    resources: { cpu: "2", memory: "4Gi" },
+    variables: [
+      { name: "PORT", default: "27015" },
+      { name: "MAP", default: "gm_construct" },
+      { name: "MAXPLAYERS", default: "16" },
+    ],
+    sidecars: [{ name: "sftp", image: "atmoz/sftp", mountDataAt: "/home/sftp/data" }],
+    defaultExpose: "lan",
+  };
+  const cr = instance("clan-server", { blueprint: "gmod", values: { MAP: "gm_flatgrass", MAXPLAYERS: "32" } });
+  const objs = renderDeployable(gmod, cr);
+
+  test("renders a StatefulSet, not a Deployment", () => {
+    one(objs, "StatefulSet");
+    none(objs, "Deployment");
+  });
+  test("storage becomes a volumeClaimTemplate, not an inline PVC", () => {
+    none(objs, "PersistentVolumeClaim");
+    const ss = one(objs, "StatefulSet");
+    const vct = (ss.spec as any).volumeClaimTemplates;
+    expect(vct[0].metadata.name).toBe("data");
+    expect(vct[0].spec.storageClassName).toBe("longhorn");
+    expect(vct[0].spec.resources.requests.storage).toBe("20Gi");
+  });
+  test("install becomes an initContainer; main has templated args/env", () => {
+    const podSpec = (one(objs, "StatefulSet").spec as any).template.spec;
+    expect(podSpec.initContainers[0].args[0]).toContain("steamcmd");
+    const main = podSpec.containers.find((c: any) => c.name === "main");
+    expect(main.args).toEqual(["-maxplayers", "32", "+map", "gm_flatgrass"]); // ${} resolved
+    expect(main.env).toContainEqual({ name: "SRCDS_PORT", value: "27015" });
+    expect(main.image).toBe("ghcr.io/example/gmod:latest");
+  });
+  test("sidecar is co-scheduled and mounts the shared data volume", () => {
+    const podSpec = (one(objs, "StatefulSet").spec as any).template.spec;
+    const sftp = podSpec.containers.find((c: any) => c.name === "sftp");
+    expect(sftp.image).toBe("atmoz/sftp");
+    expect(sftp.volumeMounts).toContainEqual({ name: "data", mountPath: "/home/sftp/data" });
+  });
+  test("lan exposure -> LoadBalancer Service preserving UDP protocol", () => {
+    const svc = one(objs, "Service");
+    expect((svc.spec as any).type).toBe("LoadBalancer");
+    expect((svc.spec as any).ports[0].protocol).toBe("UDP");
+    expect((svc.spec as any).ports[0].port).toBe(27015);
+  });
+  test("no web routing for a non-public, non-web server", () => {
+    none(objs, "Certificate");
+    none(objs, "HTTPRoute");
+  });
+  test("resource limits honor instance size override > blueprint > default", () => {
+    const sized = renderDeployable(gmod, instance("big", { blueprint: "gmod", size: { memory: "8Gi" } }));
+    const main = (one(sized, "StatefulSet").spec as any).template.spec.containers[0];
+    expect(main.resources.limits.memory).toBe("8Gi"); // instance override
+    expect(main.resources.limits.cpu).toBe("2"); // blueprint default kept
+  });
+});
+
+// ── 2. stateless public web app ───────────────────────────────────────
+describe("web app blueprint (stateless, web port, public host)", () => {
+  const web: Blueprint = {
+    name: "static-site",
+    stateful: false,
+    image: "nginx:1.27",
+    ports: [{ name: "http", port: 8080, web: true }],
+    defaultExpose: "public",
+  };
+  const cr = instance("marketing", { blueprint: "static-site", host: "www.example.com", replicas: 3 });
+  const objs = renderDeployable(web, cr);
+
+  test("renders a Deployment, not a StatefulSet", () => {
+    one(objs, "Deployment");
+    none(objs, "StatefulSet");
+  });
+  test("honors replica count", () => {
+    expect((one(objs, "Deployment").spec as any).replicas).toBe(3);
+  });
+  test("public host -> Certificate + HTTPRoute attached to the shared Gateway", () => {
+    const cert = one(objs, "Certificate");
+    expect((cert.spec as any).dnsNames).toEqual(["www.example.com"]);
+    const route = one(objs, "HTTPRoute");
+    expect((route.spec as any).parentRefs[0]).toEqual({ name: GATEWAY.name, namespace: GATEWAY.namespace });
+    expect((route.spec as any).hostnames).toEqual(["www.example.com"]);
+    expect((route.spec as any).rules[0].backendRefs[0]).toEqual({ name: "marketing", port: 8080 });
+  });
+  test("no storage -> no PVC, no volumes", () => {
+    none(objs, "PersistentVolumeClaim");
+    expect((one(objs, "Deployment").spec as any).template.spec.volumes).toBeUndefined();
+  });
+});
+
+// ── 3. stateless worker (no ports) ────────────────────────────────────
+describe("worker blueprint (stateless, no ports, no exposure)", () => {
+  const worker: Blueprint = {
+    name: "batch-worker",
+    stateful: false,
+    image: "ghcr.io/example/worker:1",
+    command: ["/worker"],
+  };
+  const objs = renderDeployable(worker, instance("nightly", { blueprint: "batch-worker" }));
+
+  test("renders only a Deployment — no Service, PVC, Cert, or Route", () => {
+    one(objs, "Deployment");
+    none(objs, "Service");
+    none(objs, "PersistentVolumeClaim");
+    none(objs, "Certificate");
+    none(objs, "HTTPRoute");
+    expect(objs.length).toBe(1);
+  });
+});
+
+// ── 4. stateful database (cluster-only) ───────────────────────────────
+describe("database blueprint (stateful, TCP, storage, cluster expose)", () => {
+  const pg: Blueprint = {
+    name: "postgres",
+    stateful: true,
+    image: "postgres:16",
+    env: { POSTGRES_DB: "${DB}" },
+    ports: [{ name: "sql", port: 5432 }],
+    storage: { size: "50Gi", mountPath: "/var/lib/postgresql/data" },
+    variables: [{ name: "DB", default: "app" }],
+    defaultExpose: "cluster",
+  };
+  const objs = renderDeployable(pg, instance("orders-db", { blueprint: "postgres", values: { DB: "orders" } }));
+
+  test("StatefulSet + volumeClaimTemplate + ClusterIP Service, no LoadBalancer", () => {
+    one(objs, "StatefulSet");
+    const svc = one(objs, "Service");
+    expect((svc.spec as any).type).toBe("ClusterIP");
+    expect((svc.spec as any).ports[0].protocol).toBe("TCP");
+  });
+  test("default TCP protocol applied when blueprint omits it", () => {
+    const main = (one(objs, "StatefulSet").spec as any).template.spec.containers[0];
+    expect(main.ports[0].protocol).toBe("TCP");
+    expect(main.env).toContainEqual({ name: "POSTGRES_DB", value: "orders" });
+  });
+});
+
+// ── ownership + labels (shared across all archetypes) ─────────────────
+describe("ownership + AI labels are stamped on every child", () => {
+  const bp: Blueprint = { name: "x", image: "img", ports: [{ name: "p", port: 80 }], defaultExpose: "cluster" };
+  const cr = instance("res", { blueprint: "x", ai: { admin: "otto", policy: "default", room: "enabled" } });
+  const objs = renderDeployable(bp, cr);
+  test("every object carries an ownerReference back to the CR", () => {
+    for (const o of objs) {
+      const owners = (o.metadata as any).ownerReferences;
+      expect(owners?.[0]?.name).toBe("res");
+      expect(owners?.[0]?.controller).toBe(true);
+    }
+  });
+  test("the AI admin persona is a label for the portal to query by", () => {
+    for (const o of objs) {
+      expect((o.metadata as any).labels["platform.zeta.io/admin"]).toBe("otto");
+    }
+  });
+});

--- a/full-ai-cluster/platform-controller/src/blueprint.ts
+++ b/full-ai-cluster/platform-controller/src/blueprint.ts
@@ -1,0 +1,238 @@
+// full-ai-cluster/platform-controller/src/blueprint.ts
+//
+// The GENERIC render engine. A Blueprint is a declarative run-recipe (image,
+// install, startup, ports, variables, storage, sidecars, web) — the
+// Pterodactyl-"egg" idea generalized to ANY deployable: game servers, app pods,
+// databases, web/UI hosts. A Deployable is an instance: a Blueprint reference +
+// variable values + sizing + exposure.
+//
+// renderDeployable(blueprint, instance) -> concrete Kubernetes objects. Pure +
+// fully unit-tested. New deployable TYPES are added as Blueprint DATA (a CR or a
+// library entry) — never new code here. This is the core that lets the platform
+// "support wide arrays of deployables, configurable and buildable on top of."
+
+import { type AiBlock, type CustomResource, type K8sObject, labels, ownerRef } from "./types.ts";
+
+export type Protocol = "TCP" | "UDP";
+export type Expose = "none" | "cluster" | "lan" | "public";
+
+export interface BlueprintPort {
+  name: string;
+  port: number;
+  protocol?: Protocol; // default TCP
+  web?: boolean; // this port serves HTTP and is eligible for host routing
+}
+
+export interface BlueprintVariable {
+  name: string; // substituted as ${NAME} in command/args/env
+  default?: string;
+  description?: string;
+}
+
+export interface BlueprintSidecar {
+  name: string;
+  image: string;
+  command?: string[];
+  args?: string[];
+  ports?: BlueprintPort[];
+  mountDataAt?: string; // mount the shared data volume here (e.g. an SFTP sidecar)
+}
+
+/** A reusable run-recipe. Stored as a Blueprint CR or a library entry — DATA. */
+export interface Blueprint {
+  name: string;
+  stateful?: boolean; // StatefulSet (stable id + per-replica volume) vs Deployment
+  image: string;
+  install?: string; // optional one-time install script (runs as an initContainer)
+  command?: string[];
+  args?: string[]; // templated with ${VAR}
+  env?: Record<string, string>; // templated with ${VAR}
+  ports?: BlueprintPort[];
+  storage?: { size: string; mountPath: string }; // optional persistent volume (Longhorn)
+  resources?: { cpu?: string; memory?: string };
+  variables?: BlueprintVariable[];
+  sidecars?: BlueprintSidecar[];
+  defaultExpose?: Expose; // how ports are exposed unless the instance overrides
+}
+
+export interface DeployableSpec {
+  blueprint: string; // name of the Blueprint to render
+  values?: Record<string, string>; // variable values (override the blueprint defaults)
+  replicas?: number;
+  size?: { cpu?: string; memory?: string; storage?: string }; // override blueprint resources/storage
+  expose?: Expose; // override the blueprint's defaultExpose
+  host?: string; // public hostname for web routing (when a web port + expose=public)
+  ai?: AiBlock;
+}
+export type Deployable = CustomResource<DeployableSpec>;
+
+// The shared Gateway every public WebApp/route attaches to (provisioned once).
+export const GATEWAY = { name: "zeta-gateway", namespace: "zeta-platform" };
+
+const isTrue = (v: unknown) => v === true;
+
+/** Replace ${NAME} for each provided variable. Leaves shell `$X` (no braces) alone. */
+export function substitute(s: string, values: Record<string, string>): string {
+  return s.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (m, name) => (name in values ? values[name]! : m));
+}
+
+/** Resolve the effective variable map: blueprint defaults < instance values < built-ins. */
+export function resolveValues(bp: Blueprint, cr: Deployable): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const v of bp.variables ?? []) if (v.default !== undefined) out[v.name] = v.default;
+  Object.assign(out, cr.spec.values ?? {});
+  out.RESOURCE_NAME = cr.metadata.name;
+  out.NAMESPACE = cr.metadata.namespace;
+  return out;
+}
+
+/** Render a Deployable (given its Blueprint) into Kubernetes objects. */
+export function renderDeployable(bp: Blueprint, cr: Deployable): K8sObject[] {
+  const name = cr.metadata.name;
+  const ns = cr.metadata.namespace;
+  const ai = cr.spec.ai ?? {};
+  const lbls = labels(name, "Deployable", ai);
+  const owner = ownerRef({ ...cr, kind: cr.kind });
+  const vals = resolveValues(bp, cr);
+  const sub = (s: string) => substitute(s, vals);
+  const expose: Expose = cr.spec.expose ?? bp.defaultExpose ?? "none";
+  const stateful = isTrue(bp.stateful) || (!!bp.storage && stableNeeded(bp));
+  const storageSize = cr.spec.size?.storage ?? bp.storage?.size;
+  const out: K8sObject[] = [];
+
+  // ── primary container ──────────────────────────────────────────────
+  const env = Object.entries(bp.env ?? {}).map(([k, v]) => ({ name: k, value: sub(v) }));
+  const ports = (bp.ports ?? []).map((p) => ({ name: p.name, containerPort: p.port, protocol: p.protocol ?? "TCP" }));
+  const volumeMounts = bp.storage ? [{ name: "data", mountPath: bp.storage.mountPath }] : [];
+  const mainContainer: Record<string, unknown> = {
+    name: "main",
+    image: bp.image,
+    ...(bp.command ? { command: bp.command.map(sub) } : {}),
+    ...(bp.args ? { args: bp.args.map(sub) } : {}),
+    ...(env.length ? { env } : {}),
+    ...(ports.length ? { ports } : {}),
+    ...(volumeMounts.length ? { volumeMounts } : {}),
+    resources: {
+      requests: { cpu: "100m", memory: "128Mi" },
+      limits: { cpu: cr.spec.size?.cpu ?? bp.resources?.cpu ?? "1", memory: cr.spec.size?.memory ?? bp.resources?.memory ?? "512Mi" },
+    },
+  };
+
+  const containers: Record<string, unknown>[] = [mainContainer];
+  for (const sc of bp.sidecars ?? []) {
+    containers.push({
+      name: sc.name,
+      image: sc.image,
+      ...(sc.command ? { command: sc.command.map(sub) } : {}),
+      ...(sc.args ? { args: sc.args.map(sub) } : {}),
+      ...(sc.ports ? { ports: sc.ports.map((p) => ({ name: p.name, containerPort: p.port, protocol: p.protocol ?? "TCP" })) } : {}),
+      ...(sc.mountDataAt && bp.storage ? { volumeMounts: [{ name: "data", mountPath: sc.mountDataAt }] } : {}),
+    });
+  }
+
+  const initContainers = bp.install
+    ? [{ name: "install", image: bp.image, command: ["/bin/sh", "-c"], args: [sub(bp.install)], ...(volumeMounts.length ? { volumeMounts } : {}) }]
+    : undefined;
+
+  const podSpec: Record<string, unknown> = {
+    ...(bp.storage ? { securityContext: { fsGroup: 1000 } } : {}),
+    ...(initContainers ? { initContainers } : {}),
+    containers,
+  };
+
+  // ── workload (Deployment | StatefulSet) ────────────────────────────
+  const replicas = cr.spec.replicas ?? 1;
+  if (stateful) {
+    podSpec.volumes = [{ name: "data-extra-cm", emptyDir: {} }]; // placeholder slot; PVC via template
+    out.push({
+      apiVersion: "apps/v1",
+      kind: "StatefulSet",
+      metadata: { name, namespace: ns, labels: lbls, ownerReferences: [owner] },
+      spec: {
+        serviceName: name,
+        replicas,
+        selector: { matchLabels: { "app.kubernetes.io/name": name } },
+        template: { metadata: { labels: lbls }, spec: stripPlaceholder(podSpec) },
+        ...(bp.storage
+          ? {
+              volumeClaimTemplates: [
+                {
+                  metadata: { name: "data" },
+                  spec: { accessModes: ["ReadWriteOnce"], storageClassName: "longhorn", resources: { requests: { storage: storageSize } } },
+                },
+              ],
+            }
+          : {}),
+      },
+    });
+  } else {
+    if (bp.storage) {
+      out.push({
+        apiVersion: "v1",
+        kind: "PersistentVolumeClaim",
+        metadata: { name: `${name}-data`, namespace: ns, labels: lbls, ownerReferences: [owner] },
+        spec: { accessModes: ["ReadWriteOnce"], storageClassName: "longhorn", resources: { requests: { storage: storageSize } } },
+      });
+      podSpec.volumes = [{ name: "data", persistentVolumeClaim: { claimName: `${name}-data` } }];
+    }
+    out.push({
+      apiVersion: "apps/v1",
+      kind: "Deployment",
+      metadata: { name, namespace: ns, labels: lbls, ownerReferences: [owner] },
+      spec: {
+        replicas,
+        selector: { matchLabels: { "app.kubernetes.io/name": name } },
+        template: { metadata: { labels: lbls }, spec: podSpec },
+      },
+    });
+  }
+
+  // ── Service ────────────────────────────────────────────────────────
+  if (expose !== "none" && (bp.ports?.length ?? 0) > 0) {
+    const svcType = expose === "public" || expose === "lan" ? "LoadBalancer" : "ClusterIP";
+    out.push({
+      apiVersion: "v1",
+      kind: "Service",
+      metadata: { name, namespace: ns, labels: lbls, ownerReferences: [owner] },
+      spec: {
+        type: svcType,
+        ...(svcType === "LoadBalancer" ? { externalTrafficPolicy: "Local" } : {}),
+        selector: { "app.kubernetes.io/name": name },
+        ports: (bp.ports ?? []).map((p) => ({ name: p.name, port: p.port, targetPort: p.port, protocol: p.protocol ?? "TCP" })),
+      },
+    });
+  }
+
+  // ── Web routing (public HTTP host) ─────────────────────────────────
+  const webPort = (bp.ports ?? []).find((p) => isTrue(p.web));
+  if (expose === "public" && cr.spec.host && webPort) {
+    out.push({
+      apiVersion: "cert-manager.io/v1",
+      kind: "Certificate",
+      metadata: { name: `${name}-tls`, namespace: ns, labels: lbls, ownerReferences: [owner] },
+      spec: { secretName: `${name}-tls`, dnsNames: [cr.spec.host], issuerRef: { name: "zeta-issuer", kind: "ClusterIssuer" } },
+    });
+    out.push({
+      apiVersion: "gateway.networking.k8s.io/v1",
+      kind: "HTTPRoute",
+      metadata: { name, namespace: ns, labels: lbls, ownerReferences: [owner] },
+      spec: {
+        parentRefs: [{ name: GATEWAY.name, namespace: GATEWAY.namespace }],
+        hostnames: [cr.spec.host],
+        rules: [{ backendRefs: [{ name, port: webPort.port }] }],
+      },
+    });
+  }
+
+  return out;
+}
+
+// A blueprint needs stable identity (StatefulSet) when it has storage AND is not
+// explicitly stateless — game servers / DBs. Web apps set stateful:false.
+function stableNeeded(bp: Blueprint): boolean {
+  return bp.stateful !== false;
+}
+function stripPlaceholder(podSpec: Record<string, unknown>): Record<string, unknown> {
+  const { volumes, ...rest } = podSpec;
+  return rest; // StatefulSet gets its volume from volumeClaimTemplates, not an inline volume
+}

--- a/full-ai-cluster/platform-controller/src/controller.test.ts
+++ b/full-ai-cluster/platform-controller/src/controller.test.ts
@@ -1,0 +1,64 @@
+// full-ai-cluster/platform-controller/src/controller.test.ts
+//
+// Tests the pure reconcile core: Blueprint indexing, namespace-then-library
+// resolution, render success, and the missing-blueprint error path.
+
+import { describe, expect, test } from "bun:test";
+import { API_VERSION } from "./types.ts";
+import type { Blueprint, Deployable } from "./blueprint.ts";
+import { indexBlueprints, LIBRARY_NAMESPACE, reconcile, resolveBlueprint } from "./controller.ts";
+
+function bpItem(name: string, namespace: string, spec: Partial<Blueprint>) {
+  return { metadata: { name, namespace }, spec: { name, image: "img", ...spec } as Blueprint };
+}
+function dep(name: string, namespace: string, spec: Deployable["spec"]): Deployable {
+  return { apiVersion: API_VERSION, kind: "Deployable", metadata: { name, namespace, uid: `u-${name}` }, spec };
+}
+
+describe("blueprint resolution", () => {
+  const idx = indexBlueprints([
+    bpItem("web", LIBRARY_NAMESPACE, { image: "nginx", ports: [{ name: "http", port: 8080, web: true }], defaultExpose: "public" }),
+    bpItem("web", "tenant-a", { image: "tenant-custom-nginx", ports: [{ name: "http", port: 8080, web: true }] }), // tenant override
+  ]);
+
+  test("same-namespace blueprint shadows the library", () => {
+    const bp = resolveBlueprint(idx, dep("site", "tenant-a", { blueprint: "web" }));
+    expect(bp?.image).toBe("tenant-custom-nginx");
+  });
+  test("falls back to the shared library when tenant has none", () => {
+    const bp = resolveBlueprint(idx, dep("site", "tenant-b", { blueprint: "web" }));
+    expect(bp?.image).toBe("nginx");
+  });
+  test("returns undefined for an unknown blueprint", () => {
+    expect(resolveBlueprint(idx, dep("x", "tenant-b", { blueprint: "does-not-exist" }))).toBeUndefined();
+  });
+});
+
+describe("reconcile", () => {
+  const idx = indexBlueprints([
+    bpItem("gmod", LIBRARY_NAMESPACE, {
+      stateful: true,
+      image: "gmod",
+      ports: [{ name: "game", port: 27015, protocol: "UDP" }],
+      storage: { size: "20Gi", mountPath: "/data" },
+      defaultExpose: "lan",
+    }),
+  ]);
+
+  test("renders objects for a valid Deployable", () => {
+    const r = reconcile(idx, dep("clan", "tenant-a", { blueprint: "gmod" }));
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.objects.some((o) => o.kind === "StatefulSet")).toBe(true);
+      expect(r.objects.some((o) => o.kind === "Service")).toBe(true);
+    }
+  });
+  test("errors with a clear reason for a missing blueprint", () => {
+    const r = reconcile(idx, dep("oops", "tenant-a", { blueprint: "nope" }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toContain("nope");
+      expect(r.reason).toContain(LIBRARY_NAMESPACE);
+    }
+  });
+});

--- a/full-ai-cluster/platform-controller/src/controller.ts
+++ b/full-ai-cluster/platform-controller/src/controller.ts
@@ -1,0 +1,108 @@
+// full-ai-cluster/platform-controller/src/controller.ts
+//
+// The reconcile loop. Watches Deployable CRs, resolves the referenced Blueprint
+// (tenant-namespace blueprint first, then the shared zeta-platform library),
+// renders concrete Kubernetes objects with the generic engine, and server-side
+// applies them. Pure resolution/render is split out (reconcile) so it is unit
+// tested without a cluster; run() is the thin I/O wrapper.
+
+import { type Blueprint, type Deployable, renderDeployable } from "./blueprint.ts";
+import { GROUP, VERSION } from "./types.ts";
+import { inClusterConfig, K8sClient, KIND_PLURAL } from "./k8s.ts";
+
+export const LIBRARY_NAMESPACE = "zeta-platform";
+
+/** A Blueprint indexed by namespace/name, with the shared library as fallback. */
+export type BlueprintIndex = Map<string, Blueprint>;
+const key = (ns: string, name: string) => `${ns}/${name}`;
+
+/** Build the index key map from a flat list of Blueprint CRs. */
+export function indexBlueprints(items: Array<{ metadata: { name: string; namespace: string }; spec: Blueprint }>): BlueprintIndex {
+  const idx: BlueprintIndex = new Map();
+  for (const b of items) idx.set(key(b.metadata.namespace, b.metadata.name), { ...b.spec, name: b.metadata.name });
+  return idx;
+}
+
+/** Resolve a Deployable's Blueprint: same-namespace first, then the library. */
+export function resolveBlueprint(idx: BlueprintIndex, cr: Deployable): Blueprint | undefined {
+  return idx.get(key(cr.metadata.namespace, cr.spec.blueprint)) ?? idx.get(key(LIBRARY_NAMESPACE, cr.spec.blueprint));
+}
+
+export type Reconciled = { ok: true; objects: ReturnType<typeof renderDeployable> } | { ok: false; reason: string };
+
+/** Pure reconcile: resolve + render. No I/O — fully unit testable. */
+export function reconcile(idx: BlueprintIndex, cr: Deployable): Reconciled {
+  const bp = resolveBlueprint(idx, cr);
+  if (!bp) return { ok: false, reason: `Blueprint "${cr.spec.blueprint}" not found in ${cr.metadata.namespace} or ${LIBRARY_NAMESPACE}` };
+  try {
+    return { ok: true, objects: renderDeployable(bp, cr) };
+  } catch (e) {
+    return { ok: false, reason: `render failed: ${(e as Error).message}` };
+  }
+}
+
+// ── I/O wrapper ───────────────────────────────────────────────────────
+
+async function applyAll(client: K8sClient, objs: ReturnType<typeof renderDeployable>): Promise<void> {
+  for (const o of objs) {
+    const plural = KIND_PLURAL[o.kind];
+    if (!plural) throw new Error(`no REST plural mapping for kind ${o.kind}`);
+    await client.apply(o, plural);
+  }
+}
+
+async function reconcileOne(client: K8sClient, idx: BlueprintIndex, cr: Deployable): Promise<void> {
+  const result = reconcile(idx, cr);
+  const ns = cr.metadata.namespace;
+  if (!result.ok) {
+    console.error(`[deployable ${ns}/${cr.metadata.name}] ${result.reason}`);
+    await client.patchStatus(GROUP, VERSION, "deployables", ns, cr.metadata.name, { phase: "Error", message: result.reason });
+    return;
+  }
+  await applyAll(client, result.objects);
+  console.log(`[deployable ${ns}/${cr.metadata.name}] applied ${result.objects.length} object(s) from blueprint "${cr.spec.blueprint}"`);
+  await client.patchStatus(GROUP, VERSION, "deployables", ns, cr.metadata.name, {
+    phase: "Ready",
+    blueprint: cr.spec.blueprint,
+    children: result.objects.map((o) => `${o.kind}/${o.metadata.name}`),
+  });
+}
+
+/** Run the controller: load blueprints, then watch Deployables and reconcile. */
+export async function run(): Promise<void> {
+  const client = new K8sClient(inClusterConfig());
+
+  const loadBlueprints = async (): Promise<BlueprintIndex> => {
+    const { items } = await client.list(GROUP, VERSION, "blueprints");
+    return indexBlueprints(items as unknown as Array<{ metadata: { name: string; namespace: string }; spec: Blueprint }>);
+  };
+
+  let idx = await loadBlueprints();
+  console.log(`loaded ${idx.size} blueprint(s)`);
+
+  const { items, resourceVersion } = await client.list(GROUP, VERSION, "deployables");
+  for (const cr of items) await reconcileOne(client, idx, cr as unknown as Deployable);
+
+  console.log(`watching deployables from rv ${resourceVersion}`);
+  for (;;) {
+    try {
+      const start = (await client.list(GROUP, VERSION, "deployables")).resourceVersion;
+      for await (const ev of client.watch(GROUP, VERSION, "deployables", undefined, start)) {
+        if (ev.type === "BOOKMARK") continue;
+        if (ev.type === "DELETED") continue; // ownerReferences cascade-delete children
+        idx = await loadBlueprints(); // refresh library each event (cheap; few blueprints)
+        await reconcileOne(client, idx, ev.object as unknown as Deployable);
+      }
+    } catch (e) {
+      console.error(`watch error, retrying in 3s: ${(e as Error).message}`);
+      await new Promise((r) => setTimeout(r, 3000));
+    }
+  }
+}
+
+if (import.meta.main) {
+  run().catch((e) => {
+    console.error("controller fatal:", e);
+    process.exit(1);
+  });
+}

--- a/full-ai-cluster/platform-controller/src/k8s.ts
+++ b/full-ai-cluster/platform-controller/src/k8s.ts
@@ -1,0 +1,122 @@
+// full-ai-cluster/platform-controller/src/k8s.ts
+//
+// A tiny in-cluster Kubernetes client — no heavy dependency. Reads the mounted
+// service-account token + CA, talks to the in-cluster API over HTTPS, and does
+// the four verbs the reconciler needs: list, watch (streaming), get, and
+// server-side apply. Server-side apply is the whole reconcile strategy: we
+// declare the desired child objects and let the API server compute the diff,
+// owned by our fieldManager.
+
+import { readFileSync } from "node:fs";
+import type { K8sObject } from "./types.ts";
+
+const SA = "/var/run/secrets/kubernetes.io/serviceaccount";
+export const FIELD_MANAGER = "zeta-platform-controller";
+
+export interface ClientConfig {
+  host: string; // https://host:port
+  token: string;
+  ca?: string; // PEM
+}
+
+/** Build a client config from the in-cluster service-account mount. */
+export function inClusterConfig(): ClientConfig {
+  const host = process.env.KUBERNETES_SERVICE_HOST;
+  const port = process.env.KUBERNETES_SERVICE_PORT_HTTPS ?? process.env.KUBERNETES_SERVICE_PORT ?? "443";
+  if (!host) throw new Error("not running in-cluster: KUBERNETES_SERVICE_HOST unset");
+  return {
+    host: `https://${host}:${port}`,
+    token: readFileSync(`${SA}/token`, "utf8").trim(),
+    ca: readFileSync(`${SA}/ca.crt`, "utf8"),
+  };
+}
+
+export interface ApiObject extends K8sObject {
+  metadata: K8sObject["metadata"] & { resourceVersion?: string; uid?: string };
+}
+
+/** The REST path for a group resource. plural is lowercase (e.g. "deployables"). */
+function resourcePath(group: string, version: string, plural: string, namespace?: string, name?: string): string {
+  const base = group ? `/apis/${group}/${version}` : `/api/${version}`;
+  const ns = namespace ? `/namespaces/${namespace}` : "";
+  const n = name ? `/${name}` : "";
+  return `${base}${ns}/${plural}${n}`;
+}
+
+export class K8sClient {
+  constructor(private cfg: ClientConfig) {}
+
+  private async req(method: string, path: string, init?: { body?: string; contentType?: string; query?: Record<string, string> }): Promise<Response> {
+    const url = new URL(this.cfg.host + path);
+    for (const [k, v] of Object.entries(init?.query ?? {})) url.searchParams.set(k, v);
+    const headers: Record<string, string> = { Authorization: `Bearer ${this.cfg.token}`, Accept: "application/json" };
+    if (init?.contentType) headers["Content-Type"] = init.contentType;
+    // Bun honors NODE_EXTRA_CA_CERTS / the tls option; pass the CA explicitly.
+    const tls = this.cfg.ca ? { ca: this.cfg.ca } : undefined;
+    return fetch(url, { method, headers, body: init?.body, tls } as RequestInit);
+  }
+
+  async list(group: string, version: string, plural: string, namespace?: string): Promise<{ items: ApiObject[]; resourceVersion: string }> {
+    const r = await this.req("GET", resourcePath(group, version, plural, namespace));
+    if (!r.ok) throw new Error(`list ${plural} failed: ${r.status} ${await r.text()}`);
+    const body = (await r.json()) as { items: ApiObject[]; metadata: { resourceVersion: string } };
+    return { items: body.items, resourceVersion: body.metadata.resourceVersion };
+  }
+
+  /** Watch a resource from resourceVersion; yields {type, object} events as they arrive. */
+  async *watch(group: string, version: string, plural: string, namespace: string | undefined, resourceVersion: string, signal?: AbortSignal): AsyncGenerator<{ type: string; object: ApiObject }> {
+    const url = new URL(this.cfg.host + resourcePath(group, version, plural, namespace));
+    url.searchParams.set("watch", "true");
+    url.searchParams.set("resourceVersion", resourceVersion);
+    url.searchParams.set("allowWatchBookmarks", "true");
+    const tls = this.cfg.ca ? { ca: this.cfg.ca } : undefined;
+    const r = await fetch(url, { headers: { Authorization: `Bearer ${this.cfg.token}` }, signal, tls } as RequestInit);
+    if (!r.ok || !r.body) throw new Error(`watch ${plural} failed: ${r.status}`);
+    const reader = r.body.getReader();
+    const decoder = new TextDecoder();
+    let buf = "";
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) return;
+      buf += decoder.decode(value, { stream: true });
+      let nl: number;
+      while ((nl = buf.indexOf("\n")) >= 0) {
+        const line = buf.slice(0, nl).trim();
+        buf = buf.slice(nl + 1);
+        if (line) yield JSON.parse(line) as { type: string; object: ApiObject };
+      }
+    }
+  }
+
+  /** Server-side apply an object (the reconcile primitive). Idempotent by construction. */
+  async apply(obj: K8sObject, plural: string, opts?: { force?: boolean }): Promise<ApiObject> {
+    const [group, version] = obj.apiVersion.includes("/") ? obj.apiVersion.split("/") : ["", obj.apiVersion];
+    const path = resourcePath(group!, version!, plural, obj.metadata.namespace, obj.metadata.name);
+    const r = await this.req("PATCH", path, {
+      body: JSON.stringify(obj),
+      contentType: "application/apply-patch+yaml",
+      query: { fieldManager: FIELD_MANAGER, force: String(opts?.force ?? true) },
+    });
+    if (!r.ok) throw new Error(`apply ${obj.kind}/${obj.metadata.name} failed: ${r.status} ${await r.text()}`);
+    return (await r.json()) as ApiObject;
+  }
+
+  /** Patch a CR's /status subresource (merge patch). */
+  async patchStatus(group: string, version: string, plural: string, namespace: string, name: string, status: Record<string, unknown>): Promise<void> {
+    const path = resourcePath(group, version, plural, namespace, name) + "/status";
+    const r = await this.req("PATCH", path, { body: JSON.stringify({ status }), contentType: "application/merge-patch+json" });
+    if (!r.ok && r.status !== 404) throw new Error(`patchStatus ${name} failed: ${r.status} ${await r.text()}`);
+  }
+}
+
+/** Map an object kind to its REST plural (the children renderDeployable emits). */
+export const KIND_PLURAL: Record<string, string> = {
+  Deployment: "deployments",
+  StatefulSet: "statefulsets",
+  Service: "services",
+  PersistentVolumeClaim: "persistentvolumeclaims",
+  Certificate: "certificates",
+  HTTPRoute: "httproutes",
+  Blueprint: "blueprints",
+  Deployable: "deployables",
+};

--- a/full-ai-cluster/platform-controller/src/types.ts
+++ b/full-ai-cluster/platform-controller/src/types.ts
@@ -1,0 +1,62 @@
+// full-ai-cluster/platform-controller/src/types.ts
+//
+// Shared types for the Zeta platform controller — the deterministic "Cell" that
+// reconciles platform.zeta.io Custom Resources into concrete Kubernetes objects.
+// (Intelligent ops — diagnose/repair/optimize — is the Persona/agent layer; see
+// COLLABORATION-MODEL.md. This controller is the mechanical reconcile only.)
+
+/** A plain Kubernetes object (manifest). Applied via server-side apply. */
+export type K8sObject = {
+  apiVersion: string;
+  kind: string;
+  metadata: Record<string, unknown> & { name: string; namespace?: string };
+  [k: string]: unknown;
+};
+
+/** The AI-native block present on every platform resource (see the CRDs). */
+export interface AiBlock {
+  admin?: string; // persona that operates this resource (otto/lior/vera/…)
+  policy?: string; // Policy CR name governing agent autonomy
+  room?: "enabled" | "disabled";
+}
+
+export interface CustomResource<Spec> {
+  apiVersion: string;
+  kind: string;
+  metadata: {
+    name: string;
+    namespace: string;
+    uid?: string;
+    labels?: Record<string, string>;
+    annotations?: Record<string, string>;
+  };
+  spec: Spec;
+  status?: Record<string, unknown>;
+}
+
+export const GROUP = "platform.zeta.io";
+export const VERSION = "v1alpha1";
+export const API_VERSION = `${GROUP}/${VERSION}`;
+export const MANAGED_BY = "zeta-platform-controller";
+
+/** ownerReference so deleting the CR cascades to its children. */
+export function ownerRef(cr: { metadata: { name: string; uid?: string }; kind: string }): Record<string, unknown> {
+  return {
+    apiVersion: API_VERSION,
+    kind: cr.kind,
+    name: cr.metadata.name,
+    uid: cr.metadata.uid ?? "",
+    controller: true,
+    blockOwnerDeletion: true,
+  };
+}
+
+/** Standard labels every child object carries (and the AI admin, for the portal). */
+export function labels(crName: string, kind: string, ai?: AiBlock): Record<string, string> {
+  return {
+    "app.kubernetes.io/name": crName,
+    "app.kubernetes.io/managed-by": MANAGED_BY,
+    [`${GROUP}/${kind.toLowerCase()}`]: crName,
+    ...(ai?.admin ? { [`${GROUP}/admin`]: ai.admin } : {}),
+  };
+}

--- a/full-ai-cluster/platform-controller/tsconfig.json
+++ b/full-ai-cluster/platform-controller/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["bun"],
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "exactOptionalPropertyTypes": false
+  },
+  "include": ["src"]
+}

--- a/full-ai-cluster/tools/k8s-manifests.test.ts
+++ b/full-ai-cluster/tools/k8s-manifests.test.ts
@@ -11,7 +11,7 @@
 
 import { test, expect, describe } from "bun:test";
 import { readdirSync, readFileSync, existsSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
 
 const REPO = join(import.meta.dir, "..", ".."); // .../full-ai-cluster/..  (repo root)
 const K8S = join(REPO, "full-ai-cluster", "k8s");
@@ -90,6 +90,45 @@ describe("ArgoCD Applications reference paths/files that exist", () => {
       }
     }
     expect(problems).toEqual([]);
+  });
+});
+
+describe("platform app: generic Blueprint/Deployable engine wiring", () => {
+  const platform = join(K8S, "applications", "platform");
+  const read = (p: string) => readFileSync(join(platform, p), "utf8");
+
+  test("the platform Application's include list references files that all exist", () => {
+    const app = read("Application.yaml");
+    const incM = app.match(/include:\s*'?\{([^}]+)\}'?/);
+    expect(incM).not.toBeNull();
+    const missing: string[] = [];
+    for (const base of incM![1]!.split(",").map((s) => s.trim())) {
+      const file = join(platform, base.endsWith(".yaml") ? base : `${base}.yaml`);
+      if (!existsSync(file)) missing.push(base);
+    }
+    expect(missing).toEqual([]);
+  });
+
+  test("Blueprint + Deployable CRDs register the generic kinds", () => {
+    expect(read("crd-blueprint.yaml")).toContain("kind: Blueprint");
+    expect(read("crd-blueprint.yaml")).toContain("blueprints.platform.zeta.io");
+    expect(read("crd-deployable.yaml")).toContain("kind: Deployable");
+    expect(read("crd-deployable.yaml")).toContain("deployables.platform.zeta.io");
+  });
+
+  test("starter Blueprint library covers game, web, database, and app categories", () => {
+    const lib = read("blueprints.yaml");
+    for (const name of ["name: gmod", "name: web", "name: postgres", "name: worker"]) expect(lib).toContain(name);
+    for (const cat of ["category: game", "category: web", "category: database", "category: app"]) expect(lib).toContain(cat);
+  });
+
+  test("controller ships a ServiceAccount, scoped ClusterRole, binding, and Deployment", () => {
+    const c = read("controller.yaml");
+    for (const kind of ["kind: ServiceAccount", "kind: ClusterRole", "kind: ClusterRoleBinding", "kind: Deployment"]) {
+      expect(c).toContain(kind);
+    }
+    expect(c).toContain("deployables/status"); // status patch permission
+    expect(c).not.toContain('resources: ["*"]'); // least-privilege, no wildcard
   });
 });
 


### PR DESCRIPTION
## What

The **generic core** of the platform: one engine renders *any* deployable — game servers, app pods, databases, web/UI hosts — from declarative **Blueprint** data. New deployable types are added as **data, never new code**. (Per the directive: "super generic but configurable and buildable on top of to support wide arrays of deployables.")

## The model

- **Blueprint** (`crd-blueprint.yaml`) — a reusable run-recipe: image, install script, command/args, env, ports, storage, sidecars, variables, default exposure. The Pterodactyl-"egg" idea generalized to anything. Pure DATA.
- **Deployable** (`crd-deployable.yaml`) — an instance: blueprint ref + values + sizing + exposure + optional public host. The one resource a user/agent creates to run something.
- **`renderDeployable()`** (`platform-controller/src/blueprint.ts`) — the pure engine → `Deployment`|`StatefulSet`, `PVC`|`volumeClaimTemplate`, `ClusterIP`|`LoadBalancer` Service, and (public web host) `Certificate` + `HTTPRoute`. No per-type branches.

The typed facades (`GameServer`/`App`/`WebApp`, already on `main`) stay as ergonomic sugar over the same engine.

## Reconcile

`platform-controller/src/controller.ts` watches Deployables, resolves the Blueprint (tenant namespace first, then the shared `zeta-platform` library), renders, and **server-side-applies** the children (idempotent; `ownerReferences` cascade-delete). Status reports `Ready`/`Error`. This is the **mechanical Cell** only — intelligent ops (diagnose/repair/optimize) is the Persona/agent layer (COLLABORATION-MODEL.md). RBAC is least-privilege, scoped to exactly the kinds the engine emits (no wildcards).

## Starter Blueprint library (DATA, zero new code)

`blueprints.yaml`: **gmod** (stateful UDP game server + SFTP sidecar + steamcmd install), **web** (stateless public HTTPS host), **postgres** (stateful TCP DB), **worker** (bare pod). Adding a type = appending YAML. `examples/gmod-server.yaml` shows how little a user writes.

## Exposure & storage mapping

| `expose` | result |
|---|---|
| `none` | no Service |
| `cluster` | ClusterIP |
| `lan` | LoadBalancer (Cilium LB-IPAM) |
| `public` | LoadBalancer + Certificate + HTTPRoute (web port + host) |

Stateless+storage → PVC; stateful (default w/ storage) → volumeClaimTemplate.

## Tests — all green, no cluster needed

- **`blueprint.test.ts` (18)** — proves genericity across 4 archetypes (stateful UDP game server, stateless public web app, bare worker, stateful DB) + substitution, value layering, exposure→Service type, storage→PVC vs volumeClaimTemplate, ownership + AI-admin labels.
- **`controller.test.ts` (5)** — namespace-then-library resolution, render success, missing-blueprint error path.
- **`k8s-manifests.test.ts` (+4)** — platform Application include coherence, CRD registration, library category coverage, controller RBAC least-privilege.
- **`tsc --noEmit` strict** — clean.

```
23 pass / 0 fail  (platform-controller)
11 pass / 0 fail  (k8s-manifests)
```

## Zeta doctrine

The default Policy encodes the **no-directives** model: standing-authority autonomy for routine ops, `propose` for spend/mods, `forbidden` for data/security, with the gated classes (`budget, non-reversible, wont-do, hard-limits, force-push, external-repo`). Every Deployable carries an `ai` block — a persona operates it within a Policy, with a Room.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
