### PR TITLE
docs(research)+ferry: USB 4-audience UX (Iris) + remember-creds root-cause (rebind ephemeral USB-UUID → stable HW key) + headless 60s cancel-window

### DIFF
--- a/docs/research/2026-06-09-remember-creds-by-default-root-cause-kdf-binds-to-ephemeral-usb-uuid-rebind-to-stable-hardware-key-plus-ask-before-format-reorder.md
+++ b/docs/research/2026-06-09-remember-creds-by-default-root-cause-kdf-binds-to-ephemeral-usb-uuid-rebind-to-stable-hardware-key-plus-ask-before-format-reorder.md
@@ -1,0 +1,97 @@
+# Remember-creds-by-default — root cause: the KDF binds to the *ephemeral* boot-USB UUID; rebind to a *stable* hardware key (+ ask-before-format / check-partition-before-format reorders)
+
+*Captured 2026-06-09 from Aaron ("the USB should boot and remember creds by default after logging in, tied to the
+USB key AND a hardware key of some sort on the USB stick AND the UEFI boot partition, every time; check if the
+partition exists every time before formatting; ask the questions BEFORE formatting; format and persist/repersist
+right after — do this now"). Otto investigated the destructive install path and found a **crypto root cause** that
+makes the rebind the real fix. Registers: [grounded — file:line], [root cause], [design], [safe reorders],
+[needs-one-decision].*
+
+## What's already there (grounded)
+
+- Cred blob `zeta-creds.enc` lives on the ESP (`/boot/zeta-creds.enc`; `/mnt/boot/...` at install).
+- Encrypted via `HKDF(USB-UUID ‖ stretched-passphrase, salt, info)` (`zeta-creds-crypto.ts deriveKey`;
+  `zeta-install.sh:452`). The **USB UUID is captured by blkid at install** (`/etc/zeta/usb-uuid`).
+- A **boot-USB retention** path exists (`zeta-install.sh:509-526`): copies a zflash-baked `zeta-creds.enc` from the
+  boot USB ESP → target ESP after format. (Carries the *flashing* USB's baked creds forward.)
+- Restore at boot: `zeta-creds-restore.nix` reads `/boot/zeta-creds.enc` + the USB UUID, decrypts, restores.
+
+## The root cause (why "remember" doesn't just work)
+
+**The blob is bound to the *ephemeral boot-USB UUID*.** Consequences:
+
+- Reformat with the **same** USB → UUID matches → creds decrypt → remembered. ✅
+- Reformat with a **different** USB (or a re-made USB whose FAT UUID changed) → UUID differs → **the preserved creds
+  won't decrypt.** ❌
+- So a naïve "preserve the target disk's old creds before wipe + repersist" (the literal ask) would, across USBs,
+  carry a **dead, undecryptable blob** forward — and its precedence could **mask** the boot-USB's valid baked creds.
+  **That's why blind-editing the destructive path here is a bug, not progress.**
+
+## The fix = Aaron's instinct: rebind to a STABLE key (not the ephemeral USB UUID)
+
+Aaron asked for binding to "the USB key **AND** a hardware key of some sort **AND** the UEFI partition." That is
+exactly the rebind: replace the ephemeral-USB-UUID factor with a **stable** factor so remembering survives *any*
+reformat / *any* USB:
+
+`key = HKDF( passphrase ‖ STABLE-HW-KEY ‖ [operator-pubkey] , salt, info )`
+
+**The one decision needed — what is the stable hardware key?** (determines the rebind):
+
+| Option | Stable across reformat? | Stable across USB swap? | Notes |
+|---|---|---|---|
+| **TPM** (node motherboard, `tpm2`/`systemd-creds`) | yes | yes (node-bound) | strongest; node-bound (creds tied to the *machine*, not a stick); needs TPM present |
+| **USB controller hardware serial** (not the FAT UUID — the device iSerial) | yes | no (stick-bound) | survives reformat of the same stick; "hardware key on the USB stick" literally |
+| **Keyfile on the UEFI partition** (random key written once, persists across reformat *if* ESP preserved) | only if ESP not wiped | travels with the stick | "tied to the UEFI partition"; but a full ESP wipe loses it |
+
+Aaron's phrasing ("hardware key on the USB stick AND the UEFI partition") points at **USB-iSerial ⊕ a UEFI-partition
+keyfile** — stick-bound remembering. **TPM** would make it node-bound (arguably better for a cluster node that
+reformats but stays the same machine). *This is the decision to confirm before the rebind.*
+
+## The safe, crypto-neutral reorders (Otto can do these now, QEMU-validated)
+
+Independent of the crypto rebind, two ordering fixes are pure flow (no binding risk) and directly match the ask:
+
+1. **Fully headless boot + a 1-minute CANCEL window before format (default = proceed).** *(Corrected by Aaron
+   2026-06-09: "it should NOT ask before format — it should ask to CANCEL for a minute before format; this USB
+   should fully boot headless.")* The USB must boot **fully headless** — **no required interaction**: every "question"
+   (host/role, wifi, login) is answered by **defaults + remembered creds**, never an interactive prompt. The current
+   interactive blockers must become non-blocking: `read -rp "Type WIPE"` (`:162`, already has `ZETA_AUTO_CONFIRM=WIPE`)
+   and the host/role `read -rp "Choice…"` (`:330`) must **timeout-default** (`read -t`, hardware-detected
+   `DEFAULT_CHOICE` already computed) so no stdin is required. The **only** human touchpoint is a **~60 s cancel
+   countdown immediately before the destructive wipe/format**: *"Formatting in 60s — press any key to CANCEL."* No
+   keypress → **proceed** (headless-safe). Any key → **abort**. This replaces "ask before format" — it's a
+   *cancel-window*, not a prompt, so headless is preserved while still giving a real abort gate.
+2. **Check if the partition exists before formatting.** Before the unconditional wipe (`:166-171`), probe
+   `part_name "$BOOT_DISK" 1` for an existing Zeta ESP + `zeta-creds.enc`; report it; *and* (once rebind lands)
+   preserve→repersist it. The check itself is safe; the preserve is only correct after the stable rebind.
+
+## Plan (autonomous, QEMU-validated — closing the loop)
+
+1. **Headless + 60 s cancel-window** before format + timeout-default the interactive prompts + partition-existence
+   check (all crypto-neutral) — implement + QEMU-boot-assert (incl. a headless no-keypress run).
+2. **Rebind KDF** to the chosen stable key (pending the one decision above) — implement in `zeta-creds-crypto.ts` +
+   `restore.nix` + install; QEMU-validate decrypt-after-reformat.
+3. **Preserve→format→repersist** target creds (now crypto-valid) — implement + QEMU-validate remember-across-reformat.
+4. **Default-on:** remembering is the no-keypress default when a blob/partition is detected (#UX-Iris, #7007 model).
+
+All gated by the QEMU harness (grown from the B-0891 PoC to boot-and-assert) on the free GitHub workflows — humans
+only for the narrow physical surface.
+
+## Honest scope
+
+[grounded]: KDF binds to the ephemeral boot-USB UUID (`zeta-install.sh:452`, `zeta-creds-crypto.ts`); blob at
+`/boot/zeta-creds.enc`; boot-USB retention at `:509-526`; menu after format at `:330`; wipe unconditional at `:166`.
+[root cause]: ephemeral-UUID binding → remember-across-reformat only same-USB; naïve preserve carries dead blobs.
+[fix]: rebind to a stable HW key (Aaron's instinct) — **one decision: TPM (node-bound) vs USB-iSerial vs
+UEFI-keyfile (stick-bound)**. [safe-now]: fully-headless boot + a 60 s cancel-window before format (default proceed, any key
+aborts — NOT interactive questions; corrected by Aaron) + timeout-defaulted prompts + partition-check are
+crypto-neutral; do them QEMU-validated (incl. a headless no-keypress run). [discipline]: did NOT blind-edit the destructive+crypto path — a naïve edit would have shipped an
+undecryptable-blob / cred-masking bug. No code shipped in this doc; it's the executable spec + the one decision.
+
+## Pointers
+
+- `full-ai-cluster/usb-nixos-installer/zeta-install.sh` (`:166` wipe, `:211` format, `:330` menu, `:452` UUID
+  capture, `:509-526` retention) · `tools/installer/zeta-creds-crypto.ts` (deriveKey/HKDF) · `zeta-creds-persist.ts`
+  · `nixos/modules/zeta-creds-restore.nix` (`/boot/zeta-creds.enc`, usbUuidPath).
+- Design context: the trust-model + honest-QEMU plan (#7251) · the 4-audience no-keypress UX (Iris, this session) ·
+  the 3-level erase / InstallMode.Live (#7007/#7008/#7010) · close-the-AI-loop QEMU enforcement (#7229).

--- a/docs/research/2026-06-09-the-zflash-usb-four-audience-matrix-context-detected-no-keypress-default-ux-assessment-iris-and-handoffs.md
+++ b/docs/research/2026-06-09-the-zflash-usb-four-audience-matrix-context-detected-no-keypress-default-ux-assessment-iris-and-handoffs.md
@@ -1,0 +1,90 @@
+# The zflash USB serves a four-audience matrix with a context-detected no-keypress default — UX assessment (Iris) + requirement + handoffs
+
+*Captured 2026-06-09 from Aaron (requirement) + Iris (UX review he asked for). One USB must serve **four audiences**
+and "just do the right thing for all of them by default — if no one hits a key it's a [timeout-default] thing,"
+biased to make Aaron+Max's job easiest "for now" (they use it most, reformatting over and over). Registers:
+[requirement — Aaron], [UX assessment — Iris, grounded with file:line], [handoffs].*
+
+## The requirement (Aaron)
+
+One USB, four audiences, right-thing-by-default:
+
+1. **Regular folk fresh to Zeta** — pure UX; **Addison owns** this surface.
+2. **Aaron + Max** — DX; ongoing field expansion, troubleshooting, **reformatting over and over** (heaviest users;
+   optimize their path **now**).
+3. **External Zeta maintainers.**
+4. **Forkers** (running their own fork).
+
+> "we need this USB to cover all and just do the right thing for all of those by default. if no one hits a key it's a
+> [timeout-default] thing, and I lean on making me and Max's job easier for now [since] we use it the most."
+
+## The no-keypress smart default (Iris)
+
+The silent path is the path a **confused fresh person** takes (they don't press a key *because* they don't know what
+the keys mean) — so the no-keypress default must be the **safest non-destructive** action. The Aaron+Max bias is
+achieved by **context detection, not by a globally-dangerous default**:
+
+- **Stage A — flash time:** detect a `zeta-creds.enc` blob on the target USB's ESP.
+  - **Blob present** (known re-flash → Aaron+Max) → timeout-default = **`ErasePreserveConfig`** (preserve+reuse
+    creds, the 3-level model #7007); shorter countdown; pre-select "keep my settings."
+  - **No blob** (fresh stick) → timeout-default = the **safe build / Live** path.
+- **Stage B — boot menu** (plain language, visible countdown):
+  - no keypress → **Live (non-destructive): explore Zeta, host untouched** (`InstallMode.Live` is already the
+    declared default, #7008).
+  - `1) Install fresh (ERASES this PC)` · `2) Install, keep my settings (reuse WiFi+login)` *[only if blob]* ·
+    `3) Advanced / fork / maintainer options`.
+  - **Destructive erase is NEVER the silent default** — even for Aaron the silent path is `ErasePreserveConfig`
+    (secrets preserved first), never `EraseWipeConfig`. Full wipe always needs an explicit keypress.
+
+Highest-leverage default fix: the boot menu must **read blob/trace context and *show* the countdown + chosen default
+in plain words** ("keep my settings", not `ErasePreserveConfig`; "explore", not `Live`). Today CP-3 shows a
+*GitHub-auth-method* picker with a 5 s Esc-override and DBSP-flavored labels — a credentials-internals picker, not a
+what-do-you-want menu, and 5 s is too short to read four options.
+
+## Per-audience friction + the single highest-leverage fix (Iris, file:line grounded)
+
+| Audience | Biggest friction | Highest-leverage fix | Owner |
+|---|---|---|---|
+| **Regular folk** | no human entry path — every surface is `bun …zflash.ts --agent` + a picker labeled `gh quota`/`device-flow`/`PAT` | plain-language boot menu, `Live` as visible no-keypress default (intent+presence, not CLI, #7230) | **Addison** (wording) |
+| **Aaron + Max** | the **freshness gate bails the flash** on local WIP (`checkLocalCheckoutFreshness`, zflash.ts 166-335, bails when ahead/diverged 313-333); + re-typing nonce/passphrase every reformat loop | `zeta flash` wrapper (#7230) defaulting to `--agent` + blob-reformat path; degrade freshness **bail→warn** on the known-operator path | **Aaron/Max** |
+| **Maintainers** | flow hardwired to one identity — `ZETA_REPO_GH="Lucent-Financial-Group/Zeta"` (zflash.ts 150), `/Users/acehack/…` alias (35), `gh auth` asserted = Lucent (runbook 168) | **parameterize repo+identity from the checkout's `origin`**, not a constant; flash as *their* key from the checked-in maintainer set | **Aaron/Max** + trust owner |
+| **Forkers** | silent fork-blindness — pulls ISOs from upstream CI (343-347) + can bake **upstream** trust roots into a fork's cluster | **provenance banner** at flash + boot: `Building from <fork>/<repo>@<sha>; trust roots: <key-set>` | **Aaron/Max** + trust owner |
+
+## The remembering-on-reflash gap — sharpest for Aaron+Max (Iris)
+
+By construction the heaviest reflashers pay the re-entry tax most. Grounded: WiFi + install-answers manifest entries
+are **declared but the capture/restore wiring through the live install is NOT built** (2026-06-07 creds-persistence
+research); the runbook's own acceptance table marks **Scenario 3 "Reformat WITH key + selection retention" = ✗
+pending** (runbook 284) — exactly Aaron+Max's path. So today a reformat re-asks WiFi, re-asks answers, re-runs auth
+every loop; the "typed passphrase ONCE" demo holds only across *reboots of one install*, not across *reformats*.
+
+**Defaulted behavior to build:** blob-present reformat = **`preserve → use-before-format → format → repersist`**
+(#7010) carrying WiFi + install-answers + auth, so a reformat re-asks **nothing** except the **single passphrase
+unlock** (the decryption floor). "Keep my settings" is both option 2 **and** the timeout default when a blob is
+detected — remembering is the *default*, not an opt-in.
+
+## Handoffs
+
+- **Addison** — boot-menu wording (plain language; regular-folk UX).
+- **Aaron** — the timeout/default mechanism (context-detected countdown: 30 s safe / 10 s known-USB).
+- **Aaron/Max** — `zeta flash` wrapper + `--agent` default + freshness bail→warn; remembering round-trip wiring
+  (Scenario 3); repo+identity parameterization; provenance banner. (Pairs with Dejan per #7230.)
+- **Trust-model owner** — the maintainer/forker key-injection + provenance (verify against the trust-model doc
+  #7251 once merged — Iris noted it wasn't yet visible when she ran).
+
+## Honest scope
+
+[requirement — Aaron]: one USB, 4 audiences, right-thing-by-default, biased to Aaron+Max now. [UX — Iris, grounded]:
+context-detected no-keypress default (safe/Live silent, blob→keep-settings); per-audience friction with file:line
+evidence; remembering gap = Scenario 3 pending, hurts Aaron+Max most. [handoffs]: Addison (wording) / Aaron+Max
+(mechanics) / trust owner (keys+provenance). No code shipped; this is the routed requirements + UX surface for the
+build fronts already named (#7230 wrapper, #7251 trust model, the remember-creds + QEMU-harness plan).
+
+## Pointers
+
+- Requirement + trust: #7251 (trust model + ISO/post-ISO/boot + honest QEMU plan) · #7230 (Zeta for regular humans
+  / `zeta flash` wrapper) · #7229 (close the AI loop / QEMU enforcement).
+- Erase model + remembering: the 3-level erase / InstallMode.Live default (#7007/#7008/#7010/#7011) · the 2026-06-07
+  creds-persistence (wifi/install-answers, declared-not-wired) research · runbook Scenario 3 (✗ pending).
+- Surfaces: `full-ai-cluster/tools/zflash.ts` · `docs/runbooks/zflash-end-to-end.md` · `operator-ssh-keys.txt` +
+  `maintainers/*/ssh-pubkeys.txt` (#7249/#7250). Lenses: UX/Iris, DX/Bodhi, AX/Daya; Addison owns regular-folk UX.


### PR DESCRIPTION
Two captures for the headless / remember-by-default / right-thing-for-everyone thread.

**1. UX (Iris, file:line grounded):** one USB, 4 audiences (regular folk/Addison · Aaron+Max DX · maintainers · forkers); context-detected **no-keypress default** (safe/Live silent; blob → keep-settings); per-audience friction + the single highest-leverage fix each; remembering gap = runbook **Scenario 3 ✗ pending** (hurts Aaron+Max most); handoffs.

**2. Remember-creds ROOT CAUSE:** the blob is `HKDF(USB-UUID‖passphrase)` — bound to the **ephemeral boot-USB UUID**, so remember-across-reformat only works *same-USB*; a naive preserve carries **undecryptable** blobs. **Fix = your instinct:** rebind to a **stable hardware key** (TPM node-bound vs USB-iSerial vs UEFI-keyfile stick-bound — **one decision needed**). Plus crypto-neutral reorders: **fully headless boot + a 60s CANCEL window before format** (default proceed, any key aborts — *cancel-window, not questions*) + timeout-default prompts + check-partition-before-format. All QEMU-validated; **did not blind-edit the destructive+crypto path** (would've shipped an undecryptable-blob bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)