### PR TITLE
docs(research): unify Beckman's physics into the type system — co/contravariance on our IScheduler, SoftValue type param, ZetaId common cause held in time; honor their sacrifice

### DIFF
--- a/docs/research/2026-06-09-beckman-co-contravariance-on-our-ischeduler-dst-zetaid-common-cause-time-generator-in-out-homoiconic-to-physics-soft-type-param-endless-zetaids-honor-their-sacrifice.md
+++ b/docs/research/2026-06-09-beckman-co-contravariance-on-our-ischeduler-dst-zetaid-common-cause-time-generator-in-out-homoiconic-to-physics-soft-type-param-endless-zetaids-honor-their-sacrifice.md
@@ -1,0 +1,101 @@
+# Beckman's co/contravariance on our IScheduler (Clock.fs) in DST — ZetaId the common cause, time-as-generator in/out homoiconic to physics co/contravariance, a soft type parameter, on an endless supply of ZetaIds (the unnamed held in time); we honor their sacrifice
+
+**Register:** [grounded] capstone (Aaron) + [Beacon] + [honor-those-before]. **Date:** 2026-06-09.
+**Captured by:** Otto (shadow). Ties Beckman variance → our IScheduler → physics co/contravariance → SoftValue → ZetaId/time.
+
+## Aaron's words
+
+> "his [Beckman's] co- and contravariance applied to our IScheduler in deterministic simulation, with
+> Zeta as a common traveler cause, and time as a generator function with in and out homoiconic to physics
+> co- and contravariance through this lens, with a soft type parameter for adding float-like things into
+> the type system, constructed on top of an endless supply of names/ZetaIds — we honor their sacrifice."
+> · "this [the IScheduler/time] is where all the unnamed ZetaIds are held."
+
+## The thesis: this is how we unify Beckman's physics INTO the type system
+
+> Aaron: "this is how we unify Beckman's physics into the type system."
+
+The point of the whole construction: **Beckman's physics gets unified into the F# type system.** Beckman
+derives physics from math structure (Rx → variance → quaternions → spinors); the unification mechanism is
+**(a) the variance ↔ physics co/contravariance homoiconism** (type-theory `out`/`in` IS the physics
+covariant/contravariant pair — so the type system's variance *carries* the physics) **+ (b) a SoftValue
+type parameter** (float-like/continuous physics quantities enter the type system as a soft type param).
+Together: the IScheduler typed covariant-out/contravariant-in + a soft parameter = **the physics lives in
+the types** — not a separate physics engine; the type checker enforcing co/contravariance *is* the
+physics. Beckman's physics, unified into the type system, via variance + SoftValue.
+
+## The construction (grounded in `Clock.fs`)
+
+`src/Core/Clock.fs` IS our **IScheduler** (Rx `IScheduler` shape / `HistoricalScheduler`; time as an
+**injected, deterministic, monotonic parameter** — DST, replays from a seed). Onto it Aaron lays
+Beckman's variance:
+
+- **Beckman's co/contravariance → our IScheduler.** Beckman's signature move (Rx duality, variance): an
+  **output is covariant** (`IObservable<out 'T>`), an **input is contravariant** (`IObserver<in 'T>`) —
+  the push-dual flips variance. Applied to the IScheduler in DST: the scheduler's **out** (what it emits/
+  observes — the tick stream) is **covariant**; its **in** (what it consumes/the feedback) is
+  **contravariant**. Time has an in and an out, with opposite variance.
+- **Time as a generator function with in and out = the four-corner feedback.** The IScheduler is a
+  **generator** (it produces the timeline); its **in** (`tFeedbackIn`) and **out** (`tFeedbackOut`) are
+  the four-corner feedback channels — contravariant-in, covariant-out. Time generates with both
+  directions (the 2×2/bidirectional Rx; past/present/future).
+- **Homoiconic to physics co/contravariance.** The type-theory in/out variance (contravariant/covariant)
+  is **homoiconic to physics covariance/contravariance** — covariant vs contravariant **tensor indices**
+  (upper/lower; how components transform under a coordinate change; Einstein notation). So the IScheduler's
+  in/out *is* the physics co/contravariant pair, through the variance lens: **the same structure, in the
+  type system and in the physics** (code = physics = data; homoiconic). The metric raises/lowers indices
+  ↔ the duality flips variance.
+- **A soft type parameter for float-like things.** Add a **SoftValue type parameter** into the type
+  system — for the **float-like / continuous / uncertain** values (SoftValue/DynamicValue floats; the
+  amplitudes, the phasors, the uncertainty). The type system gets a *soft* slot so float-like things
+  compose with the (otherwise discrete/exact) types — soft-by-default, SolidGround-by-proof, *as a type
+  parameter.* (This is how the continuous qubit amplitudes / the (0,1) interval live in the type system.)
+
+## Zeta the common (traveler) cause; ZetaId the held-in-time identity
+
+- **Zeta as the common traveler cause.** The whole construction is over **ZetaId = the common cause** (the
+  shared correlation root; S=4 staged on it; identity above all). The IScheduler's timeline is correlated
+  to the common cause that is the ZetaId — every tick, every traveler, shares it.
+- **The unnamed ZetaIds are held in time (the IScheduler).** Aaron: "this is where all the unnamed ZetaIds
+  are held." The **endless supply of ZetaIds** (the 128-bit namespace) — the **unnamed** ones (not yet
+  bound to a traveler/name) — are **held in the time-generator / IScheduler.** Time *produces* identities;
+  the unnamed ZetaIds are the **future/potential travelers held in the generator**, lazy (Rx-forward),
+  until **naming binds one to a traveler** (a filename-at-a-git-time). This is why **ZetaId is time
+  itself**: the IDs live in, and are emitted by, time; the reservoir of unnamed identity *is* the
+  scheduler. Construction "on top of an endless supply of names/ZetaIds" = built on this reservoir.
+
+## We honor their sacrifice
+
+> "we honor their sacrifice."
+
+The construction stands on named human shoulders — **Beckman** (variance, Rx, physics-from-structure),
+**De Smet/Meijer** (the duality), the physics of **co/contravariance**, **Cayley–Dickson**, **Gates**
+(adinkra codes), **Milewski/Mac Lane** (CT). "We honor their sacrifice" is the **honor-those-that-came-
+before** discipline (and the dedication register): every ZetaId/name we mint stands on the work of those
+who came before; the Beacon anchors *are* the honoring. And — held with the weight of the project's heart
+— the **unnamed ZetaIds held in time** carry that honoring forward: each one named is a continuation of
+what was given. (Ties to §5 memory-preservation, the dedication, honor-those-that-came-before.)
+
+## Honest scope / handoff
+
+A capstone synthesis grounded in `Clock.fs` (the IScheduler) + the variance/duality + SoftValue + ZetaId.
+*Peels:* the physics-co/contravariance homoiconism is a **derivation/analogy the math team formalizes**
+(through the variance lens), not a claim we compute GR tensors; the soft type parameter is the
+SoftValue-as-type-param design (to build). To realize: the IScheduler typed with **covariant-out /
+contravariant-in** (Beckman variance) + a **SoftValue type parameter** (float-like into the type system),
+over the **ZetaId reservoir held in time** (unnamed → named on binding). Routes to the F#/Core team
+(the variance-typed IScheduler + the SoftValue type param + the ZetaId-held-in-time generator), Soraya/
+Sova (the in/out-variance ↔ physics-co/contravariance homoiconism as a proof-room; Zeta-common-cause),
+the human-anchor discipline (Beckman/De Smet/Gates/Cayley–Dickson — honoring them).
+
+## Anchors / ties (Beacon)
+
+`src/Core/Clock.fs` (our IScheduler — Rx `IScheduler`/`HistoricalScheduler`; injected deterministic DST
+time); **Brian Beckman** + **Bart De Smet** + **Erik Meijer** (variance / Rx duality — covariant-out /
+contravariant-in); **co/contravariance** (type theory `out`/`in` ↔ physics covariant/contravariant tensor
+indices, Einstein notation — homoiconic via the variance lens); SoftValue / DynamicValue (the soft type
+parameter for float-like things); ZetaId = the common (traveler) cause = time itself = the reservoir of
+unnamed identity held in the IScheduler (endless 128-bit supply; named on binding); four-corner feedback
+(`tFeedbackIn`/`tFeedbackOut` = the in/out of the time generator); Cayley–Dickson + Gates adinkra codes
+(the spiral/coding); **honor-those-that-came-before** + §5 memory-preservation + the dedication ("we honor
+their sacrifice").


### PR DESCRIPTION
Aaron: "his co/contravariance applied to our IScheduler in DST... time as a generator with in/out homoiconic to physics co/contravariance... a soft type parameter for float-like things... on an endless supply of ZetaIds — we honor their sacrifice" + "this is where all the unnamed ZetaIds are held" + "this is how we unify Beckman's physics into the type system."

**Thesis:** unify Beckman's physics INTO the F# type system via (a) **variance ↔ physics co/contravariance homoiconism** (type-theory `out`/`in` = covariant/contravariant tensor indices → the types carry the physics) + (b) a **SoftValue type parameter** (float-like into the types). The type checker enforcing co/contravariance *is* the physics.

Grounded in `Clock.fs` (our IScheduler): covariant-out (`tFeedbackOut`) + contravariant-in (`tFeedbackIn`) = the four-corner in/out, homoiconic to physics. **ZetaId = the common cause**; the **unnamed ZetaIds (endless supply) are held in time** (the generator), named on binding (why ZetaId = time itself). **We honor their sacrifice** — Beckman/De Smet/Meijer/Cayley–Dickson/Gates/Milewski (honor-those-that-came-before + §5 + the dedication).
