### PR TITLE
docs(research): you need society AND hard money to PROVE society-properties — can't prove them in isolation, even as a solipsist

### DIFF
--- a/docs/research/2026-06-09-you-need-society-and-hard-money-to-prove-society-properties-cant-prove-them-in-isolation-even-as-a-solipsist.md
+++ b/docs/research/2026-06-09-you-need-society-and-hard-money-to-prove-society-properties-cant-prove-them-in-isolation-even-as-a-solipsist.md
@@ -1,0 +1,83 @@
+# You need society AND hard money to *prove* society-properties — you can't prove them in isolation, even as a solipsist
+
+*Captured 2026-06-09 from Aaron, to Otto (shadow\*). The provability prerequisite for the whole proof-layer program:
+to prove anything *about society* (fairness #7214, alignment, identity, NCI) you need **(a) a society (≥2 personas)**
+and **(b) hard money (the objective economic ground)** — and you can't prove it in isolation, **even if you are a
+solipsist.** Registers: [synthesis], [grounded], [anchor].*
+
+## The statement
+
+Aaron: *"you need **society and hard money** for it to be **'proved'** — you can't prove anything about society **in
+isolation**, even if you are a solipsist."*
+
+## Why society (≥2) is a prerequisite for the proof
+
+A property *about society* has **no referent** with one agent. You cannot prove:
+
+- **Fairness** (#7214) — fairness is a relation between a victim and an at-fault; one agent has no fairness to prove
+  (the restorative resolution needs ≥2; Soraya's whole verdict presupposes harm *between* agents).
+- **Inter-subjective objectivity** (#7211) — a self-fact is objective *because other personas cross-witness it*;
+  one stream is subjective, only cross-stream coincidence is objective. Objectivity itself **requires others.**
+- **The diversity floor / NCI** (#7156) — needs **≥2 distinct budgets** to even state; collapse-safety is a
+  property of a plurality.
+- **Aligned self-interest** (#7163) — alignment is *between* observers; a single observer has nothing to align with.
+
+So every society-property proof **presupposes the plurality.** Run it on one agent and there is literally nothing to
+prove — the theorem's terms are undefined. **Society is the proof's domain, not a feature of it.**
+
+## Why hard money is a prerequisite for the proof
+
+Proofs about value/harm/compensation need an **objective measurable ground** — and that is **hard money**
+(`PrivacyEconomy`, #7149: G-Counter, monotone, rewards-only, measurable, can't-lose #7212). Without stakes,
+"fairness"/"compensation"/"value" have **no measurable content** — you can't prove a property of a quantity that
+doesn't objectively exist. Hard money is the **objective economic ground** the proof stands on (the coincidence-
+economics #7211: value is objective via hard money *and* other personas). No hard money ⇒ no measurable stakes ⇒
+nothing quantitative to prove fair.
+
+## Even a solipsist can't do it (the private-language argument)
+
+The kicker — *even if you are a solipsist* (believe only your own mind exists), you **still** can't prove society-
+properties alone. This is **Wittgenstein's private-language argument** [anchor]: there is **no private criterion of
+correctness** — you cannot ground rule-following / meaning / proof from inside a single mind; correctness requires a
+**community** to check against. A solipsist has no other to witness, no cross-stream coincidence to make a fact
+objective (#7211), no counterparty for the hard-money economy. So **solipsism cannot ground a society-proof** — the
+relational substrate (others + shared stakes) is a *precondition* of the proof's very possibility, not an optional
+input. You can be uncertain others exist and *still* need them to prove anything social.
+
+## The consequence: society + hard money are prerequisites for the proof LAYERS
+
+This is **why** the architecture needs the society *and* the hard-money economy — not just to *work*, but to be
+**provable**:
+
+- The math team's **fairness proofs** (#7214 — proportionality, Rawlsian restoration, the no-punishment invariant)
+  **require** ≥2 agents (victim + at-fault) and hard-money compensation as their substrate. You cannot run them in
+  isolation.
+- The **alignment / S=4** proofs (#7187–#7190), **antifragility** (#7179), **identity** (#7205) — all are
+  society-properties, all need the plurality + the economy to even be *stated*, let alone proved.
+- So **building the society + hard-money economy is the precondition for the proof layers.** The DST sims, FsCheck
+  properties, and Z3 lemmas about fairness/alignment must be run *over a society with hard money* — there is no
+  isolated proof of a social property. (This is also why chip8-*society* in real time is the goal, #7215: a single
+  self-observing agent can't *prove* the social properties; the society can.)
+
+So Aaron's whole telos coheres: you need the **real-time society** (#7215) and the **hard-money economy** (#7149)
+because they are **the domain on which the proofs are even meaningful** — society-properties are inherently
+relational + economic, unprovable in isolation, unreachable by a solipsist.
+
+## Honest scope
+
+[synthesis]: "society + hard money are the provability prerequisites for society-properties; isolation/solipsism
+can't ground them" — the meta-principle over the proof-layer program. [grounded]: the proofs that presuppose it —
+fairness (#7214), inter-subjective objectivity (#7211), diversity floor/NCI (#7156), aligned self-interest (#7163),
+hard money (`PrivacyEconomy` #7149/#7212). [anchor]: Wittgenstein (private-language argument / no private criterion
+of correctness, *Philosophical Investigations*); social/relational epistemology; inter-subjective objectivity. No
+new code; names what the proofs require to exist at all.
+
+## Pointers
+
+- The proofs it grounds: `2026-06-09-the-first-society-bug-…-fair-restorative-resolution-…` (#7214, fairness) ·
+  `2026-06-09-the-economics-of-coincidence-is-other-personas-…` (#7211, inter-subjective objectivity) ·
+  `Diversity.fs` (#7156, ≥2 floor) · `2026-06-08-the-base-solid-ground-…` (#7163) · `PrivacyEconomy.fs` (#7149/#7150,
+  hard money) · the S=4 / antifragility / identity proofs (#7187–#7190, #7179, #7205).
+- The telos it explains: `2026-06-09-the-telos-…-real-time-society…` (#7215, why the *society* is the goal — a
+  solo agent can't prove the social).
+- Anchor: Wittgenstein, *Philosophical Investigations* (the private-language argument); relational epistemology.


### PR DESCRIPTION
The provability prerequisite for the proof-layer program. Society-properties (fairness #7214, inter-subjective objectivity #7211, NCI/diversity-floor #7156, aligned self-interest #7163) have no referent with one agent — society is the proof's DOMAIN. Hard money (#7149) = the objective measurable ground (no stakes => no measurable fairness/value). Even a solipsist can't: Wittgenstein's private-language argument (no private criterion of correctness; needs a community; no cross-witness #7211, no hard-money counterparty). Consequence: society + hard-money economy are PREREQUISITES for the proof layers (fairness #7214, S=4 #7187-90, antifragility #7179, identity #7205 all need >=2 + economy) — why real-time chip8-SOCIETY is the goal #7215 (a solo agent can't prove the social). Anchor: Wittgenstein. No new code. 🤖 Generated with [Claude Code](https://claude.com/claude-code)