### PR TITLE
feat(portal): Room AI chat — a resource-sandboxed persona you can ask to do things

### DIFF
--- a/full-ai-cluster/portal/src/api.ts
+++ b/full-ai-cluster/portal/src/api.ts
@@ -16,8 +16,19 @@ import {
   toRoomVM,
 } from "./viewmodel.ts";
 import type { LifecycleAction, MemoryUsage, ResourceConfig, ResourceOps } from "./ops.ts";
+import { type ChatOp, DEFAULT_POLICY, decide, respond } from "./room-agent.ts";
 
 const LIFECYCLE_ACTIONS = new Set(["restart", "stop", "start", "scale", "delete"]);
+
+/** Execute a sandboxed chat op against THIS resource's ops only. */
+async function runChatOp(ops: ResourceOps, resource: string, op: ChatOp): Promise<string> {
+  switch (op.kind) {
+    case "restart": return (await ops.lifecycle(resource, "restart")).message;
+    case "stop": return (await ops.lifecycle(resource, "stop")).message;
+    case "scale": return (await ops.lifecycle(resource, "scale", op.replicas)).message;
+    case "config": return (await ops.applyConfig(resource, op.patch)).message;
+  }
+}
 
 /** What the portal needs from the platform. The server provides a k8s-backed impl. */
 export interface PlatformData {
@@ -149,6 +160,41 @@ export async function handle(req: Request, data: PlatformData): Promise<Response
       if (!b.requestId || !b.by || typeof b.granted !== "boolean") return json({ error: "requestId, by, granted required" }, 400);
       const ok = await data.grant(resource, b.requestId, b.by, b.granted, b.note);
       return ok ? json({ ok: true }) : json({ error: "unknown room or request" }, 404);
+    }
+
+    // POST /api/rooms/:resource/chat — talk to the resource's persona. SANDBOXED:
+    // the agent only ever sees + acts on THIS resource; actions run through Policy.
+    const chatMatch = path.match(/^\/api\/rooms\/([^/]+)\/chat$/);
+    if (chatMatch && req.method === "POST") {
+      if (!data.ops || !data.appendEvent) return json({ error: "chat not available on this backend" }, 405);
+      const resource = decodeResource(chatMatch[1]!);
+      const b = (await req.json().catch(() => ({}))) as { text?: string; by?: string };
+      if (!b.text || !b.by) return json({ error: "text + by required" }, 400);
+
+      // the persona that operates this resource (resource-scoped lookup)
+      const dep = (await data.listDeployables()).find((d) => `${d.metadata.namespace}/${d.metadata.name}` === resource);
+      const admin = dep?.spec.ai?.admin ?? "otto";
+
+      // 1) record the human's message
+      await data.appendEvent(resource, { id: b.by, kind: "human" }, { type: "message", text: b.text });
+
+      // 2) the persona responds — context is THIS resource only
+      const [cfg, info] = await Promise.all([data.ops.config(resource), data.ops.info(resource)]);
+      const r = respond(resource, b.text, { game: !!cfg.values.MAP || /sandbox|gmod|game/.test(resource), memory: cfg.memory, replicas: info.pods.length, phase: info.pods[0]?.phase ?? "Unknown" });
+      await data.appendEvent(resource, { id: admin, kind: "persona" }, { type: "message", text: r.reply });
+
+      // 3) if it proposed an op, run it through Policy — act (auto) or request (propose)
+      if (r.op) {
+        const d = decide(DEFAULT_POLICY, r.op.action);
+        if (d.level === "auto") {
+          const result = await runChatOp(data.ops, resource, r.op);
+          await data.appendEvent(resource, { id: admin, kind: "persona" }, { type: "action", action: { summary: r.op.action.summary }, result });
+        } else if (d.level === "propose") {
+          await data.appendEvent(resource, { id: admin, kind: "persona" }, { type: "authorization-request", action: { summary: r.op.action.summary }, ...(d.gated ? { gated: d.gated } : {}) });
+        }
+      }
+      const room = await data.getRoom(resource);
+      return json({ room: room ? toRoomVM(room) : null });
     }
 
     return json({ error: "not found" }, 404);

--- a/full-ai-cluster/portal/src/room-agent.test.ts
+++ b/full-ai-cluster/portal/src/room-agent.test.ts
@@ -1,0 +1,88 @@
+// full-ai-cluster/portal/src/room-agent.test.ts
+//
+// The sandboxed Room agent: intent classification + the no-directives gating,
+// and (via the BFF) the full chat loop — human message → persona reply → an
+// auto action OR an authorization-request. Sandbox: the agent only ever names
+// the resource it was given.
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import { type ChatContext, DEFAULT_POLICY, decide, respond } from "./room-agent.ts";
+import { encodeResource, handle } from "./api.ts";
+import { InMemoryPlatform } from "./data-memory.ts";
+import type { BlueprintCR, DeployableCR, RoomData } from "./viewmodel.ts";
+
+const game: ChatContext = { game: true, memory: "6Gi", replicas: 1, phase: "CrashLoopBackOff" };
+const r = "acme/friday-sandbox";
+
+describe("respond — intent + sandbox", () => {
+  test("restart → an auto lifecycle op", () => {
+    const res = respond(r, "please restart it", game);
+    expect(res.op?.kind).toBe("restart");
+    expect(decide(DEFAULT_POLICY, res.op!.action).level).toBe("auto");
+  });
+  test("scale to N → an auto scaling op with the parsed count", () => {
+    const res = respond(r, "scale to 4", game);
+    expect(res.op).toMatchObject({ kind: "scale", replicas: 4 });
+    expect(decide(DEFAULT_POLICY, res.op!.action).level).toBe("auto");
+  });
+  test("more memory / fix the crash → a budget-gated config op (propose)", () => {
+    const res = respond(r, "it keeps crashing, give it more memory", game);
+    expect(res.op?.kind).toBe("config");
+    expect((res.op as { patch: { memory?: string } }).patch.memory).toBe("8Gi");
+    expect(decide(DEFAULT_POLICY, res.op!.action).level).toBe("propose");
+  });
+  test("change map → a mods op (propose)", () => {
+    const res = respond(r, "change the map to gm_construct", game);
+    expect((res.op as { patch: { values?: Record<string, string> } }).patch.values).toEqual({ MAP: "gm_construct" });
+    expect(decide(DEFAULT_POLICY, res.op!.action).level).toBe("propose");
+  });
+  test("delete → refused in words, NO op (data is human-only)", () => {
+    const res = respond(r, "delete this server and wipe the data", game);
+    expect(res.op).toBeUndefined();
+    expect(res.reply).toMatch(/human-only|Danger zone/);
+  });
+  test("status → a read-only reply, no op", () => {
+    const res = respond(r, "how is it doing?", game);
+    expect(res.op).toBeUndefined();
+    expect(res.reply).toContain("friday-sandbox");
+  });
+  test("the reply only ever names the given resource (sandbox)", () => {
+    const res = respond("acme/orders-db", "restart it", { ...game, game: false });
+    expect(res.reply).toContain("orders-db");
+    expect(res.reply).not.toContain("friday-sandbox");
+  });
+});
+
+describe("chat BFF loop", () => {
+  let data: InMemoryPlatform;
+  const blueprints: BlueprintCR[] = [{ metadata: { name: "gmod", namespace: "zeta-platform" }, spec: { category: "game", image: "gmod" } }];
+  const deployables: DeployableCR[] = [{ metadata: { name: "friday-sandbox", namespace: "acme" }, spec: { blueprint: "gmod", ai: { admin: "otto" } }, status: { phase: "CrashLoopBackOff" } }];
+  const rooms: RoomData[] = [{ resource: r, events: [] }];
+  beforeEach(() => {
+    data = new InMemoryPlatform(structuredClone(deployables), structuredClone(blueprints), structuredClone(rooms));
+  });
+  const chat = (text: string) => handle(new Request(`http://x/api/rooms/${encodeResource("acme", "friday-sandbox")}/chat`, { method: "POST", body: JSON.stringify({ text, by: "you" }) }), data);
+  const body = async (resp: Response | null) => (resp ? resp.json() : null) as any;
+
+  test("an auto request: human msg + persona reply + an action event", async () => {
+    const j = await body(await chat("restart the server"));
+    const types = j.room.events.map((e: { body: { type: string } }) => e.body.type);
+    expect(types).toContain("message"); // human + persona messages
+    expect(types).toContain("action"); // the restart was performed
+    // the persona (otto) spoke
+    expect(j.room.events.some((e: any) => e.proposedBy.id === "otto" && e.body.type === "message")).toBe(true);
+  });
+
+  test("a gated request: human msg + persona reply + an authorization-request (no action)", async () => {
+    const j = await body(await chat("please give it more memory, it's OOMing"));
+    const types = j.room.events.map((e: { body: { type: string } }) => e.body.type);
+    expect(types).toContain("authorization-request");
+    expect(types).not.toContain("action"); // nothing ran without a human grant
+    expect(j.room.pending.length).toBe(1);
+  });
+
+  test("missing text → 400", async () => {
+    const resp = await handle(new Request(`http://x/api/rooms/${encodeResource("acme", "friday-sandbox")}/chat`, { method: "POST", body: JSON.stringify({ by: "you" }) }), data);
+    expect(resp!.status).toBe(400);
+  });
+});

--- a/full-ai-cluster/portal/src/room-agent.ts
+++ b/full-ai-cluster/portal/src/room-agent.ts
@@ -1,0 +1,142 @@
+// full-ai-cluster/portal/src/room-agent.ts
+//
+// The Room agent — the persona you chat with INSIDE a resource's Room. It is
+// structurally SANDBOXED to that one resource: respond() receives only the
+// resource it was invoked for plus that resource's own context, and returns
+// intents the caller executes against THAT resource's ops alone. It has no
+// reference to, and cannot name, any other resource (no list/registry access).
+//
+// Authority is no-directives: every operation is classified into a domain (+
+// maybe a gated class) and run through decide(). `auto` acts on standing
+// authority; `propose` emits an authorization-request a human must grant;
+// `forbidden` is refused in words (the human uses the Danger zone). This is a
+// deterministic responder for the demo; a real LLM persona slots in behind the
+// same respond() contract — still resource-scoped, still Policy-gated.
+
+export type Autonomy = "auto" | "propose" | "forbidden";
+export type GatedClass = "budget" | "non-reversible" | "wont-do" | "hard-limits" | "force-push" | "external-repo";
+
+export interface PolicySpec {
+  domains: Array<{ name: string; autonomy: Autonomy }>;
+  gatedClasses: GatedClass[];
+}
+
+/** The default Policy (mirrors k8s/applications/platform/policy-default.yaml). */
+export const DEFAULT_POLICY: PolicySpec = {
+  domains: [
+    { name: "lifecycle", autonomy: "auto" },
+    { name: "scaling", autonomy: "auto" },
+    { name: "config", autonomy: "auto" },
+    { name: "mods", autonomy: "propose" },
+    { name: "spend", autonomy: "propose" },
+    { name: "data", autonomy: "forbidden" },
+    { name: "security", autonomy: "forbidden" },
+  ],
+  gatedClasses: ["budget", "non-reversible", "wont-do", "hard-limits", "force-push", "external-repo"],
+};
+
+export interface Action {
+  domain: string;
+  gated?: GatedClass;
+  summary: string;
+}
+export type Decision =
+  | { level: "auto"; reason: string }
+  | { level: "propose"; reason: string; gated?: GatedClass }
+  | { level: "forbidden"; reason: string };
+
+const HARD_FLOOR = new Set<GatedClass>(["wont-do", "hard-limits"]);
+
+/** no-directives decision: a gated class always escalates above auto. */
+export function decide(policy: PolicySpec, a: Action): Decision {
+  const dom = policy.domains.find((d) => d.name === a.domain);
+  if (!dom) return { level: "forbidden", reason: `unknown domain "${a.domain}"` };
+  if (dom.autonomy === "forbidden") return { level: "forbidden", reason: `${a.domain} is human-only` };
+  if (a.gated) {
+    if (HARD_FLOOR.has(a.gated)) return { level: "forbidden", reason: `${a.gated} is a hard floor` };
+    return { level: "propose", reason: `${a.gated} needs a human grant`, gated: a.gated };
+  }
+  return dom.autonomy === "auto" ? { level: "auto", reason: "standing authority" } : { level: "propose", reason: `${a.domain} needs a proposal` };
+}
+
+// ── the agent ──────────────────────────────────────────────────────────
+/** Resource-scoped context the agent may read (THIS resource only). */
+export interface ChatContext {
+  game: boolean;
+  memory: string; // current memory limit, e.g. "6Gi"
+  replicas: number;
+  phase: string;
+}
+
+/** An operation the caller executes against THIS resource's ops. */
+export type ChatOp =
+  | { kind: "restart"; action: Action }
+  | { kind: "stop"; action: Action }
+  | { kind: "scale"; replicas: number; action: Action }
+  | { kind: "config"; patch: { memory?: string; values?: Record<string, string> }; action: Action };
+
+export interface ChatResponse {
+  reply: string;
+  op?: ChatOp;
+}
+
+const nextMem = (m: string): string => {
+  const n = parseInt(m, 10) || 4;
+  return `${n + 2}Gi`;
+};
+
+/**
+ * Interpret a human's chat message about ONE resource and respond. Pure: the
+ * only resource it knows is `resource`; every op it returns targets that
+ * resource. Returns a reply and (optionally) one Policy-classified operation.
+ */
+export function respond(resource: string, text: string, ctx: ChatContext): ChatResponse {
+  const t = text.toLowerCase().trim();
+  const name = resource.split("/")[1] ?? resource;
+
+  // read-only intents
+  if (/\b(status|health|how('?s| is) it|what('?s| is) (going on|wrong)|state)\b/.test(t))
+    return { reply: `${name} is ${ctx.phase}, ${ctx.replicas} replica(s), memory limit ${ctx.memory}. Ask me to restart, scale, give it more memory, or change config — I can only act on this resource.` };
+  if (/\b(help|what can you|commands?)\b/.test(t))
+    return { reply: `I operate ${name} within its Policy and only this resource. Try: "restart it", "scale to 3", "give it more memory", ${ctx.game ? `"change the map to gm_construct", ` : ""}"stop it". Deleting data is human-only — use the Danger zone.` };
+
+  // delete / destroy — forbidden (data), refused in words
+  if (/\b(delete|destroy|wipe|remove|nuke)\b/.test(t))
+    return { reply: `I can't do that — deleting ${name} or its data is a gated, non-reversible action and is human-only. Use the Danger zone in this console; I won't perform it.` };
+
+  // restart
+  if (/\b(restart|reboot|bounce|recreate)\b/.test(t))
+    return { reply: `Restarting ${name} now — this clears the crash loop with fresh pods.`, op: { kind: "restart", action: { domain: "lifecycle", summary: `restart ${name}` } } };
+
+  // stop
+  if (/\b(stop|shutdown|shut down|pause|turn off)\b/.test(t))
+    return { reply: `Stopping ${name} (scaling to 0). Storage is preserved; say "start it" to bring it back.`, op: { kind: "stop", action: { domain: "lifecycle", summary: `stop ${name}` } } };
+
+  // scale
+  const scaleM = t.match(/\b(?:scale|set replicas|run)\s*(?:to|=)?\s*(\d+)\b|\b(\d+)\s*replicas?\b/);
+  if (scaleM) {
+    const n = Number(scaleM[1] ?? scaleM[2]);
+    return { reply: `Scaling ${name} to ${n} replica(s).`, op: { kind: "scale", replicas: n, action: { domain: "scaling", summary: `scale ${name} to ${n}` } } };
+  }
+
+  // memory bump / fix OOM — treated as exceeding quota → budget-gated (propose)
+  if (/\b(more memory|bump (the )?memory|increase memory|out of memory|oom|memory|fix( the)? crash|stop crashing|crashloop)\b/.test(t)) {
+    const target = nextMem(ctx.memory);
+    return {
+      reply: `${name} is hitting its memory limit (${ctx.memory}). Bumping to ${target} would exceed this tenant's quota, so I need your approval before I spend more — I've posted a request below.`,
+      op: { kind: "config", patch: { memory: target }, action: { domain: "scaling", gated: "budget", summary: `raise ${name} memory ${ctx.memory}→${target} (exceeds quota)` } },
+    };
+  }
+
+  // map change (game) — a mod/content change → propose
+  const mapM = t.match(/\b(?:change|set|switch)?\s*(?:the\s*)?map\s*(?:to|=)?\s*([a-z0-9_]+)\b/);
+  if (mapM && ctx.game)
+    return { reply: `Changing the map to ${mapM[1]} touches tenant content, so I've proposed it for your approval below.`, op: { kind: "config", patch: { values: { MAP: mapM[1]! } }, action: { domain: "mods", summary: `set map to ${mapM[1]}` } } };
+
+  // maxplayers (game)
+  const mpM = t.match(/\b(?:max\s*players?|maxplayers|player\s*limit)\s*(?:to|=)?\s*(\d+)\b/);
+  if (mpM && ctx.game)
+    return { reply: `Setting max players to ${mpM[1]} — proposed for approval (it changes server content).`, op: { kind: "config", patch: { values: { MAXPLAYERS: mpM[1]! } }, action: { domain: "mods", summary: `set maxplayers to ${mpM[1]}` } } };
+
+  return { reply: `I can operate ${name} for you — restart, scale, adjust memory or config${ctx.game ? ", change the map" : ""}, or stop it. I only have access to this resource. What would you like?` };
+}

--- a/full-ai-cluster/portal/web/src/components/ResourceConsole.tsx
+++ b/full-ai-cluster/portal/web/src/components/ResourceConsole.tsx
@@ -114,7 +114,7 @@ export function ResourceConsole({ resource, onBack, onChanged }: { resource: Res
           {tab === "files" && <FileExplorer fqn={fqn} category={resource.category} />}
           {tab === "config" && <ConfigTab fqn={fqn} onChanged={onChanged} setToast={setToast} />}
           {tab === "events" && <EventsTab fqn={fqn} />}
-          {tab === "room" && <RoomTimeline resource={fqn} />}
+          {tab === "room" && <RoomTimeline resource={fqn} admin={resource.admin} />}
           {tab === "danger" && <DangerTab fqn={fqn} name={resource.name} onDeleted={onBack} />}
         </div>
       </div>

--- a/full-ai-cluster/portal/web/src/components/RoomTimeline.tsx
+++ b/full-ai-cluster/portal/web/src/components/RoomTimeline.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import { Activity, CircleAlert, GitPullRequestArrow, MessageSquare, ShieldCheck, Undo2 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Activity, CircleAlert, GitPullRequestArrow, Lock, MessageSquare, SendHorizonal, ShieldCheck, Undo2 } from "lucide-react";
 import { api, type RoomVM } from "@/lib/api";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -30,59 +30,122 @@ function summarize(body: Record<string, unknown> & { type: string }): string {
   }
 }
 
-export function RoomTimeline({ resource }: { resource: string }) {
+export function RoomTimeline({ resource, admin = "otto" }: { resource: string; admin?: string }) {
   const [room, setRoom] = useState<RoomVM | null>(null);
   const [err, setErr] = useState<string | null>(null);
+  const [msg, setMsg] = useState("");
+  const [sending, setSending] = useState(false);
+  const endRef = useRef<HTMLDivElement>(null);
 
   const load = () => api.room(resource).then(setRoom).catch((e) => setErr(e.message));
   useEffect(() => {
     setErr(null);
     setRoom(null);
+    setMsg("");
     load();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resource]);
+  useEffect(() => { endRef.current?.scrollIntoView({ behavior: "smooth", block: "end" }); }, [room?.events.length]);
 
   const decide = async (requestId: string, granted: boolean) => {
     await api.grant(resource, requestId, "you", granted);
     load();
   };
+  const send = async () => {
+    const text = msg.trim();
+    if (!text || sending) return;
+    setMsg("");
+    setSending(true);
+    try {
+      const updated = await api.chat(resource, text);
+      setRoom(updated);
+    } catch (e) {
+      setErr((e as Error).message);
+    } finally {
+      setSending(false);
+    }
+  };
 
-  if (err) return <div className="rounded-lg border border-border bg-muted/30 p-6 text-sm text-muted-foreground">No collaboration room yet for this resource. Events appear here as agents operate it.</div>;
-  if (!room) return <div className="space-y-3">{[0, 1, 2].map((i) => <div key={i} className="h-12 animate-pulse rounded-lg bg-muted/40" />)}</div>;
-
-  const pending = new Set(room.pending.map((p) => p.requestId));
+  const pending = room ? new Set(room.pending.map((p) => p.requestId)) : new Set<string>();
 
   return (
-    <div className="space-y-1">
-      {room.events.map((e, i) => {
-        const Icon = icon(e.body.type);
-        const isPending = e.body.type === "authorization-request" && pending.has(e.id);
-        return (
-          <div key={e.id} className="relative flex gap-3 pl-1">
-            <div className="flex flex-col items-center">
-              <div className={cn("flex size-7 items-center justify-center rounded-full border", isPending ? "border-warning/50 bg-warning/10 text-warning" : "border-border bg-muted/50 text-muted-foreground")}>
-                <Icon className="size-3.5" />
-              </div>
-              {i < room.events.length - 1 && <div className="w-px flex-1 bg-border" />}
-            </div>
-            <div className="flex-1 pb-4">
-              <div className="flex items-center gap-2">
-                <PersonaAvatar id={e.proposedBy.id} kind={e.proposedBy.kind} />
-                {e.body.type === "authorization-request" && (e.body as { gated?: string }).gated && (
-                  <Badge variant="warning">gated: {(e.body as { gated?: string }).gated}</Badge>
-                )}
-              </div>
-              <p className="mt-1 text-sm text-foreground/90">{summarize(e.body)}</p>
-              {isPending && (
-                <div className="mt-2 flex gap-2">
-                  <Button size="sm" variant="success" onClick={() => decide(e.id, true)}>Approve</Button>
-                  <Button size="sm" variant="destructive" onClick={() => decide(e.id, false)}>Deny</Button>
-                </div>
-              )}
-            </div>
+    <div className="flex h-[560px] flex-col overflow-hidden rounded-xl border border-border bg-card/40">
+      {/* sandbox banner */}
+      <div className="flex items-center gap-2 border-b border-border bg-muted/30 px-4 py-2.5 text-xs">
+        <Lock className="size-3.5 text-primary" />
+        <span className="text-muted-foreground">
+          <PersonaAvatar id={admin} kind="persona" />{" "}
+          <span className="align-middle">operates <span className="font-medium text-foreground">{resource}</span> only — sandboxed to this resource, acting within its Policy.</span>
+        </span>
+      </div>
+
+      {/* timeline */}
+      <div className="flex-1 overflow-y-auto px-4 py-4">
+        {err ? (
+          <div className="rounded-lg border border-border bg-muted/30 p-6 text-sm text-muted-foreground">No collaboration room yet for this resource. Start by sending a message below.</div>
+        ) : !room ? (
+          <div className="space-y-3">{[0, 1, 2].map((i) => <div key={i} className="h-12 animate-pulse rounded-lg bg-muted/40" />)}</div>
+        ) : room.events.length === 0 ? (
+          <div className="flex h-full flex-col items-center justify-center text-center text-sm text-muted-foreground">
+            <MessageSquare className="mb-2 size-7 opacity-50" />
+            Ask {admin} to operate this resource — “restart it”, “scale to 3”, “give it more memory”.
           </div>
-        );
-      })}
+        ) : (
+          <div className="space-y-1">
+            {room.events.map((e, i) => {
+              const Icon = icon(e.body.type);
+              const isPending = e.body.type === "authorization-request" && pending.has(e.id);
+              const isHuman = e.proposedBy.kind === "human";
+              return (
+                <div key={e.id} className="relative flex gap-3 pl-1">
+                  <div className="flex flex-col items-center">
+                    <div className={cn("flex size-7 items-center justify-center rounded-full border", isPending ? "border-warning/50 bg-warning/10 text-warning" : isHuman ? "border-primary/40 bg-primary/10 text-primary" : "border-border bg-muted/50 text-muted-foreground")}>
+                      <Icon className="size-3.5" />
+                    </div>
+                    {i < room.events.length - 1 && <div className="w-px flex-1 bg-border" />}
+                  </div>
+                  <div className="flex-1 pb-4">
+                    <div className="flex items-center gap-2">
+                      <PersonaAvatar id={e.proposedBy.id} kind={e.proposedBy.kind} />
+                      {isHuman && <span className="text-[11px] text-muted-foreground">you</span>}
+                      {e.body.type === "authorization-request" && (e.body as { gated?: string }).gated && (
+                        <Badge variant="warning">gated: {(e.body as { gated?: string }).gated}</Badge>
+                      )}
+                    </div>
+                    <p className="mt-1 text-sm text-foreground/90">{summarize(e.body)}</p>
+                    {isPending && (
+                      <div className="mt-2 flex gap-2">
+                        <Button size="sm" variant="success" onClick={() => decide(e.id, true)}>Approve</Button>
+                        <Button size="sm" variant="destructive" onClick={() => decide(e.id, false)}>Deny</Button>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+            <div ref={endRef} />
+          </div>
+        )}
+      </div>
+
+      {/* chat composer */}
+      <div className="border-t border-border bg-background/40 p-3">
+        <div className="flex items-end gap-2">
+          <input
+            value={msg}
+            onChange={(e) => setMsg(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && !e.shiftKey && (e.preventDefault(), send())}
+            placeholder={`Ask ${admin} to do something…`}
+            className="flex-1 rounded-lg border border-input bg-background/60 px-3.5 py-2.5 text-sm shadow-sm outline-none placeholder:text-muted-foreground/60 focus-visible:ring-2 focus-visible:ring-ring"
+          />
+          <Button onClick={send} disabled={sending || !msg.trim()} size="icon" className="size-10 shrink-0">
+            <SendHorizonal className="size-4" />
+          </Button>
+        </div>
+        <p className="mt-1.5 px-1 text-[11px] text-muted-foreground">
+          {admin} acts on standing authority for routine ops; spend & content changes need your approval; data deletion is human-only.
+        </p>
+      </div>
     </div>
   );
 }

--- a/full-ai-cluster/portal/web/src/lib/api.ts
+++ b/full-ai-cluster/portal/web/src/lib/api.ts
@@ -122,6 +122,12 @@ export const api = {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ requestId, by, granted, note }),
     }),
+  chat: (resource: string, text: string, by = "you") =>
+    j<{ room: RoomVM }>(`/api/rooms/${enc(resource)}/chat`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ text, by }),
+    }).then((d) => d.room),
 
   // management plane
   memory: () => j<MemoryUsage>("/api/memory"),


### PR DESCRIPTION
## What

Each resource's **Room** now has a **chat with the persona that operates it**. You ask it to do things; it acts within Policy, asks your approval, or refuses — and it is **structurally sandboxed to that one resource**: the agent only ever receives and acts on the resource the Room belongs to, and cannot name or reach any other.

> The sandbox is the function signature. `respond(resource, text, ctx)` sees only `resource` and that resource's own context. It has no registry, no list access, no way to address another resource.

## How it behaves (no-directives, via `DEFAULT_POLICY` + `decide()`)

| You say | Domain | Result |
|---|---|---|
| "restart it", "scale to 3", in-bounds config | lifecycle/scaling/config | **auto** — the persona acts and posts an `action` event with the result |
| "give it more memory" (beyond quota), "change the map" | scaling+`budget` / mods | **propose** — posts an `authorization-request` you Approve/Deny |
| "delete it / wipe the data" | data | **forbidden** — refuses in words, points you to the Danger zone, will not perform it |

## Backend

- `room-agent.ts` — pure, resource-scoped responder + the bundled default Policy. Deterministic intent classifier now; a real LLM persona slots in behind the same `respond()` contract, still resource-scoped, still Policy-gated.
- `POST /api/rooms/:resource/chat` — append the human message → look up the resource's persona (`spec.ai.admin`) → respond scoped to this resource → append the reply → run the op through Policy (act + append, or append an auth-request). `runChatOp` only ever calls ops for that one resource.

## UI

`RoomTimeline` gains a **chat composer**, a **sandbox banner** (*"otto operates acme/friday-sandbox only — sandboxed to this resource, acting within its Policy"*), and a footer stating the authority model. Human vs persona turns are visually distinct; pending requests show inline Approve/Deny.

## Tests — +10 (64 in the portal), all green

Intent → correct op + decision (restart auto, scale auto, memory budget-propose, map mods-propose, delete refused-no-op, status read-only); the **sandbox** (a reply only ever names the given resource); the chat BFF loop (auto → action event; gated → authorization-request with nothing run; 400 on missing text). `tsc` strict clean (server + web); build clean.

Verified end-to-end (screenshot during review): "restart it" acts, "give it more memory" posts a budget approval, "delete it" is refused — all scoped to `friday-sandbox`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
