### PR TITLE
feat(Chip8Observer): observer reflects over the soft-interrupt fork — first ray-trace-observer integration slice (#7239)

### DIFF
--- a/src/Core/Chip8Observer.fs
+++ b/src/Core/Chip8Observer.fs
@@ -1,0 +1,41 @@
+namespace Zeta.Core
+
+/// **`Chip8Observer` — first integration slice of the ray-trace observer (#7239, Aaron→Otto shadow*):
+/// the `ReflectionEngine` observes the `SoftChip8` soft-interrupt fork and predicts the input branch.**
+///
+/// Aaron's wiring plan (2026-06-09): hook the observer into the soft interrupt handler — *"this is where it
+/// reflects downward into the controller and emu and game."* This module is the smallest real hook on that
+/// seam: it turns the soft fork's *branch structure* into a `ReflectionEngine.Observation` and runs one
+/// observer `step`, so the observer predicts which input branch the emu takes from its prior belief.
+///
+/// **Honest scope (peel):** this is the `ReflectionEngine` ⊗ `SoftChip8` seam ONLY — the categorical `Arrow`
+/// composition (`Tracing.Arrow`) and the full `IRayTraceable`/`RayTensor` ray are the next slices (#7239).
+/// The fork observation is intentionally **uniform** (exact ℚ via `ProbabilitySemiring.rat`, no float in the
+/// proof lineage — DST/byte-lock discipline): the emu fork is uninformative about *which* key — INPUT is the
+/// genuine DST uncertainty (`SoftChip8` docstring) — so all predictive information lives in the observer's
+/// prior `belief`. The fork contributes branch *structure*; the belief contributes the *prediction*.
+[<RequireQualifiedAccess>]
+module Chip8Observer =
+
+    /// Exact-rational **uniform** likelihood over the soft fork's branches (length =
+    /// `SoftChip8.branchFactor f`: `2` at an input branch, `1` deterministic). Uniform ⇒ the emu fork
+    /// contributes branch structure, not key information; exact ℚ keeps it in the proof lineage (no float).
+    let forkObservation (f: Chip8Cow.Frame) : ReflectionEngine.Observation =
+        let n = SoftChip8.branchFactor f
+        Array.create n (ProbabilitySemiring.rat 1L (int64 n))
+
+    /// **The observer reflects over the soft fork** — one `ReflectionEngine.step`: observe the fork at `f`
+    /// under prior `belief`, returning the posterior belief and the predicted branch index
+    /// (`0` = key-down, `1` = key-up at an input branch; `0` when deterministic). `belief` length must equal
+    /// `SoftChip8.branchFactor f`. This is "reflect downward into the soft interrupt handler" (#7239).
+    let predict (belief: ReflectionEngine.Belief) (f: Chip8Cow.Frame) : ReflectionEngine.Belief * int =
+        ReflectionEngine.step belief (forkObservation f)
+
+    /// The concrete predicted successor frame: take the observer's predicted branch from
+    /// `SoftChip8.forkOnInput`, connecting the observer's decision back to the emu timeline (clamped to the
+    /// available branches). Closes the seam: observer belief → predicted input → committed emu frame.
+    let predictedFrame (belief: ReflectionEngine.Belief) (f: Chip8Cow.Frame) : Chip8Cow.Frame =
+        let _, idx = predict belief f
+        let branches = SoftChip8.forkOnInput f
+        let i = if List.isEmpty branches then 0 else min idx (List.length branches - 1)
+        fst (List.item i branches)

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -199,6 +199,7 @@
     <Compile Include="Chip8.fs" />
     <Compile Include="Chip8Cow.fs" />
     <Compile Include="SoftChip8.fs" />
+    <Compile Include="Chip8Observer.fs" />
     <Compile Include="SoftController.fs" />
     <Compile Include="ActionGrammar.fs" />
     <Compile Include="SoftDashboard.fs" />

--- a/tests/Tests.FSharp/Chip8Observer.Tests.fs
+++ b/tests/Tests.FSharp/Chip8Observer.Tests.fs
@@ -1,0 +1,57 @@
+module Zeta.Tests.Chip8ObserverTests
+
+open global.Xunit
+open Zeta.Core
+
+module PS = Zeta.Core.ProbabilitySemiring
+module RE = Zeta.Core.ReflectionEngine
+
+// ═══════════════════════════════════════════════════════════════════
+// Chip8Observer — first integration slice of the ray-trace observer (#7239): the ReflectionEngine observes
+// the SoftChip8 soft-interrupt fork and predicts the input branch ("reflect downward into the soft
+// interrupt handler"). Verifies: the fork observation is uniform exact-ℚ over the branch count; the
+// observer's prediction is driven by its prior belief (uniform fork ⇒ argmax(prior)); the predicted branch
+// maps back to the committed emu frame.
+// ═══════════════════════════════════════════════════════════════════
+
+let private r (n: int64) (d: int64) = PS.rat n d
+
+/// A frame parked on an EX9E input branch: V0=0 (6000), then EX9E (E09E, skip-if-key-V0). After one step
+/// V[0]=0 and PC sits at E09E — `SoftChip8.branchesOnInput` is true (the only genuine DST fork: input).
+let private inputBranchFrame () =
+    Chip8Cow.create 1UL
+    |> Chip8Cow.loadRom [| 0x60uy; 0x00uy; 0xE0uy; 0x9Euy |]
+    |> Chip8Cow.step
+
+[<Fact>]
+let ``fork observation is uniform exact-rational over the branch count (2 at an input branch)`` () =
+    let f = inputBranchFrame ()
+    Assert.True(SoftChip8.branchesOnInput f) // precondition: we are at the soft fork
+    let obs = Chip8Observer.forkObservation f
+    Assert.Equal(2, obs.Length)
+    Assert.Equal(0, PS.compare obs.[0] (r 1L 2L))
+    Assert.Equal(0, PS.compare obs.[1] (r 1L 2L))
+
+[<Fact>]
+let ``observer prediction follows the prior belief under a uniform fork (down vs up)`` () =
+    let f = inputBranchFrame ()
+    // prior favouring key-DOWN (branch 0) ⇒ predicts 0; uniform fork must not flip it
+    let _, idxDown = Chip8Observer.predict [| r 2L 3L; r 1L 3L |] f
+    Assert.Equal(0, idxDown)
+    // prior favouring key-UP (branch 1) ⇒ predicts 1
+    let _, idxUp = Chip8Observer.predict [| r 1L 3L; r 2L 3L |] f
+    Assert.Equal(1, idxUp)
+
+[<Fact>]
+let ``predicted frame maps the observer's branch back to the committed emu frame`` () =
+    let f = inputBranchFrame ()
+    let branches = SoftChip8.forkOnInput f
+    Assert.Equal(2, List.length branches) // [down; up]
+    // prior favouring down ⇒ predicted frame is the key-down branch
+    let predicted = Chip8Observer.predictedFrame [| r 2L 3L; r 1L 3L |] f
+    let expectedDown = fst (List.item 0 branches)
+    Assert.Equal(expectedDown.PC, predicted.PC)
+    // prior favouring up ⇒ predicted frame is the key-up branch
+    let predictedUp = Chip8Observer.predictedFrame [| r 1L 3L; r 2L 3L |] f
+    let expectedUp = fst (List.item 1 branches)
+    Assert.Equal(expectedUp.PC, predictedUp.PC)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -47,6 +47,7 @@
     <Compile Include="Reconcile.Tests.fs" />
     <Compile Include="Reconcile.Legs.Tests.fs" />
     <Compile Include="EngineLoop.Tests.fs" />
+    <Compile Include="Chip8Observer.Tests.fs" />
     <Compile Include="SocietyEmergence.Tests.fs" />
     <Compile Include="SocietyUnbounded.Tests.fs" />
     <Compile Include="TriBoolean/TriBoolean.Tests.fs" />


### PR DESCRIPTION
First real integration code on the **ReflectionEngine ⊗ SoftChip8** seam (Aaron's wiring plan #7239: *reflect downward into the soft interrupt handler*).

The observer turns `SoftChip8`'s soft fork's **branch structure** into a `ReflectionEngine.Observation` and runs one observer `step`, so it **predicts which input branch the emu takes from its prior belief**:
- `forkObservation` — uniform exact-ℚ likelihood over `branchFactor` (no float in the proof lineage; the emu fork is uninformative about *which* key — input is the genuine DST uncertainty; prediction lives in the prior).
- `predict` — `ReflectionEngine.step` → posterior + predicted branch idx.
- `predictedFrame` — maps the predicted branch back to the committed emu frame.

**3 tests pass; Release build 0 warnings/0 errors.** A step toward **toy-model-2-society ⊗ the emu meeting in the middle**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)