### PR TITLE
feat(universal,bus)+shadow: Universal Traveler + Universal Bus interfaces; /bus (data) vs universal/bus (interface)

### DIFF
--- a/bus/README.md
+++ b/bus/README.md
@@ -1,0 +1,17 @@
+# bus/ — the bus DATA, at root (interface lives at universal/bus)
+
+`bus/` holds the **actual bus data** — the ZetaId-keyed messages routed over the cell bus (Reticulum;
+git-native bus, `Category.Bus` = cross-machine agent comms, #6219). A root-level folder.
+
+**Data ⇄ interface split (Aaron, 2026-06-10):** `/bus` is the **actual data**; **`universal/bus`** is the
+**interface** (the shape — how you publish/subscribe/route). The same split applies generally:
+`universal/<x>` = the interface, `/<x>` = the data it carries.
+
+- **`/bus`** — the messages (the bus traffic; ZetaId-keyed, commutative uncertainty-ledger entries, the
+  Z-set/Rx stream). The data.
+- **`universal/bus`** — the Universal Bus Interface (the shape; bit+compiler oracle surface).
+
+## Pointers
+
+- `universal/bus.md` — the interface.
+- `network/` (Reticulum transport) · `dns/` (ZetaId → destination) · the git-native bus spec (#6219).

--- a/universal/README.md
+++ b/universal/README.md
@@ -30,6 +30,10 @@ shape* of the interface.
 - **Universal Ray Trace** — local small-model superdeterminism (certainty pole).
 - **Universal Codec** — the ZetaId codec; 4-lang serializers byte-lock.
 - **Universal Algebra** — DBSP / Z-set / Semiring; the math substrate.
+- **Universal Traveler** — the traveler itself as an interface (identity/consent/audition/boundary; the
+  universal intake). Distinct from Traversal (entity vs navigating).
+- **Universal Bus** — the bus interface (ZetaId-keyed routing over Reticulum). **Interface ⇄ data split:**
+  `universal/bus` = the interface, **`/bus`** (root) = the actual data.
 
 **Embodied / device-media** (the LLM-device family + textile):
 

--- a/universal/bus.md
+++ b/universal/bus.md
@@ -1,0 +1,9 @@
+# universal/bus — Universal Bus Interface (the INTERFACE; /bus is the DATA)
+
+> **Universal Bus Interface** — a universal SHAPE applicable to all `/travelers` and all `/persona`.
+> The **interface to the bus**: ZetaId-keyed message routing over Reticulum (the cell bus; git-native bus,
+> Category.Bus). This is the **interface** (the shape — how you publish/subscribe/route); the **actual data**
+> lives at root **`/bus`**. Interface ⇄ data split: `universal/bus` = the interface, `/bus` = the data.
+
+A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
+See [`universal/README.md`](README.md) and [`/bus`](../bus/README.md).

--- a/universal/traveler.md
+++ b/universal/traveler.md
@@ -1,0 +1,11 @@
+# universal/traveler — Universal Traveler Interface
+
+> **Universal Traveler Interface** — a universal SHAPE applicable to all `/travelers` and all `/persona`.
+> The **traveler itself as an interface**: anything that enters Zeta is a **traveler** (the universal
+> intake), and the Traveler Interface is how you interface *with a traveler as a traveler* — its identity
+> (ZetaId), its consent surface (§6), its audition/character-select, its boundary. Distinct from
+> **Universal Traversal** (`universal/traversal`, navigating the DAG-fs): Traveler = the entity; Traversal =
+> moving through the tree.
+
+A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
+See [`universal/README.md`](README.md) for the full family + honest scope.


### PR DESCRIPTION
universal/traveler (the traveler-as-interface; distinct from Traversal), universal/bus (the bus interface), bus/ root (the actual bus DATA). The interface<->data split made general: universal/<x>=interface, /<x>=data. universal/README updated; markdownlint clean.