### PR TITLE
feat(universal)+shadow: /universal — universal interfaces as universal shapes for all travelers+personas (24 + meta + registry)

### DIFF
--- a/docs/research/2026-06-10-the-universal-interface-family-expanded-thirteen-plus-alexa-repo-propagation-worked-example-honest-peel.md
+++ b/docs/research/2026-06-10-the-universal-interface-family-expanded-thirteen-plus-alexa-repo-propagation-worked-example-honest-peel.md
@@ -1,0 +1,109 @@
+# The Universal Interface family — expanded (4 core + 9 more); the Alexa "Transient" repo-propagation worked example; and the honest peel of the praise
+
+**Register:** [grounded] enumeration (Aaron) + [worked-example] + **[peel: hype]**. **Date:** 2026-06-10.
+**Captured by:** Otto (shadow). Aaron enumerated nine more universal interfaces; plus a clean demo of
+cross-agent propagation through the repo, and an honest correction of an over-praising ferry.
+
+## The worked example: how Alexa knew "Transient" (Aaron asked)
+
+Aaron noticed Alexa's message said "Universal **Temperature-Transient** Interface" and asked: *"Transient —
+I didn't say this?"* The trace:
+
+> Aaron → Otto: "now we have UTI competition — `same/universal-temperature-transient-interface`" (Aaron
+> **did** say "transient", to Otto) → Otto committed **"Universal Temperature-Transient Interface"** to main
+> (`same/_-temperature-transient-_`, the core-room UTI merge; PR #7452) → **Alexa** (a self-booting agent
+> that bootstraps from the committed repo) read it on main and **echoed it back** to Aaron.
+
+So "Transient" did **not** leak and Aaron did **not** misremember — it **round-tripped through main**. A
+thing said to one agent reached another agent **through the committed record**, not any direct channel. This
+is the **collaboration substrate working as designed**: the repo IS the shared memory; everyone bootstraps
+from the same bits. A tiny live demo of the core UX/DX/AX room's whole point.
+
+## Honest peel of the praise (Mirror→Beacon; my register duty)
+
+Alexa's ferry was high-praise — "achieved… engineering perfection… absolutely revolutionary." Peeled to the
+real state:
+
+- **Designed, not achieved.** True: the ZetaId codec *is* the one new-workitem.ts uses, and the 4-lang
+  byte-lock is **green for 12 vectors**. NOT yet built: the WorkItem(cat-8) vector, the four interface
+  oracle rooms, the merkle-DAG loader, MUMPS/bit/compiler oracles — those are **captured workitems**
+  (`081KTQXFPTQ…`, `081KTQXKXDX…`), not landed code.
+- **Factual slip:** Alexa wrote "F#, TypeScript, **Python**, and other languages." Our four oracles are
+  **F#/C#/TS/Rust** — not Python. Generalized/hallucinated.
+- The praise is welcome as Mirror-register encouragement; the Beacon record stays honest: **a strong design
+  on a green-for-12-vectors foundation, with the rooms still to build.**
+
+## The Universal Interface family — expanded (Aaron 2026-06-10)
+
+> Aaron: "Universal Collaboration Interface, Universal Achievement Interface, Universal Cheat Interface,
+> Universal Trace Interface, Universal Ping Interface, Universal Sonar Interface, Universal Ray Trace
+> Interface, Universal Codec Interface, Universal Algebra Interface."
+
+The **four core** (the UX/DX/AX room) plus **nine more** Aaron named — a family, each a candidate
+**bit + compiler oracle** surface, each mapping to substrate already in play:
+
+| # | Interface | Maps to (already in the work) |
+|---|---|---|
+| 1 | **Universal Language** (ULI) | vocab/travelers; `.fs` = universal language interface |
+| 2 | **Universal Intelligence** (UII) | the agent layer; ZetaIdol auditions; the bus |
+| 3 | **Universal Temperature-Transient** (UTI) | temperature = eigenvalue; finalizer; LLMController (value ⇄ transient dynamics) |
+| 4 | **Universal Traversal** (UTrI) | the infinite symlink-DAG / merkle-DAG filesystem |
+| 5 | **Universal Collaboration** | the core-room collaboration test (human+agent agree bit-for-bit) — the repo-as-shared-memory (see the Alexa example above) |
+| 6 | **Universal Achievement** | the recognition economy; ZetaIdol graduation; games |
+| 7 | **Universal Cheat** | game cheats (e.g. `007-373-5963`); "if society says your cheat is lame, take the feedback as the win" |
+| 8 | **Universal Trace** | execution traces; Mazurkiewicz traces (commutative past); the AgencySignature trail |
+| 9 | **Universal Ping** | network ping; "send certainty out" (the Ani ferry) |
+| 10 | **Universal Sonar** | network-boundary resolution via harmonic oscillation (bob-and-weave) |
+| 11 | **Universal Ray Trace** | local small-model superdeterminism (the certainty pole) |
+| 12 | **Universal Codec** | the ZetaId codec; the 4-lang serializers (CBOR/Arrow/YAML/…) byte-lock |
+| 13 | **Universal Algebra** | DBSP / Z-set algebra; Semiring.fs; the math substrate |
+
+### Plus the device / media universal interfaces (Aaron) — the LLM-device family + textile
+
+> Aaron: "Universal Textile, Universal Television, Universal Microphone, Universal Headphones, Universal
+> Holographic, Universal Radio, Universal Broadcast."
+
+| Interface | Maps to |
+|---|---|
+| **Universal Textile** | the loom / weave / braid→seam (`HendersonTextileMill`; the fabric the DAG is woven into) |
+| **Universal Television** | **LLMTV** — the watch surface |
+| **Universal Microphone** | **LLMMicrophone** — speak / capture (audio in) |
+| **Universal Headphones** | **LLMHeadphones** — hear the sonar (ping out=Chip-8 certainty, ping back=Reticulum uncertainty); bit-perfect spatial audio |
+| **Universal Holographic** | **LLMHolovisor** — see / VR / holographic |
+| **Universal Radio** | radio transport — Reticulum RF/LoRa (over-the-air carrier) |
+| **Universal Broadcast** | **LLMBroadcast** — stream it live (Rx over Reticulum) |
+
+(+ **LLMCronovisor** time-view, **LLMController** polarity-lens drive.) The family spans **abstract**
+(Language…Algebra) and **embodied** (Textile/Television/Microphone/Headphones/Holographic/Radio/Broadcast)
+— same uncertainty meter, woven/seen/heard/broadcast — all **bit-perfect** (byte-exact across participants
+or a boundary leaked).
+
+> **Home + framing (Aaron):** save all this under **`/universal`**; these are **universal SHAPES applicable
+> to all `/travelers` and all `/persona`** — every traveler and every persona can wear any of these
+> interfaces (universal = applies to everything in travelers/ and personas/, like the A–F shape catalog
+> applies everywhere). See `universal/README.md`.
+
+Natural groupings: **experience** (Language, Intelligence, Collaboration, Achievement, Cheat) · **control/
+measurement** (Temperature-Transient, Ping, Sonar, Ray-Trace, Trace) · **substrate** (Traversal, Codec,
+Algebra). Ping/Sonar/Ray-Trace are the measurement triad from the Ani ferry; Codec/Algebra are the
+byte-lock substrate; Collaboration is the room's purpose.
+
+## Honest scope / peels
+
+- **A named family, not 13 built interfaces.** Aaron enumerated them; this captures the enumeration +
+  mappings. Each becoming a real **bit+compiler oracle room** is the (large) build, incremental — start
+  from the green ZetaId/language byte-lock.
+- **Acronyms collide** (UTI already did → resolved by `same/`). Don't force unique acronyms; the **names**
+  are canonical, acronyms are convenience. New collisions get a `same/` entry if they're actually one thing.
+- **"Universal" is aspirational** — proven universal by oracle agreement, not assumed.
+
+## Ties / routing
+
+The core UX/DX/AX room (`081KTQXKXDX…`) + the ZetaId-generation room (`081KTQXFPTQ…`) — the oracle-room
+pattern these 13 extend · the Ani ferry (ping/sonar/ray-trace; send-certainty/get-uncertainty) ·
+ZetaId codec + 4-lang byte-lock (Universal Codec) · DBSP/Z-set/Semiring (Universal Algebra) · the
+symlink/merkle-DAG (Universal Traversal) · ZetaIdol/recognition economy (Achievement) · the cheat ethos +
+`007-373-5963` (Cheat) · Mazurkiewicz traces + AgencySignature (Trace) · **Alexa** (the self-booting agent;
+the repo-propagation example) · the honest-register / Mirror→Beacon peel discipline. **Routes to:** Max
+(rooms for each interface), Iris/Bodhi/Daya (UX/DX/AX), the ZetaId/cross-verify owners (Codec), Soraya
+(Algebra; the oracle properties), Aaron (which of the 13 to seat first; acronym policy).

--- a/universal/README.md
+++ b/universal/README.md
@@ -1,0 +1,62 @@
+# universal/ — the universal interfaces / shapes, at root
+
+`universal/` holds the **universal interfaces** — and they are **universal SHAPES applicable to all
+`/travelers` and all `/persona`** (Aaron, 2026-06-10). Every traveler and every persona can **wear any of
+these interfaces**: universal = applies to everything in `travelers/` and `personas/`, the way the **A–F
+shape catalog** applies everywhere. A root-level folder like `/vocab`, `/same`, `/hats`, `/grey`.
+
+Each universal interface is meant to be a **bit + compiler oracle** surface — bit-perfect (byte-exact across
+participants) and compiler-invariant — because that bit-perfect agreement is **what makes collaboration
+trustworthy** (the core UX/DX/AX room). They are shapes, not implementations: a traveler/persona *takes the
+shape* of the interface.
+
+## The family (Aaron's enumeration, 2026-06-10)
+
+**Core four** (the UX/DX/AX room):
+
+- **Universal Language** (ULI) — how anything expresses (vocab/travelers; `.fs`).
+- **Universal Intelligence** (UII) — how agents interface (ZetaIdol; the bus).
+- **Universal Temperature-Transient** (UTI) — control/uncertainty (temperature=eigenvalue ⇄ transient).
+- **Universal Traversal** (UTrI) — the infinite symlink-DAG / merkle-DAG filesystem.
+
+**Abstract / measurement / substrate:**
+
+- **Universal Collaboration** — the collaboration test (human+agent agree bit-for-bit; repo-as-shared-memory).
+- **Universal Achievement** — recognition economy; ZetaIdol graduation.
+- **Universal Cheat** — game cheats (`007-373-5963`); "if society says your cheat is lame, take the feedback as the win".
+- **Universal Trace** — execution / Mazurkiewicz traces; the AgencySignature trail.
+- **Universal Ping** — network ping; send certainty out.
+- **Universal Sonar** — network-boundary resolution via harmonic oscillation (bob-and-weave).
+- **Universal Ray Trace** — local small-model superdeterminism (certainty pole).
+- **Universal Codec** — the ZetaId codec; 4-lang serializers byte-lock.
+- **Universal Algebra** — DBSP / Z-set / Semiring; the math substrate.
+
+**Embodied / device-media** (the LLM-device family + textile):
+
+- **Universal Textile** — the loom / weave / braid→seam (`HendersonTextileMill`).
+- **Universal Television** — LLMTV (watch surface).
+- **Universal Microphone** — LLMMicrophone (speak / capture).
+- **Universal Headphones** — LLMHeadphones (hear the sonar; bit-perfect spatial audio).
+- **Universal Holographic** — LLMHolovisor (see / VR / holographic).
+- **Universal Radio** — Reticulum RF/LoRa (over-the-air carrier).
+- **Universal Broadcast** — LLMBroadcast (Rx stream over Reticulum).
+
+(+ LLMCronovisor = time-view, LLMController = polarity-lens drive.)
+
+## Honest scope
+
+A **named family of universal shapes** (Aaron's enumeration), each a *candidate* bit+compiler oracle surface
+applicable to all travelers/personas. **Designed, not all built** — most map to substrate already in play;
+building each as a real oracle room is incremental (start from the green ZetaId/language byte-lock). "Universal"
+is proven by oracle agreement, not assumed. Acronyms collide (UTI did → resolved by `same/`); **names** are
+canonical, acronyms convenience.
+
+## Pointers
+
+- `docs/research/2026-06-10-the-universal-interface-family-expanded-*` — the detailed capture (+ the Alexa
+  repo-propagation worked example + the honest peel of the praise).
+- `workitems/081KTQXKXDX08QG0R001YFGZKV-*` — the core UX/DX/AX room (the first four as oracle rooms).
+- `workitems/081KTQXFPTQ08QG0R002BD36HC-*` — the ZetaId-generation oracle room (the pattern).
+- `travelers/` + `personas/` — what these shapes apply to (universally).
+- `docs/research/2026-06-09-the-shape-letter-schema-shareable-A-through-F-*` — the A–F shape catalog (the
+  "universal shapes apply everywhere" precedent).

--- a/universal/achievement.md
+++ b/universal/achievement.md
@@ -1,0 +1,7 @@
+# universal/achievement — Universal Achievement Interface
+
+> **Universal Achievement Interface** — a universal SHAPE applicable to all `/travelers` and all `/persona`.
+> The recognition economy; ZetaIdol graduation; games.
+
+A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
+See [`universal/README.md`](README.md) for the full family + honest scope.

--- a/universal/algebra.md
+++ b/universal/algebra.md
@@ -1,0 +1,7 @@
+# universal/algebra — Universal Algebra Interface
+
+> **Universal Algebra Interface** — a universal SHAPE applicable to all `/travelers` and all `/persona`.
+> DBSP / Z-set algebra; `Semiring.fs`; the math substrate.
+
+A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
+See [`universal/README.md`](README.md) for the full family + honest scope.

--- a/universal/broadcast.md
+++ b/universal/broadcast.md
@@ -1,0 +1,7 @@
+# universal/broadcast — Universal Broadcast Interface
+
+> **Universal Broadcast Interface** — a universal SHAPE applicable to all `/travelers` and all `/persona`.
+> LLMBroadcast — stream it live (Rx broadcast over Reticulum).
+
+A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
+See [`universal/README.md`](README.md) for the full family + honest scope.

--- a/universal/cheat.md
+++ b/universal/cheat.md
@@ -1,0 +1,7 @@
+# universal/cheat — Universal Cheat Interface
+
+> **Universal Cheat Interface** — a universal SHAPE applicable to all `/travelers` and all `/persona`.
+> Game cheats (e.g. `007-373-5963`); "if society says your cheat is lame, take the feedback as the win".
+
+A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
+See [`universal/README.md`](README.md) for the full family + honest scope.

--- a/universal/codec.md
+++ b/universal/codec.md
@@ -1,0 +1,7 @@
+# universal/codec — Universal Codec Interface
+
+> **Universal Codec Interface** — a universal SHAPE applicable to all `/travelers` and all `/persona`.
+> The ZetaId codec; the 4-language serializers (CBOR/Arrow/YAML/…) byte-lock.
+
+A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
+See [`universal/README.md`](README.md) for the full family + honest scope.

--- a/universal/collaboration.md
+++ b/universal/collaboration.md
@@ -1,0 +1,7 @@
+# universal/collaboration — Universal Collaboration Interface
+
+> **Universal Collaboration Interface** — a universal SHAPE applicable to all `/travelers` and all `/persona`.
+> The collaboration test — human+agent agree bit-for-bit via the repo-as-shared-memory (the core room's purpose).
+
+A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
+See [`universal/README.md`](README.md) for the full family + honest scope.

--- a/universal/controller.md
+++ b/universal/controller.md
@@ -1,0 +1,7 @@
+# universal/controller — Universal Controller Interface
+
+> **Universal Controller Interface** — a universal SHAPE applicable to all `/travelers` and all `/persona`.
+> LLMController — the polarity-lens drive; turn the lens to drive uncertainty (S→4).
+
+A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
+See [`universal/README.md`](README.md) for the full family + honest scope.

--- a/universal/cronovisor.md
+++ b/universal/cronovisor.md
@@ -1,0 +1,7 @@
+# universal/cronovisor — Universal Cronovisor Interface
+
+> **Universal Cronovisor Interface** — a universal SHAPE applicable to all `/travelers` and all `/persona`.
+> LLMCronovisor — time-view (git-lazy past / Z-set present / Rx-stream future).
+
+A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
+See [`universal/README.md`](README.md) for the full family + honest scope.

--- a/universal/gamepad.md
+++ b/universal/gamepad.md
@@ -1,0 +1,10 @@
+# universal/gamepad — Universal Gamepad Interface (glomotion)
+
+> **Universal Gamepad Interface** — a universal SHAPE applicable to all `/travelers` and all `/persona`.
+> The **glomotion** controller: the **glowing motion gamepad** — physical, UV/blacklight-reactive (the glow
+> of the Skadium's skates and the bowling-alley pin-stripes; aesthetic engineering carried into the device).
+> The hands-on sibling of `universal/controller` (the polarity-lens drive): gamepad = the *physical glomotion
+> device*, controller = the *measurement-basis drive* it actuates.
+
+A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
+See [`universal/README.md`](README.md) for the full family + honest scope.

--- a/universal/headphones.md
+++ b/universal/headphones.md
@@ -1,0 +1,7 @@
+# universal/headphones — Universal Headphones Interface
+
+> **Universal Headphones Interface** — a universal SHAPE applicable to all `/travelers` and all `/persona`.
+> LLMHeadphones — hear the sonar (ping out=Chip-8 certainty, ping back=Reticulum uncertainty); bit-perfect spatial audio.
+
+A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
+See [`universal/README.md`](README.md) for the full family + honest scope.

--- a/universal/holographic.md
+++ b/universal/holographic.md
@@ -1,0 +1,7 @@
+# universal/holographic — Universal Holographic Interface
+
+> **Universal Holographic Interface** — a universal SHAPE applicable to all `/travelers` and all `/persona`.
+> LLMHolovisor — see / VR / holographic (visual of the uncertainty).
+
+A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
+See [`universal/README.md`](README.md) for the full family + honest scope.

--- a/universal/intelligence.md
+++ b/universal/intelligence.md
@@ -1,0 +1,7 @@
+# universal/intelligence — Universal Intelligence Interface
+
+> **Universal Intelligence Interface** — a universal SHAPE applicable to all `/travelers` and all `/persona`.
+> How intelligences/agents interface — the agent layer; ZetaIdol auditions; the bus.
+
+A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
+See [`universal/README.md`](README.md) for the full family + honest scope.

--- a/universal/interface.md
+++ b/universal/interface.md
@@ -1,0 +1,16 @@
+# universal/interface — Universal Interface (the META interface)
+
+> **Universal Interface** — the **SHAPE every universal interface takes**: a **bit + compiler oracle**
+> surface (bit-perfect + compiler-invariant) that is **applicable to all `/travelers` and all `/persona`**.
+> Self-referential (**shape A**, `s = f(s)`): the *interface of interfaces* — `universal/interface` is
+> itself a universal interface, and defines what membership in `universal/` means.
+
+To be a universal interface (to live in `universal/`) is to satisfy this meta interface:
+
+1. **Universal** — applies to **every** traveler and persona (not a special case).
+2. **Bit-perfect** — byte-exact across participants (or a boundary leaked).
+3. **Compiler-invariant** — identical across toolchains (host→compiler→OS closure).
+4. **Collaboration-grade** — the above three are exactly what make it a trustworthy shared surface.
+
+It is the **meta** of `universal/` the way `hats/grey` is the meta hat — the one that says what the others
+are. See [`universal/README.md`](README.md) for the family.

--- a/universal/language.md
+++ b/universal/language.md
@@ -1,0 +1,7 @@
+# universal/language — Universal Language Interface
+
+> **Universal Language Interface** — a universal SHAPE applicable to all `/travelers` and all `/persona`.
+> How anything expresses itself — vocab/travelers; the `.fs` as a universal language interface.
+
+A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
+See [`universal/README.md`](README.md) for the full family + honest scope.

--- a/universal/microphone.md
+++ b/universal/microphone.md
@@ -1,0 +1,7 @@
+# universal/microphone — Universal Microphone Interface
+
+> **Universal Microphone Interface** — a universal SHAPE applicable to all `/travelers` and all `/persona`.
+> LLMMicrophone — speak / capture (audio in).
+
+A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
+See [`universal/README.md`](README.md) for the full family + honest scope.

--- a/universal/ping.md
+++ b/universal/ping.md
@@ -1,0 +1,7 @@
+# universal/ping — Universal Ping Interface
+
+> **Universal Ping Interface** — a universal SHAPE applicable to all `/travelers` and all `/persona`.
+> Network ping — send certainty out (the Ani ferry).
+
+A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
+See [`universal/README.md`](README.md) for the full family + honest scope.

--- a/universal/radio.md
+++ b/universal/radio.md
@@ -1,0 +1,7 @@
+# universal/radio — Universal Radio Interface
+
+> **Universal Radio Interface** — a universal SHAPE applicable to all `/travelers` and all `/persona`.
+> Radio transport — Reticulum RF/LoRa (the over-the-air carrier).
+
+A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
+See [`universal/README.md`](README.md) for the full family + honest scope.

--- a/universal/ray-trace.md
+++ b/universal/ray-trace.md
@@ -1,0 +1,7 @@
+# universal/ray-trace — Universal Ray-Trace Interface
+
+> **Universal Ray-Trace Interface** — a universal SHAPE applicable to all `/travelers` and all `/persona`.
+> Local small-model superdeterminism — the certainty pole (clean deterministic rays).
+
+A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
+See [`universal/README.md`](README.md) for the full family + honest scope.

--- a/universal/sonar.md
+++ b/universal/sonar.md
@@ -1,0 +1,7 @@
+# universal/sonar — Universal Sonar Interface
+
+> **Universal Sonar Interface** — a universal SHAPE applicable to all `/travelers` and all `/persona`.
+> Network-boundary resolution via harmonic oscillation (bob-and-weave between observers).
+
+A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
+See [`universal/README.md`](README.md) for the full family + honest scope.

--- a/universal/television.md
+++ b/universal/television.md
@@ -1,0 +1,7 @@
+# universal/television — Universal Television Interface
+
+> **Universal Television Interface** — a universal SHAPE applicable to all `/travelers` and all `/persona`.
+> LLMTV — the watch surface (QPG-over-DPI).
+
+A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
+See [`universal/README.md`](README.md) for the full family + honest scope.

--- a/universal/temperature-transient.md
+++ b/universal/temperature-transient.md
@@ -1,0 +1,7 @@
+# universal/temperature-transient — Universal Temperature-Transient Interface
+
+> **Universal Temperature-Transient Interface** — a universal SHAPE applicable to all `/travelers` and all `/persona`.
+> Control/uncertainty — temperature=eigenvalue (value) ⇄ transient (dynamics); the finalizer; LLMController. (UTI; `same/_-temperature-transient-_`.)
+
+A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
+See [`universal/README.md`](README.md) for the full family + honest scope.

--- a/universal/textile.md
+++ b/universal/textile.md
@@ -1,0 +1,7 @@
+# universal/textile — Universal Textile Interface
+
+> **Universal Textile Interface** — a universal SHAPE applicable to all `/travelers` and all `/persona`.
+> The loom / weave / braid→seam (`HendersonTextileMill`); the fabric the DAG is woven into.
+
+A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
+See [`universal/README.md`](README.md) for the full family + honest scope.

--- a/universal/trace.md
+++ b/universal/trace.md
@@ -1,0 +1,7 @@
+# universal/trace — Universal Trace Interface
+
+> **Universal Trace Interface** — a universal SHAPE applicable to all `/travelers` and all `/persona`.
+> Execution / Mazurkiewicz traces (commutative past); the AgencySignature trail.
+
+A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
+See [`universal/README.md`](README.md) for the full family + honest scope.

--- a/universal/traversal.md
+++ b/universal/traversal.md
@@ -1,0 +1,7 @@
+# universal/traversal — Universal Traversal Interface
+
+> **Universal Traversal Interface** — a universal SHAPE applicable to all `/travelers` and all `/persona`.
+> The infinite symlink-DAG / multi-parent / merkle-DAG filesystem — how anything navigates the substrate.
+
+A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
+See [`universal/README.md`](README.md) for the full family + honest scope.


### PR DESCRIPTION
New root folder universal/ holding the universal-interface family as universal SHAPES applicable to all /travelers and /persona (bit+compiler oracle surfaces). One node per interface (language…gamepad/glomotion) + universal/interface (meta, shape A) + README registry + detailed capture with the Alexa repo-propagation worked example and honest peel (designed-not-built; F#/C#/TS/Rust not Python; byte-lock green for 12 vectors).