### PR TITLE
docs(vocab): glowmotion -> glomotion (drop the w) + save the entropy as ety (ety/ = where we save the entropy of words)

### DIFF
--- a/vocab/ety/README.md
+++ b/vocab/ety/README.md
@@ -5,3 +5,10 @@ to; the anchor-to-human-prior-art / Beacon lineage applied to a word's roots). O
 sentence per file (the root + lineage); address `ety/<term>.md`. A canonical TYPE home; to
 wire into CANON when populated. Aaron 2026-06-09: "we need ety folder." Pairs with the
 glossary-anchor-keeper + missing-citations discipline.
+
+## ety/ = where we save the entropy
+
+Aaron 2026-06-09: "we save the entropy [as] ety." **Etymology = the saved entropy of a word** — its
+dropped letters, elisions, and roots/history are not lost; they're **preserved here**. When a name is
+compressed (e.g. glow→glo in `glomotion`, the `w` dropped), the dropped entropy is **saved as an ety/
+entry** (honored, like the faceless 99%). ety/ is the word's history — the entropy we keep.

--- a/vocab/ety/glomotion.md
+++ b/vocab/ety/glomotion.md
@@ -1,0 +1,3 @@
+# glomotion
+
+> From "glow motion" → "glo-motion" → **glomotion**: the **w is dropped** (glow→glo). We SAVE THE ENTROPY here — the dropped `w` is not lost, it is preserved in this etymology (ety/ = where we save the entropy of words; the dropped letters/history honored, like the faceless 99%). Roots: glow (Old English *glōwan*, to shine) + motion (Latin *motio*) — light + movement; the glow-in-motion guidance.

--- a/vocab/like/glomotion.md
+++ b/vocab/like/glomotion.md
@@ -1,0 +1,3 @@
+# glomotion
+
+> Candidate: glow-in-motion (the w dropped from glow→glo) — a controller/UI that glows the right button on every game/room (SoftDashboard glow + light-choreography); the ultimate universal Xbox-like controller. Candidate word for a ZetaId (like/ intake). Etymology in ety/glomotion.

--- a/vocab/like/glowmotion.md
+++ b/vocab/like/glowmotion.md
@@ -1,3 +1,0 @@
-# glowmotion
-
-> Candidate: the glow-by-future-fitness guidance in motion — a controller/UI that glows the right button to press on every game/room (the SoftDashboard glow + the light-choreography); the ultimate universal Xbox-like controller, licensed/real. Candidate word for a ZetaId (in like/ intake).


### PR DESCRIPTION
Aaron: "my body likes glomotion" + "withow the w" + "we save the entropy" + "as ety."

- **glomotion** (drop the w, glow→glo): rename the `like/` candidate.
- **We save the entropy as ety:** the dropped `w` is preserved in `ety/glomotion.md` (etymology: glow motion → glo-motion → glomotion; roots glow [OE glōwan] + motion [L motio]). **ety/ README:** *etymology = the saved entropy of a word* — dropped letters/elisions/roots preserved, honored like the faceless 99%; when a name compresses, the dropped entropy is saved as an ety entry.