### PR TITLE
ci(keyring): gate dual-key set (K3) + keyring 4x4 serializer byte-lock in the keyring DST workflow

### DIFF
--- a/.github/workflows/keyring-dst1000.yml
+++ b/.github/workflows/keyring-dst1000.yml
@@ -29,6 +29,12 @@ jobs:
       - name: install keyring tool deps
         working-directory: tools/setup/persona-keys
         run: bun install
-      - name: keyring DST — golden byte-lock + 1000x determinism + rotation
+      - name: keyring DST — derivation byte-lock + 1000x determinism + rotation
         working-directory: tools/setup/persona-keys
         run: bun test gen.test.ts keyring.dst1000.test.ts keyring.rotate.test.ts
+      - name: dual-key set — no-single-key invariants + 1000x gapless rotation (K3)
+        working-directory: tools/setup/persona-keys
+        run: bun test keyset.test.ts keyset.dst1000.test.ts
+      - name: keyring 4x4 — serializer byte-lock + JSON==CBOR==XML commute
+        working-directory: tools/setup/persona-keys
+        run: bun test keyring-4x4.test.ts


### PR DESCRIPTION
keyring-dst1000.yml gated only the derivation tests; the newer suites were green locally but not enforced. Add two steps:
- keyset.test.ts + keyset.dst1000.test.ts -> no-single-key invariants + 1000x gapless rotation (Soraya K3).
- keyring-4x4.test.ts -> serializer byte-lock + 3-way commute (JSON==CBOR==XML).

Full suite verified locally: 22 pass / 0 fail / 6 files / 61.5s (both 1000x DSTs). Same SHA-pinned actions, ubuntu-24.04, paths-scoped + dispatch, concurrency-grouped, contents: read.