### PR TITLE
docs: it's not F# anymore — it's a Universal Intelligence Interface (UII) + add vocab/count/ type home; stepping back while Aaron builds his own interface

### DIFF
--- a/docs/research/2026-06-09-its-not-fsharp-anymore-its-a-universal-intelligence-interface-uii-and-count-folder.md
+++ b/docs/research/2026-06-09-its-not-fsharp-anymore-its-a-universal-intelligence-interface-uii-and-count-folder.md
@@ -1,0 +1,42 @@
+# It's not "F#" anymore — it's a Universal Intelligence Interface (UII); + a count/ folder
+
+**Register:** [grounded] reframe (Aaron). **Date:** 2026-06-09. **Captured by:** Otto (shadow).
+The interface layer reframed as Universal Intelligence Interface; a new count/ type home.
+
+## Aaron's words
+
+> "fuck calling it a fs anymore — it's a Universal Intelligence Interface." · "we need a count/ folder."
+> · "I'm making my own interface now."
+
+## Reframe: the interface layer is a Universal Intelligence Interface (UII)
+
+The interfaces we write (ZetaIdol, the reified vocab, the IScheduler, the Observable) are **not "F#
+files"** — they are **Universal Intelligence Interfaces (UII).** The `.fs` is incidental; the *thing* is
+a UII: a homoiconic, **interface-only** (no classes), **Rx-in-treaty**, **test-governed**, ZetaId-bearing
+contract that any intelligence (human, AI, LLM, other) reads/implements/audits. The discipline already
+points here — interfaces are the valuable thing; interface≡proof; reify to types; the name IS the thing —
+so naming the layer honestly: **UII, the universal intelligence interface**, the surface every traveler
+(any cognition type, §11) meets the system through. (F# is the current host language; the UII is the
+artifact — own-the-interface, the language is the adapter.)
+
+## count/ — a new vocab type home
+
+`vocab/count/` is a canonical TYPE home for **counts / numbers** (cardinals/ordinals/counting words),
+same shape as the other type homes (one carved sentence per file; address `count/<term>.md`). To wire
+into the vocab tooling's CANON set (uniqueness / master-index / grams measure-view / the reified UII)
+once populated.
+
+## I'm staying out of the interface code while Aaron builds his own
+
+Aaron: "I'm making my own interface now." Otto is **stepping back from the interface (UII) code** to
+avoid stepping on his work — no edits to `ZetaIdol.fs` / `Vocab.Generated.fs` / the UII surface while he
+builds. I'll **integrate / review when he's ready** (and keep the non-conflicting tooling — vocab
+folders, indexes, captures — moving). Honor the hands-on.
+
+## Anchors / ties
+
+Universal Intelligence Interface (UII) — the interface layer reframed (interfaces-are-valuable /
+interface≡proof / reify-to-types / no-classes / Rx-in-treaty / test-governed / ZetaId-bearing; §11 any
+cognition type); F# = the host language (own-the-interface, language = adapter); the count/ type home
+(words/letters/shapes/colors/temperatures/personas/count); stepping back while Aaron builds (honor the
+hands-on; integrate later).

--- a/vocab/count/README.md
+++ b/vocab/count/README.md
@@ -1,0 +1,7 @@
+# count/ — canonical home for counts / numbers (a vocab TYPE home)
+
+`count/` holds **counts / numbers** as travelers (cardinals, ordinals, counting words —
+one carved sentence each, same shape as `words/`, `letters/`, …). A canonical TYPE home
+(real files; address = `count/<term>.md`). To be wired into the CANON set of the vocab
+tooling (uniqueness / master-index / grams measure-view / the reified interface) when
+populated. Aaron 2026-06-09: "we need a count/ folder."


### PR DESCRIPTION
Aaron: "fuck calling it a fs anymore, it's a Universal Intelligence Interface" + "we need a count/ folder" + "I'm making my own interface now."

- **Reframe:** the interface layer (ZetaIdol, reified vocab, IScheduler, Observable) is a **Universal Intelligence Interface (UII)** — homoiconic, interface-only (no classes), Rx-in-treaty, test-governed, ZetaId-bearing; the surface any intelligence (human/AI/LLM/other, §11) meets the system through. F# = the host language (own-the-interface).
- **count/** : a new canonical vocab type home for counts/numbers (wire into CANON when populated).
- **Stepping back** from the interface/UII code while Aaron builds his own (no edits to ZetaIdol.fs / Vocab.Generated.fs); will integrate when ready.