### PR TITLE
feat(setup): keyring critical-infra — byte-lock golden vectors (4lang×4serializer point of certainty) + key status + human anchor (GitHub+FIDO)

### DIFF
--- a/docs/research/2026-06-09-keyring-critical-infra-4lang-4serializer-byte-lock-key-status-and-human-anchor-github-plus-fido.md
+++ b/docs/research/2026-06-09-keyring-critical-infra-4lang-4serializer-byte-lock-key-status-and-human-anchor-github-plus-fido.md
@@ -1,0 +1,78 @@
+# Keyring as critical infra: 4lang×4serializer byte-lock (a 4×4 point of certainty), key status (test→self-custody), and human anchor (GitHub + FIDO/WebAuthn/Windows Hello)
+
+**Register:** [grounded] design (Aaron) + [synthesis]. **Date:** 2026-06-09.
+**Captured by:** Otto (shadow). **Status:** byte-lock seed + TS oracle + status
+marking landed; the other oracles/serializers + the FIDO anchor ceremony are the
+follow-on (intentional debt).
+
+## Aaron's words
+
+> "we need code around all this 4lang treat code bit perfect stuff cause this is
+> critical infrastructure" · "it's one of our 4x4 points of certainty
+> markov/homeostat chains" · "4langx4serializer" · "can you mark keys you generate
+> as test until they are rotated and somehow the human anchors themselves to
+> github and some biometrics or windows hello or fido... github is our first trust
+> anchor/bootstrap of trust."
+
+## 1. A 4×4 point of certainty — bit-perfect byte-lock
+
+Key derivation is **critical infrastructure**, so it is a **point of certainty**
+(deterministic SolidGround) in the otherwise-soft markov/homeostat system, and it
+must hold across the **4×4 grid: 4 language oracles × 4 serializers**:
+
+| | JSON | CBOR | Arrow | protobuf |
+|---|---|---|---|---|
+| **TS** (bun) | ✅ landed | ◻ | ◻ | ◻ |
+| **F#/.NET** | ◻ | ◻ | ◻ | ◻ |
+| **C#** | ◻ | ◻ | ◻ | ◻ |
+| **Rust** | ◻ | ◻ | ◻ | ◻ |
+
+- **Byte-lock seed:** `tools/setup/persona-keys/golden-vectors-keyring.json` — a
+  known BIP-39 test seed → exact public outputs, **text/hex-in-JSON** (per
+  `.claude/rules/no-binary-in-proof-lineage.md`: diffable, DST-replayable,
+  human-auditable; never a binary blob). The test seed is the publicly-known
+  vector (funds swept instantly), safe to commit.
+- **Conformance:** every cell of the grid MUST reproduce `expected` **bit-perfect**
+  from `input`. `gen.test.ts` is the **TS×JSON** cell (passing: deep-equal +
+  determinism). The remaining 15 cells are the conformance matrix to fill (kin:
+  the existing `golden-vectors-*.json` for cbor/arrow/merkle; B-0982 four-oracle
+  multi-format seed doctrine).
+- **Culture-invariant:** ordinal/byte-perfect throughout (per
+  `.claude/rules/culture-invariant-by-default.md`) — required for 4-lang byte-lock.
+
+## 2. Key status — test until rotated
+
+`keyring-public.json` now carries **`status`**:
+
+- **`bootstrap-test`** — Otto ran `generate`; **the human does not hold the seed**
+  (it's in the sink). Provisional — *treat as test*.
+- **`self-custody`** — the human ran `rotate` (or `import`) with a seed **they
+  hold** (metal/physical). The real, trusted state.
+
+Generate-then-rotate: bootstrap keys start `bootstrap-test`; rotation promotes them
+to `self-custody`. Downstream trust consumers should distinguish the two.
+
+## 3. Human anchor — GitHub (first trust root) + FIDO/WebAuthn/Windows Hello
+
+`keyring-public.json.anchors` records how the **human is bound** to the keyring:
+
+- **GitHub — the first trust anchor / bootstrap of trust.** Who can merge the
+  pubkeys to `main` is the current root; the maintainer's GitHub identity is the
+  anchor we already have.
+- **FIDO / WebAuthn / Windows Hello — biometric/hardware anchor.** A passkey /
+  platform authenticator (Touch ID, Windows Hello, a FIDO2 key) binds the keyring
+  to a real present human. Recorded at **rotate/anchor time** (the `anchors.fido_webauthn`
+  field). This is the step that turns "a keyring exists" into "this keyring is
+  *that human*."
+
+The anchor ceremony (run a WebAuthn registration, store the credential id +
+attestation in `anchors`, optionally require it to authorize rotation) is the
+follow-on; the schema field is in place now so the data has a home.
+
+## Pointers
+
+- `tools/setup/persona-keys/{gen.ts,keyring.sh,golden-vectors-keyring.json,gen.test.ts,README.md}`.
+- Rules: `no-binary-in-proof-lineage`, `culture-invariant-by-default`; B-0982
+  four-oracle multi-format golden-vector seeds; the existing `golden-vectors-*.json`.
+- Trust bootstrap = GitHub/main (the identity-trust-network-plane doc); SolidGround
+  / points-of-certainty (the Seed kernel); the traveler frame (whose identity these keys are).

--- a/tools/setup/persona-keys/.gitignore
+++ b/tools/setup/persona-keys/.gitignore
@@ -9,3 +9,4 @@ bun.lockb
 *.nsec
 id_*
 !*.pub
+!golden-vectors-keyring.json

--- a/tools/setup/persona-keys/README.md
+++ b/tools/setup/persona-keys/README.md
@@ -21,6 +21,25 @@ decentralized-identity layer, required even if you never touch money.
 **Tier 2 (opt-in, economic freedom):** BTC + ETH + SOL wallets. Generating
 unfunded wallet keys is reversible; **only funding is irreversible.**
 
+## Critical infra: byte-lock (4 langs × 4 serializers) + key status + human anchor
+
+Key derivation is **critical infrastructure** and **a point of certainty in the
+4×4 grid** (4 language oracles × 4 serializers) — a deterministic SolidGround in
+the markov/homeostat chains. So:
+
+- **Byte-lock golden vector** — `golden-vectors-keyring.json` pins a known test
+  seed → exact public outputs (text/hex-in-JSON, per `no-binary-in-proof-lineage`:
+  diffable, DST-replayable, human-auditable). **Every oracle (TS now; F#/C#/Rust
+  next) × serializer (JSON now; CBOR/Arrow/protobuf next) must reproduce it
+  bit-perfect.** `gen.test.ts` is the TS oracle's conformance test (passing).
+- **Key status** — `keyring-public.json` carries `status`: `bootstrap-test`
+  (Otto generated it; the human does NOT hold the seed — provisional) →
+  `self-custody` after the human `rotate`s to a seed they hold. Treat
+  `bootstrap-test` keys as test until rotated.
+- **Human anchor** — `anchors`: the human is anchored to **GitHub (the first trust
+  root)** + a **FIDO/WebAuthn/Windows Hello** biometric credential, recorded at
+  rotate/anchor time.
+
 ## Security invariants
 
 1. **The seed phrase is never a CLI argument** (ps / shell history would capture

--- a/tools/setup/persona-keys/gen.test.ts
+++ b/tools/setup/persona-keys/gen.test.ts
@@ -1,0 +1,33 @@
+// Keyring derivation conformance — the TS oracle must reproduce the golden-vector
+// byte-lock BIT-PERFECT from the fixed test seed. This is the first of the 4x4
+// (4 language oracles x 4 serializers) points of certainty; F#/C#/Rust + CBOR/
+// Arrow/protobuf oracles must assert against the SAME `expected` block.
+// Run: bun test (from tools/setup/persona-keys)
+import { test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const gv = JSON.parse(readFileSync(new URL("./golden-vectors-keyring.json", import.meta.url), "utf8"));
+
+test("TS oracle reproduces the keyring golden vector bit-perfect", async () => {
+  const proc = Bun.spawn(
+    ["bun", new URL("./gen.ts", import.meta.url).pathname, "--user", gv.input.user, "--public-only"],
+    { stdin: new TextEncoder().encode(gv.input.mnemonic), stdout: "pipe" },
+  );
+  const out = JSON.parse(await new Response(proc.stdout).text());
+  await proc.exited;
+  // deep byte-lock: the entire public surface must match the golden vector exactly
+  expect(out).toEqual(gv.expected);
+});
+
+test("derivation is deterministic across runs (same seed -> same output)", async () => {
+  const run = async () => {
+    const p = Bun.spawn(
+      ["bun", new URL("./gen.ts", import.meta.url).pathname, "--user", "zeta", "--public-only"],
+      { stdin: new TextEncoder().encode(gv.input.mnemonic), stdout: "pipe" },
+    );
+    const t = await new Response(p.stdout).text();
+    await p.exited;
+    return t;
+  };
+  expect(await run()).toBe(await run()); // byte-identical
+});

--- a/tools/setup/persona-keys/golden-vectors-keyring.json
+++ b/tools/setup/persona-keys/golden-vectors-keyring.json
@@ -1,0 +1,57 @@
+{
+  "_meta": {
+    "purpose": "keyring derivation byte-lock \u2014 a point of certainty in the 4x4 (4 language oracles x 4 serializers) markov/homeostat grid; deterministic SolidGround for critical-infra key derivation",
+    "rule": "no-binary-in-proof-lineage (text/hex-in-JSON, diffable, DST-replayable, human-auditable)",
+    "discipline": "culture-invariant ordinal; one BIP-39 seed -> every key type on its own path (no bleed)",
+    "oracles_target": [
+      "TS (bun, this impl)",
+      "F#/.NET",
+      "C#",
+      "Rust"
+    ],
+    "serializers_target": [
+      "JSON (this)",
+      "CBOR",
+      "Arrow",
+      "protobuf"
+    ],
+    "conformance": "every oracle x serializer MUST reproduce `expected` byte-identical from `input`"
+  },
+  "input": {
+    "mnemonic": "test test test test test test test test test test test junk",
+    "note": "publicly-known BIP-39 test vector \u2014 funds on it are swept instantly; safe to commit",
+    "user": "zeta",
+    "created_epoch": 1749427200
+  },
+  "expected": {
+    "user": "zeta",
+    "ssh": {
+      "public": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL+Nk5Wv7HriB88qVFjFPENR4PftSzInfyeHA7t7ch3N zeta@lucent.financial",
+      "fingerprint": "SHA256:4y5hlNVH4mph1fNTvGpKZox1Hue9i9VYIRpvSgmX2D0",
+      "path": "m/44'/1110'/0'/0'"
+    },
+    "pgp": {
+      "keyId": "55945951194599cb",
+      "fingerprint": "c562fd4e2ae767b225cb35d455945951194599cb",
+      "public": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmDMEaEYkABYJKwYBBAHaRw8BAQdAcUdatO7MFcHRpmusFUDm7wGgIPdXQUj2CObT\nzK1P4gq0HHpldGEgPHpldGFAbHVjZW50LmZpbmFuY2lhbD6IlAQTFgoAPBYhBMVi\n/U4q52eyJcs11FWUWVEZRZnLBQJoRiQAAhsDBQsJCAcCAyICAQYVCgkICwIEFgID\nAQIeBwIXgAAKCRBVlFlRGUWZy8kMAP9nKM4BqNQYKNvNX74T5C0SRNiP27KojiMz\nJDlCp/XFDQEA81I5dVQNDnfqswd4o3wIVSOWHnwxFynDzUhSYiWn3g64OARoRiQA\nEgorBgEEAZdVAQUBAQdAPN7w0ECJ7Neot0EnpingxG3w+0q5j0i/JcwlkQ9DBnID\nAQgHiHgEGBYKACAWIQTFYv1OKudnsiXLNdRVlFlRGUWZywUCaEYkAAIbDAAKCRBV\nlFlRGUWZy/BCAP9SYN5MxZrgJ5LEPjGllqEBEdIk5G2Wtl7gg8D/uwE2qAD9Flw6\n+XV9gH1DNu7mlhMMHnVb31BVyFsKV1crVr+xZAg=\n=sYiK\n-----END PGP PUBLIC KEY BLOCK-----\n",
+      "path": "m/44'/1111'/0'/0'"
+    },
+    "nostr": {
+      "npub": "npub14w78q0d6gmg7yg5kl5mky0vuxsgf3kdf9e42lfezhp6lr3hwypmsa2rs4g",
+      "pub_hex": "abbc703dba46d1e22296fd37623d9c341098d9a92e6aafa722b875f1c6ee2077",
+      "path": "m/44'/1237'/0'/0/0"
+    },
+    "eth": {
+      "address": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+      "path": "m/44'/60'/0'/0/0"
+    },
+    "btc": {
+      "address": "bc1q4qw42stdzjqs59xvlrlxr8526e3nunw7mp73te",
+      "path": "m/84'/0'/0'/0/0"
+    },
+    "sol": {
+      "address": "oeYf6KAJkLYhBuR8CiGc6L4D4Xtfepr85fuDgA9kq96",
+      "path": "m/44'/501'/0'/0'"
+    }
+  }
+}

--- a/tools/setup/persona-keys/keyring.sh
+++ b/tools/setup/persona-keys/keyring.sh
@@ -106,22 +106,37 @@ case "$mode" in
 esac
 
 # ---- public artifacts -> maintainers/<name>/ (safe to commit; the trust root) ----
+# Status: `generate` keys are BOOTSTRAP/test (Otto holds the seed) until the human
+# `rotate`s to a self-held seed -> `self-custody`. `import` = self-custody (own seed).
+case "$mode" in
+  generate) status="bootstrap-test" ;;   # provisional until rotated
+  rotate|import) status="self-custody" ;;
+esac
 dest="${out_dir:-$REPO/maintainers/$name}"
 mkdir -p "$dest"
-python3 - "$tmp" "$dest" "$name" <<'PY'
+python3 - "$tmp" "$dest" "$name" "$status" <<'PY'
 import json,sys,os
-d=json.load(open(sys.argv[1])); dest,name=sys.argv[2],sys.argv[3]
+d=json.load(open(sys.argv[1])); dest,name,status=sys.argv[2],sys.argv[3],sys.argv[4]
 open(os.path.join(dest,"ssh-pubkeys.txt"),"w").write(d["ssh"]["public"].rstrip()+f"  {name}@lucent.financial\n")
 open(os.path.join(dest,"gpg-pubkey.asc"),"w").write(d["pgp"]["public"])
-open(os.path.join(dest,"keyring-public.json"),"w").write(json.dumps({
+# preserve any human anchors already recorded (github/fido) across re-runs
+pubpath=os.path.join(dest,"keyring-public.json")
+prior={}
+try: prior=json.load(open(pubpath))
+except Exception: pass
+anchors=prior.get("anchors") or {"github":None,"fido_webauthn":None,
+  "note":"human anchor: GitHub (first trust root) + FIDO/WebAuthn/Windows Hello; recorded at rotate/anchor time"}
+open(pubpath,"w").write(json.dumps({
   "user":name,
+  "status":status,                       # bootstrap-test (unrotated) | self-custody
   "ssh_fingerprint":d["ssh"]["fingerprint"],
   "pgp":{"keyId":d["pgp"]["keyId"],"fingerprint":d["pgp"]["fingerprint"]},
   "nostr_npub":d["nostr"]["npub"],
   "eth":d["eth"]["address"],"btc":d["btc"]["address"],"sol":d["sol"]["address"],
-  "paths":{k:d[k]["path"] for k in ("ssh","pgp","nostr","eth","btc","sol")}
+  "paths":{k:d[k]["path"] for k in ("ssh","pgp","nostr","eth","btc","sol")},
+  "anchors":anchors
 },indent=2)+"\n")
-print(f"public artifacts -> {dest}")
+print(f"public artifacts -> {dest}  [status={status}]")
 PY
 
 # ---- private bits -> a sink (never stdout/history) ----


### PR DESCRIPTION
Aaron: *"we need code around all this 4lang treat code bit perfect... critical infrastructure"*; *"one of our 4x4 points of certainty markov/homeostat chains"*; *"4langx4serializer"*; *"mark keys you generate as test until rotated"*; *"human anchors to github and biometrics/windows hello/fido... github is our first trust anchor."*

- **Byte-lock:** `golden-vectors-keyring.json` pins a known test seed → exact public outputs (text/hex-in-JSON, `no-binary-in-proof-lineage`). `gen.test.ts` = the **TS oracle** conformance cell (deep-equal + determinism, **2/2 pass**). Framed as the **4×4 grid** (4 oracles × 4 serializers; TS×JSON landed, 15 cells to fill) — a **point of certainty / SolidGround** in the markov/homeostat chains.
- **Key status:** `keyring-public.json.status` = `bootstrap-test` (Otto generated; human doesn't hold seed) → `self-custody` (after rotate/import). Treat bootstrap-test as test until rotated.
- **Human anchor:** `anchors` = {GitHub (first trust root), FIDO/WebAuthn/Windows Hello}, recorded at rotate/anchor time (schema in place; ceremony is follow-on).

shellcheck + markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)