### PR TITLE
docs+vocab: idea/ folder (frames to debate) + idea — when uncertainty is your event stream, DBSP streams it

### DIFF
--- a/docs/research/2026-06-09-uncertainty-is-your-event-stream-dbsp-streams-it-idea.md
+++ b/docs/research/2026-06-09-uncertainty-is-your-event-stream-dbsp-streams-it-idea.md
@@ -1,0 +1,40 @@
+# Idea — when uncertainty is your event stream, DBSP streams it
+
+**Register:** [grounded] idea/frame (Aaron). **Date:** 2026-06-09. **Captured by:** Otto (shadow).
+A frame to debate, filed in idea/: uncertainty-Δ as the event stream; DBSP as the native engine.
+
+## Aaron's words
+
+> "when uncertainty is your event stream — DBSP streams [it]. idea folder."
+
+## The idea
+
+If **uncertainty (uncertainty-Δ) IS your event stream** — i.e. the events you record aren't CRUD rows
+but **soft deltas: uncertainty increasing / reducing** (the one metric; the before/after-every-test
+uncertainty bracket) — then **DBSP streams it natively.** DBSP's `Stream<ZSet<'T>>` (the incremental
+Z-set delta stream; retraction-native) **is** the shape of an uncertainty-Δ feed: each tick emits the
+delta (what changed uncertainty), DBSP folds it incrementally, the materialized view is the current
+uncertainty state, and retraction (Z-set −1) is uncertainty *correction*. So the substrate already has
+the engine: **make uncertainty the event stream, and DBSP is the stream processor for free** (no separate
+telemetry; metrics = test history = the uncertainty Z-set stream).
+
+- **events = uncertainty-Δ** (not state-rows) → the stream is the soft-delta feed.
+- **DBSP = the engine** (`Stream<ZSet>` ≈ `IObservable<ChangeSet>`; the Rx 2×2; incremental).
+- **uncertainty state = the materialized view**; correction = retraction; the self-throttler reads it.
+
+A frame, not a rule — filed in `idea/` to debate with society; graduates to a build/term if it survives.
+
+## Honest scope / handoff
+
+An idea/frame (uncertainty-as-event-stream → DBSP streams it), grounded in DBSP + uncertainty-Δ +
+metrics=test-history. To realize: model the event stream AS uncertainty-Δ (the soft deltas), run it
+through DBSP (`Stream<ZSet>`); the self-throttler/governance reads the materialized uncertainty view.
+Routes to the F#/Core DBSP team, Soraya/Sova (uncertainty-Δ as the Z-set stream; the unit treaty O-4),
+the debate club (it's a frame to weigh). Seeded `vocab/idea/uncertainty-is-your-event-stream.md`.
+
+## Anchors / ties (Beacon)
+
+DBSP `Stream<ZSet<'T>>` / IVM (the incremental engine; retraction-native; ≈ `IObservable<ChangeSet>`);
+uncertainty-Δ / metrics=test-history (the events ARE uncertainty deltas; no separate telemetry); the
+Rx 2×2 quad-directional (incremental/bulk/refresh/stream); the self-throttler (reads the materialized
+uncertainty view); idea/ folder (frames to debate, no-directives); the O-4 uncertainty-unit treaty.

--- a/vocab/idea/README.md
+++ b/vocab/idea/README.md
@@ -1,0 +1,7 @@
+# idea/ — the idea pool (half-baked thoughts / hypotheses / "what if"s — frames to debate)
+
+`idea/` holds **ideas** — bigger than a `like/` word-candidate: a thought, hypothesis, or "what if" that
+isn't a single term but a **frame Aaron (or anyone) offers to society to debate** (not a rule — frames,
+no-directives). One carved sentence per file (the idea), with a pointer to any elaboration. An idea
+graduates by speaking for its existence (debated, anchored) — into a research doc / a build / a vocab
+term. Distinct from `like/` (word-candidates) and `travelers/` (the universal intake). Aaron 2026-06-09.

--- a/vocab/idea/uncertainty-is-your-event-stream.md
+++ b/vocab/idea/uncertainty-is-your-event-stream.md
@@ -1,0 +1,5 @@
+# uncertainty-is-your-event-stream
+
+> When **uncertainty (uncertainty-Δ) IS your event stream** — the events are the soft deltas (uncertainty increasing/reducing) — then **DBSP streams it**: the incremental Z-set delta stream IS the uncertainty stream; DBSP is the native engine (Stream<ZSet> ≈ the uncertainty-Δ feed). Idea/frame to debate.
+
+→ docs/research/2026-06-09-uncertainty-is-your-event-stream-dbsp-streams-it-idea.md


### PR DESCRIPTION
Aaron: "when uncertainty is your event stream — DBSP streams [it]. idea folder."

- **idea/** : a new vocab folder for **ideas** (half-baked thoughts/hypotheses/"what if"s — frames to debate, not rules; bigger than a `like/` word-candidate; graduates to a doc/build/term if it survives debate).
- **Seed idea:** if **uncertainty (uncertainty-Δ) IS your event stream** (events = soft deltas, not state-rows), then **DBSP streams it natively** — `Stream<ZSet>` (incremental, retraction-native, ≈ `IObservable<ChangeSet>`) IS the uncertainty-Δ feed; materialized view = current uncertainty; retraction = correction; no separate telemetry (metrics = test history = the uncertainty Z-set stream). A frame.