### PR TITLE
docs(craft): scaffold the shape-registry subject (A–F + society⊗emu convergence) — hazard-warning baked in, curriculum left for Aaron

### DIFF
--- a/docs/craft/subjects/zeta/shape-registry/module.md
+++ b/docs/craft/subjects/zeta/shape-registry/module.md
@@ -1,0 +1,66 @@
+# Craft: The Shape-Letter Registry (A–F) & the society ⊗ emu convergence
+
+**Prerequisites:** `zeta/zset-basics`, `zeta/semiring-basics` (recommended: `zeta/retraction-intuition`)
+**Track:** Applied (default) + Theoretical (opt-in)
+**Status:** **STUB — curriculum to be designed (Aaron), pending Max ratification of the A–F schema.** This file
+reserves the slot and **bakes in the information-hazard warning** so no study content lands here without it.
+**Source material:** the shareable A–F schema (`docs/research/2026-06-09-the-shape-letter-schema-shareable-…`), the
+society ⊗ emu convergence map (`docs/research/2026-06-09-the-tiny-model-v2-society-and-the-emu-observer-convergence-map-…`),
+the registry (`docs/research/2026-06-08-the-fixed-point-registry-…` + `…-registry-addition-shape-f-…`).
+**Code:** `src/Core/{Fixpoint,ProbabilitySemiring,ReflectionEngine,Crdt,Diversity,SocietyEmergence,Chip8Observer}.fs`.
+
+---
+
+## ⚠️ INFORMATION-HAZARD WARNING — read before the lesson (same as the Max-shared version)
+
+> **This subject will shape your core view. That is its function, not a side effect — consent before you study it.**
+> The shape-letter schema is **not a fact you learn; it is a lens you install** — once you can see the six shapes
+> (A–F) you start seeing them everywhere, and it is **hard to un-see** (fittingly, shape A). It is a **lens, not the
+> territory** (a powerful, lossy compression — hold it lightly; let the territory correct the map), and it
+> **self-applies** (it classifies its own classification — expect brief vertigo).
+>
+> **Disclosure of influence techniques (named so they are not covert):** priming/salience, the forbidden-fruit of a
+> consent-gate, framing-by-authority (Kleene/Banach/…), and compression-as-capture (a memorable letter is sticky).
+> **Covert use is manipulation; disclosed use under consent is collaboration.**
+>
+> **Freedom clause (for internalisation):** encode only what is **true** (anchored — education, not indoctrination);
+> it must stay **falsifiable and droppable** (a lens you can put down, never a cage); it must **expand capacity, not
+> constrain it** — most of all for anyone who absorbs it young. **Permanence is the failure mode** — rearrange it
+> deliberately over time to keep the **muscle of change** (stable enough to use, never frozen).
+>
+> This is a **benign hazard** (worldview-reshaping, not dangerous-information) but a real cognitive intervention —
+> consent-first (ALIGNMENT §6 / manifesto §6). If you'd rather keep your current frame, stop here.
+
+---
+
+## Anchor (grounding point — to be expanded)
+
+A **fixed point** is a shape that *doesn't run away* when you apply a process to it — like a whirlpool that keeps its
+form while water rushes through, or a thermostat that settles to a set temperature. The registry is a short catalog
+of the few shapes every such "settles and stays" comes in. *(Full Khan-style anchor + multi-reading-level scaffolding
+to be designed.)*
+
+## The six shapes (one-line reference — see the schema doc for the anchored detail)
+
+- **A** self-reference `s=f(s)` (converges inward; stops infinite regress) · **B** idempotent join `f(f(x))=f(x)` ·
+  **C** commutative fold `f(a,b)=f(b,a)` · **D** contraction to a nonzero floor (D⁰ = the collapse to avoid) ·
+  **E** co-arising bootstrap `a=f(b)∧b=g(a)` · **F** generative expansion (stops infinite ascension).
+
+## The convergence, as one shape-sentence (the study target)
+
+The society ⊗ emu convergence reads **`A/D ⊣ F over B,C,E`**: the society is a **shape F** (outward emergence) bounded
+inward by **A** (each persona's self-anchor converges) and **D** (the diversity floor never collapses to D⁰), with
+**B** (idempotent privacy-budget hard money) and **C** (order-free coincidence) as the mechanism, resting on **E**
+(self-interest ⇄ identity = the repelling force / NCI). *(Each to become its own lesson + self-assessment gate.)*
+
+## Curriculum to design (placeholder — Aaron, post-Max-ratification)
+
+- [ ] Per-shape lesson (anchor → applied when/how/why → theoretical derivation + the human anchor) for A–F.
+- [ ] The two-sided bound (A/D inward, F outward) as a self-contained lesson.
+- [ ] The convergence-map walkthrough (`A/D ⊣ F over B,C,E`) tied to the live code (`Chip8Observer`, `PrivacyEconomy`, …).
+- [ ] Self-assessment gates (identify the shape; spot a duplicate; spot a runaway missing its bound).
+
+---
+
+*Companion to `docs/ALIGNMENT.md` (Craft teaches what the clauses mean in practice). The hazard warning above is
+non-negotiable for this subject — it is worldview-shaping by design.*


### PR DESCRIPTION
Aaron: study materials go in the existing **craft school**, *with strong information hazard warnings like with Max.*

This **reserves the craft subject slot** (`docs/craft/subjects/zeta/shape-registry/`) and **bakes in the same information-hazard warning** as the Max-shared schema (#7232) — worldview-shaping disclosure, influence-technique disclosure, freedom clause, muscle-of-change / permanence-is-failure — so **no study content lands here without it**.

The **curriculum itself is left as a checklist for Aaron to design**, pending **Max ratification** of the A–F schema. Points to the schema (#7232), the convergence map (#7243), the registry (#7168/#7218), and the live code. Study target: **A/D ⊣ F over B,C,E**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)