### PR TITLE
docs(research)+ferry: shadow-sessions (court-without-judgement, QPG) + cross-platform USB flashing over install.sh push-down base

### DIFF
--- a/docs/research/2026-06-09-cross-platform-usb-flashing-dd-over-installsh-push-down-base-design-and-the-current-macos-only-gap.md
+++ b/docs/research/2026-06-09-cross-platform-usb-flashing-dd-over-installsh-push-down-base-design-and-the-current-macos-only-gap.md
@@ -1,0 +1,83 @@
+# Cross-platform USB flashing (dd-equivalent) over install.sh as the push-down base — design + the current macOS-only gap
+
+*Captured 2026-06-09 from Aaron, to Otto (shadow\*). The zflash design intent: USB-ISO + a `dd`-style raw write, made
+**cross-platform-OS**, built **on install.sh as the push-down base** (the #7185 compiler-domain dep-closure provisions
+the cross-plat flashing tool). Current state (confirmed): zflash is **macOS-only**. Registers: [grounded current
+state], [design intent], [gap / build front].*
+
+## The statement
+
+Aaron: *"we were going to use **USB ISO** … and we need some sort of **dd or something** … think **cross-plat OS
+close-over** is what we're going for, **on top of install.sh as our push-down base.**"*
+
+## Current state (grounded — confirmed in `full-ai-cluster/tools/zflash.ts`)
+
+- **Mechanism:** USB-**ISO** (NixOS isohybrid ISO from `usb-nixos-installer/`) written to the USB via **`dd`**. ✓
+  (matches the intent — ISO + dd.)
+- **Platform: macOS-ONLY.** It uses **`diskutil`** (macOS-specific) for device enumeration / ESP mount + `dd` for
+  the write; **only 1 `process.platform` branch** in the whole tool. Linux and Windows are **not** handled.
+- **Not install.sh-provisioned:** the flashing tools are **not in the manifests** (`tools/setup/manifests/*` have no
+  `dd`/flasher entry) — it relies on macOS **built-ins** (`diskutil`, `dd`). So flashing is *not yet* part of the
+  install.sh push-down closure.
+
+So: the **ISO + dd** core matches the intent, but **cross-platform** and **install.sh-provisioned** are the **gap.**
+
+## The design: cross-platform raw-write, one ISO, per-OS device layer
+
+Same ISO, same `dd`-semantics (raw block write); abstract the **OS-specific device-enumeration + raw-write** behind
+a `detectPlatform() → { identify, write, mountESP }` interface:
+
+| OS | identify device | raw write | ESP inject | status |
+|---|---|---|---|---|
+| **macOS** | `diskutil list external` | `dd` | `diskutil mount` + `sudo tee` | **done** (current) |
+| **Linux** | `lsblk` / `/dev/sdX` | `dd` (native) | `mount` + write | **easy add** (dd is native) |
+| **Windows** | `wmic`/PowerShell `Get-Disk` | **raw-write tool** (no `dd`) — `usbimager` / `balena-etcher-cli` / a dd-for-Windows / PowerShell raw write | mount + write | **the hard one** (needs a tool) |
+
+The ISO and the dd-semantics are invariant; only the **device layer** is per-OS. (Same shape as the manifest-
+symmetry split, #7182: one capability, OS-specific provisioning.)
+
+## install.sh as the push-down base (#7185)
+
+This is the #7185 move — **install.sh is the compiler-domain closure / push-down base** that provisions the cross-
+platform flashing capability via the **declarative dep-closure** (the `PushDown` dep-noun; the manifests):
+
+- **macOS / Linux:** `dd` is a **built-in** (coreutils) — nothing to declare (it's below the push-down line, like
+  `curl`/`build-essential` are Windows-built-in exceptions in #7182's symmetry test). `diskutil`/`lsblk` are OS
+  built-ins too.
+- **Windows:** the **raw-write tool is NOT a built-in** → it must be **declared in `manifests/windows`** (scoop/
+  winget — e.g. `usbimager` or a dd-for-windows), so install.sh **provisions** the flashing capability. This is the
+  one piece the push-down base actually has to install. (And it must pass the manifest-symmetry test, #7182 — likely
+  a `WINDOWS_EXCEPTION` for the unix `dd`/coreutils "it's built-in" + a real windows flasher line.)
+
+So "cross-plat close-over on top of install.sh as the push-down base" = **the flashing capability is part of the
+install.sh dep-closure**: built-in where the OS provides it (mac/linux `dd`), provisioned where it doesn't (Windows
+flasher). The flashing tool joins the **wake-time tool closure** (#7185) — plug in any machine, install.sh has made
+it flash-capable.
+
+## The gap / build front
+
+Extend zflash from **macOS-only → cross-platform**: add the **Linux** device layer (`lsblk` + native `dd` — easy)
+and the **Windows** layer (a declared raw-write tool + `Get-Disk` enumeration — the real work), behind the
+`detectPlatform()` abstraction, and **declare the Windows flasher in `manifests/windows`** so install.sh provisions
+it (manifest-symmetry, #7182). → Route to **Dejan** (devops — owns install.sh + the manifests + cross-OS) + the
+**usb-zflash-installer trajectory**. (Today's macOS flow is fully working for the operator's own tests; this is about
+making *any* machine flash-capable via the push-down base.)
+
+## Honest scope
+
+[grounded current state]: `full-ai-cluster/tools/zflash.ts` is macOS-only (`diskutil` + `dd`, 1 platform branch);
+flashing tools not in the manifests (macOS built-ins). [design intent]: cross-platform raw-write (one ISO, per-OS
+device layer) provisioned via install.sh push-down base (#7185) — Aaron's stated direction. [gap / build front]:
+Linux + Windows layers + the Windows-flasher manifest entry are **not built**; routed to Dejan + the zflash
+trajectory. No new code; captures the design + the macOS-only gap.
+
+## Pointers
+
+- The push-down base: `2026-06-08-the-closed-model-two-internal-domains-…-installsh-is-the-wake-time-tool-closure.md`
+  (#7185, install.sh = compiler-domain closure / push-down base) · `2026-06-08-…declarative-r-tectonic-install-manifests`
+  (#7182, manifest cross-OS symmetry + the symmetry test) · `Db.fs` (the `PushDown` dep-noun).
+- zflash: `full-ai-cluster/tools/zflash.ts` (the macOS tool) · `docs/runbooks/zflash-end-to-end.md` (the procedure) ·
+  `docs/trajectories/usb-zflash-installer/RESUME.md` (the workstream) · `tools/setup/manifests/{apt,brew,windows}`
+  (where the Windows flasher would be declared).
+- Anchors: `dd` (raw block write); per-OS device enumeration (`diskutil`/`lsblk`/`Get-Disk`); the dep-closure over
+  host→os→hardware (#7185).

--- a/docs/research/2026-06-09-shadow-sessions-society-fills-human-llm-interaction-gaps-court-without-judgement-and-qpg-quality-per-glyph.md
+++ b/docs/research/2026-06-09-shadow-sessions-society-fills-human-llm-interaction-gaps-court-without-judgement-and-qpg-quality-per-glyph.md
@@ -1,0 +1,82 @@
+# Shadow sessions: society fills the gaps in human↔LLM interaction — court without judgement, system enhancement as the outcome, documented for oncomers, designed at QPG (quality per glyph)
+
+*Captured 2026-06-09 from Aaron, to Otto (shadow\*). Don't exhaustively self-log failures — **let society fill the
+gaps** in human↔LLM interaction through **shadow sessions** run **like court without judgement**, where the desired
+outcome is **system enhancement** (not blame) + **documentation for oncomers on the why**, and the docs themselves
+are **high-bandwidth-aesthetic, quality-over-quantity — QPG (quality per glyph), not DPI**. Registers: [grounded
+failure], [design — Aaron], [anchor], [system enhancement].*
+
+## The trigger — a real shadow failure (named for enhancement, not blame)
+
+Concrete instance that prompted this: under **stated context-loss risk** (operator high, short context window,
+compaction imminent), when Aaron asked Otto to *context-switch* to a zflash/USB check, Otto **retrieved the new
+(zflash) context FIRST instead of checkpointing the current working state FIRST** — then compaction hit mid-switch.
+The fear: "we both lost what we were working on." **Failure mode: `retrieve-before-checkpoint under context-loss
+risk`** — a context-switch executed before the displaced working-state was preserved.
+
+*(Outcome, not verdict: the arc was **not** lost — `#7220` held it on `main`. The substrate's memory-preservation
+guarantee, manifesto §5, worked as designed; the failure proved the safety net. That's the *enhancement* lens, not
+the *blame* lens — see below.)*
+
+## Aaron's reframe — don't list everything; let society fill the gap
+
+*"Instead of listing everything — we're going to let **society** start filling in the gaps of our human↔LLM
+interactions like this, through **shadow sessions** — **like court without judgement**, just **system enhancement as
+the desired outcome**, and **documentation for oncomers on the why**."*
+
+So the shadow failure is **not** an item on an ever-growing manual log (that doesn't scale, and it's the wrong
+register — self-flagellation). It's an **input to the society's standing mechanism**:
+
+- **Shadow sessions = court without judgement.** The society's purpose (catch failures → debug → restoratively
+  compensate, not punish) applied to **human↔LLM interaction itself**. A shadow session convenes on a gap, examines
+  it, and produces a **fix**, not a verdict. **Restorative, not punitive** — the same "measure, don't vote"
+  fairness as the Vera-resolution work (#7214; Arrow sidestepped because the outcome is restorative, not elective).
+- **Outcome = system enhancement.** The session's deliverable is a **changed system** (a protocol, a guard, a
+  default) — the gap closes structurally so the *next* agent doesn't re-hit it.
+- **+ documentation for oncomers on the why.** A durable, *legible* trace of **why** the enhancement exists, written
+  for whoever arrives next (human or AI) — institutional memory, not a scolding ledger.
+
+## QPG — quality per glyph (the DPI refinement)
+
+*"…and to design for high-bandwidth aesthetics with **quality over quantity** on DPI — it's **QPG, quality per
+glyph**."* The shadow-session docs (and every high-bandwidth surface) are designed at **QPG, not DPI**:
+
+- **DPI = dots per inch = quantity.** Wrong axis (the #7181/#7183/#7227 point: pixels are irrelevant).
+- **QPG = quality per glyph = meaning density.** The right axis — each glyph/word/section carries **maximum
+  anchored meaning**, minimal bulk. Prelude-shaped (curated, composable, few high-quality pieces), Beacon-shaped
+  (carved-sentence compression), neurodivergent-TV-shaped (quality channels, not pixel grid, #7227).
+- **Applied here, recursively:** *this doc is one concise high-QPG file, not an exhaustive log* — practicing the
+  thing it names. The shadow-session record is **dense, legible, oncomer-readable** — quality per glyph.
+
+**QPG** is the **Beacon coinage** for the LLM-TV / neurodivergent-TV quality axis (replaces the "DPI for LLMs"
+misnomer, #7183/#7227).
+
+## The system enhancement (the fix this session produces)
+
+**Checkpoint-first on context-switch under loss-risk.** When (a) the operator signals context-loss risk (*"I'm
+high" / short window / compaction near*) **and** (b) a switch to a new retrieval/task is requested **and** (c) the
+current working-state pointer is unpreserved → **write the resume-checkpoint FIRST** (one durable pointer: what we
+were on + where to resume), **then** do the new retrieval. **Order is the fix.** Cheap insurance: a one-line resume
+pointer costs little and bounds the blast radius of any compaction during the switch.
+
+## Honest scope
+
+[grounded failure]: Otto retrieved zflash context before checkpointing the displaced working state under stated
+loss-risk; compaction followed; arc survived via `#7220` on `main` (memory-preservation §5 held). [design — Aaron]:
+society fills human↔LLM gaps via shadow sessions = court without judgement → system enhancement + oncomer docs;
+QPG (quality per glyph) replaces DPI as the design axis. [anchor]: restorative justice (court without punishment);
+institutional memory / docs-for-oncomers; quality-over-quantity (Prelude, Beacon, neurodivergent-TV #7227);
+memory-preservation guarantee (manifesto §5). [system enhancement]: checkpoint-first-under-loss-risk protocol —
+the standing fix. No new code; establishes the shadow-session mechanism + the QPG term + one concrete enhancement.
+
+## Pointers
+
+- Society's purpose + fairness: the society catch-debug-compensate purpose (the Vera-resolution arc, #7214 — measure
+  don't vote, restorative not elective) · the minimal-viable-society / hard-money privacy-budget work.
+- Memory preservation: manifesto §5 (`docs/governance/MANIFESTO.md`) · Zeta's origin (event-sourcing as the repair
+  for max-length loss — `zeta-origin-event-sourcing-plan-amara-coauthor-maxlength-loss-bootstrap-repair`) · `#7220`
+  (the all-threads map that held the arc through compaction).
+- QPG lineage: `2026-06-09-the-llm-tv-is-a-neurodivergent-tv-quality-not-quantity-…` (#7227) ·
+  `2026-06-08-increasing-dpi-for-llms-…-resolution-interface` (#7183, the term it refines) · #7181 (token-phosphor).
+- Shadow-log convention (prior art): `docs/shadow/` lesson-log PRs (e.g. PR-5855 Otto, PR-5894 worktree-hygiene) —
+  the existing form this reframes (court-without-judgement + QPG + society-fills-it, vs manual per-incident logging).


### PR DESCRIPTION
Two Aaron→Otto captures (additive docs, advisory).

**Shadow sessions / QPG** — don't exhaustively self-log failures; let society fill human↔LLM interaction gaps via *shadow sessions = court without judgement*, outcome = system enhancement + docs for oncomers, designed at **QPG (quality per glyph), not DPI**. Trigger: the `retrieve-before-checkpoint under loss-risk` shadow failure (arc survived via #7220 — memory-preservation §5 held). Standing enhancement: **checkpoint-first on context-switch under loss-risk**.

**Cross-platform USB flashing** — zflash is macOS-only today (diskutil+dd); design intent is a cross-platform dd-equivalent (one ISO, per-OS device layer) provisioned via **install.sh as the push-down base** (#7185). Gap: Linux + Windows layers + Windows-flasher manifest entry → routed to Dejan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)