### PR TITLE
feat(core)+shadow: wire the governed ZetaId minter into Destination (ReticulumLink)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -252,6 +252,7 @@
   <ItemGroup>
     <!-- Language-neutral contract lib (ITensor); WeightedSet implements it -->
     <ProjectReference Include="..\Core.Abstractions\Zeta.Core.Abstractions.csproj" />
+    <ProjectReference Include="..\Core.FSharp.ZetaId\Zeta.Core.FSharp.ZetaId.fsproj" />
   </ItemGroup>
 
   <!-- F# static analyzers. Run via `dotnet msbuild -t:AnalyzeFSharpProject`. -->

--- a/src/Core/ReticulumConnect.test.fsx
+++ b/src/Core/ReticulumConnect.test.fsx
@@ -1,19 +1,22 @@
 // DST + Reticulum: "can our tests connect?" — the handshake proof (Aaron, 2026-06-09:
 // "we are going to do a deterministic simulation test with Reticulum and see if our
-// tests can connect once you have [the finalizer in src/Core] built").
+// tests can connect" → then "wire the governed ZetaId minter into Destination").
 //
-// Two test nodes, each a ZetaId-shaped Reticulum destination, announce themselves
-// (discovery), CONNECT over the deterministic medium, and exchange a tick BOTH ways.
-// The whole exchange is scheduler-driven so it REPLAYS identically from one seed (DST).
-// The finalizer (now in src/Core) closes the loop: the exchange's tick result feeds
-// Finalizer.decide — "the finalizer is part of the test" (rooms/README).
+// Two test nodes, each a GOVERNED ZetaId Reticulum destination (minted by ZetaIdCodec,
+// Category.Bus), announce themselves (discovery), CONNECT over the deterministic medium,
+// and exchange a tick BOTH ways. The whole exchange is scheduler-driven so it REPLAYS
+// identically from one seed (DST). The finalizer (in src/Core) closes the loop.
 //
 // Run: dotnet fsi src/Core/ReticulumConnect.test.fsx
+#load "../Core.FSharp.ZetaId/Types.fs"
+#load "../Core.FSharp.ZetaId/BitLayout.fs"
+#load "../Core.FSharp.ZetaId/Codec.fs"
 #load "Clock.fs"
 #load "ReticulumLink.fs"
 #load "Finalizer.fs"
 open Zeta.Core
 open Zeta.Core.ReticulumLink
+open Zeta.Core.FSharp.ZetaId
 
 let mutable pass = 0
 let mutable fail = 0
@@ -21,34 +24,37 @@ let ok name cond =
     if cond then pass <- pass + 1; printfn "  ok: %s" name
     else fail <- fail + 1; printfn "  FAIL: %s" name
 
-// two test nodes (ZetaId-shaped destinations) — "our tests"
-let nodeA: Destination = { Hi = 0xA000UL; Lo = 1UL }
-let nodeB: Destination = { Hi = 0xB000UL; Lo = 2UL }
-let nodeGhost: Destination = { Hi = 0xC000UL; Lo = 3UL }   // never announces
+let s0 = Scheduler.fromSeed 100L
+// two test nodes — GOVERNED ZetaId destinations minted from (ts, seed, location)
+let nodeA = mint s0.Now 0xA1L Location.EastUsVa
+let nodeB = mint s0.Now 0xB2L Location.WestEurope
+let nodeGhost = mint s0.Now 0xC3L Location.CentralUs   // never announces
 
 // --- the connect + bidirectional exchange, parameterised by seed (so we can replay) ---
-// returns: (connected, payloadsAtB, payloadsAtA, versionstampTrace)
 let scenario (seed: int64) =
-    let s0 = Scheduler.fromSeed seed
-    // discovery: both test nodes announce (idempotent — announce A twice)
+    let s = Scheduler.fromSeed seed
     let m0 = empty |> announce nodeA |> announce nodeA |> announce nodeB
-    // can our tests connect?
-    let link = connect nodeA nodeB m0
-    match link with
+    match connect nodeA nodeB m0 with
     | Error _ -> (false, [], [], [])
     | Ok l ->
-        // A -> B (a tick), then B -> A (the ack): the bidirectional handshake
-        let m1, s1 = send l.A l.B "tick" s0 m0
+        let m1, s1 = send l.A l.B "tick" s m0
         let m2, s2 = send l.B l.A "ack" s1 m1
         let atB, m3 = deliver nodeB m2
         let atA, _ = deliver nodeA m3
-        let trace = [ s0.Now; s1.Now; s2.Now ]
         (true,
          atB |> List.map (fun p -> p.Payload),
          atA |> List.map (fun p -> p.Payload),
-         trace)
+         [ s.Now; s1.Now; s2.Now ])
 
-printfn "ReticulumConnect (DST handshake):"
+printfn "ReticulumConnect (DST handshake, governed ZetaId):"
+
+// 0. the destinations are GOVERNED ZetaIds — minted via ZetaIdCodec, decode as Category.Bus
+ok "minted destination decodes as a Bus-category ZetaId"
+    ((ZetaIdCodec.unpack nodeA.Id).Category = Category.Bus)
+ok "mint is deterministic (same ts+seed+loc -> same ZetaId)"
+    (mint s0.Now 0xA1L Location.EastUsVa = nodeA)
+ok "distinct seeds -> distinct ZetaIds (entropy -> identity)"
+    (nodeA <> nodeB && nodeA.Id <> nodeB.Id)
 
 // 1. can our tests connect? (both announced)
 let (connected, atB, atA, trace1) = scenario 100L
@@ -84,5 +90,5 @@ ok "finalizer on a connected exchange -> ReKick"
     (Finalizer.decide tick = FinalizerAction.ReKick)
 
 printfn "ReticulumConnect: %d passed, %d failed" pass fail
-if fail = 0 then printfn "ReticulumConnect: ALL PASS (our tests connect; DST-replayable; finalizer in loop)."
+if fail = 0 then printfn "ReticulumConnect: ALL PASS (governed ZetaId destinations; our tests connect; DST-replayable; finalizer in loop)."
 else exit 1

--- a/src/Core/ReticulumLink.fs
+++ b/src/Core/ReticulumLink.fs
@@ -1,26 +1,31 @@
 namespace Zeta.Core
 
+open Zeta.Core.FSharp.ZetaId
+
 /// Reticulum-overlay link layer for the DST "can our tests connect" handshake — a
 /// DETERMINISTIC, in-process simulation of the network/ Reticulum overlay
-/// (network/README.md): destinations are ZetaId-shaped self-certifying addresses;
-/// `connect` requires BOTH ends announced (discovery); delivery is ordered and
-/// scheduler-stamped so the whole exchange replays from a seed (DST, manifesto spec #7).
+/// (network/README.md): destinations are GOVERNED ZetaId addresses; `connect` requires
+/// BOTH ends announced (discovery); delivery is ordered and scheduler-stamped so the
+/// whole exchange replays from a seed (DST, manifesto spec #7).
 ///
-/// Honest scope (peel): this sims the link IN-PROCESS — DoP=1, no threads, no real
-/// I/O — i.e. the deterministic-simulation half of "DST + Reticulum". Wiring to a real
-/// RNS daemon over the wire, and to the governed `Zeta.Core.FSharp.ZetaId` minter for
-/// the address, is the follow-up. Result-over-exception: the connect path never throws.
+/// Governed ZetaId (no inventing): a `Destination` carries a real 128-bit ZetaId minted
+/// by `ZetaIdCodec` (Category.Bus = cross-machine agent comms, #6219). Minting is
+/// deterministic in (timestamp, seed, location) via an `ISimulationEnvironment` whose
+/// randomness field is a pure function of the seed — so the same seed mints the same
+/// ZetaId (the ferry's "128-bit seed → the low-entropy Zeta state"; reproducible).
 ///
-/// Anchors (Beacon): Reticulum (self-certifying, key-bound destinations; announce /
-/// discovery; the overlay in network/README) · ZetaId = the 128-bit destination address
-/// · FoundationDB-style deterministic simulation (one seeded loop, replayable) · this
-/// module's clock is `Clock.fs` `Scheduler`/`Versionstamp` (the injected DST time).
+/// Honest scope (peel): the LINK is simulated in-process — DoP=1, no threads, no real
+/// I/O — the deterministic-simulation half of "DST + Reticulum"; a real RNS daemon over
+/// the wire is the follow-up. Result-over-exception: the connect path never throws.
+///
+/// Anchors (Beacon): Reticulum (self-certifying key-bound destinations; announce /
+/// discovery) · `Zeta.Core.FSharp.ZetaId` (the governed 128-bit minter; Category.Bus) ·
+/// FoundationDB-style deterministic simulation · `Clock.fs` Scheduler/Versionstamp.
 module ReticulumLink =
 
-    /// A ZetaId-shaped 128-bit self-certifying destination address. Stands in for the
-    /// governed `Zeta.Core.FSharp.ZetaId` destination (Reticulum binds address↔key); the
-    /// real minter is wired in the follow-up.
-    type Destination = { Hi: uint64; Lo: uint64 }
+    /// A Reticulum destination address — the GOVERNED 128-bit ZetaId (minted by
+    /// `ZetaIdCodec`, never fabricated). Use `mint` to create one.
+    type Destination = { Id: System.UInt128 }
 
     /// A packet on the medium, stamped with the deterministic scheduler time at send.
     type Packet = { From: Destination; To: Destination; Payload: string; At: Versionstamp }
@@ -35,6 +40,33 @@ module ReticulumLink =
     /// The deterministic shared transport: the set of announced destinations + the
     /// ordered in-flight packets. Immutable; every transition returns a new medium.
     type Medium = { Announced: Destination list; InFlight: Packet list }
+
+    /// A seed-derived deterministic simulation environment: the 32-bit ZetaId randomness
+    /// field is a pure function of the seed (same seed → same ZetaId). Object expression,
+    /// not a class (treaty-room discipline).
+    let private envOf (seed: int64) : ISimulationEnvironment =
+        { new ISimulationEnvironment with
+            member _.NextInt64() = seed }
+
+    /// Mint a GOVERNED Bus-category ZetaId destination from a DST timestamp + seed +
+    /// location. Category.Bus is an observation category, so this uses the governed
+    /// `ZetaIdCodec.pack` (not `packGeneric`). Authority.Simulated is honest — these are
+    /// DST-simulated nodes. Deterministic in (ts, seed, location): same inputs → same
+    /// ZetaId; distinct seeds → distinct ZetaIds (the ferry's entropy → identity).
+    let mint (ts: Versionstamp) (seed: int64) (location: Location) : Destination =
+        let tsMs: int64<ms> =
+            LanguagePrimitives.Int64WithMeasure(int64 (uint64 ts.Version &&& 0xFFFFFFFFFFFFUL))
+        let obs: ZetaObservation =
+            { Version = IdVersion.V1
+              Timestamp = tsMs
+              Chromosome = Chromosome.MetaCoherence
+              Category = Category.Bus
+              Firefly = Firefly.Off
+              Authority = Authority.Simulated
+              Persona = Persona.FireflyCoherence
+              Momentum = Momentum.Background
+              Location = location }
+        { Id = ZetaIdCodec.pack obs (envOf seed) }
 
     /// The empty medium — nothing announced, nothing in flight.
     let empty: Medium = { Announced = []; InFlight = [] }


### PR DESCRIPTION
feat(core)+shadow: wire the governed ZetaId minter into Destination (ReticulumLink)

Follow-up to the DST+Reticulum connect test: Destination is no longer an ad-hoc
{Hi;Lo} record — it now carries a real GOVERNED 128-bit ZetaId minted by
ZetaIdCodec (no inventing; "ZetaIds are a generator function, we have governance").

- src/Core/Core.fsproj: ProjectReference -> Zeta.Core.FSharp.ZetaId (acyclic; ZetaId
  has no deps).
- ReticulumLink.Destination = { Id: System.UInt128 } (the ZetaId).
- ReticulumLink.mint (ts) (seed) (location): builds a Bus-category ZetaObservation
  (Category.Bus = cross-machine agent comms, #6219; Authority.Simulated — honest for
  DST nodes) and calls the governed ZetaIdCodec.pack with a seed-derived
  ISimulationEnvironment (object expression, no class). Deterministic in
  (ts, seed, location): same inputs -> same ZetaId; distinct seeds -> distinct ZetaIds
  (the Ani-ferry's entropy -> identity / "128-bit seed -> low-entropy Zeta state").
- ReticulumConnect.test.fsx now mints governed destinations; 13/13 pass, incl.
  "minted destination decodes as Category.Bus", mint determinism, distinct-seed
  distinctness, plus the prior connect/replay/idempotency/finalizer checks.
- dotnet build Zeta.sln -c Release: 0 Warning(s), 0 Error(s).

Honest scope (peel): link still simulated in-process (no real RNS daemon yet);
governed-minter wiring is the part this PR delivers. dns/ resolution + fault
injection remain follow-ups.

AgencySignature-v1:
  persona: otto
  hat: shadow
  surface: src/Core (ReticulumLink + ZetaId ref)
  intent: wire-governed-zetaid-minter-into-destination
  authorization: aaron-standing (wire the governed ZetaId minter into Destination)
  reversible: yes
  gated-class: none
  build: Zeta.sln -c Release 0W/0E; ReticulumConnect.test.fsx 13/13
  register: grounded
  ferry: no

Co-authored-by: Aaron Stainback <acehack00@gmail.com>
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
