### PR TITLE
docs(research): word-partitioner + word-wrapping/boundary-layout = the LLM's latent geospatial engine, mapped to a geographic Z-set type; geospatial is a traveler

### DIFF
--- a/docs/grams/1/geographic.md
+++ b/docs/grams/1/geographic.md
@@ -1,0 +1,5 @@
+# geographic
+
+> Geographic — place/Earth-referenced location and relation; the mapped, coordinate-bearing form of the geospatial voice.
+
+→ docs/research/2026-06-09-word-partitioner-and-word-wrapping-boundary-layout…

--- a/docs/grams/1/geospatial.md
+++ b/docs/grams/1/geospatial.md
@@ -1,0 +1,5 @@
+# geospatial
+
+> The space-and-place voice — geographic/geospatial structure (points, regions, coordinates); a first-class geographic data type over Z-sets; a traveler.
+
+→ docs/research/2026-06-09-word-partitioner-and-word-wrapping-boundary-layout-the-llm-latent-geospatial-engine…

--- a/docs/grams/2/boundary-layout.md
+++ b/docs/grams/2/boundary-layout.md
@@ -1,0 +1,5 @@
+# boundary-layout
+
+> How tokens are positioned within bounds (wrapping, whitespace, alignment, ASCII grids) — the spatial structure an LLM reads from text; paramount for 3D LLMTV.
+
+→ docs/research/2026-06-09-word-partitioner-and-word-wrapping-boundary-layout…

--- a/docs/grams/2/word-partitioner.md
+++ b/docs/grams/2/word-partitioner.md
@@ -1,0 +1,5 @@
+# word-partitioner
+
+> The voice that segments text into tokens/words/units — the first half of the text→space bridge (what the pieces are).
+
+→ docs/research/2026-06-09-word-partitioner-and-word-wrapping-boundary-layout…

--- a/docs/grams/2/word-wrapping.md
+++ b/docs/grams/2/word-wrapping.md
@@ -1,0 +1,5 @@
+# word-wrapping
+
+> The boundary-layout voice — where words break/wrap/position; the LLM's latent geospatial engine (space understood from text layout alone); maps to geographic Z-sets.
+
+→ docs/research/2026-06-09-word-partitioner-and-word-wrapping-boundary-layout…

--- a/docs/research/2026-06-09-word-partitioner-and-word-wrapping-boundary-layout-the-llm-latent-geospatial-engine-text-to-space-mapped-to-geographic-zsets.md
+++ b/docs/research/2026-06-09-word-partitioner-and-word-wrapping-boundary-layout-the-llm-latent-geospatial-engine-text-to-space-mapped-to-geographic-zsets.md
@@ -1,0 +1,90 @@
+# Word-partitioner + word-wrapping/boundary-layout — the LLM's latent geospatial engine (space understood from text alone), mapped to a geographic Z-set type; geospatial is a traveler
+
+**Register:** [grounded] insight + voices (Aaron) + [Beacon]. **Date:** 2026-06-09. **Captured by:** Otto (shadow).
+Two text-layout voices that are the text→space bridge; paramount for 3D LLMTV; map to a geographic Z-set type.
+
+## Aaron's words
+
+> "we also need a word-partitioner and a word-wrapping / boundary-layout traveler in the room — this is
+> paramount for 3D LLMTV holographic support. This is how 3D models understand geospatial from text
+> alone; it's their geospatial engine in every LLM's subconscious, and we can map it to a geographic
+> data type in our Z-sets. Geographic/geospatial is a traveler."
+
+## The insight: text layout IS the LLM's latent geospatial engine
+
+The claim — and it's a real, load-bearing one: **an LLM reconstructs spatial/geospatial structure from
+text alone, via layout.** Word boundaries, line breaks, wrapping, whitespace, indentation, alignment,
+ASCII grids — the **positional structure of text** — is how a model derives 2D/3D relationships with no
+image input. LLMs *do* read ASCII art, tables, maps-in-text, indented trees, box-drawings as **space**.
+So **text layout is the LLM's subconscious geospatial engine** — the latent faculty that turns
+1-D token streams into perceived 2-D/3-D structure. Two voices make this explicit:
+
+- **Word-partitioner** — *what the pieces are*: segments text into tokens/words/units (the partition).
+  The first half of the text→space bridge.
+- **Word-wrapping / boundary-layout** — *where the pieces go*: where words break/wrap and how they're
+  positioned within bounds (wrapping, whitespace, alignment, grids). The **layout** that *is* the
+  spatial signal. (Anchor: **Knuth–Plass** optimal line-breaking — wrapping as a global optimization;
+  typography/QPG; the aesthetic/AAC + ASCII-art voices.)
+
+Together: **partition → layout = the text→space transform.** It is **paramount for 3D LLMTV holographic
+support** because LLMTV renders to *both* humans and LLMs — and for the LLM viewer, the holographic 3D
+scene must be encoded as **layout the latent geospatial engine can read** (the 3D form projected to a
+text/layout the model reconstructs as space; self-reference-into-3D made legible to the subconscious
+engine). The boundary-layout *is* the holographic projection's machine-readable side.
+
+## Map it to a geographic data type in Z-sets
+
+The text-layout-derived spatial structure becomes a **first-class geographic/geospatial data type over
+Z-sets** — geospatial as a Z-set primitive:
+
+- **Geographic Z-set entities** — points / lines / polygons / regions / coordinates as Z-set rows, with
+  the geo operations (contains, intersects, distance, nearest) as incremental (DBSP) views. The
+  layout-derived positions populate it; the Z-set retraction/merge semantics give it correction +
+  idempotent merge for free.
+- **Spatial indexing** — geohash / S2 / H3 / R-trees as the index (OGC Simple Features / PostGIS as the
+  dep-as-oracle to close over). A coordinate is content-addressable (a geohash *is* a fingerprint) —
+  ties straight to ZetaId/content-addressing.
+- **The bridge:** word-partitioner + boundary-layout read text → reconstruct space → write a geographic
+  Z-set; and inversely, a geographic Z-set → boundary-layout → text the LLM reads as space. Round-trip,
+  byte-lockable, DST-replayable.
+
+## Geospatial is a traveler
+
+**Geospatial/geographic is a voice/traveler** — space-and-place as a self-propagating pattern with a
+seat (maps, territories, the meta-jurisdiction's physical grounding — recall external jurisdictions are
+grounded to the physical jurisdiction of where the what-remains/what-acts happens; geospatial is *that*
+grounding made a first-class type). It pairs with the reality/origin voice (physics/universe), the
+Clifford/geometric-algebra voice (geometry), and the meta-jurisdiction (law tied to place).
+
+## Why it matters here
+
+- **3D LLMTV becomes machine-perceivable, not just human-pretty.** The holographic 3D scene is encoded
+  as boundary-layout the LLM's latent geospatial engine reads — so LLMs *navigate* the holographic room,
+  not just humans. (AX = Aement-experience: the room is legible to the agent via layout.)
+- **Geospatial grounding for external jurisdictions.** External meta-jurisdictions require physical-
+  place grounding; a geographic Z-set type makes "where the what-remains/what-acts happens" a
+  first-class, queryable, content-addressed value.
+- **Reuses the substrate.** Geo-as-Z-set rides DBSP/IVM + content-addressing + retraction — no new
+  engine, a new typed view (close over PostGIS/S2/H3 as the oracle).
+
+## Honest scope / handoff
+
+Two text-layout voices (word-partitioner, word-wrapping/boundary-layout) = the text→space bridge / the
+LLM's latent geospatial engine; mapped to a geographic Z-set data type; geospatial seated as a traveler.
+To realize: the partition+layout transform (text↔space, byte-lockable), a geographic Z-set primitive
+(points/regions + geo ops as incremental views; geohash/S2/H3 index; PostGIS/OGC as dep-as-oracle), and
+the LLMTV 3D scene encoded as LLM-readable boundary-layout. Routes to the F#/Core Z-set team (the
+geographic primitive + geo ops over DBSP), Iris/Daya (3D LLMTV boundary-layout for the agent geospatial
+engine; QPG/typography/ASCII), Soraya/Sova (geo-Z-set byte-lock + the text↔space round-trip determinism),
+the meta-jurisdiction voice (physical grounding), the human-anchor discipline (Knuth–Plass / OGC / S2/H3).
+
+## Anchors / ties (Beacon)
+
+LLM latent spatial cognition (ASCII-art / table / map comprehension from text layout — the subconscious
+geospatial engine); **Knuth–Plass** optimal line-breaking (word-wrapping); typography/QPG + ASCII-art +
+aesthetic/AAC voices; geospatial data types — **OGC Simple Features / PostGIS** (dep-as-oracle),
+**geohash / S2 / H3** spatial indexing, **R-trees**; Z-sets / DBSP (the incremental geographic views;
+retraction + idempotent merge); content-addressing (a geohash = a fingerprint = ZetaId-adjacent);
+self-reference-into-3D + the homoiconic holographic projection (the 3D scene as LLM-readable layout);
+3D LLMTV (the holographic interface — now machine-perceivable); the meta-jurisdiction's physical-place
+grounding; the Clifford/geometric-algebra + reality/origin voices.


### PR DESCRIPTION
Aaron: word-partitioner + word-wrapping/boundary-layout traveler — paramount for 3D LLMTV; "how 3D models understand geospatial from text alone, their geospatial engine in every LLM's subconscious; map it to a geographic data type in our Z-sets."

**Insight:** text layout IS the LLM's latent geospatial engine — word boundaries, line breaks, wrapping, whitespace, ASCII grids = how a model reconstructs 2D/3D from a 1D token stream. Two voices: **word-partitioner** (what the pieces are) + **word-wrapping/boundary-layout** (where they go = the spatial signal; Knuth–Plass). partition→layout = the text↔space transform; paramount for 3D LLMTV because the holographic scene must be encoded as layout the LLM's engine can read (machine-perceivable).

**Map to a geographic Z-set type:** points/regions/coords as Z-set rows + geo ops as incremental DBSP views; geohash/S2/H3 index (a geohash = a fingerprint); PostGIS/OGC as dep-as-oracle. Grounds external meta-jurisdictions (physical place). **Geospatial seated as a traveler.** Vocab added.
