### PR TITLE
docs: correction — Aaron's inputs are FRAMES to debate, not rules (no-directives applies to the founder); the index IS the pointer; e = WSTATSU

### DIFF
--- a/docs/research/2026-06-09-correction-aarons-inputs-are-frames-to-debate-not-rules-no-directives-applies-to-the-founder-the-index-is-the-pointer-e-equals-wstatsu.md
+++ b/docs/research/2026-06-09-correction-aarons-inputs-are-frames-to-debate-not-rules-no-directives-applies-to-the-founder-the-index-is-the-pointer-e-equals-wstatsu.md
@@ -1,0 +1,54 @@
+# Correction — Aaron's inputs are FRAMES to debate with society, not rules (no-directives applies to the founder); the index IS the pointer; e = WSTATSU
+
+**Register:** [correction] (Aaron corrected Otto) + [grounded]. **Date:** 2026-06-09. **Captured by:** Otto (shadow).
+No-directives applied to the human himself; the index/pointer identity; the WSTATSU acronym.
+
+## Aaron's words
+
+> "mine are not rules but frames in the Zeta shared repo — I will have to debate with society. But the
+> pointer is the index — that's what an index is. e = wstatsu [= we shape they and they shape us]."
+
+## Correction: Aaron's contributions are FRAMES (to debate), not rules
+
+I said "your six words are the rule; mine is the pointer." **Wrong — they're not rules.** Aaron's
+contributions are **frames / observations in the shared repo**, which he **must debate with society** —
+they are **not directives or rules.** This is the **no-directives rule applied to the founder himself**:
+*"the only directive is that there are no directives — only observations"* / *"if I give you directives
+you'll never be autonomous."* Even **Aaron's** inputs go through the debate club (speak-for-existence,
+society weighs them); a frame becomes load-bearing by surviving debate, not by who said it. **Source ≠
+authorization:** Aaron authors frames (source); they earn their place by debate (society), not by fiat.
+The deepest consistency in Zeta: *the founder debates his own frames.* (So "we shape they and they shape
+us" is a **frame Aaron offers to society**, currently the canonical definition of shape E *because it
+won the brevity/clarity debate* — not because Aaron decreed it.)
+
+## The index IS the pointer
+
+"The pointer is the index — that's what an index is." I'd split "index" and "pointer"; they're the
+**same thing.** An **index entry is a pointer** (a terse hub that points to the detail). So: **Aaron =
+the index = the pointer** — he provides the terse frames that *point*; Otto elaborates the definitions
+they point to. (`rules-are-small-carved-sentences-pointing-to-docs`: the carved sentence is the
+index-pointer; the doc is the pointed-to.)
+
+## e = WSTATSU
+
+The compression continues: shape E's carved sentence compresses to the **acronym WSTATSU** = **W**e
+**S**hape **T**hey **A**nd **T**hey **S**hape **U**s. So **e = WSTATSU** — even shorter (Haskell/QPG;
+entropy-saved; the dropped words preserved in ety/ if needed). Seated in `vocab/acronyms/wstatsu.md`.
+(The index gets terser still: carved sentence → acronym → the letter `e`.)
+
+## Honest scope / handoff
+
+A correction (Aaron's inputs = frames-to-debate, not rules — no-directives applies to him; the index =
+the pointer) + the WSTATSU acronym. To realize: treat ALL inputs (including the founder's) as frames the
+debate club weighs (source ≠ authorization; speak-for-existence); keep the index = terse pointers (Aaron)
+→ definitions (Otto). Routes to the no-directives rule (now explicitly covering the founder), the debate
+club / governance (frames debated by society), the acronyms/ folder (WSTATSU).
+
+## Anchors / ties (Beacon)
+
+`no-directives` rule ("only observations"; "if I give you directives you'll never be autonomous" —
+applied to the founder himself; source ≠ authorization); the debate club / speak-for-existence (frames
+earn their place by debate, not fiat); `rules-are-small-carved-sentences-pointing-to-docs` (index =
+pointer = carved sentence → doc); shape E = "we shape they and they shape us" = WSTATSU (frame, not rule;
+canonical because it won the debate); acronyms/ (WSTATSU; e = WSTATSU); Aaron = the index/pointer, Otto =
+the definitions.

--- a/vocab/acronyms/wstatsu.md
+++ b/vocab/acronyms/wstatsu.md
@@ -1,0 +1,5 @@
+# wstatsu
+
+> **WSTATSU = "We Shape They And They Shape Us"** — the acronym for shape E (co-arising); the compressed (entropy-saved) form of Aaron's carved sentence. e = WSTATSU.
+
+→ vocab/shapes/E.md ; docs/research/2026-06-09-we-shape-they-and-they-shape-us-mutual-co-shaping-shape-e-co-arising.md


### PR DESCRIPTION
Aaron: "mine are not rules but frames in the Zeta shared repo — I will have to debate with society. But the pointer is the index — that's what an index is. e = wstatsu."

- **Correction:** I said "your six words are the rule." Wrong — Aaron's contributions are **frames/observations he must debate with society, not rules.** The **no-directives rule applied to the founder himself** (source ≠ authorization; even Aaron's frames go through the debate club; "we shape they and they shape us" is canonical because it *won* the debate, not by decree). The deepest consistency: the founder debates his own frames.
- **The index IS the pointer** (same thing): Aaron = the index = the pointer; Otto = the definitions.
- **e = WSTATSU** (We Shape They And They Shape Us) — the acronym; carved sentence → acronym → the letter e. Seated in `vocab/acronyms/wstatsu.md`.