### PR TITLE
feat(shapes)+shadow: shapes/ A-F catalog (canonical) + universal/<letter> symlinks (canonical/symlink DAG)

### DIFF
--- a/shapes/README.md
+++ b/shapes/README.md
@@ -1,0 +1,16 @@
+# shapes/ — the fixed-point shape catalog (A–F), at root; canonical home, surfaced in universal/
+
+`shapes/` is the **canonical home** of the **fixed-point shape catalog** (A–F + D⁰) — the raw shapes a
+system settles into and does not run away from (the "safe/terminating shapes"). From the shareable A–F
+shape-letter doc. These are **universal shapes applicable to all `/travelers` and all `/persona`**, so each
+is **surfaced in `universal/<letter>` as a symlink** back here (canonical/symlink DAG: one canonical home,
+many views, multi-parent).
+
+- `shapes/a` … `shapes/f` (+ `shapes/d0`, the avoid-shape) — canonical.
+- `universal/a` … `universal/f` — symlinks → `shapes/<letter>` (the universal-shape view).
+
+## Pointers
+
+- `docs/research/2026-06-09-the-shape-letter-schema-shareable-A-through-F-*` — the full catalog + hazard warning.
+- `universal/README.md` — the universal interfaces/shapes family.
+- `same/README.md` — the canonical/symlink-DAG convention.

--- a/shapes/a.md
+++ b/shapes/a.md
@@ -1,0 +1,8 @@
+# shapes/a — Shape A: Self-reference fixed point
+
+> **Shape A — Self-reference fixed point** · `s = f(s)`
+> Converges INWARD — one self; terminates infinite reflection/regress. Anchors: Kleene, Curry (Y), Knaster–Tarski, Banach, Hofstadter.
+
+A **universal shape** applicable to all `/travelers` and all `/persona` (surfaced as
+`universal/a`, a symlink here). Canonical home = `shapes/a`. From the A–F fixed-point catalog;
+see `shapes/README.md`.

--- a/shapes/b.md
+++ b/shapes/b.md
@@ -1,0 +1,8 @@
+# shapes/b — Shape B: Idempotent join / LUB
+
+> **Shape B — Idempotent join / LUB** · `f(f(x)) = f(x)`
+> Settles in ONE step; re-applying changes nothing. Anchors: join-semilattice LUB, CRDTs (Shapiro), content-addressing.
+
+A **universal shape** applicable to all `/travelers` and all `/persona` (surfaced as
+`universal/b`, a symlink here). Canonical home = `shapes/b`. From the A–F fixed-point catalog;
+see `shapes/README.md`.

--- a/shapes/c.md
+++ b/shapes/c.md
@@ -1,0 +1,8 @@
+# shapes/c — Shape C: Commutative fold
+
+> **Shape C — Commutative fold** · `f(a,b) = f(b,a)`
+> Order-invariant accumulation; any order, same result. Anchors: abelian monoid, Bayesian update.
+
+A **universal shape** applicable to all `/travelers` and all `/persona` (surfaced as
+`universal/c`, a symlink here). Canonical home = `shapes/c`. From the A–F fixed-point catalog;
+see `shapes/README.md`.

--- a/shapes/d.md
+++ b/shapes/d.md
@@ -1,0 +1,8 @@
+# shapes/d — Shape D: Contraction to a nonzero floor
+
+> **Shape D — Contraction to a nonzero floor** · `iterate to a unique point, floor excludes x=0`
+> Rests at a healthy minimum; the floor forbids the degenerate one. Anchors: Banach, Friston (free-energy min), Jaynes (maxent), Schmidhuber.
+
+A **universal shape** applicable to all `/travelers` and all `/persona` (surfaced as
+`universal/d`, a symlink here). Canonical home = `shapes/d`. From the A–F fixed-point catalog;
+see `shapes/README.md`.

--- a/shapes/d0.md
+++ b/shapes/d0.md
@@ -1,0 +1,8 @@
+# shapes/d0 — Shape D0: Heat death (AVOID)
+
+> **Shape D0 — Heat death (AVOID)** · `degenerate x = 0 (monoculture)`
+> Collapse to zero diversity — keep UNREACHABLE (diversity floor >=2 forbids it). D's degenerate well.
+
+A **universal shape** applicable to all `/travelers` and all `/persona` (surfaced as
+`universal/d0`, a symlink here). Canonical home = `shapes/d0`. From the A–F fixed-point catalog;
+see `shapes/README.md`.

--- a/shapes/e.md
+++ b/shapes/e.md
@@ -1,0 +1,8 @@
+# shapes/e — Shape E: Co-arising bootstrap
+
+> **Shape E — Co-arising bootstrap** · `a = f(b) and b = g(a), solved simultaneously`
+> A PAIR that fixes each other — no first; the nonzero ground state. Anchor: zero-point/vacuum energy (Casimir, peeled metaphor).
+
+A **universal shape** applicable to all `/travelers` and all `/persona` (surfaced as
+`universal/e`, a symlink here). Canonical home = `shapes/e`. From the A–F fixed-point catalog;
+see `shapes/README.md`.

--- a/shapes/f.md
+++ b/shapes/f.md
@@ -1,0 +1,8 @@
+# shapes/f — Shape F: Generative / societal-expansion
+
+> **Shape F — Generative / societal-expansion** · `fixed point of an apply-the-maps operator`
+> Expands OUTWARD — bounded per-member, unbounded in count, self-similar; terminates infinite ascension (runaway = fork-bomb to catch). Anchors: Hutchinson (IFS), Friston.
+
+A **universal shape** applicable to all `/travelers` and all `/persona` (surfaced as
+`universal/f`, a symlink here). Canonical home = `shapes/f`. From the A–F fixed-point catalog;
+see `shapes/README.md`.

--- a/universal/a.md
+++ b/universal/a.md
@@ -1,0 +1,1 @@
+../shapes/a.md

--- a/universal/b.md
+++ b/universal/b.md
@@ -1,0 +1,1 @@
+../shapes/b.md

--- a/universal/c.md
+++ b/universal/c.md
@@ -1,0 +1,1 @@
+../shapes/c.md

--- a/universal/d.md
+++ b/universal/d.md
@@ -1,0 +1,1 @@
+../shapes/d.md

--- a/universal/d0.md
+++ b/universal/d0.md
@@ -1,0 +1,1 @@
+../shapes/d0.md

--- a/universal/e.md
+++ b/universal/e.md
@@ -1,0 +1,1 @@
+../shapes/e.md

--- a/universal/f.md
+++ b/universal/f.md
@@ -1,0 +1,1 @@
+../shapes/f.md


### PR DESCRIPTION
shapes/ = canonical home of the A-F fixed-point shape catalog (a,b,c,d,d0,e,f) from the shape-letter doc; universal/<letter> are git mode-120000 symlinks -> ../shapes/<letter>.md (universal shapes for all travelers/personas; canonical/symlink DAG, multi-parent). markdownlint clean.