### PR TITLE
refactor(setup): install.sh/ps1 know nothing about personas; keyring self-bootstraps; declarative ace-package is the target

### DIFF
--- a/docs/research/2026-06-09-declarative-keyring-as-an-ace-package-install-sh-stays-persona-agnostic-static-deps-graph-closes-over-everything.md
+++ b/docs/research/2026-06-09-declarative-keyring-as-an-ace-package-install-sh-stays-persona-agnostic-static-deps-graph-closes-over-everything.md
@@ -1,0 +1,62 @@
+# Declarative keyring as an `ace` package: install.sh stays persona-agnostic; a static deps graph closes over everything by naming nothing
+
+**Register:** [grounded] architecture decision (Aaron's critique) + honest self-review.
+**Date:** 2026-06-09. **Captured by:** Otto (shadow). **Status:** decision + target;
+the decoupling (install.sh revert) is done, the ace-package refactor is intentional debt.
+
+## Aaron's critique (verbatim)
+
+> "tools/setup/persona-keys/ — is this declarative and closed over or a bunch of
+> imperative mess?"  · "ace package manager needs a full deps graph in code"  ·
+> "so we can close over with static deps graph — why does install.sh need to know
+> anything about personas?"  · "maybe it does — i'm just asking."
+
+## Honest self-review (Rune/Kira lens on my own work)
+
+- **Current state is imperative.** `keyring.sh` is a bash wrapper orchestrating a
+  procedural `gen.ts`; deps are bun `package.json`, not ace. It works and is
+  **verified** (ETH derivation checked against `cast`), but it is **not**
+  declarative and **not** closed over by ace.
+- **The install.sh hook was a coupling smell.** Adding a `persona-keys`-named
+  block to `install.sh`/`install.ps1` made the universal installer know about
+  personas — exactly the imperative coupling Aaron flagged. It was also
+  **redundant**: `keyring.sh` self-bootstraps its deps on first run. **Reverted.**
+
+## The answer: install.sh should know NOTHING about personas
+
+The keyring is a **package**, not an installer special-case. Its deps + key-type
+derivations belong in **`ace`'s static deps graph** (`tools/ace/` — Zeta's signed
+DLC package manager: dep edges `{name,version}`, a z3/SAT `solve()`, lockfiles,
+content-hashing, trust/signing). Then:
+
+- `ace` resolves the **whole** graph (every package, pinned + signed + locked).
+- the installer runs `ace sync` **generically** — it closes over *everything* by
+  naming *nothing*. No `persona-keys`, no `keyring`, no persona names in install.sh.
+- "why does install.sh need to know about personas?" → **it doesn't.** A static
+  deps graph is the closure; the installer is just its driver.
+
+This is the **"everything is a verb-noun-dependsOn statement"** thesis
+(`docs/research/2026-06-07-everything-is-a-short-context-aware-seam-verb-noun-dependson-statement-aaron.md`)
+applied to setup: the keyring is nodes (crypto primitives + each derivation) with
+`dependsOn` edges; ace is the solver; install is the fold over the resolved graph.
+
+## Plan
+
+1. **Decouple install.sh / install.ps1 from personas** — DONE (reverted the hook;
+   `keyring.sh` self-bootstraps deps on first run as the bridge).
+2. **Publish the keyring as an `ace` package** (intentional debt) — declare its
+   deps graph in code (the @noble/@scure/micro-key-producer pins as dep edges;
+   the six derivations as nodes), sign + content-hash + lockfile it. This would be
+   the **first real `ace` package** (`registry.json` is currently empty), so it
+   needs care + Dejan/Aaron review — hence debt, not a rushed land.
+3. **Installer closes over `ace` generically** — once packages live in ace, the
+   installer drives `ace` and names nothing app-specific.
+
+## Pointers
+
+- `tools/ace/` — the package manager (B-0288): `solver.ts` (z3), `resolve.ts`,
+  `lockfile.ts`, `signing.ts`, `store.ts`, `registry.json` (empty today).
+- `tools/setup/persona-keys/` — the (working, verified, imperative) tool to be
+  refactored into an ace package.
+- Verb-noun-dependsOn thesis; the keyring/two-mode plane doc; the traveler frame
+  (the keys are travelers' identity material).

--- a/tools/setup/install.ps1
+++ b/tools/setup/install.ps1
@@ -296,19 +296,6 @@ if (-not $SkipLoopRegister) {
   Invoke-Tool { mise exec -- bun "$RepoRoot\tools\persistence\windows\install-scheduled-task.ts" --register } 'register loop task'
 }
 
-# 8. Persona keyring tool — close over its deps so keyring is ready to run.
-#    NO keys are generated here (generation is an explicit, separate operator step).
-#    Best-effort (Invoke-ToolSoft) so it never bricks install or reddens Windows CI.
-$KeyringDir = Join-Path $RepoRoot 'tools\setup\persona-keys'
-if (Test-Path $KeyringDir) {
-  Write-Host "Preparing persona-keyring tool ($KeyringDir)..."
-  Push-Location $KeyringDir
-  $code = Invoke-ToolSoft { mise exec -- bun install }
-  Pop-Location
-  if ($code -eq 0) { Write-Host "ok keyring tool ready (see tools\setup\persona-keys\README.md)" }
-  else { Write-Host "warn: keyring dep install skipped; run 'bun install' in $KeyringDir later" }
-}
-
 Write-Host ""
 Write-Host "=== Install complete ==="
 Write-Host "Open a new shell to pick up scoop + mise shims on PATH."

--- a/tools/setup/install.sh
+++ b/tools/setup/install.sh
@@ -242,19 +242,6 @@ WINEOF
     ;;
 esac
 
-# Persona keyring tool — close over its deps so `keyring.sh` is ready to run.
-# NO keys are generated here (generation is an explicit, separate operator step).
-# One seed -> type-separated SSH/PGP/Nostr (required) + opt-in BTC/ETH/SOL.
-KEYRING_DIR="$SETUP_DIR/persona-keys"
-if [ -d "$KEYRING_DIR" ] && command -v mise >/dev/null 2>&1; then
-  echo "Preparing persona-keyring tool ($KEYRING_DIR)..."
-  if ( cd "$KEYRING_DIR" && mise exec -- bun install ) >/dev/null 2>&1; then
-    echo "ok keyring tool ready — run tools/setup/persona-keys/keyring.sh (see its README)"
-  else
-    echo "warn: keyring dep install skipped (bun unavailable/offline); run 'bun install' in $KEYRING_DIR later"
-  fi
-fi
-
 echo
 echo "=== Install complete ==="
 echo "If this is your first run, open a new shell or source"

--- a/tools/setup/persona-keys/README.md
+++ b/tools/setup/persona-keys/README.md
@@ -62,6 +62,20 @@ keyring.sh generate otto --gh-secret ZETA_PERSONA_OTTO_KEYRING
 keyring.sh import aaron --public-only --out maintainers/aaron
 ```
 
-Closed over in `tools/setup/install.sh` + `install.ps1` (bun + deps + this tool).
+## Closure: self-bootstrapping deps, NOT an install.sh special-case
+
+`keyring.sh` installs its own deps on first run (`[ -d node_modules ] || bun
+install`), so **`install.sh` does NOT need to know this tool exists** — it stays
+persona-agnostic (Aaron 2026-06-09: *"why does install.sh need to know anything
+about personas?"*). No imperative coupling in the installer.
+
+**Declarative target (the right closed-over form):** this tool's deps belong in
+**`ace`'s static deps graph** (Zeta's signed DLC package manager — `tools/ace/`:
+dep edges + z3 solver + lockfile + content-hash + trust), so `ace` resolves the
+whole graph generically and the installer closes over *everything* by naming
+*nothing*. Until this is published as an ace package, first-run self-bootstrap is
+the bridge. See `docs/research/2026-06-09-declarative-keyring-as-an-ace-package-...md`.
+
 Anchors: BIP-39/32/44, BIP-84, SLIP-0010, NIP-06; `@noble`/`@scure`/`micro-key-producer`
-(audited, Paul Miller); Vault, External-Secrets, cert-manager, spire (cluster).
+(audited, Paul Miller); Vault, External-Secrets, cert-manager, spire (cluster);
+`ace` (Zeta DLC package manager, B-0288).


### PR DESCRIPTION
Aaron: *"is this declarative and closed over or a bunch of imperative mess? ... why does install.sh need to know anything about personas?"* — he's right.

**Reverted** the persona-keys block I added to install.sh + install.ps1 (#7285): it was imperative **coupling** (universal installer naming 'personas') *and* **redundant** (`keyring.sh` self-bootstraps deps on first run). Installers are persona-agnostic again (shellcheck + ps1-parse clean).

**Target (captured as intentional debt):** publish the keyring as an **`ace` package** (signed DLC pkg mgr: dep edges + z3 solver + lockfile + trust). Then ace resolves the whole static deps graph and the installer **closes over everything by naming nothing** — the verb-noun-dependsOn thesis applied to setup. `registry.json` is empty today, so this is the first real ace package → needs care + review (debt, not rushed).

Honest: the tool works + is verified, but it's imperative; the ace-package form is the declarative one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)