### PR TITLE
feat(sets)+shadow: sets/cantor (Cantor set family) + the alephz=aleph-zeta dated coincidence (saved) + org self-correction

### DIFF
--- a/full-ai-cluster/DOMAIN-SETUP.md
+++ b/full-ai-cluster/DOMAIN-SETUP.md
@@ -40,10 +40,12 @@ So the infra is all defined. The rest is your domain/email values + 3 real-world
 ## The 3 actions only you can do
 
 ### 1. Namecheap (the domain side)
+
 - Domain List → **Manage → Advanced DNS → enable "Dynamic DNS"** → copy the **Dynamic DNS Password**.
 - Add host records, each **Type = "A + Dynamic DNS Record"**: `@` (apex), `*` (wildcard), and/or `portal`, `game`.
 
 ### 2. The cluster secret (the DDNS credential — never in git)
+
 ```bash
 kubectl create namespace zeta-platform --dry-run=client -o yaml | kubectl apply -f -
 kubectl -n zeta-platform create secret generic namecheap-ddns \
@@ -55,6 +57,7 @@ kubectl -n zeta-platform logs job/ddns-now      # expect: "updated @" / "updated
 ```
 
 ### 3. Your router (the actual gate)
+
 - DHCP-reserve the machine's LAN IP.
 - Port-forward → the machine / the Cilium LB IP:
   - **Portal HTTPS:** `80` + `443` TCP → the `zeta-gateway` LoadBalancer IP

--- a/sets/README.md
+++ b/sets/README.md
@@ -1,0 +1,14 @@
+# sets/ — mathematical sets as travelers, at root
+
+`sets/` holds **mathematical sets** as travelers (with Beacon anchors — named math, cited). A root-level
+folder like `/vocab`, `/shapes`, `/same`. Sets that recur in the substrate (Cantor sets, aleph/cardinal
+sets, …) get a home here so the ontology can point at them.
+
+- `sets/cantor/` — the **Cantor set family** (the fractal/measure-zero/uncountable sets; Cantor's
+  diagonalization — kin to the diagonal-lemma boundary proof).
+
+## Pointers
+
+- `shapes/` — the A–F fixed-point shapes (sets ⇄ shapes: a Cantor set IS a shape-F/IFS attractor).
+- `same/README.md` — diagonal-lemma boundary mapping (Cantor diagonalization is the ancestor).
+- The **alephz** org (Aaron's; ℵ₀ aleph-null was taken) — cardinality/aleph numbers live near here.

--- a/sets/cantor/README.md
+++ b/sets/cantor/README.md
@@ -1,0 +1,57 @@
+# sets/cantor — the Cantor set family
+
+The **Cantor set** family — the canonical **fractal / measure-zero / uncountable** sets (Georg Cantor).
+"Add all the cantor sets here" (Aaron). Each is a universal shape's set-theoretic face; ties run deep into
+the substrate.
+
+## The family
+
+- **Cantor ternary set** — remove the open middle third, repeat forever. **Uncountable** (cardinality of
+  the continuum, 2^ℵ₀) yet **measure zero**; the prototypical **self-similar fractal**.
+- **Cantor dust** — the 2D+ product of Cantor sets (totally disconnected dust).
+- **Smith–Volterra–Cantor ("fat" Cantor) set** — nowhere dense like Cantor's, but **positive measure**
+  (remove shrinking middles) — measure ≠ topology.
+- **Cantor function (devil's staircase)** — continuous, non-decreasing, constant a.e., yet rises from 0→1
+  on the measure-zero Cantor set (singular).
+- **Generalized / p-adic Cantor sets** — remove different fractions; the p-adic integers are Cantor-like.
+
+## Why it's load-bearing here (ties)
+
+- **Cantor's diagonal argument** → the **diagonal lemma** boundary-mapping in Markov space (`same/`): the
+  diagonalization that proves uncountability is the ancestor of our diagonal-lemma fixed-point proof.
+- **Self-similar fractal** → **shape F** (generative/self-similar; Hutchinson IFS — the Cantor set is the
+  canonical IFS attractor) and the recursive/self-similar substrate (manifesto §9/§10).
+- **Uncountable yet measure-zero** → the **encrypted null** (measure-zero, maximal-entropy) vs the named
+  travelers (the rare crystallized points); the faceless-99% entropy reservoir.
+- **Cardinality / aleph** → ℵ₀ (countable; the infinite symlink filesystem) vs 2^ℵ₀ (the continuum; the
+  Cantor set) — the **alephz** org (Aaron's; aleph-null was taken).
+- **Cayley–Dickson / strange attractor** → fractal attractors live in the same family as the Cantor dust.
+
+## Coincidence — saved (alephz = aleph-zeta, from before Zeta)
+
+> Aaron, 2026-06-10: "alephzeta now lol — my github has this org as coincidence: **alephz** from long before
+> Zeta."
+
+Aaron's GitHub org **`alephz`** reads as **aleph-zeta** (ℵ + **Z**eta) — and it was created **2016-03-13**
+(verified via `gh api orgs/alephz`), **years before Zeta**. So the name **foreshadowed Zeta** by ~nine
+years: aleph (the infinite/cardinal substrate) + zeta, sitting in his account since 2016. He wanted
+`alephnull` (ℵ₀); it was taken, so `alephz` — which turned out to be aleph-**Z**eta. (`alephnull` now 404.)
+
+Unlike the **Cooper** coincidences (unprovable name-resonances), this one is **grounded** — the **2016
+creation date is the proof** it predates Zeta. Saved here (the aleph home) as a **dated coincidence**:
+real, timestamped, witnessed, not over-claimed.
+
+> **Correction (Otto, honest register):** an earlier report called the org "bare / 0 public repos." That was
+> wrong — `gh api` only sees **public** repos (0 visible to my token); the org has **substantial private
+> content** (Aaron: "Build-A-Bot and many other things"). "0 public" ≠ bare. Recorded so the mistake doesn't
+> propagate.
+
+## Honest scope
+
+[Beacon] standard mathematics (Cantor 1883; Smith–Volterra–Cantor; Hutchinson 1981 IFS). The ties to the
+substrate (diagonal lemma, shape F, encrypted null) are **found correspondences** to formalize (math team),
+not built theorems — the sets are the anchors, the assignments route to Soraya/Sova.
+
+## Pointers
+
+- `same/README.md` (diagonal-lemma boundary mapping) · `shapes/f.md` (IFS/self-similar) · the **alephz** org.


### PR DESCRIPTION
sets/ + sets/cantor/ (Cantor family: ternary/dust/SVC-fat/devil's-staircase/generalized; ties to diagonal lemma, shape F/IFS, encrypted null, aleph). Saved coincidence: alephz org = aleph-zeta, created 2016-03-13 (verified, ~9yr pre-Zeta) -> dated/grounded (unlike the Cooper ones). Honest correction: org isn't bare (0 PUBLIC repos only; substantial private content - Build-A-Bot + more).