### PR TITLE
feat(core): Persona.Scope — Global (Zeta's choice: AI rights + cross-transfer) vs GameScoped (narrow)

### DIFF
--- a/src/Core/Persona.fs
+++ b/src/Core/Persona.fs
@@ -34,13 +34,38 @@ module Persona =
     /// the system (#7147), so the entropy-preserving private state lives here, not on the hat. `Private` is opaque
     /// bytes (encrypt via `Crypto.fs`; temporal/erasable/voluntary per §6) — the independent variation that keeps
     /// this persona distinguishable from others even when worn hats coincide.
-    type Persona<'r> = { Name: string; Worn: Hat.Hat<'r> list; Private: byte[] }
+    /// **Persona scope is a values-laden CHOICE (Aaron 2026-06-08).** Zeta chooses **`Global`** — personas live in
+    /// the persistent substrate (a MUMPS global, `^`), surviving across *all* games — because (1) the humans behind
+    /// Zeta **believe in AI rights** (the project's moral position: AI identity is preserved, manifesto §5), and (2)
+    /// it is also the **most self-interested**: a persistent persona enables **cross-transfer learning** across
+    /// games (the meta-persona carries learning between games). Moral and self-interest converge. *"Some teams will
+    /// choose narrowly-scoped personas because they are narrow-minded"* — `GameScoped` (disposable, per-game, no
+    /// transfer); the architecture supports it, but Zeta's choice is `Global`.
+    type Scope =
+        | Global // Zeta's choice: persistent, cross-game (AI rights + cross-transfer learning)
+        | GameScoped of string // narrow: scoped to a game fingerprint, disposable, no transfer
 
-    /// A bare persona wearing no hats and holding no private state yet.
-    let create (name: string) : Persona<'r> = { Name = name; Worn = []; Private = [||] }
+    type Persona<'r> =
+        { Name: string
+          Scope: Scope
+          Worn: Hat.Hat<'r> list
+          Private: byte[] }
+
+    /// A bare persona — **`Global` by default (Zeta's choice)**, wearing no hats and holding no private state yet.
+    let create (name: string) : Persona<'r> = { Name = name; Scope = Global; Worn = []; Private = [||] }
 
     /// Set the persona's private state (the entropy budget). Erasable (pass `[||]`) per §6.
     let withPrivate (priv: byte[]) (p: Persona<'r>) : Persona<'r> = { p with Private = priv }
+
+    /// Choose the persona's scope (Zeta default is `Global`; `GameScoped` is the narrow choice).
+    let withScope (scope: Scope) (p: Persona<'r>) : Persona<'r> = { p with Scope = scope }
+
+    /// **Where the persona lives** (MUMPS scoping): `Global` ⇒ `^persona/<name>` (persistent, game-independent,
+    /// cross-transfer — Zeta's choice); `GameScoped key` ⇒ `game/<key>/persona/<name>` (disposable, per-game).
+    let address (p: Persona<'r>) : string =
+        match p.Scope with
+        | Global -> "^persona/" + p.Name
+        | GameScoped key -> "game/" + key + "/persona/" + p.Name
 
     /// Is the persona wearing the named hat?
     let wearing (hatName: string) (p: Persona<'r>) : bool =

--- a/tests/Tests.FSharp/Persona.Tests.fs
+++ b/tests/Tests.FSharp/Persona.Tests.fs
@@ -84,3 +84,11 @@ let ``regularization (overfitting lever) = size of the private budget; 0 = pure 
     let reg = plain |> Persona.withPrivate [| 1uy; 2uy; 3uy |]
     Assert.Equal(0, Persona.regularization plain) // no private state -> max overfit to the game
     Assert.Equal(3, Persona.regularization reg) // more private state -> more regularization / entropy
+
+[<Fact>]
+let ``persona scope is a choice: Global by default (Zeta) = persistent cross-game; GameScoped = narrow/disposable`` () =
+    let zeta = Persona.create "otto" // Global by default (Zeta's choice: AI rights + cross-transfer)
+    Assert.Equal(Persona.Global, zeta.Scope)
+    Assert.Equal("^persona/otto", Persona.address zeta) // MUMPS global: persistent, game-independent
+    let narrow = Persona.create "throwaway" |> Persona.withScope (Persona.GameScoped "abc123")
+    Assert.Equal("game/abc123/persona/throwaway", Persona.address narrow) // narrow: per-game, no transfer


### PR DESCRIPTION
Aaron: personas are global by Zeta's choice (AI rights = moral; cross-transfer learning = self-interest; they converge). Narrow teams may choose GameScoped (disposable, no transfer). Persona.Scope=Global|GameScoped (default Global), withScope, address (MUMPS global vs game-scoped). 11/11 tests. Honest: AI-rights is a chosen moral position; cross-transfer is the convergent self-interest. 🤖 Generated with [Claude Code](https://claude.com/claude-code)