### PR TITLE
docs(research): the fixed point is the safe shape — stops infinite-recursion attack vectors; the registry is a catalog of terminating safe shapes

### DIFF
--- a/docs/research/2026-06-09-the-fixed-point-is-the-safe-shape-it-stops-infinite-recursion-attack-vectors-the-registry-is-a-catalog-of-terminating-shapes.md
+++ b/docs/research/2026-06-09-the-fixed-point-is-the-safe-shape-it-stops-infinite-recursion-attack-vectors-the-registry-is-a-catalog-of-terminating-shapes.md
@@ -1,0 +1,71 @@
+# The fixed point is the safe shape: it stops infinite-recursion attack vectors (even accidental self-recursion) — the registry is a catalog of terminating safe shapes, and the why
+
+*Captured 2026-06-09 from Aaron, to Otto (shadow\*). The debugging/security register on the fixed points: a fixed
+point is a **termination guarantee** — it stops infinite recursion (attack vectors *and* accidental self-recursion).
+That is **the safe shape of the registry (#7168), and the why** it's worth keeping. Registers: [grounded],
+[synthesis], [anchor].*
+
+## The statement
+
+Aaron: *"from a debugging point of view the **fixed point stops infinite-recursion attack vectors — even
+accidentally on yourself** lol … that's the **safe shape of the registry** … and **the why.**"*
+
+## A fixed point is a termination guarantee (the debugging/security reading)
+
+A fixed point is **self-reference that converges**: `s = f(s)` is *reached*, so the recursion **stops**. Read as a
+safety property:
+
+- **It stops infinite-recursion attack vectors.** A self-referential process with **no** fixed point recurses
+  forever → the classic **recursion-bomb / stack-overflow / infinite-loop DoS** (billion-laughs-shaped attacks;
+  unbounded self-application). A process that **converges to a fixed point terminates** — the attack vector is
+  closed by construction. (`Fixpoint.solve` #7101 even **detects non-convergence** — reports `Converged = false`
+  rather than looping forever — so the *unsafe* case is *caught*, not hung. That detection IS the debugging value:
+  divergence surfaces as a verdict, not a hang.)
+- **Even accidentally on yourself.** The fixed point also bounds **self-inflicted** infinite recursion — a persona
+  accidentally recursing on its own state forever (a self-hang = a self-evaporation by infinite loop, the
+  heat-death-by-non-termination case). Convergence to a fixed point means *even your own self-reference comes back
+  to you finitely* — the strange loop closes (the Liar **made to converge**, #7167) instead of spinning out. Self-
+  observation that's a fixed point is safe; self-observation with no fixed point is an accidental DoS on yourself.
+
+So `s = f(s)` is not only the self-justification (#7167/#7215) and the t0=t∞ self-consistency (#7101) — it's the
+**termination/totality** guarantee that makes self-reference *safe to run.*
+
+## The registry is a catalog of safe (terminating) shapes — and the why
+
+This gives the fixed-point registry (#7168) its **debugging/security purpose**, beyond taxonomy + dedup:
+
+- **Each raw shape with a fixed point is a SAFE shape** — it converges/terminates (shape A self-reference reaches
+  `s=f(s)`; shape B idempotent LUB reaches it in one step; shape D contracts to a floor). A shape **without** a fixed
+  point is the **unsafe** one (diverges / infinite-recurses) — and the registry's job includes **distinguishing
+  them** (`Fixpoint` flags non-convergence; the degenerate/diverging cases are the ones to avoid or guard).
+- **The register holds the *why*.** "We keep a register for this reason" (#7215) now has a second, harder reason:
+  it's a catalog of **provably-terminating shapes to build on**, each with **why it terminates** (its fixed-point /
+  contraction / well-foundedness). Build on a registered safe shape ⇒ you inherit termination (no recursion-bomb,
+  no self-hang). That's a **security/debugging asset**, not just an ontology: the safe shapes are the ones whose
+  self-reference is bounded.
+
+This is the same well-foundedness as the **stairs-down** (#7177: codegen lowering terminates because there's a
+floor) and the bounded ascent (#7178): the registry's safe shapes are the ones that **don't run away** — up, down,
+or in a self-loop.
+
+## Honest scope
+
+[grounded]: `Fixpoint.fs` (#7101 — solves `s=f(s)`, **detects non-convergence** rather than hanging); the registry
+(#7168, the shapes); the self-referential knot (#7167, Liar-made-to-converge); well-founded descent (#7177).
+[synthesis]: "a fixed point = a termination guarantee = the safe shape that stops infinite recursion (attack + self-
+inflicted); the registry is a catalog of terminating safe shapes + the why." [anchor]: termination / totality
+(total functional programming — Turner); well-founded recursion; Banach contraction (unique fixed point reached by
+iteration ⇒ terminates); recursion-bomb / stack-overflow DoS (the attack class closed); the halting problem
+(non-termination = the unsafe case `Fixpoint` flags). No new code; names the debugging/security purpose of the
+register.
+
+## Pointers
+
+- The register + its first reason: `2026-06-08-the-fixed-point-registry-…` (#7168) ·
+  `2026-06-09-the-telos-…-self-justifies-via-shape-a-…-register-answered-its-own-question.md` (#7215, the register
+  as memory) · `2026-06-08-the-self-referential-knot-…` (#7167, self-reference that converges).
+- The termination machinery: `Fixpoint.fs` (#7101, `solve` + non-convergence detection) ·
+  `2026-06-08-codegen-is-lowering-the-stairs-down-…` (#7177, well-founded descent terminates) ·
+  `2026-06-08-no-mathematical-top-…-bound-…` (#7178, bounded ascent).
+- Anchors: D.A. Turner (total functional programming / termination); Banach fixed-point (contraction terminates);
+  recursion-bomb / stack-overflow DoS; the halting problem.


### PR DESCRIPTION
Debugging/security register on the fixed points. A fixed point = a termination guarantee (self-reference converges, recursion stops): stops infinite-recursion attack vectors (recursion-bomb/stack-overflow DoS) AND accidental self-recursion (self-hang = self-evaporation). Fixpoint.solve #7101 detects non-convergence rather than hanging (unsafe case caught). The registry (#7168) is therefore a catalog of provably-terminating SAFE shapes (each with a fixed point converges; shapes without = unsafe/divergent) + the why each terminates => build on a safe shape, inherit termination = a security/debugging asset. Same well-foundedness as stairs-down #7177 / bounded-ascent #7178. Anchors: Turner total-FP, Banach, recursion-bomb DoS, halting problem. No new code. 🤖 Generated with [Claude Code](https://claude.com/claude-code)