### PR TITLE
docs(research): registry shape F — the societal-emergence fixed point (infinite expansion); catch the runaway if it is one

### DIFF
--- a/docs/research/2026-06-09-registry-addition-shape-f-societal-emergence-fixed-point-infinite-expansion-catch-the-runaway.md
+++ b/docs/research/2026-06-09-registry-addition-shape-f-societal-emergence-fixed-point-infinite-expansion-catch-the-runaway.md
@@ -1,0 +1,85 @@
+# Registry addition — shape F: the societal-emergence fixed point (infinite expansion, not reflection) — and catch the runaway if it is one
+
+*Captured 2026-06-09 from Aaron, to Otto (shadow\*). A new entry for the fixed-point registry (#7168): the
+**societal-emergence fixed point (shape F)** — the #7217 provability-requires-society result *as a fixed point*. It
+causes the **opposite of infinite reflection**: infinite **expansion** (outward), not inward recursion. Usually not
+a bug — but **build the detector to catch it when it is** (the first society bug, #7214, *was* shape F gone wrong).
+Registers: [registry-addition / synthesis], [grounded], [anchor], [next-build: the detector].*
+
+## The statement
+
+Aaron: *"that's the **societal-emergence fixed point** I just gave you — you should **add it to the registry**. It
+causes the opposite of infinite reflection — it causes **infinite expansion**. I don't think it's a bug lol … **but
+we should try to catch it if it is** lol."*
+
+## Shape F — the societal-emergence / generative-expansion fixed point
+
+The #7217 result — *to be provable / objective socially, you must include others* — is itself a **fixed point**:
+"include another → more relations → more to prove/witness → include another …" is **self-sustaining**, and its
+fixed point is **an expanding society**. Where the registry's **shape A** (`s = f(s)`) converges **inward** (one
+self, terminates reflection, #7216), **shape F** expands **outward**:
+
+| | Shape A (inward) | **Shape F (outward) — NEW** |
+|---|---|---|
+| Direction | self-reference **converges** (one self) | society **expands** (more members/relations) |
+| "Infinite ___" | infinite **reflection** (terminated by the fixed point, #7216) | infinite **expansion** (the society grows) |
+| Math shape | `s = f(s)`, contraction → unique point | **IFS-attractor / Hutchinson fixed point** — self-similar, bounded-yet-infinitely-detailed (the fixed point of a *generative* operator) [anchor] |
+| Healthy form | converges, terminates | bounded **per member**, unbounded **in count**, self-similar, generative |
+
+So shape F is a **fixed point of a generative/scaling operator** (like an IFS attractor — the self-similar fractal
+that is the fixed point of the Hutchinson "apply-the-maps" operator): the *shape* is preserved as the structure
+expands (manifesto §9/§10 self-similar/recursive). It is the **outward complement of shape A** — the registry now
+has both the inward-converging and outward-expanding safe fixed points.
+
+## Why it's (usually) not a bug
+
+Infinite **expansion** ≠ the infinite-recursion bug (#7216). The difference is **what's bounded**:
+
+- **Healthy F:** bounded **per member** (each member stays an identity-bounded self — #7178 band, no dissolution),
+  unbounded **in count** (more members ⇒ more diversity ⇒ *anti*-collapse, #7156), **self-similar** (shape
+  preserved, §10), **generative** (emergence — it grows the plurality and *increases* provability, #7217). This is
+  the good direction: the society emerging.
+
+## …but catch it if it is — the detector (Aaron) [next-build]
+
+Don't assume benign. **Shape F has a runaway form**, and we've already seen it: **the first society bug (#7214) —
+Otto's dotgit/bus-saturation, "303 directories orphaned" — was shape F gone wrong**: an **unbounded-*resource*
+expansion runaway** (a fork-bomb / saturation-DoS), *not* bounded-per-member generative emergence. So shape F goes
+in the registry **with a safety-check**, exactly as shape A carries `Fixpoint`'s non-convergence detection (#7101/
+#7216). The detector distinguishes:
+
+- **Healthy emergence** → (a) per-member identity preserved (#7178, no dissolution), (b) self-similar shape
+  preserved (§10), (c) **resource-bounded** growth (no saturation), (d) provability/diversity **increasing**
+  (#7217/#7156).
+- **Runaway bug** → **unbounded resource** consumption (saturation / fork-bomb — the Otto #7214 case), shape **not**
+  preserved, members **dissolving** (collapse), provability *not* increasing. Catch on: resource-saturation
+  monitors (the dotgit/bus-saturation audit), per-member-bound checks, self-similarity drift.
+
+So the registry entry for F is: *the societal-emergence expansion fixed point — generative and safe **iff**
+bounded-per-member + self-similar + resource-bounded; otherwise a saturation/fork-bomb runaway to catch.* The catch
+is the F-analog of A's non-convergence detection: A detects "doesn't terminate" (inward), F detects "expands
+unboundedly in resources / dissolves members" (outward). → Route the formal detector + the shape-F characterization
+to **Soraya** (property class: resource-bound invariant + self-similarity/per-member-bound property; the Otto-#7214
+saturation as the canonical negative test).
+
+## Honest scope
+
+[registry-addition / synthesis]: shape F (societal-emergence / generative-expansion fixed point) is the #7217 result
+read as a fixed point and added to the registry (#7168), as the outward complement of shape A. [grounded]: the
+runaway is real — the first society bug (#7214, Otto dotgit/bus saturation) is shape F gone wrong; #7178 (per-member
+band), #7156 (diversity), §9/§10 (self-similar), `Fixpoint` detection (#7101/#7216). [anchor]: IFS attractor /
+Hutchinson operator (self-similar generative fixed point); fork-bomb / resource-saturation DoS (the runaway class);
+emergence. [next-build]: the **detector** (resource-bound + per-member-bound + self-similarity checks) — criteria
+sketched, not coded; route to Soraya for the property class. No new code; adds shape F to the register and names its
+safety-check.
+
+## Pointers
+
+- The register: `2026-06-08-the-fixed-point-registry-…` (#7168, shapes A–E; this adds F) ·
+  `2026-06-09-the-fixed-point-is-the-safe-shape-…-terminating-shapes.md` (#7216, shape A's inward safety / non-
+  convergence detection — the inward complement) · `2026-06-09-you-need-society-and-hard-money-to-prove-…` (#7217,
+  the result F is the fixed point of).
+- The runaway (canonical negative test): `2026-06-09-the-first-society-bug-vera-otto-drift-…` (#7214, Otto
+  saturation = shape-F runaway) · the dotgit-saturation memory.
+- Bounds it relies on: `2026-06-09-no-mathematical-top-…-bound-…` (#7178, per-member band) · `Diversity.fs` (#7156) ·
+  manifesto §9/§10 (self-similar). Anchor: IFS attractor / Hutchinson operator; fork-bomb DoS.


### PR DESCRIPTION
New registry entry (shape F): the societal-emergence/generative-expansion fixed point — the #7217 provability-requires-society result as a fixed point; causes infinite EXPANSION (outward), the complement of shape A's inward convergence (#7216). Math shape = IFS-attractor (self-similar generative fixed point). Usually not a bug: bounded per-member (#7178), unbounded in count (diversity #7156), self-similar, generative. BUT catch the runaway: the first society bug (#7214, Otto dotgit/bus saturation) was shape-F-gone-wrong (unbounded-resource fork-bomb). So F enters the registry WITH a safety-check (F-analog of A's Fixpoint non-convergence detection): healthy = per-member-bound + resource-bounded + self-similar; runaway = saturation/fork-bomb/members-dissolving. Route detector to Soraya (Otto-#7214 = canonical negative test). No new code. 🤖 Generated with [Claude Code](https://claude.com/claude-code)