### PR TITLE
fix(vocab): travelers/ is FIRST (negotiation precondition); like/ is intake FOR WORDS (correct pipeline order)

### DIFF
--- a/vocab/like/README.md
+++ b/vocab/like/README.md
@@ -1,31 +1,33 @@
-# like/ — the word-candidate pool (anything "like" a word goes here first)
+# like/ — intake FOR WORDS (word candidates); travelers/ comes first
 
-`like/` holds **word candidates**: any proposed/maybe word goes in here first (a folder,
-not yet a canonical home). It's the **pre-canonical stage** — a candidate has not yet
-earned its existence (the debate-club "speak for your existence"), so it has **no
-canonical home and no governed ZetaId yet.**
+Two facts (Aaron, 2026-06-09):
 
-Pipeline:
+1. **`travelers/` is FIRST** — *"travelers is first or else we can't negotiate with it."*
+   A thing must be a **traveler** before anything can negotiate with it; you cannot
+   negotiate with a non-traveler. So becoming a traveler (`travelers/`) is the
+   **precondition** to participating at all.
+2. **`like/` is intake FOR WORDS** — *"like is intake for words."* `like/` is the
+   candidate intake **specifically for the `words/` type home** — word candidates wait
+   here before earning the canonical `words/` home + a governed ZetaId.
+
+Order:
 
 ```text
-like/<candidate>.md   →  travelers/<term>.md (admitted intake)  →  words/<term>.md (canonical home)
-  candidate pool          earned its seat                          homed + governed ZetaId
+travelers/<id>     →   like/<candidate>.md      →   words/<term>.md
+(FIRST: be a           (word-candidate intake;       (canonical word home;
+ traveler -> can         the `-like` marker)           governed ZetaId)
+ be negotiated with)
 ```
 
-A candidate in `like/` is "like" a word (similar / proposed / maybe). When it argues its
-existence (anchored + distinct + §11/NCI) it graduates to `travelers/` (intake) and then
-to a canonical TYPE home (`words/`, `letters/`, …) where it gets its ZetaId. `like/` is
-*not* a canonical home and is *not* in the uniqueness/index/grams view — it's the staging
-ground (no uniqueness/ZetaId obligations until graduation). One carved sentence per file,
-same shape as the rest.
+`like/` is **not** a canonical home and is **not** in the uniqueness/master-index/grams
+view (no ZetaId obligation until graduation). One carved sentence per file. (Other type
+homes may grow their own intake later; `like/` is the words intake.)
 
 ## The `-like` suffix convention
 
-**Whenever a term is written `xxx-like`, it means it's a CANDIDATE word for a ZetaId**
-(Aaron, 2026-06-09) — not yet a confirmed traveler. So `float-like`, `qubit-like`,
-`spinor-like`, `white-hole-like`, etc. are **candidates living in `like/`**, awaiting
-graduation (speak-for-existence → `travelers/` intake → a canonical home + a governed
-ZetaId). The `-like` suffix IS the candidate marker: it says "this is *like* a word, but
-hasn't earned its ZetaId yet." Drop the `-like` when it graduates (it becomes the real
-term with its ZetaId). Reading any doc: an `xxx-like` token = a `like/` candidate, not a
-canonical traveler.
+**Whenever a term is written `xxx-like`, it's a CANDIDATE word for a ZetaId** (Aaron) —
+not yet a confirmed traveler-word. So `float-like`, `qubit-like`, `spinor-like`,
+`white-hole-like`, etc. are **candidates in `like/`**. The `-like` suffix IS the candidate
+marker ("like a word, hasn't earned its ZetaId yet"). Drop the `-like` on graduation to
+`words/` (it becomes the real term with its ZetaId). An `xxx-like` token in any doc = a
+`like/` word-candidate, not a canonical traveler.


### PR DESCRIPTION
Aaron: "travelers is first or else we can't negotiate with it" + "like is intake for words."

Corrects the order (I had it backwards): **travelers/ is FIRST** — a thing must be a traveler before anything can negotiate with it (can't negotiate a non-traveler). **like/ is the candidate intake specifically for `words/`** (word candidates; the `-like` marker). Order: travelers/<id> → like/<candidate> → words/<term> (canonical + ZetaId). like/ stays outside the uniqueness/index/grams view. The `-like` convention retained.