### PR TITLE
feat(core): Hat.address — MUMPS scoping (meta hats = globals; normal = game-fingerprint-scoped)

### DIFF
--- a/src/Core/Hat.fs
+++ b/src/Core/Hat.fs
@@ -58,6 +58,17 @@ module Hat =
     let gameSpecific (hats: Hat<'r> list) : Hat<'r> list =
         hats |> List.filter (fun h -> h.Scope = GameSpecific)
 
+    /// **Where a hat lives (Aaron 2026-06-08, MUMPS scoping):** a normal (game-specific) hat is **tied to its game
+    /// fingerprint** — game-scoped, transient, like a MUMPS *local*. A **meta hat lives in the persistent
+    /// substrate, outside game scope, in global/meta scope** — a MUMPS *global* (`^`), surviving across games
+    /// (anti-ephemerality, manifesto §5). `address gameKey hat` is the hat's location in the persistent
+    /// multidim array: a meta hat is a global (game-independent); a game-specific hat is scoped under `gameKey`
+    /// (its game fingerprint, `GameFingerprint`).
+    let address (gameKey: string) (hat: Hat<'r>) : string =
+        match hat.Scope with
+        | Meta -> "^hat/" + hat.Name // MUMPS global: persistent, game-independent (meta scope)
+        | GameSpecific -> "game/" + gameKey + "/hat/" + hat.Name // local: scoped to the game fingerprint
+
     /// Does this hat permit `action`? (Empty `AllowedActions` ⇒ unrestricted ⇒ always true.)
     let permits (action: bool[]) (hat: Hat<'r>) : bool =
         List.isEmpty hat.AllowedActions || List.contains action hat.AllowedActions

--- a/tests/Tests.FSharp/Hat.Tests.fs
+++ b/tests/Tests.FSharp/Hat.Tests.fs
@@ -49,3 +49,13 @@ let ``controls is the coordination edge to other hats/agents`` () =
 let ``a hat bundles lenses + landmarks (the role-scoped engine)`` () =
     Assert.Equal<string list>([ "pos" ], survivalHat.Lenses |> List.map (fun l -> l.Name))
     Assert.Equal<string list>([ "I"; "frame" ], Hat.landmarkCells survivalHat)
+
+[<Fact>]
+let ``hat address: meta hats are GLOBAL (^, persistent substrate); game-specific are scoped to the game fingerprint`` () =
+    let gameKey = "abc123" // a game fingerprint sha256 (truncated)
+    // survivalHat is Scope=Meta -> global, game-independent (gameKey ignored)
+    Assert.Equal("^hat/survival", Hat.address gameKey survivalHat)
+    Assert.Equal("^hat/survival", Hat.address "other-game" survivalHat) // same global address across games
+    // a game-specific hat is scoped under the game fingerprint
+    let gs = { survivalHat with Name = "brick-scout"; Scope = Hat.GameSpecific }
+    Assert.Equal("game/abc123/hat/brick-scout", Hat.address gameKey gs)


### PR DESCRIPTION
Aaron: meta hats live in the persistent substrate (global/meta scope = MUMPS global ^); normal hats tied to game fingerprints (local). Hat.address: Meta -> ^hat/name (persistent, game-independent); GameSpecific -> game/<fp>/hat/name. 7/7 tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)