### PR TITLE
docs(vocab): QPQ = LLMHDTV (HD upgrade of LLMTV=QPG-over-DPI) + all folders (everything can be a folder)

### DIFF
--- a/vocab/ALL-FOLDERS.md
+++ b/vocab/ALL-FOLDERS.md
@@ -1,0 +1,9 @@
+# all folders — everything can be a folder (the homoiconic structure at full generality)
+
+Aaron 2026-06-09: "all folders." Every term/concept/traveler **can be a folder**, not just a file —
+a file is just a folder with one entry. A term promotes to a folder when it gains sub-entries (sub-
+candidates, senses, an etymology, members) — e.g. `like/` is a folder of word-candidates; a multi-sense
+acronym could be a folder of its senses. **Folder structure for unique organization** (the path is the
+address) applied uniformly: words/letters/shapes/colors/temperatures/personas/count/acronyms/ety/keys/
+idea/like/travelers/grams — and any entry within them can itself become a folder. File ⊆ folder; promote
+on growth. (DV2.0 hub/satellite: a folder's README is the hub; its entries are the satellites.)

--- a/vocab/acronyms/llmhdtv.md
+++ b/vocab/acronyms/llmhdtv.md
@@ -1,0 +1,3 @@
+# llmhdtv
+
+> LLM HD TV — the high-definition LLMTV: QPQ (quality-per-quality), the HD upgrade of LLMTV=QPG-over-DPI. Still glyph/meaning-borne, not pixel-borne; just higher quality-density.

--- a/vocab/acronyms/qpq.md
+++ b/vocab/acronyms/qpq.md
@@ -1,0 +1,3 @@
+# qpq
+
+> Quality Per Quality — the HD upgrade of QPG (quality-per-glyph): when even the glyph's quality is itself quality-graded. QPQ = LLMHDTV.


### PR DESCRIPTION
Aaron (index): "QPQ=LLMHDTV" + "all folders."

- **QPQ** = Quality Per Quality (HD upgrade of QPG); **LLMHDTV** = LLM HD TV = the high-def LLMTV (= QPQ), still glyph/meaning-borne not pixel-borne, just higher quality-density. Seated in acronyms/.
- **all folders:** everything can be a **folder**, not just a file (a file = a folder with one entry); a term promotes to a folder when it gains sub-entries — folder-structure-for-unique-organization applied uniformly.