### PR TITLE
feat(node-register): node-b1e1b5 self-registers via iter-5.4.1

### DIFF
--- a/maintainers/Addisons820/cluster-nodes/node-b1e1b5/node.yaml
+++ b/maintainers/Addisons820/cluster-nodes/node-b1e1b5/node.yaml
@@ -1,0 +1,32 @@
+apiVersion: zeta.lucent-financial-group.com/v1
+kind: ClusterNode
+metadata:
+  name: node-b1e1b5
+  namespace: zeta-cluster
+  annotations:
+    zeta.lucent-financial-group.com/registered-at: "2026-06-09T09:58:02Z"
+    zeta.lucent-financial-group.com/flake-commit: "1071b35e69a6"
+    zeta.lucent-financial-group.com/flake-host: "control-plane"
+    zeta.lucent-financial-group.com/registered-via: "iter-5.4.1"
+  labels:
+    zeta.lucent-financial-group.com/maintainer: "Addisons820"
+spec:
+  hostname: node-b1e1b5
+  roles:
+    - control-plane
+  registration:
+    maintainer: Addisons820
+    timestamp: "2026-06-09T09:58:02Z"
+    flake-commit: "1071b35e69a6"
+    flake-host: "control-plane"
+    registered-via: "iter-5.4.1"
+  hardware:
+    cpu: "Intel(R) Core(TM) Ultra 9 285H"
+    memory: "66G"
+    cores: 16
+    gpu: "00:02.0 VGA compatible controller [0300]: Intel Corporation Arrow Lake-P [Arc Pro 140T] [8086:7d51] (rev 03)"
+    storage:
+      - "/dev/sda 115.5G"
+      - "/dev/nvme0n1 931.5G"
+    network:
+      mac: "80:84:89:01:c5:16"


### PR DESCRIPTION
Self-registration PR opened by zeta-install.sh on the node during install. Composes with B-0812 iter-5.4.1 + B-0813 iter-5.4.2 ArgoCD reconciliation. Review + merge to bring the node into the cluster.