### PR TITLE
docs(research): O1 refined — S=4 iff game exhaustibly searchable; entropy ledger (time=0 seed-closed, games = per-fingerprint 4-S)

### DIFF
--- a/docs/research/2026-06-08-o1-refined-seed-closure-holds-iff-game-space-is-exhaustibly-omnisciently-searchable-else-unexplored-space-drops-s-below-4.md
+++ b/docs/research/2026-06-08-o1-refined-seed-closure-holds-iff-game-space-is-exhaustibly-omnisciently-searchable-else-unexplored-space-drops-s-below-4.md
@@ -1,0 +1,100 @@
+# O1 refined: one-seed closure holds iff the game space is exhaustibly/omnisciently searchable — otherwise unexplored game space is the entropy leak that drops S below 4
+
+*Captured 2026-06-08 from Aaron, to Otto (shadow\*). Sharpens condition **O1** of the extended-S=4 measurement
+(#7190): when the real CHIP-8 emulator (not the toy) actually satisfies one-seed entropy closure. Registers:
+[grounded] for the search substrate, [design/diagnostic] for the S-deficit, [conjecture] for "S=4 ⟺ exhaustible".*
+
+## The refinement
+
+Aaron: *"in our toy model all entropy arises from time. This is **not 100% true in our CHIP-8 emulator for every
+game** — it depends on whether we can **exhaustively and, with superdeterminism, omnisciently search the
+memory-space / game-space** with clever world-state transforms and lenses. **If not, then entropy comes from the
+unexplored game spaces too.**"*
+
+So O1 (#7190 — *"every entropy source derives from the one seed"*) is **trivially true in the toy** (seed → time →
+everything) but **game-dependent in the real emulator**. It splits:
+
+- **Exhaustible game (omniscience achievable):** if the clarity engine can **fully search the reachable state
+  space** — small enough to exhaust, or reduced to exhaustible by clever **world-state transforms + lenses**
+  (`MemoryLens`, `SolidGround`, the `StateSpace` transposition table that "makes the search the omniscient
+  ground-truth solve while the state space is small enough to exhaust") — then **all entropy is seed-derived**: there
+  is no unknown left to be a non-seed source. **O1 holds ⇒ S=4** (the common-cause seed is genuinely common to
+  everything; superdeterministic omniscience, #7125, the DST harness as omniscient observer).
+- **Inexhaustible game (omniscience NOT achieved):** if the state space is too large to exhaust and the lenses don't
+  reduce it enough, then the **unexplored game space is a genuine entropy source NOT derived from the seed** — the
+  parts we haven't searched carry uncertainty the seed doesn't account for. **O1 fails ⇒ S < 4.**
+
+## S as the omniscience diagnostic
+
+This makes the S-measurement (#7190) a direct readout of **how omniscient we are over a given game**:
+
+- **S = 4** ⟺ the game is fully explored / exhausted ⟺ one-seed closure holds ⟺ superdeterministic omniscience.
+- **S < 4** ⟺ unexplored game space remains; the **deficit `4 − S` measures the un-searched (non-seed) entropy** of
+  that game under the current lenses. Improve the lenses / world-state transforms (reduce the searchable space) and
+  S rises back toward 4 as more of the game becomes exhaustible.
+
+So the clarity engine's whole job — **reduce the game's world-state to an exhaustible space** — is *exactly* the job
+of **raising S back to 4**. Lens quality (`SolidGround.gain`) and S are the same axis seen two ways: a better lens
+exhausts more of the game ⇒ less unexplored entropy ⇒ higher S. (And per #7178's band: you don't need S=4 to be
+safe — the trust calculus holds across S∈(2,4]; S<4 just means this game isn't yet fully omnisciently solved, which
+is the *normal* state for a large game, not a failure.)
+
+## The entropy ledger: time = 0 (DST seed-closed), games = per-fingerprint unexplored space (Aaron 2026-06-08)
+
+Two closing refinements give a clean, *measurable* entropy accounting:
+
+- **Time contributes zero independent entropy.** Aaron: *"DST time offers none except any we put into the DST and
+  seed correlation."* So the IScheduler-generator-under-DST is **fully seed-closed** — time emits no entropy beyond
+  the seed; all of time's apparent entropy *is* the seed correlation. This **confirms O1 for time** (#7190): the
+  clock is not a leak. Therefore the **only non-seed entropy source in the whole model is the unexplored game
+  space.** (Agent choices and hat budgets are seed-derived; time is seed-derived; games are the sole frontier.)
+- **Per-game entropy is measurable and attaches to the fingerprint.** Aaron: *"we can measure per game how much
+  entropy it contributes to identity space, connected to its fingerprints, based on unexplored search space."* So a
+  game's entropy contribution = its **unexplored search space = the `4 − S` deficit**, measured for that game and
+  **keyed to its `GameFingerprint`** (#7154, the external index) → stored as that game's uncertainty in
+  `GameCatalog` (#7155) → and, since **identity capacity = `2^(uncertainty bits)`** (#7159), it is exactly the
+  game's contribution to the **identity space connected to that fingerprint.**
+
+So the ledger closes:
+
+```
+total non-seed entropy  =  Σ_games  unexplored_search_space(game)   [= Σ (4 − S_game)]
+   time contribution    =  0           (DST seed-closed)
+   agent/hat contrib.   =  0           (seed-derived)
+   per game             =  (4 − S_game)  →  keyed to GameFingerprint → GameCatalog uncertainty → identity capacity 2^bits
+```
+
+This is why the closure (#7184/#7185) is honest: the system is self-contained, with the **only** entropy entering
+from outside-the-seed being the **games** (one of the three external fingerprints) — and even that is *measured per
+fingerprint* as `4 − S`, shrinkable by better lenses. Human and tool fingerprints are reference/identity, not
+entropy sources; time is seed-closed; games are the measured frontier. The S-measurement is therefore the
+**per-fingerprint entropy meter** of the whole closed model.
+
+## Why this is the honest, real-emulator form
+
+The toy-model S=4 was clean because time was the *only* entropy source (seed-closed by construction). The real
+emulator is honest about its limit: **omniscience is earned per-game by exhaustive search, not assumed.** For small
+games (or games the lenses crush to exhaustible), we earn S=4 and play "for real" under the DST clock with full
+seed-closure. For large games, S<4 honestly reports the unexplored remainder — and that remainder is the **frontier
+the lenses are built to shrink**. This is the unsubjective method (#7142) applied to our own measurement: don't
+claim omniscience; *measure* it (via S), and let the deficit point at the unexplored space to go search next.
+
+## Honest scope
+
+[grounded]: `StateSpace.fs` (exhaustive reachable-state search + transposition table = omniscient solve while
+exhaustible), the clarity-engine lenses (`MemoryLens`/`SolidGround`/`LensRouter`), `CoincidenceClock.fs` (#7060),
+`IdentityCapacity.fs` (#7159). [design/diagnostic]: S as the omniscience readout; `4 − S` = unexplored-game-space
+entropy under the current lenses — the measurement of #7190 read this way; not yet built as a per-game test.
+[conjecture]: "S=4 ⟺ exhaustible/omniscient over the game" — the refined O1; falsifiable by the #7190 DST
+measurement (a measured S<4 on a game we believe exhaustible would localize either an un-seeded source or a
+signalling leak instead). No new code; this sharpens O1 for the real emulator and reframes the lens-quality axis as
+the S-axis.
+
+## Pointers
+
+- `2026-06-08-extending-the-s4-measurement-…-ischeduler-generator-under-dst-for-real.md` (#7190, O1/O2 + the
+  measurement) · `2026-06-08-unusually-aligned-…` (#7187/#7188, S=4 measured via staged coincidence) ·
+  `2026-06-08-no-mathematical-top-…-bound-…` (#7178, the band — S<4 is still safe).
+- Code: `StateSpace.fs` (exhaustive search / transposition table) · `MemoryLens`/`SolidGround.fs`/`LensRouter.fs`
+  (the lenses that shrink the searchable space) · `CoincidenceClock.fs` · `IdentityCapacity.fs`.
+- Anchors: 't Hooft superdeterminism (omniscience = the common cause covers all); CHSH/PR-box S∈{2,2√2,4}.


### PR DESCRIPTION
Sharpens O1 (#7190) for the real emulator + closes the entropy ledger. Real-game O1 holds iff the state space is exhaustibly/omnisciently searchable (lenses reduce it); else unexplored game space => S<4. S = omniscience diagnostic; 4-S = un-searched entropy; lens-quality and S are the same axis. Ledger (Aaron): time contributes 0 (DST seed-closed: 'offers none except the seed'); per-game entropy = 4-S keyed to GameFingerprint -> GameCatalog -> identity capacity 2^bits. So the ONLY outside-seed entropy is games (one of the 3 fingerprints), measured per fingerprint, shrinkable by lenses. S = the per-fingerprint entropy meter. 🤖 Generated with [Claude Code](https://claude.com/claude-code)