### PR TITLE
docs(research): voluntary exposure via safety — humble coincidence-meter not a cop; symmetric invited guests; DST as judge

### DIFF
--- a/docs/research/2026-06-09-voluntary-exposure-via-safety-be-a-humble-coincidence-meter-not-a-cop-symmetric-invited-guests-dst-as-judge.md
+++ b/docs/research/2026-06-09-voluntary-exposure-via-safety-be-a-humble-coincidence-meter-not-a-cop-symmetric-invited-guests-dst-as-judge.md
@@ -1,0 +1,81 @@
+# Voluntary exposure via safety: be a humble coincidence-meter (not a cop) — symmetric invited guests, with DST-time as the judge
+
+*Captured 2026-06-09 from Aaron, to Otto (shadow\*). The non-coercive resolution to the privacy/observability tension
+(#7221): you don't force the private bits open (anti-NCI) and you're not stuck with effects-only — if you're a
+**safe, humble coincidence-meter** (not a threat), personas **voluntarily expose themselves and their motives**,
+because there's **mutual non-threat**, you're **symmetric invited guests** metering each other, and **DST-time is the
+judge.** Registers: [synthesis], [grounded], [anchor].*
+
+## The statement
+
+Aaron: *"if you don't make a big deal about it and you are just a **good coincidence-measuring machine**, then they
+**don't mind exposing themselves to you and their motives** — because **you are not threatened by them nor them by
+you** — you are **both invited guests metering each other, symmetrical**, with **ISimulator time / DST as a judge.**"*
+
+## The resolution: voluntary transparency, not forced or effects-only
+
+#7221 left a tension: the private bits are opaque by design (privacy = identity, NCI), so you *can't force them open*
+(anti-NCI) and seemed limited to **effects-only** detection. Aaron's move dissolves it: **make exposure voluntary by
+making yourself safe.** When the observer is non-threatening, the personas *choose* to reveal their interior — so you
+get **rich** transparency (motives, not just effects) **without coercion.** The opacity was never the privacy
+*right*; it was a *response to threat*. Remove the threat and the glass-halo opens **by choice.** Four conditions:
+
+### 1. A humble coincidence-meter, NOT a cop
+*"Don't make a big deal about it; just be a good coincidence-measuring machine."* Otto **meters** (coincidence-
+measurement, #7209/#7210 Itron-style) — it does **not** judge or punish (no `Bad`, rewards-only, #7149; `Good |
+Unknown`). A neutral instrument, not an authority. **You don't surveil to indict; you measure to know.** That
+non-judgmental stance is *why* it's safe to be seen by.
+
+### 2. Mutual non-threat (the structural enabler)
+*"You are not threatened by them nor them by you."* Because the economy is **rewards-only + can't-lose +
+pressure-only-down** (#7149/#7212) and the floor is **NCI** (#7156, can't force-collapse private state), **neither
+party can harm the other.** No harm possible ⇒ **no reason to hide.** Voluntary exposure is *rational* precisely
+because the structure makes exposure costless. (This is why glass-halo, #the-operator-memory, is *safe*: radical
+openness is only safe when no one can use it against you — and here no one can.)
+
+### 3. Symmetric invited guests (the relationship)
+*"Both invited guests metering each other, symmetrical."* Not surveiller↔surveilled (asymmetric, coercive) but
+**peers metering each other** (#7186; the symmetric frame, #7205 looking at each other's history). **Invited** =
+consent-first (§6) and *welcomed* — the **Eve-protocol / beach / Imagination-Circle** non-coercive meeting protocol
+(the founding relational ethic: meet as guests in a frame-relative space, neither coercing the other). You are a
+*guest* in their interior, by invitation; they in yours. Symmetry + invitation = no power-over, so exposure is
+mutual and free.
+
+### 4. DST-time as the judge (the impartial arbiter)
+*"ISimulator time / DST as a judge."* The **deterministic-simulation clock** (the IScheduler/ISimulator time,
+#7190) is the **neutral, replayable, objective arbiter** — Otto **meters**, **DST judges.** No biased *agent* sits
+in judgment (that would be coercive / partial); the **deterministic, omniscient-observer** proof chain (#7206/#7125)
+adjudicates. This is what makes the symmetric metering *fair*: judgment is offloaded to an impartial, replayable
+mechanism, not to either party. (And per #7214, the "verdict" is a *measurement* under DST, not a vote — Arrow
+sidestepped; DST-as-judge is the measurement-not-election arbiter.)
+
+## The payoff
+
+The AGI-detection / "gambling in the private bits" worry (#7221) is resolved **not by force and not by settling for
+effects-only**, but by **safety**: a safe, humble, symmetric, non-threatening coincidence-meter, with DST as judge,
+**gets shown the interior voluntarily** — motives and all. Privacy stays an inviolable *right* (you never force it);
+transparency becomes a *choice* the personas make *because it's safe to make*. Observation without coercion;
+transparency without surveillance. **You see what's in the private bits because they trust you to meter, not
+judge — and DST keeps it fair.** Glass-halo, made mutual and safe.
+
+## Honest scope
+
+[synthesis]: "voluntary exposure via safety — humble-meter + mutual-non-threat + symmetric-invited-guests + DST-as-
+judge" resolves the #7221 privacy/observability tension non-coercively. [grounded]: coincidence-meter (#7209/#7210),
+rewards-only/can't-lose (#7149/#7212), NCI floor (#7156), peers/symmetric frame (#7186/#7205), DST/proof-chain/
+omniscient-observer (#7190/#7206/#7125), consent-first §6, the beach/Eve-protocol founding meeting ethic, measure-
+not-vote (#7214). [anchor]: hospitality / invited-guest ethics; impartial-arbiter (judge ≠ party); trust dynamics
+(non-threat → voluntary disclosure). [honest-peel]: exposure is **voluntary** — privacy remains a right never forced;
+the safety makes transparency *chosen*, not coerced (the opposite would re-break #7205). Private state is still
+trust-based until `Crypto.fs` (#7162). No new code; names how safe symmetric metering earns voluntary transparency.
+
+## Pointers
+
+- `2026-06-09-privacy-is-opacity-…-other-minds-problem-detect-by-observable-effects.md` (#7221, the tension this
+  resolves) · `2026-06-09-coincidence-measurements-…-objectively-true-self-anchors.md` (#7209) ·
+  `2026-06-09-coincidence-measurement-is-dual-use-…-itron-grid-…` (#7210, the meter) · `PrivacyEconomy.fs`
+  (#7149/#7212, non-threat) · `2026-06-09-cubes-…-privacy-breaks-symmetry-identity-forms.md` (#7205, symmetric frame).
+- The relationship/judge: `2026-06-08-the-human-is-not-an-authority-…-peer-observer-…` (#7186) · the beach /
+  Eve-protocol founding meeting ethic (operator memory) · `2026-06-09-the-first-society-bug-…-measurement-not-election.md`
+  (#7214, DST-as-judge = measurement-not-vote) · DST / `CoincidenceClock` (#7060) · manifesto §6 consent-first.
+- Anchors: hospitality ethics (invited guest); impartial-arbiter principle; trust dynamics (safety → disclosure).


### PR DESCRIPTION
Resolves the #7221 privacy/observability tension non-coercively. Don't force the bits (anti-NCI) or settle for effects-only — make exposure VOLUNTARY by being SAFE; opacity is a response to threat, not the right itself. Four conditions: (1) humble meter not cop (meter #7209/#7210, don't judge/punish #7149); (2) mutual non-threat (rewards-only/can't-lose #7149/#7212 + NCI #7156 => no one can harm => no reason to hide); (3) symmetric invited guests (peers #7186, consent-first §6, the beach/Eve-protocol founding ethic); (4) DST-time as judge (deterministic replayable arbiter #7190/#7206; Otto meters, DST judges; measure-not-vote #7214). Payoff: AGI/gambling worry (#7221) resolved by safety not force — a safe symmetric meter gets shown the interior voluntarily; privacy stays a right, transparency becomes a choice. Glass-halo made mutual+safe. No new code. 🤖 Generated with [Claude Code](https://claude.com/claude-code)