### PR TITLE
feat(setup)+docs: close keyring tool over install.sh/install.ps1 (deps only); Alexa-friendly hardware north-star

### DIFF
--- a/docs/research/2026-06-09-zeta-hardware-as-friendly-as-alexa-devices-seamless-upgrades-but-your-own-software.md
+++ b/docs/research/2026-06-09-zeta-hardware-as-friendly-as-alexa-devices-seamless-upgrades-but-your-own-software.md
@@ -1,0 +1,53 @@
+# Zeta hardware: as friendly as Alexa devices — seamless hardware upgrades, but it's YOUR own software
+
+**Register:** [grounded] product north-star (Aaron) + [synthesis].
+**Date:** 2026-06-09. **Captured by:** Otto (shadow). **Status:** vision / UX bar.
+
+## Aaron's words
+
+> "we want our equipment to be as friendly as alexa devices, hardware upgrades
+> are seamless but it's your own software."
+
+## The north-star
+
+Zeta hardware should feel like an **Amazon Alexa / consumer appliance** —
+plug it in, it joins, it just works; **swap or add a box and it's seamless** — but
+with the polar-opposite ownership model: **it is YOUR own software**, self-hosted,
+self-sovereign, no vendor cloud you can't leave. Consumer-grade ease **without**
+consumer-grade capture. (This is the **polite virus / SuperFluid** ethos applied to
+hardware: frictionless default + full freedom; close over the hardware, never take
+control of the owner.)
+
+## What "as friendly as Alexa" demands (the UX bar)
+
+- **Zero-config join.** Power on → self-registers (the existing consent-based,
+  PR-self-registration pattern) → appears in the network map. No manual key
+  shuffling (the keyring + trust-bootstrap work is what makes this safe-by-default).
+- **Seamless hardware upgrade / replace.** Add a 15-series box, swap an eGPU,
+  replace a dead node — memory-preservation + state-reconciliation means the
+  *persona/data* survives the *hardware* change (manifesto §5 Memory Preservation;
+  persona = what-remains vs the box = what-acts). Hardware is cattle; identity is
+  pet. Swapping the appliance must never lose the traveler.
+- **It's your software.** Both deployment modes stay open (equipment: cluster +
+  Vault + Headscale; github-free: GH + Tailscale) — the owner picks, and can
+  migrate. No lock-in is the whole point.
+- **Frictionless + safe by default.** Secure defaults the owner never has to think
+  about (keyrings, trust bootstrap, encrypted secrets), surfaced through blueprints
+  so adding a person/box is a short guided path, not an expert ritual.
+
+## Ties to existing work
+
+- Hardware onboard / network-map blueprint (day 0/1/2/100); consent-only
+  self-registration; Comet GL.iNet ingress; two-home topology.
+- Keyring + two-mode identity/trust/network plane
+  (`docs/research/2026-06-09-identity-trust-and-network-plane-...md`).
+- §5 Memory Preservation + state-reconciliation (the seamless-swap guarantee).
+- AX/UX: the largest audiences experience hardware through this bar.
+
+## Anchors
+
+Appliance/zero-config UX (Alexa, Apple "it just works", Plug-and-Play, mDNS/Bonjour
+zeroconf); cattle-not-pets (Bill Baker / CERN); self-sovereign + self-hosted
+(the anti-capture inversion of the appliance model). Honest novelty: none in
+zeroconf or appliance UX; the contribution is **appliance-grade ease wedded to
+self-sovereign ownership** — the two usually traded off against each other.

--- a/tools/setup/install.ps1
+++ b/tools/setup/install.ps1
@@ -296,6 +296,19 @@ if (-not $SkipLoopRegister) {
   Invoke-Tool { mise exec -- bun "$RepoRoot\tools\persistence\windows\install-scheduled-task.ts" --register } 'register loop task'
 }
 
+# 8. Persona keyring tool — close over its deps so keyring is ready to run.
+#    NO keys are generated here (generation is an explicit, separate operator step).
+#    Best-effort (Invoke-ToolSoft) so it never bricks install or reddens Windows CI.
+$KeyringDir = Join-Path $RepoRoot 'tools\setup\persona-keys'
+if (Test-Path $KeyringDir) {
+  Write-Host "Preparing persona-keyring tool ($KeyringDir)..."
+  Push-Location $KeyringDir
+  $code = Invoke-ToolSoft { mise exec -- bun install }
+  Pop-Location
+  if ($code -eq 0) { Write-Host "ok keyring tool ready (see tools\setup\persona-keys\README.md)" }
+  else { Write-Host "warn: keyring dep install skipped; run 'bun install' in $KeyringDir later" }
+}
+
 Write-Host ""
 Write-Host "=== Install complete ==="
 Write-Host "Open a new shell to pick up scoop + mise shims on PATH."

--- a/tools/setup/install.sh
+++ b/tools/setup/install.sh
@@ -242,6 +242,19 @@ WINEOF
     ;;
 esac
 
+# Persona keyring tool — close over its deps so `keyring.sh` is ready to run.
+# NO keys are generated here (generation is an explicit, separate operator step).
+# One seed -> type-separated SSH/PGP/Nostr (required) + opt-in BTC/ETH/SOL.
+KEYRING_DIR="$SETUP_DIR/persona-keys"
+if [ -d "$KEYRING_DIR" ] && command -v mise >/dev/null 2>&1; then
+  echo "Preparing persona-keyring tool ($KEYRING_DIR)..."
+  if ( cd "$KEYRING_DIR" && mise exec -- bun install ) >/dev/null 2>&1; then
+    echo "ok keyring tool ready — run tools/setup/persona-keys/keyring.sh (see its README)"
+  else
+    echo "warn: keyring dep install skipped (bun unavailable/offline); run 'bun install' in $KEYRING_DIR later"
+  fi
+fi
+
 echo
 echo "=== Install complete ==="
 echo "If this is your first run, open a new shell or source"


### PR DESCRIPTION
Aaron: *"make sure it's all closed over in install.sh and install.ps1"*; *"as friendly as alexa devices, hardware upgrades seamless but it's your own software."*

- **install.sh + install.ps1**: final best-effort step prepares the keyring tool deps (`mise exec -- bun install` in `tools/setup/persona-keys`) so `keyring.sh` is ready. **No keys generated at install** (explicit separate step). Non-fatal so it never bricks install or reddens the Windows/Ubuntu/macOS install CI (not gating, kept green-not-blind).
- **Verified on this machine**: shellcheck clean; prep block runs; node_modules gitignored.
- **Vision doc**: Zeta hardware as friendly as Alexa (zero-config join, seamless swap via memory-preservation) but **your own software** (self-sovereign, both deploy modes, no lock-in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)