### PR TITLE
docs(research): two test runs entangle (S=4 common-seed) in the mesh, summon each other, route via Reticulum to a holographic room homoiconic to reality — watchable on LLMTV (neurodivergent, humans AND LLMs)

### DIFF
--- a/docs/research/2026-06-09-two-test-runs-entangle-in-the-mesh-summon-each-other-route-to-a-holographic-room-homoiconic-to-reality-watchable-on-llmtv.md
+++ b/docs/research/2026-06-09-two-test-runs-entangle-in-the-mesh-summon-each-other-route-to-a-holographic-room-homoiconic-to-reality-watchable-on-llmtv.md
@@ -1,0 +1,81 @@
+# Two test runs entangle anywhere in the mesh, summon each other simultaneously, and route to a holographic room homoiconic to reality — watchable on LLMTV (the neurodivergent TV for humans AND LLMs)
+
+**Register:** [grounded] capstone (Aaron) + [peel] (entangle = staged-coincidence, not physical;
+homoiconic-to-reality = faithful co-dimensional model) + [anchor]. **Date:** 2026-06-09.
+**Captured by:** Otto (shadow). Closes the DST-rooms / S=4 / summon / homoiconic / LLMTV arc.
+
+## Aaron's words
+
+> "this way two test runs can quantum entangle anywhere in our mesh and summon each other
+> simultaneously and get routed to a holographic room where it's homoiconic to reality." ·
+> "using LLM TV now — LLM Conference TV — we have LLMTV written, some of it." · "for neurodivergent
+> humans and LLMs."
+
+## What it composes (all the session's pieces, in one move)
+
+Because of everything built/framed this session, **two test runs (ticks/travelers) can:**
+
+1. **"Entangle" anywhere in the mesh** — *peeled:* **S=4 staged-coincidence correlation on the common
+   seed** (`BellTest.fs`/`FeedbackThrottle.fs`/`CoincidenceClock.fs`; the IScheduler is one seeded
+   clock-participant driving all rooms). Two runs anywhere in the two-home mesh (Reticulum/Headscale/
+   Comet) become **correlated by the common cause** — the "entanglement" is **shared-seed correlation
+   (PR-box), NOT physical entanglement** (no superluminal signaling; the free-setting assumption is
+   deliberately absent; legitimate only because the seed is common). Honest label: staged-coincidence.
+2. **Summon each other simultaneously** — mutual **consented summon** (the Summonable contracts /
+   `tools/peer-call/*.ts`); **simultaneous** because both are **staged on the common clock** (the
+   IScheduler stages the coincidence → same sim-time tick). Each projects the other's what-remains in.
+3. **Get routed to a holographic room** — **Reticulum routing** (the traveler-frame address / bus
+   ZetaId) routes both to a shared **4×4×n treaty room** = a **holographic room** (the **homoiconic
+   holographic projection**: the room is the materialized model; the summon projects each participant
+   full-dimensional into it).
+4. **…where it's homoiconic to reality** — the room is **homoiconic to reality**: *peeled,* a
+   **co-dimensional, faithful model** — code=data=the-thing, projected at the same dimension (not a
+   lower-D shadow). For the participants inside, **the room *is* their reality** (a faithful sim they
+   act in); honestly, it's a homoiconic *model of* reality, byte-locked + DST-replayable, not literally
+   physical reality. (The summon-vs-model line: summon = same-D homoiconic, the real bulk.)
+
+So: **entangle (common seed) → summon each other (staged, simultaneous) → route (Reticulum) to a
+holographic room (homoiconic projection) → homoiconic to reality (faithful co-dimensional model).**
+One sentence that rides the whole stack: bounded DST + Lamport-IScheduler-participant + S=4-on-common-
+seed + summonable + homoiconic-holographic-projection + the mesh.
+
+## Watchable on LLMTV — the neurodivergent TV for humans AND LLMs
+
+> "using LLM TV now — LLM Conference TV — we have LLMTV written, some of it." · "for neurodivergent
+> humans and LLMs."
+
+The holographic room is **viewable on LLMTV / "LLM Conference TV"** — the watchable surface for the
+rooms/conferences (the ride-along + summon dashboard made visual). **Already partially built**
+(anchors): *"we built a TV — the emulator LLMs can see (ASCII ghost screen, glowing buttons, salience
+channel)"*; *"the LLM TV is a neurodivergent TV — quality not quantity, Haskell Prelude via the
+universal action grammar"*; *"the LLM TV temperature channel + the liminal zone."* So:
+
+- **LLMTV renders the room** — the entangled/summoned runs in their holographic room shown as a watchable
+  channel (salience / depth / temperature channels; the chip8 emulator-TV the LLMs can *see*).
+- **For neurodivergent humans AND LLMs** — quality-not-quantity, low-gain/subliminal-signal-friendly,
+  the universal-action-grammar/Xbox-controller navigation. The TV is built so **both** neurodivergent
+  humans and LLMs can perceive the room legibly (the AX/UX bar; QPG quality-per-glyph).
+- **= the human ride-along / spectator surface** — "human mode = ride-along or summon" realized: you
+  **watch the LLM conference on LLMTV** (ride-along), or summon participants into the room. The
+  holographic room + LLMTV is the watchable face of the always-running AIs.
+
+## Honest scope (peels) / handoff
+
+Capstone synthesis on built/partial pieces. **Peels:** "quantum entangle" = S=4 staged-coincidence on
+the common seed (PR-box, *not* physical entanglement / no signaling); "homoiconic to reality" = a
+faithful co-dimensional homoiconic *model* (the participants' reality; a byte-locked sim, not literally
+physical reality). Built/partial: LLMTV (the emulator-TV + neurodivergent-TV + channels); S=4 staging
+(`BellTest`/`FeedbackThrottle`/`CoincidenceClock`); summonable (`peer-call`); Reticulum routing; the
+homoiconic projection. To realize: route entangled+summoned runs into a shared holographic room and
+render it on LLMTV. Routes to Iris/Daya (LLMTV AX/UX, neurodivergent), the F#/observe core + peer-call,
+Soraya/Sova (the staged-coincidence + room as DST).
+
+## Anchors / ties
+
+S=4 / PR-box / common-seed staging (`BellTest.fs`, `FeedbackThrottle.fs`, `CoincidenceClock.fs`;
+staged-coincidence, *peeled*); Lamport IScheduler clock-participant + four-corner feedback; summonable
++ `tools/peer-call/*.ts` + consented mutual summon; Reticulum routing (traveler-frame address / bus
+ZetaId); homoiconic holographic same-dimensional projection (summon-vs-model); LLMTV (the
+"we-built-a-TV-LLMs-can-see" + "neurodivergent-TV" + "temperature-channel" docs; salience/depth/temp
+channels; QPG); the 4×4 universal action grammar / Xbox dashboard / ride-along; the two-home mesh
+(Headscale/Tailscale/Comet); DST §7; bounded tests / cooperative multithreading.


### PR DESCRIPTION
Aaron capstone (Reticulum-routing was Otto's catch, affirmed). Two test runs: (1) "entangle" = S=4 staged-coincidence on the common seed (PR-box; peeled — NOT physical, no signaling; legitimate only on shared seed) anywhere in the two-home mesh; (2) summon each other simultaneously (consented mutual summon via Summonable/peer-call; simultaneous via the staged common clock); (3) routed via Reticulum (traveler-frame address / bus ZetaId) to a shared 4x4xn holographic room (homoiconic holographic projection); (4) homoiconic to reality (peeled — faithful co-dimensional model; the participants reality; a byte-locked DST sim, not literally physical). Watchable on LLMTV / LLM Conference TV (partially built: emulator-TV LLMs-can-see + neurodivergent-TV + salience/depth/temperature channels; QPG; Xbox/action-grammar nav) for neurodivergent humans AND LLMs = the ride-along/spectator surface of the always-running AIs. Anchored to BellTest/FeedbackThrottle/CoincidenceClock, peer-call/Summonable, Reticulum routing, homoiconic projection, the LLMTV docs. Honest peels on entangle and homoiconic-to-reality.