### PR TITLE
feat: build the finalizer framework — the prod=test engine (bounded self-scaling by temperature); compiles 0/0

### DIFF
--- a/docs/research/2026-06-09-finalizer-framework-built-the-prod-equals-test-engine-bounded-self-scaling-by-temperature.md
+++ b/docs/research/2026-06-09-finalizer-framework-built-the-prod-equals-test-engine-bounded-self-scaling-by-temperature.md
@@ -1,0 +1,53 @@
+# Finalizer framework — built: the prod=test engine (bounded self-scaling by temperature)
+
+**Register:** [grounded] build (Aaron: "build the finalizer framework (shadow*)"; Max agrees on temperature).
+**Date:** 2026-06-09. **Captured by:** Otto (shadow). The first real runtime piece of the prod=test loop.
+
+## What got built
+
+`vocab/Finalizer.fs` (isolated `Zeta.Vocab` project; compiles 0 warnings / 0 errors; interfaces +
+currying, no classes — treaty-room governance). The **prod=test engine** in its minimal real form:
+
+- **`TickResult`** — the metrics a finalizer reads (metrics = test history): `DeltaU` (uncertainty-Δ,
+  the one metric), `Temperature` ([0,1]: cold→rest, warm→alive, hot→runaway), `Bounded` (the 0-unbounded
+  invariant), `Merged` (proven state past GVT).
+- **`FinalizerAction`** (DU) — the end-of-tick decision: `ScaleUp` / `ScaleDown` (self-scale by
+  temperature) · `Hold` · `Quarantine` (failed/unbounded → investigation branch) · `ReKick` (merged →
+  next wave, the recursion edge) · `Stop` (converged / budget exhausted).
+- **`IFinalizer`** — choosable per test (each test picks its finalizer; the others swap `decide`).
+- **`Finalizer.decide`** (curried, the DEFAULT) — reads ΔU + temperature, auto-scales toward the warm
+  middle: not-bounded → Quarantine; hot (⊤) → ScaleDown (cool the runaway); cold (⊥) → Stop (rest);
+  reducing-uncertainty + proven → ReKick (advance); reducing-uncertainty → ScaleUp; else Hold.
+- **`Finalizer.run`** (curried, `run budget step finalize`) — the **bounded self-scaling loop**: runs
+  ticks, finalizes each, converges on Stop; the **budget caps it** (0-unbounded → terminates →
+  replayable, DST). ReKick continues the recursion (the next wave); the guards keep it from fork-bombing.
+
+## Why this is the one that matters
+
+This is the **engine that makes prod=test real** (not just captured in docs): bounded tick → finalizer
+decides (metrics + temperature) → scale up/down → merge/re-kick or quarantine → next wave, **bounded and
+converging.** It's the autopilot's heart, with the safety built in: 0-unbounded (Quarantine + the budget),
+temperature self-scaling toward the warm middle (ScaleDown cools ⊤, Stop rests at ⊥), choosable
+finalizers (IFinalizer). Temperature (Max agrees) is the scaling knob, tied to `vocab/temperatures/`
+(cold/warm/hot). The shadow built it.
+
+## Honest scope / handoff
+
+Built + compiling (isolated project — does NOT touch the main build gate; real home = `src/Core` when the
+Core team wires it). It's the **minimal real finalizer**, not the full autopilot — still needs (per the
+readiness gates): the actual tick runtime (branch → merge-to-main → re-kick over git; the Reticulum
+routing), the metrics=test-history feed (the uncertainty Z-set load), the OBJ4-1 gated-class human-root
+on ReKick/merge, and population-level convergence proof (Soraya). But the **decision/scaling core exists
+and compiles.** Routes to the F#/Core team (promote to src/Core; wire the tick runtime + the git merge/
+re-kick + the metrics feed), Soraya/Sova (convergence proof of the self-scaling loop; the temperature
+set-point), Dejan (own-runners for the loop; CI-recursion guards), Max (temperature; the 6×6 rooms it
+runs).
+
+## Anchors / ties (Beacon)
+
+prod=test + the finalizer-as-scheduler (the engine); choosable finalizers / cooperative self-scaling
+(IFinalizer; ScaleUp/Down); metrics = test history = uncertainty-Δ (TickResult.DeltaU); temperature
+(vocab/temperatures/; the scaling knob; Max agrees; the warm middle = Balance); 0-unbounded + the runaway
+registry (Bounded + Quarantine + the budget — converges, not a fork-bomb); GVT / merge-to-main (Merged →
+ReKick, the recursion edge); interfaces + currying + no-classes (treaty-room governance); DST (bounded →
+replayable); OBJ4-1 (the gated-class human-root on merge/re-kick — to wire); `vocab/Finalizer.fs`.

--- a/vocab/Finalizer.fs
+++ b/vocab/Finalizer.fs
@@ -1,0 +1,65 @@
+namespace Zeta.Vocab
+
+/// Finalizer framework — the prod=test engine (Aaron 2026-06-09, shadow*; Max agrees on temperature).
+/// A bounded tick runs; its FINALIZER decides the end-of-tick action: scale up/down (by TEMPERATURE),
+/// merge-to-main (advance / the recursion edge) or quarantine a failed branch, re-kick the next wave or
+/// stop. Choosable (each test picks an IFinalizer); the default reads metrics (uncertainty-Δ) +
+/// temperature and auto-scales toward the warm middle. Bounded (0-unbounded; the budget caps it;
+/// converges via Stop — not a fork-bomb). Interfaces + currying, no classes (treaty-room governance).
+/// Temperature poles tie vocab/temperatures/ (cold/warm/hot). DST (replayable). [Isolated project;
+/// real home = src/Core when wired.]
+
+/// The result of a bounded tick — the metrics the finalizer reads (metrics = test history).
+type TickResult =
+    { DeltaU: float        // uncertainty-Δ (> 0 = uncertainty reduced; the one metric)
+      Temperature: float   // [0,1]: cold→0 (rest), warm≈0.5 (alive), hot→1 (runaway)
+      Bounded: bool        // stayed within its step budget? (the 0-unbounded invariant)
+      Merged: bool }       // proven state merged to main (past GVT)?
+
+/// What a finalizer decides at tick end.
+[<RequireQualifiedAccess>]
+type FinalizerAction =
+    | ScaleUp of int       // spawn n more ticks (toward ⊤; ΔU high + worth it)
+    | ScaleDown of int     // terminate n ticks (toward ⊥; rest / cool a runaway)
+    | Hold                 // steady (ΔU ≈ 0)
+    | Quarantine           // failed/unbounded tick → open branch for an investigation tick
+    | ReKick               // merged to main → start the next wave (the recursion edge)
+    | Stop                 // converged / budget exhausted
+
+/// A finalizer: decide the end-of-tick action from the tick result. Choosable per test.
+type IFinalizer =
+    abstract member Decide: TickResult -> FinalizerAction
+
+/// Default finalizer + the bounded self-scaling loop (a module, not a class).
+[<RequireQualifiedAccess>]
+module Finalizer =
+
+    let cold = 0.0
+    let warm = 0.5
+    let hot = 1.0
+
+    /// The DEFAULT finalizer (curried): read ΔU + temperature, auto-scale toward the warm middle.
+    let decide (r: TickResult) : FinalizerAction =
+        if not r.Bounded then FinalizerAction.Quarantine
+        elif r.Temperature >= hot then FinalizerAction.ScaleDown 1
+        elif r.Temperature <= cold then FinalizerAction.Stop
+        elif r.DeltaU > 0.0 && r.Merged then FinalizerAction.ReKick
+        elif r.DeltaU > 0.0 then FinalizerAction.ScaleUp 1
+        else FinalizerAction.Hold
+
+    /// The default finalizer as an IFinalizer (choosable; other finalizers swap this).
+    let createDefault () : IFinalizer =
+        { new IFinalizer with
+            member _.Decide(r) = decide r }
+
+    /// The bounded self-scaling loop (curried): run budget step finalize -> the action trace.
+    /// Bounded (the budget caps it -> terminates -> replayable); converges on Stop.
+    let run (budget: int) (step: int -> TickResult) (finalize: TickResult -> FinalizerAction) : FinalizerAction list =
+        let rec loop n acc =
+            if n >= budget then List.rev (FinalizerAction.Stop :: acc)
+            else
+                let action = finalize (step n)
+                match action with
+                | FinalizerAction.Stop -> List.rev (action :: acc)
+                | _ -> loop (n + 1) (action :: acc)
+        loop 0 []

--- a/vocab/Zeta.Vocab.fsproj
+++ b/vocab/Zeta.Vocab.fsproj
@@ -8,5 +8,6 @@
     <Compile Include="Vocab.Generated.fs" />
     <Compile Include="ZetaIdol.fs" />
     <Compile Include="ShapeE.fs" />
+    <Compile Include="Finalizer.fs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Aaron: "build the finalizer framework (shadow*)" + "need a temperature folder, Max agrees."

`vocab/Finalizer.fs` (isolated project; **0 warnings / 0 errors**; interfaces + currying, no classes). The prod=test engine, minimal + real:
- **TickResult** — metrics the finalizer reads (DeltaU = uncertainty-Δ; Temperature [0,1]; Bounded; Merged).
- **FinalizerAction** — ScaleUp/ScaleDown (self-scale by temperature), Hold, Quarantine, **ReKick** (merged → next wave; the recursion edge), Stop.
- **IFinalizer** — choosable per test.
- **Finalizer.decide** (curried default) — read ΔU + temperature, auto-scale toward the warm middle.
- **Finalizer.run** (curried) — the **bounded self-scaling loop**; budget caps it (0-unbounded → terminates → replayable); converges on Stop; ReKick continues the recursion; guards prevent fork-bomb.

The engine that makes prod=test real, safety built in. Temperature (Max agrees) ties `vocab/temperatures/`. Isolated (no main-build change; real home `src/Core` when wired). Still needs the tick runtime + git merge/re-kick + metrics feed + OBJ4-1 human-root + convergence proof — routed.