### PR TITLE
docs(research)+fix: correct zflash cross-platform record (Max shipped Windows) + Windows Hello auth-parity requirement

### DIFF
--- a/docs/research/2026-06-09-cross-platform-usb-flashing-dd-over-installsh-push-down-base-design-and-the-current-macos-only-gap.md
+++ b/docs/research/2026-06-09-cross-platform-usb-flashing-dd-over-installsh-push-down-base-design-and-the-current-macos-only-gap.md
@@ -1,40 +1,83 @@
-# Cross-platform USB flashing (dd-equivalent) over install.sh as the push-down base — design + the current macOS-only gap
+# Cross-platform USB flashing (dd-equivalent) over install.sh as the push-down base — design, state, and the Windows-Hello auth-parity requirement
+
+> *Filename keeps "macos-only-gap" for link stability — but that framing was **corrected**: flashing is already
+> cross-platform (mac + Windows + Linux). See the CORRECTION banner below.*
 
 *Captured 2026-06-09 from Aaron, to Otto (shadow\*). The zflash design intent: USB-ISO + a `dd`-style raw write, made
 **cross-platform-OS**, built **on install.sh as the push-down base** (the #7185 compiler-domain dep-closure provisions
-the cross-plat flashing tool). Current state (confirmed): zflash is **macOS-only**. Registers: [grounded current
-state], [design intent], [gap / build front].*
+the cross-plat flashing tool). State (corrected 2026-06-09): already cross-platform across **three sibling tools**
+(mac/Touch ID, Windows/UAC via Max, Linux/manual); open items are **auth-parity (Windows Hello, not just UAC)**,
+unification, and install.sh provisioning. Registers: [grounded state], [correction], [requirement — Aaron], [build
+fronts].*
 
 ## The statement
 
 Aaron: *"we were going to use **USB ISO** … and we need some sort of **dd or something** … think **cross-plat OS
 close-over** is what we're going for, **on top of install.sh as our push-down base.**"*
 
-## Current state (grounded — confirmed in `full-ai-cluster/tools/zflash.ts`)
+> **CORRECTION 2026-06-09 (Aaron + Max):** the original draft said "macOS-ONLY" — **wrong.** That described
+> `zflash.ts` (the single mac tool), not the *capability*. **Max shipped a Windows flasher** (`flash-usb-windows.ts`,
+> #6868/#6895/#6981) with mac-parity safety rails + raw-FAT ESP key injection; Linux has `flash-usb.ts` (manual).
+> So flashing is **already cross-platform** — it's **three sibling tools**, not one `detectPlatform()`. The real open
+> items are (a) **auth-parity** (see the new section — Windows uses UAC, not Touch-ID-equivalent biometric) and
+> (b) **unification + install.sh provisioning**. Corrected below.
 
-- **Mechanism:** USB-**ISO** (NixOS isohybrid ISO from `usb-nixos-installer/`) written to the USB via **`dd`**. ✓
-  (matches the intent — ISO + dd.)
-- **Platform: macOS-ONLY.** It uses **`diskutil`** (macOS-specific) for device enumeration / ESP mount + `dd` for
-  the write; **only 1 `process.platform` branch** in the whole tool. Linux and Windows are **not** handled.
-- **Not install.sh-provisioned:** the flashing tools are **not in the manifests** (`tools/setup/manifests/*` have no
-  `dd`/flasher entry) — it relies on macOS **built-ins** (`diskutil`, `dd`). So flashing is *not yet* part of the
-  install.sh push-down closure.
+## Current state (grounded — confirmed on main 2026-06-09)
 
-So: the **ISO + dd** core matches the intent, but **cross-platform** and **install.sh-provisioned** are the **gap.**
+- **Mechanism:** USB-**ISO** (NixOS isohybrid ISO from `usb-nixos-installer/`) written to the USB via **`dd`** /
+  raw-write. ✓ (matches the intent — ISO + raw write.)
+- **Platform: cross-platform already, as THREE sibling tools** (not one unified tool):
+  - **macOS** — `zflash.ts`: `diskutil` enumeration + `dd` + **Touch ID** (PAM/`sudo`) as the presence gate. (The
+    `darwin`-only bail in `zflash.ts` is *that tool's* scope, not the capability's.)
+  - **Windows** — `flash-usb-windows.ts` (Max, #6868/#6895/#6981): elevated PowerShell, `\\.\PhysicalDriveN`
+    raw-write, raw-FAT ESP key injection; **UAC / Administrator prompt** as the presence gate (Windows Hello only
+    *"if configured"*, not required). Device-path handling in `zflash-lib.ts`.
+  - **Linux** — `flash-usb.ts` (manual flow per its header): `/dev/sdX` + native `dd`.
+- **Not yet unified / install.sh-provisioned:** three tools, not one `detectPlatform()`; flashers not declared in
+  `tools/setup/manifests/*` (rely on OS built-ins / per-OS install). So the *push-down provisioning* is still open.
+
+So: the **ISO + raw-write** core AND **cross-platform coverage** are **done**; **auth-parity** and **unification +
+install.sh provisioning** are the open items.
 
 ## The design: cross-platform raw-write, one ISO, per-OS device layer
 
 Same ISO, same `dd`-semantics (raw block write); abstract the **OS-specific device-enumeration + raw-write** behind
 a `detectPlatform() → { identify, write, mountESP }` interface:
 
-| OS | identify device | raw write | ESP inject | status |
-|---|---|---|---|---|
-| **macOS** | `diskutil list external` | `dd` | `diskutil mount` + `sudo tee` | **done** (current) |
-| **Linux** | `lsblk` / `/dev/sdX` | `dd` (native) | `mount` + write | **easy add** (dd is native) |
-| **Windows** | `wmic`/PowerShell `Get-Disk` | **raw-write tool** (no `dd`) — `usbimager` / `balena-etcher-cli` / a dd-for-Windows / PowerShell raw write | mount + write | **the hard one** (needs a tool) |
+| OS | tool | identify device | raw write | ESP inject | presence gate | status |
+|---|---|---|---|---|---|---|
+| **macOS** | `zflash.ts` | `diskutil list external` | `dd` | `diskutil mount` + `sudo tee` | **Touch ID** (PAM) | **done** |
+| **Windows** | `flash-usb-windows.ts` | PowerShell `Get-Disk` | `\\.\PhysicalDriveN` raw-write | raw-FAT inject | **UAC** (Hello *if configured*) | **done** (Max) — auth-parity gap |
+| **Linux** | `flash-usb.ts` | `lsblk` / `/dev/sdX` | `dd` (native) | `mount` + write | `sudo` | **manual** |
 
-The ISO and the dd-semantics are invariant; only the **device layer** is per-OS. (Same shape as the manifest-
-symmetry split, #7182: one capability, OS-specific provisioning.)
+The ISO and raw-write semantics are invariant; the **device layer + presence gate** are per-OS. (Same shape as the
+manifest-symmetry split, #7182: one capability, OS-specific provisioning.) **Unification** into one
+`detectPlatform()` dispatcher over the three is the remaining engineering tidy.
+
+## Auth-parity: Touch ID vs UAC — Zeta needs at least Windows Hello (Aaron, 2026-06-09)
+
+The three tools cover the *write*, but their **presence gates are not parity**, and Aaron flags this as a
+**requirement, not a nicety**:
+
+- **macOS = Touch ID** — an **identity-bound biometric presence** gate. *This specific human is physically here.*
+- **Windows = UAC** — a **privilege-elevation** gate. *An administrator approved this.* That's a **different
+  thing**: it proves authority, not the identity-bound physical presence of a specific person. (Windows Hello is
+  supported only *"if configured"* — i.e. optional, not the bar.)
+
+> Aaron: *"Windows UAC is fine for Windows, but **Zeta is designing the future of human↔AI interaction**, so we need
+> **at least Windows Hello, not just Windows UAC.**"*
+
+**Why it's load-bearing (not cosmetic):** Zeta's authorization model is **consent-first / identity-bound presence**
+(manifesto §6) — the gate on a destructive, identity-injecting act (SSH-key inject into the ESP) should assert
+*"this particular human is here and consents,"* which is exactly what **biometric presence** (Touch ID / Windows
+Hello) gives and what **UAC (mere admin elevation) does not**. For a system whose whole thesis is the future of
+human↔AI interaction, the **biometric presence gate is the right default**; UAC is an acceptable **fallback**, not
+the target.
+
+**The requirement / build front:** elevate `flash-usb-windows.ts` from **UAC-only → Windows Hello required**
+(biometric presence, parity with mac Touch ID), **UAC as graceful fallback** where Hello isn't available. → Route to
+**Max** (owns the Windows flasher) + **Dejan** (cross-OS) + a backlog item. (Anchor: Windows Hello API /
+`KeyCredentialManager` for a presence assertion; the consent-first §6 / identity-bound-presence principle.)
 
 ## install.sh as the push-down base (#7185)
 
@@ -54,22 +97,30 @@ install.sh dep-closure**: built-in where the OS provides it (mac/linux `dd`), pr
 flasher). The flashing tool joins the **wake-time tool closure** (#7185) — plug in any machine, install.sh has made
 it flash-capable.
 
-## The gap / build front
+## The open items / build fronts (revised)
 
-Extend zflash from **macOS-only → cross-platform**: add the **Linux** device layer (`lsblk` + native `dd` — easy)
-and the **Windows** layer (a declared raw-write tool + `Get-Disk` enumeration — the real work), behind the
-`detectPlatform()` abstraction, and **declare the Windows flasher in `manifests/windows`** so install.sh provisions
-it (manifest-symmetry, #7182). → Route to **Dejan** (devops — owns install.sh + the manifests + cross-OS) + the
-**usb-zflash-installer trajectory**. (Today's macOS flow is fully working for the operator's own tests; this is about
-making *any* machine flash-capable via the push-down base.)
+Cross-platform *coverage* is **done** (mac + Windows + Linux). What's left:
+
+1. **Auth-parity → Windows Hello** (Aaron's requirement): elevate `flash-usb-windows.ts` from UAC-only to
+   **Windows Hello required** (biometric presence parity with mac Touch ID), UAC as fallback. → **Max** + backlog.
+   *(The load-bearing one — it's the consent-first §6 principle, not a polish.)*
+2. **Unify the three tools** behind one `detectPlatform()` dispatcher (so `zflash` is one entry point on any OS,
+   not three siblings). → engineering tidy.
+3. **install.sh provisioning** (#7185): declare the per-OS flasher deps in `tools/setup/manifests/*` so the
+   push-down base makes *any* machine flash-capable (manifest-symmetry, #7182). → **Dejan**.
+
+→ Owners: **Max** (Windows flasher / Hello), **Dejan** (install.sh + manifests + cross-OS), the
+**usb-zflash-installer trajectory**.
 
 ## Honest scope
 
-[grounded current state]: `full-ai-cluster/tools/zflash.ts` is macOS-only (`diskutil` + `dd`, 1 platform branch);
-flashing tools not in the manifests (macOS built-ins). [design intent]: cross-platform raw-write (one ISO, per-OS
-device layer) provisioned via install.sh push-down base (#7185) — Aaron's stated direction. [gap / build front]:
-Linux + Windows layers + the Windows-flasher manifest entry are **not built**; routed to Dejan + the zflash
-trajectory. No new code; captures the design + the macOS-only gap.
+[grounded current state]: flashing is **already cross-platform on main** — `zflash.ts` (macOS/Touch ID),
+`flash-usb-windows.ts` (Windows/UAC, Max #6868/#6895/#6981), `flash-usb.ts` (Linux/manual); three sibling tools,
+not unified, not in the manifests. [correction]: the original draft's "macOS-only" was wrong (described the one tool,
+not the capability). [requirement — Aaron]: **Windows Hello (biometric presence), not just UAC** — because Zeta
+designs the future of human↔AI interaction and the gate must assert identity-bound presence (consent-first §6), not
+mere admin elevation. [open build fronts]: Windows-Hello parity (Max), unification, install.sh provisioning (Dejan).
+No new code; corrects the record + captures the auth-parity requirement.
 
 ## Pointers
 


### PR DESCRIPTION
**Correction + requirement (Aaron + Max, 2026-06-09).**

The #7227 draft called zflash "macOS-only" — **wrong**; that described the single mac tool, not the capability. Flashing is **already cross-platform** on main: `zflash.ts` (mac/Touch ID), `flash-usb-windows.ts` (Windows/UAC — Max #6868/#6895/#6981), `flash-usb.ts` (Linux/manual). Three sibling tools, not unified.

**New requirement:** Windows uses **UAC** (privilege elevation); mac uses **Touch ID** (identity-bound biometric presence) — *not parity*. Since Zeta designs the future of human↔AI interaction, the destructive/identity-injecting gate must assert **identity-bound presence** (consent-first §6), not mere admin elevation → **need at least Windows Hello, not just UAC** (UAC = fallback, Hello = target).

**Build fronts:** Windows-Hello parity (Max) · unify the 3 tools · install.sh provisioning (Dejan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)