### PR TITLE
feat(platform): collaboration Room substrate + operating loop (no-directives, executable)

### DIFF
--- a/full-ai-cluster/platform-controller/README.md
+++ b/full-ai-cluster/platform-controller/README.md
@@ -45,11 +45,44 @@ renders, and **server-side-applies** the children (idempotent by construction).
 The controller is the **mechanical Cell**. Intelligent ops — diagnose, repair,
 optimize — is the Persona/agent layer (see `../COLLABORATION-MODEL.md`).
 
+## The collaboration layer (AI-native, no-directives made operable)
+
+Every Deployable carries an `ai` block — a persona operates it within a **Policy**,
+with a **Room**. Three pure, fully-tested modules implement
+[`../COLLABORATION-MODEL.md`](../COLLABORATION-MODEL.md) steps 3–4:
+
+- **`src/policy.ts`** — the "who decides" engine. `decide(policy, action)` →
+  `auto` (standing authority) | `propose` (emit an authorization-request, wait for
+  a human grant) | `forbidden` (human-only). **Source ≠ authorization**: a gated
+  class (`budget`, `non-reversible`, `wont-do`, `hard-limits`, `force-push`,
+  `external-repo`) always escalates above `auto`, even on an `auto` domain. Hard
+  floor (`wont-do`/`hard-limits`) is `forbidden`. Mirrors `policy-default.yaml`.
+- **`src/room.ts`** — the attributed, retraction-native collaboration stream. One
+  ordered Event log humans and personas both write to. Undo is a **Z-set
+  retraction** (`+1` then `−1`; both persist — HC-2). Every Event carries an
+  **AgencySignature** (proposed-by = source; authorized-by = a human, for gated).
+  Deterministic ids (no wall-clock) so a Room replays identically (DST). The
+  operating loop is `operate()` / `grant()` (human-only) / `actOnGrant()`.
+- **`src/signals.ts`** — trigger detection. Kubernetes conditions (OOM, crashloop,
+  PVC-pending, image-pull) are **data, not directives** (HC-3): classified into a
+  candidate Action the Policy then rules on. The gating flips on quota, not on the
+  fix — an in-quota memory bump is `auto`; an over-quota one is `budget`-gated.
+
+The GMod-crash worked example (COLLABORATION-MODEL §6) is proven end-to-end in
+`room.test.ts` / `signals.test.ts`: OOM → persona enters the Room → in-quota
+auto-fix, or over-quota → one inline `budget` approval → recovery.
+
+> **Seam:** persisting Rooms to the git-native event store and running the
+> ≥3 vendor-diverse personas that drive them is the agent-layer runtime
+> (`zeta-ai-agent.nix`, "control plane outside the control plane") — a separate
+> deployable, per COLLABORATION-MODEL §9. This controller ships the substrate +
+> the loop; the persona runtime consumes it.
+
 ## Develop
 
 ```bash
 bun install
-bun test          # 23 tests: engine genericity + reconcile resolution
+bun test          # 56 tests: engine genericity, reconcile, policy, room, signals
 bun run typecheck # tsc --noEmit, strict
 bun run start     # runs in-cluster (needs the service-account mount)
 ```

--- a/full-ai-cluster/platform-controller/src/policy.test.ts
+++ b/full-ai-cluster/platform-controller/src/policy.test.ts
@@ -1,0 +1,64 @@
+// full-ai-cluster/platform-controller/src/policy.test.ts
+//
+// The no-directives decision matrix: standing authority for in-bounds domains,
+// proposal for gated classes (even when the domain is auto), and the hard floor.
+
+import { describe, expect, test } from "bun:test";
+import { type Action, decide, isAutonomous, type PolicySpec } from "./policy.ts";
+
+// The default Policy (mirrors policy-default.yaml).
+const POLICY: PolicySpec = {
+  domains: [
+    { name: "lifecycle", autonomy: "auto" },
+    { name: "scaling", autonomy: "auto" },
+    { name: "config", autonomy: "auto" },
+    { name: "mods", autonomy: "propose" },
+    { name: "spend", autonomy: "propose" },
+    { name: "data", autonomy: "forbidden" },
+    { name: "security", autonomy: "forbidden" },
+  ],
+  gatedClasses: ["budget", "non-reversible", "wont-do", "hard-limits", "force-push", "external-repo"],
+};
+const act = (domain: string, gated?: Action["gated"]): Action => ({ domain, summary: `${domain}${gated ? `/${gated}` : ""}`, ...(gated ? { gated } : {}) });
+
+describe("decide — domain autonomy", () => {
+  test("in-bounds reversible domains run on standing authority", () => {
+    for (const d of ["lifecycle", "scaling", "config"]) expect(decide(POLICY, act(d)).level).toBe("auto");
+  });
+  test("side-effecting domains require a proposal", () => {
+    for (const d of ["mods", "spend"]) expect(decide(POLICY, act(d)).level).toBe("propose");
+  });
+  test("data + security are human-only", () => {
+    for (const d of ["data", "security"]) expect(decide(POLICY, act(d)).level).toBe("forbidden");
+  });
+  test("an unknown domain fails closed (least privilege)", () => {
+    expect(decide(POLICY, act("teleport")).level).toBe("forbidden");
+  });
+});
+
+describe("decide — gated classes escalate above auto", () => {
+  test("a budget-gated scaling action becomes propose even though scaling is auto", () => {
+    const d = decide(POLICY, act("scaling", "budget"));
+    expect(d.level).toBe("propose");
+    if (d.level === "propose") expect(d.gated).toBe("budget");
+  });
+  test("a non-reversible config action becomes propose despite config being auto", () => {
+    expect(decide(POLICY, act("config", "non-reversible")).level).toBe("propose");
+  });
+  test("hard-floor classes (wont-do, hard-limits) are forbidden even on an auto domain", () => {
+    expect(decide(POLICY, act("lifecycle", "wont-do")).level).toBe("forbidden");
+    expect(decide(POLICY, act("config", "hard-limits")).level).toBe("forbidden");
+  });
+  test("force-push / external-repo gated actions need a human grant", () => {
+    expect(decide(POLICY, act("config", "force-push")).level).toBe("propose");
+    expect(decide(POLICY, act("config", "external-repo")).level).toBe("propose");
+  });
+});
+
+describe("isAutonomous", () => {
+  test("true only for an auto domain with no gated class", () => {
+    expect(isAutonomous(POLICY, act("scaling"))).toBe(true);
+    expect(isAutonomous(POLICY, act("scaling", "budget"))).toBe(false);
+    expect(isAutonomous(POLICY, act("mods"))).toBe(false);
+  });
+});

--- a/full-ai-cluster/platform-controller/src/policy.ts
+++ b/full-ai-cluster/platform-controller/src/policy.ts
@@ -1,0 +1,72 @@
+// full-ai-cluster/platform-controller/src/policy.ts
+//
+// The "who decides" engine — no-directives made executable. An agent's intent to
+// act is classified into a domain + (maybe) a gated class; the Policy maps that
+// to one of three autonomy levels: auto (standing authority), propose (emit an
+// authorization-request, wait for a human grant), or forbidden (human-only).
+//
+// Source != authorization (.claude/rules/no-directives.md): WHO proposes an
+// action grants zero authority; only the autonomy level + a human grant on gated
+// classes confers it. A gated class ALWAYS escalates above `auto`, even when the
+// domain would otherwise be auto — least-privilege by construction.
+
+export type Autonomy = "auto" | "propose" | "forbidden";
+
+/** The no-directives gated classes. A gated action can never run on standing authority. */
+export type GatedClass = "budget" | "non-reversible" | "wont-do" | "hard-limits" | "force-push" | "external-repo";
+export const GATED_CLASSES: readonly GatedClass[] = ["budget", "non-reversible", "wont-do", "hard-limits", "force-push", "external-repo"];
+
+/** Mirrors the Policy CR spec (policy-default.yaml). */
+export interface PolicySpec {
+  domains: Array<{ name: string; autonomy: Autonomy }>;
+  gatedClasses: GatedClass[];
+}
+
+/** An agent's proposed action, classified for a Policy decision. */
+export interface Action {
+  domain: string; // lifecycle | scaling | config | mods | spend | data | security | …
+  gated?: GatedClass; // set when the action touches a gated class (e.g. exceeds quota → budget)
+  summary: string; // human-readable, for the Room
+}
+
+export type Decision =
+  | { level: "auto"; reason: string }
+  | { level: "propose"; reason: string; gated?: GatedClass }
+  | { level: "forbidden"; reason: string };
+
+const HARD_FLOOR: ReadonlySet<GatedClass> = new Set<GatedClass>(["wont-do", "hard-limits"]);
+
+/**
+ * Decide the autonomy for an action under a Policy.
+ * Rules, in order:
+ *   1. Unknown domain → forbidden (fail-closed; least privilege).
+ *   2. domain=forbidden → forbidden.
+ *   3. A gated class on the action escalates: hard-floor (wont-do/hard-limits) →
+ *      forbidden; any other gated class → propose (needs a fresh human grant),
+ *      EVEN IF the domain is `auto`. A gated class can never run on standing authority.
+ *   4. Otherwise the domain's autonomy stands.
+ */
+export function decide(policy: PolicySpec, action: Action): Decision {
+  const dom = policy.domains.find((d) => d.name === action.domain);
+  if (!dom) return { level: "forbidden", reason: `unknown domain "${action.domain}" — fail-closed` };
+  if (dom.autonomy === "forbidden") return { level: "forbidden", reason: `domain "${action.domain}" is human-only` };
+
+  if (action.gated) {
+    if (!policy.gatedClasses.includes(action.gated)) {
+      // A gated class the Policy doesn't even list is treated as gated anyway —
+      // never silently downgrade a non-reversible/budget/etc. action to auto.
+    }
+    if (HARD_FLOOR.has(action.gated)) {
+      return { level: "forbidden", reason: `gated class "${action.gated}" is a hard floor — human-only` };
+    }
+    return { level: "propose", reason: `gated class "${action.gated}" requires a fresh human authorization`, gated: action.gated };
+  }
+
+  if (dom.autonomy === "auto") return { level: "auto", reason: `domain "${action.domain}" runs on standing authority` };
+  return { level: "propose", reason: `domain "${action.domain}" requires a proposal` };
+}
+
+/** Convenience: does this action run without waiting on a human? */
+export function isAutonomous(policy: PolicySpec, action: Action): boolean {
+  return decide(policy, action).level === "auto";
+}

--- a/full-ai-cluster/platform-controller/src/room.test.ts
+++ b/full-ai-cluster/platform-controller/src/room.test.ts
@@ -1,0 +1,159 @@
+// full-ai-cluster/platform-controller/src/room.test.ts
+//
+// The Room: attribution, Z-set retraction (corrections not deletions), the
+// operating loop (auto-act vs propose), the human-only authorization gate, and
+// the COLLABORATION-MODEL.md GMod-crash worked example end to end.
+
+import { describe, expect, test } from "bun:test";
+import type { Action, PolicySpec } from "./policy.ts";
+import { human, persona, Room } from "./room.ts";
+
+const POLICY: PolicySpec = {
+  domains: [
+    { name: "lifecycle", autonomy: "auto" },
+    { name: "scaling", autonomy: "auto" },
+    { name: "data", autonomy: "forbidden" },
+  ],
+  gatedClasses: ["budget", "non-reversible", "wont-do", "hard-limits", "force-push", "external-repo"],
+};
+const otto = persona("otto");
+const aaron = human("aaron");
+const scaleInQuota: Action = { domain: "scaling", summary: "bump mem 4→6Gi + restart" };
+const scaleOverQuota: Action = { domain: "scaling", gated: "budget", summary: "bump mem 4→8Gi (exceeds quota)" };
+const deleteVolume: Action = { domain: "data", gated: "non-reversible", summary: "delete the world volume" };
+
+describe("attribution + glass halo", () => {
+  test("every event records who proposed it", () => {
+    const r = new Room("tenant-a/clan-server");
+    r.post(aaron, "please add gm_flatgrass");
+    const e = r.post(otto, "on it");
+    expect(e.sig.proposedBy).toEqual(otto);
+    expect(r.participants().map((p) => p.id).sort()).toEqual(["aaron", "otto"]);
+  });
+});
+
+describe("Z-set retraction — corrections, not deletions", () => {
+  test("a retracted event leaves the trace but drops out of the live view", () => {
+    const r = new Room("tenant-a/clan-server");
+    const wrong = r.post(otto, "restarting the WRONG server");
+    expect(r.live().some((e) => e.id === wrong.id)).toBe(true);
+    const ret = r.retract(otto, wrong.id, "wrong target");
+    expect(ret.weight).toBe(-1);
+    expect(r.live().some((e) => e.id === wrong.id)).toBe(false); // gone from live
+    expect(r.trace().some((e) => e.id === wrong.id)).toBe(true); // still in the trace
+    expect(r.trace().some((e) => e.id === ret.id)).toBe(true); // and so is the retraction
+  });
+  test("retracting an unknown event throws", () => {
+    expect(() => new Room("x").retract(otto, "evt-999")).toThrow();
+  });
+});
+
+describe("operating loop — auto vs propose vs forbidden", () => {
+  test("auto: an in-quota scale acts immediately and records the action", () => {
+    const r = new Room("tenant-a/clan-server");
+    const ran: string[] = [];
+    const out = r.operate(otto, scaleInQuota, POLICY, (a) => {
+      ran.push(a.summary);
+      return "scaled";
+    });
+    expect(out.kind).toBe("acted");
+    expect(ran).toEqual(["bump mem 4→6Gi + restart"]);
+    if (out.kind === "acted") expect(out.event.body).toMatchObject({ type: "action", result: "scaled" });
+  });
+  test("propose: a budget-gated scale emits an authorization-request and does NOT run", () => {
+    const r = new Room("tenant-a/clan-server");
+    let ran = false;
+    const out = r.operate(otto, scaleOverQuota, POLICY, () => ((ran = true), "x"));
+    expect(out.kind).toBe("proposed");
+    expect(ran).toBe(false); // nothing happened without a human grant
+    expect(r.pendingAuthorizations().length).toBe(1);
+  });
+  test("forbidden: a data-domain delete is refused with a reason, nothing appended", () => {
+    const r = new Room("tenant-a/clan-server");
+    const before = r.trace().length;
+    const out = r.operate(otto, deleteVolume, POLICY);
+    expect(out.kind).toBe("refused");
+    expect(r.trace().length).toBe(before);
+  });
+});
+
+describe("authorization gate — only a human authorizes (source ≠ authorization)", () => {
+  test("a persona cannot grant", () => {
+    const r = new Room("x");
+    const out = r.operate(otto, scaleOverQuota, POLICY);
+    if (out.kind !== "proposed") throw new Error("expected proposed");
+    expect(() => r.grant(persona("lior"), out.request.id, true)).toThrow();
+  });
+  test("actOnGrant refuses until a human grants, then runs and records authorized-by", () => {
+    const r = new Room("x");
+    const out = r.operate(otto, scaleOverQuota, POLICY);
+    if (out.kind !== "proposed") throw new Error("expected proposed");
+
+    // before any grant: refused
+    expect(r.actOnGrant(otto, out.request.id).kind).toBe("refused");
+
+    // human grants → now it runs, and the action carries authorized-by = the human
+    r.grant(aaron, out.request.id, true, "approved the spend");
+    let ran = false;
+    const done = r.actOnGrant(otto, out.request.id, () => ((ran = true), "scaled to 8Gi"));
+    expect(done.kind).toBe("acted");
+    expect(ran).toBe(true);
+    if (done.kind === "acted") {
+      expect(done.event.sig.authorizedBy).toEqual(aaron);
+      expect(r.pendingAuthorizations().length).toBe(0);
+    }
+  });
+  test("a denied grant keeps the action from running", () => {
+    const r = new Room("x");
+    const out = r.operate(otto, scaleOverQuota, POLICY);
+    if (out.kind !== "proposed") throw new Error("expected proposed");
+    r.grant(aaron, out.request.id, false, "too expensive this month");
+    expect(r.actOnGrant(otto, out.request.id).kind).toBe("refused");
+  });
+});
+
+describe("determinism — a Room replays identically (DST)", () => {
+  test("event ids derive from sequence, not wall-clock", () => {
+    const build = () => {
+      const r = new Room("x");
+      r.post(aaron, "hi");
+      r.operate(otto, scaleInQuota, POLICY, () => "ok");
+      return r.trace().map((e) => e.id);
+    };
+    expect(build()).toEqual(build());
+    expect(build()).toEqual(["evt-0", "evt-1"]);
+  });
+});
+
+describe("GMod-crash worked example (COLLABORATION-MODEL.md §6)", () => {
+  test("OOM → persona enters → in-quota auto-fix, all attributed and live", () => {
+    const r = new Room("acme/gmod-sandbox");
+    r.stateChange(persona("system"), "Running");
+    // server OOMs
+    r.stateChange(persona("system"), "CrashLoopBackOff", "OOMKilled at 4Gi");
+    // ops persona enters and proposes a plan, then acts (scaling within quota = auto)
+    r.post(otto, "crash: OOM. Plan: bump mem 4→6 GB + restart.");
+    const out = r.operate(otto, scaleInQuota, POLICY, () => "patched StatefulSet to 6Gi, restarted");
+    expect(out.kind).toBe("acted");
+    r.stateChange(otto, "Running", "recovered at 6Gi");
+    expect(r.phase()).toBe("Running");
+    // the whole exchange is on the glass-halo stream, attributed to system + otto
+    expect(r.participants().map((p) => p.id).sort()).toEqual(["otto", "system"]);
+  });
+
+  test("OOM fix that exceeds quota → inline gated:budget approval, then recovery", () => {
+    const r = new Room("acme/gmod-sandbox");
+    r.stateChange(persona("system"), "CrashLoopBackOff", "OOMKilled at 6Gi");
+    r.post(otto, "needs 8Gi — exceeds Acme's quota. Requesting approval.");
+    const out = r.operate(otto, scaleOverQuota, POLICY); // budget-gated → propose
+    expect(out.kind).toBe("proposed");
+    if (out.kind !== "proposed") return;
+    // human approves inline
+    r.grant(aaron, out.request.id, true, "ok for this month");
+    const done = r.actOnGrant(otto, out.request.id, () => "scaled to 8Gi");
+    expect(done.kind).toBe("acted");
+    r.stateChange(otto, "Running", "recovered at 8Gi");
+    expect(r.phase()).toBe("Running");
+    expect(r.pendingAuthorizations().length).toBe(0);
+  });
+});

--- a/full-ai-cluster/platform-controller/src/room.ts
+++ b/full-ai-cluster/platform-controller/src/room.ts
@@ -1,0 +1,178 @@
+// full-ai-cluster/platform-controller/src/room.ts
+//
+// The Room — the shared, attributed, retraction-native collaboration stream
+// around a Resource (COLLABORATION-MODEL.md §3). One ordered Event stream that
+// humans and personas both write to. The doctrine, made operable:
+//   • Append-only + attributed   — every Event carries an AgencySignature
+//     (proposed-by = source, zero authority; authorized-by = a human, for gated).
+//   • Corrections, not deletions  — undo is a Z-set RETRACTION (+1 then −1; both
+//     persist in the trace). HC-2 retraction-native made visible.
+//   • Glass halo                  — agent moves AND human authorizations share one
+//     see-through surface; neither can hide a move.
+//   • Deterministic               — Event ids derive from sequence, no wall-clock,
+//     so a Room replays identically (manifesto §7 DST). Timestamps, if any, are
+//     attached by the caller, never minted here.
+//
+// The operating loop (operate()) is the agent hook: trigger → decide(Policy) →
+// auto-act | propose (authorization-request, wait) | forbidden.
+
+import { type Action, type Decision, decide, type GatedClass, type PolicySpec } from "./policy.ts";
+
+export type ParticipantKind = "human" | "persona";
+export interface Participant {
+  id: string; // otto | lior | vera | a human handle
+  kind: ParticipantKind;
+}
+export const persona = (id: string): Participant => ({ id, kind: "persona" });
+export const human = (id: string): Participant => ({ id, kind: "human" });
+
+/** WHO proposed (source) and WHO authorized (only a human, for gated classes). */
+export interface AgencySignature {
+  proposedBy: Participant;
+  authorizedBy?: Participant;
+}
+
+export type EventBody =
+  | { type: "message"; text: string }
+  | { type: "action"; action: Action; result?: string }
+  | { type: "state-change"; phase: string; detail?: string }
+  | { type: "authorization-request"; action: Action; gated?: GatedClass }
+  | { type: "authorization-grant"; requestId: string; granted: boolean; note?: string }
+  | { type: "retraction"; retracts: string; note?: string };
+
+export interface RoomEvent {
+  id: string; // evt-<seq> — deterministic, replayable
+  seq: number;
+  weight: 1 | -1; // Z-set delta
+  sig: AgencySignature;
+  body: EventBody;
+}
+
+/** Result of an operating-loop step, for the caller to act on. */
+export type OperateOutcome =
+  | { kind: "acted"; event: RoomEvent }
+  | { kind: "proposed"; request: RoomEvent } // awaiting a human grant
+  | { kind: "refused"; decision: Decision };
+
+export class Room {
+  readonly resource: string; // namespace/name of the Resource this Room is about
+  private events: RoomEvent[] = [];
+  private seq = 0;
+
+  constructor(resource: string) {
+    this.resource = resource;
+  }
+
+  /** All events, in order, including retracted ones (the trace is never rewritten). */
+  trace(): readonly RoomEvent[] {
+    return this.events;
+  }
+
+  private append(sig: AgencySignature, body: EventBody, weight: 1 | -1 = 1): RoomEvent {
+    const ev: RoomEvent = { id: `evt-${this.seq}`, seq: this.seq, weight, sig, body };
+    this.seq++;
+    this.events.push(ev);
+    return ev;
+  }
+
+  // ── primitives ───────────────────────────────────────────────────────
+  post(by: Participant, text: string): RoomEvent {
+    return this.append({ proposedBy: by }, { type: "message", text });
+  }
+
+  stateChange(by: Participant, phase: string, detail?: string): RoomEvent {
+    return this.append({ proposedBy: by }, { type: "state-change", phase, ...(detail ? { detail } : {}) });
+  }
+
+  /** Z-set retraction: append a −1 that references the retracted event. Both persist. */
+  retract(by: Participant, eventId: string, note?: string): RoomEvent {
+    if (!this.events.some((e) => e.id === eventId)) throw new Error(`cannot retract unknown event ${eventId}`);
+    return this.append({ proposedBy: by }, { type: "retraction", retracts: eventId, ...(note ? { note } : {}) }, -1);
+  }
+
+  // ── the operating loop (the agent hook) ──────────────────────────────
+  /**
+   * A persona attempts an Action under a Policy. Returns what happened:
+   *  - auto      → the action Event is appended (acted)
+   *  - propose   → an authorization-request Event is appended; caller waits for grant (proposed)
+   *  - forbidden → nothing is appended; the refusal is returned (refused)
+   * Source != authorization: proposing never confers authority — only grant() (by a human) does.
+   */
+  operate(by: Participant, action: Action, policy: PolicySpec, run?: (a: Action) => string): OperateOutcome {
+    const d = decide(policy, action);
+    if (d.level === "forbidden") return { kind: "refused", decision: d };
+    if (d.level === "propose") {
+      const request = this.append({ proposedBy: by }, { type: "authorization-request", action, ...(d.gated ? { gated: d.gated } : {}) });
+      return { kind: "proposed", request };
+    }
+    const result = run?.(action);
+    const event = this.append({ proposedBy: by }, { type: "action", action, ...(result !== undefined ? { result } : {}) });
+    return { kind: "acted", event };
+  }
+
+  /**
+   * A human grants (or denies) a pending authorization-request. ONLY a human may
+   * authorize a gated class (no-directives: authorization is human-attached).
+   */
+  grant(by: Participant, requestId: string, granted: boolean, note?: string): RoomEvent {
+    if (by.kind !== "human") throw new Error("only a human may authorize a gated action (source ≠ authorization)");
+    const req = this.events.find((e) => e.id === requestId && e.body.type === "authorization-request");
+    if (!req) throw new Error(`no authorization-request ${requestId}`);
+    return this.append({ proposedBy: by, authorizedBy: by }, { type: "authorization-grant", requestId, granted, ...(note ? { note } : {}) });
+  }
+
+  /**
+   * After a grant, the proposer performs the now-authorized action. Refuses if the
+   * request was not granted — closing the loop: a proposed action runs only on a
+   * human grant, and the resulting Event records authorized-by.
+   */
+  actOnGrant(by: Participant, requestId: string, run?: (a: Action) => string): OperateOutcome {
+    const req = this.events.find((e) => e.id === requestId);
+    if (!req || req.body.type !== "authorization-request") throw new Error(`no authorization-request ${requestId}`);
+    const grant = this.latestGrant(requestId);
+    if (!grant || grant.body.type !== "authorization-grant" || !grant.body.granted) {
+      return { kind: "refused", decision: { level: "forbidden", reason: `authorization ${requestId} not granted` } };
+    }
+    const action = req.body.action;
+    const result = run?.(action);
+    const event = this.append(
+      { proposedBy: by, authorizedBy: grant.sig.authorizedBy },
+      { type: "action", action, ...(result !== undefined ? { result } : {}) },
+    );
+    return { kind: "acted", event };
+  }
+
+  // ── projections (the live view; retractions net out) ─────────────────
+  /** Events whose net Z-set weight is > 0 — i.e. not retracted. The trace itself is intact. */
+  live(): RoomEvent[] {
+    const retracted = new Set<string>();
+    for (const e of this.events) if (e.body.type === "retraction") retracted.add(e.body.retracts);
+    return this.events.filter((e) => e.weight === 1 && e.body.type !== "retraction" && !retracted.has(e.id));
+  }
+
+  /** The latest non-retracted state-change phase, or undefined. */
+  phase(): string | undefined {
+    const states = this.live().filter((e) => e.body.type === "state-change");
+    const last = states[states.length - 1];
+    return last && last.body.type === "state-change" ? last.body.phase : undefined;
+  }
+
+  private latestGrant(requestId: string): RoomEvent | undefined {
+    const grants = this.events.filter((e) => e.body.type === "authorization-grant" && e.body.requestId === requestId);
+    return grants[grants.length - 1];
+  }
+
+  /** Authorization-requests with no (granted) decision yet — the "needs-a-human" set. */
+  pendingAuthorizations(): RoomEvent[] {
+    const decided = new Set<string>();
+    for (const e of this.events) if (e.body.type === "authorization-grant") decided.add(e.body.requestId);
+    return this.live().filter((e) => e.body.type === "authorization-request" && !decided.has(e.id));
+  }
+
+  /** Distinct participants who have appeared in the stream. */
+  participants(): Participant[] {
+    const seen = new Map<string, Participant>();
+    for (const e of this.events) seen.set(`${e.sig.proposedBy.kind}:${e.sig.proposedBy.id}`, e.sig.proposedBy);
+    return [...seen.values()];
+  }
+}

--- a/full-ai-cluster/platform-controller/src/signals.test.ts
+++ b/full-ai-cluster/platform-controller/src/signals.test.ts
@@ -1,0 +1,95 @@
+// full-ai-cluster/platform-controller/src/signals.test.ts
+//
+// Trigger detection + the signal→remediation classification, and the full
+// detect→decide→Room path: an OOM signal driving the operating loop, both the
+// in-quota (auto) and over-quota (gated:budget → propose) branches.
+
+import { describe, expect, test } from "bun:test";
+import type { PolicySpec } from "./policy.ts";
+import { decide } from "./policy.ts";
+import { persona, Room } from "./room.ts";
+import { podSignal, pvcSignal, remediate } from "./signals.ts";
+
+const POLICY: PolicySpec = {
+  domains: [
+    { name: "lifecycle", autonomy: "auto" },
+    { name: "scaling", autonomy: "auto" },
+    { name: "config", autonomy: "auto" },
+    { name: "data", autonomy: "forbidden" },
+  ],
+  gatedClasses: ["budget", "non-reversible", "wont-do", "hard-limits", "force-push", "external-repo"],
+};
+
+describe("podSignal classification", () => {
+  test("detects OOMKilled from lastState", () => {
+    const s = podSignal({ status: { containerStatuses: [{ restartCount: 3, lastState: { terminated: { reason: "OOMKilled", exitCode: 137 } } }] } });
+    expect(s.kind).toBe("oom");
+  });
+  test("detects CrashLoopBackOff", () => {
+    expect(podSignal({ status: { containerStatuses: [{ state: { waiting: { reason: "CrashLoopBackOff" } } }] } }).kind).toBe("crashloop");
+  });
+  test("detects ImagePullBackOff", () => {
+    expect(podSignal({ status: { containerStatuses: [{ state: { waiting: { reason: "ImagePullBackOff" } } }] } }).kind).toBe("image-pull-error");
+  });
+  test("Ready=False but no container fault → unready", () => {
+    expect(podSignal({ status: { conditions: [{ type: "Ready", status: "False", reason: "ContainersNotReady" }] } }).kind).toBe("unready");
+  });
+  test("a running, ready pod is healthy", () => {
+    expect(podSignal({ status: { phase: "Running", conditions: [{ type: "Ready", status: "True" }], containerStatuses: [{ ready: true }] } }).kind).toBe("healthy");
+  });
+  test("OOM takes priority over a crashloop waiting state on the same container", () => {
+    const s = podSignal({ status: { containerStatuses: [{ restartCount: 5, state: { waiting: { reason: "CrashLoopBackOff" } }, lastState: { terminated: { reason: "OOMKilled" } } }] } });
+    expect(s.kind).toBe("oom");
+  });
+});
+
+describe("pvcSignal", () => {
+  test("Pending PVC produces a signal; Bound produces none", () => {
+    expect(pvcSignal({ status: { phase: "Pending" } })?.kind).toBe("pvc-pending");
+    expect(pvcSignal({ status: { phase: "Bound" } })).toBeUndefined();
+  });
+});
+
+describe("remediate — the gating flips on quota, not on the fix", () => {
+  test("in-quota OOM fix is plain scaling (auto under default Policy)", () => {
+    const rem = remediate({ kind: "oom", detail: "x" }, { withinQuota: true })!;
+    expect(rem.action.domain).toBe("scaling");
+    expect(rem.action.gated).toBeUndefined();
+    expect(decide(POLICY, rem.action).level).toBe("auto");
+  });
+  test("over-quota OOM fix is budget-gated (→ propose, needs a human)", () => {
+    const rem = remediate({ kind: "oom", detail: "x" }, { withinQuota: false })!;
+    expect(rem.action.gated).toBe("budget");
+    expect(decide(POLICY, rem.action).level).toBe("propose");
+  });
+  test("a healthy signal yields no remediation", () => {
+    expect(remediate({ kind: "healthy", detail: "Running" })).toBeUndefined();
+  });
+});
+
+describe("detect → decide → Room (end to end)", () => {
+  const otto = persona("otto");
+
+  test("in-quota OOM: signal drives an auto remediation posted to the Room", () => {
+    const pod = { status: { containerStatuses: [{ restartCount: 2, lastState: { terminated: { reason: "OOMKilled" } } }] } };
+    const sig = podSignal(pod);
+    const rem = remediate(sig, { withinQuota: true })!;
+
+    const r = new Room("acme/gmod-sandbox");
+    r.stateChange(persona("system"), "CrashLoopBackOff", sig.detail);
+    r.post(otto, rem.plan);
+    const out = r.operate(otto, rem.action, POLICY, () => "scaled + restarted");
+    expect(out.kind).toBe("acted");
+    r.stateChange(otto, "Running", "recovered");
+    expect(r.phase()).toBe("Running");
+  });
+
+  test("over-quota OOM: signal drives a proposal that waits for a human grant", () => {
+    const sig = podSignal({ status: { containerStatuses: [{ lastState: { terminated: { reason: "OOMKilled" } } }] } });
+    const rem = remediate(sig, { withinQuota: false })!;
+    const r = new Room("acme/gmod-sandbox");
+    const out = r.operate(otto, rem.action, POLICY);
+    expect(out.kind).toBe("proposed");
+    expect(r.pendingAuthorizations().length).toBe(1);
+  });
+});

--- a/full-ai-cluster/platform-controller/src/signals.ts
+++ b/full-ai-cluster/platform-controller/src/signals.ts
@@ -1,0 +1,97 @@
+// full-ai-cluster/platform-controller/src/signals.ts
+//
+// Trigger detection — the "detect" step of the operating loop (COLLABORATION-
+// MODEL.md §6). Kubernetes object conditions are SIGNALS, and per HC-3 a signal
+// is DATA, not a directive: we classify it into a candidate Action (domain +
+// maybe a gated class), but the Policy still decides whether the persona may act.
+// This is a deterministic reflex baseline; richer personas extend it. No I/O.
+
+import type { Action } from "./policy.ts";
+
+/** A normalized signal extracted from a watched Kubernetes object. */
+export interface Signal {
+  kind: "crashloop" | "oom" | "pvc-pending" | "image-pull-error" | "unready" | "healthy";
+  detail: string;
+}
+
+/** What the persona would PROPOSE to do about a signal (Policy decides if it may). */
+export interface Remediation {
+  signal: Signal;
+  action: Action; // classified for decide(): domain + optional gated class
+  plan: string; // the human-readable plan posted to the Room
+}
+
+// ── pod-status interpretation ─────────────────────────────────────────
+interface ContainerState {
+  waiting?: { reason?: string; message?: string };
+  terminated?: { reason?: string; exitCode?: number };
+}
+interface ContainerStatus {
+  ready?: boolean;
+  restartCount?: number;
+  state?: ContainerState;
+  lastState?: ContainerState;
+}
+interface PodLike {
+  status?: {
+    phase?: string;
+    conditions?: Array<{ type: string; status: string; reason?: string }>;
+    containerStatuses?: ContainerStatus[];
+  };
+}
+
+/** Classify a Pod's current condition into a Signal (or healthy). */
+export function podSignal(pod: PodLike): Signal {
+  const cs = pod.status?.containerStatuses ?? [];
+  for (const c of cs) {
+    const w = c.state?.waiting;
+    const lastTerm = c.lastState?.terminated;
+    if (lastTerm?.reason === "OOMKilled" || c.state?.terminated?.reason === "OOMKilled") {
+      return { kind: "oom", detail: `OOMKilled (restarts=${c.restartCount ?? 0})` };
+    }
+    if (w?.reason === "CrashLoopBackOff") return { kind: "crashloop", detail: w.message ?? `CrashLoopBackOff (restarts=${c.restartCount ?? 0})` };
+    if (w?.reason === "ImagePullBackOff" || w?.reason === "ErrImagePull") return { kind: "image-pull-error", detail: w.message ?? w.reason };
+  }
+  const ready = pod.status?.conditions?.find((c) => c.type === "Ready");
+  if (ready && ready.status !== "True") return { kind: "unready", detail: ready.reason ?? "not ready" };
+  return { kind: "healthy", detail: pod.status?.phase ?? "Running" };
+}
+
+/** Is a PVC stuck Pending (commonly: no provisioner / capacity)? */
+export function pvcSignal(pvc: { status?: { phase?: string } }): Signal | undefined {
+  if (pvc.status?.phase === "Pending") return { kind: "pvc-pending", detail: "PVC Pending — storage not bound" };
+  return undefined;
+}
+
+// ── signal → proposed remediation ─────────────────────────────────────
+/**
+ * Map a signal to the Action a persona would propose. `withinQuota` is the
+ * tenant-quota check the persona performs first: a memory bump that stays in
+ * quota is plain `scaling` (auto under the default Policy); one that exceeds it
+ * is `scaling` + gated:budget (→ propose, needs a human grant). Same fix, the
+ * gating flips on whether it costs more — exactly the no-directives line.
+ */
+export function remediate(signal: Signal, opts?: { withinQuota?: boolean }): Remediation | undefined {
+  const withinQuota = opts?.withinQuota ?? true;
+  switch (signal.kind) {
+    case "oom": {
+      const gated = withinQuota ? undefined : ("budget" as const);
+      return {
+        signal,
+        action: { domain: "scaling", summary: "increase memory limit + restart", ...(gated ? { gated } : {}) },
+        plan: withinQuota ? "OOM: bump memory one tier and restart (within quota)." : "OOM: needs more memory than the quota allows — requesting a budget increase.",
+      };
+    }
+    case "crashloop":
+      return { signal, action: { domain: "lifecycle", summary: "inspect logs + restart" }, plan: "CrashLoop: pull recent logs, restart, and watch for recurrence." };
+    case "unready":
+      return { signal, action: { domain: "lifecycle", summary: "restart to clear unready state" }, plan: "Unready: restart the workload and re-check readiness." };
+    case "pvc-pending":
+      return { signal, action: { domain: "config", summary: "verify storageClass + provisioner" }, plan: "PVC Pending: confirm the longhorn StorageClass is default and the provisioner is healthy." };
+    case "image-pull-error":
+      // An image/registry fix usually means a config change the tenant must confirm.
+      return { signal, action: { domain: "config", summary: "correct image ref / pull secret", gated: "external-repo" }, plan: "ImagePull error: the image or pull secret is wrong — proposing a corrected reference for approval." };
+    case "healthy":
+      return undefined; // nothing to do
+  }
+}


### PR DESCRIPTION
## What

The **AI-native heart** of the platform. Every Deployable's `ai` block promises a persona operates the resource *within a Policy, with a Room*. This PR makes that operable — [`COLLABORATION-MODEL.md`](../full-ai-cluster/COLLABORATION-MODEL.md) steps 3–4 as three pure, fully-tested modules. No cluster needed to test; the whole thing is deterministic.

## The three modules

### `policy.ts` — the "who decides" engine
`decide(policy, action)` → `auto` | `propose` | `forbidden`. **Source ≠ authorization** ([no-directives](../.claude/rules/no-directives.md)):
- A **gated class** (`budget`, `non-reversible`, `wont-do`, `hard-limits`, `force-push`, `external-repo`) **always escalates above `auto`** — even on an `auto` domain. A gated action can never run on standing authority.
- The **hard floor** (`wont-do`/`hard-limits`) is `forbidden`.
- Unknown domain **fails closed**. Mirrors `policy-default.yaml`.

### `room.ts` — the attributed, retraction-native collaboration stream
One ordered Event log humans and personas both write to (the **glass halo** for a piece of work).
- **Undo is a Z-set retraction** (`+1` then `−1`; both persist in the trace — **HC-2** made visible). `live()` nets retractions out; `trace()` is never rewritten.
- Every Event carries an **AgencySignature**: `proposedBy` (source, zero authority) + `authorizedBy` (a human, for gated).
- **Deterministic** Event ids (no wall-clock) → a Room replays identically (**manifesto §7 DST**).
- The operating loop: `operate()` (auto-act \| propose \| refuse), `grant()` (**human-only** — enforces source ≠ authorization), `actOnGrant()` (runs only on a granted request, records `authorizedBy`). `pendingAuthorizations()` is the "needs-a-human" set.

### `signals.ts` — trigger detection
Kubernetes conditions (OOM, crashloop, PVC-pending, image-pull, unready) are **data, not directives** (**HC-3**): classified into a candidate Action the Policy then rules on. **The gating flips on quota, not on the fix** — an in-quota memory bump is `scaling`=auto; an over-quota one is `budget`-gated → propose. Exactly the no-directives line.

## Tests — 56 total (+33 this PR), all green

- The no-directives decision matrix (domains, gated escalation, hard floor, fail-closed).
- Z-set retraction: trace intact, live view nets out, retracting an unknown event throws.
- The operating loop's three branches; the human-only authorization gate (a persona **cannot** grant; `actOnGrant` refuses until granted, then records `authorizedBy`; a denial blocks).
- Determinism/replay; signal classification incl. OOM-over-crashloop priority.
- **The GMod-crash worked example end to end** (COLLABORATION-MODEL §6): OOM → persona enters the Room → in-quota auto-fix, **and** the over-quota branch → one inline `budget` approval → recovery.
- `tsc --noEmit` strict: clean.

```
56 pass / 0 fail / 138 expect() calls
```

## Seam (honest scope boundary)

Persisting Rooms to the git-native event store and running the ≥3 vendor-diverse personas that drive them is the **agent-layer runtime** (`zeta-ai-agent.nix`, "control plane outside the control plane") — a separate deployable, per COLLABORATION-MODEL §9. This PR ships the **substrate + the loop**; the persona runtime consumes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
