### PR TITLE
feat: all letters get a folder at root — Latin a-z + Greek (eager) + unicode/ (lazy, on-demand)

### DIFF
--- a/a/README.md
+++ b/a/README.md
@@ -1,0 +1,3 @@
+# a — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `a` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/alpha/README.md
+++ b/alpha/README.md
@@ -1,0 +1,3 @@
+# alpha — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `alpha` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/b/README.md
+++ b/b/README.md
@@ -1,0 +1,3 @@
+# b — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `b` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/beta/README.md
+++ b/beta/README.md
@@ -1,0 +1,3 @@
+# beta — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `beta` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/c/README.md
+++ b/c/README.md
@@ -1,0 +1,3 @@
+# c — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `c` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/chi/README.md
+++ b/chi/README.md
@@ -1,0 +1,3 @@
+# chi — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `chi` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/d/README.md
+++ b/d/README.md
@@ -1,0 +1,3 @@
+# d — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `d` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/delta/README.md
+++ b/delta/README.md
@@ -1,0 +1,3 @@
+# delta — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `delta` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/e/README.md
+++ b/e/README.md
@@ -1,0 +1,3 @@
+# e — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `e` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/epsilon/README.md
+++ b/epsilon/README.md
@@ -1,0 +1,3 @@
+# epsilon — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `epsilon` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/eta/README.md
+++ b/eta/README.md
@@ -1,0 +1,3 @@
+# eta — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `eta` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/f/README.md
+++ b/f/README.md
@@ -1,0 +1,3 @@
+# f — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `f` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/g/README.md
+++ b/g/README.md
@@ -1,0 +1,3 @@
+# g — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `g` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/gamma/README.md
+++ b/gamma/README.md
@@ -1,0 +1,3 @@
+# gamma — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `gamma` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/h/README.md
+++ b/h/README.md
@@ -1,0 +1,3 @@
+# h — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `h` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/i/README.md
+++ b/i/README.md
@@ -1,0 +1,3 @@
+# i — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `i` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/iota/README.md
+++ b/iota/README.md
@@ -1,0 +1,3 @@
+# iota — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `iota` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/j/README.md
+++ b/j/README.md
@@ -1,0 +1,3 @@
+# j — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `j` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/k/README.md
+++ b/k/README.md
@@ -1,0 +1,3 @@
+# k — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `k` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/kappa/README.md
+++ b/kappa/README.md
@@ -1,0 +1,3 @@
+# kappa — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `kappa` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/l/README.md
+++ b/l/README.md
@@ -1,0 +1,3 @@
+# l — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `l` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/lambda/README.md
+++ b/lambda/README.md
@@ -1,0 +1,3 @@
+# lambda — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `lambda` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/m/README.md
+++ b/m/README.md
@@ -1,0 +1,3 @@
+# m — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `m` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/mu/README.md
+++ b/mu/README.md
@@ -1,0 +1,3 @@
+# mu — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `mu` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/n/README.md
+++ b/n/README.md
@@ -1,0 +1,3 @@
+# n — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `n` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/nu/README.md
+++ b/nu/README.md
@@ -1,0 +1,3 @@
+# nu — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `nu` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/o/README.md
+++ b/o/README.md
@@ -1,0 +1,3 @@
+# o — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `o` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/omega/README.md
+++ b/omega/README.md
@@ -1,0 +1,3 @@
+# omega — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `omega` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/omicron/README.md
+++ b/omicron/README.md
@@ -1,0 +1,3 @@
+# omicron — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `omicron` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/p/README.md
+++ b/p/README.md
@@ -1,0 +1,3 @@
+# p — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `p` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/phi/README.md
+++ b/phi/README.md
@@ -1,0 +1,3 @@
+# phi — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `phi` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/pi/README.md
+++ b/pi/README.md
@@ -1,0 +1,3 @@
+# pi — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `pi` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/psi/README.md
+++ b/psi/README.md
@@ -1,0 +1,3 @@
+# psi — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `psi` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/q/README.md
+++ b/q/README.md
@@ -1,0 +1,3 @@
+# q — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `q` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/r/README.md
+++ b/r/README.md
@@ -1,0 +1,3 @@
+# r — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `r` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/rho/README.md
+++ b/rho/README.md
@@ -1,0 +1,3 @@
+# rho — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `rho` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/s/README.md
+++ b/s/README.md
@@ -1,0 +1,3 @@
+# s — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `s` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/sigma/README.md
+++ b/sigma/README.md
@@ -1,0 +1,3 @@
+# sigma — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `sigma` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/t/README.md
+++ b/t/README.md
@@ -1,0 +1,3 @@
+# t — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `t` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/tau/README.md
+++ b/tau/README.md
@@ -1,0 +1,3 @@
+# tau — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `tau` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/theta/README.md
+++ b/theta/README.md
@@ -1,0 +1,3 @@
+# theta — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `theta` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/u/README.md
+++ b/u/README.md
@@ -1,0 +1,3 @@
+# u — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `u` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/unicode/README.md
+++ b/unicode/README.md
@@ -1,0 +1,9 @@
+# unicode/ — the rest of the alphabet, lazily (every Unicode letter, on-demand)
+
+The alphabet-at-root (Latin `a`–`z` + Greek `alpha`–`omega` are materialized root folders) extends to
+**all of Unicode** — but Unicode is ~149,000 characters, so `unicode/` is the **lazy namespace**: any
+Unicode letter gets a folder **on-demand** (when a word/traveler actually uses it), not all upfront.
+Hebrew (aleph–tav), Cyrillic, CJK, Arabic, Devanagari, emoji-as-letters, etc. live here — each
+materialized when first needed (the same lazy / weak-table / "cache what we can, lazy the rest" discipline
+as git-history). Address by codepoint or name (e.g. `unicode/U+05D0` or `unicode/aleph`). Aaron 2026-06-09:
+"all letters get a folder a-z and greek, at root — and the unicode." Latin/Greek = eager; the rest = lazy.

--- a/upsilon/README.md
+++ b/upsilon/README.md
@@ -1,0 +1,3 @@
+# upsilon — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `upsilon` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/v/README.md
+++ b/v/README.md
@@ -1,0 +1,3 @@
+# v — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `v` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/w/README.md
+++ b/w/README.md
@@ -1,0 +1,3 @@
+# w — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `w` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/x/README.md
+++ b/x/README.md
@@ -1,0 +1,3 @@
+# x — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `x` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/xi/README.md
+++ b/xi/README.md
@@ -1,0 +1,3 @@
+# xi — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `xi` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/y/README.md
+++ b/y/README.md
@@ -1,0 +1,3 @@
+# y — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `y` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/z/README.md
+++ b/z/README.md
@@ -1,0 +1,3 @@
+# z — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `z` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").

--- a/zeta/README.md
+++ b/zeta/README.md
@@ -1,0 +1,3 @@
+# zeta — root letter folder (trie node)
+
+> The alphabet as the top-level namespace: letter `zeta` is a root folder. Words / travelers / entries indexed by this letter live here. Latin a–z + Greek alpha–omega are root namespaces (Aaron 2026-06-09: "all letters get a folder a-z and greek, at root").


### PR DESCRIPTION
Aaron: "all letters get a folder a-z and greek, at root" → (chose) **bare letter folders AT repo root** → "and the unicode."

The alphabet as the top-level namespace (trie nodes at repo root):
- **Latin a–z (26) + Greek alpha–omega (24) = 50 eager root letter folders** (each a trie node; words/travelers indexed by the letter; README per folder).
- **unicode/** = the **lazy** namespace for the rest of Unicode (~149k): any letter (Hebrew, Cyrillic, CJK, Arabic, emoji-as-letters) materialized **on-demand** (address by codepoint or name). Latin/Greek eager; the rest lazy ("cache what we can, lazy the rest").