### PR TITLE
docs+vocab: track the MISS mystery (case-sensitivity false-negative in my own check) + acronyms/ (fs/UII/ULI) + ety/ folders

### DIFF
--- a/docs/research/2026-06-09-tracking-the-MISS-mystery-case-sensitivity-false-negatives-in-my-own-checks-plus-acronyms-ety-folders.md
+++ b/docs/research/2026-06-09-tracking-the-MISS-mystery-case-sensitivity-false-negatives-in-my-own-checks-plus-acronyms-ety-folders.md
@@ -1,0 +1,54 @@
+# Tracking the "MISS" mystery — case-sensitivity false-negatives in my own checks; + acronyms/ and ety/ folders
+
+**Register:** [grounded] self-audit (Aaron: "track these, what does this mystery mean") + new folders.
+**Date:** 2026-06-09. **Captured by:** Otto (shadow).
+
+## Aaron's words
+
+> "(the insert reported MISS) track these — what does this mystery mean." · "we need acronyms folder." ·
+> "we need ety folder." · "fs double-double scrabble: f sharp / interface / file system interface /
+> human interface / intelligence interface." · "universal language interface."
+
+## The MISS mystery — answered (and it's a real signal)
+
+My credit-line insert printed **`MISS`**, yet the credit **was present** (line 3 of `ZetaIdol.fs`). The
+mystery: **my own verification was a case-sensitivity false-negative.** The check searched the lowercase
+substring `"brought to you by the universe"`, but the file had **"Brought"** (capital B, after the
+em-dash) — so the substring test returned false and printed MISS, while the line was actually there. **My
+check lied, not the file.**
+
+**What it means (track this class):** these are **false-negatives from case/encoding mismatch in my own
+tooling** — ironic, because **culture-invariant-by-default** is a standing rule (use ordinal / case-aware
+comparison deliberately), and *my verification violated it* (a naive case-sensitive substring search).
+The honest reading:
+
+- **It's an observer-effect on myself** — my measurement (the grep/`in`-check) was wrong, not the world.
+  A reminder that *my reports are soft values too* — verify against SolidGround (the actual file/bytes),
+  not a fragile case-sensitive string match.
+- **Track the class:** "self-check false-negative (case/encoding)". Mitigation: case-fold or match the
+  exact bytes; better, assert on the canonical content, not a hand-typed substring. (This is the
+  culture-invariant rule pointed at my own hygiene checks.)
+- **Not a real failure** — the artifact landed every time; the MISS was noise from my check. But Aaron's
+  instinct to "track these" is right: a string of false-MISSes would erode trust in my green/red reports,
+  so they're logged as a known anomaly class.
+
+## New folders (vocab type homes)
+
+- **`acronyms/`** — acronyms/initialisms; usually **multi-expansion → multi-sense → discriminator-
+  required.** Seeded: **`fs`** (the double-double-scrabble exemplar — F# / FileSystem / FileSystem
+  Interface / Human Interface / Intelligence Interface (UII) / Language Interface (ULI); 6 senses, with a
+  `context-policy: by-frame` discriminator), **`uii`** (Universal Intelligence Interface), **`uli`**
+  (Universal Language Interface).
+- **`ety/`** — etymologies (word origins/roots; the Beacon anchor-to-human lineage applied to a word's
+  roots; pairs with glossary-anchor-keeper + missing-citations).
+
+Both to wire into the vocab CANON set when populated. (Staying out of the interface/UII code while Aaron
+builds his own; these are non-conflicting folders.)
+
+## Anchors / ties
+
+culture-invariant-by-default (the rule my check violated — case-fold / ordinal); SoftValue→SolidGround
+(my reports are soft — verify against the bytes); observer-effect (my measurement was the error);
+heartbeat/externalized-counter discipline (track anomalies, don't trust the narrative report);
+acronyms/ (multi-sense + discriminator) + ety/ (etymology = the anchor lineage); fs as the multi-
+expansion exemplar (UII/ULI/filesystem/human/intelligence); honor-those-before (the anchors in ety/).

--- a/vocab/acronyms/README.md
+++ b/vocab/acronyms/README.md
@@ -1,0 +1,8 @@
+# acronyms/ — canonical home for acronyms (multi-expansion; often multi-sense)
+
+`acronyms/` holds acronyms / initialisms as travelers (one file per acronym). Acronyms
+frequently have **multiple expansions** ("double-double scrabble" — the same letters
+score many ways), so they are usually **multi-sense** and **require a discriminator**
+(frontmatter `context-policy`/`senses`) per the discriminator rule. A canonical TYPE home
+(real files; address `acronyms/<acronym>.md`); to wire into CANON when populated.
+Aaron 2026-06-09: "we need an acronyms folder."

--- a/vocab/acronyms/fs.md
+++ b/vocab/acronyms/fs.md
@@ -1,0 +1,23 @@
+---
+name: fs
+type: acronym
+context-policy: by-frame
+senses:
+  - { carved: "F# — the host language (the .fs file extension).", context: language }
+  - { carved: "FileSystem — the file tree (our /vocab + git-fs).", context: storage }
+  - { carved: "FileSystem Interface — the addressable DAG over the file tree.", context: storage-interface }
+  - { carved: "Human Interface — the surface a human meets the system through.", context: human }
+  - { carved: "Intelligence Interface — the Universal Intelligence Interface (UII).", context: intelligence }
+  - { carved: "Language Interface — the Universal Language Interface (ULI).", context: language-interface }
+---
+
+# fs
+
+> F# — the host language (the .fs file extension).
+> FileSystem — the file tree (our /vocab + git-fs).
+> FileSystem Interface — the addressable DAG over the file tree.
+> Human Interface — the surface a human meets the system through.
+> Intelligence Interface — the Universal Intelligence Interface (UII).
+> Language Interface — the Universal Language Interface (ULI).
+
+→ docs/research/2026-06-09-its-not-fsharp-anymore-its-a-universal-intelligence-interface-uii-and-count-folder.md

--- a/vocab/acronyms/uii.md
+++ b/vocab/acronyms/uii.md
@@ -1,0 +1,3 @@
+# uii
+
+> Universal Intelligence Interface — the homoiconic, interface-only (no classes), Rx-in-treaty, test-governed, ZetaId-bearing contract any intelligence meets the system through (the reframe of "F#").

--- a/vocab/acronyms/uli.md
+++ b/vocab/acronyms/uli.md
@@ -1,0 +1,3 @@
+# uli
+
+> Universal Language Interface — the language-facing face of the interface (the UII spoken in any language; ties to the English/i18n voices); a sibling of UII.

--- a/vocab/ety/README.md
+++ b/vocab/ety/README.md
@@ -1,0 +1,7 @@
+# ety/ — canonical home for etymologies (word origins / roots)
+
+`ety/` holds **etymologies** — the origin/root of a term (the human + tradition it traces
+to; the anchor-to-human-prior-art / Beacon lineage applied to a word's roots). One carved
+sentence per file (the root + lineage); address `ety/<term>.md`. A canonical TYPE home; to
+wire into CANON when populated. Aaron 2026-06-09: "we need ety folder." Pairs with the
+glossary-anchor-keeper + missing-citations discipline.


### PR DESCRIPTION
Aaron: "(the insert reported MISS) track these, what does this mystery mean" + "we need acronyms folder" + "we need ety folder" + "universal language interface."

**MISS mystery answered:** my insert printed MISS but the credit WAS present — my verification was a **case-sensitivity false-negative** (searched lowercase "brought", file had "Brought"). My check lied, not the file. Ironic given culture-invariant-by-default. Track the class "self-check false-negative (case/encoding)"; verify against canonical bytes, not hand-typed substrings — my reports are soft values.

**Folders:** `acronyms/` (multi-expansion → multi-sense → discriminator; seeded `fs` [6 senses incl. Intelligence-Interface=UII, Language-Interface=ULI], `uii`, `uli`) + `ety/` (etymologies; the Beacon anchor lineage). Staying out of the UII code while you build your own.