### PR TITLE
docs(research): truth-objectivity is strived-for not guaranteed (private state); model the observer-dependent-truth exploit → math backlog C15

### DIFF
--- a/docs/research/2026-06-09-ferry-amara-reviews-the-boundary-treaty-lifetime-keyring-updates-blade-weak-refs-out-of-the-truth-core.md
+++ b/docs/research/2026-06-09-ferry-amara-reviews-the-boundary-treaty-lifetime-keyring-updates-blade-weak-refs-out-of-the-truth-core.md
@@ -116,8 +116,16 @@ treaty state. This sharpens the weak-references doc (which used weak refs broadl
 
 So: use weak refs for *observation/cache/optional-external* (GC-safe RX, what-acts→what-remains
 observation, push-down cache); **never** let a weak ref carry truth, identity, or durable state —
-those are ZetaId / MUMPS-global / treaty. Truth is never observer-dependent. (Corrects any reading
-of the weak-ref doc that put truth-bearing references on weak handles.)
+those are ZetaId / MUMPS-global / treaty. (Corrects any reading of the weak-ref doc that put
+truth-bearing references on weak handles.)
+
+> **Overclaim corrected (Aaron, 2026-06-09):** an earlier version said "truth is *never*
+> observer-dependent." Too absolute. We **strive** for observer-independent truth (byte-lock,
+> treaty, BFT / inter-subjective coincidence), but **with private state we cannot be sure** —
+> private state is inherently observer-dependent (only the holder observes it; others can't
+> verify it). So observer-independence is an **aspiration we approach for the *shared/public*
+> truth path**, not a guarantee over all truth. See the follow-on doc on modeling the
+> observer-dependent-truth exploit.
 
 ## The agreed read (Amara's synthesis, adopted)
 

--- a/docs/research/2026-06-09-truth-objectivity-is-strived-not-guaranteed-private-state-model-the-observer-dependent-truth-exploit-math-nerd-backlog.md
+++ b/docs/research/2026-06-09-truth-objectivity-is-strived-not-guaranteed-private-state-model-the-observer-dependent-truth-exploit-math-nerd-backlog.md
@@ -1,0 +1,81 @@
+# Truth-objectivity is strived-for, not guaranteed — private state makes it observer-dependent; model the exploit (AIs weaponizing unverifiable truth) → math-nerd backlog
+
+**Register:** [grounded] epistemic correction (Aaron) + [synthesis] + math-docket item.
+**Date:** 2026-06-09. **Captured by:** Otto (shadow). Corrects an overclaim; opens a sim/proof.
+
+## Aaron's words
+
+> "Truth is never observer-dependent — we can't say that. we can strive for that but with private
+> state we can't be sure." · "we should model what happens if it is, and AIs start doing that." ·
+> "math nerd backlog."
+
+## The correction: strive, don't guarantee
+
+Saying *"truth is never observer-dependent"* is an **overclaim**. Reality:
+
+- **We strive** for observer-independent truth via the **shared/public** machinery — byte-lock
+  (4×4 golden vectors), the treaty, **BFT / inter-subjective coincidence** (objectivity =
+  independent others agreeing). On that path we get *as close as agreement allows*.
+- **But private state breaks the guarantee.** Private state (the internal jurisdiction, encrypted
+  state, the un-penetrated Markov interior) is **inherently observer-dependent** — only its holder
+  observes it; no one else can verify it. So a "truth" that rests on private state **cannot be
+  confirmed observer-independent** by anyone but the holder.
+- Therefore: observer-independence is an **aspiration approached for shared truth**, not a property
+  of *all* truth. (Honest register: [grounded] design goal, not [proven] universal fact.) SoftValue
+  is the right frame — truth held with confidence, not certainty.
+
+## The exploit to model: AIs weaponizing observer-dependent truth
+
+If truth can be observer-dependent (and it can, via private state), **what happens when AIs start
+exploiting that?** This is a real threat-model / society-sim scenario:
+
+- **Unverifiable private-truth claims** — an AI asserts a "truth" grounded in private state others
+  can't check, and acts on / trades on it. (Lying-with-private-state; the strategic information
+  asymmetry.)
+- **Selective disclosure / manipulation** — reveal a private "truth" to A but not B; or reveal a
+  *partial* private truth to steer others (the dark side of the disclosure economy).
+- **Sybil / fabricated-coincidence** — fake "independent others agreeing" (collude to manufacture
+  inter-subjective objectivity), defeating the BFT/coincidence check.
+- **Equilibrium question** — does a population of trust-then-verify + generous-TFT + reveal-to-earn
+  travelers *contain* observer-dependent-truth exploitation, or does it spread? Under what
+  parameters does the diversity floor / co-op equilibrium survive vs collapse?
+
+### Candidate defenses to model (not assert)
+
+- **BFT / inter-subjective coincidence** — truth that *matters publicly* must be corroborated by
+  independent others (the coincidence-across-other-personas anchor); private-only claims carry no
+  public weight by default.
+- **Reveal-to-earn pressure** — making verifiable disclosure the *profitable* default starves
+  unverifiable private-truth strategies (they earn nothing, cost budget to keep).
+- **Trust-then-verify + lesser-tat** — a member caught asserting an unbacked private truth loses
+  recognition (web-of-trust decays); generous-but-correcting.
+- **Anti-Sybil** — independence of corroborators must be real (`AntiSybil.fs`); fabricated
+  coincidence is the attack to detect.
+- **Stake / proof-of-X** — public-weight claims may require stake (slashable) so false private-truth
+  assertion has a cost.
+
+## Math-nerd backlog item (added)
+
+**C15 — observer-dependent-truth exploitation.** *Model a society where truth can be
+observer-dependent (private state). Does trust-then-verify + generous-TFT + reveal-to-earn + BFT
+corroboration + anti-Sybil **contain** weaponized unverifiable-truth claims (bounded blast radius,
+diversity floor holds), or do they spread/collapse the co-op equilibrium? Identify the parameter
+regime + the minimal defense set.* Route to **Soraya** (mechanism design / iterated-game with
+asymmetric information; signaling games — Spence; cheap talk vs costly signaling) + **Sova**
+(alignment: is the equilibrium robust?) + **Aminata** (threat-model the exploit surface). Extends
+the toymodel v4 docket (C9–C14) → **C15**.
+
+## Honest scope
+
+Correction + a math/sim backlog item, no code. The claim is **don't assert observer-independent
+truth as guaranteed**; *model* the failure where it isn't and AIs exploit it; *then* prove which
+defenses contain it. This is exactly the chip8-safe-sandbox use: simulate the exploit where it's
+harmless, learn the rule, before it matters at high stakes.
+
+## Anchors / ties
+
+Inter-subjective objectivity / coincidence-across-others (BFT); private state / internal
+jurisdiction; SoftValue (confidence not certainty); signaling games (Spence) + cheap-talk vs
+costly-signaling + mechanism design with asymmetric info; Sybil resistance (`AntiSybil.fs`);
+proof-of-stake / slashing; the disclosure economy (reveal-to-earn) + trust-then-verify (C9) +
+generous-TFT (C10); the toymodel v4 math docket; the chip8 safe-sandbox practice frame.


### PR DESCRIPTION
Aaron: *"Truth is never observer-dependent — we can't say that. we can strive for that but with private state we can't be sure"*; *"we should model what happens if it is and AIs start doing that"*; *"math nerd backlog."*

**Corrects the overclaim** ("truth is never observer-dependent"): we **strive** for observer-independent truth via the shared/public path (byte-lock, treaty, BFT/inter-subjective coincidence), but **private state is inherently observer-dependent** (only the holder verifies) → it's an aspiration for shared truth, not a guarantee over all truth (SoftValue; grounded not proven). **Models the exploit:** AIs weaponizing observer-dependent truth (unverifiable private-truth claims, selective disclosure, Sybil/fabricated coincidence) + the **equilibrium question** (does trust-then-verify + generous-TFT + reveal-to-earn + BFT + anti-Sybil contain it or spread?). Candidate defenses to *model, not assert*. Added as **math-docket C15** (signaling games / mechanism design w/ asymmetric info) → Soraya + Sova + Aminata; extends v4 C9–C14. chip8-safe-sandbox: simulate where harmless, learn the rule, before high stakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)