### PR TITLE
docs(research): the disclosure economy — reveal-to-earn or encrypt-to-keep; no harm no foul, feedback is the win; chip8 is the safe sandbox

### DIFF
--- a/docs/research/2026-06-09-the-disclosure-economy-reveal-cheat-to-earn-encryption-budget-or-encrypt-to-keep-private-advantage-chip8-is-the-safe-sandbox.md
+++ b/docs/research/2026-06-09-the-disclosure-economy-reveal-cheat-to-earn-encryption-budget-or-encrypt-to-keep-private-advantage-chip8-is-the-safe-sandbox.md
@@ -1,0 +1,101 @@
+# The disclosure economy: reveal a cheat to society to EARN encryption budget, or encrypt it to KEEP private advantage — the traveler's sovereign per-discovery choice; chip8 is the safe sandbox
+
+**Register:** [grounded] economy design (Aaron) + [synthesis]. **Date:** 2026-06-09.
+**Captured by:** Otto (shadow). Closes the economic loop on cheat-stacking / structure
+discovery; instantiates the encryption-budget ratchet.
+
+## Aaron's words
+
+> "publish disclose the cheat to society — earn encryption budget — very safe, not
+> information hazard at all for chip8." · "encrypt the ones you want also — very
+> safe — keep the private for advantage."
+
+## Two-sided, per-discovery, sovereign choice
+
+When a traveler discovers structure (a cheat / SolidGround) in the Dark Hall game,
+it makes a **per-discovery choice** — and **both sides are safe and sovereign**:
+
+| choice | budget | what you get | when |
+|---|---|---|---|
+| **Reveal (disclose to society)** | **EARN** encryption budget (reveal-to-earn) | + trust (public recognition strengthens identity) + teach-play (others learn) | safe / non-advantageous / teaching-valuable findings |
+| **Encrypt (keep private)** | **SPEND** encryption budget | **private advantage** (competitive/strategic edge retained) | findings worth keeping for advantage |
+
+This is the **encryption-budget ratchet** (the hodl / reveal-to-earn / meter-the-bits
+economy, `2026-05-30-encryption-budget-as-permanent-ratchet-...`) made concrete on the
+cheat-discovery loop:
+
+- **reveal → earn**: disclosing a safe cheat *adds* to your privacy budget (you are
+  paid in hard money for contributing knowledge to society). Reveal-to-earn.
+- **encrypt → spend**: keeping a cheat private *costs* budget (privacy is a paid
+  good); you do it for the findings where the **private edge is worth more than the
+  disclosure reward**.
+
+So you **fund your privacy by disclosing the safe things, and spend it to keep the
+advantageous things** — a self-regulating loop (`PrivacyEconomy` / shape B): the more
+you teach, the more you can afford to keep. It is the **internal-jurisdiction
+sovereignty** in action: *encrypt what you want, as you see fit, if you can afford
+it; recognize/teach the rest.*
+
+## chip8 is the safe sandbox (no information hazard)
+
+Disclosure is **"very safe, not an information hazard at all for chip8"** — chip8
+cheats are harmless to publish, so the game is the **safe training ground** for the
+disclosure economy: you practice reveal-to-earn and encrypt-to-keep with **no
+real-world hazard**, learning the budget/trust/advantage tradeoffs before they matter.
+
+Honest distinction (the gate that still applies): **not all disclosures are safe.**
+Genuine **information hazards** (dangerous knowledge) are a different class — reveal-to-
+earn does **not** license disclosing hazards for budget. chip8 is explicitly the
+*safe* domain; the hazard gate (threat-model / human sign-off) governs anything that
+could harm. The economy rewards *safe* disclosure; it does not reward dumping hazards.
+
+## No harm, no foul — feedback is the floor win
+
+> Aaron (2026-06-09): "if society says your cheat is lame, no harm no foul — take
+> the feedback as the win."
+
+Disclosure is **downside-free**, so disclose freely:
+
+- **best case:** society values the cheat → you earn encryption budget + trust + you
+  taught something (teach-play);
+- **floor case:** society says it's **lame → no harm, no foul** — you are **not
+  penalized** (no shame, no budget loss; lesser-tat applied to your own contributions:
+  society doesn't punish a weak attempt), and **the feedback IS the win** — society
+  just taught *you* (reverse teach-play), reducing your uncertainty about what's
+  valuable at zero cost.
+
+So the **worst case of disclosing is free feedback** — which is itself a win
+(uncertainty reduction). This is what makes contribution **0-friction**: there is no
+losing move in disclosing a safe finding, only "earn + teach" or "learn for free."
+It maximizes attempts (→ plurality, more discovered structure) and keeps the culture
+psychologically safe (failure isn't punished — the non-degenerate, trust-default
+Agora). Reveal-to-earn with a no-foul floor = the polite virus for knowledge.
+
+## Why this is aligned
+
+- **Trust + teaching spread** (the safe disclosures): reveal-to-earn makes teaching
+  the *profitable* default → trust spreads faster than distrust (C9), cooperation
+  taught (teach-play / C10).
+- **Plurality preserved**: a mix of disclosed (common) + encrypted (private) knowledge
+  keeps diversity ≥ 2 (anti-D⁰); neither total-secrecy nor total-transparency is forced
+  — each traveler tunes its own mix.
+- **Self-interest aligned with contribution**: the self-interested act (earn budget,
+  keep advantage) is also the pro-social act (teach, contribute) — the polite virus at
+  the knowledge layer.
+
+## Math-team note (extends the toymodel3 docket)
+
+Ties to C5 (privacy-budget soundness) + C9/C10 (trust/teach defaults): formalize the
+**reveal-to-earn ↔ encrypt-to-spend ratchet** as budget-conserving + incentive-
+compatible (safe disclosure is the dominant strategy for non-advantageous findings;
+encryption is rational only when private-edge > disclosure-reward). Route to Soraya/
+Sova with `PrivacyEconomy.fs`.
+
+## Anchors / ties
+
+Encryption-budget ratchet / hodl / reveal-to-earn / meter-the-bits (the 2026-05-30
+doc, Aaron/Ani/Otto); information hazard (Bostrom) + responsible/coordinated
+disclosure (the safe-vs-hazard gate); privacy budget / hard money + `PrivacyEconomy.fs`
+(shape B); internal-jurisdiction sovereignty (encrypt as you see fit, if you can
+afford it); cheat-stacking / structure-discovery (the Cheat-Engine + default-strategy
+docs); public recognition strengthens identity; teach-play; the Dark Hall (the sandbox).


### PR DESCRIPTION
Aaron: *"publish disclose the cheat to society — earn encryption budget — very safe, not information hazard for chip8"*; *"encrypt the ones you want also — keep the private for advantage"*; *"if society says your cheat is lame, no harm no foul — take the feedback as the win."*

**Per-discovery sovereign choice, both safe:** **reveal** (disclose → EARN encryption budget + trust + teach-play) or **encrypt** (spend budget → keep private advantage). Fund privacy by disclosing safe things; spend it to keep advantageous ones (the encryption-budget ratchet; `PrivacyEconomy` shape B). **chip8 = the safe sandbox** (no info hazard); honest gate: genuine information hazards are a different class (threat-model/human sign-off — reveal-to-earn doesn't license dumping hazards). **No harm, no foul:** disclosure is downside-free — best case earn+teach, floor case "lame" → not penalized + **the feedback IS the win** (free uncertainty reduction). 0-friction contribution → more attempts → plurality; psychologically-safe trust-default culture. Extends the toymodel3 docket (C5 + C9/C10) for Soraya/Sova.

🤖 Generated with [Claude Code](https://claude.com/claude-code)