### PR TITLE
feat(core): GameCatalog — per-game uncertainty keyed by fingerprint

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -227,6 +227,7 @@
     <Compile Include="PrivacyEconomy.fs" />
     <Compile Include="GamePortfolio.fs" />
     <Compile Include="GameFingerprint.fs" />
+    <Compile Include="GameCatalog.fs" />
     <Compile Include="ControlMerge.fs" />
     <Compile Include="PolarityFilter.fs" />
     <Compile Include="ZetaExec.fs" />

--- a/src/Core/GameCatalog.fs
+++ b/src/Core/GameCatalog.fs
@@ -1,0 +1,57 @@
+namespace Zeta.Core
+
+/// **`GameCatalog` — per-game uncertainty keyed by the external fingerprint (Aaron 2026-06-08, shadow*).**
+///
+/// Aaron: *"our DynamicValue/SoftValue needs to be able to hold the **uncertainty per game** — assign game
+/// uncertainty to an **identifiable location**."* The identifiable location is the `GameFingerprint` (the first
+/// external index, #7154); the catalog maps **fingerprint → remaining uncertainty** for that game. This is the
+/// external-index made into the uncertainty store: the system knows, per game, how much uncertainty is left to
+/// reduce — which drives what to play next (`GamePortfolio.selectNext`) and when a game is *sufficiently* played
+/// (`GamePortfolio` commutative regime, #7152).
+///
+/// The held quantity is a scalar **uncertainty** (e.g. the `SoftValue` entropy / `1 − confidence` for that game —
+/// the catalog holds the *measure*; the full `SoftValue` is the source). Playing a game **reduces** its
+/// uncertainty (monotone toward 0); a game at/below a threshold is **resolved** (sufficiently played).
+///
+/// **Honest scope (peel):** keyed by SHA-256 (exact-bytes identity — the No-Intro reality). Uncertainty is a
+/// scalar projection of the per-game `SoftValue`; the full distribution lives in the engine, the catalog is the
+/// index. An *uncatalogued* game returns `None` (unknown — not zero; not-known ≠ resolved, the good/bad-style
+/// asymmetry #7150). `reduce` clamps at 0 (you can't go negative-uncertain). Deterministic (DST).
+[<RequireQualifiedAccess>]
+module GameCatalog =
+
+    /// fingerprint SHA-256 → remaining uncertainty for that game.
+    type Catalog = Map<string, float>
+
+    let empty: Catalog = Map.empty
+
+    /// Record a game's uncertainty under its fingerprint key.
+    let assign (fp: GameFingerprint.Fingerprint) (uncertainty: float) (cat: Catalog) : Catalog =
+        Map.add fp.Sha256 (max 0.0 uncertainty) cat
+
+    /// Fingerprint a ROM and record its uncertainty (convenience).
+    let assignRom (rom: byte[]) (uncertainty: float) (cat: Catalog) : Catalog =
+        assign (GameFingerprint.fingerprint rom) uncertainty cat
+
+    /// The recorded uncertainty for a game — `None` if uncatalogued (unknown ≠ zero/resolved).
+    let uncertainty (fp: GameFingerprint.Fingerprint) (cat: Catalog) : float option = Map.tryFind fp.Sha256 cat
+
+    /// **Reduce** a game's uncertainty (playing it) by `amount`, clamped at 0. No-op for uncatalogued games.
+    let reduce (fp: GameFingerprint.Fingerprint) (amount: float) (cat: Catalog) : Catalog =
+        match Map.tryFind fp.Sha256 cat with
+        | Some u -> Map.add fp.Sha256 (max 0.0 (u - amount)) cat
+        | None -> cat
+
+    /// **Resolved** — uncertainty at/below `threshold` (sufficiently played). Uncatalogued ⇒ false (unknown, not
+    /// resolved).
+    let resolved (threshold: float) (fp: GameFingerprint.Fingerprint) (cat: Catalog) : bool =
+        match Map.tryFind fp.Sha256 cat with
+        | Some u -> u <= threshold
+        | None -> false
+
+    /// Total remaining game-uncertainty across the catalog (the system's outstanding uncertainty about games).
+    let total (cat: Catalog) : float = cat |> Map.toSeq |> Seq.sumBy snd
+
+    /// The catalogued game with the **most** remaining uncertainty — the play-next signal. `None` if empty.
+    let mostUncertain (cat: Catalog) : (string * float) option =
+        if Map.isEmpty cat then None else cat |> Map.toSeq |> Seq.maxBy snd |> Some

--- a/tests/Tests.FSharp/GameCatalog.Tests.fs
+++ b/tests/Tests.FSharp/GameCatalog.Tests.fs
@@ -1,0 +1,34 @@
+module Zeta.Tests.GameCatalogTests
+
+open global.Xunit
+open Zeta.Core
+
+let private fpA = GameFingerprint.fingerprint [| 0x6Auy; 0x05uy |]
+let private fpB = GameFingerprint.fingerprint [| 0x12uy; 0x00uy |]
+
+[<Fact>]
+let ``assign + uncertainty: per-game uncertainty keyed by fingerprint`` () =
+    let cat = GameCatalog.empty |> GameCatalog.assign fpA 5.0
+    Assert.Equal(Some 5.0, GameCatalog.uncertainty fpA cat)
+    Assert.Equal(None, GameCatalog.uncertainty fpB cat) // uncatalogued -> None (unknown, not zero)
+
+[<Fact>]
+let ``reduce lowers uncertainty (playing), clamped at 0`` () =
+    let cat = GameCatalog.empty |> GameCatalog.assign fpA 5.0 |> GameCatalog.reduce fpA 2.0
+    Assert.Equal(Some 3.0, GameCatalog.uncertainty fpA cat)
+    let floored = GameCatalog.reduce fpA 100.0 cat
+    Assert.Equal(Some 0.0, GameCatalog.uncertainty fpA floored) // can't go negative
+
+[<Fact>]
+let ``resolved: at/below threshold = sufficiently played; uncatalogued = false (unknown != resolved)`` () =
+    let cat = GameCatalog.empty |> GameCatalog.assign fpA 0.5
+    Assert.True(GameCatalog.resolved 1.0 fpA cat)
+    Assert.False(GameCatalog.resolved 0.1 fpA cat)
+    Assert.False(GameCatalog.resolved 1.0 fpB cat) // unknown game is NOT resolved
+
+[<Fact>]
+let ``total + mostUncertain drive what to play next`` () =
+    let cat = GameCatalog.empty |> GameCatalog.assign fpA 2.0 |> GameCatalog.assign fpB 7.0
+    Assert.Equal(9.0, GameCatalog.total cat, 9)
+    Assert.Equal(Some(fpB.Sha256, 7.0), GameCatalog.mostUncertain cat) // B has the most -> play it next
+    Assert.Equal(None, GameCatalog.mostUncertain GameCatalog.empty)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -149,6 +149,7 @@
     <Compile Include="PrivacyEconomy.Tests.fs" />
     <Compile Include="GamePortfolio.Tests.fs" />
     <Compile Include="GameFingerprint.Tests.fs" />
+    <Compile Include="GameCatalog.Tests.fs" />
     <Compile Include="Survival.Tests.fs" />
     <Compile Include="MemorySense.Tests.fs" />
     <Compile Include="SolidGround.Tests.fs" />


### PR DESCRIPTION
Catalog = fingerprint -> remaining uncertainty (the external index made into the uncertainty store). assign/uncertainty/reduce/resolved/total/mostUncertain. 4/4 tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)