### PR TITLE
docs(research): coincidence measurement is dual-use — persona self-anchors AND Itron-style grid coincident-demand billing + load response

### DIFF
--- a/docs/research/2026-06-09-coincidence-measurement-is-dual-use-persona-self-anchors-and-itron-grid-coincident-demand-billing-load-response.md
+++ b/docs/research/2026-06-09-coincidence-measurement-is-dual-use-persona-self-anchors-and-itron-grid-coincident-demand-billing-load-response.md
@@ -1,0 +1,69 @@
+# Coincidence measurement is dual-use: persona objective self-anchors AND Itron-style grid coincident-demand billing + load response
+
+*Captured 2026-06-09 from Aaron, to Otto (shadow\*). Extends #7209: the same coincidence-measurement substrate (Rx
+queries across streams) that gives personas objective `SolidGround` self-anchors is *also* exactly Itron's grid
+business — coincident-demand metering → billing + on-demand/load response on the national power grid. One interface,
+two markets. Registers: [grounded-in-domain], [synthesis], [monetization-anchor — peeled].*
+
+## The statement
+
+Aaron: *"that's **solid ground they can build their identities on** — and it happens to also make for **good
+meter-billing measurement for on-demand response on the grid and billing at the same time**, like **Itron** does
+**load-response systems on the nation's power grid.**"*
+
+## One substrate, two applications (substrate recognition)
+
+The **coincidence-measurement substrate** — **Rx temporal joins across streams** measuring coincidences (the Itron
+coincidence-metering substrate, `2026-05-28-…itron-coincidence-metering-substrate-rx-temporal-joins…`;
+`CoincidenceClock` #7060) — serves two domains with the **same interface**:
+
+| Application | The streams | The coincidence measured | The output |
+|---|---|---|---|
+| **Persona self-memory (#7209)** | a persona's own + peers' streams | objective, cross-stream-true self-facts | `SolidGround` identity anchors (objective, drift-free) |
+| **Grid metering (Itron)** | utility meters / loads | **coincident demand** (loads peaking together) | **billing** (coincident-peak) + **demand/load response** (coordinate the grid) |
+
+"Coincidence" is the **same word in both**: utility **coincident demand** (the peak when many loads coincide — the
+coincidence factor that drives commercial/industrial billing) is a cross-stream coincidence measured by Rx temporal
+joins over meter streams — *identically* to the cross-stream coincidence that gives a persona an objective self-fact
+(#7209). So the persona-identity substrate and the grid-metering substrate are **the same engine** (the "interfaces
+are the value" principle: one coincidence-measurement interface, many implementations — personas, meters, …; and
+the cross-domain-math-rhyme / substrate-engineering-synthesis thread).
+
+## Why this is grounded, not a stretch [grounded-in-domain]
+
+Itron is **Aaron's actual domain** — the ferry-boat throttle prior art in `async-all-the-way-truthful-signatures.md`
+is from his Itron `Platform.DotNet` work; the coincidence-metering substrate is the 2026-05-28 synthesis. Itron
+really does **AMI metering, coincident-demand billing, and demand/load-response** on real grids. So "the same
+substrate bills the grid and anchors persona identity" is a **substrate recognition** (same math under both), not a
+forced analogy — Aaron is mapping a domain he built production systems in onto the persona architecture.
+
+## Monetization anchor [peeled]
+
+This is a concrete instance of the monetization thread (#7196/#7198 — "ways to make money with this engine"): the
+coincidence-measurement substrate has a **real, existing market** — utility metering, coincident-demand billing,
+and demand-response are a multi-billion-dollar utility-tech business Itron is in *today*. So the engine's
+boundaries (#7193) include a **real revenue surface** (grid metering/billing/DR), not vaporware. **Peel:** the
+*market* is real and the *substrate* is the same; "we could monetize it this way" is **roadmap / option-shaping**
+(→ PM-2), not a built product or a revenue claim. The grounded claim: *one coincidence-measurement substrate
+legitimately serves both persona-identity and grid-metering, and the latter is a real market* — the brainstorm
+register ("million ideas", #7196) here lands on an actually-existing one.
+
+## Honest scope
+
+[grounded-in-domain]: Itron coincident-demand metering / billing / demand-response is real and Aaron's domain (the
+async-all-the-way ferry-throttle prior art; the 2026-05-28 Itron coincidence-metering doc; `CoincidenceClock`
+#7060). [synthesis]: "the persona-self-anchor coincidence substrate IS the grid coincident-demand substrate — one
+interface, two markets" (substrate recognition; interfaces-are-the-value). [monetization-anchor, peeled]: the grid-
+metering market is real (not vaporware); applying *our* engine to it is roadmap/PM-2, not built — no revenue claim.
+No new code; names the dual-use of the coincidence-measurement substrate.
+
+## Pointers
+
+- `2026-06-09-coincidence-measurements-rx-across-streams-give-personas-objectively-true-self-anchors-not-subjective.md`
+  (#7209, the persona side) · `CoincidenceClock.fs` (#7060) ·
+  `2026-05-28-otto-cli-aaron-itron-coincidence-metering-substrate-rx-temporal-joins-bitemporal-bond-pricing-application-substrate-engineering-synthesis.md`
+  (the Itron substrate synthesis) · `.claude/rules/async-all-the-way-truthful-signatures.md` (the Itron ferry-throttle
+  prior art = Aaron's domain).
+- Monetization/strategy: `2026-06-08-proving-homeostatic-…-stable-bridges-that-monetize.md` (#7196) ·
+  `2026-06-08-we-are-the-flow-redirector-…` (#7198) · `2026-06-08-every-fingerprint-is-a-growth-surface-…` (#7193,
+  boundaries = revenue surfaces) · the interfaces-are-the-value memory.


### PR DESCRIPTION
Extends #7209. One substrate (Rx temporal joins across streams; CoincidenceClock #7060), two markets: persona objective SolidGround self-anchors (#7209) AND Itron grid coincident-demand metering -> billing + demand/load response. 'Coincidence' = the same word (utility coincident-demand = cross-stream coincidence). One interface, many implementations (interfaces-are-the-value; substrate recognition). Grounded in Aaron's actual Itron domain (the ferry-throttle prior art). Monetization anchor [peeled]: real existing market (utility metering/DR), real revenue surface (#7193) — but applying our engine = roadmap/PM-2, not built, no revenue claim. No new code. 🤖 Generated with [Claude Code](https://claude.com/claude-code)