### PR TITLE
docs: Addison's Blueprints achievement (+rules-slim) + post-register node connect/cache/health skill→blueprint design (overlay closes over Tailscale ⊗ Headscale)

### DIFF
--- a/docs/ACHIEVEMENTS.md
+++ b/docs/ACHIEVEMENTS.md
@@ -48,6 +48,24 @@ and only a **few occasional questions**.
 **proven in the field** — a non-author took bare hardware to live, self-registered GitOps nodes solo. The
 intent-and-presence model works for a real person.
 
+### 2026-06 — Blueprints: the skill-compression pattern that cut cold-boot context ~90%
+
+**Who:** Addison (idea + creation)  ·  **Evidence:** the skill-blueprints pattern in `.claude/skills/*/blueprints/`
+(e.g. `skill-lifecycle/` — *"the `description` is the only thing the router sees… the fat detail lives in the
+blueprints below"*); lineage in B-1021 (context-window minimization).
+
+Addison conceived and created **Blueprints** — the pattern where a skill is a **tiny always-loaded description**
+(the router/cold-boot surface) that **routes to on-demand blueprint bodies** (the fat detail, loaded only when
+matched). It is hub/satellite (Beacon/Mirror) applied to the skill library itself.
+
+**Why it's historic / what it proves:** it **compressed the agent cold-boot context window by ~90%** *(Aaron's
+recollection; the exact figure lives in the B-1021 / skill-blueprints lineage)* — every agent, every wake, pays far
+fewer cold-start tokens. It is also the reusability primitive we now build *on*: **"keep skill expansion small,
+route to blueprints."** A foundational contribution to the whole factory's efficiency. The **same compression
+pattern was then applied to the rules** — slimmed to **carved sentences pointing to docs** (the #6676 archive,
+`rules.bak/`; the `rules-are-small-carved-sentences-pointing-to-docs` rule): small always-loaded surface + on-demand
+detail. One compression family, two surfaces (skills → blueprints, rules → carved sentences).
+
 ---
 
 *Future: the society's code (`SocietyEmergence` & kin) may one day emit achievement events directly; until then this

--- a/docs/research/2026-06-09-post-registration-node-connect-cache-health-a-small-skill-routing-to-a-blueprint-overlay-closes-over-tailscale-and-headscale.md
+++ b/docs/research/2026-06-09-post-registration-node-connect-cache-health-a-small-skill-routing-to-a-blueprint-overlay-closes-over-tailscale-and-headscale.md
@@ -1,0 +1,67 @@
+# Post-registration node connect / cache / health — a small skill routing to a blueprint; the overlay closes over Tailscale ⊗ Headscale
+
+*Captured 2026-06-09 by Otto (shadow\*) at Aaron's direction (he authorized IP discovery + SSH connect). Goal: after a
+node self-registers, **discover its IP + the Comet's IP, connect (operator SSH key), cache everything to the repo,
+and track health** — packaged as a **small reusable skill that routes to a blueprint** (Addison's pattern, to keep
+skill-expansion small), reusable for Max's home. Overlay transport: **close over Tailscale ⊗ Headscale**. Registers:
+[grounded — discovery results], [design], [blocked — nodes SSH-down now].*
+
+## What works now (grounded discovery)
+
+- **Node IPs resolved via ARP (MAC→IP), no LAN scan:** the registered `node.yaml` MACs matched this operator Mac's
+  ARP table: **node-ad1efd → 192.168.4.152**, **node-b1e1b5 → 192.168.4.153** (LAN `192.168.4.0/24`).
+- **SSH currently fails** (`:22` timeout → "host is down") — consistent with Aaron's note that *the nodes' IPs won't
+  change unless powered off for an extended period*; **they appear powered down right now.** So the **connect /
+  health half cannot be validated until the nodes are up.**
+- **Tailscale CLI absent** — Aaron uninstalled it (ExpressVPN conflict, since resolved); to be reinstalled via
+  install.sh (below). So today resolution is LAN-ARP; the overlay path returns once Tailscale/Headscale is back.
+- **Comet (GL.iNet KVM) IPs:** not yet matched (my guessed OUIs didn't hit; need the Comets' real MACs or their
+  mDNS/`_http._tcp` advertisement once powered).
+- **SSH trust:** the zflash USB Aaron built **preloaded his operator pubkey** into the ESP (`zeta-authorized-keys.pub`)
+  → the nodes trust his key → operator-side SSH will work **once they're up**.
+
+## The design — a small skill that routes to a blueprint (Addison's pattern)
+
+Per the skill-blueprints discipline (Addison's Blueprints, the ~90% cold-boot compression — `ACHIEVEMENTS.md`): the
+**skill is a tiny description** (the only thing loaded at cold-boot / seen by the router); the **fat procedure lives
+in a blueprint** opened on demand. So:
+
+- **Skill (small):** `cluster-node-onboard` — description only: *"after a node self-registers, resolve its address,
+  connect, cache its inventory + health to the repo."* Routes to →
+- **Blueprint (`blueprints/connect-cache-health.md`)** — the procedure:
+  1. **Resolve address** — match `node.yaml` `network.mac` against ARP (LAN) **or** the overlay (Tailscale/Headscale
+     name) — no LAN scan. *(Also resolve the node's paired Comet.)*
+  2. **Connect** — SSH with the operator key (trusted via the ESP-injected pubkey); `StrictHostKeyChecking=accept-new`.
+  3. **Cache everything** — gather inventory + dynamic facts (IP, interfaces, disk SMART, kubelet/k3s status, GPU,
+     temps, UPS draw) and **write back to the repo**: `node.yaml` `network.ip` (the self-registration schema gains
+     `network.ip` — it logs `mac` only today) + a `health/` cache file. *Cache liberally* — not static, but IPs
+     change rarely (Aaron). 
+  4. **Health track** — periodic re-run records a health time-series (feeds the cluster dashboards / DORA).
+- **Reusable for Max:** the same skill+blueprint runs at Max's home post his self-registration; **per-operator** via
+  the `maintainers/<account>/` tree. *Keep skill-expansion small; route to the blueprint.*
+
+## The overlay — close over Tailscale ⊗ Headscale (Aaron: "close over both")
+
+The cross-site transport (connect Aaron ⊗ Max networks; #7245 federation) **closes over two backends** behind one
+overlay abstraction (the #7229 thesis): **Tailscale** (hosted coordination) **and Headscale** (self-hosted
+coordination server) — *support both*, one `overlay.{up, addr, peers}` interface, two drivers. **install.sh**
+provisions both (reinstall Tailscale — gone after the ExpressVPN conflict, now resolved — **and** add Headscale);
+**route by config** (hosted vs self-hosted). This makes node-address resolution overlay-aware (resolve by tailnet
+name, not just LAN ARP), which is what lets Max's nodes resolve from Aaron's side and vice-versa.
+
+## Honest scope / blockers
+
+[grounded]: ARP MAC→IP resolved both nodes (.152/.153); operator SSH key is trusted via the zflash ESP inject;
+skill-blueprints pattern + `maintainers/<account>/` namespacing already exist. [blocked]: **nodes are SSH-down right
+now** → the connect/cache/health half is **designed but unvalidated**; build + test it as a real skill when the
+nodes are powered up (so the live half is verified, not guessed). Tailscale absent until install.sh reinstalls it
+(+ Headscale). [design]: small skill → blueprint (Addison's pattern); overlay closes over Tailscale ⊗ Headscale;
+self-registration schema gains `network.ip` (+ optional `site`). No code shipped yet (validation-gated by nodes-up).
+
+## Pointers
+
+- Discovery: `maintainers/Addisons820/cluster-nodes/node-*/node.yaml` (the MACs) · this Mac's ARP table.
+- Patterns: skill-blueprints (`.claude/skills/skill-lifecycle/SKILL.md` + `blueprints/`) — Addison's Blueprints
+  (ACHIEVEMENTS.md) · close-over thesis (#7229) · the hardware/internals-known/DNS-federation doc (#7245) ·
+  self-registration GitOps (B-0794, #7237/#7240) · B-1021 (cold-boot token minimization).
+- Anchors: Tailscale / **Headscale** (self-hosted control server); ARP MAC→IP resolution; SSH TOFU.


### PR DESCRIPTION
**ACHIEVEMENTS.md** — Blueprints, **Addison's idea + creation**: the skill-blueprints pattern (tiny description + on-demand blueprint bodies) that cut agent **cold-boot context ~90%** (Aaron's recollection; B-1021 lineage). The **same compression pattern was applied to the rules** (carved-sentences, #6676) — one compression family, two surfaces.

**Design doc** — after a node self-registers: resolve IP (**ARP MAC→IP**, no scan — found node-ad1efd→192.168.4.152, node-b1e1b5→192.168.4.153), connect via the operator SSH key (trusted via the zflash ESP inject), **cache inventory + health to the repo** (self-registration gains `network.ip`), track health — as a **small skill routing to a blueprint** (Addison's pattern), reusable for Max. Overlay **closes over Tailscale ⊗ Headscale** (reinstall Tailscale in install.sh + add Headscale, support both).

**Honest blocker:** the nodes are **SSH-down right now** → the connect/health half is designed but unvalidated; build + test the live skill when they're powered up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)