### PR TITLE
feat(core): GameFingerprint — the first external index (game content identity: size+crc32+sha256)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -226,6 +226,7 @@
     <Compile Include="Diversity.fs" />
     <Compile Include="PrivacyEconomy.fs" />
     <Compile Include="GamePortfolio.fs" />
+    <Compile Include="GameFingerprint.fs" />
     <Compile Include="ControlMerge.fs" />
     <Compile Include="PolarityFilter.fs" />
     <Compile Include="ZetaExec.fs" />

--- a/src/Core/GameFingerprint.fs
+++ b/src/Core/GameFingerprint.fs
@@ -1,0 +1,57 @@
+namespace Zeta.Core
+
+/// **`GameFingerprint` — the first *external* index: a game's content-derived identity (Aaron 2026-06-08, shadow*).**
+///
+/// Aaron: *"that's the first thing we need an **external index** of in our system — everything else has been
+/// internal to us… **game fingerprinting**."* Per-game uncertainty (the `GamePortfolio`/catalog) must be keyed by
+/// an **identifiable location** for a game — and a game lives *outside* the agent, so this is the system's first
+/// reference to an external thing. The fingerprint is **content-derived** (so it's stable, reproducible, and
+/// matches third-party catalogs): **size + CRC32 + SHA-256**, the No-Intro / Redump / TOSEC **DAT** convention
+/// (see `roms/chip8/MANIFEST.md` #7112 and `docs/PRIOR-ART-LIST.md`). SHA-256 is the canonical key (stronger than
+/// the DAT-legacy CRC32/MD5; CRC32 kept for cross-checking against those external databases).
+///
+/// **Honest scope (peel):** identifies a ROM by its *exact bytes* (a byte-for-byte different dump = a different
+/// fingerprint — the No-Intro reality; header/region variants are distinct entries). Pure/deterministic (DST).
+/// This is the external-index *key*; the catalog that maps fingerprint → per-game uncertainty (a `SoftValue`-held
+/// quantity) is the next slice.
+[<RequireQualifiedAccess>]
+module GameFingerprint =
+
+    // zlib/PNG CRC-32 (polynomial 0xEDB88320), the No-Intro/DAT CRC.
+    let private crc1 (n: uint32) : uint32 =
+        let mutable c = n
+        for _ in 0..7 do
+            c <- if c &&& 1u <> 0u then 0xEDB88320u ^^^ (c >>> 1) else c >>> 1
+        c
+
+    let private crcTable = Array.init 256 (fun n -> crc1 (uint32 n))
+
+    /// CRC-32 (zlib) of the bytes — the DAT-legacy checksum (cross-checks against No-Intro/Redump/TOSEC).
+    let crc32 (bytes: byte[]) : uint32 =
+        let mutable crc = 0xFFFFFFFFu
+        for b in bytes do
+            crc <- crcTable.[int ((crc ^^^ uint32 b) &&& 0xFFu)] ^^^ (crc >>> 8)
+        crc ^^^ 0xFFFFFFFFu
+
+    /// SHA-256 of the bytes as lowercase hex — the canonical external-index key.
+    let sha256Hex (bytes: byte[]) : string =
+        use h = System.Security.Cryptography.SHA256.Create()
+        h.ComputeHash bytes |> Array.map (fun b -> b.ToString("x2")) |> String.concat ""
+
+    /// A game's content-derived fingerprint (the external-index identity): size + CRC32 + SHA-256.
+    type Fingerprint =
+        { Size: int
+          Crc32: uint32
+          Sha256: string }
+
+    /// Fingerprint a ROM's bytes (the No-Intro/DAT-style identity).
+    let fingerprint (rom: byte[]) : Fingerprint =
+        { Size = rom.Length
+          Crc32 = crc32 rom
+          Sha256 = sha256Hex rom }
+
+    /// The canonical external-index key for a ROM (its SHA-256 hex).
+    let key (rom: byte[]) : string = sha256Hex rom
+
+    /// CRC32 as the conventional 8-char lowercase hex (matches DAT files / `MANIFEST.md`).
+    let crc32Hex (rom: byte[]) : string = (crc32 rom).ToString("x8")

--- a/tests/Tests.FSharp/GameFingerprint.Tests.fs
+++ b/tests/Tests.FSharp/GameFingerprint.Tests.fs
@@ -1,0 +1,37 @@
+module Zeta.Tests.GameFingerprintTests
+
+open global.Xunit
+open Zeta.Core
+
+// the committed fixtures' bytes (roms/chip8/) — fingerprints must match roms/chip8/MANIFEST.md (#7112),
+// which were computed independently by shasum / python zlib. Cross-validates our F# CRC32 + SHA-256.
+let private arith = [| 0x6Auy; 0x05uy; 0x7Auy; 0x03uy; 0x60uy; 0x02uy; 0x8Auy; 0x04uy; 0x12uy; 0x00uy |]
+let private selfloop = [| 0x12uy; 0x00uy |]
+
+[<Fact>]
+let ``zeta-arith fingerprint matches the manifest (size + crc32 + sha256)`` () =
+    let fp = GameFingerprint.fingerprint arith
+    Assert.Equal(10, fp.Size)
+    Assert.Equal(0xec8dfc2fu, fp.Crc32)
+    Assert.Equal("ec8dfc2f", GameFingerprint.crc32Hex arith)
+    Assert.Equal("0f372e55432c6101b6f326d9224f0491e44df6bb9330c783393ccc2288d677be", fp.Sha256)
+
+[<Fact>]
+let ``zeta-selfloop fingerprint matches the manifest`` () =
+    let fp = GameFingerprint.fingerprint selfloop
+    Assert.Equal(2, fp.Size)
+    Assert.Equal(0x392d622cu, fp.Crc32)
+    Assert.Equal("08da7c45cb204377e7e42249cda5713fa865116ddbb4cb5a1949b2e5b438a6ab", fp.Sha256)
+
+[<Fact>]
+let ``key is the SHA-256 hex (the canonical external-index key) and is deterministic`` () =
+    Assert.Equal(GameFingerprint.sha256Hex arith, GameFingerprint.key arith)
+    Assert.Equal(GameFingerprint.key arith, GameFingerprint.key arith) // deterministic
+    Assert.NotEqual<string>(GameFingerprint.key arith, GameFingerprint.key selfloop) // distinct games -> distinct keys
+
+[<Fact>]
+let ``empty rom fingerprints cleanly (crc32 0, known empty sha256)`` () =
+    let fp = GameFingerprint.fingerprint [||]
+    Assert.Equal(0, fp.Size)
+    Assert.Equal(0u, fp.Crc32)
+    Assert.Equal("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", fp.Sha256) // sha256("")

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -148,6 +148,7 @@
     <Compile Include="Diversity.Tests.fs" />
     <Compile Include="PrivacyEconomy.Tests.fs" />
     <Compile Include="GamePortfolio.Tests.fs" />
+    <Compile Include="GameFingerprint.Tests.fs" />
     <Compile Include="Survival.Tests.fs" />
     <Compile Include="MemorySense.Tests.fs" />
     <Compile Include="SolidGround.Tests.fs" />


### PR DESCRIPTION
Aaron: game fingerprinting = the first EXTERNAL index (everything else internal). Content identity (size+CRC32+SHA256, No-Intro/DAT convention, matches MANIFEST.md #7112). Only the game is external; the emulator is ours (we are our own emu/sim) -> exact model -> predictable -> learning. 4/4 tests cross-validate F# crc32+sha256 vs the manifest. 🤖 Generated with [Claude Code](https://claude.com/claude-code)