### PR TITLE
feat(trust): add Addison's operator SSH pubkey — persona-owned + baked into node trust

### DIFF
--- a/full-ai-cluster/nixos/modules/operator-ssh-keys.txt
+++ b/full-ai-cluster/nixos/modules/operator-ssh-keys.txt
@@ -21,3 +21,6 @@
 # regardless of which machine flashed its USB. Takes effect on next flash / nixos-rebuild;
 # the already-running nodes need this added via console/Comet or rebuild to trust it live.
 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDGTU+CghueXG43ltkRkD3Ly81/f6Z36oda45TdIvRFB acehack@Mac.lan
+# addison (maintainers/Addisons820/ssh-pubkeys.txt) — locally-generated 2026-06-09; not yet
+# attached to her GitHub (Addisons820) — "we will attach it later".
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGTQkxT8U6CRnvNKZM9hwQZ0WhiCjNZlpqHuNeIGplxw addison-stainback

--- a/maintainers/Addisons820/ssh-pubkeys.txt
+++ b/maintainers/Addisons820/ssh-pubkeys.txt
@@ -1,0 +1,13 @@
+# Addison — operator SSH public keys (persona-owned)
+#
+# Owner: Addison Stainback (GitHub `Addisons820`).
+#
+# These are PUBLIC keys — safe to publish (they grant no access; only the private key
+# authenticates). Locally generated 2026-06-09 (Addison had never used SSH; key created on the
+# shared Mac she uses under Aaron's login, ~/.ssh/id_ed25519_addison). NOT yet attached to her
+# GitHub account — "we will attach it later". Composed into node trust via the operator-ssh-keys
+# substrate (`full-ai-cluster/nixos/modules/operator-ssh-keys.txt` → `zeta` authorized_keys).
+#
+# Format: one OpenSSH pubkey per line; `#` comments + blank lines ignored.
+
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGTQkxT8U6CRnvNKZM9hwQZ0WhiCjNZlpqHuNeIGplxw addison-stainback


### PR DESCRIPTION
Addison had never used SSH — generated a local ed25519 key for her (on the shared Mac, `~/.ssh/id_ed25519_addison`) and published the **public** key:
- `maintainers/Addisons820/ssh-pubkeys.txt` — persona-owned original.
- `operator-ssh-keys.txt` — baked into the `zeta` trust set.

Not yet attached to her GitHub (`Addisons820`) — *"we will attach it later"*. Now **both operators (Aaron + Addison) are trusted on every future-flashed/rebuilt node**; the live nodes still need these added via console/Comet or `nixos-rebuild`. Public keys only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)