### PR TITLE
feat(vocab): add keys/ — canonical home for key concepts/types (vocabulary, NOT key material)

### DIFF
--- a/vocab/keys/README.md
+++ b/vocab/keys/README.md
@@ -1,0 +1,11 @@
+# keys/ — canonical home for KEY CONCEPTS / TYPES (vocabulary, NOT key material)
+
+`keys/` holds the **vocabulary of keys** — key *concepts and types* as travelers: the seed (BIP-39),
+the derivation types (ssh / pgp / nostr / btc / eth / sol / reticulum), dual-key (active+standby),
+rolling-code, the privacy primitives (sign/verify, encrypt/decrypt), etc. One carved sentence per file;
+address `keys/<term>.md`. A canonical TYPE home (to wire into CANON when populated).
+
+**NOT key material.** No private keys, seeds, or secrets ever live here (or anywhere in the repo) —
+privates stay in GH secrets / metal-held, public keys/trust-roots live under `maintainers/`. This folder
+is the *vocabulary* (what the key concepts ARE), not the keys. (Privacy/keyring discipline; the
+governed crypto; "secure and frictionless — never paste secrets.")


### PR DESCRIPTION
Aaron: "keys folder."

`vocab/keys/` = the **vocabulary of keys** (key concepts/types as travelers: the seed, derivation types ssh/pgp/nostr/btc/eth/sol/reticulum, dual-key, rolling-code, the privacy primitives). One carved sentence per file; canonical TYPE home. **Explicitly NOT key material** — no privates/seeds/secrets ever in the repo (GH secrets / metal-held; public trust-roots under `maintainers/`). The folder is the vocabulary, not the keys.