### PR TITLE
feat(trust): publish Aaron's operator SSH pubkey — persona-owned + baked into node trust

### DIFF
--- a/full-ai-cluster/nixos/modules/operator-ssh-keys.txt
+++ b/full-ai-cluster/nixos/modules/operator-ssh-keys.txt
@@ -15,3 +15,9 @@
 #
 # Example (replace with real pubkey content):
 #   ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI... operator@workstation
+
+# --- baked operator keys (persona-owned originals under maintainers/<account>/ssh-pubkeys.txt) ---
+# aaron (maintainers/aaron/ssh-pubkeys.txt) — published 2026-06-09 so every node trusts Aaron
+# regardless of which machine flashed its USB. Takes effect on next flash / nixos-rebuild;
+# the already-running nodes need this added via console/Comet or rebuild to trust it live.
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDGTU+CghueXG43ltkRkD3Ly81/f6Z36oda45TdIvRFB acehack@Mac.lan

--- a/maintainers/aaron/ssh-pubkeys.txt
+++ b/maintainers/aaron/ssh-pubkeys.txt
@@ -1,0 +1,14 @@
+# Aaron — operator SSH public keys (persona-owned)
+#
+# Owner: Aaron (maintainer `aaron`; email aaron_bond@yahoo.com — confirm if canonical
+# vs the acehack00@gmail.com used in older commit trailers).
+#
+# These are PUBLIC keys — safe to publish (they grant no access; only the private
+# key authenticates). Published 2026-06-09 so every Zeta node trusts Aaron regardless
+# of which machine flashed its USB (the durable fix for the "only the flashing machine
+# can SSH" fragility). Composed into node trust via the operator-ssh-keys substrate
+# (`full-ai-cluster/nixos/modules/operator-ssh-keys.txt` → `zeta` authorized_keys).
+#
+# Format: one OpenSSH pubkey per line; `#` comments + blank lines ignored.
+
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDGTU+CghueXG43ltkRkD3Ly81/f6Z36oda45TdIvRFB acehack@Mac.lan


### PR DESCRIPTION
Aaron authorized publishing his SSH **public** key (safe — grants no access; only the private key authenticates).

- **`maintainers/aaron/ssh-pubkeys.txt`** — persona-owned original (his identity).
- **`operator-ssh-keys.txt`** — baked into the `zeta` trust set (read into `authorized_keys`).

**Why:** trust was USB-inject-only — a node trusts only the key of the machine that flashed its USB, which is why `acehack@Mac.lan` was denied on the live nodes (flashed from a different machine's key). Baking Aaron's key makes **every future-flashed/rebuilt node trust him regardless of flashing machine** — the durable fix. *Note: the already-running nodes (.152/.153) still need this added via console/Comet or `nixos-rebuild` to trust it live.*

Email `aaron_bond@yahoo.com` per Aaron (confirm vs `acehack00@gmail.com`). Public key only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)