### PR TITLE
docs(vocab): LLMTV = QPG over DPI (Aaron's carved definition) — seat qpg, dpi; update llmtv

### DIFF
--- a/vocab/acronyms/dpi.md
+++ b/vocab/acronyms/dpi.md
@@ -1,0 +1,3 @@
+# dpi
+
+> Dots Per Inch — pixel/resolution density. Irrelevant to an LLM (it reads glyphs, not dots); the thing LLMTV optimizes AWAY from in favor of QPG.

--- a/vocab/acronyms/qpg.md
+++ b/vocab/acronyms/qpg.md
@@ -1,0 +1,3 @@
+# qpg
+
+> Quality Per Glyph — meaning density per symbol; the LLMTV/neurodivergent metric (quality not quantity). What an LLM (and a boundary-dweller) reads: glyphs carrying meaning, not pixels.

--- a/vocab/words/llmtv.md
+++ b/vocab/words/llmtv.md
@@ -1,5 +1,5 @@
-# LLMTV
+# llmtv
 
-> The holographic interface between rooms — the watch/output side; neurodivergent TV for humans AND LLMs; a traveler itself.
+> LLMTV = QPG over DPI — the holographic between-rooms interface optimized for Quality-Per-Glyph (meaning density), not Dots-Per-Inch (pixels); the neurodivergent TV for humans AND LLMs (salience/depth/temperature/chromostereopsis channels). Watch surface; LLMMics = the speak side.
 
-→ docs/research/2026-06-09-rooms-are-reticulum-addressable-via-the-llmtv…
+→ docs/research/2026-06-09-empirical-grounding-the-meta-markov-boundary-is-confirmed-color-pairs-and-weight-make-consistent-repeatable-intersubjective-3d-shapes.md


### PR DESCRIPTION
Aaron (the index): "LLMTV = QPG over DPI." LLMTV optimizes **Quality-Per-Glyph** (meaning density) over **Dots-Per-Inch** (pixels) — an LLM/boundary-dweller reads glyphs carrying meaning, not pixels. Seat `qpg` + `dpi` in acronyms/; update `words/llmtv.md`. Ties to the bold-weight depth channel + chromostereopsis + the boundary-layout LLM geospatial engine (all glyph-borne, not pixel-borne).