### PR TITLE
feat: add rooms/ at root — the treaty/test/DST rooms (shadow*)

### DIFF
--- a/rooms/README.md
+++ b/rooms/README.md
@@ -1,0 +1,22 @@
+# rooms/ — the treaty / test / DST rooms, at root (shadow*)
+
+`rooms/` holds the **rooms** — every fingerprintable, closeable item is a room (content-addressed; the
+path/fingerprint is the room id = ZetaId). A room is a **bounded DST tick** = a test = a treaty space:
+
+```text
+treaty room       — the 4×4 (now 6×6×n) byte-lock/consensus room (oracles × serializers × OS × …)
+moonshot conf.    — where the oracles/personas convene + work tightly (LLMTV the watch surface)
+proof room        — formal verification inside DST (TLA+/Z3/Lean/… as a tick; the math-team docket)
+dependency room   — every dependency closed over (dep-as-oracle + own-impl; ace orchestrates)
+ZetaIdol          — the audition / deterministic synchronized performance room
+investigation rm  — a failed branch + its investigation tick (graceful failure)
+the Nexus / UN    — the uber treaty room (shape G; the United Nations of the Agora)
+```
+
+Every room is **4×4×n** (the byte-lock floor × n room-specific axes), **hat-governed** (time-bound auth;
+who-holds-the-hat decides), **judged on uncertainty-Δ** (the strange-attractor quality), with judgments
+**cascading** (bounded, idempotent). Each is a **DST tick** (bounded, replayable; merge-to-main = the
+advance; the finalizer is part of the test). Root-level (like `/vocab`, `/dns`, `/network`). `network/`
+is the transport, `dns/` the resolution, `rooms/` the **places** travelers convene.
+
+(shadow* = Otto, the shadow — the attribution convention.)


### PR DESCRIPTION
Aaron: "rooms folder at root (shadow*)."

`/rooms/` = the **rooms** — every fingerprintable closeable item is a room (content-addressed; fingerprint = room id = ZetaId); a room is a **bounded DST tick = a test = a treaty space.** Kinds: treaty room (6×6×n byte-lock), moonshot conference (LLMTV), proof room (TLA+/Z3/Lean as a tick), dependency room (dep-as-oracle; ace), **ZetaIdol** (audition/synchronized performance), investigation room (failed-branch tick), the **Nexus/UN** (shape G). Every room = 4×4×n, hat-governed, judged on uncertainty-Δ, judgments cascade. Root-level: `network/` = transport, `dns/` = resolution, **`rooms/` = the places travelers convene.**