### PR TITLE
feat(platform): multi-tenancy — Tenant CRD + controller + Admin portal (cluster capacity + quotas), real k8s reads

### DIFF
--- a/full-ai-cluster/k8s/applications/platform/Application.yaml
+++ b/full-ai-cluster/k8s/applications/platform/Application.yaml
@@ -26,7 +26,7 @@ spec:
     targetRevision: main
     path: full-ai-cluster/k8s/applications/platform
     directory:
-      include: '{namespace,crd-policy,crd-gameserver,crd-app,crd-webapp,crd-blueprint,crd-deployable,policy-default,blueprints,controller,portal}.yaml'
+      include: '{namespace,crd-policy,crd-gameserver,crd-app,crd-webapp,crd-blueprint,crd-deployable,crd-tenant,policy-default,blueprints,controller,portal}.yaml'
   destination:
     server: https://kubernetes.default.svc
     namespace: zeta-platform

--- a/full-ai-cluster/k8s/applications/platform/controller.yaml
+++ b/full-ai-cluster/k8s/applications/platform/controller.yaml
@@ -22,17 +22,29 @@ metadata:
     argocd.argoproj.io/sync-wave: "-10"
 rules:
   - apiGroups: ["platform.zeta.io"]
-    resources: ["deployables", "blueprints"]
+    resources: ["deployables", "blueprints", "tenants"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["platform.zeta.io"]
-    resources: ["deployables/status"]
+    resources: ["deployables/status", "tenants/status"]
     verbs: ["get", "patch", "update"]
+  - apiGroups: ["platform.zeta.io"]
+    resources: ["policies"]   # the tenant reconcile writes a default Policy per namespace
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
   - apiGroups: ["apps"]
     resources: ["deployments", "statefulsets"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]
   - apiGroups: [""]
     resources: ["services", "persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]   # tenant provisioning: namespace + quota + limits
+    resources: ["namespaces", "resourcequotas", "limitranges"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["networking.k8s.io"]   # tenant isolation
+    resources: ["networkpolicies"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]   # admin: read cluster capacity + per-namespace usage
+    resources: ["nodes", "pods"]
+    verbs: ["get", "list"]
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]

--- a/full-ai-cluster/k8s/applications/platform/crd-tenant.yaml
+++ b/full-ai-cluster/k8s/applications/platform/crd-tenant.yaml
@@ -1,0 +1,60 @@
+# Tenant — a customer/owner boundary. Creating one provisions a namespace with a
+# ResourceQuota (the CPU/RAM/storage/pods "hardware" sold to this tenant), a
+# LimitRange (per-pod defaults/max), a NetworkPolicy (tenants can't see each
+# other), and the default Policy. The controller reconciles Tenant → those
+# objects (renderTenant). Editing the quota re-patches the ResourceQuota. This is
+# the §4.2 multi-tenancy design made real.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: tenants.platform.zeta.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "-20"
+spec:
+  group: platform.zeta.io
+  scope: Cluster   # a Tenant owns namespace(s) — it is cluster-scoped
+  names:
+    kind: Tenant
+    plural: tenants
+    singular: tenant
+    shortNames: [tn]
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [namespace]
+              properties:
+                displayName: { type: string, description: "human-facing tenant name" }
+                namespace: { type: string, description: "the namespace provisioned for this tenant" }
+                quota:
+                  type: object
+                  description: "the hardware sold to this tenant (ResourceQuota hard caps)"
+                  properties:
+                    cpu: { type: string, default: "4", description: "total requests.cpu cap (cores)" }
+                    memory: { type: string, default: "16Gi", description: "total requests.memory cap" }
+                    storage: { type: string, default: "100Gi", description: "total PVC storage cap" }
+                    pods: { type: integer, default: 30, description: "max pods" }
+                  default: {}
+                isolated: { type: boolean, default: true, description: "deny cross-tenant network traffic (NetworkPolicy)" }
+                admin: { type: string, default: otto, description: "persona that operates this tenant's resources" }
+                policy: { type: string, default: default, description: "default Policy for the tenant namespace" }
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - { name: Namespace, type: string, jsonPath: ".spec.namespace" }
+        - { name: CPU, type: string, jsonPath: ".spec.quota.cpu" }
+        - { name: Memory, type: string, jsonPath: ".spec.quota.memory" }
+        - { name: Storage, type: string, jsonPath: ".spec.quota.storage" }
+        - { name: Pods, type: integer, jsonPath: ".spec.quota.pods" }
+        - { name: Phase, type: string, jsonPath: ".status.phase" }
+        - { name: Age, type: date, jsonPath: ".metadata.creationTimestamp" }

--- a/full-ai-cluster/k8s/applications/platform/portal.yaml
+++ b/full-ai-cluster/k8s/applications/platform/portal.yaml
@@ -25,6 +25,12 @@ rules:
   - apiGroups: ["platform.zeta.io"]
     resources: ["deployables", "blueprints"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["platform.zeta.io"]   # admin: read + apply tenants (set quotas)
+    resources: ["tenants"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]   # admin: cluster capacity + per-namespace usage (read-only)
+    resources: ["nodes", "pods", "namespaces", "resourcequotas"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/full-ai-cluster/platform-controller/src/controller.ts
+++ b/full-ai-cluster/platform-controller/src/controller.ts
@@ -9,6 +9,7 @@
 import { type Blueprint, type Deployable, renderDeployable } from "./blueprint.ts";
 import { GROUP, VERSION } from "./types.ts";
 import { inClusterConfig, K8sClient, KIND_PLURAL } from "./k8s.ts";
+import { renderTenant, type Tenant, TENANT_KIND_PLURAL } from "./tenant.ts";
 
 export const LIBRARY_NAMESPACE = "zeta-platform";
 
@@ -95,7 +96,19 @@ async function reconcileOne(client: K8sClient, idx: BlueprintIndex, cr: Deployab
   await emitState(cr, "Ready", `applied ${result.objects.length} object(s) from blueprint "${cr.spec.blueprint}"`);
 }
 
-/** Run the controller: load blueprints, then watch Deployables and reconcile. */
+/** Reconcile one Tenant: render + server-side-apply its namespace/quota/isolation. */
+async function reconcileTenant(client: K8sClient, cr: Tenant): Promise<void> {
+  const objs = renderTenant(cr);
+  for (const o of objs) {
+    const plural = TENANT_KIND_PLURAL[o.kind];
+    if (!plural) throw new Error(`no REST plural for tenant child ${o.kind}`);
+    await client.apply(o, plural);
+  }
+  console.log(`[tenant ${cr.metadata.name}] applied ${objs.length} object(s) → namespace ${cr.spec.namespace}`);
+  await client.patchStatus(GROUP, VERSION, "tenants", "", cr.metadata.name, { phase: "Ready", namespace: cr.spec.namespace, children: objs.map((o) => `${o.kind}/${o.metadata.name}`) });
+}
+
+/** Run the controller: reconcile + watch BOTH Deployables and Tenants concurrently. */
 export async function run(): Promise<void> {
   const client = new K8sClient(inClusterConfig());
 
@@ -104,27 +117,48 @@ export async function run(): Promise<void> {
     return indexBlueprints(items as unknown as Array<{ metadata: { name: string; namespace: string }; spec: Blueprint }>);
   };
 
-  let idx = await loadBlueprints();
-  console.log(`loaded ${idx.size} blueprint(s)`);
-
-  const { items, resourceVersion } = await client.list(GROUP, VERSION, "deployables");
-  for (const cr of items) await reconcileOne(client, idx, cr as unknown as Deployable);
-
-  console.log(`watching deployables from rv ${resourceVersion}`);
-  for (;;) {
-    try {
-      const start = (await client.list(GROUP, VERSION, "deployables")).resourceVersion;
-      for await (const ev of client.watch(GROUP, VERSION, "deployables", undefined, start)) {
-        if (ev.type === "BOOKMARK") continue;
-        if (ev.type === "DELETED") continue; // ownerReferences cascade-delete children
-        idx = await loadBlueprints(); // refresh library each event (cheap; few blueprints)
-        await reconcileOne(client, idx, ev.object as unknown as Deployable);
+  // ── Deployable reconcile + watch ───────────────────────────────────
+  const runDeployables = async (): Promise<void> => {
+    let idx = await loadBlueprints();
+    console.log(`loaded ${idx.size} blueprint(s)`);
+    const { items } = await client.list(GROUP, VERSION, "deployables");
+    for (const cr of items) await reconcileOne(client, idx, cr as unknown as Deployable);
+    console.log("watching deployables");
+    for (;;) {
+      try {
+        const start = (await client.list(GROUP, VERSION, "deployables")).resourceVersion;
+        for await (const ev of client.watch(GROUP, VERSION, "deployables", undefined, start)) {
+          if (ev.type === "BOOKMARK" || ev.type === "DELETED") continue;
+          idx = await loadBlueprints();
+          await reconcileOne(client, idx, ev.object as unknown as Deployable);
+        }
+      } catch (e) {
+        console.error(`deployable watch error, retrying in 3s: ${(e as Error).message}`);
+        await new Promise((r) => setTimeout(r, 3000));
       }
-    } catch (e) {
-      console.error(`watch error, retrying in 3s: ${(e as Error).message}`);
-      await new Promise((r) => setTimeout(r, 3000));
     }
-  }
+  };
+
+  // ── Tenant reconcile + watch (cluster-scoped) ──────────────────────
+  const runTenants = async (): Promise<void> => {
+    const { items } = await client.list(GROUP, VERSION, "tenants");
+    for (const cr of items) await reconcileTenant(client, cr as unknown as Tenant).catch((e) => console.error(`[tenant ${(cr as { metadata: { name: string } }).metadata.name}] ${(e as Error).message}`));
+    console.log("watching tenants");
+    for (;;) {
+      try {
+        const start = (await client.list(GROUP, VERSION, "tenants")).resourceVersion;
+        for await (const ev of client.watch(GROUP, VERSION, "tenants", undefined, start)) {
+          if (ev.type === "BOOKMARK" || ev.type === "DELETED") continue;
+          await reconcileTenant(client, ev.object as unknown as Tenant);
+        }
+      } catch (e) {
+        console.error(`tenant watch error, retrying in 3s: ${(e as Error).message}`);
+        await new Promise((r) => setTimeout(r, 3000));
+      }
+    }
+  };
+
+  await Promise.all([runDeployables(), runTenants()]);
 }
 
 if (import.meta.main) {

--- a/full-ai-cluster/platform-controller/src/tenant.test.ts
+++ b/full-ai-cluster/platform-controller/src/tenant.test.ts
@@ -1,0 +1,75 @@
+// full-ai-cluster/platform-controller/src/tenant.test.ts
+//
+// renderTenant: a Tenant becomes Namespace + ResourceQuota (the sold hardware) +
+// LimitRange + NetworkPolicy + Policy, with quota caps and isolation honored.
+
+import { describe, expect, test } from "bun:test";
+import { API_VERSION } from "./types.ts";
+import { renderTenant, type Tenant } from "./tenant.ts";
+
+function tenant(name: string, spec: Tenant["spec"]): Tenant {
+  return { apiVersion: API_VERSION, kind: "Tenant", metadata: { name, namespace: "", uid: `u-${name}` }, spec };
+}
+const byKind = (objs: ReturnType<typeof renderTenant>, kind: string) => objs.find((o) => o.kind === kind);
+
+describe("renderTenant", () => {
+  const cr = tenant("acme", { namespace: "tenant-acme", displayName: "Acme Corp", quota: { cpu: "8", memory: "32Gi", storage: "200Gi", pods: 40 } });
+  const objs = renderTenant(cr);
+
+  test("provisions a Namespace named from spec.namespace", () => {
+    const ns = byKind(objs, "Namespace")!;
+    expect(ns.metadata.name).toBe("tenant-acme");
+    expect((ns.metadata.labels as Record<string, string>)["platform.zeta.io/display-name"]).toBe("Acme Corp");
+  });
+
+  test("ResourceQuota encodes the sold CPU/RAM/storage/pods caps", () => {
+    const rq = byKind(objs, "ResourceQuota")!;
+    const hard = (rq.spec as { hard: Record<string, string> }).hard;
+    expect(hard["requests.cpu"]).toBe("8");
+    expect(hard["requests.memory"]).toBe("32Gi");
+    expect(hard["requests.storage"]).toBe("200Gi");
+    expect(hard["pods"]).toBe("40");
+    expect(rq.metadata.namespace).toBe("tenant-acme");
+  });
+
+  test("LimitRange caps a single pod at the tenant quota", () => {
+    const lr = byKind(objs, "LimitRange")!;
+    const max = (lr.spec as { limits: Array<{ max: Record<string, string> }> }).limits[0]!.max;
+    expect(max.cpu).toBe("8");
+    expect(max.memory).toBe("32Gi");
+  });
+
+  test("isolated tenants get a default-deny-cross-tenant NetworkPolicy", () => {
+    const np = byKind(objs, "NetworkPolicy")!;
+    expect(np).toBeDefined();
+    const ingress = (np.spec as { ingress: Array<{ from: Array<{ namespaceSelector: { matchLabels: Record<string, string> } }> }> }).ingress;
+    expect(ingress[0]!.from[0]!.namespaceSelector.matchLabels["platform.zeta.io/namespace"]).toBe("tenant-acme");
+  });
+
+  test("isolated:false omits the NetworkPolicy", () => {
+    expect(byKind(renderTenant(tenant("open", { namespace: "tenant-open", isolated: false })), "NetworkPolicy")).toBeUndefined();
+  });
+
+  test("a default Policy lands in the tenant namespace with the no-directives gated classes", () => {
+    const p = byKind(objs, "Policy")!;
+    expect(p.metadata.namespace).toBe("tenant-acme");
+    expect((p.spec as { gatedClasses: string[] }).gatedClasses).toContain("budget");
+    expect((p.spec as { domains: Array<{ name: string; autonomy: string }> }).domains.find((d) => d.name === "data")?.autonomy).toBe("forbidden");
+  });
+
+  test("defaults apply when quota is omitted", () => {
+    const rq = byKind(renderTenant(tenant("def", { namespace: "tenant-def" })), "ResourceQuota")!;
+    const hard = (rq.spec as { hard: Record<string, string> }).hard;
+    expect(hard["requests.cpu"]).toBe("4");
+    expect(hard["requests.memory"]).toBe("16Gi");
+    expect(hard["pods"]).toBe("30");
+  });
+
+  test("every child carries an ownerReference to the Tenant (cascade delete)", () => {
+    for (const o of objs) {
+      const owners = (o.metadata as { ownerReferences?: Array<{ kind: string; controller: boolean }> }).ownerReferences;
+      expect(owners?.[0]?.kind).toBe("Tenant");
+      expect(owners?.[0]?.controller).toBe(true);
+    }
+  });
+});

--- a/full-ai-cluster/platform-controller/src/tenant.ts
+++ b/full-ai-cluster/platform-controller/src/tenant.ts
@@ -1,0 +1,128 @@
+// full-ai-cluster/platform-controller/src/tenant.ts
+//
+// The tenant reconcile — the multi-tenancy half of the platform (PLATFORM-
+// ARCHITECTURE.md §4.2). A Tenant is the customer boundary; renderTenant() turns
+// it into the Kubernetes objects that SELL and ISOLATE hardware:
+//   • Namespace      — where everything the tenant owns lives.
+//   • ResourceQuota  — the hard CPU/RAM/storage/pods caps (the hardware sold).
+//   • LimitRange     — per-pod defaults + max so one pod can't eat the quota.
+//   • NetworkPolicy  — default-deny cross-tenant traffic (tenants can't see each
+//                      other) when isolated.
+//   • Policy         — the default agent-autonomy Policy for the namespace.
+// Pure + unit-tested. Editing a Tenant's quota re-patches the ResourceQuota.
+
+import { API_VERSION, type CustomResource, type K8sObject, MANAGED_BY } from "./types.ts";
+
+export interface TenantSpec {
+  displayName?: string;
+  namespace: string;
+  quota?: { cpu?: string; memory?: string; storage?: string; pods?: number };
+  isolated?: boolean;
+  admin?: string;
+  policy?: string;
+}
+export type Tenant = CustomResource<TenantSpec>;
+
+const DEFAULTS = { cpu: "4", memory: "16Gi", storage: "100Gi", pods: 30 };
+
+function ownerRef(cr: Tenant): Record<string, unknown> {
+  return { apiVersion: API_VERSION, kind: "Tenant", name: cr.metadata.name, uid: cr.metadata.uid ?? "", controller: true, blockOwnerDeletion: true };
+}
+const labels = (tenant: string, ns: string): Record<string, string> => ({
+  "app.kubernetes.io/managed-by": MANAGED_BY,
+  "platform.zeta.io/tenant": tenant,
+  "platform.zeta.io/namespace": ns,
+});
+
+/** Render a Tenant into the namespace + quota + isolation objects. */
+export function renderTenant(cr: Tenant): K8sObject[] {
+  const tenant = cr.metadata.name;
+  const ns = cr.spec.namespace;
+  const q = { ...DEFAULTS, ...(cr.spec.quota ?? {}) };
+  const isolated = cr.spec.isolated !== false;
+  const lbls = labels(tenant, ns);
+  const owner = ownerRef(cr);
+  const out: K8sObject[] = [];
+
+  // ── Namespace ──────────────────────────────────────────────────────
+  out.push({
+    apiVersion: "v1",
+    kind: "Namespace",
+    metadata: { name: ns, labels: { ...lbls, ...(cr.spec.displayName ? { "platform.zeta.io/display-name": cr.spec.displayName } : {}) }, ownerReferences: [owner] },
+  });
+
+  // ── ResourceQuota — the hardware sold to this tenant ───────────────
+  out.push({
+    apiVersion: "v1",
+    kind: "ResourceQuota",
+    metadata: { name: "tenant-quota", namespace: ns, labels: lbls, ownerReferences: [owner] },
+    spec: {
+      hard: {
+        "requests.cpu": String(q.cpu),
+        "requests.memory": String(q.memory),
+        "limits.cpu": String(q.cpu),
+        "limits.memory": String(q.memory),
+        "requests.storage": String(q.storage),
+        pods: String(q.pods),
+        "persistentvolumeclaims": String(q.pods), // at most one PVC per pod by default
+      },
+    },
+  });
+
+  // ── LimitRange — per-pod defaults + max ────────────────────────────
+  out.push({
+    apiVersion: "v1",
+    kind: "LimitRange",
+    metadata: { name: "tenant-limits", namespace: ns, labels: lbls, ownerReferences: [owner] },
+    spec: {
+      limits: [
+        { type: "Container", default: { cpu: "500m", memory: "512Mi" }, defaultRequest: { cpu: "100m", memory: "128Mi" }, max: { cpu: String(q.cpu), memory: String(q.memory) } },
+      ],
+    },
+  });
+
+  // ── NetworkPolicy — default-deny cross-tenant (allow same-ns + DNS) ─
+  if (isolated) {
+    out.push({
+      apiVersion: "networking.k8s.io/v1",
+      kind: "NetworkPolicy",
+      metadata: { name: "tenant-isolation", namespace: ns, labels: lbls, ownerReferences: [owner] },
+      spec: {
+        podSelector: {},
+        policyTypes: ["Ingress"],
+        // ingress only from the same namespace (cross-tenant denied by omission)
+        ingress: [{ from: [{ namespaceSelector: { matchLabels: { "platform.zeta.io/namespace": ns } } }] }],
+      },
+    });
+  }
+
+  // ── default Policy in the tenant namespace ─────────────────────────
+  out.push({
+    apiVersion: API_VERSION,
+    kind: "Policy",
+    metadata: { name: cr.spec.policy ?? "default", namespace: ns, labels: lbls, ownerReferences: [owner] },
+    spec: {
+      domains: [
+        { name: "lifecycle", autonomy: "auto" },
+        { name: "scaling", autonomy: "auto" },
+        { name: "config", autonomy: "auto" },
+        { name: "mods", autonomy: "propose" },
+        { name: "spend", autonomy: "propose" },
+        { name: "data", autonomy: "forbidden" },
+        { name: "security", autonomy: "forbidden" },
+      ],
+      gatedClasses: ["budget", "non-reversible", "wont-do", "hard-limits", "force-push", "external-repo"],
+    },
+  });
+
+  return out;
+}
+
+/** The children renderTenant emits, by kind → REST plural (for SSA). */
+export const TENANT_KIND_PLURAL: Record<string, string> = {
+  Namespace: "namespaces",
+  ResourceQuota: "resourcequotas",
+  LimitRange: "limitranges",
+  NetworkPolicy: "networkpolicies",
+  Policy: "policies",
+};

--- a/full-ai-cluster/portal/src/admin-demo.ts
+++ b/full-ai-cluster/portal/src/admin-demo.ts
@@ -1,0 +1,59 @@
+// full-ai-cluster/portal/src/admin-demo.ts
+//
+// A seeded AdminData for local dev (PORTAL_DEMO) — a small 3-node cluster and a
+// couple of tenants, run through the SAME pure parsers as the real reads so the
+// numbers add up consistently. applyTenant mutates the in-memory tenant list.
+
+import {
+  type AdminData,
+  type ClusterCapacity,
+  type NamespaceObj,
+  type NodeObj,
+  parseClusterCapacity,
+  parseTenants,
+  type PodObj,
+  type ResourceQuotaObj,
+  type TenantSpecInput,
+  type TenantUsage,
+} from "./admin.ts";
+
+const NODES: NodeObj[] = [
+  { metadata: { name: "zeta-cp-0", labels: { "node-role.kubernetes.io/control-plane": "" } }, status: { allocatable: { cpu: "8", memory: "32Gi", pods: "110" }, capacity: { cpu: "8", memory: "32Gi", pods: "110" }, conditions: [{ type: "Ready", status: "True" }] } },
+  { metadata: { name: "zeta-w-1" }, status: { allocatable: { cpu: "16", memory: "64Gi", pods: "110" }, capacity: { cpu: "16", memory: "64Gi", pods: "110" }, conditions: [{ type: "Ready", status: "True" }] } },
+  { metadata: { name: "zeta-w-2" }, status: { allocatable: { cpu: "16", memory: "64Gi", pods: "110" }, capacity: { cpu: "16", memory: "64Gi", pods: "110" }, conditions: [{ type: "Ready", status: "True" }] } },
+];
+const POD = (ns: string, node: string, cpu: string, mem: string): PodObj => ({ metadata: { namespace: ns }, spec: { nodeName: node, containers: [{ resources: { requests: { cpu, memory: mem } } }] }, status: { phase: "Running" } });
+const PODS: PodObj[] = [
+  POD("acme", "zeta-w-1", "2", "4Gi"), POD("acme", "zeta-w-1", "1", "1Gi"), POD("acme", "zeta-w-2", "1", "2Gi"),
+  POD("northwind", "zeta-w-2", "4", "8Gi"), POD("northwind", "zeta-cp-0", "500m", "512Mi"),
+  POD("zeta-platform", "zeta-cp-0", "250m", "256Mi"),
+];
+
+export function demoAdmin(): AdminData {
+  const namespaces: NamespaceObj[] = [
+    { metadata: { name: "acme", labels: { "platform.zeta.io/tenant": "acme", "platform.zeta.io/display-name": "Acme Corp" } } },
+    { metadata: { name: "northwind", labels: { "platform.zeta.io/tenant": "northwind", "platform.zeta.io/display-name": "Northwind Traders" } } },
+  ];
+  const quotas: ResourceQuotaObj[] = [
+    { metadata: { namespace: "acme" }, spec: { hard: { "requests.cpu": "8", "requests.memory": "32Gi", "requests.storage": "200Gi", pods: "40" } }, status: { used: { "requests.cpu": "4", "requests.memory": "7Gi", "requests.storage": "60Gi", pods: "3" } } },
+    { metadata: { namespace: "northwind" }, spec: { hard: { "requests.cpu": "12", "requests.memory": "48Gi", "requests.storage": "300Gi", pods: "60" } }, status: { used: { "requests.cpu": "4500m", "requests.memory": "8704Mi", "requests.storage": "120Gi", pods: "2" } } },
+  ];
+
+  return {
+    async cluster(): Promise<ClusterCapacity> {
+      return parseClusterCapacity(NODES, PODS);
+    },
+    async tenants(): Promise<TenantUsage[]> {
+      return parseTenants(namespaces, quotas);
+    },
+    async applyTenant(spec: TenantSpecInput): Promise<{ ok: boolean; message: string }> {
+      const existing = namespaces.find((n) => n.metadata.name === spec.namespace);
+      if (!existing) namespaces.push({ metadata: { name: spec.namespace, labels: { "platform.zeta.io/tenant": spec.name, ...(spec.displayName ? { "platform.zeta.io/display-name": spec.displayName } : {}) } } });
+      const q = quotas.find((x) => x.metadata.namespace === spec.namespace);
+      const hard = { "requests.cpu": spec.quota.cpu, "requests.memory": spec.quota.memory, "requests.storage": spec.quota.storage, pods: String(spec.quota.pods) };
+      if (q) q.spec = { hard };
+      else quotas.push({ metadata: { namespace: spec.namespace }, spec: { hard }, status: { used: { "requests.cpu": "0", "requests.memory": "0", "requests.storage": "0", pods: "0" } } });
+      return { ok: true, message: `Tenant "${spec.name}" applied — quota set on ${spec.namespace}.` };
+    },
+  };
+}

--- a/full-ai-cluster/portal/src/admin.test.ts
+++ b/full-ai-cluster/portal/src/admin.test.ts
@@ -1,0 +1,116 @@
+// full-ai-cluster/portal/src/admin.test.ts
+//
+// The pure parsers that turn real Kubernetes object shapes into cluster capacity
+// + per-tenant allocation. These are the verifiable core of the real k8s reads.
+
+import { describe, expect, test } from "bun:test";
+import { parseClusterCapacity, parseCpu, parseMemMi, parseTenants, type NodeObj, type PodObj } from "./admin.ts";
+import { demoAdmin } from "./admin-demo.ts";
+import { handle, type PlatformData } from "./api.ts";
+
+describe("admin BFF + demo", () => {
+  const data = { admin: demoAdmin() } as unknown as PlatformData;
+  const get = (p: string) => handle(new Request(`http://x${p}`), data);
+  const body = async (r: Response | null) => (r ? r.json() : null) as any;
+
+  test("GET /api/admin/cluster returns capacity totals", async () => {
+    const j = await body(await get("/api/admin/cluster"));
+    expect(j.totals.nodeCount).toBe(3);
+    expect(j.totals.cpuAllocMilli).toBe(40000); // 8+16+16 cores
+    expect(j.totals.cpuRequestedMilli).toBeGreaterThan(0);
+  });
+  test("GET /api/admin/tenants returns per-tenant alloc vs used", async () => {
+    const j = await body(await get("/api/admin/tenants"));
+    const acme = j.tenants.find((t: { namespace: string }) => t.namespace === "acme");
+    expect(acme.cpu.allocMilli).toBe(8000);
+    expect(acme.cpu.usedMilli).toBe(4000);
+  });
+  test("POST /api/admin/tenants applies a tenant + it appears with the new quota", async () => {
+    const r = await handle(new Request("http://x/api/admin/tenants", { method: "POST", body: JSON.stringify({ name: "globex", namespace: "globex", quota: { cpu: "6", memory: "24Gi", storage: "150Gi", pods: 30 } }) }), data);
+    expect((await r!.json() as { ok: boolean }).ok).toBe(true);
+    const j = await body(await get("/api/admin/tenants"));
+    expect(j.tenants.find((t: { namespace: string }) => t.namespace === "globex")?.cpu.allocMilli).toBe(6000);
+  });
+  test("POST without quota → 400", async () => {
+    const r = await handle(new Request("http://x/api/admin/tenants", { method: "POST", body: JSON.stringify({ name: "x", namespace: "x" }) }), data);
+    expect(r!.status).toBe(400);
+  });
+});
+
+describe("k8s quantity parsing", () => {
+  test("cpu → millicores", () => {
+    expect(parseCpu("8")).toBe(8000);
+    expect(parseCpu("500m")).toBe(500);
+    expect(parseCpu("2.5")).toBe(2500);
+    expect(parseCpu("250000000n")).toBe(250); // nanocores
+    expect(parseCpu(undefined)).toBe(0);
+  });
+  test("memory → MiB across binary + decimal suffixes", () => {
+    expect(parseMemMi("32Gi")).toBe(32768);
+    expect(parseMemMi("512Mi")).toBe(512);
+    expect(parseMemMi("1Ti")).toBe(1024 * 1024);
+    expect(parseMemMi("2000000Ki")).toBe(Math.round((2_000_000 * 1024) / 1024 ** 2));
+    expect(parseMemMi("1G")).toBe(Math.round(1e9 / 1024 ** 2)); // decimal G ≈ 953 MiB
+  });
+});
+
+describe("parseClusterCapacity", () => {
+  const nodes: NodeObj[] = [
+    { metadata: { name: "cp-0", labels: { "node-role.kubernetes.io/control-plane": "" } }, status: { allocatable: { cpu: "8", memory: "32Gi", pods: "110" }, capacity: { cpu: "8", memory: "32Gi", pods: "110" }, conditions: [{ type: "Ready", status: "True" }] } },
+    { metadata: { name: "w-1" }, status: { allocatable: { cpu: "16", memory: "64Gi", pods: "110" }, capacity: { cpu: "16", memory: "64Gi", pods: "110" }, conditions: [{ type: "Ready", status: "True" }] } },
+  ];
+  const pods: PodObj[] = [
+    { metadata: { namespace: "tenant-a" }, spec: { nodeName: "w-1", containers: [{ resources: { requests: { cpu: "2", memory: "4Gi" } } }] }, status: { phase: "Running" } },
+    { metadata: { namespace: "tenant-a" }, spec: { nodeName: "cp-0", containers: [{ resources: { requests: { cpu: "500m", memory: "512Mi" } } }] }, status: { phase: "Running" } },
+    { metadata: { namespace: "old" }, spec: { nodeName: "w-1", containers: [{ resources: { requests: { cpu: "8", memory: "16Gi" } } }] }, status: { phase: "Succeeded" } }, // ignored (terminal)
+  ];
+
+  test("sums allocatable across nodes + requested across live pods", () => {
+    const c = parseClusterCapacity(nodes, pods);
+    expect(c.totals.nodeCount).toBe(2);
+    expect(c.totals.cpuAllocMilli).toBe(24000); // 8 + 16 cores
+    expect(c.totals.memAllocMi).toBe(98304); // 32 + 64 GiB
+    expect(c.totals.cpuRequestedMilli).toBe(2500); // 2 + 0.5 (Succeeded pod ignored)
+    expect(c.totals.memRequestedMi).toBe(4096 + 512);
+    expect(c.totals.pods).toBe(2); // terminal pod not counted
+  });
+  test("per-node requested + role + ready", () => {
+    const c = parseClusterCapacity(nodes, pods);
+    const cp = c.nodes.find((n) => n.name === "cp-0")!;
+    expect(cp.role).toBe("control-plane");
+    expect(cp.ready).toBe(true);
+    expect(cp.cpuRequestedMilli).toBe(500);
+    const w = c.nodes.find((n) => n.name === "w-1")!;
+    expect(w.cpuRequestedMilli).toBe(2000);
+    expect(w.role).toBe("worker");
+  });
+});
+
+describe("parseTenants", () => {
+  const namespaces = [
+    { metadata: { name: "tenant-acme", labels: { "platform.zeta.io/tenant": "acme", "platform.zeta.io/display-name": "Acme Corp" } } },
+    { metadata: { name: "kube-system" } }, // not a tenant, no quota → excluded
+  ];
+  const quotas = [
+    { metadata: { namespace: "tenant-acme" }, spec: { hard: { "requests.cpu": "8", "requests.memory": "32Gi", "requests.storage": "200Gi", pods: "40" } }, status: { used: { "requests.cpu": "2500m", "requests.memory": "6Gi", "requests.storage": "50Gi", pods: "7" } } },
+  ];
+
+  test("joins namespace + quota into allocated-vs-used per resource", () => {
+    const t = parseTenants(namespaces, quotas);
+    expect(t.length).toBe(1); // kube-system excluded
+    const acme = t[0]!;
+    expect(acme.displayName).toBe("Acme Corp");
+    expect(acme.cpu).toEqual({ allocMilli: 8000, usedMilli: 2500 });
+    expect(acme.mem).toEqual({ allocMi: 32768, usedMi: 6144 });
+    expect(acme.storage.allocMi).toBe(200 * 1024);
+    expect(acme.pods).toEqual({ alloc: 40, used: 7 });
+    expect(acme.hasQuota).toBe(true);
+  });
+
+  test("a tenant namespace with no quota still appears (unbounded)", () => {
+    const t = parseTenants([{ metadata: { name: "tenant-free", labels: { "platform.zeta.io/tenant": "free" } } }], []);
+    expect(t.length).toBe(1);
+    expect(t[0]!.hasQuota).toBe(false);
+    expect(t[0]!.cpu.allocMilli).toBe(0);
+  });
+});

--- a/full-ai-cluster/portal/src/admin.ts
+++ b/full-ai-cluster/portal/src/admin.ts
@@ -1,0 +1,181 @@
+// full-ai-cluster/portal/src/admin.ts
+//
+// The cluster-admin substrate: total cluster capacity/usage and per-tenant
+// (per-namespace) hardware allocation vs consumption. The PARSERS here are pure
+// and unit-tested against real Kubernetes object shapes (Node, Pod, Namespace,
+// ResourceQuota) so the aggregation is proven even where the live API calls
+// aren't reachable from a dev box. The k8s-backed AdminData (data-admin-k8s.ts)
+// feeds these parsers real lists; the demo feeds seeded ones.
+
+// ── Kubernetes quantity parsing ────────────────────────────────────────
+/** Parse a CPU quantity → millicores. "8" → 8000, "500m" → 500, "2.5" → 2500. */
+export function parseCpu(q: string | undefined): number {
+  if (!q) return 0;
+  const s = q.trim();
+  if (s.endsWith("m")) return Math.round(parseFloat(s.slice(0, -1)) || 0);
+  if (s.endsWith("n")) return Math.round((parseFloat(s.slice(0, -1)) || 0) / 1e6); // nanocores
+  return Math.round((parseFloat(s) || 0) * 1000);
+}
+
+const MEM_SUFFIX: Record<string, number> = {
+  Ki: 1024, Mi: 1024 ** 2, Gi: 1024 ** 3, Ti: 1024 ** 4, Pi: 1024 ** 5,
+  K: 1e3, M: 1e6, G: 1e9, T: 1e12, k: 1e3,
+};
+/** Parse a memory/storage quantity → MiB. "32Gi" → 32768, "512Mi" → 512. */
+export function parseMemMi(q: string | undefined): number {
+  if (!q) return 0;
+  const s = q.trim();
+  const m = s.match(/^([0-9.]+)\s*([A-Za-z]+)?$/);
+  if (!m) return 0;
+  const n = parseFloat(m[1]!) || 0;
+  const bytes = m[2] ? n * (MEM_SUFFIX[m[2]] ?? 1) : n;
+  return Math.round(bytes / (1024 ** 2));
+}
+
+// ── inbound k8s shapes (minimal) ───────────────────────────────────────
+export interface NodeObj {
+  metadata: { name: string; labels?: Record<string, string> };
+  status?: { allocatable?: Record<string, string>; capacity?: Record<string, string>; conditions?: Array<{ type: string; status: string }> };
+}
+export interface PodObj {
+  metadata: { namespace: string };
+  spec?: { nodeName?: string; containers?: Array<{ resources?: { requests?: Record<string, string> } }> };
+  status?: { phase?: string };
+}
+export interface NamespaceObj {
+  metadata: { name: string; labels?: Record<string, string> };
+}
+export interface ResourceQuotaObj {
+  metadata: { namespace: string };
+  spec?: { hard?: Record<string, string> };
+  status?: { hard?: Record<string, string>; used?: Record<string, string> };
+}
+
+// ── outbound view models ───────────────────────────────────────────────
+export interface NodeVM {
+  name: string;
+  ready: boolean;
+  role: string;
+  cpuAllocMilli: number;
+  cpuCapMilli: number;
+  memAllocMi: number;
+  memCapMi: number;
+  podCapacity: number;
+  podsRunning: number;
+  cpuRequestedMilli: number;
+  memRequestedMi: number;
+}
+export interface ClusterCapacity {
+  nodes: NodeVM[];
+  totals: {
+    nodeCount: number;
+    cpuAllocMilli: number;
+    cpuRequestedMilli: number;
+    memAllocMi: number;
+    memRequestedMi: number;
+    pods: number;
+    podCapacity: number;
+  };
+}
+
+export interface TenantUsage {
+  namespace: string;
+  displayName?: string;
+  cpu: { allocMilli: number; usedMilli: number };
+  mem: { allocMi: number; usedMi: number };
+  storage: { allocMi: number; usedMi: number };
+  pods: { alloc: number; used: number };
+  hasQuota: boolean;
+}
+
+const nodeRole = (labels?: Record<string, string>): string => {
+  if (!labels) return "worker";
+  if ("node-role.kubernetes.io/control-plane" in labels || "node-role.kubernetes.io/master" in labels) return "control-plane";
+  return "worker";
+};
+
+/** Aggregate Node + Pod lists into cluster capacity + live requested totals. */
+export function parseClusterCapacity(nodes: NodeObj[], pods: PodObj[]): ClusterCapacity {
+  // sum pod requests per node + per cluster
+  const reqByNode = new Map<string, { cpu: number; mem: number; count: number }>();
+  let totalPods = 0;
+  for (const p of pods) {
+    if (p.status?.phase === "Succeeded" || p.status?.phase === "Failed") continue;
+    totalPods++;
+    const node = p.spec?.nodeName ?? "";
+    const agg = reqByNode.get(node) ?? { cpu: 0, mem: 0, count: 0 };
+    agg.count++;
+    for (const c of p.spec?.containers ?? []) {
+      agg.cpu += parseCpu(c.resources?.requests?.cpu);
+      agg.mem += parseMemMi(c.resources?.requests?.memory);
+    }
+    reqByNode.set(node, agg);
+  }
+
+  const nodeVMs: NodeVM[] = nodes.map((n) => {
+    const req = reqByNode.get(n.metadata.name) ?? { cpu: 0, mem: 0, count: 0 };
+    return {
+      name: n.metadata.name,
+      ready: n.status?.conditions?.some((c) => c.type === "Ready" && c.status === "True") ?? false,
+      role: nodeRole(n.metadata.labels),
+      cpuAllocMilli: parseCpu(n.status?.allocatable?.cpu),
+      cpuCapMilli: parseCpu(n.status?.capacity?.cpu),
+      memAllocMi: parseMemMi(n.status?.allocatable?.memory),
+      memCapMi: parseMemMi(n.status?.capacity?.memory),
+      podCapacity: parseInt(n.status?.allocatable?.pods ?? "0", 10) || 0,
+      podsRunning: req.count,
+      cpuRequestedMilli: req.cpu,
+      memRequestedMi: req.mem,
+    };
+  });
+
+  return {
+    nodes: nodeVMs,
+    totals: {
+      nodeCount: nodeVMs.length,
+      cpuAllocMilli: nodeVMs.reduce((s, n) => s + n.cpuAllocMilli, 0),
+      cpuRequestedMilli: nodeVMs.reduce((s, n) => s + n.cpuRequestedMilli, 0),
+      memAllocMi: nodeVMs.reduce((s, n) => s + n.memAllocMi, 0),
+      memRequestedMi: nodeVMs.reduce((s, n) => s + n.memRequestedMi, 0),
+      pods: totalPods,
+      podCapacity: nodeVMs.reduce((s, n) => s + n.podCapacity, 0),
+    },
+  };
+}
+
+/** Join Namespaces with their ResourceQuota into per-tenant allocated-vs-used. */
+export function parseTenants(namespaces: NamespaceObj[], quotas: ResourceQuotaObj[]): TenantUsage[] {
+  const qByNs = new Map<string, ResourceQuotaObj>();
+  for (const q of quotas) qByNs.set(q.metadata.namespace, q); // first quota per ns
+  return namespaces
+    .filter((ns) => !!ns.metadata.labels?.["platform.zeta.io/tenant"] || qByNs.has(ns.metadata.name))
+    .map((ns) => {
+      const q = qByNs.get(ns.metadata.name);
+      const hard = q?.spec?.hard ?? q?.status?.hard ?? {};
+      const used = q?.status?.used ?? {};
+      return {
+        namespace: ns.metadata.name,
+        ...(ns.metadata.labels?.["platform.zeta.io/display-name"] ? { displayName: ns.metadata.labels["platform.zeta.io/display-name"] } : {}),
+        cpu: { allocMilli: parseCpu(hard["requests.cpu"] ?? hard["limits.cpu"]), usedMilli: parseCpu(used["requests.cpu"] ?? used["limits.cpu"]) },
+        mem: { allocMi: parseMemMi(hard["requests.memory"] ?? hard["limits.memory"]), usedMi: parseMemMi(used["requests.memory"] ?? used["limits.memory"]) },
+        storage: { allocMi: parseMemMi(hard["requests.storage"]), usedMi: parseMemMi(used["requests.storage"]) },
+        pods: { alloc: parseInt(hard["pods"] ?? "0", 10) || 0, used: parseInt(used["pods"] ?? "0", 10) || 0 },
+        hasQuota: !!q,
+      };
+    });
+}
+
+// ── the admin data interface (k8s + demo impls) ────────────────────────
+export interface TenantSpecInput {
+  name: string;
+  namespace: string;
+  displayName?: string;
+  quota: { cpu: string; memory: string; storage: string; pods: number };
+  isolated?: boolean;
+}
+export interface AdminData {
+  cluster(): Promise<ClusterCapacity>;
+  tenants(): Promise<TenantUsage[]>;
+  /** Create/patch a Tenant CR (apply). Returns a message. */
+  applyTenant(spec: TenantSpecInput): Promise<{ ok: boolean; message: string }>;
+}

--- a/full-ai-cluster/portal/src/api.ts
+++ b/full-ai-cluster/portal/src/api.ts
@@ -16,6 +16,7 @@ import {
   toRoomVM,
 } from "./viewmodel.ts";
 import type { LifecycleAction, MemoryUsage, ResourceConfig, ResourceOps } from "./ops.ts";
+import type { AdminData, TenantSpecInput } from "./admin.ts";
 import { type ChatOp, DEFAULT_POLICY, decide, respond } from "./room-agent.ts";
 
 const LIFECYCLE_ACTIONS = new Set(["restart", "stop", "start", "scale", "delete"]);
@@ -48,6 +49,8 @@ export interface PlatformData {
   ops?: ResourceOps;
   /** Aggregate memory usage (durable Room logs + agent-memory). Optional. */
   memoryUsage?(): Promise<MemoryUsage>;
+  /** Cluster-admin: capacity + per-tenant allocation. Optional. */
+  admin?: AdminData;
 }
 
 /** The typed Event bodies the write endpoint accepts (mirrors the Room substrate). */
@@ -90,6 +93,22 @@ export async function handle(req: Request, data: PlatformData): Promise<Response
     if (path === "/api/memory" && req.method === "GET") {
       if (!data.memoryUsage) return json({ rooms: [], totalEvents: 0, totalBytes: 0 });
       return json(await data.memoryUsage());
+    }
+
+    // ── admin: cluster capacity + tenants ──────────────────────────────
+    if (path === "/api/admin/cluster" && req.method === "GET") {
+      if (!data.admin) return json({ error: "admin not available on this backend" }, 405);
+      return json(await data.admin.cluster());
+    }
+    if (path === "/api/admin/tenants" && req.method === "GET") {
+      if (!data.admin) return json({ error: "admin not available on this backend" }, 405);
+      return json({ tenants: await data.admin.tenants() });
+    }
+    if (path === "/api/admin/tenants" && req.method === "POST") {
+      if (!data.admin) return json({ error: "admin not available on this backend" }, 405);
+      const b = (await req.json().catch(() => ({}))) as Partial<TenantSpecInput>;
+      if (!b.name || !b.namespace || !b.quota) return json({ error: "name, namespace, quota required" }, 400);
+      return json(await data.admin.applyTenant(b as TenantSpecInput));
     }
 
     // ── management plane: /api/resources/:resource/* ───────────────────

--- a/full-ai-cluster/portal/src/data-admin-k8s.ts
+++ b/full-ai-cluster/portal/src/data-admin-k8s.ts
@@ -1,0 +1,85 @@
+// full-ai-cluster/portal/src/data-admin-k8s.ts
+//
+// The REAL cluster-admin reads. Talks to the in-cluster API with the mounted
+// service-account token: lists Nodes + Pods (cluster capacity + live requests),
+// Namespaces + ResourceQuotas (per-tenant allocation vs usage), and server-side-
+// applies a Tenant CR (the controller reconciles it into ns + quota + isolation).
+// Aggregation is the pure, unit-tested admin.ts parsers; this only does the I/O.
+
+import { readFileSync } from "node:fs";
+import {
+  type AdminData,
+  type ClusterCapacity,
+  type NamespaceObj,
+  type NodeObj,
+  parseClusterCapacity,
+  parseTenants,
+  type PodObj,
+  type ResourceQuotaObj,
+  type TenantSpecInput,
+  type TenantUsage,
+} from "./admin.ts";
+
+const SA = "/var/run/secrets/kubernetes.io/serviceaccount";
+const GROUP = "platform.zeta.io";
+const VERSION = "v1alpha1";
+
+export class K8sAdmin implements AdminData {
+  private host: string;
+  private token: string;
+  private ca: string;
+
+  constructor() {
+    const h = process.env.KUBERNETES_SERVICE_HOST;
+    const p = process.env.KUBERNETES_SERVICE_PORT_HTTPS ?? process.env.KUBERNETES_SERVICE_PORT ?? "443";
+    if (!h) throw new Error("not running in-cluster: KUBERNETES_SERVICE_HOST unset");
+    this.host = `https://${h}:${p}`;
+    this.token = readFileSync(`${SA}/token`, "utf8").trim();
+    this.ca = readFileSync(`${SA}/ca.crt`, "utf8");
+  }
+
+  private async get<T>(path: string): Promise<T> {
+    const r = await fetch(`${this.host}${path}`, { headers: { Authorization: `Bearer ${this.token}`, Accept: "application/json" }, tls: { ca: this.ca } } as RequestInit);
+    if (!r.ok) throw new Error(`GET ${path}: ${r.status} ${await r.text()}`);
+    return (await r.json()) as T;
+  }
+
+  async cluster(): Promise<ClusterCapacity> {
+    const [nodes, pods] = await Promise.all([
+      this.get<{ items: NodeObj[] }>("/api/v1/nodes"),
+      this.get<{ items: PodObj[] }>("/api/v1/pods"),
+    ]);
+    return parseClusterCapacity(nodes.items, pods.items);
+  }
+
+  async tenants(): Promise<TenantUsage[]> {
+    const [ns, rq] = await Promise.all([
+      this.get<{ items: NamespaceObj[] }>("/api/v1/namespaces"),
+      this.get<{ items: ResourceQuotaObj[] }>("/api/v1/resourcequotas"),
+    ]);
+    return parseTenants(ns.items, rq.items).sort((a, b) => a.namespace.localeCompare(b.namespace));
+  }
+
+  async applyTenant(spec: TenantSpecInput): Promise<{ ok: boolean; message: string }> {
+    const body = {
+      apiVersion: `${GROUP}/${VERSION}`,
+      kind: "Tenant",
+      metadata: { name: spec.name },
+      spec: {
+        ...(spec.displayName ? { displayName: spec.displayName } : {}),
+        namespace: spec.namespace,
+        quota: spec.quota,
+        isolated: spec.isolated !== false,
+      },
+    };
+    const path = `/apis/${GROUP}/${VERSION}/tenants/${spec.name}`;
+    const r = await fetch(`${this.host}${path}?fieldManager=zeta-portal&force=true`, {
+      method: "PATCH",
+      headers: { Authorization: `Bearer ${this.token}`, "Content-Type": "application/apply-patch+yaml", Accept: "application/json" },
+      body: JSON.stringify(body),
+      tls: { ca: this.ca },
+    } as RequestInit);
+    if (!r.ok) return { ok: false, message: `apply Tenant ${spec.name}: ${r.status} ${await r.text()}` };
+    return { ok: true, message: `Tenant "${spec.name}" applied — the controller is provisioning ${spec.namespace} with its quota.` };
+  }
+}

--- a/full-ai-cluster/portal/src/server.ts
+++ b/full-ai-cluster/portal/src/server.ts
@@ -7,29 +7,38 @@
 
 import { join } from "node:path";
 import { handle, type PlatformData } from "./api.ts";
+import type { AdminData } from "./admin.ts";
 import { K8sPlatform } from "./data-k8s.ts";
+import { K8sAdmin } from "./data-admin-k8s.ts";
 import { FileRoomStore } from "./data-file.ts";
 import { CompositePlatform } from "./data-composite.ts";
 import { DemoOps } from "./ops-demo.ts";
+import { demoAdmin } from "./admin-demo.ts";
 import { demoPlatform, demoResources } from "./demo.ts";
 
 // The built React SPA (web/ -> dist/). Built by `bun run build` in web/.
 const UI_DIR = join(import.meta.dir, "..", "dist");
 const PORT = Number(process.env.PORT ?? 8080);
 
+/** Attach the cluster-admin reads to a platform (PlatformData.admin is optional). */
+function withAdmin(p: PlatformData, admin: AdminData): PlatformData {
+  (p as { admin?: AdminData }).admin = admin;
+  return p;
+}
+
 function makeData(): PlatformData {
   // Local dev with DURABLE rooms: demo resources + a real FileRoomStore. Lets you
   // exercise the durable room-service on a laptop (set ZETA_ROOMS_DIR).
   if (process.env.PORTAL_DEMO === "1") {
     const dir = process.env.ZETA_ROOMS_DIR;
-    if (dir) return new CompositePlatform(demoResources(), new FileRoomStore(dir), new DemoOps());
-    return demoPlatform();
+    const base = dir ? new CompositePlatform(demoResources(), new FileRoomStore(dir), new DemoOps()) : demoPlatform();
+    return withAdmin(base, demoAdmin());
   }
-  // In-cluster: live resources from k8s; Rooms persisted to a Longhorn-backed
-  // append-only JSONL log (durable across pod restarts — the StatefulSet volume),
-  // which is also the persistent collaboration / agent-memory substrate (#5).
+  // In-cluster: live resources + cluster-admin reads from k8s; Rooms persisted to
+  // a Longhorn-backed append-only JSONL log (durable across pod restarts — the
+  // StatefulSet volume) which is also the agent-memory substrate (#5).
   const roomsDir = process.env.ZETA_ROOMS_DIR ?? "/var/lib/zeta-rooms";
-  return new K8sPlatform(new FileRoomStore(roomsDir));
+  return withAdmin(new K8sPlatform(new FileRoomStore(roomsDir)), new K8sAdmin());
 }
 
 const data = makeData();

--- a/full-ai-cluster/portal/web/src/App.tsx
+++ b/full-ai-cluster/portal/web/src/App.tsx
@@ -1,21 +1,23 @@
 import { useCallback, useEffect, useState } from "react";
-import { Boxes, Brain, LayoutGrid, Plus, RefreshCw, ShieldAlert } from "lucide-react";
+import { Boxes, Brain, Gauge, LayoutGrid, Plus, RefreshCw, ShieldAlert } from "lucide-react";
 import { api, type CatalogEntryVM, type CategoryGroupVM, type NeedsMeItemVM, type ResourceVM } from "@/lib/api";
 import { Toaster } from "sonner";
 import { Resources } from "@/views/Resources";
 import { Create } from "@/views/Create";
 import { NeedsMe } from "@/views/NeedsMe";
 import { Memory } from "@/views/Memory";
+import { Admin } from "@/views/Admin";
 import { ResourceConsole } from "@/components/ResourceConsole";
 import { cn } from "@/lib/utils";
 
-type View = "resources" | "create" | "needsme" | "memory";
+type View = "resources" | "create" | "needsme" | "memory" | "admin";
 
 const NAV: Array<{ id: View; label: string; icon: typeof LayoutGrid }> = [
   { id: "resources", label: "Resources", icon: LayoutGrid },
   { id: "create", label: "Create", icon: Plus },
   { id: "memory", label: "Memory", icon: Brain },
   { id: "needsme", label: "Needs me", icon: ShieldAlert },
+  { id: "admin", label: "Admin", icon: Gauge },
 ];
 
 export default function App() {
@@ -118,6 +120,8 @@ export default function App() {
             <Create catalog={catalog} />
           ) : view === "memory" ? (
             <Memory />
+          ) : view === "admin" ? (
+            <Admin />
           ) : (
             <NeedsMe items={needs} onChange={refresh} />
           )}

--- a/full-ai-cluster/portal/web/src/lib/api.ts
+++ b/full-ai-cluster/portal/web/src/lib/api.ts
@@ -104,6 +104,11 @@ export interface MemoryUsage {
 
 export interface QueryResult { columns: string[]; rows: Array<Array<string | number>>; rowCount: number; durationMs: number; error?: string }
 
+export interface NodeVM { name: string; ready: boolean; role: string; cpuAllocMilli: number; cpuCapMilli: number; memAllocMi: number; memCapMi: number; podCapacity: number; podsRunning: number; cpuRequestedMilli: number; memRequestedMi: number }
+export interface ClusterCapacity { nodes: NodeVM[]; totals: { nodeCount: number; cpuAllocMilli: number; cpuRequestedMilli: number; memAllocMi: number; memRequestedMi: number; pods: number; podCapacity: number } }
+export interface TenantUsage { namespace: string; displayName?: string; cpu: { allocMilli: number; usedMilli: number }; mem: { allocMi: number; usedMi: number }; storage: { allocMi: number; usedMi: number }; pods: { alloc: number; used: number }; hasQuota: boolean }
+export interface TenantSpecInput { name: string; namespace: string; displayName?: string; quota: { cpu: string; memory: string; storage: string; pods: number }; isolated?: boolean }
+
 export type Dashboard =
   | { kind: "game"; status: string; game: string; map: string; gamemode: string; players: { online: number; max: number }; address: string; tickrate: number; uptime: string; recentJoins: Array<{ name: string; at: string }> }
   | { kind: "database"; status: string; engine: string; connections: { active: number; max: number }; sizeMi: number; tables: number; queriesPerSec: number; cacheHitPct: number; replication: string; topTables: Array<{ name: string; rows: number; sizeMi: number }> }
@@ -138,6 +143,11 @@ export const api = {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ text, by }),
     }).then((d) => d.room),
+
+  // admin plane
+  cluster: () => j<ClusterCapacity>("/api/admin/cluster"),
+  tenants: () => j<{ tenants: TenantUsage[] }>("/api/admin/tenants").then((d) => d.tenants),
+  applyTenant: (spec: TenantSpecInput) => post("/api/admin/tenants", spec),
 
   // management plane
   memory: () => j<MemoryUsage>("/api/memory"),

--- a/full-ai-cluster/portal/web/src/views/Admin.tsx
+++ b/full-ai-cluster/portal/web/src/views/Admin.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useState } from "react";
+import { Boxes, Cpu, MemoryStick, Plus, Server } from "lucide-react";
+import { api, type ClusterCapacity, type TenantUsage } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Input, Label } from "@/components/ui/input";
+import { Dialog, DialogBody, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import { toast } from "sonner";
+
+const cores = (m: number) => (m / 1000).toFixed(m % 1000 === 0 ? 0 : 1);
+const gib = (mi: number) => (mi / 1024).toFixed(mi >= 10240 ? 0 : 1);
+const pctOf = (a: number, b: number) => (b > 0 ? Math.min(100, Math.round((a / b) * 100)) : 0);
+
+function Meter({ used, total, label }: { used: number; total: number; label: string }) {
+  const pct = pctOf(used, total);
+  return (
+    <div className="mt-2">
+      <div className="flex justify-between text-xs text-muted-foreground"><span>{label}</span><span className="tabular-nums">{pct}%</span></div>
+      <div className="mt-1 h-1.5 overflow-hidden rounded-full bg-muted"><div className={cn("h-full rounded-full", pct > 85 ? "bg-destructive" : pct > 65 ? "bg-warning" : "bg-primary")} style={{ width: `${pct}%` }} /></div>
+    </div>
+  );
+}
+
+export function Admin() {
+  const [tab, setTab] = useState<"cluster" | "tenants">("cluster");
+  return (
+    <div className="mx-auto max-w-5xl">
+      <div className="mb-5">
+        <h1 className="text-[22px] font-semibold tracking-tight">Admin</h1>
+        <p className="mt-0.5 text-[13px] text-muted-foreground">Cluster capacity and per-tenant hardware allocation.</p>
+      </div>
+      <div className="mb-5 flex items-center gap-0.5 border-b border-border">
+        {(["cluster", "tenants"] as const).map((t) => (
+          <button key={t} onClick={() => setTab(t)} className={cn("-mb-px border-b-2 px-3 py-2 text-[13px] capitalize", tab === t ? "border-foreground text-foreground" : "border-transparent text-muted-foreground hover:text-foreground")}>{t}</button>
+        ))}
+      </div>
+      {tab === "cluster" ? <ClusterView /> : <TenantsView />}
+    </div>
+  );
+}
+
+// ── Cluster capacity ────────────────────────────────────────────────────
+function ClusterView() {
+  const [c, setC] = useState<ClusterCapacity | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  useEffect(() => { api.cluster().then(setC).catch((e) => setErr(e.message)); }, []);
+  if (err) return <Empty text="Cluster reads need the in-cluster admin backend (Node/Pod RBAC)." />;
+  if (!c) return <div className="grid grid-cols-3 gap-3">{[0, 1, 2].map((i) => <div key={i} className="h-28 animate-pulse rounded-lg bg-muted/40" />)}</div>;
+  const t = c.totals;
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <Card icon={Cpu} label="CPU" value={`${cores(t.cpuRequestedMilli)} / ${cores(t.cpuAllocMilli)} cores`} sub="requested / allocatable"><Meter used={t.cpuRequestedMilli} total={t.cpuAllocMilli} label="committed" /></Card>
+        <Card icon={MemoryStick} label="Memory" value={`${gib(t.memRequestedMi)} / ${gib(t.memAllocMi)} GiB`} sub="requested / allocatable"><Meter used={t.memRequestedMi} total={t.memAllocMi} label="committed" /></Card>
+        <Card icon={Boxes} label="Pods" value={`${t.pods} / ${t.podCapacity}`} sub={`${t.nodeCount} nodes`}><Meter used={t.pods} total={t.podCapacity} label="scheduled" /></Card>
+      </div>
+      <div>
+        <h3 className="mb-2 flex items-center gap-2 text-sm font-semibold"><Server className="size-4 text-muted-foreground" /> Nodes</h3>
+        <div className="overflow-hidden rounded-lg border border-border">
+          <table className="w-full text-[13px]">
+            <thead className="bg-muted/30 text-left text-xs text-muted-foreground"><tr><th className="px-4 py-2 font-medium">Node</th><th className="px-4 py-2 font-medium">Role</th><th className="px-4 py-2 font-medium">Status</th><th className="px-4 py-2 font-medium">CPU</th><th className="px-4 py-2 font-medium">Memory</th><th className="px-4 py-2 font-medium">Pods</th></tr></thead>
+            <tbody>
+              {c.nodes.map((n) => (
+                <tr key={n.name} className="border-t border-border">
+                  <td className="px-4 py-2 font-mono text-xs">{n.name}</td>
+                  <td className="px-4 py-2 text-muted-foreground">{n.role}</td>
+                  <td className="px-4 py-2"><span className={n.ready ? "text-success" : "text-destructive"}>{n.ready ? "Ready" : "NotReady"}</span></td>
+                  <td className="px-4 py-2 tabular-nums text-muted-foreground">{cores(n.cpuRequestedMilli)} / {cores(n.cpuAllocMilli)}</td>
+                  <td className="px-4 py-2 tabular-nums text-muted-foreground">{gib(n.memRequestedMi)} / {gib(n.memAllocMi)} Gi</td>
+                  <td className="px-4 py-2 tabular-nums text-muted-foreground">{n.podsRunning} / {n.podCapacity}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Tenants ──────────────────────────────────────────────────────────────
+function TenantsView() {
+  const [tenants, setTenants] = useState<TenantUsage[] | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [edit, setEdit] = useState<TenantUsage | "new" | null>(null);
+  const load = () => api.tenants().then(setTenants).catch((e) => setErr(e.message));
+  useEffect(() => { load(); }, []);
+  if (err) return <Empty text="Tenant reads need the in-cluster admin backend (Namespace/ResourceQuota RBAC)." />;
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="text-[13px] text-muted-foreground">{tenants?.length ?? "…"} tenants</div>
+        <Button size="sm" onClick={() => setEdit("new")}><Plus className="size-3.5" /> New tenant</Button>
+      </div>
+      {!tenants ? (
+        <div className="space-y-2">{[0, 1].map((i) => <div key={i} className="h-24 animate-pulse rounded-lg bg-muted/40" />)}</div>
+      ) : tenants.length === 0 ? (
+        <Empty text="No tenants yet. Create one to allocate a namespace + quota." />
+      ) : (
+        <div className="space-y-3">
+          {tenants.map((t) => (
+            <div key={t.namespace} className="rounded-lg border border-border p-4">
+              <div className="flex items-center justify-between">
+                <div><div className="text-[13px] font-medium">{t.displayName ?? t.namespace}</div><div className="font-mono text-xs text-muted-foreground">{t.namespace}{!t.hasQuota && " · no quota"}</div></div>
+                <Button variant="outline" size="sm" onClick={() => setEdit(t)}>Edit quota</Button>
+              </div>
+              {t.hasQuota && (
+                <div className="mt-3 grid grid-cols-2 gap-x-6 gap-y-1 sm:grid-cols-4">
+                  <Meter used={t.cpu.usedMilli} total={t.cpu.allocMilli} label={`CPU ${cores(t.cpu.usedMilli)}/${cores(t.cpu.allocMilli)}`} />
+                  <Meter used={t.mem.usedMi} total={t.mem.allocMi} label={`Mem ${gib(t.mem.usedMi)}/${gib(t.mem.allocMi)}Gi`} />
+                  <Meter used={t.storage.usedMi} total={t.storage.allocMi} label={`Disk ${gib(t.storage.usedMi)}/${gib(t.storage.allocMi)}Gi`} />
+                  <Meter used={t.pods.used} total={t.pods.alloc} label={`Pods ${t.pods.used}/${t.pods.alloc}`} />
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+      {edit && <TenantDialog tenant={edit === "new" ? null : edit} onClose={() => setEdit(null)} onSaved={() => { setEdit(null); load(); }} />}
+    </div>
+  );
+}
+
+function TenantDialog({ tenant, onClose, onSaved }: { tenant: TenantUsage | null; onClose: () => void; onSaved: () => void }) {
+  const isNew = !tenant;
+  const [f, setF] = useState({
+    name: tenant?.namespace ?? "",
+    namespace: tenant?.namespace ?? "",
+    displayName: tenant?.displayName ?? "",
+    cpu: tenant ? cores(tenant.cpu.allocMilli) : "4",
+    memory: tenant ? `${gib(tenant.mem.allocMi)}Gi` : "16Gi",
+    storage: tenant ? `${gib(tenant.storage.allocMi)}Gi` : "100Gi",
+    pods: String(tenant?.pods.alloc ?? 30),
+  });
+  const set = (p: Partial<typeof f>) => setF((x) => ({ ...x, ...p }));
+  const save = async () => {
+    await toast.promise(api.applyTenant({ name: f.name, namespace: f.namespace, displayName: f.displayName || undefined, quota: { cpu: f.cpu, memory: f.memory, storage: f.storage, pods: Number(f.pods) || 0 } }), {
+      loading: "Applying tenant…", success: (r) => { onSaved(); return r.message; }, error: (e) => (e as Error).message,
+    });
+  };
+  return (
+    <Dialog open onClose={onClose}>
+      <DialogHeader><DialogTitle>{isNew ? "New tenant" : `Edit ${tenant!.namespace}`}</DialogTitle></DialogHeader>
+      <DialogBody>
+        <div className="space-y-4">
+          {isNew && (
+            <div className="grid grid-cols-2 gap-3">
+              <F label="Name"><Input value={f.name} onChange={(e) => set({ name: e.target.value, namespace: f.namespace || e.target.value })} placeholder="acme" /></F>
+              <F label="Namespace"><Input value={f.namespace} onChange={(e) => set({ namespace: e.target.value })} placeholder="acme" /></F>
+              <F label="Display name"><Input value={f.displayName} onChange={(e) => set({ displayName: e.target.value })} placeholder="Acme Corp" /></F>
+            </div>
+          )}
+          <div>
+            <div className="mb-2 text-sm font-medium">Quota — hardware sold to this tenant</div>
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              <F label="CPU (cores)"><Input value={f.cpu} onChange={(e) => set({ cpu: e.target.value })} /></F>
+              <F label="Memory"><Input value={f.memory} onChange={(e) => set({ memory: e.target.value })} /></F>
+              <F label="Storage"><Input value={f.storage} onChange={(e) => set({ storage: e.target.value })} /></F>
+              <F label="Max pods"><Input type="number" value={f.pods} onChange={(e) => set({ pods: e.target.value })} /></F>
+            </div>
+            <p className="mt-2 text-xs text-muted-foreground">Applies a Tenant CR → the controller provisions the namespace, ResourceQuota, LimitRange and NetworkPolicy.</p>
+          </div>
+        </div>
+      </DialogBody>
+      <DialogFooter>
+        <Button variant="outline" onClick={onClose}>Cancel</Button>
+        <Button onClick={save} disabled={isNew && (!f.name || !f.namespace)}>{isNew ? "Create tenant" : "Save quota"}</Button>
+      </DialogFooter>
+    </Dialog>
+  );
+}
+
+const Card = ({ icon: Icon, label, value, sub, children }: { icon: typeof Cpu; label: string; value: string; sub?: string; children?: React.ReactNode }) => (
+  <div className="rounded-lg border border-border p-4">
+    <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground"><Icon className="size-3.5" /> {label}</div>
+    <div className="mt-1.5 text-lg font-semibold tabular-nums tracking-tight">{value}</div>
+    {sub && <div className="text-xs text-muted-foreground">{sub}</div>}
+    {children}
+  </div>
+);
+const F = ({ label, children }: { label: string; children: React.ReactNode }) => <div className="space-y-1.5"><Label>{label}</Label>{children}</div>;
+const Empty = ({ text }: { text: string }) => <div className="rounded-lg border border-dashed border-border bg-muted/20 px-6 py-10 text-center text-[13px] text-muted-foreground">{text}</div>;


### PR DESCRIPTION
## What

The **admin / multi-tenancy layer** (PLATFORM-ARCHITECTURE.md §4.2), wired to the **real cluster API** — not demo-faked. This is question #1: *see total cluster resources used/available, and control namespaces + hardware allocated to each.*

### Tenant CRD + controller — the allocation & isolation engine
- **`crd-tenant.yaml`** — a cluster-scoped `Tenant{ namespace, quota: {cpu, memory, storage, pods}, isolated, admin }`.
- **`renderTenant()`** (pure, like `renderDeployable`) → **Namespace** + **ResourceQuota** (the hardware *sold*: requests/limits CPU+mem, requests.storage, pods) + **LimitRange** (per-pod defaults/max) + **NetworkPolicy** (default-deny cross-tenant) + the default no-directives **Policy**. Editing the quota re-patches the ResourceQuota.
- The controller now watches **both Deployables and Tenants** concurrently and server-side-applies each. RBAC extended accordingly.

### Real cluster-admin reads (portal)
- **`admin.ts`** — **pure, unit-tested parsers** over real k8s shapes: `parseCpu` (→ millicores), `parseMemMi` (binary+decimal suffixes), `parseClusterCapacity` (Node allocatable + live Pod requests, terminal pods excluded), `parseTenants` (Namespace ⋈ ResourceQuota → allocated-vs-used).
- **`K8sAdmin`** — **real reads**: `GET /api/v1/nodes`, `/pods`, `/namespaces`, `/resourcequotas`; `applyTenant` SSA-applies the Tenant CR.
- **`admin-demo.ts`** — a seeded 3-node cluster + 2 tenants run through the *same* parsers (`PORTAL_DEMO`). BFF: `GET /api/admin/cluster`, `GET`/`POST /api/admin/tenants`.

### Admin portal UI (new top-level nav)
- **Cluster** — CPU / Memory / Pods *committed-vs-allocatable* meters + a Nodes table (role, ready, requested/allocatable, pods).
- **Tenants** — per-tenant allocated-vs-consumed bars for CPU/mem/storage/pods, and a **New/Edit-tenant dialog** that sets the quota → applies a Tenant CR.

## Tests — +14, all green

`renderTenant` (8: quota caps, isolation toggle, default Policy, owner refs, defaults); admin parsers (6: quantity parsing, cluster aggregation excluding terminal pods, tenant join) + the admin BFF routes. `tsc` strict clean (controller + portal + web); build clean.

**Verified end-to-end (demo):** cluster shows 40-core / 160 GiB across 3 nodes with live committed totals (8.75 cores / 16 GiB); tenants show acme/northwind quota-vs-usage; applying a new tenant (`globex`, 6 cores / 150 GiB) lands its quota. *(Headless screenshot tool down this session — verification is DOM-level + tests.)*

The k8s-backed path uses the tested parsers and runs against a live cluster in-cluster. Per-resource `ResourceOps` (real logs/metrics/exec) is the next real-deal slice; the **Blueprint Builder** is the follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
