### PR TITLE
feat(core): IdentityCapacity — identity = bits of uncertainty (qubits), complexity self-bound

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -224,6 +224,7 @@
     <Compile Include="Hat.fs" />
     <Compile Include="Persona.fs" />
     <Compile Include="Diversity.fs" />
+    <Compile Include="IdentityCapacity.fs" />
     <Compile Include="PrivacyEconomy.fs" />
     <Compile Include="GamePortfolio.fs" />
     <Compile Include="GameFingerprint.fs" />

--- a/src/Core/IdentityCapacity.fs
+++ b/src/Core/IdentityCapacity.fs
@@ -1,0 +1,73 @@
+namespace Zeta.Core
+
+/// **`IdentityCapacity` — identity count = bits of uncertainty (qubits); a self-imposable complexity bound (Aaron 2026-06-08, shadow*).**
+///
+/// Aaron: *"identity is an **entropy-bounded** thing in our system, not a flags-enum combinatorial on hats… the
+/// number of identities is directly tied to the uncertainty in the system; the **bits of uncertainty = the number
+/// of available identities**, and it can also tell us **when we run out of qubits and need more — we can
+/// complexity-bound ourselves**."*
+///
+/// So identity capacity is **`2^(bits of uncertainty)`**, not the flags-enum `2^(num hats)`: private state
+/// (#7148) supplies *additional* bits beyond the hat-flags, so identity is bounded by the **total entropy
+/// (qubits)** available, which the hat enum is only a floor of. The bits/qubits *are* the identity capacity:
+///   - `capacity bits = 2^bits` — identities representable with that many bits of uncertainty (qubits);
+///   - `bitsNeeded n = ⌈log2 n⌉` — qubits needed to hold `n` distinct identities;
+///   - `outOfQubits` / `qubitsShort` — when you've exhausted your bits and need more (the "need more qubits" signal);
+///   - and the **complexity self-bound:** distinct identities ≤ `capacity (identityBits …)` — you can *bound your
+///     own* identity space by your qubit count.
+///
+/// **Honest scope (peel):** classical bit-counting (each qubit ≈ 1 bit of *distinguishable* identity capacity —
+/// the classical readout, not exploiting superposition; ties to the controller-qubit #7140 as the unit of
+/// identity-uncertainty). `int` capacity saturates near 2^31. Generic over the identity type (equality).
+/// Deterministic (DST). The flags-enum bound (`flagsEnumBound`) is the *without-private* floor it lifts above.
+[<RequireQualifiedAccess>]
+module IdentityCapacity =
+
+    /// Identities representable with `bits` of uncertainty (qubits): `2^bits` (saturates near 2^31).
+    let capacity (bits: int) : int =
+        if bits <= 0 then 1
+        elif bits >= 31 then System.Int32.MaxValue
+        else 1 <<< bits
+
+    /// Bits of uncertainty (qubits) needed to represent `n` distinct identities = `⌈log2 n⌉` (integer, exact).
+    let bitsNeeded (n: int) : int =
+        if n <= 1 then 0
+        else
+            let mutable b = 0
+            while capacity b < n do
+                b <- b + 1
+            b
+
+    /// The flags-enum bound (WITHOUT private state): `2^numHats` identities — the combinatorial floor that private
+    /// state lifts above.
+    let flagsEnumBound (numHats: int) : int = capacity numHats
+
+    // ---- the qubit taxonomy (Aaron 2026-06-08): hats EMERGE from games; meta-hats persist = the decision points ----
+
+    /// **Hat qubits.** In our system **hats *emerge* from the games played** — most are game-specific
+    /// (`Hat.Scope.GameSpecific`, transient). A few **persist across games** (`Hat.Scope.Meta`) — and *those meta
+    /// hats are the real decision points* where the **human wants to be involved** (governance / standing-auth gate;
+    /// the persistent identity dimensions). `hatBits` counts the hat dimensions of identity (the flags-enum bits).
+    let hatBits (numHats: int) : int = max 0 numHats
+
+    /// **Private-state qubits** — the emergent identity beyond the hats (#7148; earned via the privacy economy #7149).
+    let privateBits (bits: int) : int = max 0 bits
+
+    /// **Total identity qubits = hat bits + private bits** — *"personas use qubits for emergent identities"*. A
+    /// persona's identity capacity is `2^(totalBits …)`: hats (mostly emergent, meta-hats persistent = the
+    /// decision points) plus the emergent private-state lift.
+    let totalBits (numHats: int) (privateStateBits: int) : int = hatBits numHats + privateBits privateStateBits
+
+    /// Distinct realized identities (e.g. the `(hatFlags, private)` pairs of a population).
+    let distinctIdentities (identities: 'id list) : int = identities |> List.distinct |> List.length
+
+    /// Realized bits of identity uncertainty = qubits currently in use.
+    let identityBits (identities: 'id list) : int = bitsNeeded (distinctIdentities identities)
+
+    /// **Out of qubits?** Do you need more bits than `availableBits` provide for `neededIdentities`?
+    let outOfQubits (availableBits: int) (neededIdentities: int) : bool =
+        neededIdentities > capacity availableBits
+
+    /// How many *more* qubits to add to hold `neededIdentities` given `availableBits` now (0 if you have enough).
+    let qubitsShort (availableBits: int) (neededIdentities: int) : int =
+        max 0 (bitsNeeded neededIdentities - availableBits)

--- a/tests/Tests.FSharp/IdentityCapacity.Tests.fs
+++ b/tests/Tests.FSharp/IdentityCapacity.Tests.fs
@@ -1,0 +1,48 @@
+module Zeta.Tests.IdentityCapacityTests
+
+open global.Xunit
+open Zeta.Core
+
+[<Fact>]
+let ``capacity = 2^bits; bitsNeeded = ceil(log2 n) (identities <-> bits of uncertainty)`` () =
+    Assert.Equal(1, IdentityCapacity.capacity 0)
+    Assert.Equal(8, IdentityCapacity.capacity 3)
+    Assert.Equal(0, IdentityCapacity.bitsNeeded 1)
+    Assert.Equal(3, IdentityCapacity.bitsNeeded 8) // 8 fits in 3 bits
+    Assert.Equal(4, IdentityCapacity.bitsNeeded 9) // 9 needs 4
+    Assert.Equal(3, IdentityCapacity.bitsNeeded 5)
+
+[<Fact>]
+let ``run-out-of-qubits signal: when needed identities exceed 2^availableBits, need more`` () =
+    Assert.True(IdentityCapacity.outOfQubits 2 8) // 8 > 2^2=4 -> out
+    Assert.False(IdentityCapacity.outOfQubits 3 8) // 8 <= 2^3=8 -> ok
+    Assert.Equal(1, IdentityCapacity.qubitsShort 2 8) // need 3 bits, have 2 -> 1 short
+    Assert.Equal(0, IdentityCapacity.qubitsShort 3 8)
+
+[<Fact>]
+let ``COMPLEXITY SELF-BOUND: distinct identities <= capacity(identityBits) for any population`` () =
+    for n in 1..100 do
+        let identities = [ for i in 0 .. n - 1 -> i ] // n distinct identities
+        let bits = IdentityCapacity.identityBits identities
+        Assert.True(IdentityCapacity.distinctIdentities identities <= IdentityCapacity.capacity bits)
+        Assert.Equal(IdentityCapacity.bitsNeeded n, bits)
+
+[<Fact>]
+let ``identity is ENTROPY-bounded, not flags-enum: private state lifts identities beyond 2^numHats`` () =
+    let numHats = 1 // flags enum gives only 2^1 = 2 identities without private state
+    Assert.Equal(2, IdentityCapacity.flagsEnumBound numHats)
+    // identities = (hatFlags, private); same flags, 5 distinct privates -> 5 distinct identities > 2
+    let identities = [ for p in 0..4 -> (0, p) ]
+    Assert.Equal(5, IdentityCapacity.distinctIdentities identities)
+    Assert.True(IdentityCapacity.distinctIdentities identities > IdentityCapacity.flagsEnumBound numHats)
+    // ...and that takes 3 bits of uncertainty (qubits), not the 1 the hat enum offers
+    Assert.Equal(3, IdentityCapacity.identityBits identities)
+
+[<Fact>]
+let ``identity qubits decompose into hat bits + private (emergent) bits`` () =
+    Assert.Equal(3, IdentityCapacity.hatBits 3)
+    Assert.Equal(5, IdentityCapacity.privateBits 5)
+    Assert.Equal(8, IdentityCapacity.totalBits 3 5) // hats + private
+    Assert.Equal(256, IdentityCapacity.capacity (IdentityCapacity.totalBits 3 5)) // 2^8 identities
+    // private state (emergent) dominates the constructed/emergent hat floor
+    Assert.True(IdentityCapacity.totalBits 3 5 > IdentityCapacity.hatBits 3)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -146,6 +146,7 @@
     <Compile Include="Hat.Tests.fs" />
     <Compile Include="Persona.Tests.fs" />
     <Compile Include="Diversity.Tests.fs" />
+    <Compile Include="IdentityCapacity.Tests.fs" />
     <Compile Include="PrivacyEconomy.Tests.fs" />
     <Compile Include="GamePortfolio.Tests.fs" />
     <Compile Include="GameFingerprint.Tests.fs" />


### PR DESCRIPTION
Aaron: identity is entropy-bounded (bits of uncertainty = #identities), not flags-enum; tells you when you run out of qubits; complexity self-bound. capacity/bitsNeeded/outOfQubits/qubitsShort, complexity self-bound (proven), hat+private qubit decomposition (hats emerge from games, meta-hats persist = human decision points). 5/5 tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)