### PR TITLE
feat(setup): close over GPG in install.sh — gnupg in apt/brew/windows manifests (symmetric)

### DIFF
--- a/tools/setup/manifests/apt
+++ b/tools/setup/manifests/apt
@@ -82,3 +82,4 @@ r-base
 # download-then-exec shape cleanly. Linux tectonic install is therefore a BEST-EFFORT GAP pending an
 # install-graph decision (`cargo install tectonic`, or a GitHub-release extraction onto PATH) —
 # Dejan/devops call (mirrors the kiro-cli Linux gap precedent in manifests/one-liner-tools).
+gnupg           # GPG — commit/artifact signing (close-over GPG, Aaron 2026-06-09)

--- a/tools/setup/manifests/brew
+++ b/tools/setup/manifests/brew
@@ -77,3 +77,4 @@ r
 # (WebSearch 2026-06-08): brew formula `tectonic`, MIT; idempotent. Symmetric with windows
 # `tectonic` (scoop main). Linux: best-effort gap — see the NOTE in manifests/apt.
 tectonic
+gnupg  # GPG — commit/artifact signing (close-over GPG, Aaron 2026-06-09)

--- a/tools/setup/manifests/windows
+++ b/tools/setup/manifests/windows
@@ -60,3 +60,4 @@ r         winget=RProject.R    choco=R.Project
 # scoop main `tectonic` (winget has NO official package — issue #976; choco unverified — so rely on
 # scoop, the resolver-primary). MIT. `optional` (best-effort): network-bundle fetch on first run.
 tectonic    optional
+gnupg     winget=GnuPG.GnuPG    choco=gnupg    # GPG — commit/artifact signing


### PR DESCRIPTION
Aaron: "close over GPG everywhere and in install.sh." First concrete step — **gnupg added to all three manifests** (apt/brew/windows, `winget=GnuPG.GnuPG choco=gnupg`) so `install.sh`/`install.ps1` provision it on every OS. **manifest-symmetry: 9 pass / 0 fail.** Pairs with the operator-ssh-keys close-over; next: configure signing in the installer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)