### PR TITLE
fix(vocab)+shadow: vocab index MD012 double-blanks — normalize generator + regenerate

### DIFF
--- a/vocab/MASTER-INDEX.md
+++ b/vocab/MASTER-INDEX.md
@@ -4,7 +4,6 @@
 > homes (words/letters/shapes/colors/temperatures). grams/ is the generated measure-view.
 > The DST test framework loads THIS as the master index (one read). 116 travelers.
 
-
 ## colors
 
 - **amber** — Amber — caution / pending / provisional (bootstrap-test, awaiting corroboration); the liminal between red and green. `(colors/amber.md)`

--- a/vocab/gen/MasterIndex.ts
+++ b/vocab/gen/MasterIndex.ts
@@ -36,6 +36,8 @@ const lines = (e: Entry): string =>
     : `- **${e.term}** \`(${e.rel})\` — ${e.senses.length} senses (discriminator required):\n` + e.senses.map((s, i) => `  ${i + 1}. ${s}\n`).join("");
 
 const writes: { path: string; body: string }[] = [];
+// markdownlint MD012: collapse any run of 3+ newlines to a single blank line.
+const norm = (s: string): string => s.replace(/\n{3,}/g, "\n\n");
 function folderIndex(f: Folder) {
   let md = `# ${relative(VOCAB, f.dir)}/INDEX — regenerated (do not edit)\n\n`;
   for (const e of [...f.entries].sort((a, b) => a.term.localeCompare(b.term))) md += lines(e);
@@ -43,7 +45,7 @@ function folderIndex(f: Folder) {
     md += `\n## ${relative(VOCAB, c.dir)}/\n\n`;
     for (const e of flatten(c).sort((a, b) => a.term.localeCompare(b.term))) md += lines(e);
   }
-  writes.push({ path: join(f.dir, "INDEX.md"), body: md });
+  writes.push({ path: join(f.dir, "INDEX.md"), body: norm(md) });
   for (const c of f.children) folderIndex(c);
 }
 
@@ -57,7 +59,7 @@ root += `> homes (words/letters/shapes/colors/temperatures). grams/ is the gener
 root += `> The DST test framework loads THIS as the master index (one read). ${all.length} travelers.\n\n`;
 let last = "";
 for (const e of all) { const r = e.rel.split("/")[0] ?? ""; if (r !== last) { root += `\n## ${r}\n\n`; last = r; } root += lines(e); }
-writes.push({ path: ROOT_INDEX, body: root });
+writes.push({ path: ROOT_INDEX, body: norm(root) });
 
 const check = process.argv.includes("--check");
 let stale = 0;

--- a/vocab/letters/INDEX.md
+++ b/vocab/letters/INDEX.md
@@ -1,6 +1,5 @@
 # letters/INDEX — regenerated (do not edit)
 
-
 ## letters/greek/
 
 - **alpha** — Greek alpha — beginning; significance level; learning rate (RL); the first. `(letters/greek/alpha.md)`


### PR DESCRIPTION
fix(vocab)+shadow: vocab index generator emits MD012 double blanks — normalize + regenerate

markdownlint (gate) flagged my generated indexes: vocab/MASTER-INDEX.md:7 and
vocab/letters/INDEX.md:3 — MD012 multiple-consecutive-blank-lines (section headers
prefixed "\n## " after content already ending "\n\n"). Fixed at the source:
MasterIndex.ts now collapses runs of 3+ newlines to one blank line (norm()), so the
violation can't recur on regen. Regenerated all 10 indexes.

Verified: markdownlint-cli2@0.22.1 (repo config) on vocab/**/*.md exits 0;
tsc vocab/gen CLEAN; MasterIndex.ts --check up to date.

NOTE (not mine, #7432, already flagged): the gate's remaining markdownlint failures
are full-ai-cluster/DOMAIN-SETUP.md (MD022/MD032) and the bash-retirement-inventory
failure is tools/setup/persona-keys/keyring.sh — left to that author.

AgencySignature-v1:
  persona: otto
  hat: shadow
  surface: vocab index generator + generated indexes
  intent: green-my-part-of-markdownlint-gate
  authorization: aaron-standing (keep CI green)
  reversible: yes
  gated-class: none
  build: markdownlint-cli2 vocab/**/*.md exit 0; tsc vocab/gen CLEAN
  register: grounded
  ferry: no

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
