### PR TITLE
feat(platform): durable Rooms — Longhorn-backed StatefulSet room-service

### DIFF
--- a/full-ai-cluster/k8s/applications/platform/Application.yaml
+++ b/full-ai-cluster/k8s/applications/platform/Application.yaml
@@ -26,7 +26,7 @@ spec:
     targetRevision: main
     path: full-ai-cluster/k8s/applications/platform
     directory:
-      include: '{namespace,crd-policy,crd-gameserver,crd-app,crd-webapp,crd-blueprint,crd-deployable,policy-default,blueprints,controller}.yaml'
+      include: '{namespace,crd-policy,crd-gameserver,crd-app,crd-webapp,crd-blueprint,crd-deployable,policy-default,blueprints,controller,portal}.yaml'
   destination:
     server: https://kubernetes.default.svc
     namespace: zeta-platform

--- a/full-ai-cluster/k8s/applications/platform/controller.yaml
+++ b/full-ai-cluster/k8s/applications/platform/controller.yaml
@@ -82,6 +82,9 @@ spec:
         - name: controller
           image: ghcr.io/lucent-financial-group/zeta-platform-controller:latest
           imagePullPolicy: IfNotPresent
+          env:
+            # Emit lifecycle Events into the durable Room log (best-effort).
+            - { name: ROOM_SERVICE_URL, value: "http://portal.zeta-platform.svc.cluster.local" }
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/full-ai-cluster/k8s/applications/platform/portal.yaml
+++ b/full-ai-cluster/k8s/applications/platform/portal.yaml
@@ -1,0 +1,134 @@
+# The Zeta portal — the human+agent UI + room-service. A StatefulSet (NOT a
+# Deployment) because it owns the DURABLE Room/event log: a Longhorn-backed
+# volumeClaimTemplate -> `longhorn` StorageClass, re-bound to the same volume
+# across pod restart / reschedule / node failure. That append-only log is the
+# persistent collaboration + agent-memory substrate (Memory Preservation #5) —
+# the same StatefulSet+PVC->longhorn pattern as agent-memory, here for Rooms.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: portal
+  namespace: zeta-platform
+  annotations:
+    argocd.argoproj.io/sync-wave: "-10"
+---
+# Read-only on the platform resources it renders. No write — the only state the
+# portal mutates is its own Room log on the PVC.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: portal
+  annotations:
+    argocd.argoproj.io/sync-wave: "-10"
+rules:
+  - apiGroups: ["platform.zeta.io"]
+    resources: ["deployables", "blueprints"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: portal
+  annotations:
+    argocd.argoproj.io/sync-wave: "-10"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: portal
+subjects:
+  - kind: ServiceAccount
+    name: portal
+    namespace: zeta-platform
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: portal
+  namespace: zeta-platform
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  labels:
+    app.kubernetes.io/name: portal
+    app.kubernetes.io/part-of: zeta-platform
+spec:
+  serviceName: portal
+  replicas: 1   # single-writer of the Room log; the volume is the source of truth
+  selector:
+    matchLabels: { app.kubernetes.io/name: portal }
+  template:
+    metadata:
+      labels: { app.kubernetes.io/name: portal }
+    spec:
+      serviceAccountName: portal
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000   # own the Longhorn rooms volume
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: portal
+          image: ghcr.io/lucent-financial-group/zeta-portal:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - { name: http, containerPort: 8080 }
+          env:
+            - { name: PORT, value: "8080" }
+            - { name: ZETA_ROOMS_DIR, value: /var/lib/zeta-rooms }
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: { drop: ["ALL"] }
+          volumeMounts:
+            - name: rooms
+              mountPath: /var/lib/zeta-rooms
+          readinessProbe:
+            httpGet: { path: /api/catalog, port: http }
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          resources:
+            requests: { cpu: "50m", memory: "96Mi" }
+            limits: { cpu: "500m", memory: "256Mi" }
+  # The durable Room/event log — one Longhorn-backed volume, re-bound across
+  # restarts. THIS is the StatefulSet PVC -> storageClass the design needs.
+  volumeClaimTemplates:
+    - metadata:
+        name: rooms
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: longhorn
+        resources:
+          requests:
+            storage: 5Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: portal
+  namespace: zeta-platform
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  labels:
+    app.kubernetes.io/name: portal
+spec:
+  type: ClusterIP
+  selector: { app.kubernetes.io/name: portal }
+  ports:
+    - { name: http, port: 80, targetPort: http }
+---
+# Publish the portal on the shared Cilium Gateway (HTTPS via cert-manager). The
+# hostname is a placeholder — set it to your domain.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: portal
+  namespace: zeta-platform
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  parentRefs:
+    - { name: zeta-gateway, namespace: zeta-platform }
+  hostnames: ["portal.zeta.example.com"]
+  rules:
+    - backendRefs:
+        - { name: portal, port: 80 }

--- a/full-ai-cluster/platform-controller/src/controller.test.ts
+++ b/full-ai-cluster/platform-controller/src/controller.test.ts
@@ -6,7 +6,7 @@
 import { describe, expect, test } from "bun:test";
 import { API_VERSION } from "./types.ts";
 import type { Blueprint, Deployable } from "./blueprint.ts";
-import { indexBlueprints, LIBRARY_NAMESPACE, reconcile, resolveBlueprint } from "./controller.ts";
+import { indexBlueprints, LIBRARY_NAMESPACE, reconcile, resolveBlueprint, roomEventUrl } from "./controller.ts";
 
 function bpItem(name: string, namespace: string, spec: Partial<Blueprint>) {
   return { metadata: { name, namespace }, spec: { name, image: "img", ...spec } as Blueprint };
@@ -60,5 +60,14 @@ describe("reconcile", () => {
       expect(r.reason).toContain("nope");
       expect(r.reason).toContain(LIBRARY_NAMESPACE);
     }
+  });
+});
+
+describe("roomEventUrl", () => {
+  test("builds the room-service append URL, encoding ns/name as ns~name", () => {
+    expect(roomEventUrl("http://portal.svc", "acme", "clan")).toBe("http://portal.svc/api/rooms/acme~clan/events");
+  });
+  test("tolerates a trailing slash on the base", () => {
+    expect(roomEventUrl("http://portal.svc/", "acme", "clan")).toBe("http://portal.svc/api/rooms/acme~clan/events");
   });
 });

--- a/full-ai-cluster/platform-controller/src/controller.ts
+++ b/full-ai-cluster/platform-controller/src/controller.ts
@@ -12,6 +12,31 @@ import { inClusterConfig, K8sClient, KIND_PLURAL } from "./k8s.ts";
 
 export const LIBRARY_NAMESPACE = "zeta-platform";
 
+/** Build the room-service append URL for a resource (ns/name → ns~name path seg). */
+export function roomEventUrl(base: string, namespace: string, name: string): string {
+  return `${base.replace(/\/$/, "")}/api/rooms/${namespace}~${name}/events`;
+}
+
+/**
+ * Emit a state-change Event to the room-service (best-effort: a reconcile must
+ * never fail because the portal is down). The persona that "operates" the
+ * resource is the proposer of the lifecycle Event.
+ */
+async function emitState(cr: Deployable, phase: string, detail?: string): Promise<void> {
+  const base = process.env.ROOM_SERVICE_URL;
+  if (!base) return;
+  const by = cr.spec.ai?.admin ?? "system";
+  try {
+    await fetch(roomEventUrl(base, cr.metadata.namespace, cr.metadata.name), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ by, kind: "persona", body: { type: "state-change", phase, ...(detail ? { detail } : {}) } }),
+    });
+  } catch {
+    // room-service unreachable — the reconcile itself succeeded; skip the Event
+  }
+}
+
 /** A Blueprint indexed by namespace/name, with the shared library as fallback. */
 export type BlueprintIndex = Map<string, Blueprint>;
 const key = (ns: string, name: string) => `${ns}/${name}`;
@@ -57,6 +82,7 @@ async function reconcileOne(client: K8sClient, idx: BlueprintIndex, cr: Deployab
   if (!result.ok) {
     console.error(`[deployable ${ns}/${cr.metadata.name}] ${result.reason}`);
     await client.patchStatus(GROUP, VERSION, "deployables", ns, cr.metadata.name, { phase: "Error", message: result.reason });
+    await emitState(cr, "Error", result.reason);
     return;
   }
   await applyAll(client, result.objects);
@@ -66,6 +92,7 @@ async function reconcileOne(client: K8sClient, idx: BlueprintIndex, cr: Deployab
     blueprint: cr.spec.blueprint,
     children: result.objects.map((o) => `${o.kind}/${o.metadata.name}`),
   });
+  await emitState(cr, "Ready", `applied ${result.objects.length} object(s) from blueprint "${cr.spec.blueprint}"`);
 }
 
 /** Run the controller: load blueprints, then watch Deployables and reconcile. */

--- a/full-ai-cluster/portal/src/api.test.ts
+++ b/full-ai-cluster/portal/src/api.test.ts
@@ -93,3 +93,19 @@ describe("grant (the only write — human authorizes)", () => {
     expect(r!.status).toBe(404);
   });
 });
+
+describe("append events (controller / personas write the room log)", () => {
+  const post = (p: string, b: unknown) => handle(new Request(`http://x${p}`, { method: "POST", body: JSON.stringify(b) }), data);
+
+  test("a state-change event is appended and shows up in the room", async () => {
+    const r = await post(`/api/rooms/${encodeResource("tenant-a", "clan")}/events`, { by: "otto", kind: "persona", body: { type: "state-change", phase: "Ready" } });
+    expect(r!.status).toBe(200);
+    const j = (await body(await get(`/api/rooms/${encodeResource("tenant-a", "clan")}`))) as any;
+    expect(j.room.phase).toBe("Ready"); // the latest state-change wins
+  });
+
+  test("a missing/invalid body → 400", async () => {
+    const r = await post(`/api/rooms/${encodeResource("tenant-a", "clan")}/events`, { by: "otto", body: { type: "bogus" } });
+    expect(r!.status).toBe(400);
+  });
+});

--- a/full-ai-cluster/portal/src/api.ts
+++ b/full-ai-cluster/portal/src/api.ts
@@ -24,7 +24,23 @@ export interface PlatformData {
   getRoom(resource: string): Promise<RoomData | undefined>;
   /** Append a human authorization grant to a Room. Returns false if the request is unknown. */
   grant(resource: string, requestId: string, by: string, granted: boolean, note?: string): Promise<boolean>;
+  /**
+   * Append a typed Event to a Room (the room-service write path the controller +
+   * persona runtime use). Optional: not every backend supports writes. Returns the
+   * appended Event's id, or null if appends aren't supported / failed.
+   */
+  appendEvent?(resource: string, by: { id: string; kind?: "human" | "persona" }, body: RoomEventBody): Promise<string | null>;
 }
+
+/** The typed Event bodies the write endpoint accepts (mirrors the Room substrate). */
+export type RoomEventBody =
+  | { type: "message"; text: string }
+  | { type: "state-change"; phase: string; detail?: string }
+  | { type: "action"; action: Record<string, unknown>; result?: string }
+  | { type: "authorization-request"; action: Record<string, unknown>; gated?: string }
+  | { type: "retraction"; retracts: string; note?: string };
+
+const EVENT_TYPES = new Set(["message", "state-change", "action", "authorization-request", "retraction"]);
 
 const json = (body: unknown, status = 200): Response =>
   new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
@@ -59,6 +75,17 @@ export async function handle(req: Request, data: PlatformData): Promise<Response
       const room = await data.getRoom(resource);
       if (!room) return json({ error: `no room for ${resource}` }, 404);
       return json({ room: toRoomVM(room) });
+    }
+
+    // POST /api/rooms/:resource/events — append a typed Event (controller / personas)
+    const eventsMatch = path.match(/^\/api\/rooms\/([^/]+)\/events$/);
+    if (eventsMatch && req.method === "POST") {
+      if (!data.appendEvent) return json({ error: "append not supported by this backend" }, 405);
+      const resource = decodeResource(eventsMatch[1]!);
+      const b = (await req.json().catch(() => ({}))) as { by?: string; kind?: "human" | "persona"; body?: RoomEventBody };
+      if (!b.by || !b.body || !EVENT_TYPES.has(b.body.type)) return json({ error: "by + a valid body{type,…} required" }, 400);
+      const id = await data.appendEvent(resource, { id: b.by, ...(b.kind ? { kind: b.kind } : {}) }, b.body);
+      return id ? json({ ok: true, id }) : json({ error: "append failed" }, 500);
     }
 
     // POST /api/rooms/:resource/grant — a human authorizes (or denies) a request

--- a/full-ai-cluster/portal/src/data-composite.ts
+++ b/full-ai-cluster/portal/src/data-composite.ts
@@ -1,0 +1,40 @@
+// full-ai-cluster/portal/src/data-composite.ts
+//
+// CompositePlatform — resources from one source, Rooms from another. Lets the
+// durable FileRoomStore pair with EITHER live k8s resources (in-cluster) or
+// seeded demo resources (local dev), without each room backend re-implementing
+// resource reads. The room write-path (grant/append) is delegated to the
+// RoomSource, so durability is decided purely by which RoomSource is injected.
+
+import type { PlatformData } from "./api.ts";
+import type { RoomSource } from "./data-k8s.ts";
+import type { BlueprintCR, DeployableCR, RoomData, RoomEventVM } from "./viewmodel.ts";
+
+export interface ResourceSource {
+  listDeployables(): Promise<DeployableCR[]>;
+  listBlueprints(): Promise<BlueprintCR[]>;
+}
+
+export class CompositePlatform implements PlatformData {
+  constructor(private resources: ResourceSource, private rooms: RoomSource) {}
+
+  listDeployables(): Promise<DeployableCR[]> {
+    return this.resources.listDeployables();
+  }
+  listBlueprints(): Promise<BlueprintCR[]> {
+    return this.resources.listBlueprints();
+  }
+  listRooms(): Promise<RoomData[]> {
+    return this.rooms.listRooms();
+  }
+  getRoom(resource: string): Promise<RoomData | undefined> {
+    return this.rooms.getRoom(resource);
+  }
+  grant(resource: string, requestId: string, by: string, granted: boolean, note?: string): Promise<boolean> {
+    return this.rooms.grant(resource, requestId, by, granted, note);
+  }
+  async appendEvent(resource: string, by: { id: string; kind?: "human" | "persona" }, body: RoomEventVM["body"]): Promise<string | null> {
+    if (!this.rooms.append) return null;
+    return (await this.rooms.append(resource, by, body)).id;
+  }
+}

--- a/full-ai-cluster/portal/src/data-file.test.ts
+++ b/full-ai-cluster/portal/src/data-file.test.ts
@@ -1,0 +1,81 @@
+// full-ai-cluster/portal/src/data-file.test.ts
+//
+// FileRoomStore durability: appends persist to JSONL, a FRESH store on the same
+// directory replays them (survives a "restart"), grants persist, and a torn
+// final line (crash mid-append) is tolerated without losing the rest.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { appendFileSync, existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { FileRoomStore } from "./data-file.ts";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "zeta-rooms-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("FileRoomStore durability", () => {
+  test("appended events persist and a fresh store replays them (restart-survival)", async () => {
+    const s1 = new FileRoomStore(dir);
+    await s1.append("acme/clan", { id: "system" }, { type: "state-change", phase: "Running" });
+    await s1.append("acme/clan", { id: "otto" }, { type: "authorization-request", gated: "budget", action: { summary: "bump mem" } });
+
+    // a brand-new store on the SAME dir == a pod restart re-binding the volume
+    const s2 = new FileRoomStore(dir);
+    const room = await s2.getRoom("acme/clan");
+    expect(room?.events.length).toBe(2);
+    expect(room?.events[0]!.body.type).toBe("state-change");
+    expect(room?.events[1]!.id).toBe("evt-1");
+  });
+
+  test("grant persists across a restart and clears the pending request", async () => {
+    const s1 = new FileRoomStore(dir);
+    await s1.append("acme/clan", { id: "otto" }, { type: "authorization-request", gated: "budget", action: { summary: "x" } });
+    const okBad = await s1.grant("acme/clan", "evt-999", "aaron", true);
+    expect(okBad).toBe(false); // unknown request
+    const ok = await s1.grant("acme/clan", "evt-0", "aaron", true, "approved");
+    expect(ok).toBe(true);
+
+    const s2 = new FileRoomStore(dir);
+    const room = await s2.getRoom("acme/clan");
+    expect(room?.events.length).toBe(2);
+    const grant = room!.events[1]!;
+    expect(grant.body).toMatchObject({ type: "authorization-grant", requestId: "evt-0", granted: true });
+    expect(grant.authorizedBy).toEqual({ id: "aaron", kind: "human" }); // human-authored
+  });
+
+  test("each room is its own file; listRooms returns all", async () => {
+    const s = new FileRoomStore(dir);
+    await s.append("acme/clan", { id: "otto" }, { type: "message", text: "hi" });
+    await s.append("beta/raid", { id: "lior" }, { type: "message", text: "yo" });
+    expect(existsSync(join(dir, "acme~clan.jsonl"))).toBe(true);
+    expect(existsSync(join(dir, "beta~raid.jsonl"))).toBe(true);
+    const rooms = await s.listRooms();
+    expect(rooms.map((r) => r.resource).sort()).toEqual(["acme/clan", "beta/raid"]);
+  });
+
+  test("a torn final line (crash mid-append) is skipped; prior events survive", async () => {
+    const s1 = new FileRoomStore(dir);
+    await s1.append("acme/clan", { id: "otto" }, { type: "message", text: "intact" });
+    // simulate a half-written final line
+    appendFileSync(join(dir, "acme~clan.jsonl"), '{"id":"evt-1","seq":1,"weig');
+
+    const s2 = new FileRoomStore(dir);
+    const room = await s2.getRoom("acme/clan");
+    expect(room?.events.length).toBe(1); // the torn line dropped, the good one kept
+    expect(room?.events[0]!.body.type).toBe("message");
+  });
+
+  test("retraction is appended with weight -1", async () => {
+    const s = new FileRoomStore(dir);
+    await s.append("acme/clan", { id: "otto" }, { type: "message", text: "oops" });
+    const ret = await s.append("acme/clan", { id: "otto" }, { type: "retraction", retracts: "evt-0" });
+    expect(ret.weight).toBe(-1);
+    const persisted = readFileSync(join(dir, "acme~clan.jsonl"), "utf8").trim().split("\n");
+    expect(persisted.length).toBe(2);
+  });
+});

--- a/full-ai-cluster/portal/src/data-file.ts
+++ b/full-ai-cluster/portal/src/data-file.ts
@@ -1,0 +1,96 @@
+// full-ai-cluster/portal/src/data-file.ts
+//
+// FileRoomStore — durable Rooms on an append-only JSONL log, one file per Room
+// (<namespace>~<name>.jsonl) under a directory mounted on a Longhorn volume.
+// This is the persistent collaboration / agent-memory substrate (Memory
+// Preservation #5): every Event is appended as one JSON line, never rewritten,
+// so the log is replayable (DST) and a Z-set retraction is just another appended
+// line. On startup we replay each file into memory; writes append to disk first,
+// then update the in-memory view. Single-writer (the StatefulSet pod owns it).
+
+import { appendFileSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { RoomSource } from "./data-k8s.ts";
+import type { RoomData, RoomEventVM } from "./viewmodel.ts";
+
+const FILE_SUFFIX = ".jsonl";
+const fileFor = (resource: string) => `${resource.replace("/", "~")}${FILE_SUFFIX}`;
+const resourceOf = (file: string) => file.slice(0, -FILE_SUFFIX.length).replace("~", "/");
+
+export class FileRoomStore implements RoomSource {
+  private rooms = new Map<string, RoomData>();
+
+  constructor(private dir: string) {
+    mkdirSync(dir, { recursive: true });
+    this.replay();
+  }
+
+  /** Load every <ns>~<name>.jsonl into memory (one Event per line). */
+  private replay(): void {
+    for (const file of readdirSync(this.dir)) {
+      if (!file.endsWith(FILE_SUFFIX)) continue;
+      const resource = resourceOf(file);
+      const events: RoomEventVM[] = [];
+      const raw = readFileSync(join(this.dir, file), "utf8");
+      for (const line of raw.split("\n")) {
+        const t = line.trim();
+        if (!t) continue;
+        try {
+          events.push(JSON.parse(t) as RoomEventVM);
+        } catch {
+          // a torn final line (crash mid-append) — skip it; the log is otherwise intact
+        }
+      }
+      this.rooms.set(resource, { resource, events });
+    }
+  }
+
+  /** Append one Event to a Room's log (durable) and to the in-memory view. */
+  private appendEvent(resource: string, ev: RoomEventVM): void {
+    appendFileSync(join(this.dir, fileFor(resource)), JSON.stringify(ev) + "\n");
+    const room = this.rooms.get(resource);
+    if (room) room.events.push(ev);
+    else this.rooms.set(resource, { resource, events: [ev] });
+  }
+
+  /** The next deterministic id/seq for a Room (length-based; single-writer). */
+  private nextSeq(resource: string): number {
+    return this.rooms.get(resource)?.events.length ?? 0;
+  }
+
+  // ── RoomSource ────────────────────────────────────────────────────────
+  async listRooms(): Promise<RoomData[]> {
+    return [...this.rooms.values()];
+  }
+  async getRoom(resource: string): Promise<RoomData | undefined> {
+    return this.rooms.get(resource);
+  }
+
+  async grant(resource: string, requestId: string, by: string, granted: boolean, note?: string): Promise<boolean> {
+    const room = this.rooms.get(resource);
+    if (!room) return false;
+    if (!room.events.some((e) => e.id === requestId && e.body.type === "authorization-request")) return false;
+    const seq = this.nextSeq(resource);
+    this.appendEvent(resource, {
+      id: `evt-${seq}`,
+      seq,
+      weight: 1,
+      proposedBy: { id: by, kind: "human" },
+      authorizedBy: { id: by, kind: "human" }, // only a human authorizes (no-directives)
+      body: { type: "authorization-grant", requestId, granted, ...(note ? { note } : {}) },
+    });
+    return true;
+  }
+
+  /**
+   * Append a typed Event to a Room (the room-service write path the controller +
+   * persona runtime use). `by` is the proposer; `kind` defaults to persona.
+   * Returns the appended Event so the caller can reference its id.
+   */
+  async append(resource: string, by: { id: string; kind?: "human" | "persona" }, body: RoomEventVM["body"]): Promise<RoomEventVM> {
+    const seq = this.nextSeq(resource);
+    const ev: RoomEventVM = { id: `evt-${seq}`, seq, weight: body.type === "retraction" ? -1 : 1, proposedBy: { id: by.id, kind: by.kind ?? "persona" }, body };
+    this.appendEvent(resource, ev);
+    return ev;
+  }
+}

--- a/full-ai-cluster/portal/src/data-k8s.ts
+++ b/full-ai-cluster/portal/src/data-k8s.ts
@@ -20,6 +20,8 @@ export interface RoomSource {
   listRooms(): Promise<RoomData[]>;
   getRoom(resource: string): Promise<RoomData | undefined>;
   grant(resource: string, requestId: string, by: string, granted: boolean, note?: string): Promise<boolean>;
+  /** Append a typed Event; returns its id. Optional (read-only sources may omit). */
+  append?(resource: string, by: { id: string; kind?: "human" | "persona" }, body: import("./viewmodel.ts").RoomEventVM["body"]): Promise<import("./viewmodel.ts").RoomEventVM>;
 }
 
 export class K8sPlatform implements PlatformData {
@@ -57,5 +59,9 @@ export class K8sPlatform implements PlatformData {
   }
   grant(resource: string, requestId: string, by: string, granted: boolean, note?: string): Promise<boolean> {
     return this.rooms.grant(resource, requestId, by, granted, note);
+  }
+  async appendEvent(resource: string, by: { id: string; kind?: "human" | "persona" }, body: import("./viewmodel.ts").RoomEventVM["body"]): Promise<string | null> {
+    if (!this.rooms.append) return null;
+    return (await this.rooms.append(resource, by, body)).id;
   }
 }

--- a/full-ai-cluster/portal/src/data-memory.ts
+++ b/full-ai-cluster/portal/src/data-memory.ts
@@ -45,4 +45,20 @@ export class InMemoryPlatform implements PlatformData {
     room.events.push(grant);
     return true;
   }
+
+  async append(resource: string, by: { id: string; kind?: "human" | "persona" }, body: RoomEventVM["body"]): Promise<RoomEventVM> {
+    let room = this.rooms.find((r) => r.resource === resource);
+    if (!room) {
+      room = { resource, events: [] };
+      this.rooms.push(room);
+    }
+    const seq = room.events.length;
+    const ev: RoomEventVM = { id: `evt-${seq}`, seq, weight: body.type === "retraction" ? -1 : 1, proposedBy: { id: by.id, kind: by.kind ?? "persona" }, body };
+    room.events.push(ev);
+    return ev;
+  }
+
+  async appendEvent(resource: string, by: { id: string; kind?: "human" | "persona" }, body: RoomEventVM["body"]): Promise<string | null> {
+    return (await this.append(resource, by, body)).id;
+  }
 }

--- a/full-ai-cluster/portal/src/demo.ts
+++ b/full-ai-cluster/portal/src/demo.ts
@@ -6,31 +6,41 @@
 // pending budget approval), so the needs-me board is non-empty in the demo.
 
 import { InMemoryPlatform } from "./data-memory.ts";
+import type { ResourceSource } from "./data-composite.ts";
 import type { BlueprintCR, DeployableCR, RoomData } from "./viewmodel.ts";
 
+const DEMO_BLUEPRINTS: BlueprintCR[] = [
+  { metadata: { name: "gmod", namespace: "zeta-platform" }, spec: { category: "game", image: "ghcr.io/ich777/steamcmd:gmod", stateful: true, defaultExpose: "lan", variables: [{ name: "MAP", default: "gm_construct" }, { name: "MAXPLAYERS", default: "16" }] } },
+  { metadata: { name: "web", namespace: "zeta-platform" }, spec: { category: "web", image: "nginx:1.27-alpine", stateful: false, defaultExpose: "public" } },
+  { metadata: { name: "postgres", namespace: "zeta-platform" }, spec: { category: "database", image: "postgres:16-alpine", stateful: true, defaultExpose: "cluster", variables: [{ name: "DB", default: "app" }] } },
+  { metadata: { name: "worker", namespace: "zeta-platform" }, spec: { category: "app", image: "busybox:1.36", stateful: false, defaultExpose: "none" } },
+];
+
+const DEMO_DEPLOYABLES: DeployableCR[] = [
+  { metadata: { name: "friday-sandbox", namespace: "acme" }, spec: { blueprint: "gmod", expose: "lan", ai: { admin: "otto" } }, status: { phase: "CrashLoopBackOff", message: "OOMKilled at 6Gi", children: ["StatefulSet/friday-sandbox", "Service/friday-sandbox"] } },
+  { metadata: { name: "landing", namespace: "acme" }, spec: { blueprint: "web", host: "demo.zeta.example.com", expose: "public", ai: { admin: "otto" } }, status: { phase: "Ready", children: ["Deployment/landing", "Service/landing", "HTTPRoute/landing"] } },
+  { metadata: { name: "orders-db", namespace: "acme" }, spec: { blueprint: "postgres", ai: { admin: "vera" } }, status: { phase: "Ready", children: ["StatefulSet/orders-db", "Service/orders-db"] } },
+  { metadata: { name: "nightly", namespace: "acme" }, spec: { blueprint: "worker", ai: { admin: "lior" } }, status: { phase: "Running", children: ["Deployment/nightly"] } },
+];
+
+const DEMO_ROOMS: RoomData[] = [
+  {
+    resource: "acme/friday-sandbox",
+    events: [
+      { id: "evt-0", seq: 0, weight: 1, proposedBy: { id: "system", kind: "persona" }, body: { type: "state-change", phase: "Running" } },
+      { id: "evt-1", seq: 1, weight: 1, proposedBy: { id: "system", kind: "persona" }, body: { type: "state-change", phase: "CrashLoopBackOff", detail: "OOMKilled at 6Gi" } },
+      { id: "evt-2", seq: 2, weight: 1, proposedBy: { id: "otto", kind: "persona" }, body: { type: "message", text: "Crash: OOM at 6Gi. Needs 8Gi — that exceeds Acme's quota. Requesting approval." } },
+      { id: "evt-3", seq: 3, weight: 1, proposedBy: { id: "otto", kind: "persona" }, body: { type: "authorization-request", gated: "budget", action: { domain: "scaling", summary: "bump memory 6→8Gi (exceeds quota)" } } },
+    ],
+  },
+];
+
+/** The seeded demo resources (blueprints + deployables), without any rooms. */
+export function demoResources(): ResourceSource {
+  return { listDeployables: async () => DEMO_DEPLOYABLES, listBlueprints: async () => DEMO_BLUEPRINTS };
+}
+
+/** A full in-memory demo platform: seeded resources + a Room mid-incident. */
 export function demoPlatform(): InMemoryPlatform {
-  const blueprints: BlueprintCR[] = [
-    { metadata: { name: "gmod", namespace: "zeta-platform" }, spec: { category: "game", image: "ghcr.io/ich777/steamcmd:gmod", stateful: true, defaultExpose: "lan", variables: [{ name: "MAP", default: "gm_construct" }, { name: "MAXPLAYERS", default: "16" }] } },
-    { metadata: { name: "web", namespace: "zeta-platform" }, spec: { category: "web", image: "nginx:1.27-alpine", stateful: false, defaultExpose: "public" } },
-    { metadata: { name: "postgres", namespace: "zeta-platform" }, spec: { category: "database", image: "postgres:16-alpine", stateful: true, defaultExpose: "cluster", variables: [{ name: "DB", default: "app" }] } },
-    { metadata: { name: "worker", namespace: "zeta-platform" }, spec: { category: "app", image: "busybox:1.36", stateful: false, defaultExpose: "none" } },
-  ];
-  const deployables: DeployableCR[] = [
-    { metadata: { name: "friday-sandbox", namespace: "acme" }, spec: { blueprint: "gmod", expose: "lan", ai: { admin: "otto" } }, status: { phase: "CrashLoopBackOff", message: "OOMKilled at 6Gi", children: ["StatefulSet/friday-sandbox", "Service/friday-sandbox"] } },
-    { metadata: { name: "landing", namespace: "acme" }, spec: { blueprint: "web", host: "demo.zeta.example.com", expose: "public", ai: { admin: "otto" } }, status: { phase: "Ready", children: ["Deployment/landing", "Service/landing", "HTTPRoute/landing"] } },
-    { metadata: { name: "orders-db", namespace: "acme" }, spec: { blueprint: "postgres", ai: { admin: "vera" } }, status: { phase: "Ready", children: ["StatefulSet/orders-db", "Service/orders-db"] } },
-    { metadata: { name: "nightly", namespace: "acme" }, spec: { blueprint: "worker", ai: { admin: "lior" } }, status: { phase: "Running", children: ["Deployment/nightly"] } },
-  ];
-  const rooms: RoomData[] = [
-    {
-      resource: "acme/friday-sandbox",
-      events: [
-        { id: "evt-0", seq: 0, weight: 1, proposedBy: { id: "system", kind: "persona" }, body: { type: "state-change", phase: "Running" } },
-        { id: "evt-1", seq: 1, weight: 1, proposedBy: { id: "system", kind: "persona" }, body: { type: "state-change", phase: "CrashLoopBackOff", detail: "OOMKilled at 6Gi" } },
-        { id: "evt-2", seq: 2, weight: 1, proposedBy: { id: "otto", kind: "persona" }, body: { type: "message", text: "Crash: OOM at 6Gi. Needs 8Gi — that exceeds Acme's quota. Requesting approval." } },
-        { id: "evt-3", seq: 3, weight: 1, proposedBy: { id: "otto", kind: "persona" }, body: { type: "authorization-request", gated: "budget", action: { domain: "scaling", summary: "bump memory 6→8Gi (exceeds quota)" } } },
-      ],
-    },
-  ];
-  return new InMemoryPlatform(deployables, blueprints, rooms);
+  return new InMemoryPlatform(structuredClone(DEMO_DEPLOYABLES), structuredClone(DEMO_BLUEPRINTS), structuredClone(DEMO_ROOMS));
 }

--- a/full-ai-cluster/portal/src/server.ts
+++ b/full-ai-cluster/portal/src/server.ts
@@ -7,18 +7,27 @@
 
 import { join } from "node:path";
 import { handle, type PlatformData } from "./api.ts";
-import { InMemoryPlatform } from "./data-memory.ts";
 import { K8sPlatform } from "./data-k8s.ts";
-import { demoPlatform } from "./demo.ts";
+import { FileRoomStore } from "./data-file.ts";
+import { CompositePlatform } from "./data-composite.ts";
+import { demoPlatform, demoResources } from "./demo.ts";
 
 const UI_DIR = join(import.meta.dir, "ui");
 const PORT = Number(process.env.PORT ?? 8080);
 
 function makeData(): PlatformData {
-  if (process.env.PORTAL_DEMO === "1") return demoPlatform();
-  // In-cluster: live resources from k8s; Rooms from an in-memory source until the
-  // git-event-store-backed persona runtime lands (COLLABORATION-MODEL §9).
-  return new K8sPlatform(new InMemoryPlatform([], [], []));
+  // Local dev with DURABLE rooms: demo resources + a real FileRoomStore. Lets you
+  // exercise the durable room-service on a laptop (set ZETA_ROOMS_DIR).
+  if (process.env.PORTAL_DEMO === "1") {
+    const dir = process.env.ZETA_ROOMS_DIR;
+    if (dir) return new CompositePlatform(demoResources(), new FileRoomStore(dir));
+    return demoPlatform();
+  }
+  // In-cluster: live resources from k8s; Rooms persisted to a Longhorn-backed
+  // append-only JSONL log (durable across pod restarts — the StatefulSet volume),
+  // which is also the persistent collaboration / agent-memory substrate (#5).
+  const roomsDir = process.env.ZETA_ROOMS_DIR ?? "/var/lib/zeta-rooms";
+  return new K8sPlatform(new FileRoomStore(roomsDir));
 }
 
 const data = makeData();

--- a/full-ai-cluster/tools/k8s-manifests.test.ts
+++ b/full-ai-cluster/tools/k8s-manifests.test.ts
@@ -130,6 +130,17 @@ describe("platform app: generic Blueprint/Deployable engine wiring", () => {
     expect(c).toContain("deployables/status"); // status patch permission
     expect(c).not.toContain('resources: ["*"]'); // least-privilege, no wildcard
   });
+
+  test("portal is a StatefulSet with a Longhorn volumeClaimTemplate (durable rooms = agent-memory pattern)", () => {
+    const p = read("portal.yaml");
+    expect(p).toContain("kind: StatefulSet");
+    expect(p).not.toContain("kind: Deployment"); // must be stateful, not a Deployment
+    expect(p).toContain("volumeClaimTemplates");
+    expect(p).toContain("storageClassName: longhorn");
+    expect(p).toContain("/var/lib/zeta-rooms"); // the durable mount
+    expect(p).toContain('verbs: ["get", "list", "watch"]'); // read-only RBAC
+    expect(p).toContain("kind: HTTPRoute"); // published on the shared Gateway
+  });
 });
 
 describe("session-added apps: required objects present", () => {


### PR DESCRIPTION
## What

Makes the collaboration **Room/event log durable across pod restarts** — and that same append-only log **is** the persistent agent-memory substrate (Memory Preservation #5). Uses the canonical **StatefulSet + `volumeClaimTemplate` → `longhorn` StorageClass** pattern (the same one `agent-memory` uses): persistent state needs a StatefulSet whose PVC points at the Longhorn StorageClass, re-bound to the same volume across restart / reschedule / node failure.

## How

- **`FileRoomStore`** — append-only JSONL, one file per Room (`<ns>~<name>.jsonl`) on the mounted volume. Every Event is one JSON line, never rewritten (a Z-set retraction is just another `−1` line) → replayable (DST). Replays each file on startup; writes append to disk first. Single-writer (the StatefulSet pod). A torn final line (crash mid-append) is tolerated.
- **`POST /api/rooms/:resource/events`** — the room-service write path the controller and (future) persona runtime use to append typed Events.
- **`CompositePlatform`** — resources from one source, Rooms from another, so the durable store pairs with **either** live k8s resources (in-cluster) **or** seeded demo resources (local dev).
- **Controller emits** `Ready`/`Error` state-change Events to the room-service on reconcile (best-effort — a reconcile never fails if the portal is down), so Rooms populate from real activity.
- **k8s:** the portal is now a **StatefulSet** (not a Deployment) with a Longhorn `volumeClaimTemplate` at `/var/lib/zeta-rooms`, read-only RBAC, a Service, and an HTTPRoute on the shared Cilium Gateway.

## Verified

Unit (+8): a **fresh store on the same dir replays the log (restart-survival)**, grant persists across restart, per-room files, torn-line tolerance, retraction weight, the `/events` endpoint, `roomEventUrl` encoding.

**End-to-end through HTTP:** an authorization posted to one server instance **survived a restart** (second instance, same volume) and stayed on the needs-me board, JSONL on disk:
```
needs-me before restart: {"items":[{"resource":"acme/clan","requestId":"evt-0",...,"gated":"budget"}]}
needs-me AFTER restart:  {"items":[{"resource":"acme/clan","requestId":"evt-0",...,"gated":"budget"}]}
```

```
portal 26 pass · controller 58 pass · manifests 12 pass · tsc strict clean
```

This is the durability seam from the platform build, closed with the StatefulSet+Longhorn pattern. Next: the new shadcn/Tailwind portal UI consuming this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
