### PR TITLE
feat(keyring): crypto forward 4x4-style — keyring serializer axis byte-locked (JSON+CBOR), commute proven, golden seeds the four oracles

### DIFF
--- a/docs/research/2026-06-09-crypto-forward-4x4-style-keyring-serializer-axis-bootstrapped-json-plus-cbor-byte-locked-commute-proven-golden-seeds-the-four-oracles.md
+++ b/docs/research/2026-06-09-crypto-forward-4x4-style-keyring-serializer-axis-bootstrapped-json-plus-cbor-byte-locked-commute-proven-golden-seeds-the-four-oracles.md
@@ -1,0 +1,59 @@
+# Crypto forward, 4×4 style — the keyring's serializer axis is bootstrapped: JSON + CBOR byte-locked, commute proven, the golden seeds the four oracles
+
+**Register:** [grounded] build (Aaron: "push crypto forward 4x4 style"). **Date:** 2026-06-09.
+**Captured by:** Otto (shadow). Wires the keyring into the existing byte-lock substrate, not a reinvention.
+
+## What "4×4 style" means for the keyring
+
+The keyring treaty is **4 language oracles × 4 serializers**, byte-locked, golden-vectored,
+DST-replayable (the Amara ferry / `no-sh-inside-the-boundary` doc). This step lands the **serializer
+axis** by **reusing the repo's existing canonical serializers** (`src/Core.TypeScript/dynamic-value/`)
+rather than writing new ones — the keyring becomes one more value the byte-lock substrate already locks.
+
+## What landed (PR-shipped, green)
+
+- **`keyring-4x4.ts`** — encodes the deterministic **public** keyring as a language-neutral `Tagged`
+  value (all leaves are strings; insertion-order canonical because `derive.ts` builds `pub` in fixed
+  order) and serializes it across the locked serializers: **canonical-JSON** (`json.ts`, RFC 8259
+  minimal) + **canonical-CBOR** (`cbor.ts`, RFC 8949 preferred). CBOR is stored **hex-in-JSON** (text,
+  per `no-binary-in-proof-lineage` — diffable, DST-replayable, no binary in the proof lineage).
+- **`golden-vectors-keyring-4x4.json`** — the byte-lock: the golden seed →
+  `{ canonical_json, canonical_cbor_hex }`. **This golden IS the treaty seed** the F#/C#/Rust oracles
+  must replay byte-for-byte.
+- **`keyring-4x4.test.ts` (6 pass)** — proves: **COMMUTE** (JSON and CBOR decode to the *same* keyring
+  — the 4×4 cross-serializer agreement, mirroring `dynamic-value/format-matrix.test.ts`); **BYTE-LOCK**
+  (serialized bytes match the golden exactly); **ROUND-TRIP** (decode∘encode = id per serializer);
+  **DETERMINISM** (re-derive + re-serialize byte-identical); the CBOR hex is text + even-length; no
+  private material leaks into either form.
+
+## The 4×4 matrix status (honest)
+
+```text
+              JSON      CBOR      Arrow     XML/YAML
+F# oracle      .         .         .         .
+C# oracle      .         .         .         .
+TS oracle    [LOCKED]  [LOCKED]    .         .       <- this PR (commute proven, golden seeded)
+Rust oracle    .         .         .         .
+```
+
+- **Done:** the TS oracle × {JSON, CBOR} cell — locked, commuting, golden-seeded.
+- **Next (serializer axis):** add Arrow + XML/YAML for the TS oracle (the dynamic-value substrate
+  already has `golden-vectors-arrow.json` / `xml.ts` to reuse — same pattern).
+- **Next (oracle axis):** F#/C#/Rust keyring derivation replaying this exact golden (the cross-language
+  byte-lock; the golden vector is the conformance target — "the compilers don't lie").
+- **Composes with:** the dual-key set (`keyset.ts`, PR #7349) — a `KeyringSet`'s public projection
+  serializes the same way; and Soraya's **K3** (no-single-key) + **K1** (1000× determinism) proof-rooms.
+
+## Honest scope / handoff
+
+The serializer axis is bootstrapped (2 of 4 serializers, TS oracle); commute + byte-lock + determinism
+proven. Reuses existing substrate (no new serializer). To finish 4×4: Arrow + XML for TS, then the
+three other language oracles replaying the golden. Routes to the F#/C#/Rust core (oracle axis), Soraya
+(K1/K3 proof-rooms), Dejan (CI gate for the 4×4 golden, alongside `keyring-dst1000.yml`).
+
+## Anchors / ties
+
+RFC 8259 (canonical JSON) · RFC 8949 (canonical CBOR, preferred encoding) — via the repo's
+`dynamic-value` serializers (the existing 4×4 substrate: `golden-vectors-cbor/arrow/xml/values.json`,
+`format-matrix.test.ts`); `no-binary-in-proof-lineage` (CBOR as hex-in-JSON); `derive.ts` (the keyring
+oracle); `keyset.ts` (dual-key, PR #7349); the keyring-4×4-treaty docs; Soraya's K1/K3.

--- a/tools/setup/persona-keys/keyring-4x4.test.ts
+++ b/tools/setup/persona-keys/keyring-4x4.test.ts
@@ -1,0 +1,63 @@
+// Keyring 4x4 treaty conformance — the SERIALIZER axis.
+//   COMMUTE   — JSON and CBOR decode to the SAME keyring (the 4x4 cross-serializer
+//               agreement; mirrors dynamic-value/format-matrix.test.ts).
+//   BYTE-LOCK — derived+serialized bytes match the golden vector exactly (the seed
+//               the F#/C#/Rust oracles must replay).
+//   ROUND-TRIP— decode(encode(x)) == x for each serializer.
+//   DETERMINISM— re-derive+re-serialize is byte-identical (DST; full 1000x is in
+//               keyring.dst1000.test.ts for derivation).
+// Run: bun test keyring-4x4.test.ts   (from tools/setup/persona-keys)
+import { test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { keyring4x4, keyringToTagged, serializeKeyring, deserializeKeyring } from "./keyring-4x4.ts";
+import { deriveKeyring } from "./derive.ts";
+import { canonicalJson } from "../../../src/Core.TypeScript/dynamic-value/json.ts";
+import { canonicalCbor, toHex } from "../../../src/Core.TypeScript/dynamic-value/cbor.ts";
+
+const HERE = new URL(".", import.meta.url).pathname;
+const gv = JSON.parse(readFileSync(HERE + "golden-vectors-keyring.json", "utf8"));
+const gv4 = JSON.parse(readFileSync(HERE + "golden-vectors-keyring-4x4.json", "utf8"));
+const M = gv.input.mnemonic;
+
+test("COMMUTE: JSON and CBOR decode the keyring to the same value", () => {
+  const { json, cborHex } = keyring4x4(M, "zeta");
+  const { fromJson, fromCbor } = deserializeKeyring(json, cborHex);
+  expect(fromJson.ok).toBe(true);
+  expect(fromCbor.ok).toBe(true);
+  expect(JSON.stringify(fromJson)).toBe(JSON.stringify(fromCbor));
+});
+
+test("BYTE-LOCK: serialized bytes match the golden vector (the treaty seed)", () => {
+  const { json, cborHex } = keyring4x4(M, "zeta");
+  expect(json).toBe(gv4.expected.canonical_json);
+  expect(cborHex).toBe(gv4.expected.canonical_cbor_hex);
+});
+
+test("ROUND-TRIP: decode(encode(keyring)) recovers the Tagged for both serializers", () => {
+  const tagged = keyringToTagged(deriveKeyring(M, "zeta").pub);
+  const { json, cborHex } = serializeKeyring(deriveKeyring(M, "zeta").pub);
+  const { fromJson, fromCbor } = deserializeKeyring(json, cborHex);
+  expect(fromJson.ok && JSON.stringify(fromJson.value)).toBe(JSON.stringify(tagged));
+  expect(fromCbor.ok && JSON.stringify(fromCbor.value)).toBe(JSON.stringify(tagged));
+});
+
+test("DETERMINISM: re-derive + re-serialize is byte-identical", () => {
+  const a = keyring4x4(M, "zeta");
+  const b = keyring4x4(M, "zeta");
+  expect(a.json).toBe(b.json);
+  expect(a.cborHex).toBe(b.cborHex);
+});
+
+test("the golden CBOR hex is text (no binary in the proof lineage) + even-length hex", () => {
+  expect(gv4.expected.canonical_cbor_hex).toMatch(/^[0-9a-f]*$/);
+  expect(gv4.expected.canonical_cbor_hex.length % 2).toBe(0);
+});
+
+test("no private material leaks into either serialized form", () => {
+  const { json, cborHex } = keyring4x4(M, "zeta");
+  for (const blob of [json, JSON.stringify(deserializeKeyring(json, cborHex))]) {
+    expect(blob).not.toContain("nsec");
+    expect(blob).not.toContain("privkey");
+    expect(blob).not.toMatch(/BEGIN .*PRIVATE KEY/);
+  }
+});

--- a/tools/setup/persona-keys/keyring-4x4.ts
+++ b/tools/setup/persona-keys/keyring-4x4.ts
@@ -1,0 +1,36 @@
+// Keyring 4x4 treaty — the SERIALIZER axis. The deterministic public keyring is
+// encoded as a language-neutral `Tagged` value and locked across the repo's canonical
+// serializers (canonical-JSON + canonical-CBOR), REUSING src/Core.TypeScript/dynamic-value
+// (not reinventing). CBOR bytes are stored hex-in-JSON (text, per no-binary-in-proof-lineage).
+// This is the "4 serializers" half of the keyring 4x4; the "4 oracles" half (F#/C#/Rust)
+// replays the SAME byte-locked golden vector this TS oracle seeds. The seed is the treaty.
+import { deriveKeyring } from "./derive.ts";
+import { canonicalJson, fromCanonicalJson, type Tagged } from "../../../src/Core.TypeScript/dynamic-value/json.ts";
+import { canonicalCbor, fromCanonicalCbor, toHex, fromHex } from "../../../src/Core.TypeScript/dynamic-value/cbor.ts";
+
+type Pub = ReturnType<typeof deriveKeyring>["pub"];
+
+/** Public keyring -> language-neutral Tagged (all fields are strings; insertion order
+ *  is canonical and stable because derive.ts builds `pub` with a fixed literal order). */
+export function keyringToTagged(v: unknown): Tagged {
+  if (typeof v === "string") return { t: "str", v };
+  if (Array.isArray(v)) return { t: "arr", v: v.map(keyringToTagged) };
+  if (v && typeof v === "object") return { t: "obj", v: Object.entries(v).map(([k, c]) => [k, keyringToTagged(c)] as [string, Tagged]) };
+  throw new Error(`keyring Tagged: unexpected non-string leaf: ${typeof v}`);
+}
+
+/** Serialize a public keyring across the locked serializers. CBOR as hex (text-in-JSON). */
+export function serializeKeyring(pub: Pub) {
+  const tagged = keyringToTagged(pub);
+  return { json: canonicalJson(tagged), cborHex: toHex(canonicalCbor(tagged)) };
+}
+
+/** Decode each serialized form back to a Tagged (for the commute / round-trip proof). */
+export function deserializeKeyring(json: string, cborHex: string) {
+  return { fromJson: fromCanonicalJson(json), fromCbor: fromCanonicalCbor(fromHex(cborHex)) };
+}
+
+/** Derive + serialize in one step (the treaty's emit path). */
+export function keyring4x4(mnemonic: string, user = "zeta") {
+  return serializeKeyring(deriveKeyring(mnemonic, user).pub);
+}


### PR DESCRIPTION
Aaron: "push crypto forward 4x4 style." Lands the SERIALIZER axis of the keyring 4x4 treaty by REUSING the repo canonical serializers (src/Core.TypeScript/dynamic-value), not reinventing.

- keyring-4x4.ts: encodes the deterministic PUBLIC keyring as a language-neutral Tagged value, serializes across canonical-JSON (RFC 8259) + canonical-CBOR (RFC 8949). CBOR stored hex-in-JSON (text, per no-binary-in-proof-lineage).
- golden-vectors-keyring-4x4.json: the byte-lock; this golden IS the treaty seed the F#/C#/Rust oracles must replay.
- keyring-4x4.test.ts (6 pass): COMMUTE (JSON & CBOR decode to the SAME keyring — the cross-serializer agreement); BYTE-LOCK (matches golden); ROUND-TRIP; DETERMINISM; CBOR-is-text; no-private-leak.

Matrix: TS oracle x {JSON,CBOR} LOCKED + commuting + golden-seeded. Next serializer axis: Arrow + XML. Next oracle axis: F#/C#/Rust replay this golden. Composes with keyset.ts (#7349) + Soraya K1/K3. Regression: gen + keyset tests still green.