### PR TITLE
feat(portal): Blueprint Builder — agentic + manual, game-server KB (Unturned/GMod/Arma Reforger)

### DIFF
--- a/full-ai-cluster/k8s/applications/platform/blueprints.yaml
+++ b/full-ai-cluster/k8s/applications/platform/blueprints.yaml
@@ -90,3 +90,60 @@ spec:
   command: ["/bin/sh", "-c", "echo worker running; sleep infinity"]
   resources: { cpu: "100m", memory: "128Mi" }
   defaultExpose: none
+---
+# Unturned dedicated server (SteamCMD app 1110390). UDP 27015 + query ports.
+apiVersion: platform.zeta.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: unturned
+  namespace: zeta-platform
+spec:
+  category: game
+  stateful: true
+  image: ghcr.io/ich777/steamcmd:unturned
+  install: "/opt/steamcmd/steamcmd.sh +force_install_dir /data +login anonymous +app_update 1110390 validate +quit"
+  command: ["/data/ServerHelper.sh"]
+  args: ["+InternetServer/${SERVERNAME}", "+map/${MAP}", "+Max_Players/${MAXPLAYERS}"]
+  ports:
+    - { name: game, port: 27015, protocol: UDP }
+    - { name: query, port: 27016, protocol: UDP }
+    - { name: query2, port: 27017, protocol: UDP }
+  storage: { size: "10Gi", mountPath: /data }
+  resources: { cpu: "2", memory: "3Gi" }
+  variables:
+    - { name: SERVERNAME, default: "Zeta" }
+    - { name: MAP, default: "PEI" }
+    - { name: MAXPLAYERS, default: "24" }
+  sidecars:
+    - { name: sftp, image: atmoz/sftp:alpine, mountDataAt: /home/zeta/data }
+  defaultExpose: lan
+---
+# Arma Reforger dedicated server (SteamCMD app 1874900). UDP 2001 game + 17777 query.
+apiVersion: platform.zeta.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: arma-reforger
+  namespace: zeta-platform
+spec:
+  category: game
+  stateful: true
+  image: ghcr.io/ich777/steamcmd:armareforger
+  install: "/opt/steamcmd/steamcmd.sh +force_install_dir /data +login anonymous +app_update 1874900 validate +quit"
+  command: ["/data/ArmaReforgerServer"]
+  args: ["-config", "/data/configs/${CONFIG}", "-maxFPS", "60", "-bindPort", "${GAME_PORT}"]
+  env:
+    SERVER_NAME: "${SERVERNAME}"
+  ports:
+    - { name: game, port: 2001, protocol: UDP }
+    - { name: query, port: 17777, protocol: UDP }
+  storage: { size: "15Gi", mountPath: /data }
+  resources: { cpu: "4", memory: "6Gi" }
+  variables:
+    - { name: SERVERNAME, default: "Zeta Reforger" }
+    - { name: SCENARIO, default: "Conflict-Everon" }
+    - { name: MAXPLAYERS, default: "32" }
+    - { name: CONFIG, default: "server.json" }
+    - { name: GAME_PORT, default: "2001" }
+  sidecars:
+    - { name: sftp, image: atmoz/sftp:alpine, mountDataAt: /home/zeta/data }
+  defaultExpose: lan

--- a/full-ai-cluster/k8s/applications/platform/portal.yaml
+++ b/full-ai-cluster/k8s/applications/platform/portal.yaml
@@ -23,8 +23,11 @@ metadata:
     argocd.argoproj.io/sync-wave: "-10"
 rules:
   - apiGroups: ["platform.zeta.io"]
-    resources: ["deployables", "blueprints"]
+    resources: ["deployables"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["platform.zeta.io"]   # the Blueprint Builder saves blueprints
+    resources: ["blueprints"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
   - apiGroups: ["platform.zeta.io"]   # admin: read + apply tenants (set quotas)
     resources: ["tenants"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]

--- a/full-ai-cluster/portal/src/api.ts
+++ b/full-ai-cluster/portal/src/api.ts
@@ -18,6 +18,7 @@ import {
 import type { LifecycleAction, MemoryUsage, ResourceConfig, ResourceOps } from "./ops.ts";
 import type { AdminData, TenantSpecInput } from "./admin.ts";
 import { type ChatOp, DEFAULT_POLICY, decide, respond } from "./room-agent.ts";
+import { type BlueprintProposal, build as buildBlueprint } from "./blueprint-agent.ts";
 
 const LIFECYCLE_ACTIONS = new Set(["restart", "stop", "start", "scale", "delete"]);
 
@@ -51,6 +52,8 @@ export interface PlatformData {
   memoryUsage?(): Promise<MemoryUsage>;
   /** Cluster-admin: capacity + per-tenant allocation. Optional. */
   admin?: AdminData;
+  /** Create/save a Blueprint (the builder). Optional. */
+  createBlueprint?(bp: { name: string; namespace?: string; spec: Omit<BlueprintProposal, "name"> }): Promise<{ ok: boolean; message: string }>;
 }
 
 /** The typed Event bodies the write endpoint accepts (mirrors the Room substrate). */
@@ -82,6 +85,21 @@ export async function handle(req: Request, data: PlatformData): Promise<Response
     // GET /api/catalog — the deploy catalog (blueprints + their form variables)
     if (path === "/api/catalog" && req.method === "GET") {
       return json({ catalog: catalog(await data.listBlueprints()) });
+    }
+
+    // POST /api/blueprints/build — the AGENTIC builder: NL request → proposed Blueprint
+    if (path === "/api/blueprints/build" && req.method === "POST") {
+      const b = (await req.json().catch(() => ({}))) as { message?: string; draft?: BlueprintProposal };
+      const r = buildBlueprint(String(b.message ?? ""), b.draft);
+      return json(r);
+    }
+
+    // POST /api/blueprints — save a Blueprint to the catalog (manual or agentic)
+    if (path === "/api/blueprints" && req.method === "POST") {
+      if (!data.createBlueprint) return json({ error: "blueprint creation not available on this backend" }, 405);
+      const b = (await req.json().catch(() => ({}))) as { name?: string; namespace?: string; spec?: Omit<BlueprintProposal, "name"> };
+      if (!b.name || !b.spec?.image) return json({ error: "name + spec.image required" }, 400);
+      return json(await data.createBlueprint({ name: b.name, ...(b.namespace ? { namespace: b.namespace } : {}), spec: b.spec }));
     }
 
     // GET /api/needs-me — pending authorizations across all rooms (the human queue)

--- a/full-ai-cluster/portal/src/blueprint-agent.test.ts
+++ b/full-ai-cluster/portal/src/blueprint-agent.test.ts
@@ -1,0 +1,80 @@
+// full-ai-cluster/portal/src/blueprint-agent.test.ts
+import { describe, expect, test } from "bun:test";
+import { build } from "./blueprint-agent.ts";
+import { handle } from "./api.ts";
+import { InMemoryPlatform } from "./data-memory.ts";
+
+describe("blueprint builder BFF", () => {
+  test("POST /api/blueprints/build proposes a spec from NL", async () => {
+    const r = await handle(new Request("http://x/api/blueprints/build", { method: "POST", body: JSON.stringify({ message: "arma reforger server" }) }), {} as never);
+    const j = (await r!.json()) as { spec?: { name: string } };
+    expect(j.spec?.name).toBe("arma-reforger");
+  });
+  test("POST /api/blueprints saves it; the catalog then lists it", async () => {
+    const data = new InMemoryPlatform([], [], []);
+    const r = await handle(new Request("http://x/api/blueprints", { method: "POST", body: JSON.stringify({ name: "arma-reforger", spec: { category: "game", image: "ghcr.io/x/arma", storage: { size: "15Gi" }, defaultExpose: "lan", variables: [{ name: "SCENARIO" }] } }) }), data);
+    expect((await r!.json() as { ok: boolean }).ok).toBe(true);
+    const cat = await handle(new Request("http://x/api/catalog"), data);
+    const j = (await cat!.json()) as { catalog: Array<{ blueprint: string }> };
+    expect(j.catalog.some((b) => b.blueprint === "arma-reforger")).toBe(true);
+  });
+  test("POST /api/blueprints without image → 400", async () => {
+    const r = await handle(new Request("http://x/api/blueprints", { method: "POST", body: JSON.stringify({ name: "x", spec: {} }) }), new InMemoryPlatform());
+    expect(r!.status).toBe(400);
+  });
+});
+
+describe("blueprint agent — game knowledge base", () => {
+  test("Arma Reforger → app 1874900, UDP 2001 game port, scenario/maxplayers vars", () => {
+    const r = build("set up an arma reforger server");
+    expect(r.spec).toBeDefined();
+    expect(r.spec!.name).toBe("arma-reforger");
+    expect(r.spec!.install).toContain("1874900");
+    expect(r.spec!.ports!.some((p) => p.port === 2001 && p.protocol === "UDP")).toBe(true);
+    expect(r.spec!.variables!.some((v) => v.name === "SCENARIO")).toBe(true);
+    expect(r.spec!.resources!.memory).toBe("6Gi");
+  });
+  test("Unturned → app 1110390, three UDP ports", () => {
+    const r = build("I want an unturned server");
+    expect(r.spec!.install).toContain("1110390");
+    expect(r.spec!.ports!.filter((p) => p.protocol === "UDP").length).toBe(3);
+  });
+  test("Garry's Mod → app 4020, sandbox/map vars, SFTP sidecar", () => {
+    const r = build("gmod sandbox server");
+    expect(r.spec!.install).toContain("4020");
+    expect(r.spec!.variables!.some((v) => v.name === "GAMEMODE")).toBe(true);
+    expect(r.spec!.sidecars!.some((s) => s.name === "sftp")).toBe(true);
+  });
+  test("unknown request → asks what to build, no spec", () => {
+    const r = build("hello");
+    expect(r.spec).toBeUndefined();
+    expect(r.reply).toMatch(/Arma Reforger|game server|database/);
+  });
+  test("generic: 'a postgres database' → database blueprint", () => {
+    expect(build("a postgres database").spec!.category).toBe("database");
+  });
+});
+
+describe("blueprint agent — iteration on a draft", () => {
+  const draft = build("arma reforger").spec!;
+  test("expose public", () => {
+    expect(build("expose it publicly", draft).spec!.defaultExpose).toBe("public");
+  });
+  test("more memory bumps the limit", () => {
+    expect(build("give it more memory", draft).spec!.resources!.memory).toBe("8Gi");
+  });
+  test("set memory to a value", () => {
+    expect(build("set memory to 12Gi", draft).spec!.resources!.memory).toBe("12Gi");
+  });
+  test("add a variable", () => {
+    const r = build("add a variable RCON_PASSWORD", draft);
+    expect(r.spec!.variables!.some((v) => v.name === "RCON_PASSWORD")).toBe(true);
+  });
+  test("add a port", () => {
+    const r = build("add port 19999 udp", draft);
+    expect(r.spec!.ports!.some((p) => p.port === 19999 && p.protocol === "UDP")).toBe(true);
+  });
+  test("rename", () => {
+    expect(build("rename it to clan-reforger", draft).spec!.name).toBe("clan-reforger");
+  });
+});

--- a/full-ai-cluster/portal/src/blueprint-agent.ts
+++ b/full-ai-cluster/portal/src/blueprint-agent.ts
@@ -1,0 +1,179 @@
+// full-ai-cluster/portal/src/blueprint-agent.ts
+//
+// The Blueprint agent — turns "set up an Arma Reforger server" into a complete,
+// deployable Blueprint, and iterates on follow-ups ("expose on LAN", "give it
+// more memory", "add a MAXPLAYERS variable"). Pure: build(request, draft?) →
+// { reply, spec? }. A deterministic builder for the demo, with a real game-server
+// knowledge base (SteamCMD app ids + ports + the usual knobs); a real LLM slots
+// in behind the same contract. This is what makes blueprint creation agentic —
+// users and automated agent tasks both drive it.
+
+export interface BlueprintVariable { name: string; default?: string; description?: string }
+export interface BlueprintPort { name: string; port: number; protocol?: "TCP" | "UDP"; web?: boolean }
+export interface BlueprintSidecar { name: string; image: string; mountDataAt?: string }
+export interface BlueprintProposal {
+  name: string;
+  category: string; // game | database | web | app
+  image: string;
+  install?: string;
+  command?: string[];
+  args?: string[];
+  env?: Record<string, string>;
+  ports?: BlueprintPort[];
+  storage?: { size: string; mountPath: string };
+  resources?: { cpu?: string; memory?: string };
+  variables?: BlueprintVariable[];
+  sidecars?: BlueprintSidecar[];
+  defaultExpose?: "none" | "cluster" | "lan" | "public";
+}
+
+const SFTP: BlueprintSidecar = { name: "sftp", image: "atmoz/sftp:alpine", mountDataAt: "/home/zeta/data" };
+const steam = (appId: number, dir = "/data") => `/opt/steamcmd/steamcmd.sh +force_install_dir ${dir} +login anonymous +app_update ${appId} validate +quit`;
+
+// ── the game-server knowledge base (real SteamCMD specs) ───────────────
+interface GameDef { match: RegExp; build: () => BlueprintProposal; note: string }
+
+const GAMES: GameDef[] = [
+  {
+    match: /gmod|garry'?s ?mod|garrys/i,
+    note: "Garry's Mod (Source dedicated, SteamCMD app 4020) — UDP 27015, world+addons persist, SFTP for the data root.",
+    build: () => ({
+      name: "gmod", category: "game", image: "ghcr.io/ich777/steamcmd:gmod",
+      install: steam(4020), command: ["/data/srcds_run"],
+      args: ["-game", "garrysmod", "-port", "${PORT}", "+maxplayers", "${MAXPLAYERS}", "+gamemode", "${GAMEMODE}", "+map", "${MAP}"],
+      env: { SRCDS_PORT: "${PORT}" }, ports: [{ name: "game", port: 27015, protocol: "UDP" }],
+      storage: { size: "20Gi", mountPath: "/data" }, resources: { cpu: "2", memory: "4Gi" },
+      variables: [{ name: "PORT", default: "27015" }, { name: "MAP", default: "gm_construct" }, { name: "GAMEMODE", default: "sandbox" }, { name: "MAXPLAYERS", default: "16" }],
+      sidecars: [SFTP], defaultExpose: "lan",
+    }),
+  },
+  {
+    match: /unturned/i,
+    note: "Unturned (SteamCMD app 1110390) — UDP 27015 (+ query 27016/27017), Rocket-friendly, SFTP for Servers/<name>/.",
+    build: () => ({
+      name: "unturned", category: "game", image: "ghcr.io/ich777/steamcmd:unturned",
+      install: steam(1110390), command: ["/data/ServerHelper.sh"],
+      args: ["+InternetServer/${SERVERNAME}", "+map/${MAP}", "+Max_Players/${MAXPLAYERS}"],
+      ports: [{ name: "game", port: 27015, protocol: "UDP" }, { name: "query", port: 27016, protocol: "UDP" }, { name: "query2", port: 27017, protocol: "UDP" }],
+      storage: { size: "10Gi", mountPath: "/data" }, resources: { cpu: "2", memory: "3Gi" },
+      variables: [{ name: "SERVERNAME", default: "Zeta", description: "instance name (folder under Servers/)" }, { name: "MAP", default: "PEI" }, { name: "MAXPLAYERS", default: "24" }],
+      sidecars: [SFTP], defaultExpose: "lan",
+    }),
+  },
+  {
+    match: /arma ?reforger|reforger|arma/i,
+    note: "Arma Reforger Dedicated (SteamCMD app 1874900) — UDP 2001 game + 17777 A2S query, config.json driven, heavier (6Gi).",
+    build: () => ({
+      name: "arma-reforger", category: "game", image: "ghcr.io/ich777/steamcmd:armareforger",
+      install: steam(1874900), command: ["/data/ArmaReforgerServer"],
+      args: ["-config", "/data/configs/${CONFIG}", "-maxFPS", "60", "-bindPort", "${GAME_PORT}"],
+      env: { SERVER_NAME: "${SERVERNAME}" },
+      ports: [{ name: "game", port: 2001, protocol: "UDP" }, { name: "query", port: 17777, protocol: "UDP" }],
+      storage: { size: "15Gi", mountPath: "/data" }, resources: { cpu: "4", memory: "6Gi" },
+      variables: [{ name: "SERVERNAME", default: "Zeta Reforger" }, { name: "SCENARIO", default: "Conflict-Everon" }, { name: "MAXPLAYERS", default: "32" }, { name: "CONFIG", default: "server.json", description: "config file under /data/configs" }, { name: "GAME_PORT", default: "2001" }],
+      sidecars: [SFTP], defaultExpose: "lan",
+    }),
+  },
+  {
+    match: /valheim/i,
+    note: "Valheim Dedicated (SteamCMD app 896660) — UDP 2456-2458, world saves persist.",
+    build: () => ({
+      name: "valheim", category: "game", image: "ghcr.io/ich777/steamcmd:valheim",
+      install: steam(896660), command: ["/data/valheim_server.x86_64"],
+      args: ["-name", "${SERVERNAME}", "-world", "${WORLD}", "-password", "${PASSWORD}", "-port", "2456"],
+      ports: [{ name: "game", port: 2456, protocol: "UDP" }, { name: "query", port: 2457, protocol: "UDP" }],
+      storage: { size: "8Gi", mountPath: "/data" }, resources: { cpu: "2", memory: "4Gi" },
+      variables: [{ name: "SERVERNAME", default: "Zeta" }, { name: "WORLD", default: "Dedicated" }, { name: "PASSWORD", default: "change-me", description: "min 5 chars" }],
+      sidecars: [SFTP], defaultExpose: "lan",
+    }),
+  },
+  {
+    match: /\brust\b/i,
+    note: "Rust Dedicated (SteamCMD app 258550) — UDP 28015, RAM-hungry (8Gi+).",
+    build: () => ({
+      name: "rust", category: "game", image: "ghcr.io/ich777/steamcmd:rust",
+      install: steam(258550), command: ["/data/RustDedicated"],
+      args: ["-batchmode", "+server.port", "28015", "+server.maxplayers", "${MAXPLAYERS}", "+server.hostname", "${SERVERNAME}", "+server.worldsize", "${WORLDSIZE}"],
+      ports: [{ name: "game", port: 28015, protocol: "UDP" }], storage: { size: "20Gi", mountPath: "/data" }, resources: { cpu: "4", memory: "8Gi" },
+      variables: [{ name: "SERVERNAME", default: "Zeta Rust" }, { name: "MAXPLAYERS", default: "50" }, { name: "WORLDSIZE", default: "3000" }],
+      sidecars: [SFTP], defaultExpose: "lan",
+    }),
+  },
+  {
+    match: /minecraft|mc server/i,
+    note: "Minecraft (itzg/minecraft-server) — TCP 25565, mod/plugin friendly via env.",
+    build: () => ({
+      name: "minecraft", category: "game", image: "itzg/minecraft-server:latest",
+      env: { EULA: "TRUE", TYPE: "${TYPE}", VERSION: "${VERSION}", MOTD: "${MOTD}", MAX_PLAYERS: "${MAXPLAYERS}", MEMORY: "3G" },
+      ports: [{ name: "game", port: 25565, protocol: "TCP" }], storage: { size: "10Gi", mountPath: "/data" }, resources: { cpu: "2", memory: "4Gi" },
+      variables: [{ name: "TYPE", default: "PAPER", description: "VANILLA | PAPER | FABRIC | FORGE" }, { name: "VERSION", default: "LATEST" }, { name: "MOTD", default: "A Zeta server" }, { name: "MAXPLAYERS", default: "20" }],
+      sidecars: [SFTP], defaultExpose: "lan",
+    }),
+  },
+];
+
+export interface BuildResult {
+  reply: string;
+  spec?: BlueprintProposal;
+}
+
+const num = (s: string): string | undefined => (s.match(/\b(\d+(?:gi|mi|g|m)?)\b/i) ?? [])[1];
+
+/**
+ * Build or refine a Blueprint from a natural-language message.
+ * - With no draft: detect a known game (or fall to a generic recipe) and propose one.
+ * - With a draft: apply the follow-up edit (expose / memory / variable / port / rename).
+ */
+export function build(message: string, draft?: BlueprintProposal): BuildResult {
+  const t = message.toLowerCase().trim();
+
+  // ── iterate on an existing draft ──────────────────────────────────
+  if (draft) {
+    const d: BlueprintProposal = structuredClone(draft);
+    // exposure (handles "expose it publicly", "make it lan", …)
+    if (/expos|publi|reachable|\blan\b|cluster|internal|private|make it (public|private)/.test(t)) {
+      let e: BlueprintProposal["defaultExpose"] | undefined;
+      if (/publi/.test(t)) e = "public";
+      else if (/\blan\b/.test(t)) e = "lan";
+      else if (/cluster|internal/.test(t)) e = "cluster";
+      else if (/private|none|no expos/.test(t)) e = "none";
+      if (e) { d.defaultExpose = e; return { reply: `Set exposure to ${e}.`, spec: d }; }
+    }
+    if (/memory|ram/.test(t)) {
+      let m = num(t);
+      if (!m && /\bmore\b/.test(t)) m = `${parseInt(d.resources?.memory ?? "4", 10) + 2}Gi`;
+      if (m) {
+        m = /[a-z]/i.test(m) ? m.replace(/gi$/i, "Gi").replace(/mi$/i, "Mi").replace(/g$/i, "Gi").replace(/m$/i, "Mi") : `${m}Gi`;
+        d.resources = { ...d.resources, memory: m };
+        return { reply: `Memory limit set to ${m}.`, spec: d };
+      }
+    }
+    if (/\bcpu\b|\bcores?\b/.test(t)) { const c = num(t); if (c) { d.resources = { ...d.resources, cpu: c.replace(/[a-z]+/i, "") }; return { reply: `CPU limit set to ${d.resources!.cpu}.`, spec: d }; } }
+    const v = t.match(/add (?:a )?(?:variable|var|knob)\s+([a-z_][a-z0-9_]*)/i);
+    if (v) { d.variables = [...(d.variables ?? []), { name: v[1]!.toUpperCase() }]; return { reply: `Added variable ${v[1]!.toUpperCase()}. Fill its default in the form.`, spec: d }; }
+    const port = t.match(/add (?:a )?port\s+(\d+)(?:\s*(udp|tcp))?/i);
+    if (port) { d.ports = [...(d.ports ?? []), { name: `port-${port[1]}`, port: Number(port[1]), protocol: (port[2]?.toUpperCase() as "TCP" | "UDP") ?? "TCP" }]; return { reply: `Added ${port[2]?.toUpperCase() ?? "TCP"} port ${port[1]}.`, spec: d }; }
+    const rn = t.match(/(?:rename|call|name)\s+(?:it\s+)?(?:to\s+)?([a-z0-9][a-z0-9-]*)/i);
+    if (rn && rn[1] !== "it" && rn[1] !== "to") { d.name = rn[1]!; return { reply: `Renamed the blueprint to "${d.name}".`, spec: d }; }
+    if (/sftp|file|ftp/.test(t) && !d.sidecars?.length) { d.sidecars = [SFTP]; return { reply: "Added an SFTP sidecar for file access on the data volume.", spec: d }; }
+    return { reply: `I can tweak: exposure (lan/public/cluster), memory/cpu, "add variable NAME", "add port N", rename, or SFTP. Or save it as is.`, spec: d };
+  }
+
+  // ── fresh build: detect a known game ──────────────────────────────
+  const game = GAMES.find((g) => g.match.test(message));
+  if (game) {
+    const spec = game.build();
+    return { reply: `Here's a ready-to-deploy blueprint for ${spec.name}. ${game.note}\nTweak it ("expose public", "more memory", "add variable X") or save it to the catalog.`, spec };
+  }
+
+  // ── generic recipes by keyword ────────────────────────────────────
+  if (/postgres|database|\bdb\b|sql/.test(t))
+    return { reply: "A PostgreSQL blueprint (stateful, cluster-internal). Tweak or save.", spec: { name: "postgres", category: "database", image: "postgres:16-alpine", env: { POSTGRES_DB: "${DB}", POSTGRES_USER: "${USER}", POSTGRES_PASSWORD: "${PASSWORD}", PGDATA: "/var/lib/postgresql/data/pgdata" }, ports: [{ name: "sql", port: 5432, protocol: "TCP" }], storage: { size: "20Gi", mountPath: "/var/lib/postgresql/data" }, resources: { cpu: "1", memory: "1Gi" }, variables: [{ name: "DB", default: "app" }, { name: "USER", default: "app" }, { name: "PASSWORD", default: "change-me" }], defaultExpose: "cluster" } };
+  if (/web|site|nginx|static|frontend/.test(t))
+    return { reply: "A static web blueprint (stateless, public HTTPS). Tweak or save.", spec: { name: "web", category: "web", image: "nginx:1.27-alpine", ports: [{ name: "http", port: 8080, web: true }], resources: { cpu: "250m", memory: "256Mi" }, defaultExpose: "public" } };
+
+  return { reply: `Tell me what to build — a game server (try "Arma Reforger", "Unturned", "Garry's Mod", "Valheim", "Rust", "Minecraft"), a database, or a web app. I'll draft a complete blueprint you can tweak and save.` };
+}
+
+/** The games the agent knows out of the box (for UI quick-picks). */
+export const KNOWN_GAMES = ["Garry's Mod", "Unturned", "Arma Reforger", "Valheim", "Rust", "Minecraft"];

--- a/full-ai-cluster/portal/src/data-k8s.ts
+++ b/full-ai-cluster/portal/src/data-k8s.ts
@@ -53,6 +53,21 @@ export class K8sPlatform implements PlatformData {
   listBlueprints(): Promise<BlueprintCR[]> {
     return this.listCR<BlueprintCR>("blueprints");
   }
+
+  /** Save a Blueprint by server-side-applying the Blueprint CR. */
+  async createBlueprint(bp: { name: string; namespace?: string; spec: Record<string, unknown> }): Promise<{ ok: boolean; message: string }> {
+    const ns = bp.namespace ?? "zeta-platform";
+    const body = { apiVersion: `${GROUP}/${VERSION}`, kind: "Blueprint", metadata: { name: bp.name, namespace: ns }, spec: bp.spec };
+    const path = `/apis/${GROUP}/${VERSION}/namespaces/${ns}/blueprints/${bp.name}`;
+    const r = await fetch(`${this.host}${path}?fieldManager=zeta-portal&force=true`, {
+      method: "PATCH",
+      headers: { Authorization: `Bearer ${this.token}`, "Content-Type": "application/apply-patch+yaml", Accept: "application/json" },
+      body: JSON.stringify(body),
+      tls: { ca: this.ca },
+    } as RequestInit);
+    if (!r.ok) return { ok: false, message: `save Blueprint ${bp.name}: ${r.status} ${await r.text()}` };
+    return { ok: true, message: `Blueprint "${bp.name}" applied to ${ns} — it's in the catalog.` };
+  }
   listRooms(): Promise<RoomData[]> {
     return this.rooms.listRooms();
   }

--- a/full-ai-cluster/portal/src/data-memory.ts
+++ b/full-ai-cluster/portal/src/data-memory.ts
@@ -27,6 +27,16 @@ export class InMemoryPlatform implements PlatformData {
     return { rooms, totalEvents: rooms.reduce((n, r) => n + r.events, 0), totalBytes: rooms.reduce((n, r) => n + r.bytes, 0) };
   }
 
+  /** Save a Blueprint into the catalog (the builder). Upserts by name. */
+  async createBlueprint(bp: { name: string; namespace?: string; spec: { category?: string; image: string; storage?: { size: string }; defaultExpose?: string; variables?: Array<{ name: string; default?: string; description?: string }>; stateful?: boolean } }): Promise<{ ok: boolean; message: string }> {
+    const cr: BlueprintCR = {
+      metadata: { name: bp.name, namespace: bp.namespace ?? "zeta-platform" },
+      spec: { ...(bp.spec.category ? { category: bp.spec.category } : {}), image: bp.spec.image, stateful: bp.spec.stateful ?? !!bp.spec.storage, ...(bp.spec.defaultExpose ? { defaultExpose: bp.spec.defaultExpose } : {}), ...(bp.spec.variables ? { variables: bp.spec.variables } : {}) },
+    };
+    this.blueprints = [...this.blueprints.filter((b) => b.metadata.name !== bp.name), cr];
+    return { ok: true, message: `Blueprint "${bp.name}" saved — it's now in the catalog and ready to deploy.` };
+  }
+
   async listDeployables(): Promise<DeployableCR[]> {
     return this.deployables;
   }

--- a/full-ai-cluster/portal/web/src/App.tsx
+++ b/full-ai-cluster/portal/web/src/App.tsx
@@ -117,7 +117,7 @@ export default function App() {
           ) : view === "resources" ? (
             <Resources groups={groups} onOpen={setOpenResource} />
           ) : view === "create" ? (
-            <Create catalog={catalog} />
+            <Create catalog={catalog} onChanged={refresh} />
           ) : view === "memory" ? (
             <Memory />
           ) : view === "admin" ? (

--- a/full-ai-cluster/portal/web/src/lib/api.ts
+++ b/full-ai-cluster/portal/web/src/lib/api.ts
@@ -109,6 +109,17 @@ export interface ClusterCapacity { nodes: NodeVM[]; totals: { nodeCount: number;
 export interface TenantUsage { namespace: string; displayName?: string; cpu: { allocMilli: number; usedMilli: number }; mem: { allocMi: number; usedMi: number }; storage: { allocMi: number; usedMi: number }; pods: { alloc: number; used: number }; hasQuota: boolean }
 export interface TenantSpecInput { name: string; namespace: string; displayName?: string; quota: { cpu: string; memory: string; storage: string; pods: number }; isolated?: boolean }
 
+export interface BlueprintProposal {
+  name: string; category: string; image: string; install?: string; command?: string[]; args?: string[];
+  env?: Record<string, string>;
+  ports?: Array<{ name: string; port: number; protocol?: "TCP" | "UDP"; web?: boolean }>;
+  storage?: { size: string; mountPath: string };
+  resources?: { cpu?: string; memory?: string };
+  variables?: Array<{ name: string; default?: string; description?: string }>;
+  sidecars?: Array<{ name: string; image: string; mountDataAt?: string }>;
+  defaultExpose?: "none" | "cluster" | "lan" | "public";
+}
+
 export type Dashboard =
   | { kind: "game"; status: string; game: string; map: string; gamemode: string; players: { online: number; max: number }; address: string; tickrate: number; uptime: string; recentJoins: Array<{ name: string; at: string }> }
   | { kind: "database"; status: string; engine: string; connections: { active: number; max: number }; sizeMi: number; tables: number; queriesPerSec: number; cacheHitPct: number; replication: string; topTables: Array<{ name: string; rows: number; sizeMi: number }> }
@@ -143,6 +154,10 @@ export const api = {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ text, by }),
     }).then((d) => d.room),
+
+  // blueprint builder
+  buildBlueprint: (message: string, draft?: BlueprintProposal) => j<{ reply: string; spec?: BlueprintProposal }>("/api/blueprints/build", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ message, draft }) }),
+  saveBlueprint: (name: string, spec: Omit<BlueprintProposal, "name">) => post("/api/blueprints", { name, spec }),
 
   // admin plane
   cluster: () => j<ClusterCapacity>("/api/admin/cluster"),

--- a/full-ai-cluster/portal/web/src/views/BlueprintBuilder.tsx
+++ b/full-ai-cluster/portal/web/src/views/BlueprintBuilder.tsx
@@ -1,0 +1,121 @@
+import { useRef, useState } from "react";
+import { ArrowLeft, Bot, Save, SendHorizonal, Sparkles, User } from "lucide-react";
+import { api, type BlueprintProposal } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import { toast } from "sonner";
+
+const GAMES = ["Garry's Mod", "Unturned", "Arma Reforger", "Valheim", "Rust", "Minecraft"];
+
+function yaml(p: BlueprintProposal): string {
+  const L: string[] = ["apiVersion: platform.zeta.io/v1alpha1", "kind: Blueprint", "metadata:", `  name: ${p.name}`, `  namespace: zeta-platform`, "spec:"];
+  if (p.category) L.push(`  category: ${p.category}`);
+  L.push(`  image: ${p.image}`);
+  if (p.install) L.push(`  install: ${JSON.stringify(p.install)}`);
+  if (p.command) L.push(`  command: [${p.command.map((c) => JSON.stringify(c)).join(", ")}]`);
+  if (p.args) L.push(`  args: [${p.args.map((c) => JSON.stringify(c)).join(", ")}]`);
+  if (p.env && Object.keys(p.env).length) { L.push("  env:"); for (const [k, v] of Object.entries(p.env)) L.push(`    ${k}: ${JSON.stringify(v)}`); }
+  if (p.ports?.length) { L.push("  ports:"); for (const pt of p.ports) L.push(`    - { name: ${pt.name}, port: ${pt.port}, protocol: ${pt.protocol ?? "TCP"}${pt.web ? ", web: true" : ""} }`); }
+  if (p.storage) L.push(`  storage: { size: ${p.storage.size}, mountPath: ${p.storage.mountPath} }`);
+  if (p.resources) L.push(`  resources: { cpu: ${JSON.stringify(p.resources.cpu ?? "1")}, memory: ${JSON.stringify(p.resources.memory ?? "512Mi")} }`);
+  if (p.variables?.length) { L.push("  variables:"); for (const v of p.variables) L.push(`    - { name: ${v.name}${v.default ? `, default: ${JSON.stringify(v.default)}` : ""} }`); }
+  if (p.sidecars?.length) { L.push("  sidecars:"); for (const s of p.sidecars) L.push(`    - { name: ${s.name}, image: ${s.image}${s.mountDataAt ? `, mountDataAt: ${s.mountDataAt}` : ""} }`); }
+  if (p.defaultExpose) L.push(`  defaultExpose: ${p.defaultExpose}`);
+  return L.join("\n");
+}
+
+type Msg = { who: "you" | "agent"; text: string };
+
+export function BlueprintBuilder({ onExit, onSaved }: { onExit: () => void; onSaved: () => void }) {
+  const [msgs, setMsgs] = useState<Msg[]>([{ who: "agent", text: "Tell me what to build — a game server (try the chips below), a database, or a web app — and I'll draft a complete blueprint you can tweak and save." }]);
+  const [draft, setDraft] = useState<BlueprintProposal | null>(null);
+  const [input, setInput] = useState("");
+  const [busy, setBusy] = useState(false);
+  const endRef = useRef<HTMLDivElement>(null);
+
+  const send = async (text: string) => {
+    const t = text.trim();
+    if (!t || busy) return;
+    setInput("");
+    setMsgs((m) => [...m, { who: "you", text: t }]);
+    setBusy(true);
+    try {
+      const r = await api.buildBlueprint(t, draft ?? undefined);
+      setMsgs((m) => [...m, { who: "agent", text: r.reply }]);
+      if (r.spec) setDraft(r.spec);
+    } catch (e) {
+      toast.error((e as Error).message);
+    } finally {
+      setBusy(false);
+      setTimeout(() => endRef.current?.scrollIntoView({ behavior: "smooth" }), 50);
+    }
+  };
+
+  const save = async () => {
+    if (!draft) return;
+    const { name, ...spec } = draft;
+    await toast.promise(api.saveBlueprint(name, spec), { loading: "Saving blueprint…", success: (r) => { onSaved(); return r.message; }, error: (e) => (e as Error).message });
+  };
+
+  return (
+    <div className="mx-auto max-w-5xl">
+      <button onClick={onExit} className="mb-4 inline-flex items-center gap-1.5 text-[13px] text-muted-foreground hover:text-foreground"><ArrowLeft className="size-4" /> Back to catalog</button>
+      <div className="mb-5">
+        <h1 className="text-[22px] font-semibold tracking-tight">Build a blueprint</h1>
+        <p className="mt-0.5 text-[13px] text-muted-foreground">Describe what you want and an agent drafts a deployable blueprint. Iterate, then save it to the catalog — usable by you and by automated agent tasks.</p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-5 lg:grid-cols-2">
+        {/* agentic chat */}
+        <div className="flex h-[560px] flex-col overflow-hidden rounded-xl border border-border">
+          <div className="flex-1 space-y-3 overflow-y-auto p-4">
+            {msgs.map((m, i) => (
+              <div key={i} className={cn("flex gap-2.5", m.who === "you" && "flex-row-reverse")}>
+                <div className={cn("flex size-6 shrink-0 items-center justify-center rounded-md", m.who === "you" ? "bg-foreground/85 text-background" : "bg-secondary text-muted-foreground")}>{m.who === "you" ? <User className="size-3.5" /> : <Bot className="size-3.5" />}</div>
+                <div className={cn("max-w-[80%] whitespace-pre-wrap rounded-lg px-3 py-2 text-[13px]", m.who === "you" ? "bg-secondary" : "bg-muted/40")}>{m.text}</div>
+              </div>
+            ))}
+            <div ref={endRef} />
+          </div>
+          {!draft && (
+            <div className="flex flex-wrap gap-1.5 border-t border-border p-2.5">
+              {GAMES.map((g) => <button key={g} onClick={() => send(`Set up a ${g} server`)} className="rounded-md border border-border px-2.5 py-1 text-xs text-muted-foreground hover:bg-white/[0.04] hover:text-foreground">{g}</button>)}
+            </div>
+          )}
+          <div className="flex items-center gap-2 border-t border-border p-2.5">
+            <Input value={input} onChange={(e) => setInput(e.target.value)} onKeyDown={(e) => e.key === "Enter" && send(input)} placeholder={draft ? 'Tweak it — "expose public", "more memory", "add variable RCON"…' : "Describe the server…"} className="text-[13px]" />
+            <Button size="icon" onClick={() => send(input)} disabled={busy || !input.trim()}><SendHorizonal className="size-4" /></Button>
+          </div>
+        </div>
+
+        {/* live draft */}
+        <div className="flex h-[560px] flex-col overflow-hidden rounded-xl border border-border">
+          {!draft ? (
+            <div className="flex h-full flex-col items-center justify-center px-6 text-center text-[13px] text-muted-foreground">
+              <Sparkles className="mb-2 size-7 opacity-50" />
+              Your blueprint preview appears here as the agent drafts it.
+            </div>
+          ) : (
+            <>
+              <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-2.5">
+                <div className="min-w-0">
+                  <input value={draft.name} onChange={(e) => setDraft({ ...draft, name: e.target.value })} className="w-full bg-transparent text-[15px] font-semibold outline-none" />
+                  <div className="text-xs text-muted-foreground">{draft.category} · {draft.image}</div>
+                </div>
+                <Button size="sm" onClick={save}><Save className="size-3.5" /> Save</Button>
+              </div>
+              <div className="flex flex-wrap gap-1.5 border-b border-border px-4 py-2 text-xs">
+                {draft.defaultExpose && <span className="rounded bg-muted px-1.5 py-0.5 text-muted-foreground">expose: {draft.defaultExpose}</span>}
+                {draft.resources?.memory && <span className="rounded bg-muted px-1.5 py-0.5 text-muted-foreground">{draft.resources.memory}</span>}
+                {draft.ports?.map((p) => <span key={p.name} className="rounded bg-muted px-1.5 py-0.5 text-muted-foreground">{p.port}/{p.protocol ?? "TCP"}</span>)}
+                {draft.variables?.map((v) => <span key={v.name} className="rounded bg-primary/10 px-1.5 py-0.5 text-primary">{v.name}</span>)}
+              </div>
+              <pre className="flex-1 overflow-auto bg-[#0b0f17] p-4 text-xs leading-relaxed text-foreground/90">{yaml(draft)}</pre>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/full-ai-cluster/portal/web/src/views/Create.tsx
+++ b/full-ai-cluster/portal/web/src/views/Create.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input, Label, Select } from "@/components/ui/input";
 import { catIcon, categoryMeta } from "@/components/bits";
+import { BlueprintBuilder } from "@/views/BlueprintBuilder";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 
@@ -40,14 +41,19 @@ function buildManifest(bp: CatalogEntryVM, f: Form): string {
 }
 
 // ── catalog (step 0) ───────────────────────────────────────────────────
-export function Create({ catalog }: { catalog: CatalogEntryVM[] }) {
+export function Create({ catalog, onChanged }: { catalog: CatalogEntryVM[]; onChanged?: () => void }) {
   const [picked, setPicked] = useState<CatalogEntryVM | null>(null);
+  const [building, setBuilding] = useState(false);
+  if (building) return <BlueprintBuilder onExit={() => setBuilding(false)} onSaved={() => { setBuilding(false); onChanged?.(); }} />;
   if (picked) return <DeployWizard bp={picked} onExit={() => setPicked(null)} />;
   return (
     <div>
-      <div className="mb-6">
-        <h1 className="text-2xl font-semibold tracking-tight">Create a resource</h1>
-        <p className="mt-1 text-sm text-muted-foreground">Choose a blueprint to deploy. New types are data — the same engine renders them all.</p>
+      <div className="mb-6 flex items-end justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Create a resource</h1>
+          <p className="mt-1 text-sm text-muted-foreground">Choose a blueprint to deploy — or build a new one with an agent.</p>
+        </div>
+        <Button variant="outline" onClick={() => setBuilding(true)}><Sparkles className="size-4" /> Build a blueprint</Button>
       </div>
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
         {catalog.map((bp) => {


### PR DESCRIPTION
## What

Easy blueprint creation, **user-driven and agentic** — so you (or an automated agent task) iterate with an agent to stand up a server and **save it as a reusable blueprint**. Question #2.

### The agent (`blueprint-agent.ts`, pure + tested)
`build(message, draft?) → { reply, spec? }` with a real **game-server knowledge base** (correct SteamCMD specs):

| Game | App ID | Ports |
|---|---|---|
| Garry's Mod | 4020 | UDP 27015 |
| **Unturned** | **1110390** | UDP 27015 + 27016/27017 query |
| **Arma Reforger** | **1874900** | UDP 2001 game + 17777 query (6 GiB) |
| Valheim | 896660 | UDP 2456-2458 |
| Rust | 258550 | UDP 28015 (8 GiB) |
| Minecraft | itzg image | TCP 25565 |

Each with the usual knobs as variables + an SFTP sidecar. Generic recipes for database/web too.

It **iterates on a draft**: "expose public", "give it more memory" / "set memory 12Gi", "add variable RCON", "add port 19999 udp", "rename to clan-reforger", add SFTP. Deterministic for the demo; **a real LLM slots in behind the same `build()` contract** — which is what makes it agentic *and automatable* (an agent task can call `/api/blueprints/build` then `/api/blueprints` to save unattended).

### Backend
- BFF `POST /api/blueprints/build` (propose/iterate) + `POST /api/blueprints` (save). `createBlueprint`: demo upserts the in-memory catalog; **k8s SSA-applies the Blueprint CR**. Portal RBAC extended to write blueprints.
- **Library:** added `unturned` + `arma-reforger` blueprints (real SteamCMD ids/ports) alongside `gmod` — deployable out of the box.

### UI (`BlueprintBuilder.tsx`)
A chat panel with **game quick-pick chips** (GMod/Unturned/Arma Reforger/Valheim/Rust/Minecraft) on the left and a **live draft** (editable name; badges for ports/vars/expose/memory; YAML preview) on the right. Describe → propose → iterate → **Save** → it lands in the catalog. (Create gains a "Build a blueprint" button; saving refreshes the catalog.)

## Tests — +14 (97 in the portal), all green

Agent KB (arma 1874900, unturned 1110390, gmod 4020 + sidecar, unknown→prompt, generic db), iteration (expose, more/exact memory, add var/port, rename), and the BFF build/save routes. `tsc` strict clean; build clean.

**Verified end-to-end:** "arma reforger" → app 1874900 / port 2001 → "expose publicly" → public → save → `my-reforger` in the catalog; builder UI shows the game chips + chat + live YAML. *(Headless screenshot tool down this session — DOM + tests.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
