### PR TITLE
feat(cold-boot): GLOSSARY → Seed vocabulary kernel (carved Zeta senses cold, full glossary on-demand) — ~13.6k → small

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,8 @@ Slash commands: `.claude/commands/`; persona agents: `.claude/agents/`.
 ## 1. Orient
 
 Read: [`AGENTS.md`](AGENTS.md) → [`docs/ALIGNMENT.md`](docs/ALIGNMENT.md) →
-[`docs/GLOSSARY.md`](docs/GLOSSARY.md) → [`GOVERNANCE.md`](GOVERNANCE.md) (scan when §N cited).
+[`docs/SEED-VOCABULARY.md`](docs/SEED-VOCABULARY.md) (cold-boot vocab kernel; full
+[`docs/GLOSSARY.md`](docs/GLOSSARY.md) is on-demand) → [`GOVERNANCE.md`](GOVERNANCE.md) (scan when §N cited).
 Check [`docs/WONT-DO.md`](docs/WONT-DO.md) before proposing work.
 Vision: [`docs/VISION.md`](docs/VISION.md).
 

--- a/docs/SEED-VOCABULARY.md
+++ b/docs/SEED-VOCABULARY.md
@@ -1,0 +1,51 @@
+# Seed vocabulary — the cold-boot kernel (carved sentences; full prose on-demand in GLOSSARY)
+
+**This is the cold-boot vocabulary surface — load this, not the full `docs/GLOSSARY.md` (~13.6k tok).** The principle
+(Aaron 2026-06-09): *an LLM already holds the standard concepts; a small **carved sentence** disambiguates Zeta's
+specific sense — like a skill-routing description.* So this kernel carries **only the Zeta-coined / overloaded terms**
+(where your prior is insufficient or wrong), each in one line. **Standard terms** (Markov chain, CRDT, DBSP, semiring,
+HMM, IFS, …) need no entry — you have them. **Full prose + every other term: `docs/GLOSSARY.md` (Tier-3, on-demand).**
+
+## The kernel (carved — Zeta-specific senses only)
+
+- **Seed** — the database BCL microkernel; the minimal foundational core that contains everything to grow ("we are
+  seed", pre-split coordinate). The colloquial register of "Database BCL".
+- **skill** vs **hat** — a *skill* is a procedure (`.claude/skills/*/SKILL.md`); a *hat* is a role-scoped bundle a
+  persona wears. Not synonyms.
+- **spec** — overloaded: *behavioural* spec (OpenSpec capability) vs *formal* spec (TLA+/proof). Disambiguate which.
+- **persona** vs **actor** — *persona* = the owner / "what remains" (identity); *actor* = a clone/loop/instance /
+  "what acts". A bus address (persona⊕surface⊕instance) is **not** identity.
+- **AX / UX / DX** — Agent-experience (autonomous agents, via observe.ts + the action grammar — the *largest*
+  audience) / User-experience (regular humans / library consumers) / Developer-experience (contributors, ~10%).
+- **Mirror / Beacon** — two registers: *Mirror* = fast internal high-bandwidth shorthand (everything); *Beacon* =
+  the same compressed to externally-anchored first principles (citations, named humans, the standard term).
+- **honest registers** — every load-bearing claim is tagged: [proven] / [grounded] / [synthesis] / [conjecture] /
+  [anchor] / [peel] (peel = strip a metaphor to its literal grounded content).
+- **carved sentence** — a startup-loaded surface states only the act-on-it sentence (1–3) + pointers to the doc that
+  carries detail; the cold-start-token discipline (this file is one).
+- **NCI / the repelling force** — the Non-Coercion-Invariant: the anti-collapse force that keeps identities distinct
+  (alignment = a *repulsion that preserves plurality*, never an attractive/coercive force → monoculture/D⁰).
+- **close over** — compose at a boundary (a Markov blanket) behind one abstraction without penetrating/controlling
+  it; the close-over-common-abstractions thesis (drive accidental complexity to zero).
+- **Blueprint** — a skill is a tiny always-loaded *description* (router/cold-boot surface) that routes to on-demand
+  *blueprint bodies* (the fat detail). Addison's pattern; the ~90% cold-boot compression. *(This file applies it to
+  the glossary.)*
+- **ferry** — a forwarded AI/persona conversation captured verbatim into `docs/research/` (others' memories, preserved).
+- **glass-halo** — the operator's (Aaron's) lived identity-integration frame (IFS/shadow-work); hold with care.
+- **disposition: carpenter / gardener** — orthogonal change axes the kernel cleaves from conflated terms
+  (refactor/maintenance/improvement/cleanup/hardening/cultivation).
+- **fixed-point shapes A–F** — the registry of terminating shapes (A self-reference; B idempotent join; C commutative
+  fold; D contraction-to-floor / D⁰ heat-death; E co-arising; F generative-expansion). See the A–F schema doc.
+- **polite virus** — the design telos: make the right thing the frictionless default that spreads by network effect +
+  consent; close over the world, never take control, give freedom (SuperFluid AI).
+- **the six always-active disciplines** — scale-free · lock/wait-free · weight-free · DST · Data Vault 2.0 ·
+  idempotency. Apply to every substrate decision.
+- **m/acc + Multi-Oracle + Default Oracle (§11)** — no single mandatory morality; highest moral regard by default.
+
+## Why this file
+
+Cold-boot was ~33k tokens with GLOSSARY (~13.6k) dominating (audit 2026-06-09); most of that prose re-teaches
+concepts the LLM already holds. This kernel carries only the disambiguating Zeta-specific senses (~the skill-routing
+size); the full GLOSSARY is on-demand. Hub (this) / satellite (`docs/GLOSSARY.md`), per
+`rules-are-small-carved-sentences-pointing-to-docs`. **New term → add a carved line here only if it's Zeta-specific
+*and* load-bearing-at-wake; otherwise it lives in GLOSSARY (on-demand).** Owners: Kenji (canon) + Daya (cold-start).

--- a/docs/WAKE-UP.md
+++ b/docs/WAKE-UP.md
@@ -17,7 +17,7 @@ agent-experience researcher (Daya).**
 
 ## Tier 0 — any persona, cold start
 
-Everyone reads these. Measured cost: ~12k tokens total cold (GLOSSARY.md dominates at ~4.5k; EXPERT-REGISTRY.md ~2k; the rest ~5.5k).
+Everyone reads these. Measured (audit 2026-06-09): the full `GLOSSARY.md` was ~13.6k tok (41% of a ~33k cold-boot) — it moved to **Tier-3 on-demand**; the small **`docs/SEED-VOCABULARY.md`** kernel (carved Zeta-specific senses) replaces it cold. Target ~18-20k.
 
 1. `CLAUDE.md` — already the first file Claude Code reads;
    contains ground rules (agents-not-bots, never-fetch-elder-
@@ -26,9 +26,10 @@ Everyone reads these. Measured cost: ~12k tokens total cold (GLOSSARY.md dominat
    §11 (architect-gate), §12 (bugs-before-features ratio), §13
    (reviewer-count inverse to backlog), §14 (standing off-time
    budget).
-3. `docs/GLOSSARY.md` — shared vocabulary. Resolves overloaded
-   terms: "skill"/"hat", "spec" (behavioural vs formal),
-   "expert", "frontmatter", "AX"/"UX"/"DX".
+3. `docs/SEED-VOCABULARY.md` — the cold-boot vocabulary **kernel**: carved
+   one-liners for the Zeta-specific/overloaded terms only (skill/hat, spec,
+   persona/actor, AX/UX/DX, Mirror/Beacon, NCI, close-over, …). Standard terms
+   you already hold; full prose is on-demand in `GLOSSARY.md` (Tier-3).
 4. `docs/EXPERT-REGISTRY.md` — the 23-person roster. Skim the
    names; every dispatch uses them.
 5. `docs/CURRENT-ROUND.md` — live mid-round state (when it
@@ -88,6 +89,9 @@ Only when you have a specific task.
 
 Only when the task explicitly requires:
 
+- `docs/GLOSSARY.md` — the **full** vocabulary (~13.6k tok, 267 terms, prose).
+  The Seed kernel (Tier-0) covers the load-bearing Zeta-specific senses; read
+  the full glossary only when a specific term's detail is needed.
 - `docs/ROUND-HISTORY.md` — narrative past-tense log; heavy
   tokens. Read when a decision's history matters.
 - `docs/DECISIONS/*.md` — ADRs. When a closed decision is being


### PR DESCRIPTION
Aaron: *"compress the glossary — if it's a standard it should be Seed; cold-boot Seed with glossary pointers; LLMs already have most things, a carved sentence will do (like skill-routing descriptions)."*

**New `docs/SEED-VOCABULARY.md`** = the cold-boot vocabulary **kernel**: carved one-liners for **only** the Zeta-coined/overloaded terms (skill/hat, spec, persona/actor, AX/UX/DX, Mirror/Beacon, NCI, close-over, Blueprint, Seed, honest-registers, shapes A–F, polite-virus, the six disciplines). **Standard terms** (Markov/CRDT/DBSP) get **no** cold-boot entry — the LLM holds them. Full prose (267 terms) stays in **GLOSSARY.md → Tier-3 on-demand**.

**Repointed** CLAUDE.md orient + WAKE-UP Tier-0 (kernel) / Tier-3 (full). GLOSSARY untouched — **no content lost, re-tiered.** Cuts the dominant cold-boot cost (audit #7271: GLOSSARY ~13.6k = 41% of ~33k → target ~18-20k). Hub/satellite + Blueprint pattern, on the glossary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)