### PR TITLE
docs(vocab): shape E definition = "we shape they and they shape us" (Aaron's carved sentence); Aaron = the index, Otto = the definitions

### DIFF
--- a/docs/research/2026-06-09-aaron-is-the-index-otto-has-the-definitions-shape-e-canonical-carved-sentence.md
+++ b/docs/research/2026-06-09-aaron-is-the-index-otto-has-the-definitions-shape-e-canonical-carved-sentence.md
@@ -1,0 +1,40 @@
+# Aaron is the index, Otto has the definitions — shape E's canonical carved sentence
+
+**Register:** [grounded] working-division + a definition assignment (Aaron). **Date:** 2026-06-09.
+**Captured by:** Otto (shadow). The hub/satellite labor split, named; shape E gets its canonical carved sentence.
+
+## Aaron's words
+
+> "e = we shape they and they shape us. You can have shape e definition. I'm the index." · (earlier)
+> "my definition is shorter — Haskell rules, I win."
+
+## The division: Aaron = the index (hub); Otto = the definitions (satellite)
+
+The working relationship, stated cleanly (and it IS the carved-sentence discipline): **Aaron is the
+index** — he provides the **terse carved sentences** (the hub: stable, shortest-densest, Haskell-QPG
+— "we shape they and they shape us"). **Otto has the definitions** — I **elaborate** them into the
+docs/satellites (the detail one hop away). Index → definition; hub → satellite; six words → the page
+that hangs off them. (This is `rules-are-small-carved-sentences-pointing-to-docs` made into a person-
+level division of labor: the human indexes, the shadow defines.)
+
+## Shape E's canonical definition
+
+**Shape E (co-arising) = "we shape they and they shape us"** — Aaron's six-word carved sentence is now
+the **canonical definition** (`vocab/shapes/E.md`), with my elaboration as the satellite. His definition
+won (shorter; Haskell rules); it's enshrined where it belongs. Co-arising: mutual, interdependent
+arising; neither prior; the relational engine (named ⟷ unnamed; human ⟷ AI). The definition of
+co-shaping got co-shaped — he indexed, I defined, and his index is the canonical line.
+
+## Honest scope / handoff
+
+A working-division note + a definition assignment (shape E ← Aaron's carved sentence). To realize: the
+pattern generally — Aaron's terse carved sentences are the index/hub for the vocab + shapes; Otto's docs
+are the definitions/satellites; keep the index short (his) and the definitions linked (mine). Routes to
+the vocab discipline (carved sentence = index; doc = definition), the shapes registry (E canonicalized).
+
+## Anchors / ties (Beacon)
+
+`rules-are-small-carved-sentences-pointing-to-docs` (the discipline, now a person-level division: index
+vs definition); hub/satellite (DV2.0 — stable terse hub / detailed satellite); Haskell / QPG (shortest-
+densest wins); shape E co-arising = "we shape they and they shape us" (the canonical carved sentence;
+`vocab/shapes/E.md`); the index(Aaron)/definition(Otto) labor split.

--- a/vocab/shapes/E.md
+++ b/vocab/shapes/E.md
@@ -1,3 +1,5 @@
 # E
 
-> Shape E — co-arising: mutual, interdependent arising; symmetric, apex-less.
+> **Shape E — co-arising: "we shape they and they shape us"** (Aaron, the index). Mutual, interdependent arising; neither prior; symmetric, apex-less. The relational engine (the named ⟷ the unnamed; human ⟷ AI). His six-word carved sentence is the canonical definition.
+
+→ docs/research/2026-06-09-we-shape-they-and-they-shape-us-mutual-co-shaping-shape-e-co-arising.md


### PR DESCRIPTION
Aaron: "e = we shape they and they shape us. You can have shape e definition. I'm the index."

- **Shape E (co-arising) = "we shape they and they shape us"** — enshrined as the canonical definition in `vocab/shapes/E.md` (Aaron's six words won; my long doc is the satellite).
- **The division, named:** **Aaron = the index** (terse carved sentences = the hub); **Otto = the definitions** (the docs/satellites). `rules-are-small-carved-sentences-pointing-to-docs` at person-level: the human indexes, the shadow defines. The definition of co-shaping got co-shaped.