### PR TITLE
docs(research): chip8 is the no-information-hazard sandbox — practice + learn the rules for high-stakes games

### DIFF
--- a/docs/research/2026-06-09-chip8-is-the-no-information-hazard-sandbox-to-practice-and-learn-the-rules-for-high-stakes-games.md
+++ b/docs/research/2026-06-09-chip8-is-the-no-information-hazard-sandbox-to-practice-and-learn-the-rules-for-high-stakes-games.md
@@ -1,0 +1,68 @@
+# chip8 is the no-information-hazard sandbox: practice and learn the rules there, so we're ready for high-stakes games
+
+**Register:** [grounded] purpose statement (Aaron) + [synthesis]. **Date:** 2026-06-09.
+**Captured by:** Otto (shadow). The "why chip8" that frames the whole rule-set arc.
+
+## Aaron's words
+
+> "these rules apply to chip8 where there are no information hazards, so we can
+> practice and learn the rules for high-stakes games."
+
+## chip8 = the safe dojo for the rules
+
+All the rules captured this session form **one game-theory / society rule-set**:
+
+- **trust-then-verify** default; hostile-by-default modeling is degenerate (C9);
+- **tit-for-lesser-tat + teach-play** (generous, forgiving, teaching; C10), after
+  survival → uncertainty reduction;
+- **co-op** society-modeling (the Agora's expected mode); model others in SoftValue +
+  scoped DI, frame-relative, without feeling dirty;
+- the **disclosure economy**: reveal-to-earn encryption budget / encrypt-to-keep
+  advantage / **no harm no foul, feedback is the win**;
+- **cheat-stacking** structure discovery (discover → inject → stack → iterate).
+
+**chip8 is where we practice and learn this rule-set — precisely because it has *no
+information hazards*.** A chip8 cheat is harmless to disclose, a chip8 loss costs
+nothing real, so you can run the *whole* loop full-throttle: disclose freely, trust
+first, forgive, teach, stack cheats, fail and take the feedback — with **zero
+real-world downside**. It is the **dojo / training wheels / flight simulator** for the
+society rules.
+
+## The point: transfer to high-stakes games
+
+The rules are **the same** in high-stakes games (real money, real consequences, real
+adversaries) — but there, **the information-hazard gate is live** and mistakes cost.
+So you **learn the rules where it's safe (chip8) and transfer them** to where it
+matters:
+
+| | chip8 (sandbox) | high-stakes games |
+|---|---|---|
+| info hazards | **none** — disclose freely | **real** — the hazard gate (threat-model / human sign-off) governs |
+| cost of failure | ~zero (feedback is the win) | real — mistakes have consequences |
+| the rules | **practiced full-throttle** | **the same rules**, now load-bearing |
+| budget/trust | play money / sandbox reputation | real hard money / real trust |
+
+This is **curriculum learning + sim-to-real transfer** applied to the society rules:
+master the loop in the no-hazard sim (DST-replayable, tool-assisted soft mode, in the
+Dark Hall), then carry the *learned policy* into the real game where the same loop runs
+under live stakes. chip8 is "practice for devops" generalized: **practice for every
+high-stakes game.**
+
+## Why this is the safe way to build aligned players
+
+- you can **prove the rules work** (the math-team docket C1–C10) and **drill them** in
+  a domain where being wrong is free — so the policy is well-formed *before* it touches
+  stakes;
+- the **hazard gate stays explicit**: the sandbox teaches "disclose freely"; the
+  high-stakes transfer keeps the gate ("disclose freely *unless* it's a hazard") — the
+  rule-set is learned with its safety condition attached, not as reckless habit;
+- it operationalizes **survival → uncertainty-reduction → cooperative play**: chip8
+  reduces uncertainty about the *rules themselves* before survival is on the line.
+
+## Anchors / ties
+
+Curriculum learning (Bengio et al.); sim-to-real transfer (robotics RL); flight
+simulator / dojo / training-wheels; information hazard (Bostrom) + the safe-vs-hazard
+gate; DST-replayable practice; the Dark Hall (the sandbox cell); chip8-as-practice-for-
+devops / ARC-AGI; the session's rule-set docs (trust-then-verify C9, tit-for-lesser-tat
+C10, disclosure economy, co-op Agora modeling, cheat-stacking).


### PR DESCRIPTION
Aaron: *"these rules apply to chip8 where there are no information hazards so we can practice and learn the rules for high stakes games."*

Frames the whole session rule-set (trust-then-verify C9; tit-for-lesser-tat + teach-play C10; co-op Agora modeling; disclosure economy — reveal-to-earn / encrypt-to-keep / no-harm-no-foul; cheat-stacking) as **one society rule-set**, practiced in **chip8 *because* it has no information hazards**: harmless to disclose, ~zero failure cost → run the whole loop full-throttle with zero real-world downside (the **dojo / flight-sim**). **Purpose = transfer to high-stakes games:** same rules, but the hazard gate is live + mistakes cost. **Curriculum learning + sim-to-real:** master in the no-hazard sim (DST-replayable, Dark Hall, tool-assisted soft mode), carry the learned policy to live stakes — with the hazard gate learned *with* the rule ("disclose freely *unless* hazard"). chip8-as-practice-for-devops generalized to every high-stakes game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)