### PR TITLE
feat(keyring): dual-key set treaty — no single key, >=2 to rotate, gapless rotation, 1000x DST green

### DIFF
--- a/tools/setup/persona-keys/keyset.dst1000.test.ts
+++ b/tools/setup/persona-keys/keyset.dst1000.test.ts
@@ -1,0 +1,41 @@
+// 1000x DST for the dual-key set — the "not done until regenerate/rotate retested
+// 1000x" bar, for rotation. Two properties, each 1000 cycles, watchable here + in CI:
+//   (1) DETERMINISM  — same seeds -> byte-identical public set, 1000x, 0 drift.
+//   (2) GAPLESS CHAIN — rotate 1000 times in a chain; at EVERY link the set is
+//                       well-formed (>=2 keys, never single-key) and the promoted
+//                       active is byte-identical to the prior standby (continuity).
+// Run: bun test keyset.dst1000.test.ts   (from tools/setup/persona-keys)
+import { test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { makeKeyringSet, rotate, assertWellFormed, publicSet } from "./keyset.ts";
+import { freshMnemonic } from "./derive.ts";
+
+const HERE = new URL(".", import.meta.url).pathname;
+const gv = JSON.parse(readFileSync(HERE + "golden-vectors-keyring.json", "utf8"));
+const A = gv.input.mnemonic;
+const B = "legal winner thank year wave sausage worth useful legal winner thank yellow";
+const C = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+const N = 1000;
+
+test(`(1) rotation is byte-deterministic across ${N} cycles (0 drift)`, () => {
+  const canonical = JSON.stringify(publicSet(rotate(makeKeyringSet(A, B, "zeta"), C)));
+  let drift = 0;
+  for (let i = 0; i < N; i++) {
+    if (JSON.stringify(publicSet(rotate(makeKeyringSet(A, B, "zeta"), C))) !== canonical) drift++;
+  }
+  expect(drift).toBe(0);
+}, 180_000);
+
+test(`(2) a ${N}-link rotation chain is gapless + continuous at every link`, () => {
+  let set = makeKeyringSet(A, B, "zeta");
+  let breaks = 0, discontinuities = 0;
+  for (let i = 0; i < N; i++) {
+    const priorStandbyEth = set.standby[0].keyring.eth.address;
+    set = rotate(set, freshMnemonic());                 // fresh standby each link
+    try { assertWellFormed(set); } catch { breaks++; }   // never single-key
+    if (set.active.keyring.eth.address !== priorStandbyEth) discontinuities++; // promoted == prior standby
+  }
+  expect(breaks).toBe(0);
+  expect(discontinuities).toBe(0);
+  expect(set.retired.length).toBe(N);                    // every retiring active recorded for revocation
+}, 120_000);

--- a/tools/setup/persona-keys/keyset.test.ts
+++ b/tools/setup/persona-keys/keyset.test.ts
@@ -1,0 +1,66 @@
+// Dual-key set conformance — proves "no single key, >=2 to rotate" as invariants.
+// Run: bun test keyset.test.ts   (from tools/setup/persona-keys)
+import { test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { makeKeyringSet, rotate, assertWellFormed, publicSet, freshKeyringSet } from "./keyset.ts";
+
+const HERE = new URL(".", import.meta.url).pathname;
+const gv = JSON.parse(readFileSync(HERE + "golden-vectors-keyring.json", "utf8"));
+// two distinct known seeds for deterministic tests
+const A = gv.input.mnemonic; // "test test ... junk"
+const B = "legal winner thank year wave sausage worth useful legal winner thank yellow";
+const C = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+test("a fresh set holds exactly one active + one standby (>=2), both well-formed", () => {
+  const s = freshKeyringSet("zeta");
+  expect(s.active.state).toBe("active");
+  expect(s.standby.length).toBeGreaterThanOrEqual(1);
+  assertWellFormed(s); // throws if malformed
+});
+
+test("active and standby derive from DIFFERENT seeds (one compromise must not take both)", () => {
+  const s = makeKeyringSet(A, B, "zeta");
+  expect(s.active.mnemonic).not.toBe(s.standby[0].mnemonic);
+  expect(s.active.keyring.eth.address).not.toBe(s.standby[0].keyring.eth.address);
+});
+
+test("reusing a seed across slots is rejected (distinct-seed invariant)", () => {
+  expect(() => makeKeyringSet(A, A, "zeta")).toThrow(/distinct/);
+});
+
+test("rotation is GAPLESS and CONTINUOUS: old standby becomes new active, byte-identical", () => {
+  const s0 = makeKeyringSet(A, B, "zeta");
+  const oldStandbyEth = s0.standby[0].keyring.eth.address;
+  const s1 = rotate(s0, C);
+  // continuity: the promoted keyring is byte-identical to what it was as standby
+  expect(s1.active.keyring.eth.address).toBe(oldStandbyEth);
+  expect(s1.active.keyring.eth.privkey).toBe(s0.standby[0].keyring.eth.privkey);
+  // gapless: still >=2 keys at every step (1 active + >=1 standby), never single-key
+  assertWellFormed(s1);
+  // the retiring active is recorded for revocation, not silently dropped
+  expect(s1.retired.map((r) => r.keyring.eth.address)).toContain(s0.active.keyring.eth.address);
+  // the new standby is the fresh seed we supplied
+  expect(s1.standby[s1.standby.length - 1].keyring.eth.address).toBe(makeKeyringSet(C, A, "zeta").active.keyring.eth.address);
+});
+
+test("rotation is deterministic given the fresh-standby seed (DST-replayable)", () => {
+  const a = rotate(makeKeyringSet(A, B, "zeta"), C);
+  const b = rotate(makeKeyringSet(A, B, "zeta"), C);
+  expect(JSON.stringify(publicSet(a))).toBe(JSON.stringify(publicSet(b)));
+});
+
+test("rotating into a single-key state is forbidden", () => {
+  // a hand-built malformed set with no standby must be rejected by both guards
+  const s = makeKeyringSet(A, B, "zeta");
+  const broken = { ...s, standby: [] };
+  expect(() => assertWellFormed(broken as any)).toThrow(/single-key/);
+  expect(() => rotate(broken as any, C)).toThrow(/single-key|no standby/);
+});
+
+test("publicSet leaks no private material", () => {
+  const blob = JSON.stringify(publicSet(makeKeyringSet(A, B, "zeta")));
+  expect(blob).not.toContain("nsec");
+  expect(blob).not.toContain("privkey");
+  expect(blob).not.toContain("priv_hex");
+  expect(blob).not.toMatch(/BEGIN .*PRIVATE KEY/);
+});

--- a/tools/setup/persona-keys/keyset.ts
+++ b/tools/setup/persona-keys/keyset.ts
@@ -1,0 +1,98 @@
+// Zeta dual-key set — the "no single key, >=2 to rotate" treaty, as a PURE oracle.
+// Invariant (ISM/SKMS "never just one key"): a KeyringSet always holds exactly one
+// ACTIVE keyring and >=1 STANDBY keyring, each derived from its OWN seed (no shared
+// seed -> compromise of one seed never takes both). Rotation is GAPLESS: the standby
+// is promoted to active (byte-identical continuity, already provisioned + trusted),
+// the retiring active is recorded for revocation, and a fresh standby is minted -- so
+// at NO point are there fewer than two keys. Operational logic lives HERE (the typed
+// boundary oracle), not in bash: bash only calls the edge. Deterministic -> DST-replayable.
+import { deriveKeyring, freshMnemonic } from "./derive.ts";
+
+export type KeyState = "active" | "standby" | "retired";
+
+/** One slot in the set: a keyring + its lifecycle state + the seed that derives it. */
+export interface KeySlot {
+  state: KeyState;
+  mnemonic: string;                       // the slot's OWN seed (never shared across slots)
+  keyring: ReturnType<typeof deriveKeyring>["full"];
+}
+
+/** The set the invariant guards: exactly one active, >=1 standby. */
+export interface KeyringSet {
+  user: string;
+  active: KeySlot;
+  standby: KeySlot[];
+  retired: KeySlot[];
+}
+
+function slot(state: KeyState, mnemonic: string, user: string): KeySlot {
+  return { state, mnemonic, keyring: deriveKeyring(mnemonic, user).full };
+}
+
+/** Build a fresh dual-key set: one active + one standby, each from its own fresh seed. */
+export function freshKeyringSet(user = "zeta"): KeyringSet {
+  return makeKeyringSet(freshMnemonic(), freshMnemonic(), user);
+}
+
+/** Build a set from explicit seeds (>=2). First = active, rest = standby. Deterministic. */
+export function makeKeyringSet(activeMnemonic: string, standbyMnemonic: string, user = "zeta", ...moreStandby: string[]): KeyringSet {
+  const seeds = [activeMnemonic, standbyMnemonic, ...moreStandby];
+  assertDistinctSeeds(seeds);
+  return {
+    user,
+    active: slot("active", seeds[0], user),
+    standby: seeds.slice(1).map((m) => slot("standby", m, user)),
+    retired: [],
+  };
+}
+
+/**
+ * Gapless rotation: promote a standby to active, retire the old active, mint a fresh
+ * standby -- so the count never drops below 2. The promoted keyring is byte-identical
+ * to what it was as standby (continuity: already provisioned, already trust-anchored).
+ * Pure: pass the fresh standby seed in (the only randomness) for DST-replayability.
+ */
+export function rotate(set: KeyringSet, freshStandbyMnemonic: string): KeyringSet {
+  if (set.standby.length < 1) throw new Error("malformed set: no standby to promote (single-key state forbidden)");
+  const [promote, ...restStandby] = set.standby;
+  assertDistinctSeeds([promote.mnemonic, ...restStandby.map((s) => s.mnemonic), freshStandbyMnemonic, set.active.mnemonic]);
+  const newActive: KeySlot = { ...promote, state: "active" };           // continuity: same bytes
+  const newStandby: KeySlot = slot("standby", freshStandbyMnemonic, set.user);
+  const retiredNow: KeySlot = { ...set.active, state: "retired" };
+  return {
+    user: set.user,
+    active: newActive,
+    standby: [...restStandby.map((s) => ({ ...s, state: "standby" as const })), newStandby],
+    retired: [...set.retired, retiredNow],
+  };
+}
+
+/** The invariant the whole treaty enforces. Throws if the set is malformed. */
+export function assertWellFormed(set: KeyringSet): void {
+  if (set.active.state !== "active") throw new Error("malformed set: active slot not active");
+  if (set.standby.length < 1) throw new Error("malformed set: single-key state forbidden (>=2 required to rotate)");
+  if (!set.standby.every((s) => s.state === "standby")) throw new Error("malformed set: non-standby in standby list");
+  assertDistinctSeeds([set.active.mnemonic, ...set.standby.map((s) => s.mnemonic)]);
+}
+
+function assertDistinctSeeds(seeds: string[]): void {
+  if (new Set(seeds).size !== seeds.length) throw new Error("malformed set: seeds must be distinct (one compromise must not take two)");
+}
+
+/** Public-only projection of the whole set (pubkeys are the trust roots; privates stay out).
+ *  Projects from the already-derived keyring in each slot -- no re-derivation (cheap, DST-fast). */
+export function publicSet(set: KeyringSet) {
+  const pub = (s: KeySlot) => {
+    const k = s.keyring;
+    return {
+      state: s.state, user: set.user,
+      ssh: { public: k.ssh.public, fingerprint: k.ssh.fingerprint, path: k.ssh.path },
+      pgp: { keyId: k.pgp.keyId, fingerprint: k.pgp.fingerprint, public: k.pgp.public, path: k.pgp.path },
+      nostr: { npub: k.nostr.npub, pub_hex: k.nostr.pub_hex, path: k.nostr.path },
+      eth: { address: k.eth.address, path: k.eth.path },
+      btc: { address: k.btc.address, path: k.btc.path },
+      sol: { address: k.sol.address, path: k.sol.path },
+    };
+  };
+  return { user: set.user, active: pub(set.active), standby: set.standby.map(pub), retired: set.retired.map(pub) };
+}


### PR DESCRIPTION
Implements Aaron's locked invariant ("no single key so we can rotate") as a PURE TS oracle (keyset.ts) over derive.ts — operational logic in the typed boundary, NOT bash (Amara ferry: .sh is edge glue only). Matches Soraya's K3 routing (P0; Alloy well-formedness + TLA+ gapless-rotation safety).

- KeyringSet = exactly one ACTIVE + >=1 STANDBY, each from its OWN distinct seed (one compromise cannot take both).
- rotate(): GAPLESS + CONTINUOUS — promote standby->active (byte-identical continuity), record retiree for revocation, mint fresh standby. Never <2 keys.
- assertWellFormed: single-key state is malformed, rejected at the door.
- Pure + deterministic -> DST-replayable.

Tests: keyset.test.ts 7/7 (invariants); keyset.dst1000.test.ts 2/2 in 48.9s — (1) 1000-cycle byte-determinism 0 drift; (2) 1000-link rotation chain gapless (0 breaks) + continuous (0 discontinuities) + every retiree recorded.