### PR TITLE
feat(platform): portal UI base — top-down resources, catalog, needs-me board

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "zeta-portal-demo",
+      "runtimeExecutable": "bun",
+      "runtimeArgs": ["run", "src/server.ts"],
+      "cwd": "full-ai-cluster/portal",
+      "env": { "PORTAL_DEMO": "1", "PORT": "8080" },
+      "port": 8080
+    }
+  ]
+}

--- a/full-ai-cluster/portal/.gitignore
+++ b/full-ai-cluster/portal/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/full-ai-cluster/portal/Dockerfile
+++ b/full-ai-cluster/portal/Dockerfile
@@ -1,0 +1,10 @@
+# Zeta portal — Bun server (BFF + static Fluent UI). Non-root, no build step.
+FROM oven/bun:1.3.14-alpine
+WORKDIR /app
+COPY package.json bun.lock* ./
+RUN bun install --frozen-lockfile --production || bun install --production
+COPY src ./src
+USER bun
+ENV PORT=8080
+EXPOSE 8080
+ENTRYPOINT ["bun", "run", "src/server.ts"]

--- a/full-ai-cluster/portal/README.md
+++ b/full-ai-cluster/portal/README.md
@@ -1,0 +1,47 @@
+# Zeta portal
+
+The human+agent **top-down view** of the platform — the "UI base for everything".
+A dependency-free Bun server (BFF) + a Fluent/Azure-styled SPA. Three views:
+
+- **Resources** — everything deployed, grouped by category (game / web / database /
+  app) with health badges, the operating persona, exposure/host, and child objects.
+- **Create** — the blueprint catalog. New deployable types appear here as **data**
+  (the same engine renders them all); each surfaces its variables for the form.
+- **Needs me** — the no-directives action queue: pending authorizations agents
+  **proposed**, which only a **human** may grant (source ≠ authorization). Approve /
+  Deny posts the grant and clears the item.
+
+## Architecture
+
+```
+ Browser (SPA)  ──fetch──►  /api/*  ──►  handle()  ──►  PlatformData
+   ui/ (static)              api.ts        (pure)         ├─ K8sPlatform  (live Deployables/Blueprints from the cluster)
+                                                          └─ Room source  (git-event-store-backed, once the persona runtime lands)
+```
+
+- `src/viewmodel.ts` — **pure** view models (resource groups, catalog, room view,
+  needs-me board). Fully unit-tested.
+- `src/api.ts` — the BFF: pure request routing over an injected `PlatformData`.
+- `src/data-k8s.ts` — reads Deployables + Blueprints live from the k8s API (mounted
+  service-account, no heavy dependency). Rooms come from an injected source.
+- `src/data-memory.ts` / `src/demo.ts` — in-memory platform + a seeded demo.
+- `src/server.ts` — Bun.serve: `/api/*` → BFF, everything else → the static SPA.
+- `src/ui/` — the vanilla SPA (index.html + styles.css + app.js), no build step.
+
+## Develop
+
+```bash
+bun install
+bun test          # 19 tests: view models + BFF endpoints + grant flow
+bun run typecheck # tsc --noEmit, strict
+bun run demo      # PORTAL_DEMO=1 — runs with seeded data, no cluster, on :8080
+bun run start     # in-cluster: live resources from k8s
+```
+
+## Seam
+
+The collaboration **Room** pane (the per-resource event stream) and live `needs-me`
+data become real when Rooms are persisted to the git-native event store and the
+≥3 vendor-diverse personas drive them (COLLABORATION-MODEL §9). The portal already
+renders Rooms from any `PlatformData` source — that backend slots in unchanged.
+The `Deploy` button activates with the same provisioning flow.

--- a/full-ai-cluster/portal/bun.lock
+++ b/full-ai-cluster/portal/bun.lock
@@ -1,0 +1,24 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "zeta-portal",
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+  }
+}

--- a/full-ai-cluster/portal/package.json
+++ b/full-ai-cluster/portal/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "zeta-portal",
+  "version": "0.1.0",
+  "description": "The Zeta platform portal — the human+agent top-down view of every deployable, the deploy catalog, and the 'needs me' authorization board.",
+  "type": "module",
+  "private": true,
+  "module": "src/server.ts",
+  "scripts": {
+    "start": "bun run src/server.ts",
+    "demo": "PORTAL_DEMO=1 bun run src/server.ts",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5"
+  }
+}

--- a/full-ai-cluster/portal/src/api.test.ts
+++ b/full-ai-cluster/portal/src/api.test.ts
@@ -1,0 +1,95 @@
+// full-ai-cluster/portal/src/api.test.ts
+//
+// The BFF endpoints over the in-memory platform: resource view, catalog,
+// needs-me board, a single Room, and the human grant write (which clears the
+// pending item). Non-/api paths pass through (null) for static serving.
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import { encodeResource, handle } from "./api.ts";
+import { InMemoryPlatform } from "./data-memory.ts";
+import type { BlueprintCR, DeployableCR, RoomData } from "./viewmodel.ts";
+
+const BLUEPRINTS: BlueprintCR[] = [
+  { metadata: { name: "gmod", namespace: "zeta-platform" }, spec: { category: "game", image: "gmod", stateful: true, defaultExpose: "lan", variables: [{ name: "MAP", default: "gm_construct" }] } },
+  { metadata: { name: "web", namespace: "zeta-platform" }, spec: { category: "web", image: "nginx", defaultExpose: "public" } },
+];
+const DEPLOYABLES: DeployableCR[] = [
+  { metadata: { name: "clan", namespace: "tenant-a" }, spec: { blueprint: "gmod", expose: "lan" }, status: { phase: "Running" } },
+  { metadata: { name: "site", namespace: "tenant-a" }, spec: { blueprint: "web", host: "x.example.com" }, status: { phase: "Error", message: "image pull" } },
+];
+const room = (): RoomData => ({
+  resource: "tenant-a/clan",
+  events: [
+    { id: "evt-0", seq: 0, weight: 1, proposedBy: { id: "system", kind: "persona" }, body: { type: "state-change", phase: "CrashLoopBackOff" } },
+    { id: "evt-1", seq: 1, weight: 1, proposedBy: { id: "otto", kind: "persona" }, body: { type: "authorization-request", gated: "budget", action: { summary: "bump mem 6→8Gi" } } },
+  ],
+});
+
+let data: InMemoryPlatform;
+beforeEach(() => {
+  data = new InMemoryPlatform(structuredClone(DEPLOYABLES), structuredClone(BLUEPRINTS), [room()]);
+});
+
+const get = (p: string) => handle(new Request(`http://x${p}`), data);
+const body = async (r: Response | null) => (r ? r.json() : null);
+
+describe("read endpoints", () => {
+  test("GET /api/resources returns category groups", async () => {
+    const r = await get("/api/resources");
+    const j = (await body(r)) as any;
+    expect(j.groups.map((g: any) => g.category)).toEqual(["game", "web"]);
+    expect(j.groups[1].resources[0]).toMatchObject({ name: "site", health: "error", message: "image pull" });
+  });
+
+  test("GET /api/catalog surfaces blueprints + variables", async () => {
+    const j = (await body(await get("/api/catalog"))) as any;
+    expect(j.catalog.map((e: any) => e.blueprint)).toEqual(["gmod", "web"]);
+    expect(j.catalog[0].variables[0].name).toBe("MAP");
+  });
+
+  test("GET /api/needs-me lists the pending budget authorization", async () => {
+    const j = (await body(await get("/api/needs-me"))) as any;
+    expect(j.items.length).toBe(1);
+    expect(j.items[0]).toMatchObject({ resource: "tenant-a/clan", gated: "budget", proposedBy: "otto" });
+  });
+
+  test("GET /api/rooms/:resource returns the room view", async () => {
+    const j = (await body(await get(`/api/rooms/${encodeResource("tenant-a", "clan")}`))) as any;
+    expect(j.room.resource).toBe("tenant-a/clan");
+    expect(j.room.phase).toBe("CrashLoopBackOff");
+    expect(j.room.pending.length).toBe(1);
+  });
+
+  test("GET an unknown room is 404", async () => {
+    const r = await get(`/api/rooms/${encodeResource("tenant-z", "nope")}`);
+    expect(r!.status).toBe(404);
+  });
+
+  test("non-/api paths pass through as null (static serving)", async () => {
+    expect(await get("/index.html")).toBeNull();
+    expect(await get("/")).toBeNull();
+  });
+});
+
+describe("grant (the only write — human authorizes)", () => {
+  const post = (p: string, b: unknown) => handle(new Request(`http://x${p}`, { method: "POST", body: JSON.stringify(b) }), data);
+
+  test("a valid grant clears the needs-me item", async () => {
+    const before = ((await body(await get("/api/needs-me"))) as any).items.length;
+    expect(before).toBe(1);
+    const r = await post(`/api/rooms/${encodeResource("tenant-a", "clan")}/grant`, { requestId: "evt-1", by: "aaron", granted: true });
+    expect(r!.status).toBe(200);
+    const after = ((await body(await get("/api/needs-me"))) as any).items.length;
+    expect(after).toBe(0);
+  });
+
+  test("missing fields → 400", async () => {
+    const r = await post(`/api/rooms/${encodeResource("tenant-a", "clan")}/grant`, { requestId: "evt-1" });
+    expect(r!.status).toBe(400);
+  });
+
+  test("unknown request → 404", async () => {
+    const r = await post(`/api/rooms/${encodeResource("tenant-a", "clan")}/grant`, { requestId: "evt-999", by: "aaron", granted: true });
+    expect(r!.status).toBe(404);
+  });
+});

--- a/full-ai-cluster/portal/src/api.ts
+++ b/full-ai-cluster/portal/src/api.ts
@@ -1,0 +1,87 @@
+// full-ai-cluster/portal/src/api.ts
+//
+// The BFF (backend-for-frontend) — pure request routing over an injected data
+// source, so the whole API is unit-tested without a live cluster. The server
+// (server.ts) wires a real K8s/Room-backed PlatformData into `handle`; tests
+// wire an in-memory one. Read endpoints render view models; the single write
+// endpoint is the human authorization grant (no-directives: only a human grants).
+
+import {
+  type BlueprintCR,
+  catalog,
+  type DeployableCR,
+  needsMe,
+  resourceGroups,
+  type RoomData,
+  toRoomVM,
+} from "./viewmodel.ts";
+
+/** What the portal needs from the platform. The server provides a k8s-backed impl. */
+export interface PlatformData {
+  listDeployables(): Promise<DeployableCR[]>;
+  listBlueprints(): Promise<BlueprintCR[]>;
+  listRooms(): Promise<RoomData[]>;
+  getRoom(resource: string): Promise<RoomData | undefined>;
+  /** Append a human authorization grant to a Room. Returns false if the request is unknown. */
+  grant(resource: string, requestId: string, by: string, granted: boolean, note?: string): Promise<boolean>;
+}
+
+const json = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+
+/** Route + handle one API request. Returns null for non-/api paths (server serves static). */
+export async function handle(req: Request, data: PlatformData): Promise<Response | null> {
+  const url = new URL(req.url);
+  const path = url.pathname;
+  if (!path.startsWith("/api/")) return null;
+
+  try {
+    // GET /api/resources — the top-down, category-grouped resource view
+    if (path === "/api/resources" && req.method === "GET") {
+      const [deps, bps] = await Promise.all([data.listDeployables(), data.listBlueprints()]);
+      return json({ groups: resourceGroups(deps, bps) });
+    }
+
+    // GET /api/catalog — the deploy catalog (blueprints + their form variables)
+    if (path === "/api/catalog" && req.method === "GET") {
+      return json({ catalog: catalog(await data.listBlueprints()) });
+    }
+
+    // GET /api/needs-me — pending authorizations across all rooms (the human queue)
+    if (path === "/api/needs-me" && req.method === "GET") {
+      return json({ items: needsMe(await data.listRooms()) });
+    }
+
+    // GET /api/rooms/:resource — one Room's collaboration view (resource is ns~name)
+    const roomMatch = path.match(/^\/api\/rooms\/([^/]+)$/);
+    if (roomMatch && req.method === "GET") {
+      const resource = decodeResource(roomMatch[1]!);
+      const room = await data.getRoom(resource);
+      if (!room) return json({ error: `no room for ${resource}` }, 404);
+      return json({ room: toRoomVM(room) });
+    }
+
+    // POST /api/rooms/:resource/grant — a human authorizes (or denies) a request
+    const grantMatch = path.match(/^\/api\/rooms\/([^/]+)\/grant$/);
+    if (grantMatch && req.method === "POST") {
+      const resource = decodeResource(grantMatch[1]!);
+      const b = (await req.json().catch(() => ({}))) as { requestId?: string; by?: string; granted?: boolean; note?: string };
+      if (!b.requestId || !b.by || typeof b.granted !== "boolean") return json({ error: "requestId, by, granted required" }, 400);
+      const ok = await data.grant(resource, b.requestId, b.by, b.granted, b.note);
+      return ok ? json({ ok: true }) : json({ error: "unknown room or request" }, 404);
+    }
+
+    return json({ error: "not found" }, 404);
+  } catch (e) {
+    return json({ error: (e as Error).message }, 500);
+  }
+}
+
+/** Resources are addressed as `namespace~name` in URLs (slash-free). */
+export function encodeResource(namespace: string, name: string): string {
+  return `${namespace}~${name}`;
+}
+function decodeResource(seg: string): string {
+  const [ns, name] = seg.split("~");
+  return name ? `${ns}/${name}` : seg;
+}

--- a/full-ai-cluster/portal/src/data-k8s.ts
+++ b/full-ai-cluster/portal/src/data-k8s.ts
@@ -1,0 +1,61 @@
+// full-ai-cluster/portal/src/data-k8s.ts
+//
+// A k8s-backed PlatformData: reads Deployables + Blueprints from the cluster API
+// using the mounted service-account token (same approach as the controller's
+// k8s client — no heavy dependency). Rooms come from the git-native event store
+// once the persona runtime lands (COLLABORATION-MODEL §9); until then a Room
+// source is injected (empty in-cluster, in-memory in dev), so the portal renders
+// resources + catalog for real today and gains the collaboration pane unchanged.
+
+import { readFileSync } from "node:fs";
+import type { PlatformData } from "./api.ts";
+import type { BlueprintCR, DeployableCR, RoomData } from "./viewmodel.ts";
+
+const SA = "/var/run/secrets/kubernetes.io/serviceaccount";
+const GROUP = "platform.zeta.io";
+const VERSION = "v1alpha1";
+
+/** Rooms are sourced separately (event store / in-memory) — injected here. */
+export interface RoomSource {
+  listRooms(): Promise<RoomData[]>;
+  getRoom(resource: string): Promise<RoomData | undefined>;
+  grant(resource: string, requestId: string, by: string, granted: boolean, note?: string): Promise<boolean>;
+}
+
+export class K8sPlatform implements PlatformData {
+  private host: string;
+  private token: string;
+  private ca: string;
+
+  constructor(private rooms: RoomSource) {
+    const h = process.env.KUBERNETES_SERVICE_HOST;
+    const p = process.env.KUBERNETES_SERVICE_PORT_HTTPS ?? process.env.KUBERNETES_SERVICE_PORT ?? "443";
+    if (!h) throw new Error("not running in-cluster: KUBERNETES_SERVICE_HOST unset");
+    this.host = `https://${h}:${p}`;
+    this.token = readFileSync(`${SA}/token`, "utf8").trim();
+    this.ca = readFileSync(`${SA}/ca.crt`, "utf8");
+  }
+
+  private async listCR<T>(plural: string): Promise<T[]> {
+    const url = `${this.host}/apis/${GROUP}/${VERSION}/${plural}`;
+    const r = await fetch(url, { headers: { Authorization: `Bearer ${this.token}`, Accept: "application/json" }, tls: { ca: this.ca } } as RequestInit);
+    if (!r.ok) throw new Error(`list ${plural}: ${r.status} ${await r.text()}`);
+    return ((await r.json()) as { items: T[] }).items;
+  }
+
+  listDeployables(): Promise<DeployableCR[]> {
+    return this.listCR<DeployableCR>("deployables");
+  }
+  listBlueprints(): Promise<BlueprintCR[]> {
+    return this.listCR<BlueprintCR>("blueprints");
+  }
+  listRooms(): Promise<RoomData[]> {
+    return this.rooms.listRooms();
+  }
+  getRoom(resource: string): Promise<RoomData | undefined> {
+    return this.rooms.getRoom(resource);
+  }
+  grant(resource: string, requestId: string, by: string, granted: boolean, note?: string): Promise<boolean> {
+    return this.rooms.grant(resource, requestId, by, granted, note);
+  }
+}

--- a/full-ai-cluster/portal/src/data-memory.ts
+++ b/full-ai-cluster/portal/src/data-memory.ts
@@ -1,0 +1,48 @@
+// full-ai-cluster/portal/src/data-memory.ts
+//
+// An in-memory PlatformData — for local dev and tests, and the seam the real
+// k8s/git-event-store backend slots into. Holds Deployables, Blueprints, and
+// Rooms; grant() appends a human authorization-grant event to a Room (the only
+// write the portal performs). Deterministic: event seq derives from length.
+
+import type { PlatformData } from "./api.ts";
+import type { BlueprintCR, DeployableCR, RoomData, RoomEventVM } from "./viewmodel.ts";
+
+export class InMemoryPlatform implements PlatformData {
+  constructor(
+    private deployables: DeployableCR[] = [],
+    private blueprints: BlueprintCR[] = [],
+    private rooms: RoomData[] = [],
+  ) {}
+
+  async listDeployables(): Promise<DeployableCR[]> {
+    return this.deployables;
+  }
+  async listBlueprints(): Promise<BlueprintCR[]> {
+    return this.blueprints;
+  }
+  async listRooms(): Promise<RoomData[]> {
+    return this.rooms;
+  }
+  async getRoom(resource: string): Promise<RoomData | undefined> {
+    return this.rooms.find((r) => r.resource === resource);
+  }
+
+  async grant(resource: string, requestId: string, by: string, granted: boolean, note?: string): Promise<boolean> {
+    const room = this.rooms.find((r) => r.resource === resource);
+    if (!room) return false;
+    const req = room.events.find((e) => e.id === requestId && e.body.type === "authorization-request");
+    if (!req) return false;
+    const seq = room.events.length;
+    const grant: RoomEventVM = {
+      id: `evt-${seq}`,
+      seq,
+      weight: 1,
+      proposedBy: { id: by, kind: "human" },
+      authorizedBy: { id: by, kind: "human" }, // only a human authorizes (no-directives)
+      body: { type: "authorization-grant", requestId, granted, ...(note ? { note } : {}) },
+    };
+    room.events.push(grant);
+    return true;
+  }
+}

--- a/full-ai-cluster/portal/src/demo.ts
+++ b/full-ai-cluster/portal/src/demo.ts
@@ -1,0 +1,36 @@
+// full-ai-cluster/portal/src/demo.ts
+//
+// A seeded in-memory platform so the portal runs with no cluster (PORTAL_DEMO=1)
+// — for design review and local UI work. Mirrors the starter Blueprint library
+// and shows one of each archetype plus a Room mid-incident (the GMod OOM with a
+// pending budget approval), so the needs-me board is non-empty in the demo.
+
+import { InMemoryPlatform } from "./data-memory.ts";
+import type { BlueprintCR, DeployableCR, RoomData } from "./viewmodel.ts";
+
+export function demoPlatform(): InMemoryPlatform {
+  const blueprints: BlueprintCR[] = [
+    { metadata: { name: "gmod", namespace: "zeta-platform" }, spec: { category: "game", image: "ghcr.io/ich777/steamcmd:gmod", stateful: true, defaultExpose: "lan", variables: [{ name: "MAP", default: "gm_construct" }, { name: "MAXPLAYERS", default: "16" }] } },
+    { metadata: { name: "web", namespace: "zeta-platform" }, spec: { category: "web", image: "nginx:1.27-alpine", stateful: false, defaultExpose: "public" } },
+    { metadata: { name: "postgres", namespace: "zeta-platform" }, spec: { category: "database", image: "postgres:16-alpine", stateful: true, defaultExpose: "cluster", variables: [{ name: "DB", default: "app" }] } },
+    { metadata: { name: "worker", namespace: "zeta-platform" }, spec: { category: "app", image: "busybox:1.36", stateful: false, defaultExpose: "none" } },
+  ];
+  const deployables: DeployableCR[] = [
+    { metadata: { name: "friday-sandbox", namespace: "acme" }, spec: { blueprint: "gmod", expose: "lan", ai: { admin: "otto" } }, status: { phase: "CrashLoopBackOff", message: "OOMKilled at 6Gi", children: ["StatefulSet/friday-sandbox", "Service/friday-sandbox"] } },
+    { metadata: { name: "landing", namespace: "acme" }, spec: { blueprint: "web", host: "demo.zeta.example.com", expose: "public", ai: { admin: "otto" } }, status: { phase: "Ready", children: ["Deployment/landing", "Service/landing", "HTTPRoute/landing"] } },
+    { metadata: { name: "orders-db", namespace: "acme" }, spec: { blueprint: "postgres", ai: { admin: "vera" } }, status: { phase: "Ready", children: ["StatefulSet/orders-db", "Service/orders-db"] } },
+    { metadata: { name: "nightly", namespace: "acme" }, spec: { blueprint: "worker", ai: { admin: "lior" } }, status: { phase: "Running", children: ["Deployment/nightly"] } },
+  ];
+  const rooms: RoomData[] = [
+    {
+      resource: "acme/friday-sandbox",
+      events: [
+        { id: "evt-0", seq: 0, weight: 1, proposedBy: { id: "system", kind: "persona" }, body: { type: "state-change", phase: "Running" } },
+        { id: "evt-1", seq: 1, weight: 1, proposedBy: { id: "system", kind: "persona" }, body: { type: "state-change", phase: "CrashLoopBackOff", detail: "OOMKilled at 6Gi" } },
+        { id: "evt-2", seq: 2, weight: 1, proposedBy: { id: "otto", kind: "persona" }, body: { type: "message", text: "Crash: OOM at 6Gi. Needs 8Gi — that exceeds Acme's quota. Requesting approval." } },
+        { id: "evt-3", seq: 3, weight: 1, proposedBy: { id: "otto", kind: "persona" }, body: { type: "authorization-request", gated: "budget", action: { domain: "scaling", summary: "bump memory 6→8Gi (exceeds quota)" } } },
+      ],
+    },
+  ];
+  return new InMemoryPlatform(deployables, blueprints, rooms);
+}

--- a/full-ai-cluster/portal/src/server.ts
+++ b/full-ai-cluster/portal/src/server.ts
@@ -1,0 +1,42 @@
+// full-ai-cluster/portal/src/server.ts
+//
+// The portal server: routes /api/* through the BFF (api.ts) over a PlatformData
+// source, and serves the static Fluent UI shell for everything else. In-cluster
+// it reads Deployables/Blueprints live from k8s; with PORTAL_DEMO=1 it serves a
+// seeded in-memory platform so the UI runs on a laptop with no cluster.
+
+import { join } from "node:path";
+import { handle, type PlatformData } from "./api.ts";
+import { InMemoryPlatform } from "./data-memory.ts";
+import { K8sPlatform } from "./data-k8s.ts";
+import { demoPlatform } from "./demo.ts";
+
+const UI_DIR = join(import.meta.dir, "ui");
+const PORT = Number(process.env.PORT ?? 8080);
+
+function makeData(): PlatformData {
+  if (process.env.PORTAL_DEMO === "1") return demoPlatform();
+  // In-cluster: live resources from k8s; Rooms from an in-memory source until the
+  // git-event-store-backed persona runtime lands (COLLABORATION-MODEL §9).
+  return new K8sPlatform(new InMemoryPlatform([], [], []));
+}
+
+const data = makeData();
+
+const server = Bun.serve({
+  port: PORT,
+  async fetch(req) {
+    const apiResp = await handle(req, data);
+    if (apiResp) return apiResp;
+
+    // static file serving (the SPA shell)
+    const url = new URL(req.url);
+    const rel = url.pathname === "/" ? "/index.html" : url.pathname;
+    const file = Bun.file(join(UI_DIR, rel));
+    if (await file.exists()) return new Response(file);
+    // SPA fallback
+    return new Response(Bun.file(join(UI_DIR, "index.html")));
+  },
+});
+
+console.log(`zeta portal on http://localhost:${server.port}  (demo=${process.env.PORTAL_DEMO === "1"})`);

--- a/full-ai-cluster/portal/src/ui/app.js
+++ b/full-ai-cluster/portal/src/ui/app.js
@@ -1,0 +1,125 @@
+// Zeta Portal SPA — vanilla, dependency-free. Fetches the BFF view models and
+// renders the three views: Resources (top-down), Create (catalog), Needs me.
+"use strict";
+
+const main = document.getElementById("main");
+const navButtons = [...document.querySelectorAll(".nav")];
+const badge = document.getElementById("needsme-badge");
+
+const api = (p, opts) => fetch(p, opts).then((r) => r.json());
+const esc = (s) => String(s ?? "").replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+const avatar = (id) => `<span class="persona"><span class="av">${esc(id[0] || "?").toUpperCase()}</span>${esc(id)}</span>`;
+const healthBadge = (h, phase) => `<span class="health h-${h}"><span class="dot"></span>${esc(phase)}</span>`;
+
+const views = { resources: renderResources, catalog: renderCatalog, needsme: renderNeedsMe };
+let current = "resources";
+
+navButtons.forEach((b) =>
+  b.addEventListener("click", () => {
+    current = b.dataset.view;
+    navButtons.forEach((n) => n.classList.toggle("active", n === b));
+    render();
+  }),
+);
+
+async function render() {
+  main.innerHTML = '<div class="loading">Loading…</div>';
+  try {
+    await views[current]();
+  } catch (e) {
+    main.innerHTML = `<div class="empty">Failed to load: ${esc(e.message)}</div>`;
+  }
+  refreshBadge();
+}
+
+async function refreshBadge() {
+  try {
+    const { items } = await api("/api/needs-me");
+    if (items.length) {
+      badge.textContent = items.length;
+      badge.classList.remove("hidden");
+    } else badge.classList.add("hidden");
+  } catch {}
+}
+
+// ── Resources (top-down, grouped by category) ──────────────────────────
+async function renderResources() {
+  const { groups } = await api("/api/resources");
+  let html = `<h1>Resources</h1><p class="sub">Everything you and your agents have deployed, top-down.</p>`;
+  if (!groups.length) html += `<div class="empty">No resources yet. Use <b>Create</b> to deploy from a blueprint.</div>`;
+  for (const g of groups) {
+    html += `<div class="cat-head">${esc(g.category)} <span class="cat-count">${g.count}</span></div><div class="grid">`;
+    for (const r of g.resources) {
+      html += `<div class="card">
+        <div class="card-top"><span class="card-title">${esc(r.name)}</span>${healthBadge(r.health, r.phase)}</div>
+        <div class="card-rows">
+          <div class="row"><span class="k">blueprint</span><span>${esc(r.blueprint)}</span></div>
+          <div class="row"><span class="k">namespace</span><span>${esc(r.namespace)}</span></div>
+          <div class="row"><span class="k">expose</span><span>${esc(r.expose)}${r.host ? " · " + esc(r.host) : ""}</span></div>
+          <div class="row"><span class="k">operated by</span><span>${avatar(r.admin)}</span></div>
+          ${r.message ? `<div class="row"><span class="k">note</span><span class="h-error">${esc(r.message)}</span></div>` : ""}
+        </div>
+        ${r.children.length ? `<div class="chips">${r.children.map((c) => `<span class="chip">${esc(c)}</span>`).join("")}</div>` : ""}
+      </div>`;
+    }
+    html += `</div>`;
+  }
+  main.innerHTML = html;
+}
+
+// ── Create (the blueprint catalog) ─────────────────────────────────────
+async function renderCatalog() {
+  const { catalog } = await api("/api/catalog");
+  let html = `<h1>Create</h1><p class="sub">Deploy from a blueprint. New types are data — the same engine renders them all.</p><div class="grid">`;
+  for (const e of catalog) {
+    html += `<div class="card">
+      <div class="card-top"><span class="card-title">${esc(e.blueprint)}</span><span class="chip">${esc(e.category)}</span></div>
+      <div class="card-rows">
+        <div class="row"><span class="k">image</span><span>${esc(e.image)}</span></div>
+        <div class="row"><span class="k">kind</span><span>${e.stateful ? "stateful" : "stateless"}</span></div>
+        <div class="row"><span class="k">expose</span><span>${esc(e.defaultExpose)}</span></div>
+      </div>
+      ${e.variables.length ? `<div class="chips" style="flex-direction:column;align-items:stretch">${e.variables.map((v) => `<div class="var"><span>${esc(v.name)}</span><span class="muted">${esc(v.default ?? "—")}</span></div>`).join("")}</div>` : ""}
+      <div class="actions"><button class="btn" disabled title="provisioning flow lands with the persona runtime">Deploy</button></div>
+    </div>`;
+  }
+  html += `</div>`;
+  main.innerHTML = html;
+}
+
+// ── Needs me (pending human authorizations across all rooms) ────────────
+async function renderNeedsMe() {
+  const { items } = await api("/api/needs-me");
+  let html = `<h1>Needs me</h1><p class="sub">Agents proposed these; only a human authorizes a gated action (source ≠ authorization).</p>`;
+  if (!items.length) { main.innerHTML = html + `<div class="empty">Nothing waiting on you. Agents are operating within standing authority.</div>`; return; }
+  html += `<div class="grid">`;
+  for (const it of items) {
+    html += `<div class="card needsme-card">
+      <div class="card-top"><span class="card-title">${esc(it.resource)}</span>${it.gated ? `<span class="gated">gated: ${esc(it.gated)}</span>` : ""}</div>
+      <div class="card-rows">
+        <div class="row"><span class="k">proposed by</span><span>${avatar(it.proposedBy)}</span></div>
+        <div class="row"><span class="k">action</span><span>${esc(it.summary)}</span></div>
+      </div>
+      <div class="actions">
+        <button class="btn" data-grant="1" data-res="${esc(it.resource)}" data-req="${esc(it.requestId)}">Approve</button>
+        <button class="btn danger" data-grant="0" data-res="${esc(it.resource)}" data-req="${esc(it.requestId)}">Deny</button>
+      </div>
+    </div>`;
+  }
+  html += `</div>`;
+  main.innerHTML = html;
+  main.querySelectorAll("[data-grant]").forEach((btn) =>
+    btn.addEventListener("click", async () => {
+      const res = btn.dataset.res, req = btn.dataset.req, granted = btn.dataset.grant === "1";
+      btn.disabled = true;
+      await fetch(`/api/rooms/${res.replace("/", "~")}/grant`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ requestId: req, by: "you", granted }),
+      });
+      render();
+    }),
+  );
+}
+
+render();

--- a/full-ai-cluster/portal/src/ui/index.html
+++ b/full-ai-cluster/portal/src/ui/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Zeta Portal</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <header class="topbar">
+      <div class="brand"><span class="logo">◆</span> Zeta Portal</div>
+      <div class="tenant">acme · <span class="muted">human + agents</span></div>
+    </header>
+    <div class="shell">
+      <nav class="sidenav">
+        <button class="nav active" data-view="resources">▦ Resources</button>
+        <button class="nav" data-view="catalog">＋ Create</button>
+        <button class="nav" data-view="needsme">⚑ Needs me <span id="needsme-badge" class="badge hidden">0</span></button>
+        <div class="nav-foot muted">AI-native · no-directives</div>
+      </nav>
+      <main id="main" class="content"><div class="loading">Loading…</div></main>
+    </div>
+    <script src="/app.js"></script>
+  </body>
+</html>

--- a/full-ai-cluster/portal/src/ui/styles.css
+++ b/full-ai-cluster/portal/src/ui/styles.css
@@ -1,0 +1,77 @@
+/* Zeta Portal — Fluent/Azure-portal-inspired dark theme, dependency-free. */
+:root {
+  --bg: #1b1a19;
+  --panel: #252423;
+  --card: #2d2c2b;
+  --card-hover: #333231;
+  --border: #3b3a39;
+  --text: #f3f2f1;
+  --muted: #a19f9d;
+  --accent: #2b88d8;
+  --accent-deep: #0078d4;
+  --green: #6bb700;
+  --amber: #ffb900;
+  --red: #d13438;
+  --font: "Segoe UI", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+}
+* { box-sizing: border-box; }
+body { margin: 0; background: var(--bg); color: var(--text); font-family: var(--font); font-size: 14px; }
+.muted { color: var(--muted); }
+.hidden { display: none !important; }
+
+.topbar { display: flex; align-items: center; justify-content: space-between; height: 48px; padding: 0 20px; background: var(--accent-deep); color: #fff; }
+.brand { font-weight: 600; font-size: 16px; letter-spacing: .2px; }
+.logo { margin-right: 6px; }
+.tenant { font-size: 13px; opacity: .95; }
+
+.shell { display: grid; grid-template-columns: 220px 1fr; height: calc(100vh - 48px); }
+.sidenav { background: var(--panel); border-right: 1px solid var(--border); padding: 12px 8px; display: flex; flex-direction: column; gap: 2px; }
+.nav { text-align: left; background: none; border: none; color: var(--text); padding: 10px 12px; border-radius: 4px; cursor: pointer; font-size: 14px; font-family: var(--font); display: flex; align-items: center; gap: 8px; }
+.nav:hover { background: var(--card); }
+.nav.active { background: var(--card-hover); box-shadow: inset 3px 0 0 var(--accent); }
+.nav-foot { margin-top: auto; padding: 12px; font-size: 11px; letter-spacing: .3px; }
+.badge { background: var(--red); color: #fff; border-radius: 10px; padding: 0 7px; font-size: 11px; font-weight: 600; margin-left: auto; }
+
+.content { overflow-y: auto; padding: 24px 28px; }
+.loading { color: var(--muted); padding: 40px; }
+h1 { font-size: 20px; font-weight: 600; margin: 0 0 4px; }
+.sub { color: var(--muted); margin: 0 0 20px; font-size: 13px; }
+
+.cat-head { display: flex; align-items: center; gap: 8px; margin: 22px 0 10px; font-size: 13px; font-weight: 600; text-transform: uppercase; letter-spacing: .6px; color: var(--muted); }
+.cat-count { background: var(--card); border-radius: 10px; padding: 0 8px; font-size: 11px; }
+
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 12px; }
+.card { background: var(--card); border: 1px solid var(--border); border-radius: 6px; padding: 14px 16px; transition: background .1s; }
+.card:hover { background: var(--card-hover); }
+.card-top { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.card-title { font-weight: 600; font-size: 15px; }
+.card-rows { margin-top: 10px; display: flex; flex-direction: column; gap: 5px; }
+.row { display: flex; justify-content: space-between; font-size: 12.5px; }
+.row .k { color: var(--muted); }
+.chips { margin-top: 10px; display: flex; flex-wrap: wrap; gap: 5px; }
+.chip { background: var(--panel); border: 1px solid var(--border); border-radius: 4px; padding: 2px 7px; font-size: 11px; color: var(--muted); }
+
+.health { display: inline-flex; align-items: center; gap: 6px; font-size: 12px; }
+.dot { width: 9px; height: 9px; border-radius: 50%; }
+.h-ready .dot { background: var(--green); } .h-ready { color: var(--green); }
+.h-progressing .dot { background: var(--amber); } .h-progressing { color: var(--amber); }
+.h-error .dot { background: var(--red); } .h-error { color: var(--red); }
+.h-unknown .dot { background: var(--muted); } .h-unknown { color: var(--muted); }
+
+.persona { display: inline-flex; align-items: center; gap: 5px; }
+.persona .av { width: 18px; height: 18px; border-radius: 50%; background: var(--accent); color: #fff; display: inline-flex; align-items: center; justify-content: center; font-size: 10px; font-weight: 600; }
+
+.btn { background: var(--accent-deep); color: #fff; border: none; border-radius: 4px; padding: 7px 14px; cursor: pointer; font-family: var(--font); font-size: 13px; }
+.btn:hover { background: var(--accent); }
+.btn.ghost { background: none; border: 1px solid var(--border); color: var(--text); }
+.btn.ghost:hover { background: var(--card); }
+.btn.danger { background: none; border: 1px solid var(--red); color: var(--red); }
+.btn.danger:hover { background: rgba(209,52,56,.12); }
+
+.needsme-card { border-left: 3px solid var(--amber); }
+.gated { background: rgba(255,185,0,.14); color: var(--amber); border: 1px solid rgba(255,185,0,.4); border-radius: 4px; padding: 1px 7px; font-size: 11px; font-weight: 600; }
+.actions { margin-top: 12px; display: flex; gap: 8px; }
+.empty { color: var(--muted); padding: 30px; text-align: center; background: var(--card); border: 1px dashed var(--border); border-radius: 6px; }
+
+.var { display: flex; justify-content: space-between; font-size: 12px; padding: 3px 0; border-bottom: 1px solid var(--border); }
+.var:last-child { border: none; }

--- a/full-ai-cluster/portal/src/viewmodel.test.ts
+++ b/full-ai-cluster/portal/src/viewmodel.test.ts
@@ -1,0 +1,126 @@
+// full-ai-cluster/portal/src/viewmodel.test.ts
+//
+// The portal view-model: health mapping, category-grouped resource view, the
+// deploy catalog, the per-room view, and the "needs-me" board aggregating
+// pending authorizations across rooms (incl. retraction + grant exclusion).
+
+import { describe, expect, test } from "bun:test";
+import {
+  type BlueprintCR,
+  catalog,
+  type DeployableCR,
+  health,
+  needsMe,
+  resourceGroups,
+  type RoomData,
+  toResourceVM,
+  toRoomVM,
+} from "./viewmodel.ts";
+
+const BLUEPRINTS: BlueprintCR[] = [
+  { metadata: { name: "gmod", namespace: "zeta-platform" }, spec: { category: "game", image: "gmod", stateful: true, defaultExpose: "lan", variables: [{ name: "MAP", default: "gm_construct" }] } },
+  { metadata: { name: "web", namespace: "zeta-platform" }, spec: { category: "web", image: "nginx", stateful: false, defaultExpose: "public" } },
+  { metadata: { name: "postgres", namespace: "zeta-platform" }, spec: { category: "database", image: "postgres", stateful: true, defaultExpose: "cluster" } },
+];
+
+const dep = (name: string, blueprint: string, status?: DeployableCR["status"], spec?: Partial<DeployableCR["spec"]>): DeployableCR => ({
+  metadata: { name, namespace: "tenant-a" },
+  spec: { blueprint, ...spec },
+  ...(status ? { status } : {}),
+});
+
+describe("health", () => {
+  test("maps phases to badges", () => {
+    expect(health("Ready")).toBe("ready");
+    expect(health("Running")).toBe("ready");
+    expect(health("Error")).toBe("error");
+    expect(health("CrashLoopBackOff")).toBe("error");
+    expect(health("Provisioning")).toBe("progressing");
+    expect(health(undefined)).toBe("unknown");
+  });
+});
+
+describe("toResourceVM", () => {
+  test("resolves category from the blueprint and fills defaults", () => {
+    const vm = toResourceVM(dep("clan", "gmod", { phase: "Running", children: ["StatefulSet/clan"] }), BLUEPRINTS);
+    expect(vm).toMatchObject({ category: "game", health: "ready", phase: "Running", expose: "lan", admin: "otto" });
+    expect(vm.children).toEqual(["StatefulSet/clan"]);
+  });
+  test("unknown blueprint falls back to category other", () => {
+    expect(toResourceVM(dep("x", "mystery"), BLUEPRINTS).category).toBe("other");
+  });
+  test("carries an error message through for the badge", () => {
+    const vm = toResourceVM(dep("bad", "gmod", { phase: "Error", message: "blueprint not found" }), BLUEPRINTS);
+    expect(vm.health).toBe("error");
+    expect(vm.message).toBe("blueprint not found");
+  });
+});
+
+describe("resourceGroups", () => {
+  test("groups by category in canonical order and sorts resources by name", () => {
+    const groups = resourceGroups(
+      [dep("zeta-site", "web"), dep("alpha-db", "postgres"), dep("clan", "gmod"), dep("beta-db", "postgres")],
+      BLUEPRINTS,
+    );
+    expect(groups.map((g) => g.category)).toEqual(["game", "web", "database"]); // canonical order
+    const db = groups.find((g) => g.category === "database")!;
+    expect(db.count).toBe(2);
+    expect(db.resources.map((r) => r.name)).toEqual(["alpha-db", "beta-db"]); // name-sorted
+  });
+});
+
+describe("catalog", () => {
+  test("one entry per blueprint, category-ordered, with variables surfaced for the form", () => {
+    const c = catalog(BLUEPRINTS);
+    expect(c.map((e) => e.blueprint)).toEqual(["gmod", "web", "postgres"]);
+    expect(c[0]!.variables.map((v) => v.name)).toEqual(["MAP"]);
+  });
+});
+
+// ── rooms + needs-me ───────────────────────────────────────────────────
+const persona = (id: string) => ({ id, kind: "persona" as const });
+const human = (id: string) => ({ id, kind: "human" as const });
+
+function roomWithPending(resource: string): RoomData {
+  return {
+    resource,
+    events: [
+      { id: "evt-0", seq: 0, weight: 1, proposedBy: persona("system"), body: { type: "state-change", phase: "CrashLoopBackOff" } },
+      { id: "evt-1", seq: 1, weight: 1, proposedBy: persona("otto"), body: { type: "authorization-request", gated: "budget", action: { summary: "bump mem 6→8Gi" } } },
+    ],
+  };
+}
+
+describe("needsMe board", () => {
+  test("aggregates pending authorizations across rooms", () => {
+    const board = needsMe([roomWithPending("tenant-a/clan"), roomWithPending("tenant-b/raid")]);
+    expect(board.length).toBe(2);
+    expect(board[0]).toMatchObject({ resource: "tenant-a/clan", gated: "budget", proposedBy: "otto", summary: "bump mem 6→8Gi" });
+  });
+
+  test("a granted request drops off the board", () => {
+    const room = roomWithPending("tenant-a/clan");
+    room.events.push({ id: "evt-2", seq: 2, weight: 1, proposedBy: human("aaron"), authorizedBy: human("aaron"), body: { type: "authorization-grant", requestId: "evt-1", granted: true } });
+    expect(needsMe([room]).length).toBe(0);
+  });
+
+  test("a retracted request drops off the board", () => {
+    const room = roomWithPending("tenant-a/clan");
+    room.events.push({ id: "evt-2", seq: 2, weight: -1, proposedBy: persona("otto"), body: { type: "retraction", retracts: "evt-1" } });
+    expect(needsMe([room]).length).toBe(0);
+  });
+});
+
+describe("toRoomVM", () => {
+  test("nets out retractions, reports latest phase, lists participants + pending", () => {
+    const room = roomWithPending("tenant-a/clan");
+    room.events.push({ id: "evt-2", seq: 2, weight: 1, proposedBy: persona("otto"), body: { type: "message", text: "wrong" } });
+    room.events.push({ id: "evt-3", seq: 3, weight: -1, proposedBy: persona("otto"), body: { type: "retraction", retracts: "evt-2" } });
+    const vm = toRoomVM(room);
+    expect(vm.phase).toBe("CrashLoopBackOff");
+    expect(vm.events.some((e) => e.id === "evt-2")).toBe(false); // retracted, not live
+    expect(vm.events.some((e) => e.id === "evt-3")).toBe(false); // the retraction itself isn't a live event
+    expect(vm.participants.map((p) => p.id).sort()).toEqual(["otto", "system"]);
+    expect(vm.pending.length).toBe(1);
+  });
+});

--- a/full-ai-cluster/portal/src/viewmodel.ts
+++ b/full-ai-cluster/portal/src/viewmodel.ts
@@ -1,0 +1,198 @@
+// full-ai-cluster/portal/src/viewmodel.ts
+//
+// The portal's pure view-model layer — the "base for everything". Turns raw
+// platform data (Deployable CRs, Blueprint CRs, collaboration Rooms) into the
+// clean view objects the UI renders: the top-down Resource list, the deploy
+// Catalog, a Room view, and the human's "needs-me" board (pending authorizations
+// aggregated across every Room). Pure + fully unit-tested; the server and the
+// React shell are thin layers over this.
+
+// ── inbound shapes (minimal slices of the CRs / Room we read) ──────────
+export interface DeployableCR {
+  metadata: { name: string; namespace: string };
+  spec: { blueprint: string; expose?: string; host?: string; ai?: { admin?: string; policy?: string; room?: string } };
+  status?: { phase?: string; children?: string[]; message?: string };
+}
+export interface BlueprintCR {
+  metadata: { name: string; namespace: string };
+  spec: { category?: string; image: string; stateful?: boolean; defaultExpose?: string; variables?: Array<{ name: string; default?: string; description?: string }> };
+}
+
+export type ParticipantKind = "human" | "persona";
+export interface RoomEventVM {
+  id: string;
+  seq: number;
+  weight: 1 | -1;
+  proposedBy: { id: string; kind: ParticipantKind };
+  authorizedBy?: { id: string; kind: ParticipantKind };
+  body: Record<string, unknown> & { type: string };
+}
+export interface RoomData {
+  resource: string; // namespace/name
+  events: RoomEventVM[];
+}
+
+// ── outbound view models ───────────────────────────────────────────────
+export type Health = "ready" | "progressing" | "error" | "unknown";
+
+export interface ResourceVM {
+  name: string;
+  namespace: string;
+  blueprint: string;
+  category: string;
+  health: Health;
+  phase: string;
+  expose: string;
+  host?: string;
+  admin: string;
+  message?: string;
+  children: string[];
+}
+
+export interface CategoryGroupVM {
+  category: string;
+  count: number;
+  resources: ResourceVM[];
+}
+
+export interface CatalogEntryVM {
+  blueprint: string;
+  category: string;
+  image: string;
+  stateful: boolean;
+  defaultExpose: string;
+  variables: Array<{ name: string; default?: string; description?: string }>;
+}
+
+export interface NeedsMeItemVM {
+  resource: string;
+  requestId: string;
+  proposedBy: string;
+  gated?: string;
+  summary: string;
+}
+
+const CATEGORY_ORDER = ["game", "web", "database", "app", "other"];
+
+/** Map a Deployable's status phase to a coarse health for the portal badge. */
+export function health(phase: string | undefined): Health {
+  switch (phase) {
+    case "Ready":
+    case "Running":
+      return "ready";
+    case "Error":
+    case "CrashLoopBackOff":
+    case "Failed":
+      return "error";
+    case undefined:
+    case "":
+      return "unknown";
+    default:
+      return "progressing";
+  }
+}
+
+/** Build the per-resource view model, resolving its Blueprint's category. */
+export function toResourceVM(d: DeployableCR, blueprints: BlueprintCR[]): ResourceVM {
+  const bp = blueprints.find((b) => b.metadata.name === d.spec.blueprint);
+  const phase = d.status?.phase ?? "";
+  return {
+    name: d.metadata.name,
+    namespace: d.metadata.namespace,
+    blueprint: d.spec.blueprint,
+    category: bp?.spec.category ?? "other",
+    health: health(phase),
+    phase: phase || "Unknown",
+    expose: d.spec.expose ?? bp?.spec.defaultExpose ?? "none",
+    ...(d.spec.host ? { host: d.spec.host } : {}),
+    admin: d.spec.ai?.admin ?? "otto",
+    ...(d.status?.message ? { message: d.status.message } : {}),
+    children: d.status?.children ?? [],
+  };
+}
+
+/** The top-down view: resources grouped by category, stable order, sorted by name. */
+export function resourceGroups(deployables: DeployableCR[], blueprints: BlueprintCR[]): CategoryGroupVM[] {
+  const vms = deployables.map((d) => toResourceVM(d, blueprints));
+  const byCat = new Map<string, ResourceVM[]>();
+  for (const vm of vms) (byCat.get(vm.category) ?? byCat.set(vm.category, []).get(vm.category)!).push(vm);
+  const cats = [...byCat.keys()].sort((a, b) => {
+    const ia = CATEGORY_ORDER.indexOf(a), ib = CATEGORY_ORDER.indexOf(b);
+    return (ia === -1 ? CATEGORY_ORDER.length : ia) - (ib === -1 ? CATEGORY_ORDER.length : ib) || a.localeCompare(b);
+  });
+  return cats.map((category) => {
+    const resources = byCat.get(category)!.sort((a, b) => a.name.localeCompare(b.name));
+    return { category, count: resources.length, resources };
+  });
+}
+
+/** The deploy catalog: one entry per Blueprint, ordered by category then name. */
+export function catalog(blueprints: BlueprintCR[]): CatalogEntryVM[] {
+  return blueprints
+    .map((b) => ({
+      blueprint: b.metadata.name,
+      category: b.spec.category ?? "other",
+      image: b.spec.image,
+      stateful: b.spec.stateful ?? !!b.spec.variables, // best-effort; engine decides authoritatively
+      defaultExpose: b.spec.defaultExpose ?? "none",
+      variables: b.spec.variables ?? [],
+    }))
+    .sort((a, b) => {
+      const ia = CATEGORY_ORDER.indexOf(a.category), ib = CATEGORY_ORDER.indexOf(b.category);
+      return (ia === -1 ? 99 : ia) - (ib === -1 ? 99 : ib) || a.blueprint.localeCompare(b.blueprint);
+    });
+}
+
+/** Pending authorizations in one Room (live requests with no grant yet). */
+export function pendingInRoom(room: RoomData): NeedsMeItemVM[] {
+  const retracted = new Set<string>();
+  const decided = new Set<string>();
+  for (const e of room.events) {
+    if (e.body.type === "retraction") retracted.add(String(e.body.retracts));
+    if (e.body.type === "authorization-grant") decided.add(String(e.body.requestId));
+  }
+  const out: NeedsMeItemVM[] = [];
+  for (const e of room.events) {
+    if (e.weight !== 1 || e.body.type !== "authorization-request") continue;
+    if (retracted.has(e.id) || decided.has(e.id)) continue;
+    const action = (e.body.action ?? {}) as { summary?: string };
+    out.push({
+      resource: room.resource,
+      requestId: e.id,
+      proposedBy: e.proposedBy.id,
+      ...(e.body.gated ? { gated: String(e.body.gated) } : {}),
+      summary: action.summary ?? "(no summary)",
+    });
+  }
+  return out;
+}
+
+/** The "needs-me" board: every pending authorization across all Rooms, the human's queue. */
+export function needsMe(rooms: RoomData[]): NeedsMeItemVM[] {
+  return rooms.flatMap(pendingInRoom);
+}
+
+/** A compact Room view for the collaboration pane: live events + participants + phase. */
+export interface RoomVM {
+  resource: string;
+  phase?: string;
+  participants: Array<{ id: string; kind: ParticipantKind }>;
+  events: RoomEventVM[]; // live (retractions netted out), in order
+  pending: NeedsMeItemVM[];
+}
+export function toRoomVM(room: RoomData): RoomVM {
+  const retracted = new Set<string>();
+  for (const e of room.events) if (e.body.type === "retraction") retracted.add(String(e.body.retracts));
+  const live = room.events.filter((e) => e.weight === 1 && e.body.type !== "retraction" && !retracted.has(e.id));
+  const states = live.filter((e) => e.body.type === "state-change");
+  const lastPhase = states.length ? String(states[states.length - 1]!.body.phase) : undefined;
+  const seen = new Map<string, { id: string; kind: ParticipantKind }>();
+  for (const e of room.events) seen.set(`${e.proposedBy.kind}:${e.proposedBy.id}`, e.proposedBy);
+  return {
+    resource: room.resource,
+    ...(lastPhase ? { phase: lastPhase } : {}),
+    participants: [...seen.values()],
+    events: live,
+    pending: pendingInRoom(room),
+  };
+}

--- a/full-ai-cluster/portal/tsconfig.json
+++ b/full-ai-cluster/portal/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["bun"],
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/ui"]
+}


### PR DESCRIPTION
## What

The **"UI base for everything"** — the human+agent top-down view of the platform. A dependency-free Bun BFF + a Fluent/Azure-styled SPA (no build step, ships as static files). **Verified end-to-end in a browser** against the live BFF (screenshots below).

## Three views

| View | What it shows |
|---|---|
| **Resources** | Everything deployed, grouped by category (game/web/database/app), with health badges, the operating persona, exposure/host, and child-object chips. |
| **Create** | The Blueprint catalog. New deployable types appear here as **data** — *"the same engine renders them all"*; each surfaces its variables for the form. |
| **Needs me** | The **no-directives action queue**: pending authorizations agents *proposed*, which only a **human** may grant (source ≠ authorization). Approve/Deny posts the grant and clears the item. |

The Needs-me board is the doctrine made visible — *"Agents proposed these; only a human authorizes a gated action."* Approving clears it to *"Agents are operating within standing authority."*

## Architecture (testable by construction)

```
 Browser (SPA)  ──fetch──►  /api/*  ──►  handle()  ──►  PlatformData
   ui/ (static)              api.ts        (pure)         ├─ K8sPlatform  (live Deployables/Blueprints)
                                                          └─ Room source  (git-event-store, when persona runtime lands)
```

- `viewmodel.ts` — **pure** view models (resource groups, catalog, room view, needs-me aggregation across rooms, retraction/grant exclusion). Fully unit-tested.
- `api.ts` — the BFF: pure routing over an injected `PlatformData`, so every endpoint tests without a cluster. One write: the human grant.
- `data-k8s.ts` — reads Deployables + Blueprints **live** from the k8s API (mounted service-account, no heavy dependency).
- `data-memory.ts` / `demo.ts` — in-memory platform + a seeded demo (`PORTAL_DEMO=1`).
- `server.ts` — `Bun.serve`: `/api/*` → BFF, else the static SPA. `ui/` — vanilla SPA, no toolchain.

## Tests — 19, all green

Health mapping; category-grouped resource view; catalog with form variables; per-room view (retractions netted out); the needs-me board (aggregation + grant/retraction exclusion); and **every BFF endpoint incl. the grant write clearing the pending item**. `tsc --noEmit` strict: clean.

`.claude/launch.json` adds a `zeta-portal-demo` config so the seeded portal boots on `:8080` with no cluster.

## Seam

The per-resource **Room pane** + live needs-me data become real when Rooms are persisted to the git-native event store and the personas drive them (COLLABORATION-MODEL §9). The portal renders Rooms from any `PlatformData` source, so that backend slots in unchanged. The `Deploy` button activates with the same provisioning flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
