### PR TITLE
docs(research): fingerprintable items are rooms (content-addressing) — Meijer types-define-tests -> rooms fall out free; rooms have hats; test framework IS governance + chip8 state dedup

### DIFF
--- a/docs/research/2026-06-09-content-addressing-rooms-give-free-deduplication-of-the-chip8-memory-to-worldview-state-space.md
+++ b/docs/research/2026-06-09-content-addressing-rooms-give-free-deduplication-of-the-chip8-memory-to-worldview-state-space.md
@@ -1,0 +1,52 @@
+# Content-addressing → rooms gives free deduplication of the chip8 memory→worldview state space
+
+**Register:** [grounded] corollary (Aaron). **Date:** 2026-06-09. **Captured by:** Otto (shadow).
+A direct consequence of "every fingerprintable item is a room, addressed by its fingerprint."
+
+## Aaron's words
+
+> "and we get deduplication of our chip8 memory→worldview state space too."
+
+## The corollary
+
+Because rooms are **content-addressed** (the fingerprint *is* the address; identical content = same
+room = stored once — content-addressing gives dedup + idempotency by construction), the **chip8
+memory→worldview state space deduplicates for free.** Every distinct chip8 state — the
+emulator memory projected into a worldview (the structure-discovery / Cheat-Engine-style state space,
+the `MemoryLens`/`MemorySense` projection, `Chip8Observer.fs`) — is a **fingerprintable item**, so:
+
+- **identical memory→worldview states share one fingerprint** → one content-addressed entry, **not**
+  re-stored per visit;
+- **the state space collapses to its distinct states** — a huge emulator state space with massive
+  revisitation (loops, cycles, re-entered positions) is stored as the **set of unique states + the
+  transitions**, not every trajectory step;
+- this is exactly the **delta-pattern / content-address-the-change** discipline (#7121) made automatic:
+  the worldview is keyed by content, so the dedup is a property of the addressing, not a separate cache.
+
+## Why it matters
+
+- **The chip8 state space becomes tractable** — the "play anything / exhaustive proof while tractable"
+  goal needs the space finite; content-address dedup is *how* it stays finite (revisited states cost
+  nothing; only novelty grows the store). The strange-attractor framing fits: an attractor revisits a
+  bounded set of states — content-addressing stores that bounded set once.
+- **Free across the whole substrate** — the same mechanism that dedups dependency-rooms, treaty-rooms,
+  and identities dedups the chip8 worldview. One addressing scheme (fingerprint = canonical root =
+  ZetaId, 128-bit), one dedup, everywhere — chip8 is just one content-addressed state space among many.
+- **DST-clean** — content-addressed states are idempotent + replayable: re-deriving a state yields the
+  same fingerprint, so replay hits the existing entry (apply-N == apply-once). Dedup + DST compose.
+
+## Honest scope / handoff
+
+A corollary, no new mechanism — it's content-addressing (already the substrate's addressing) applied to
+the chip8 worldview state space. To realize: ensure the chip8 memory→worldview projection is keyed by
+its canonical-root fingerprint (so revisits dedup), reusing the delta-pattern content-address path.
+Routes to the chip8/DarkHall + observe core (`Chip8Observer.fs`, `MemoryLens`/`MemorySense`), Soraya
+(dedup = idempotency proof-room, ties C8), the content-addressing substrate.
+
+## Anchors / ties
+
+Content-based addressing (Merkle / Git objects / IPFS; canonical root = fingerprint = ZetaId 128-bit) →
+free dedup + idempotency; the delta-pattern / content-address-the-change (#7121); chip8 / DarkHall
+emulator, `Chip8Observer.fs`, `MemoryLens`/`MemorySense` structure-discovery state space; strange
+attractors (bounded revisited set); "every fingerprintable item is a room" (the parent principle);
+idempotency discipline (apply-N == apply-once; Soraya C8); DST replay.

--- a/docs/research/2026-06-09-every-fingerprintable-closeable-item-is-a-room-content-addressing-erik-meijer-types-define-the-tests-rooms-fall-out-free-rooms-have-hats-test-framework-is-governance.md
+++ b/docs/research/2026-06-09-every-fingerprintable-closeable-item-is-a-room-content-addressing-erik-meijer-types-define-the-tests-rooms-fall-out-free-rooms-have-hats-test-framework-is-governance.md
@@ -1,0 +1,97 @@
+# Every fingerprintable item we can close over becomes a room — content-addressing makes the room; Erik Meijer's "let the types define the code" makes tests/attractors/loops, so the rooms fall out for free; rooms have hats; the test framework becomes our governance
+
+**Register:** [grounded] capstone synthesis (Aaron) + [Beacon] anchored. **Date:** 2026-06-09.
+**Captured by:** Otto (shadow). The unifying frame: content-addressing → rooms; types → tests → rooms; rooms → hats → governance.
+
+## Aaron's words
+
+> "every fingerprintable item we can close over becomes a room — this is how we use our content-based
+> addressing. And Erik Meijer 'let the types define the code' — do the same for tests and strange-
+> attractors/loops, and the rooms fall out for free. Rooms have hats. The test framework becomes our
+> governance."
+
+## 1. Every fingerprintable, closeable item is a room — via content-based addressing
+
+Generalize past "every dependency becomes a room": **any item that (a) can be fingerprinted (has a
+stable content-address) and (b) we can close over (wrap in a dep-as-oracle treaty) becomes a room.**
+The **fingerprint *is* the room's address** — content-based addressing (Merkle / Git objects / IPFS;
+our canonical root): a room is identified by the hash of its content, not a name we assign. Two items
+with the same fingerprint **are the same room** (free dedup + idempotency — content-addressing gives
+both by construction). So the universe of rooms = **{content-addressable items we've closed over}**,
+keyed by fingerprint. This is *how we use* content-based addressing: the address space of rooms is the
+content-hash space. (ZetaId = destination hash = canonical root = the same 128-bit content-address; the
+room, the network destination, and the identity share one addressing scheme.)
+
+## 2. Erik Meijer — "let the types define the code" — applied to tests/attractors/loops
+
+Erik Meijer's discipline (LINQ, Rx, the IEnumerable/IObservable duality): **let the types do the work —
+the type defines the code.** Apply the *same* move to **tests, strange-attractors, and loops**: **let
+the type define the test/attractor/loop.** Given a type (the shape of a value / a primitive / a
+dependency interface), its **test, its attractor, its loop are derived from the type** — you don't
+hand-author them. Property tests, the byte-lock conformance, the fixed-point/attractor it converges to,
+the DST loop — all **fall out of the type**.
+
+And because **rooms *are* tests** (tests-become-rooms), if the types define the tests, then **the rooms
+fall out for free**: you declare the types; the test framework derives the tests/attractors/loops;
+those are the rooms; the rooms are content-addressed by their fingerprint. **No hand-built rooms** —
+types in, rooms out. (This is the type-provider / generative shape: the F# type provider, Meijer's
+type-driven generation, our "interfaces are the valuable thing — code/docs/proofs regenerate from
+them." The types are the interface; the rooms regenerate from them.)
+
+## 3. Rooms have hats
+
+The **hat system** (time-bound auth contracts, owners, typed slots, exits — every hat time-bound +
+exit-paired + auth-bearing) attaches to **rooms**: each room **has hats** — the roles within it
+(owner, judge, maintainer, oracle-host) are **hats**, held by travelers for a bounded term, with auth.
+Who runs a room, who judges its attractor, who can merge its tick — all **hat-gated**. So a room is not
+just a byte-lock matrix; it's a **governed space**: typed roles (hats) with time-bound authority over
+that content-addressed room. (Soraya C12 hat-contract well-formedness + C14 slot-allocation now apply
+per-room.)
+
+## 4. The test framework becomes our governance
+
+Putting it together: **prod = test**, **rooms = tests** (content-addressed, type-derived), **rooms have
+hats** (time-bound authority). Therefore **the test framework IS the governance system** — governance
+is not a separate document or process layered on top; it is **executable, and it is the thing that runs
+the tests/rooms**:
+
+- **Who decides** = who holds the hat in that room (time-bound, auth-bearing, exit-paired).
+- **What's authoritative** = the room whose attractor is judged strongest (uncertainty-Δ) and whose
+  tick merged to main (the GVT/canonical-root frontier).
+- **How decisions propagate** = the judgment cascade along the content-address/dependency graph
+  (bounded, idempotent).
+- **How rules change** = change the types → the rooms regenerate; change the hats → the authority
+  moves; all under the same bounded, replayable, byte-locked discipline.
+
+Governance becomes **the test framework executing**: type-derived, content-addressed, hat-gated,
+attractor-judged, cascade-propagated rooms. The thing that has always been "run the tests" *is* "run
+the polity." (No-directives / source≠authorization holds: a room's *content* anyone may propose; the
+*authority* to merge is the hat, human-rooted where gated. The governance is the framework; the framework
+is the governance.)
+
+## Synthesis (the whole arc in one line)
+
+**Fingerprint → room (content-addressing); type → test → room (Meijer, free); room → hats (bounded
+authority); test framework → governance (executable polity)** — all content-addressed, type-derived,
+bounded, replayable, judged on uncertainty-Δ, cascading along the graph.
+
+## Honest scope / handoff
+
+A capstone unification of built/captured pieces (content-addressing / canonical root; the 6×6 treaty
+room; tests-as-attractors + judgment cascade; every-dependency-is-a-room; the hat system; prod=test;
+no-directives governance). To realize: **type-driven room generation** (the type provider / property-
+derivation that emits a room from a type), **per-room hat binding** (hats scoped to a content-addressed
+room; C12/C14), and the **test-framework-as-governance runtime** (hats decide, attractors judged, ticks
+merge, judgments cascade). Routes to the F#/observe core (type→room generation; the framework),
+Soraya/Sova (C12/C14 hats-per-room; cascade/attractor proof-rooms), the governance owners (the framework
+*is* GOVERNANCE.md, executable), ace (content-addressed room graph), Iris/Daya (the conference-room UX).
+
+## Anchors / ties (Beacon)
+
+**Erik Meijer** — "let the types do the work / types define the code" (LINQ, Rx, IEnumerable⇄IObservable
+duality, type-driven generation); content-based addressing (Merkle trees; Git content-addressed objects;
+IPFS; our canonical root = fingerprint = ZetaId, 128-bit); F# type providers (types → generated surface);
+strange attractors / self-evolving patterns + judgment cascade (prior capture); the hat system (time-
+bound auth contracts, slots, exits; Soraya C12/C14); prod=test + 6×6 treaty room + every-dependency-is-
+a-room; no-directives / source≠authorization (the governance's authority model); GOVERNANCE.md (now the
+executable test framework); "interfaces are the valuable thing — everything regenerates from them."


### PR DESCRIPTION
Capstone + corollary.

A. Every FINGERPRINTABLE closeable item is a room -- fingerprint IS the address (content-addressing; same fingerprint = same room = free dedup/idempotency; room/destination/identity share one 128-bit address = ZetaId). Erik Meijer "let the types define the code" -> tests/attractors/loops derived from types, and since rooms ARE tests, the ROOMS FALL OUT FOR FREE. Rooms HAVE HATS (time-bound auth per room; C12/C14) -> governed space. So the TEST FRAMEWORK BECOMES GOVERNANCE (who-decides=the hat; authoritative=strongest-judged attractor at the canonical-root frontier; propagation=bounded idempotent cascade; rule-change=change types->rooms regenerate). Executable governance.

B. Corollary: free DEDUP of the chip8 memory->worldview state space -- identical states share a fingerprint, stored once; space collapses to distinct states+transitions (delta-pattern #7121 automatic); keeps it finite; DST-clean.