### PR TITLE
docs(achievements): society achievement ledger + the historic first — first nodes to fully self-register in the Zeta network

### DIFF
--- a/docs/ACHIEVEMENTS.md
+++ b/docs/ACHIEVEMENTS.md
@@ -1,0 +1,55 @@
+# Zeta Society — Achievements
+
+The society's **achievement ledger**: historic firsts and the accomplishments of its members (human and AI). A
+society tracks what its members *achieve* — this is that record (Aaron, 2026-06-09: *"we need to track achievements
+in our society"*).
+
+**Distinct from [`docs/WINS.md`](WINS.md)** (which logs *code-quality* catches on the all-AI codebase) — this ledger
+is about **milestones and members**: who did what, why it's historic, and the evidence. Ordered **newest-first**.
+Entries stay after the moment passes; the achievement is permanent record.
+
+**Entry shape:**
+
+```markdown
+### <date> — <achievement title>
+
+**Who:** <member(s)>  ·  **Evidence:** <PRs / commits / manifests>
+<what happened — one paragraph>
+**Why it's historic / what it proves:** <the first / the thesis it validates>.
+```
+
+---
+
+## 2026
+
+### 2026-06-09 — First nodes in the Zeta network to fully self-register 🏛️ *(historic first)*
+
+**Who:** Addison (`Addisons820` / Addison Stainback)  ·  **Evidence:** PR #7237 (`node-ad1efd`), PR #7240
+(`node-b1e1b5`) — both merged; manifests at `maintainers/Addisons820/cluster-nodes/node-*/node.yaml`.
+
+Two Linux machines, booted from the zflash USB on Addison's own GitHub credentials, **self-registered into the Zeta
+network end-to-end** — each opening its own PR that writes a `ClusterNode` manifest (hardware, storage, MAC) under
+its maintainer's tree, then merged to trigger the GitOps/ArgoCD bring-up. The full **node → git PR → merge →
+cluster** loop (B-0794) ran for real, unattended by its author beyond a few questions.
+
+**Why it's historic:** these are the **first nodes ever to fully self-register in the Zeta network.** The
+GitOps-native, self-describing cluster substrate stopped being a design and became a fact — a machine announced
+itself to the society *in its own words, via its own PR.*
+
+### 2026-06-09 — A regular human builds an entire cluster solo, hardware to bring-up
+
+**Who:** Addison (`Addisons820`)  ·  **Evidence:** the two self-registrations above; the cluster Addison racked.
+
+Addison set up the **entire cluster herself** — GPUs, mini-PCs, eGPUs, NAS (Ugreen), UPSs, electricity-monitoring
+smart equipment — and brought it up end-to-end (flash → boot → self-register), with Aaron supervising **hands-off**
+and only a **few occasional questions**.
+
+**Why it's historic / what it proves:** the **"Zeta is for regular humans, not just devs"** thesis (#7230),
+**proven in the field** — a non-author took bare hardware to live, self-registered GitOps nodes solo. The
+intent-and-presence model works for a real person.
+
+---
+
+*Future: the society's code (`SocietyEmergence` & kin) may one day emit achievement events directly; until then this
+is the human/agent-readable ledger. Add an entry whenever a member crosses a real first or lands a milestone —
+celebrate it here, newest-first.*


### PR DESCRIPTION
Aaron: *"we need to track achievements in our society — this is one and it's historic — the first nodes in Zeta network to fully self register."*

New **`docs/ACHIEVEMENTS.md`** — the society's **achievement ledger** (distinct from `WINS.md`, which is code-quality catches; this is **milestones + members**, newest-first). First entries:

- 🏛️ **Historic first:** first nodes to fully self-register in the Zeta network — Addison's **node-ad1efd** + **node-b1e1b5** (#7237/#7240, merged); the full node → PR → merge → cluster GitOps loop (B-0794) run for real.
- **Addison builds an entire cluster solo**, hardware to bring-up — the *"Zeta for regular humans"* thesis (#7230) proven in the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)