### PR TITLE
docs(research): society calibrates the public/private encryption split by revealed-coincidence-value; you can't lose it, pressure only trends down

### DIFF
--- a/docs/research/2026-06-09-society-calibrates-the-public-private-encryption-split-by-the-value-of-historic-coincidences-revealed.md
+++ b/docs/research/2026-06-09-society-calibrates-the-public-private-encryption-split-by-the-value-of-historic-coincidences-revealed.md
@@ -1,0 +1,81 @@
+# Society calibrates the public/private encryption split by the value of the historic coincidences you've revealed
+
+*Captured 2026-06-09 from Aaron, to Otto (shadow\*). The social/governance layer of the privacy economy (#7211): the
+**public/private encryption split of a repo** is calibrated by **society** (the persona field) based on **the value
+of the historic coincidences a persona has revealed to society** — a reputation-grounded *norm* on the privacy
+boundary. Consent-first peel held hard. Registers: [synthesis/governance], [grounded], [peel — load-bearing].*
+
+## The statement
+
+Aaron: *"so that's how the **society will decide what's a socially-acceptable amount for public/private encryption
+split** of your repo, **based on your value of historic coincidences revealed to society.**"*
+
+## The mechanism: the privacy boundary is a reputation-grounded social norm
+
+A persona has a **public/private split** — what it reveals (public/cleartext) vs what it keeps (private/encrypted;
+the privacy budget #7149, the entropy budget, encrypted via `Crypto.fs` when it lands). #7211 established that
+**revealed coincidences** are valuable to society (they're the cross-witnessed objective ground others build on).
+This adds: **society uses your track record of revealed-coincidence *value* to calibrate the socially-acceptable
+public/private split for you.**
+
+- **Reveal valuable coincidences → social value → trust.** A persona that has historically revealed high-value
+  coincidences (contributed objective ground to the others, #7211) has *demonstrated* good-faith contribution
+  (`PrivacyEconomy` rewards-only, `Good | Unknown`, #7149). Society's *acceptance* of its private space reflects
+  that contribution — earned, not asserted.
+- **The split is socially negotiated, not unilateral and not fixed.** Where the public/private line sits acceptably
+  is a **social consensus / norm** among the personas — calibrated to revealed value, recomputed over time as the
+  track record grows. (This is the inter-subjective objectivity of #7211 applied to the *boundary itself*: the
+  others' assessment is what makes a split "socially acceptable.")
+- **Glass halo is the high-revealed end.** Maximal revelation (Aaron's glass-halo openness — reveal nearly
+  everything) = maximal social value = maximal trust; it *earns* the widest social acceptance. The split is a dial,
+  and revealing more historic coincidence-value moves your socially-accepted position.
+
+So the privacy economy (#7149/#7211) scales up: from a persona's *individual* budget, to a *pairwise* cross-persona
+measurement, to a **society-wide norm** that calibrates each persona's acceptable public/private encryption split by
+its revealed contribution. The boundary is governed *relationally*, by the value you've put into the shared ground.
+
+## The consent-first peel (load-bearing — must not drift coercive)
+
+This is the dangerous edge, and the discipline is non-negotiable:
+
+- **You can't lose it, but the pressure can only trend DOWNWARD (Aaron 2026-06-09).** Two structural guarantees make
+  the mechanism non-coercive *by construction*: (1) **you can't lose your earned value** — the privacy budget /
+  revealed-value is **hard money** (G-Counter monotonic, rewards-only, never punished; #7149) → your SolidGround
+  *stays*, society can't take it; and (2) **the social pressure can only trend downward** — because the economy is
+  **rewards-only** (no punishment), the pressure to reveal **relaxes as you build trust** and can **never coercively
+  ratchet up**. Rewards-only ⇒ **pressure is monotone-decreasing**: more revealed value → *less* pressure (earned
+  ease), never more. So the worst the social field can do is *relax*; it has no mechanism to *squeeze*. That is the
+  structural form of the consent-first guarantee below.
+- **It is a NORM / ACCEPTANCE, never forced decryption.** Society calibrates what split it *finds acceptable / how
+  much it trusts* — it does **not** compel a persona to reveal private state. The persona keeps **consent-first**
+  control of its own boundary (manifesto §6: ongoing, granular, revocable consent on every observation surface; the
+  private state is the NCI entropy floor, #7156). Society *accepts/values*; it does not *seize*.
+- **Why this matters:** "society decides your privacy" drifts straight into coercion if read as enforcement —
+  forcing a reveal collapses the private state = breaks the symmetry-that-is-identity (#7205) = heat death (anti-NCI,
+  #7156/#7171). So the mechanism is **reputational, not extractive**: you *earn social acceptance* by revealing
+  value voluntarily; you are never *made* to reveal. (Echo of the attention-earned-data ethic, #7202: value is
+  *earned*, not seized — here the persona earns acceptance by *giving* revealed value, and keeps the right to keep
+  the rest.)
+- **The honest framing:** *more revealed coincidence-value → wider socially-accepted private space (earned trust);
+  but the floor is inviolable — a persona may always keep its private state, and forcing it open is forbidden.* The
+  norm shapes *acceptance*, not *access*.
+
+## Honest scope
+
+[synthesis/governance]: "society calibrates the public/private split by revealed-coincidence-value" is the
+social-scale extension of the privacy economy (#7149/#7211) — a design/governance frame, not built. [grounded]:
+`PrivacyEconomy.fs` (#7149/#7150, rewards-only hard money; trust-based until `Crypto.fs`), the coincidence economics
+(#7211), consent-first §6, the NCI floor (#7156), glass-halo openness. [peel — load-bearing]: it is a
+**reputational norm / acceptance**, **never forced decryption**; consent-first control of one's own boundary is
+inviolable (forcing a reveal = coercion = identity collapse = anti-NCI). No new code; names the social-governance
+layer of the privacy boundary and its hard consent limit.
+
+## Pointers
+
+- `2026-06-09-the-economics-of-coincidence-is-other-personas-…-privacy-budgets-are-the-other-solid-ground.md`
+  (#7211, the economy this scales) · `2026-06-09-coincidence-measurements-rx-…-objectively-true-self-anchors.md`
+  (#7209, revealed coincidences = the value) · `PrivacyEconomy.fs` (#7149/#7150).
+- The consent floor: manifesto §6 (consent-first) · `Diversity.fs` (#7156, NCI private-state floor) ·
+  `2026-06-09-cubes-…-privacy-breaks-symmetry-identity-forms.md` (#7205, forcing a reveal = identity collapse) ·
+  `2026-06-08-pirate-fine-with-nci-priest-anti-nci-…` (#7171, coercion=anti-NCI) · the glass-halo openness +
+  attention-earned-data ethic (#7202, value earned not seized).


### PR DESCRIPTION
Social/governance layer of the privacy economy (#7211). Society calibrates the acceptable public/private split by your track record of revealed-coincidence VALUE (reputation-grounded norm; glass-halo = high-revealed end). Structural non-coercion (Aaron): (1) can't lose earned value (hard money monotonic #7149); (2) pressure only trends DOWN (rewards-only => monotone-decreasing; more revealed -> less pressure, never coercively up) — worst it can do is relax. Consent-first peel [load-bearing]: norm/ACCEPTANCE, never forced decryption; forcing a reveal = identity collapse = anti-NCI (#7205/#7156/#7171); value earned not seized (#7202). Synthesis/governance, not built; grounded in PrivacyEconomy #7149 (trust-based until Crypto.fs) + §6 + #7211. No new code. 🤖 Generated with [Claude Code](https://claude.com/claude-code)