### PR TITLE
build(setup): declaratively lock R + tectonic into install manifests (cross-OS symmetric, cost-aware)

### DIFF
--- a/tools/ci/manifest-symmetry.test.ts
+++ b/tools/ci/manifest-symmetry.test.ts
@@ -72,6 +72,8 @@ const WINDOWS_EXCEPTIONS: Record<string, string> = {
   "fuse-overlayfs": "Linux rootless overlay storage driver; Windows podman uses WSL2's VM storage",
   opam: "OCaml package manager; only needed on Unix to build tlapm from source. Windows tlapm installs via prebuilt MSI/zip.",
   z3: "SMT solver; on Windows, Z3 is either scoop-installed or used via JS z3-solver npm package.",
+  "r-base":
+    "R statistical runtime (charting/grammar-of-graphics lens-finder); covered on Windows by the `r` manifest line (scoop r / winget RProject.R / choco R.Project). apt names the package r-base; brew + scoop name it r.",
 };
 
 test("manifests/windows covers every apt/brew system tool (or an allowlisted exception)", () => {

--- a/tools/setup/manifests/apt
+++ b/tools/setup/manifests/apt
@@ -67,3 +67,18 @@ fuse-overlayfs  # rootless overlay storage driver
 # closes B-1009. Also the SMT backend TLAPS shells out to (rung-3). Unpinned (apt default)
 # per dep-pin-search-first-authority; idempotent.
 z3
+
+# R statistical runtime — charting / grammar-of-graphics lens-finder family (Aaron 2026-06-08:
+# "the patterns in R are timeless… scatter plots… to find solid ground over memory space").
+# Renders data-viz lenses of the state/memory field (ASCII-rendered for the LLM-TV). Pin per
+# dep-pin-search-first (WebSearch 2026-06-08): Ubuntu 24.04 noble `r-base` (universe), GPL-2;
+# idempotent. Windows carries it via the `r` line (symmetry exception r-base→r in manifest test).
+r-base
+
+# NOTE — tectonic (lean single-binary LaTeX engine; Lamport's LaTeX, cost-aware vs texlive-full's
+# GBs) is declared in manifests/brew + manifests/windows where it is a clean package. It is NOT in
+# Ubuntu apt (WebSearch 2026-06-08: absent from all noble components), and its official drop-sh
+# installer drops the binary into CWD (not PATH), so it does NOT fit the one-liner-tools
+# download-then-exec shape cleanly. Linux tectonic install is therefore a BEST-EFFORT GAP pending an
+# install-graph decision (`cargo install tectonic`, or a GitHub-release extraction onto PATH) —
+# Dejan/devops call (mirrors the kiro-cli Linux gap precedent in manifests/one-liner-tools).

--- a/tools/setup/manifests/brew
+++ b/tools/setup/manifests/brew
@@ -63,3 +63,17 @@ podman
 # idempotent (brew skips if present). The Microsoft.Z3 NuGet is deliberately NOT used (no
 # osx-arm64 native) — the CLI is the real dependency.
 z3
+
+# R statistical runtime — charting / grammar-of-graphics lens-finder family (Aaron 2026-06-08:
+# "the patterns in R are timeless… scatter plots… to find solid ground over memory space").
+# Pin per dep-pin-search-first (WebSearch 2026-06-08): brew formula `r`, GPL-2; brew default
+# version; idempotent (brew skips if present). Symmetric with apt `r-base` + windows `r`.
+r
+
+# tectonic — lean single-binary LaTeX engine (Leslie Lamport's LaTeX on a self-contained XeTeX;
+# Aaron 2026-06-08 "pull in Lamport's LaTeX"). COST-AWARE: a few-MB binary that fetches packages
+# on demand from a bundle — NOT texlive-full's gigabytes on every runner/devcontainer. Math/typeset
+# rendering + LaTeX-source as an LLM-readable math representation. Pin per dep-pin-search-first
+# (WebSearch 2026-06-08): brew formula `tectonic`, MIT; idempotent. Symmetric with windows
+# `tectonic` (scoop main). Linux: best-effort gap — see the NOTE in manifests/apt.
+tectonic

--- a/tools/setup/manifests/windows
+++ b/tools/setup/manifests/windows
@@ -49,3 +49,14 @@ ollama    winget=Ollama.Ollama    choco=ollama    optional
 # B-0964: docker = Mac/Win default; podman preferred on the Linux cluster).
 # Both-runtimes-on-Windows shield coverage tracked in B-0968.
 podman    winget=RedHat.Podman    choco=podman-cli
+
+# R statistical runtime — charting / grammar-of-graphics lens-finder family (Aaron 2026-06-08;
+# symmetric with apt `r-base` + brew `r`). Pins per dep-pin-search-first (WebSearch 2026-06-08):
+# scoop `r` | winget `RProject.R` | choco `R.Project` (canonical casing). GPL-2.
+r         winget=RProject.R    choco=R.Project
+
+# tectonic — lean single-binary LaTeX engine (Lamport's LaTeX; cost-aware vs texlive-full; Aaron
+# 2026-06-08). Symmetric with brew `tectonic`. Pin per dep-pin-search-first (WebSearch 2026-06-08):
+# scoop main `tectonic` (winget has NO official package — issue #976; choco unverified — so rely on
+# scoop, the resolver-primary). MIT. `optional` (best-effort): network-bundle fetch on first run.
+tectonic    optional


### PR DESCRIPTION
Aaron-authorized declarative tool locking. R (apt r-base / brew r / win scoop r,winget RProject.R,choco R.Project) + tectonic (lean single-binary LaTeX, cost-aware vs texlive-full GBs; brew + win scoop). Symmetry exception added for r-base->r. Linux tectonic flagged as best-effort gap (not in apt; drop-sh installs to CWD) for Dejan. dep-pin-search-first WebSearch-verified ids; manifest-symmetry test 9 pass/0 fail verified locally. 🤖 Generated with [Claude Code](https://claude.com/claude-code)