### PR TITLE
fix(full-ai-cluster): green the red gate — erasableSyntaxOnly + exactOptionalPropertyTypes + unused + web-app exclude

### DIFF
--- a/full-ai-cluster/platform-controller/src/k8s.ts
+++ b/full-ai-cluster/platform-controller/src/k8s.ts
@@ -44,7 +44,10 @@ function resourcePath(group: string, version: string, plural: string, namespace?
 }
 
 export class K8sClient {
-  constructor(private cfg: ClientConfig) {}
+  private cfg: ClientConfig;
+  constructor(cfg: ClientConfig) {
+    this.cfg = cfg;
+  }
 
   private async req(method: string, path: string, init?: { body?: string; contentType?: string; query?: Record<string, string> }): Promise<Response> {
     const url = new URL(this.cfg.host + path);

--- a/full-ai-cluster/platform-controller/src/room.ts
+++ b/full-ai-cluster/platform-controller/src/room.ts
@@ -136,7 +136,7 @@ export class Room {
     const action = req.body.action;
     const result = run?.(action);
     const event = this.append(
-      { proposedBy: by, authorizedBy: grant.sig.authorizedBy },
+      { proposedBy: by, ...(grant.sig.authorizedBy !== undefined ? { authorizedBy: grant.sig.authorizedBy } : {}) },
       { type: "action", action, ...(result !== undefined ? { result } : {}) },
     );
     return { kind: "acted", event };

--- a/full-ai-cluster/portal/src/data-composite.ts
+++ b/full-ai-cluster/portal/src/data-composite.ts
@@ -18,7 +18,14 @@ export interface ResourceSource {
 }
 
 export class CompositePlatform implements PlatformData {
-  constructor(private resources: ResourceSource, private rooms: RoomSource, readonly ops?: ResourceOps) {}
+  private resources: ResourceSource;
+  private rooms: RoomSource;
+  readonly ops?: ResourceOps;
+  constructor(resources: ResourceSource, rooms: RoomSource, ops?: ResourceOps) {
+    this.resources = resources;
+    this.rooms = rooms;
+    if (ops !== undefined) this.ops = ops;
+  }
 
   async memoryUsage(): Promise<MemoryUsage> {
     const all = await this.rooms.listRooms();

--- a/full-ai-cluster/portal/src/data-file.ts
+++ b/full-ai-cluster/portal/src/data-file.ts
@@ -19,8 +19,10 @@ const resourceOf = (file: string) => file.slice(0, -FILE_SUFFIX.length).replace(
 
 export class FileRoomStore implements RoomSource {
   private rooms = new Map<string, RoomData>();
+  private dir: string;
 
-  constructor(private dir: string) {
+  constructor(dir: string) {
+    this.dir = dir;
     mkdirSync(dir, { recursive: true });
     this.replay();
   }

--- a/full-ai-cluster/portal/src/data-k8s.ts
+++ b/full-ai-cluster/portal/src/data-k8s.ts
@@ -28,8 +28,10 @@ export class K8sPlatform implements PlatformData {
   private host: string;
   private token: string;
   private ca: string;
+  private rooms: RoomSource;
 
-  constructor(private rooms: RoomSource) {
+  constructor(rooms: RoomSource) {
+    this.rooms = rooms;
     const h = process.env.KUBERNETES_SERVICE_HOST;
     const p = process.env.KUBERNETES_SERVICE_PORT_HTTPS ?? process.env.KUBERNETES_SERVICE_PORT ?? "443";
     if (!h) throw new Error("not running in-cluster: KUBERNETES_SERVICE_HOST unset");

--- a/full-ai-cluster/portal/src/data-memory.ts
+++ b/full-ai-cluster/portal/src/data-memory.ts
@@ -13,11 +13,14 @@ import type { BlueprintCR, DeployableCR, RoomData, RoomEventVM } from "./viewmod
 
 export class InMemoryPlatform implements PlatformData {
   readonly ops: ResourceOps = new DemoOps();
-  constructor(
-    private deployables: DeployableCR[] = [],
-    private blueprints: BlueprintCR[] = [],
-    private rooms: RoomData[] = [],
-  ) {}
+  private deployables: DeployableCR[];
+  private blueprints: BlueprintCR[];
+  private rooms: RoomData[];
+  constructor(deployables: DeployableCR[] = [], blueprints: BlueprintCR[] = [], rooms: RoomData[] = []) {
+    this.deployables = deployables;
+    this.blueprints = blueprints;
+    this.rooms = rooms;
+  }
 
   async memoryUsage(): Promise<MemoryUsage> {
     const rooms = this.rooms.map((r) => ({ resource: r.resource, events: r.events.length, bytes: roomBytes(r) }));

--- a/full-ai-cluster/portal/src/ops-demo.ts
+++ b/full-ai-cluster/portal/src/ops-demo.ts
@@ -148,13 +148,15 @@ export class DemoOps implements ResourceOps {
   async config(resource: string): Promise<ResourceConfig> {
     const o = this.ov(resource);
     const game = GAME(resource), db = DB(resource);
+    const storage = o.storage ?? (game ? "20Gi" : db ? "20Gi" : undefined);
+    const host = !game && !db ? "demo.zeta.example.com" : undefined;
     return {
       replicas: o.replicas ?? (game || db ? 1 : 2),
       cpu: o.cpu ?? (game ? "2" : "1"),
       memory: o.memory ?? (game ? "6Gi" : db ? "1Gi" : "256Mi"),
-      storage: o.storage ?? (game ? "20Gi" : db ? "20Gi" : undefined),
+      ...(storage !== undefined ? { storage } : {}),
       expose: game ? "lan" : db ? "cluster" : "public",
-      host: !game && !db ? "demo.zeta.example.com" : undefined,
+      ...(host !== undefined ? { host } : {}),
       values: o.values ?? (game ? { MAP: "gm_flatgrass", MAXPLAYERS: "32" } : db ? { DB: "orders" } : {}),
       env: game ? { SRCDS_PORT: "27015" } : db ? { POSTGRES_DB: "orders" } : {},
     };

--- a/full-ai-cluster/tools/k8s-manifests.test.ts
+++ b/full-ai-cluster/tools/k8s-manifests.test.ts
@@ -11,7 +11,7 @@
 
 import { test, expect, describe } from "bun:test";
 import { readdirSync, readFileSync, existsSync, statSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { join } from "node:path";
 
 const REPO = join(import.meta.dir, "..", ".."); // .../full-ai-cluster/..  (repo root)
 const K8S = join(REPO, "full-ai-cluster", "k8s");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,6 +39,8 @@
     "tools/alloy/**",
     "tools/tla/**",
     "agentic-organization",
-    "agentic-organization/**"
+    "agentic-organization/**",
+    "full-ai-cluster/portal/web",
+    "full-ai-cluster/portal/web/**"
   ]
 }


### PR DESCRIPTION
The gate's 'lint (tsc tools)' was red on pre-existing full-ai-cluster TS (Aaron-authorized fix: 'Max broke it, isn't looking, you can fix the red gate'). Fixes: param-properties -> explicit fields (erasableSyntaxOnly); conditional-spread + truly-optional ops field (exactOptionalPropertyTypes); drop unused dirname; exclude the separate vite web app (portal/web, own tsconfig+deps) from the root tools tsc. Verified locally: tsc --noEmit -p tsconfig.json => 0 errors. Behavior-identical, minimal-diff, no architecture change. 🤖 Generated with [Claude Code](https://claude.com/claude-code)