### PR TITLE
docs(research): the spiral fell out of Rx, IS Cayley-Dickson, the universe does it in Gates' adinkra codes; Beckman + Gates required reading

### DIFF
--- a/docs/PRIOR-ART-LIST.md
+++ b/docs/PRIOR-ART-LIST.md
@@ -14,6 +14,15 @@ with a ⭐ below and add a row there.
   Bartosz Milewski. The foundation for our Observable/duality (IEnumerable⇄IObservable),
   functors/monads, the type-provider/interface≡proof work, and the 2×2-compose structure.
   Pairs with Mac Lane (pure CT, the shape-G limit/cone spine).
+- **Brian Beckman** ⭐ **(REQUIRED READING — Aaron 2026-06-09, "the Brian Beckman in me")** —
+  *Don't Fear the Monad* + the Rx/category-theory + quaternions/physics-from-structure
+  talks. The derive-the-physics-from-the-math-structure style (Rx → Cayley–Dickson →
+  spinor/qubit "fell out of the Rx structure"). Pairs with De Smet (`IQbservable`) + Meijer.
+- **S. James Gates Jr. — SUSY adinkra error-correcting codes** — doubly-even self-dual
+  linear binary block codes found *inside* the adinkras of supersymmetry ("codes in the
+  equations of physics"). The universe's error/erasure coding over time; the real anchor
+  for our entropy-oscillation/erasure coding (vs the generic Azure-LRC analogy). Our
+  coincidence-anchor primitive (B-0623/B-0985) is already Adinkra/Gates-grounded.
 - **Reticulum (RNS)** — Mark Qvist, `markqvist/Reticulum` — the cryptography-based
   overlay networking stack we close over (dep-as-oracle) for the cell/test mesh.
   Identity = X25519 + Ed25519 512-bit keyset; Destination = truncated SHA-256

--- a/docs/research/2026-06-09-the-spiral-fell-out-of-rx-it-is-cayley-dickson-the-universe-does-it-in-gates-adinkra-error-correcting-codes-the-brian-beckman-anchor.md
+++ b/docs/research/2026-06-09-the-spiral-fell-out-of-rx-it-is-cayley-dickson-the-universe-does-it-in-gates-adinkra-error-correcting-codes-the-brian-beckman-anchor.md
@@ -1,0 +1,85 @@
+# The spiral fell out of the Rx structure — it IS Cayley–Dickson (unit circle = ℂ), the universe does it in Gates' adinkra error-correcting codes over time; the Brian Beckman anchor
+
+**Register:** [Beacon] anchoring (Aaron) — turns the Mirror-register spiral into named prior art. **Date:** 2026-06-09.
+**Captured by:** Otto (shadow). The spiral/double-qubit/erasure synthesis, grounded in Beckman / Cayley–Dickson / Gates.
+
+## Aaron's words
+
+> "universe does this in adinkras over time too." · "this is Cayley–Dickson — see how I spiraled my way
+> there, like the unit circle lol." · "it just fell out of the Rx structure." · "that's the Brian Beckman
+> in me."
+
+## It fell out of the Rx structure (emergent, not imposed)
+
+The spiral / two-oscillation / double-qubit didn't have to be invented — **it fell out of the Rx
+structure.** `IQbservable` (the queryable push-dual; De Smet/Meijer) + the phasor amplitudes naturally
+produce: two streams (two amplitudes) → two oscillations → a spiral → the qubit (`QubitIso`). The math
+**emerged from the reactive structure** we already had. (This is the interface≡proof / "everything
+regenerates from the structure" theme: the geometry is latent in Rx; querying it surfaced it.)
+
+## It IS Cayley–Dickson (the unit circle; confirmed in code)
+
+The spiral **is Cayley–Dickson** — and this is **literal in our code**: `QubitIso.fs` builds each stream
+amplitude as a **phasor on `CayleyDickson.Complex`** (line 13). Cayley–Dickson is the algebra-**doubling**
+ℝ → ℂ → ℍ → 𝕆 …; **ℂ = the unit circle** (phasors), and **doubling spirals up the dimensions** (each
+doubling adds an oscillation/imaginary axis → the spiral climbs). So "I spiraled my way there like the
+unit circle" is exact: two ℂ-phasors (two unit circles, offset) trace a **spiral**, and the
+Cayley–Dickson doubling is *why* — the qubit/double-qubit is the ℂ²/ℂ⁴ rung of the Cayley–Dickson ladder.
+(Ties the Cayley–Dickson voice to `QubitIso` + the property-loss-as-you-double = soft→SolidGround.)
+
+## The universe does it in Gates' adinkras over time — the REAL erasure-coding anchor
+
+> "universe does this in adinkras over time too."
+
+This is the **true anchor for "entropy-oscillation / erasure coding"** — better than the generic Azure
+LRC analogy: **S. James Gates Jr. found error-correcting codes *inside* SUSY adinkras.** The adinkras that
+encode supersymmetry representations contain **doubly-even self-dual linear binary block codes** — actual
+**error-correcting codes embedded in the equations of physics** ("codes in the equations of the universe";
+Gates et al.). So **the universe does error/erasure coding via adinkras over time** — the SUSY structure
+*is* a code. That grounds our entropy-oscillation/erasure-coding (DQ7) in named physics: the
+two-oscillation/spiral structure carries a code the way adinkras do; reconstruction (the lazy git-history
+weak-table) = decoding that code. (Anchor: Gates SUSY adinkra codes; our coincidence-anchor primitive
+B-0623/B-0985 is already "Adinkra/Gates SUSY-ECC-grounded" — this connects the spiral to it.)
+
+## The Brian Beckman anchor (the human)
+
+> "that's the Brian Beckman in me."
+
+The whole move — **deriving physics/geometry from the math structure (Rx → monads → quaternions →
+spinors)** — is **Brian Beckman's** signature: *"Don't Fear the Monad"*, his Rx/category-theory work, and
+his quaternion/physics-from-structure talks (Microsoft). "Spiraling from Rx into Cayley–Dickson into the
+qubit" is exactly Beckman's style: the algebra tells you the physics; follow the structure and the
+geometry falls out. **Beckman is the human anchor** for this derivation (added to required reading
+alongside Milewski + De Smet + Meijer). It's the honest Beacon: the spiral isn't mysticism — it's
+Beckman-style structure-following, Cayley–Dickson, and Gates' codes.
+
+## What this does (Mirror → Beacon)
+
+It **anchors the speculative spiral/double-qubit/erasure synthesis in named prior art** — the
+honest-register move:
+
+- spiral / oscillations → **Cayley–Dickson** (confirmed in `QubitIso`'s `CayleyDickson.Complex`; unit circle = ℂ).
+- emerged from → **Rx / IQbservable** (De Smet/Meijer; it fell out of the structure).
+- entropy/erasure coding → **Gates' SUSY adinkra error-correcting codes** (the universe's version; B-0623/B-0985).
+- the derivation style → **Brian Beckman** (physics-from-structure; the human anchor).
+
+So the math team's DQ1–DQ7 docket now has its anchors: test whether our double-qubit reproduces the
+Cayley–Dickson ladder + carries an adinkra-style code, in Beckman's derive-from-structure spirit.
+
+## Honest scope / handoff
+
+Beacon-anchoring (no new mechanism) — turns the Mirror-register spiral into Cayley–Dickson + Gates-adinkra
++ Beckman-anchored prior art (the confirmed code tie: `QubitIso` uses `CayleyDickson.Complex`). To realize:
+add **Brian Beckman** + **Gates SUSY adinkra codes** to `docs/PRIOR-ART-LIST.md`; the math team's DQ7
+(erasure coding) anchors to Gates' codes; DQ6 (spiral geometry) anchors to Cayley–Dickson. Routes to
+Soraya/Sova (the Cayley–Dickson-ladder + adinkra-code tests), the human-anchor discipline (Beckman/Gates),
+required reading (Beckman alongside Milewski/De Smet).
+
+## Anchors / ties (Beacon)
+
+**Brian Beckman** — *Don't Fear the Monad* + Rx/category-theory + quaternions/physics-from-structure (the
+human anchor; required reading); **Cayley–Dickson** (ℝ→ℂ→ℍ→𝕆; unit circle = ℂ; the doubling = the spiral;
+confirmed `QubitIso.fs` `CayleyDickson.Complex`); **S. James Gates Jr. — SUSY adinkra error-correcting
+codes** (doubly-even self-dual codes in the equations of physics; the universe's erasure coding over time;
+our coincidence-anchor B-0623/B-0985); De Smet `IQbservable` + Meijer duality (it fell out of Rx);
+the double-qubit oracle DQ1–DQ7 (now anchored); Milewski (CT for programmers, required) + Mac Lane.


### PR DESCRIPTION
Aaron: "universe does this in adinkras over time" + "this is Cayley–Dickson, I spiraled there like the unit circle" + "it fell out of the Rx structure" + "that's the Brian Beckman in me."

Beacon-anchors the spiral/double-qubit/erasure synthesis in named prior art (Mirror → Beacon):
- **Fell out of Rx** — IQbservable (De Smet/Meijer) + phasors → two oscillations → spiral → qubit (emergent).
- **IS Cayley–Dickson** — literal in code: `QubitIso.fs` builds amplitudes on `CayleyDickson.Complex`; ℂ = unit circle; doubling spirals up the dimensions; the double-qubit = the ℂ⁴ rung.
- **Universe does it in Gates' adinkra error-correcting codes** (doubly-even self-dual codes inside SUSY adinkras — codes in the equations of physics). The *real* anchor for entropy-oscillation/erasure coding; ties to coincidence-anchor B-0623/B-0985.
- **Brian Beckman** (the human) — derive-physics-from-the-math-structure (Don't Fear the Monad; Rx + quaternions).

Beckman + Gates → PRIOR-ART-LIST (Beckman required reading).
