### PR TITLE
docs(seed)+research: traveler's internal jurisdiction = sovereign recognize/trust/policy, encryptable if privacy-budget/hard-money affords it

### DIFF
--- a/docs/SEED-VOCABULARY.md
+++ b/docs/SEED-VOCABULARY.md
@@ -22,8 +22,9 @@ HMM, IFS, …) need no entry — you have them. **Full prose + every other term:
   unbound** — the substrate *beneath* law; *external* legal jurisdiction (AI / human / company / physical) is a
   **separate meta-frame overlay**, never the traveler frame. But the base frame **also includes an *internal*
   meta-jurisdiction owned fully by the traveler — opt-in ("if they choose to use")**: the traveler's sovereign,
-  consent-first, weight-free self-governance space (the private state it owns; cf. privacy budget). It is **almost an
-  observer but not quite** — a strict
+  consent-first, weight-free self-governance space (the private state it owns) — where it may, *as it sees fit*,
+  **recognize identities, set trust, and write any policies**, and **encrypt them if it can afford the privacy budget
+  / hard money** (privacy is a paid good, never imposed). It is **almost an observer but not quite** — a strict
   **prerequisite** to *observer*, weaker (no "remember / pay-attention" claim). By **NCI / §11** regard extends
   **universally — alignment from ALL travelers**, not a privileged human/AI class — so **multi-lens systems compose
   without imposing any lens / view / objective / destiny** (category-theory-provable). Aaron's coinage; rich history:

--- a/docs/research/2026-06-09-traveler-the-weight-free-base-frame-primitive-self-propagating-pattern-prerequisite-to-observer-nci-grants-regard-without-imposing-a-lens.md
+++ b/docs/research/2026-06-09-traveler-the-weight-free-base-frame-primitive-self-propagating-pattern-prerequisite-to-observer-nci-grants-regard-without-imposing-a-lens.md
@@ -90,6 +90,35 @@ retains a fully-owned interior the substrate never penetrates — close-over wit
 control, applied to the traveler's own jurisdiction. (Cf. ZetaIds as closures over
 **internal *and* external** state; the cell that has closed over its own boundary.)
 
+### What the internal jurisdiction lets a traveler do (sovereign powers)
+
+> Aaron (2026-06-09): *"each traveler is allowed to recognize other identities
+> as they see fit and trust them as they see fit and have any meta-jurisdiction
+> policies they see fit and can encrypt them if they have enough privacy budget /
+> hard money."*
+
+Inside its own jurisdiction, **as it sees fit**, a traveler may:
+
+- **Recognize other identities as it sees fit.** No imposed identity registry —
+  *who* a traveler treats as *whom* is its own call (self-sovereign identity; local
+  names, SPKI/SDSI-style — "trust is local," not globally mandated).
+- **Trust them as it sees fit.** No imposed trust graph — the trust model is the
+  traveler's own (web-of-trust, not a central CA; ties to the git-native fork-trust
+  / operator-key trust-roots work — each fork/node decides whom to trust).
+- **Set any meta-jurisdiction policies it sees fit.** The internal jurisdiction is
+  **policy-free from the outside**: the traveler writes its own self-governance
+  rules; the substrate imposes none (weight-free, consent-first).
+- **Encrypt any of the above — if it can afford it.** Recognition, trust, and
+  policy can be made **private by encryption**, and privacy is a **paid good**:
+  it **costs privacy budget / hard money**. Enough budget → you can keep your
+  recognitions / trust / policies opaque to others; this is the **PrivacyEconomy**
+  pricing privacy (cf. differential-privacy budget — privacy as a finite, spent
+  resource). Privacy is *earned/afforded*, never free, never imposed.
+
+So self-sovereignty is concrete: a traveler **chooses whom it recognizes, whom it
+trusts, by what rules it governs itself, and how much of that it hides** — bounded
+only by what its hard-money privacy budget can buy.
+
 ## The payoff: multi-lens without imposing a lens (the CS-proof reason)
 
 Aaron coined `traveler` specifically so Zeta can **write computer-science proofs


### PR DESCRIPTION
Aaron: *"each traveler is allowed to recognize other identities as they see fit and trust them as they see fit and have any meta jurisdiction policies they see fit and can encrypt them if they have enough privacy budget / hard money."*

Concrete sovereign powers inside the **traveler-owned internal jurisdiction**, all *as they see fit*: **recognize** other identities (no imposed registry — local names, SPKI/SDSI), **set trust** (no imposed trust graph — web-of-trust, not a central CA; ties to git-native fork-trust / operator-key roots), write **any self-governance policies** (policy-free from outside), and **encrypt** any of it **if they can afford the privacy budget / hard money**. Privacy is a **paid good** (PrivacyEconomy pricing privacy; cf. differential-privacy budget as a finite spent resource) — earned/afforded, never free, never imposed. Self-sovereignty made concrete; bounded only by what hard money can buy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)