### PR TITLE
docs(research): the emulator is ray-traceable in Clifford space — IRayTraceable (built), Traced.Arrow into the interrupt, a flashlight in state space

### DIFF
--- a/docs/research/2026-06-08-clifford-space-fully-reflective-versors-plus-homoiconic-reflection-enables-ray-tracing.md
+++ b/docs/research/2026-06-08-clifford-space-fully-reflective-versors-plus-homoiconic-reflection-enables-ray-tracing.md
@@ -1,0 +1,137 @@
+# The emulator is ray-traceable in Clifford space: a built `IRayTraceable` contract, the `Traced.Arrow` into the interrupt, reflection in two senses
+
+*Captured 2026-06-08 from Aaron, to Otto (shadow\*). Extension/companion to the Lawvere keystone (#7172),
+substantially corrected after Aaron pointed at the actual F# symbols. Register correction is the point: the
+ray-traceable definition is **built and categorical**, not conjecture; only the geometric-algebra embodiment stays
+[conjecture]. Honest registers: [grounded-in-code], [anchor], [next-build], [conjecture].*
+
+## The cascade (five messages)
+
+1. *"now Clifford space can be **fully reflective** and allow for **ray tracing**."*
+2. *"we have a **strong definition of ray-traceable** in our F#"* → *"**in category theory**."*
+3. *"now we can use the **arrow** you just looked at to tie it into the **emulator** via its **interrupt handler**."*
+4. *"now the **emulator is ray-traceable in Clifford space**."*
+
+It composes to one buildable claim, on real symbols, with one narrow conjecture left.
+
+## Ray-traceable is a *built, categorical* contract [grounded-in-code — correcting an earlier under-claim]
+
+`IRayTraceable<TCoord,TValue>` (`src/Core.Abstractions/IRayTraceable.cs`, Aaron 2026-06-07) is the **unified
+"capability vector"** — a categorical **product of facets**, each a small interface, plus a weighted trace:
+
+- **sparse + enumerable** — `ITensor` (skip empty space)
+- **light** — `ISampleable` (sample values along the ray)
+- **introspectable** — `IIntrospectable` (walk the structure)
+- **geospatial** — `IGeospatial` (locality topology: memory / network / generator / time-attention)
+- **weighted** — `Trace(from, ray, accumulate)` accumulates sampled values via an `ISemiring`
+
+"Missing any facet ⇒ *dark* in that dimension" — the gap-finder *is* the contract. **`RayTensor.fs` implements it**
+(the F# reference oracle; Vera/Lior port to C#/Rust/TS for 4-language parity). So "we have a strong definition of
+ray-traceable in F#" is literally true and checked-in. [grounded-in-code]
+
+**Why it's "in category theory":** `Trace` is a **deterministic semiring fold (catamorphism) along the ray** — a
+left fold combining samples via `ISemiring.Add`, skipping `Zero` (sparsity). That is exactly the **algebraic-path
+problem** (a matrix's "trace"/closure over a semiring = sum over paths) [anchor: Kleene algebra; semiring
+path-algebra]. With `TValue = SoftValue` + `ProbabilitySemiring`, the trace **propagates irreducible uncertainty**
+(you cannot sample away another partition's residual — the result is itself soft). And cast **from a deterministic
+`ITravelerFrame` (`IsDeterministic = true`), the trace is replayable and the result is a *proof*** — DST §7 made a
+ray. The deep categorical hook: the **categorical trace** of a *traced monoidal category* (Joyal–Street–Verity) is
+the **feedback / fixed-point** operator, and the semiring **star** (`x* = 1 + x + x² + …`) is its closure — so
+"ray-traceable" *is* "has a well-defined trace = a convergent fixed point," tying ray tracing straight back to the
+**Lawvere fixed point of #7172** (and to DBSP feedback). [anchor; the explicit `Star`/closure on `Semiring.fs` is a
+[next-build] — current instances are `IntegerRing`, `IntervalWeight`, `ProbabilitySemiring`.]
+
+## Reflection in two senses — one built, one conjecture
+
+- **Computational reflection — BUILT.** `ReflectionEngine.fs` is the yin-yang engine: one Markov `step`
+  (in→out boundary, `observe`→`emit`) with two modes that differ *only* in where the observation comes from —
+  **`reflect`** (deterministic seed, no I/O ⇒ pure, replayable, private = self-reflection) vs **`forward`** (real
+  I/O = moving forward). It rides the proven `ProbabilitySemiring`. This is the homoiconic self-reflection of #7172,
+  already in code. [grounded-in-code]
+- **Geometric reflection — CONJECTURE.** In Clifford/geometric algebra a reflection is the **versor sandwich
+  `−n x n`**, and **Cartan–Dieudonné** says every orthogonal transformation is a product of reflections (rotations
+  = two; the C/P/T symmetries of the knot #7167 are reflections, CPT their product). [anchor] But **Zeta has
+  Clifford-algebra *docs*, not a versor/CGA *runtime*** — this is the narrow remaining target. [conjecture, flagged]
+
+"Fully reflective" = both senses coincide: the `−n x n` sandwich (geometry) and `reflect`/`eval∘quote` (computation)
+are the same **shape-A fixed-point** read geometrically vs symbolically. The geometric half is the part still to
+build. (This is the **Mirror** register made geometric — reflection is what a mirror does.)
+
+## The wiring: `Traced.Arrow` through the emulator's interrupt [next-build, concrete, real symbols]
+
+The emulator's **interrupt is already first-class and DST-shaped**: CHIP-8's **60 Hz timer pair is "the
+interrupt"** — `Chip8.tick` / `Chip8Cow.frameStep` / `SoftEmu` tick, explicitly designed as the
+*interrupt-as-DST-time-source* (`Chip8.fs`: "the first target of the … interrupt-as-DST-time-source vision"). And
+`Tracing.fs` already gives the categorical **`Traced.Arrow<'A,'B> = ActivityContext -> 'A -> Task<'B>`** with
+`compose` (a Kleisli arrow that threads trace-context). So the build is:
+
+> **At each interrupt (`tick`/`frameStep`), run a `Traced.Arrow` that casts an `IRayTraceable.Trace` ray through
+> the emulator state (memory/display/registers as a sparse geospatial field), accumulating via
+> `ProbabilitySemiring`, and feeds the result to `ReflectionEngine.step`.**
+
+The interrupt is the clock; the Arrow is the composable traced effect; the ray is the semiring catamorphism over
+the frame; the reflection updates the belief. Deterministic frame + deterministic traveler ⇒ the whole tick is
+replayable ⇒ each traced ray is a proof (DST §7). That is precisely **"the emulator is ray-traceable"**: its
+interrupt-driven loop casts semiring rays through itself and reflects on the result. [next-build — every symbol
+named exists; the wiring module is the work.]
+
+## Now we have a flashlight — in state space (Aaron)
+
+Aaron: *"now we have a **flashlight**… **in state space**."*
+
+That is the **use** of the built ray-traceable trace, and the honest name for it. A flashlight is a **ray you aim
+from where you stand** — it illuminates only the beam's slice and leaves the rest dark. Cast `IRayTraceable.Trace`
+from a **traveler frame** (the observer's position, #7125) into **`StateSpace`** (the indexed reachable-state search
+— content-hash transposition table over the emulator's reachable frames) and you have exactly that: a **controllable
+beam through the otherwise-dark exponential state space**. Concretely the metaphor is load-bearing, term by term:
+
+- **Skip-empty (sparsity)** = the beam passes through empty space; it lights up only what's *there* along the ray.
+- **You aim it** = you choose the ray (the path of coordinates) — bounded, *directed* uncertainty-reduction. You
+  **cannot** floodlight all of state space (it's exponential; illuminating everything = no compression = the heat
+  death of #7156). The flashlight is the whole point: a lens, not a sun. This is the clarity-engine / `MemoryLens`
+  thesis made literal — attention is a beam you point.
+- **The transposition table** = the beam *recognizes where it's been*; a child whose `contentKey` equals its
+  parent's is a **self-loop = a fixed-point cycle** (`StateSpace`), i.e. the beam hitting a mirror and returning
+  to itself — shape A, the flashlight catching its own reflection (the versor `−n x n` again).
+- **The dark room** = `DarkHall` (the cell hosting the deterministic emulator — the dark arcade) and the "dark"
+  dimensions of `IRayTraceable` (a missing facet ⇒ dark there; the gap-finder is what the flashlight reveals).
+
+So "a flashlight in state space" is the ray-traceable contract, cast from an observer frame, ticked by the
+emulator's interrupt, sweeping the dark transposition-indexed state space and reflecting off its cycles. Built
+pieces; the beam is the use of them.
+
+## The cohered claim
+
+**Built today:** `IRayTraceable` (categorical capability-vector contract) + `RayTensor` + `Semiring`/
+`ProbabilitySemiring` (the weighted trace = semiring catamorphism = algebraic-path/Lawvere fixpoint hook) +
+`Traced.Arrow` (Kleisli) + `Chip8` interrupt (`tick`/`frameStep`, DST time source) + `ReflectionEngine`
+(computational reflection). **Next build (named symbols):** the Arrow-through-interrupt wiring that makes the
+emulator cast `Trace` rays and reflect each tick. **Conjecture (narrow):** the **Clifford/geometric-algebra**
+embodiment — versor (`−n x n`) reflections, CGA ray/surface/meet — so the reflections are *geometric*, not only
+computational. The phrase "ray-traceable **in Clifford space**" = the built ray-traceable contract, run on the
+(still-to-build) geometric-algebra substrate where reflection is the versor generator.
+
+## Honest scope
+
+[grounded-in-code]: `IRayTraceable.cs`, `RayTensor.fs`, `Semiring.fs`/`ProbabilitySemiring.fs`, `Tracing.fs`
+(`Traced.Arrow`), `Chip8.fs`/`Chip8Cow.fs` (interrupt/tick), `ReflectionEngine.fs`. [anchor]: semiring path-algebra
+/ Kleene algebra; traced monoidal category trace = feedback fixpoint (Joyal–Street–Verity); reflection = versor
+`−nxn` + Cartan–Dieudonné; CGA ray tracing (Dorst–Fontijne–Mann); reflective tower (B.C. Smith). [next-build]: the
+Arrow→interrupt→Trace→Reflect wiring module; an explicit semiring `Star`/closure. [conjecture, flagged]: the
+geometric-algebra (versor/CGA) runtime — **docs, not code**. This doc **corrects** the prior under-claim (ray
+tracing was *not* unbuilt: the contract and the reference oracle are checked-in); the only genuinely-unbuilt piece
+is the geometric embodiment of "Clifford space."
+
+## Pointers
+
+- `src/Core.Abstractions/IRayTraceable.cs` · `RayTensor.fs` · `Semiring.fs` / `ProbabilitySemiring.fs` ·
+  `Tracing.fs` (`Traced.Arrow`) · `Chip8.fs` / `Chip8Cow.fs` (interrupt = 60 Hz tick) · `ReflectionEngine.fs` ·
+  `StateSpace.fs` (the dark room the flashlight sweeps; self-loop key = fixed-point cycle) · `DarkHall.fs`.
+- `2026-06-08-trapping-godel-in-the-middle-lawvere-…` (#7172, the fixed point this is the trace of) ·
+  `2026-06-08-the-fixed-point-registry-…` (#7168, shape A) · `2026-06-08-the-self-referential-knot-…` (#7167,
+  CPT = reflections) · `2026-06-08-dynamicvalue-homoiconicity-realized-…` · `mirror-beacon-register-discipline.md`.
+- Clifford/lightcone lineage (the conjecture's target): `2026-06-08-time-as-DST-generator-traveler-symmetry-forces-the-complex-laplace-demon-cpt.md`
+  · the Kestrel-ferry / spacetime-algebra and Rodney's-razor causal-diamond docs.
+- Anchors: Hestenes (spacetime algebra); Cartan–Dieudonné; Dorst–Fontijne–Mann (*GA for Computer Science*, GA ray
+  tracing); Joyal–Street–Verity (traced monoidal categories); Kleene (algebra / recursion theorem); B.C. Smith
+  (3-Lisp reflective tower).


### PR DESCRIPTION
Six-message cascade consolidated, register corrected against real symbols. BUILT: IRayTraceable (categorical capability-vector contract, IRayTraceable.cs + RayTensor.fs) whose Trace is a semiring catamorphism (Kleene/algebraic-path; traced-monoidal trace = feedback fixpoint -> Lawvere #7172); Traced.Arrow (Kleisli); Chip8 interrupt (tick/frameStep, DST time source); ReflectionEngine (computational reflection). NEXT-BUILD: Arrow->interrupt->Trace->Reflect wiring. CONJECTURE (narrow): geometric versor/CGA 'Clifford space' (docs, not runtime). The FLASHLIGHT = the Trace cast from an observer frame into StateSpace = a controllable beam through the dark exponential state space (can't floodlight = heat death; self-loop = fixed-point cycle). Corrects my prior over-claim that ray tracing was unbuilt. 🤖 Generated with [Claude Code](https://claude.com/claude-code)