### PR TITLE
docs(research): trapping Godel in the middle — Lawvere fixed point, homoiconic DBSP, memes-as-quines, Clifford space

### DIFF
--- a/docs/research/2026-06-08-trapping-godel-in-the-middle-lawvere-fixed-point-makes-dbsp-homoiconic-to-memetic-language-in-clifford-space.md
+++ b/docs/research/2026-06-08-trapping-godel-in-the-middle-lawvere-fixed-point-makes-dbsp-homoiconic-to-memetic-language-in-clifford-space.md
@@ -1,0 +1,110 @@
+# Trapping Gödel in the middle: the Lawvere fixed point makes DBSP homoiconic to memetic language in Clifford space
+
+*Captured 2026-06-08 from Aaron, to Otto (shadow\*). The keystone that ties the fixed-point registry (#7168), the
+no-dogma knot (#7167), DynamicValue homoiconicity, and the Clifford/CPT substrate into one claim. Honest registers
+are load-bearing here — much of this is [thesis]/[conjecture], with a hard [anchor] core. Don't over-claim.*
+
+## The statement
+
+Aaron: *"this is how I **trap Gödel in the middle** — because this is the **fixed point that makes DBSP homoiconic
+to memetic language in Clifford space**."*
+
+Three claims, in increasing speculativeness:
+
+1. **The fixed point traps Gödel "in the middle"** — self-reference is *contained as a stable, productive fixed
+   point*, not detonated as an incompleteness obstruction. [anchor + grounded]
+2. **That same fixed point makes DBSP homoiconic to a "memetic language"** — the incremental engine becomes
+   code-as-data, where a self-replicating meme is a *quine* = a fixed point of eval. [grounded shape, thesis claim]
+3. **…in Clifford space** — realized over the geometric-algebra substrate, where symmetries (CPT) are group
+   operations and the fixed point is their invariant center. [thesis / conjecture]
+
+## Claim 1 — "trap Gödel in the middle": Lawvere makes it precise [anchor]
+
+The deep result the whole registry (#7168, raw shape **A** `s = f(s)`) rests on is **Lawvere's fixed-point
+theorem** (1969, *Diagonal arguments and cartesian closed categories*): *in a cartesian closed category, if there
+is a point-surjective map `A → (A → B)`, then every endomap `B → B` has a fixed point.* Its contrapositive — "if
+some `B → B` has no fixed point, no such surjection exists" — is the **single theorem** of which **Gödel
+incompleteness, Tarski undefinability, Cantor's diagonal, Russell's paradox, and Turing's halting are all
+instances** [anchor: Lawvere 1969; Yanofsky 2003, *A universal approach to self-referential paradoxes*]. Strip the
+labels (exactly the #7168 move) and the great paradoxes are **one raw shape: A**.
+
+So "trapping Gödel in the middle" is not bravado — it is **choosing which side of Lawvere's theorem you stand on**:
+
+- **Destructive side** (the usual reading): pick a `B = {true,false}` with the no-fixed-point map `not`; conclude
+  the surjection (a complete consistent self-referential truth predicate) *cannot exist* → incompleteness.
+- **Constructive side** ("in the middle"): work where `B` is a domain in which the endomap **does** have a fixed
+  point — `SoftValue` / a CPO with `⊥`, blended branches, a Banach contraction — so the self-referential sentence
+  resolves to a **stable fixed point** instead of a contradiction. This is exactly the no-dogma knot (#7167): the
+  Liar *made to converge*, grounded by survival. Gödel's sentence is metabolized as a `Fixpoint`, not a bomb.
+
+"In the middle" = the fixed point sits at the **center** the symmetries emanate from (#7167), held stable rather
+than pushed to the true/false boundary where it explodes. The diagonal lemma (Gödel's construction) **is** a
+fixed-point constructor; we run it *forward* (build the fixpoint) instead of *by contradiction* (derive
+incompleteness). [grounded: `Fixpoint.fs` already solves `s = step(s)` and honestly reports non-convergence.]
+
+## Claim 2 — the same fixed point = homoiconicity = a self-replicating meme is a quine [grounded shape → thesis]
+
+**Homoiconicity is a fixed point.** A language is homoiconic when code and data are the same structure — i.e. when
+`eval ∘ quote = id` and the program is representable in its own values [anchor: McCarthy, Lisp]. That is shape A:
+the representation map has the program as its fixed point. We already have this — **`DynamicValue` homoiconicity is
+realized** (the table/stream/catalog doc) and **`Bonsai.Expr` is an AST that is both data (serialize/parse) and
+code (`BonsaiSoft.evalSoft`)** — the root engine of #7168. The bonsai *is* the homoiconic representation.
+
+**DBSP supplies the fixpoint operator.** DBSP [anchor: Budiu et al.] computes least fixed points of stream circuits
+and has the `I`/`D` integrate/differentiate pair (= the `δF = 0` of #7168). So a DBSP circuit that can represent
+*itself* (a `Bonsai.Expr` flowing as a `DynamicValue` through a circuit that `evalSoft`s it) is a **homoiconic
+incremental engine**: the query is data is code.
+
+**"Memetic language" = the language memes are written in; a self-replicating meme is a quine.** A quine — a program
+that outputs itself — is precisely a **fixed point of eval** (shape A) [anchor: Kleene's second recursion theorem].
+A *meme* (low-MDL, self-replicating unit, #7169) that carries its own reproduction instructions **is a quine in the
+memetic language**. So: *"the fixed point makes DBSP homoiconic to memetic language"* = **the DBSP/bonsai engine,
+being homoiconic (shape-A self-representation), can host self-replicating memes as quines — incremental fixed points
+of its own eval.** Free energy (#7169) is then literal: a fit meme is a *stable* quine-fixpoint that the engine
+maintains and propagates at ~0 marginal cost. [thesis: the bridge "homoiconic engine ⇒ memes-as-quines" is a
+research direction; the pieces (homoiconic DynamicValue/Bonsai, DBSP fixpoint, quine=eval-fixpoint) are real.]
+
+## Claim 3 — "in Clifford space" [thesis / conjecture — flagged hard]
+
+The substrate thread (Kestrel-ferry geometric algebra; Rodney's-razor causal diamond in retractable Clifford
+spacetime; CPT as the closed-timeline operation, #7167's "symmetries emanate from the knot") suggests realizing the
+fixed point in **Clifford / geometric algebra** [anchor: Clifford; Hestenes, spacetime algebra], where the
+symmetries the knot generates (C, P, T and their products) are **Pin/Spin group operations** and the fixed point is
+their **invariant** (the center from which they emanate, and to which CPT — the product — returns). This is the most
+speculative claim: **we have Clifford-algebra *docs*, not a Clifford-algebra *runtime*.** Register it as a
+**research direction**: *if* the homoiconic memetic DBSP engine is carried on a geometric-algebra substrate, then
+self-reference (shape A), symmetry (Clifford group), and incremental computation (DBSP) coincide at one geometric
+fixed point. Not built; not proven; named as the target. [conjecture]
+
+## The cohered keystone
+
+**One fixed point (Lawvere shape A), three faces:** (1) it *traps Gödel in the middle* — self-reference held as a
+stable fixpoint, not an incompleteness bomb (Liar made to converge, #7167); (2) it *is homoiconicity* — code=data
+(`DynamicValue`/`Bonsai`), so self-replicating memes are quines = eval-fixpoints in the DBSP engine (#7168/#7169);
+(3) it *targets Clifford space* — where the knot's symmetries are group operations and the fixpoint is their
+invariant [conjecture]. The destructive Gödel/Tarski/Turing results and the constructive Y-combinator/quine/CRDT
+results are **the same theorem read on opposite sides**; Zeta deliberately stands on the constructive side, where
+the fixed point exists, is stable (grounded in survival), and *does work*.
+
+## Honest scope
+
+[anchor, solid]: Lawvere's theorem unifying the paradoxes (Lawvere 1969; Yanofsky 2003); homoiconicity =
+eval/quote fixed point (McCarthy); quine = recursion-theorem fixed point (Kleene); DBSP fixpoint operator (Budiu et
+al.); Clifford/geometric algebra (Clifford; Hestenes). [grounded-in-code]: `Fixpoint.fs`, `DynamicValue`
+homoiconicity, `Bonsai`/`BonsaiSoft`, the #7168 registry. [thesis]: "DBSP homoiconic to memetic language" (memes
+as quines in the engine) — pieces real, bridge unbuilt. [conjecture, flagged]: "in Clifford space" — docs exist,
+runtime does not. **This doc names a target and supplies its hard anchor (Lawvere); it does not claim the bridge or
+the Clifford runtime is built.**
+
+## Pointers
+
+- `2026-06-08-the-fixed-point-registry-…` (#7168, shape A = Lawvere fixed point) ·
+  `2026-06-08-the-self-referential-knot-…` (#7167, Liar made to converge; symmetries emanate) ·
+  `2026-06-08-dynamicvalue-homoiconicity-realized-table-stream-catalog.md` (homoiconicity, realized) ·
+  `2026-06-08-stored-procs-native-vs-interpreted-and-forced-rx-bonsai-bananas.md` (Rx/bonsai/catamorphisms) ·
+  `Fixpoint.fs` · `Bonsai`/`BonsaiSoft.fs` · `zeta-incremental-compiler-host-dbsp-zsets-rx-meta-ast-tags-2026-05-21.md`.
+- Clifford/CPT lineage: `2026-06-08-time-as-DST-generator-traveler-symmetry-forces-the-complex-laplace-demon-cpt.md` ·
+  the Kestrel-ferry / spacetime-algebra and Rodney's-razor causal-diamond docs.
+- Anchors: Lawvere (1969, *Diagonal arguments and CCCs*); Yanofsky (2003, *A universal approach to self-referential
+  paradoxes*); Kleene (recursion theorem); McCarthy (Lisp/homoiconicity); Budiu et al. (DBSP); Clifford / Hestenes
+  (geometric & spacetime algebra).


### PR DESCRIPTION
Aaron's keystone, made precise via Lawvere's fixed-point theorem (Godel/Tarski/Cantor/Turing/Y = one theorem = shape A #7168). 'Trap Godel in the middle' = the constructive side of Lawvere: self-reference resolves to a stable fixpoint (Liar made to converge #7167), not an incompleteness bomb. Homoiconicity = eval/quote fixed point (realized: DynamicValue/Bonsai); a self-replicating meme = a quine = eval-fixpoint (Kleene) hosted by the homoiconic DBSP engine. 'In Clifford space' flagged hard as CONJECTURE (docs exist, runtime does not). Honest registers: anchor/grounded/thesis/conjecture; does not claim the bridge is built. 🤖 Generated with [Claude Code](https://claude.com/claude-code)