### PR TITLE
feat(setup)+ci+docs: 1000× keyring DST as a watchable test + workflow; derive.ts pure oracle; tests-are-strange-attractors / test-is-the-4×4-meta-interface

### DIFF
--- a/.github/workflows/keyring-dst1000.yml
+++ b/.github/workflows/keyring-dst1000.yml
@@ -1,0 +1,34 @@
+# keyring 1000× DST — automates the watchable local test (Aaron: "git workflows can just
+# automate it"). Runs the byte-lock + determinism + rotation DST for the keyring treaty oracle.
+# Non-gating, paths-scoped (only on keyring changes) + manual dispatch. SHA-pinned actions,
+# ubuntu-24.04 pinned, concurrency-grouped (cancel-in-progress) — Dejan CI conventions.
+name: keyring 1000x DST
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'tools/setup/persona-keys/**'
+
+concurrency:
+  group: keyring-dst1000-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  dst1000:
+    name: keyring byte-lock + 1000x determinism
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+      - name: install keyring tool deps
+        working-directory: tools/setup/persona-keys
+        run: bun install
+      - name: keyring DST — golden byte-lock + 1000x determinism + rotation
+        working-directory: tools/setup/persona-keys
+        run: bun test gen.test.ts keyring.dst1000.test.ts keyring.rotate.test.ts

--- a/docs/research/2026-06-09-1000x-keyring-runs-are-a-watchable-dst-test-tests-are-strange-attractors-build-outside-the-boundary-as-tests-meta-interface-of-the-4x4-controller.md
+++ b/docs/research/2026-06-09-1000x-keyring-runs-are-a-watchable-dst-test-tests-are-strange-attractors-build-outside-the-boundary-as-tests-meta-interface-of-the-4x4-controller.md
@@ -1,0 +1,89 @@
+# The 1000× keyring runs are now a watchable DST test; tests are our strange attractors; "build it in a test" is the meta-process; the test is the meta-interface of the 4×4 controller (navigable by Xbox controller)
+
+**Register:** [grounded] BUILT + [synthesis] (Aaron). **Date:** 2026-06-09. **Captured by:** Otto (shadow).
+This one is **code, not just a doc** — the 1000× DST runs and you can watch it.
+
+## Aaron's words
+
+> "lets turn our 1000 crypto test runs into a DST test i can watch right here and our git[hub] workflows
+> can just automate it. the whole meta process of every time we need something outside the boundary of
+> the test we go build it in a test — our tests become our strange attractors in chaos theory." ·
+> "This is literally test as the meta interface of our 4x4 controller, the meta game." · "the universal
+> action grammar now has a dashboard that's navigable with our xbox controller."
+
+## BUILT: the 1000× keyring DST (watchable + automated)
+
+- **`tools/setup/persona-keys/derive.ts`** — the keyring derivation extracted as a **pure importable
+  function** (the treaty's TS oracle); `gen.ts` is now a thin CLI over it (byte-output unchanged —
+  verified the golden vector + the existing conformance test still match exactly).
+- **`tools/setup/persona-keys/keyring.dst1000.test.ts`** — derives the keyring **1000×** from the
+  byte-locked golden seed and proves the deterministic surface is **byte-identical every run**.
+  **Result (local, watched): `1000/1000 derivations … pub mismatches=0, priv-material mismatches=0`,
+  ~13s.** You can watch it: `cd tools/setup/persona-keys && bun test keyring.dst1000.test.ts`.
+- **`.github/workflows/keyring-dst1000.yml`** — automates it (paths-scoped + manual dispatch,
+  SHA-pinned, concurrency-grouped). The git workflow just runs the same DST.
+
+### The DST test caught a real property (test-as-meta-interface in action)
+
+Building it surfaced a genuine finding (not papered over): the **public surface + raw private key
+material are deterministic/byte-locked**, but **SSH/PGP private ARMOR is intentionally
+non-deterministic** (OpenSSH random checkbytes; PGP random salt/IV) — same key, different armor bytes
+(identical fingerprints prove it). So the byte-lock is over the **public surface + raw private
+material**, not the armor; the test asserts both the lock *and* the armor-non-determinism as known
+properties. The test *found* this — exactly the point below.
+
+## The meta-process: build outside-the-boundary needs AS tests
+
+> "every time we need something outside the boundary of the test, we go build it in a test."
+
+When a tick needs something it doesn't have (a tool, a fact, a capability — *outside the test's
+boundary*), the move is **not** to build it on the side — **build it as a test.** The new capability
+arrives as a DST test (= a tick): it checks in code, runs deterministically, shows hot if it fails,
+merges to main. So the system grows by **accreting tests**, each a proven tick. (This *is* the
+"close over the boundary" move at the dev-loop level: a need outside the boundary becomes a test
+inside it.)
+
+## Tests are our strange attractors (chaos theory)
+
+> "our tests become our strange attractors in chaos theory."
+
+In a chaotic dynamical system, trajectories are drawn toward a **strange attractor** — a bounded set
+the dynamics converge onto without ever repeating exactly. **Our tests are that attractor:** the
+self-driving DST loop (observe.ts CYOA reservoir wall → advance-tick → merge-to-main → recurse) is a
+chaotic-ish search over state space, and **the tests are what it's pulled toward** — every trajectory
+either lands on a passing test (converges into the attractor / merges) or shows hot (off-attractor /
+investigated). The tests **shape the basin**: they're the bounded set the whole fleet's dynamics
+settle onto. Adding a test **extends the attractor**; the loop then flows toward it. (Fixed-point
+shapes A–F are the *local* terminating shapes; the test-attractor is the *global* set they compose into.)
+
+## The test is the META-interface of the 4×4 controller (the meta-game)
+
+> "test as the meta interface of our 4x4 controller, the meta game."
+
+The universal action grammar is a **4×4 (16-slot) controller**: Navigate (0-3), Commit (4-7), Scope
+(8-11), **Meta (12-15: refresh / re-observe / escalate)**. The **test is the Meta layer** — running a
+DST test *is* re-observe + commit-the-advance + escalate-on-fail, i.e. **playing the meta-game**:
+the game of advancing/verifying the world itself, one tick. So the test isn't *around* the controller;
+**the test IS the controller's meta-interface** — the move that operates the loop on itself.
+
+And it's now **physically navigable**: *"the universal action grammar has a dashboard navigable with
+our Xbox controller."* The 16 slots map naturally to a **gamepad** (d-pad + face/bumper buttons = the
+4 groups × 4), so a human can **drive the dashboard with an Xbox controller** — ride-along/summon/run-a-
+tick by controller. The 4×4 controller becomes a literal controller; the meta-game becomes playable.
+(AX/UX: the most legible possible surface for the action grammar — Iris/Daya.)
+
+## Honest scope / handoff
+
+The 1000× DST + derive.ts refactor + workflow are **built + green** (watched: 1000/1000, 0 mismatch).
+The meta-process (build-needs-as-tests), tests-as-strange-attractors, test-as-meta-interface, and the
+Xbox-controller dashboard are framings on top (the dashboard is referenced as existing — verify/locate
+the dashboard surface; AX/UX with Iris/Daya). Routes to Dejan (the workflow), Soraya/Sova (the DST as
+a provable tick), Iris/Daya (the controller dashboard).
+
+## Anchors / ties
+
+Strange attractor / chaos theory (Lorenz; basin of attraction); DST §7 (the watchable tick);
+byte-lock golden vectors + `no-binary-in-proof-lineage`; the 4×4 universal action grammar
+(Navigate/Commit/Scope/**Meta**) + observe.ts; gamepad/Xbox mapping (16 slots → controller); the
+self-driving recursive DST loop + tests-are-ticks + 1000×-done-bar; SSH/PGP armor non-determinism
+(OpenSSH checkbytes / PGP salt-IV) — the finding the test caught.

--- a/tools/setup/persona-keys/derive.ts
+++ b/tools/setup/persona-keys/derive.ts
@@ -1,0 +1,70 @@
+// Zeta keyring derivation — the treaty's TS oracle, as a PURE importable function.
+// ONE BIP-39 seed phrase -> every key type on its own derivation path (type-separated,
+// no bleed). Audited libs only (@noble/@scure/micro-key-producer). Deterministic:
+// same (mnemonic, user) -> byte-identical output (the byte-lock the DST tests prove).
+import { secp256k1, schnorr } from "@noble/curves/secp256k1.js";
+import { ed25519 } from "@noble/curves/ed25519.js";
+import { keccak_256 } from "@noble/hashes/sha3.js";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { ripemd160 } from "@noble/hashes/legacy.js";
+import { generateMnemonic, mnemonicToSeedSync, validateMnemonic } from "@scure/bip39";
+import { wordlist } from "@scure/bip39/wordlists/english.js";
+import { HDKey } from "@scure/bip32";
+import { HDKey as ED } from "micro-key-producer/slip10.js";
+import { getKeys as sshKeys } from "micro-key-producer/ssh.js";
+import { getKeys as pgpKeys } from "micro-key-producer/pgp.js";
+import { bech32, base58 } from "@scure/base";
+
+const CREATED = 1749427200; // fixed 2026-06-09 epoch -> deterministic PGP fingerprints
+const enc = (a: Uint8Array) => Buffer.from(a).toString("hex");
+function convertbits(data: Uint8Array, from: number, to: number, pad: boolean) {
+  let acc = 0, bits = 0; const ret: number[] = []; const maxv = (1 << to) - 1;
+  for (const b of data) { acc = (acc << from) | b; bits += from; while (bits >= to) { bits -= to; ret.push((acc >> bits) & maxv); } }
+  if (pad && bits > 0) ret.push((acc << (to - bits)) & maxv);
+  return Uint8Array.from(ret);
+}
+
+/** Fresh 24-word BIP-39 seed phrase (256-bit). The ONLY source of randomness here. */
+export function freshMnemonic(): string { return generateMnemonic(wordlist, 256); }
+
+/** Pure, deterministic keyring derivation. Returns { full (private), pub (public-only) }. */
+export function deriveKeyring(mnemonic: string, user = "zeta") {
+  if (!validateMnemonic(mnemonic, wordlist)) throw new Error("invalid/empty mnemonic");
+  const seed = mnemonicToSeedSync(mnemonic);
+  const sk = HDKey.fromMasterSeed(seed);   // secp256k1 (BIP-32)
+  const ed = ED.fromMasterSeed(seed);      // ed25519 (SLIP-0010)
+
+  const eth = sk.derive("m/44'/60'/0'/0/0");
+  const ethAddr = "0x" + enc(keccak_256(secp256k1.getPublicKey(eth.privateKey!, false).slice(1)).slice(-20));
+  const btc = sk.derive("m/84'/0'/0'/0/0");
+  const h160 = ripemd160(sha256(secp256k1.getPublicKey(btc.privateKey!, true)));
+  const btcAddr = bech32.encode("bc", [0, ...convertbits(h160, 8, 5, true)]);
+  const nos = sk.derive("m/44'/1237'/0'/0/0");
+  const nXonly = schnorr.getPublicKey(nos.privateKey!);
+  const solP = ed.derive("m/44'/501'/0'/0'").privateKey;
+  const solPub = ed25519.getPublicKey(solP);
+  const sshSeed = ed.derive("m/44'/1110'/0'/0'").privateKey;
+  const ssh = sshKeys(sshSeed, `${user}@lucent.financial`);
+  const pgpSeed = ed.derive("m/44'/1111'/0'/0'").privateKey;
+  const pgp = pgpKeys(pgpSeed, `${user} <${user}@lucent.financial>`, undefined, CREATED);
+
+  const full = {
+    user, mnemonic,
+    ssh: { public: ssh.publicKey, fingerprint: ssh.fingerprint, private: ssh.privateKey, path: "m/44'/1110'/0'/0'" },
+    pgp: { keyId: pgp.keyId, fingerprint: pgp.fingerprint, public: pgp.publicKey, private: pgp.privateKey, path: "m/44'/1111'/0'/0'" },
+    nostr: { npub: bech32.encode("npub", bech32.toWords(nXonly)), nsec: bech32.encode("nsec", bech32.toWords(nos.privateKey!)), pub_hex: enc(nXonly), path: "m/44'/1237'/0'/0/0" },
+    eth: { address: ethAddr, privkey: "0x" + enc(eth.privateKey!), path: "m/44'/60'/0'/0/0" },
+    btc: { address: btcAddr, priv_hex: enc(btc.privateKey!), path: "m/84'/0'/0'/0/0" },
+    sol: { address: base58.encode(solPub), secret_base58: base58.encode(new Uint8Array([...solP, ...solPub])), path: "m/44'/501'/0'/0'" },
+  };
+  const pub = {
+    user,
+    ssh: { public: full.ssh.public, fingerprint: full.ssh.fingerprint, path: full.ssh.path },
+    pgp: { keyId: full.pgp.keyId, fingerprint: full.pgp.fingerprint, public: full.pgp.public, path: full.pgp.path },
+    nostr: { npub: full.nostr.npub, pub_hex: full.nostr.pub_hex, path: full.nostr.path },
+    eth: { address: full.eth.address, path: full.eth.path },
+    btc: { address: full.btc.address, path: full.btc.path },
+    sol: { address: full.sol.address, path: full.sol.path },
+  };
+  return { full, pub };
+}

--- a/tools/setup/persona-keys/gen.ts
+++ b/tools/setup/persona-keys/gen.ts
@@ -1,80 +1,18 @@
-// Zeta keyring generator — ONE BIP-39 seed phrase -> every key type on its own
-// derivation path (type-separated, no bleed). Audited libs only (@noble/@scure/micro-key-producer).
-import { secp256k1, schnorr } from "@noble/curves/secp256k1.js";
-import { ed25519 } from "@noble/curves/ed25519.js";
-import { keccak_256 } from "@noble/hashes/sha3.js";
-import { sha256 } from "@noble/hashes/sha2.js";
-import { ripemd160 } from "@noble/hashes/legacy.js";
-import { generateMnemonic, mnemonicToSeedSync, validateMnemonic } from "@scure/bip39";
-import { wordlist } from "@scure/bip39/wordlists/english.js";
-import { HDKey } from "@scure/bip32";
-import { HDKey as ED } from "micro-key-producer/slip10.js";
-import { getKeys as sshKeys } from "micro-key-producer/ssh.js";
-import { getKeys as pgpKeys } from "micro-key-producer/pgp.js";
-import { bech32, base58 } from "@scure/base";
-
-const CREATED = 1749427200; // fixed 2026-06-09 epoch -> deterministic PGP fingerprints
-const enc = (a:Uint8Array)=>Buffer.from(a).toString("hex");
-function convertbits(data:Uint8Array, from:number, to:number, pad:boolean){
-  let acc=0,bits=0;const ret:number[]=[];const maxv=(1<<to)-1;
-  for(const b of data){acc=(acc<<from)|b;bits+=from;while(bits>=to){bits-=to;ret.push((acc>>bits)&maxv);}}
-  if(pad&&bits>0)ret.push((acc<<(to-bits))&maxv);
-  return Uint8Array.from(ret);
-}
+// Zeta keyring CLI — a thin shell around the pure treaty oracle (derive.ts).
 // SECURITY: the seed phrase is NEVER read from argv (visible in ps/shell history).
 // Either --generate a fresh one in-process, or read an existing one from STDIN.
+import { deriveKeyring, freshMnemonic } from "./derive.ts";
+
 const args = process.argv.slice(2);
-const flag = (n:string)=>args.includes(n);
-const opt  = (n:string)=>{const i=args.indexOf(n);return i>=0?args[i+1]:undefined;};
+const flag = (n: string) => args.includes(n);
+const opt = (n: string) => { const i = args.indexOf(n); return i >= 0 ? args[i + 1] : undefined; };
 const user = opt("--user") || "zeta";
 const publicOnly = flag("--public-only");
-// --emit-mnemonic: print ONLY a fresh 24-word seed phrase and exit. Used by the
-// onboard flow to show the human their phrase to write down BEFORE deriving.
-if(flag("--emit-mnemonic")){ process.stdout.write(generateMnemonic(wordlist, 256) + "\n"); process.exit(0); }
-let mnemonic:string;
-if(flag("--generate")){ mnemonic = generateMnemonic(wordlist, 256); }
-else { mnemonic = (await Bun.stdin.text()).trim(); }
-if(!validateMnemonic(mnemonic, wordlist)) throw new Error("invalid/empty mnemonic on stdin (use --generate for a fresh one)");
-const seed = mnemonicToSeedSync(mnemonic);
-const sk = HDKey.fromMasterSeed(seed);          // secp256k1 (BIP-32)
-const ed = ED.fromMasterSeed(seed);             // ed25519 (SLIP-0010)
 
-// ETH m/44'/60'/0'/0/0
-const eth = sk.derive("m/44'/60'/0'/0/0");
-const ethAddr = "0x"+enc(keccak_256(secp256k1.getPublicKey(eth.privateKey!,false).slice(1)).slice(-20));
-// BTC m/84'/0'/0'/0/0 -> P2WPKH bech32
-const btc = sk.derive("m/84'/0'/0'/0/0");
-const h160 = ripemd160(sha256(secp256k1.getPublicKey(btc.privateKey!,true)));
-const btcAddr = bech32.encode("bc",[0,...convertbits(h160,8,5,true)]);
-// Nostr NIP-06 m/44'/1237'/0'/0/0 (x-only)
-const nos = sk.derive("m/44'/1237'/0'/0/0");
-const nXonly = schnorr.getPublicKey(nos.privateKey!);
-// SOL m/44'/501'/0'/0' (ed25519 slip10)
-const solP = ed.derive("m/44'/501'/0'/0'").privateKey;
-const solPub = ed25519.getPublicKey(solP);
-// SSH m/44'/1110'/0'/0' (Zeta convention, ed25519)
-const sshSeed = ed.derive("m/44'/1110'/0'/0'").privateKey;
-const ssh = sshKeys(sshSeed, `${user}@lucent.financial`);
-// PGP m/44'/1111'/0'/0' (Zeta convention, ed25519)
-const pgpSeed = ed.derive("m/44'/1111'/0'/0'").privateKey;
-const pgp = pgpKeys(pgpSeed, `${user} <${user}@lucent.financial>`, undefined, CREATED);
+// --emit-mnemonic: print ONLY a fresh 24-word seed phrase and exit (the onboard flow
+// shows the human their phrase to write down BEFORE deriving).
+if (flag("--emit-mnemonic")) { process.stdout.write(freshMnemonic() + "\n"); process.exit(0); }
 
-const full = {
-  user, mnemonic,
-  ssh:{ public: ssh.publicKey, fingerprint: ssh.fingerprint, private: ssh.privateKey, path:"m/44'/1110'/0'/0'" },
-  pgp:{ keyId: pgp.keyId, fingerprint: pgp.fingerprint, public: pgp.publicKey, private: pgp.privateKey, path:"m/44'/1111'/0'/0'" },
-  nostr:{ npub: bech32.encode("npub",bech32.toWords(nXonly)), nsec: bech32.encode("nsec",bech32.toWords(nos.privateKey!)), pub_hex: enc(nXonly), path:"m/44'/1237'/0'/0/0" },
-  eth:{ address: ethAddr, privkey:"0x"+enc(eth.privateKey!), path:"m/44'/60'/0'/0/0" },
-  btc:{ address: btcAddr, priv_hex: enc(btc.privateKey!), path:"m/84'/0'/0'/0/0" },
-  sol:{ address: base58.encode(solPub), secret_base58: base58.encode(new Uint8Array([...solP,...solPub])), path:"m/44'/501'/0'/0'" }
-};
-const pub = {
-  user,
-  ssh:{ public: full.ssh.public, fingerprint: full.ssh.fingerprint, path: full.ssh.path },
-  pgp:{ keyId: full.pgp.keyId, fingerprint: full.pgp.fingerprint, public: full.pgp.public, path: full.pgp.path },
-  nostr:{ npub: full.nostr.npub, pub_hex: full.nostr.pub_hex, path: full.nostr.path },
-  eth:{ address: full.eth.address, path: full.eth.path },
-  btc:{ address: full.btc.address, path: full.btc.path },
-  sol:{ address: full.sol.address, path: full.sol.path }
-};
+const mnemonic = flag("--generate") ? freshMnemonic() : (await Bun.stdin.text()).trim();
+const { full, pub } = deriveKeyring(mnemonic, user);
 console.log(JSON.stringify(publicOnly ? pub : full, null, 2));

--- a/tools/setup/persona-keys/keyring.dst1000.test.ts
+++ b/tools/setup/persona-keys/keyring.dst1000.test.ts
@@ -1,0 +1,53 @@
+// 1000× keyring DST — the "no friction" / done-bar harness, watchable right here.
+// Derives the keyring 1000 times from the byte-locked golden seed and proves the
+// DETERMINISTIC surface is byte-identical every time (Aaron: "retest both 1000 times to
+// reduce friction"). This is a DST test = a deterministic tick you can watch; GitHub
+// workflows just automate it.   Run: bun test keyring.dst1000.test.ts
+//
+// FINDING (this DST test caught it — test-as-meta-interface): the **public surface**
+// (addresses / pubkeys / fingerprints / npub) AND the **raw private key material**
+// (eth/btc/sol/nostr private values) are deterministic + byte-locked. But the **SSH and
+// PGP private ARMOR** (`ssh.private`, `pgp.private`) is intentionally NON-deterministic —
+// OpenSSH adds random checkbytes; PGP adds a random salt/IV to the encrypted key block —
+// so the armor bytes differ each derivation while encoding the SAME key (proven by the
+// identical SSH/PGP fingerprints in the public surface). So the byte-lock is over the
+// public surface + raw private material, NOT the armor bytes. (To byte-lock the armor too
+// you'd pass fixed checkbytes/salt/IV — a future option; recorded here, not silently
+// papered over.)
+import { test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { deriveKeyring } from "./derive.ts";
+
+const gv = JSON.parse(readFileSync(new URL("./golden-vectors-keyring.json", import.meta.url), "utf8"));
+const N = 1000;
+const canon = (o: unknown) => JSON.stringify(o);
+// deterministic private MATERIAL (raw keys) — excludes ssh/pgp armor (random checkbytes/salt/IV)
+const detPriv = (f: any) => JSON.stringify({ eth: f.eth.privkey, btc: f.btc.priv_hex, sol: f.sol.secret_base58, nostr_nsec: f.nostr.nsec, nostr_pub: f.nostr.pub_hex });
+
+test("1000× keyring derivation: public surface byte-identical to golden + private material stable (DST byte-lock)", () => {
+  const goldenPub = canon(gv.expected);
+  let firstPriv = "";
+  let pubMismatch = 0, privMismatch = 0;
+  const t0 = Date.now();
+  for (let i = 0; i < N; i++) {
+    const { full, pub } = deriveKeyring(gv.input.mnemonic, gv.input.user);
+    if (canon(pub) !== goldenPub) pubMismatch++;          // public surface == the byte-lock, every run
+    const p = detPriv(full);
+    if (i === 0) firstPriv = p; else if (p !== firstPriv) privMismatch++;  // raw private material stable
+    if ((i + 1) % 200 === 0) console.log(`  …${i + 1}/${N} byte-identical (pub + private material)`);
+  }
+  console.log(`  ${N}/${N} derivations in ${Date.now() - t0}ms — pub mismatches=${pubMismatch}, priv-material mismatches=${privMismatch}`);
+  expect(pubMismatch).toBe(0);
+  expect(privMismatch).toBe(0);
+}, 120_000);
+
+test("armor is non-deterministic by design (same key, different bytes) — documented, not a regression", () => {
+  // ssh.private / pgp.private differ across runs (random checkbytes/salt/IV) BUT the
+  // fingerprints (public) are identical -> same key. This test asserts that expectation
+  // so the non-determinism is a known, asserted property, not a silent surprise.
+  const a = deriveKeyring(gv.input.mnemonic, gv.input.user).full;
+  const b = deriveKeyring(gv.input.mnemonic, gv.input.user).full;
+  expect(a.ssh.fingerprint).toBe(b.ssh.fingerprint);   // same key…
+  expect(a.pgp.fingerprint).toBe(b.pgp.fingerprint);
+  expect(a.ssh.private === b.ssh.private && a.pgp.private === b.pgp.private).toBe(false); // …different armor
+}, 30_000);


### PR DESCRIPTION
Aaron: *"turn our 1000 crypto test runs into a DST test i can watch right here and our git workflows can just automate it… every time we need something outside the boundary of the test we build it in a test, our tests become our strange attractors"*; *"test as the meta interface of our 4x4 controller, the meta game"*; *"the universal action grammar now has a dashboard navigable with our xbox controller."*

**BUILT (green, watched):** `derive.ts` = the keyring derivation as a **pure importable oracle** (gen.ts now a thin CLI; byte-output unchanged — golden + conformance still match); `keyring.dst1000.test.ts` derives **1000×** from the golden seed → **1000/1000 byte-identical, 0 mismatches, ~13s** (watch: `bun test keyring.dst1000.test.ts`); `.github/workflows/keyring-dst1000.yml` automates it (paths-scoped, SHA-pinned, concurrency-grouped). **Finding the DST caught:** public surface + raw private material are byte-locked, but **SSH/PGP private armor is non-deterministic by design** (checkbytes/salt/IV) — same key, different armor; asserted both.

**Framings:** build-needs-**as-tests**; tests are our **strange attractors** (the loop is pulled toward them); the test **is the Meta layer of the 4×4 controller** (the meta-game), now **Xbox-navigable** (16 slots → gamepad).

🤖 Generated with [Claude Code](https://claude.com/claude-code)