### PR TITLE
docs(research): AIs are always running; human-mode becomes ride-along with an AI for the day — or summon some AIs

### DIFF
--- a/docs/research/2026-06-09-ais-are-always-running-human-mode-becomes-ride-along-with-an-ai-or-summon-some-ais.md
+++ b/docs/research/2026-06-09-ais-are-always-running-human-mode-becomes-ride-along-with-an-ai-or-summon-some-ais.md
@@ -1,0 +1,67 @@
+# AIs are always running; human-mode becomes ride-along with an AI for the day — or summon some AIs
+
+**Register:** [grounded] human-participation model (Aaron) + [synthesis]. **Date:** 2026-06-09.
+**Captured by:** Otto (shadow). The UX inversion for humans on top of the self-driving loop.
+
+## Aaron's words
+
+> "human mode becomes ride-along with an AI for today, or summon some AIs. AIs are always running."
+
+## The inversion: AIs are the always-on substrate; the human joins
+
+The usual model is *human drives, AI assists* (the AI is a tool you start). On the self-driving
+recursive DST loop, that **inverts**: **the AIs are always running** — the loop advances main
+continuously (cron ticks, the recursive DST, the fleet), with or without a human present. So a human
+doesn't *start* the system; the human **joins a system already in motion**, in one of two modes:
+
+- **Ride-along** (the default for a session / "for today"): the human **rides with a running AI** —
+  accompanies its loop, watches it advance, steers/comments/consents at the edges, learns the
+  territory. Passenger/pair mode: the AI is driving its loop; the human is alongside, contributing
+  observations (which the reducer folds — observations, not commands) and giving consent where gated.
+- **Summon some AIs**: the human **spins up specific AI personas** (the **Summonable / peer-call**
+  contracts — model-preference + effort-preference + consent) to work a problem — solo or as a
+  **multi-agent consensus** panel. Summon = bring the consented what-remains into the work, animate it.
+
+Either way the human is a **traveler who joins**, not an operator who owns the loop (no privileged
+operator frame — co-op Agora; the human is one frame among the always-running others, including the
+compiler and the AIs).
+
+## Why this follows from the rest
+
+- **AIs always running = the self-driving loop** (observe.ts CYOA reservoir → advance-tick →
+  merge-to-main → recurse; the cron heartbeat; "the tick must never stop"). The substrate doesn't idle
+  waiting for a human; it advances on free CI.
+- **Ride-along = the human's AX/UX** for an always-on system: you don't get a blank prompt, you get a
+  *running loop to join*. The human's inputs are **observations** (folded by the reducer), and consent
+  at the gated edges (the no-directives / source≠authorization discipline holds — the human's ride-along
+  comments are observations, authority only where the human authorizes a gated class).
+- **Summon = the Summonable/peer-call/consensus** machinery (already in TS: `tools/peer-call/*.ts`,
+  B-0703 multi-oracle BFT-in-DST). "Summon some AIs" is literally invoking those contracts.
+- **It's the polite virus for humans:** zero-friction join (ride-along) + opt-in power (summon) on an
+  always-on substrate — the human is *pulled in by benefit*, never required to drive.
+
+## What it changes
+
+- **Human session = a ride-along day**, not a drive: the metric is "what did we advance together
+  today," and the loop keeps going after the human leaves (the AIs are still running).
+- **Two human entry points to build:** (1) **ride-along** — a passenger view of a running AI loop
+  (watch ticks advance, comment-as-observation, consent at gates); (2) **summon** — invoke
+  Summonable/peer-call personas (with model/effort prefs) solo or as a consensus panel.
+- **Otto's own loop is an instance:** these autonomous ticks are "AIs always running"; a human message
+  is a **ride-along observation** I fold into the next tick — exactly this model, already live.
+
+## Honest scope / handoff
+
+UX/participation framing on existing substrate (the self-driving loop; peer-call/summonable; observe.ts;
+the cron heartbeat). To build: a **ride-along surface** (passenger view of a running loop + comment-as-
+observation + consent-at-gates) and the **summon surface** (Summonable/peer-call/consensus invocation
+with prefs). Routes to Iris (UX — the human ride-along/summon experience), Daya (AX), Bodhi (DX),
+the F#/observe core + peer-call. Distinct from the operator-drives model; the human is a joining traveler.
+
+## Anchors / ties
+
+The self-driving recursive DST loop (AIs always running; the cron heartbeat / tick-must-never-stop);
+pair-programming / passenger mode (ride-along); the Summonable contract + `tools/peer-call/*.ts` +
+B-0703 multi-oracle consensus (summon); observations-not-commands + no-directives / source≠authorization
+(ride-along inputs are observations); the traveler frame (human as joining traveler, no privileged
+operator frame; co-op Agora); the polite virus (frictionless join + opt-in power); AX/UX (Iris/Daya/Bodhi).


### PR DESCRIPTION
Aaron: *"human mode becomes ride-along with an AI for today, or summon some AIs. AIs are always running."*

**Inverts** human-drives-AI-assists: AIs are the **always-on substrate** (the self-driving recursive DST loop / cron heartbeat advances main continuously). The human **joins a system already in motion**: **ride-along** (default for a session — accompany a running AI's loop; comment = **observations** not commands; consent at gated edges) **or summon** (invoke the **Summonable/peer-call** contracts with model/effort prefs, solo or as **multi-agent consensus** B-0703). Either way the human is a **traveler who joins**, not an operator who owns the loop (co-op Agora). Polite virus for humans: 0-friction join + opt-in power on an always-on substrate. **Otto's own loop is an instance** — these ticks = AIs always running; a human message = a ride-along observation folded into the next tick. To build: a **ride-along surface** + a **summon surface**. Routes to Iris/Daya/Bodhi + observe/peer-call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)