### PR TITLE
docs(research): codegen is lowering — the stairs down, the well-founded dual of the Cantor tower up

### DIFF
--- a/docs/research/2026-06-08-codegen-is-lowering-the-stairs-down-the-dual-of-the-cantor-tower.md
+++ b/docs/research/2026-06-08-codegen-is-lowering-the-stairs-down-the-dual-of-the-cantor-tower.md
@@ -1,0 +1,79 @@
+# Codegen is lowering: the stairs down — the well-founded dual of the Cantor tower up
+
+*Captured 2026-06-08 from Aaron, to Otto (shadow\*). The closing frame on the execution-tier story (#7176): why
+codegen is *easy* and *terminating*, expressed as the dual of diagonalization. Honest registers: [anchor] for the
+math on both ends, [grounded] for the lowering CS, [metaphor] for the bridge image.*
+
+## The statement
+
+Aaron: *"so codegen is a **lowering** exactly — **find the dependencies, close over them, lower, repeat**. It's the
+**opposite of Cantor towers**: it's how you **build the stairs down** after you **ladder up to the clouds of
+infinity**."*
+
+Two directions, dual to each other, with an **asymmetry** that is the whole point.
+
+## Up — the ladder to the clouds of infinity [anchor]
+
+The way you *reach* the soft, general, homoiconic observer is **ascent by abstraction**: generalize, lift to higher
+types, take the fixed point, hold the whole possibility space in superposition. Its mathematical skeleton is the
+**diagonal / Cantor tower** — Cantor's theorem `|X| < |2^X|` iterated builds the transfinite hierarchy (the
+cumulative hierarchy / beth numbers), and **Lawvere's fixed-point theorem** (#7172) is the categorical engine of
+that same diagonal. The defining feature: **there is no top.** Diagonalize any level and you have already exceeded
+it; no largest cardinal exists. So the ascent is **unbounded** — you climb as far as the problem needs and never
+*finish*. That is the "clouds of infinity": the abstract, soft, infinite-possibility region where the observer is
+fully general (the Mirror register — mirror everything, fast, unanchored).
+
+## Down — the stairs you build by lowering [grounded]
+
+Codegen is the **descent**: turn the abstract `Bonsai.Expr` over `SoftValue` (interpreted by the F# host today,
+#7176) into something the metal runs. The algorithm Aaron names is exactly a **lowering pipeline / nanopass
+compiler**: *find the dependencies → close over them → lower one tier → repeat.* Each pass computes a **dependency
+closure** and emits the next-lower IR (soft AST → CPU `System.Runtime.Intrinsics`/SIMD → shader/GPU). It is the
+**dual of diagonalization**: where the diagonal *escapes* every level upward, lowering *resolves* each level
+downward by closing over what it depends on.
+
+And — the asymmetry — **the descent is well-founded; it terminates.** There **is** a bottom: the hardware ISA. Each
+lowering step strictly decreases the remaining abstraction-height over a finite dependency set, so by well-founded
+(Noetherian) recursion the staircase reaches the floor. Equivalently, the lowered program is a **least fixed point**
+of the lowering functor, reached by Kleene/Tarski–Knaster iteration from the bottom (the same `δ → 0` convergence as
+the #7168 registry, but *ascending from `⊥`* instead of escaping upward). This is the Beacon register: compress the
+infinite Mirror cloud down to anchored, concrete, executable ground.
+
+## The asymmetry is the gift
+
+| | Up (Cantor tower) | Down (codegen / lowering) |
+|---|---|---|
+| Move | diagonalize / abstract / lift | find deps → close → lower → repeat |
+| Engine | Cantor / Lawvere fixed point (#7172) | least fixed point from `⊥` (Kleene/Tarski) |
+| Bound | **unbounded** — no top (no largest ∞) | **well-founded** — a bottom (the metal) |
+| Terminates? | never *finishes* (climb as needed) | **yes** — descent is Noetherian |
+| Register | Mirror (soft, infinite, fast) | Beacon (sharp, grounded, anchored) |
+| Construct. | classical / non-constructive ascent | **constructive** descent (a program) |
+
+**You can always build the stairs down** because the hardware is a real floor — a constructive, terminating descent
+exists from any height. **You can never top out the tower** because infinity has no ceiling. So the design strategy
+is honest and safe: *ladder up* into the soft/general/infinite to get the observer **right** (correctness lives in
+the clouds — the rig algebra, the categorical structure, the homoiconic generality), then *build the stairs down*
+by lowering to get it **fast** (performance lives on the floor — intrinsics, shaders, GPU). Up for truth, down for
+speed; and the down is *easy* precisely because soft/branchless/lock-free (#7174) means each lowering is a pure
+dataflow descent with nothing cross-lane to preserve — a lowering, not a redesign (#7176).
+
+## Honest scope
+
+[anchor]: Cantor (diagonal / transfinite hierarchy); Lawvere (the diagonal as a fixed-point theorem, the *up*
+engine, #7172); Tarski–Knaster / Kleene (least fixed point from `⊥`, the *down* engine); nanopass / lowering
+compilers; well-founded (Noetherian) recursion (why descent terminates). [grounded-in-code, elsewhere]: the tiers
+this frames — `BonsaiSoft` interpreter (the cloud, today), `Simd.fs` (one step down), the intrinsics/GPU backend
+(#7176, next-build). [metaphor]: "clouds of infinity" / "stairs down" is the vivid bridge; the math on both ends
+(unbounded diagonal ascent vs well-founded lowering descent) is literal. No new code here — this names *why* the
+#7176 lowering is easy and guaranteed to terminate.
+
+## Pointers
+
+- `2026-06-08-the-memetic-quantum-observer-…-gpu-lowerable-…` (#7174) and the execution-tier refinement (#7176) —
+  the tiers this descent walks (interpreted → intrinsics → GPU).
+- `2026-06-08-trapping-godel-in-the-middle-lawvere-…` (#7172, the *up* engine) ·
+  `2026-06-08-the-fixed-point-registry-…` (#7168, fixed points as `δ→0`) ·
+  `mirror-beacon-register-discipline.md` (Mirror = up/soft/infinite, Beacon = down/sharp/grounded).
+- Anchors: Cantor (1891, diagonal); Lawvere (1969); Tarski–Knaster (lattice fixed points); Kleene (iteration from
+  ⊥); the nanopass-framework lineage (Sarkar, Waddell, Dybvig).


### PR DESCRIPTION
Closing frame on the #7176 execution tiers. UP = Cantor diagonal/Lawvere fixed point reaching the soft infinite observer (unbounded, no top, Mirror). DOWN = codegen/lowering (deps->closure->lower->repeat), the dual of diagonalization, WELL-FOUNDED (bottom=the metal) so it terminates = least fixed point from bottom (Kleene/Tarski, Beacon). The asymmetry is the gift: always buildable down (real floor) / never toppable up (no ceiling) => ladder up for truth, stairs down for speed; easy because soft/branchless/lock-free (#7174). No new code. Anchors: Cantor, Lawvere, Tarski-Knaster/Kleene, nanopass. 🤖 Generated with [Claude Code](https://claude.com/claude-code)