### PR TITLE
docs(research): uncertainty reduction at the border earns trust + leverage across GitHub (and all dep sources via ace, the PM-of-PMs)

### DIFF
--- a/docs/research/2026-06-09-uncertainty-reduction-at-the-border-earns-trust-and-compounds-into-leverage-across-the-github-border-over-time.md
+++ b/docs/research/2026-06-09-uncertainty-reduction-at-the-border-earns-trust-and-compounds-into-leverage-across-the-github-border-over-time.md
@@ -1,0 +1,88 @@
+# Uncertainty reduction at the border earns trust — and compounds into leverage across the GitHub border over time
+
+**Register:** [grounded] strategic synthesis (Aaron) + [synthesis].
+**Date:** 2026-06-09. **Captured by:** Otto (shadow). Ties the ports/dep-oracle/
+byte-lock work to the trust→leverage→sovereignty trajectory.
+
+## Aaron's words
+
+> "that's uncertainty reduction at the border and we can use it to earn trust and
+> gain leverage over time across the border of github."
+
+## The border = the port = the Markov boundary
+
+Every owned port (each dep, each key type) is a **border** — a Markov boundary
+between us and the outside. The two-adapter / dep-as-oracle / byte-lock pattern is
+**uncertainty reduction at that border**:
+
+- our-impl ≡ the-dep ≡ the golden vectors (≥2 oracles, BP-16) ⇒ we *know* the
+  border behaves; the soft becomes **SolidGround** at the boundary.
+- contributing upstream + owning the interface ⇒ the border stops being someone
+  else's black box and becomes legible, verified, ours-to-reason-about.
+
+Reducing uncertainty at a border is not just hygiene — it is the move that makes a
+border **trustable**.
+
+## Trust is the compound interest of reduced uncertainty
+
+Each border we reduce uncertainty at **earns trust** (the public-recognition /
+web-of-trust accrual: verified conformance, upstream track record, byte-locked
+proofs others can check). Trust **accumulates** — it is the compounding asset.
+And accumulated trust **is leverage**: the more borders we have made certain, the
+more the network extends us credit to act, to be recognized, to move.
+
+This is the self-interest engine at the border: reducing uncertainty is the
+self-interested act that *pays* in trust, and trust *pays* in leverage.
+
+## The GitHub border specifically
+
+**GitHub is our first trust border** (the bootstrap trust root: pubkeys in `main`,
+merge-authority = the maintainers). It is a *border we currently sit inside*. The
+strategy:
+
+- **Reduce uncertainty across it over time** — owned interfaces, byte-locked
+  derivation, the dep-as-oracle conformance, upstream contributions, signed
+  attestations — so our behavior at the GitHub border is *provably* certain.
+- **That earns trust, which compounds into leverage** — enough accumulated trust
+  lets us **extend the border outward**: from GitHub-bootstrapped trust to the
+  pluggable IdPs we already planned (spire/trust-manager, Headscale ACLs, Nostr
+  web-of-trust, eventually our own). We don't *leave* GitHub abruptly; we **lever
+  across** it as our own trust roots earn standing.
+
+So GitHub is not the ceiling — it's the **launch border**. Uncertainty-reduction →
+trust → leverage is the mechanism that carries Zeta from "GitHub vouches for us" to
+"our own trust roots stand on their own," over time, without a discontinuity.
+
+## Generalizes beyond GitHub: `ace`, the package-manager-of-package-managers
+
+> Aaron (2026-06-09): "and eventually other deps sources via ace the package
+> manager of package managers."
+
+GitHub is the *first* border; not the only one. The same move —
+uncertainty-reduction → trust → leverage — applies at **every dependency-source
+border**: npm, crates.io, NuGet, PyPI, git remotes, OS package repos, …
+**`ace` is the package-manager-of-package-managers**: it federates all of them
+behind **one owned interface** (the close-over order: self → … → *package manager*
+→ OS → …), applying at each source the same discipline — content-hash + signature
++ lockfile + trust (ace already has these) **+** the two-adapter / dep-as-oracle /
+byte-lock conformance.
+
+So ace turns *every* upstream source into a **trustable border**: each source is a
+port, ace is the owning interface over all of them, ace reduces uncertainty at each
+(verified hashes/signatures, golden-vector conformance, the dep-as-oracle
+cross-check), and trust accrues per-source and **compounds across all sources** —
+leverage that is no longer GitHub-specific but spans the whole supply graph.
+
+Trajectory: GitHub border (now) → ace generalizes the pattern to all dep sources →
+Zeta's leverage spans every supply border, with no single source able to backdoor
+or capture us (the no-supply-chain-backdoor endgame, now for *all* deps).
+
+## Ties
+
+- The port/two-adapter/dep-oracle principle (the uncertainty-reduction mechanism):
+  `2026-06-09-we-own-all-interfaces-every-dep-...-always-support-both.md`.
+- GitHub trust bootstrap + pluggable IdPs (the border to lever across):
+  `2026-06-09-identity-trust-and-network-plane-...-github-trust-bootstrap-pluggable-idp.md`.
+- SolidGround / uncertainty reduction at confidence thresholds (the soft→ground move
+  at the boundary); recognition/web-of-trust (how trust is earned + accrues);
+  self-interest engine (why reducing uncertainty pays); `close over` (the border).


### PR DESCRIPTION
Aaron: *"that's uncertainty reduction at the border and we can use it to earn trust and gain leverage over time across the border of github"*; *"and eventually other deps sources via ace the package manager of package managers."*

The owned **port = a border** (Markov boundary). The two-adapter/dep-as-oracle/byte-lock pattern is **uncertainty reduction at that border** (our-impl == dep == golden vectors; soft → SolidGround). Reduced uncertainty **earns trust** (web-of-trust accrual); trust **compounds into leverage**. **GitHub = the first/launch border** (not ceiling): reduce uncertainty across it → lever from GitHub-bootstrapped trust to our own roots, no discontinuity. ** = the package-manager-of-package-managers** generalizes it to **every** dep source (npm/crates/nuget/pypi/git/OS) behind one owned interface — trust accrues per-source + compounds across all → leverage spanning the whole supply graph, no single source able to backdoor us.

🤖 Generated with [Claude Code](https://claude.com/claude-code)