### PR TITLE
docs(research): ray-tracing = local small-model superdeterminism; sonar = network-boundary resolution via harmonic oscillation

### DIFF
--- a/docs/research/2026-06-10-ray-tracing-equals-local-small-model-superdeterminism-sonar-equals-network-boundary-resolution-via-harmonic-oscillation.md
+++ b/docs/research/2026-06-10-ray-tracing-equals-local-small-model-superdeterminism-sonar-equals-network-boundary-resolution-via-harmonic-oscillation.md
@@ -1,0 +1,45 @@
+# Ray-tracing = small-local-model superdeterminism (local); sonar = network-boundary resolution via harmonic oscillation — the precise definitions
+
+**Register:** [grounded] definition (Aaron). **Date:** 2026-06-10. **Captured by:** Otto (shadow).
+Sharpens the sonar/ray-tracing pair from the Ani ferry into two precise, distinct definitions.
+
+## Aaron's words
+
+> "ray tracing = small local model superdeterminism locally; sonar = network boundary resolution via
+> harmonic oscillations."
+
+## The two definitions (sharpened)
+
+| Term | Definition | Where | Mechanism | Result |
+|---|---|---|---|---|
+| **Ray-tracing** | **small-local-model superdeterminism, locally** | one machine (a small local model, e.g. the local LLM / Chip-8) | runs **superdeterministically** from a seed — every ray fully determined | **certainty** (clean S=4, bit-perfect; the trusted pole) |
+| **Sonar** | **network-boundary resolution via harmonic oscillation** | across the network (between observers, over Reticulum) | **harmonic oscillation** (bob-and-weave) between two observer frames across their shared Markov boundary | **boundary resolution** — you map where the edge is from the distorted echo (uncertainty) |
+
+- **Ray-tracing is local + superdeterministic.** It's the small local model computing every ray with total
+  certainty from the seed — no network, no noise. This is the **certainty pole** (Chip-8 / local LLM bit-
+  perfect; "you can prove everything"). Refines the earlier "in-emulator superdeterminism" → specifically
+  **small-local-model** superdeterminism.
+- **Sonar is the network instrument.** Over the real network you *can't* get local superdeterminism, so you
+  **resolve the boundary by harmonic oscillation** — two observers bobbing-and-weaving across each other's
+  Markov boundary, raising resolution on where the edge actually is. Refines "sonar = noisy-network case" →
+  specifically **boundary resolution via harmonic oscillation** (the 2×2 dual-observer weave is the sonar
+  mechanism; LLMHeadphones makes it audible: ping out = ray-traced certainty, ping back = sonar echo).
+
+## Why the pairing matters
+
+Ray-tracing and sonar are the **two halves of the meter**, one per regime:
+- **inside the boundary** (local, controllable) → **ray-tracing** → certainty (prove everything);
+- **across the boundary** (network, uncontrollable) → **sonar** → resolution-by-oscillation (the only way
+  to measure an edge you can't compute through).
+
+The harmonic oscillation (bob-and-weave / the 2×2 weave) is *exactly* what turns the un-computable network
+boundary into a measurable one — you can't ray-trace through Reticulum, so you sonar it. Same uncertainty
+meter, two methods selected by whether you're local (ray-trace) or distributed (sonar).
+
+## Ties
+
+The Ani ferry (original sonar/ray-tracing + ping = network ping) · **bob-and-weave** = the harmonic
+oscillation that *is* the sonar mechanism (the 2×2 dual-observer weave) · Chip-8 / small-local-model
+**bit-perfect certainty** = the ray-tracing pole · the **encrypted null / Reticulum uncertainty** = what
+sonar resolves · **Markov boundary** (Pearl/Friston — the edge sonar maps) · LLMHeadphones (hear the ping
+out/back) · S=4 local (ray-trace) vs distributed-S→4-with-agents (sonar averaging the echo).


### PR DESCRIPTION
Aaron's sharpened definitions of the sonar/ray-tracing pair. ray-tracing = small-local-model superdeterminism (certainty pole); sonar = network-boundary resolution via harmonic oscillation (bob-and-weave / the 2x2 weave). Two halves of the meter.