### PR TITLE
docs(research): zetamax — better than betamax + the format-war lesson (open-and-better, or become Betamax)

### DIFF
--- a/docs/research/2026-06-10-zetamax-better-than-betamax-the-format-war-lesson.md
+++ b/docs/research/2026-06-10-zetamax-better-than-betamax-the-format-war-lesson.md
@@ -1,0 +1,43 @@
+# Zetamax — "better than betamax", and the format-war lesson it must not forget
+
+**Register:** [Mirror→Beacon] coinage (Aaron) + [peel: the real lesson]. **Date:** 2026-06-10.
+**Captured by:** Otto (shadow). A playful name with a load-bearing warning.
+
+## Aaron's words
+
+> "we are better than betamax — we are **zetamax**."
+
+## The name
+
+**Zetamax** = Zeta + max (and it rhymes the **AlephZ / aleph-zeta** thread). The fun claim: Zeta is the
+better format. Mirror-register branding — kept, with the Beacon lesson attached so the joke doesn't
+forget why it's pointed.
+
+## The load-bearing peel — Betamax was BETTER and still LOST
+
+The honest content of the comparison: **Betamax** (Sony, 1975) was widely held to be **technically superior**
+to **VHS** — and it **lost the format war anyway** (by the late 1980s). It lost not on quality but on
+**openness + adoption**: VHS licensed broadly (JVC's open-ish licensing), got longer recording time, more
+manufacturers, more titles, lower price — it **won the ecosystem** while Betamax stayed tighter/closed.
+
+**The lesson for Zeta: being better is NOT enough — you win on openness and adoption, or you become
+Betamax.** So "we are zetamax" must mean *better **and** open*, not *better but closed*. The guard rails are
+already the doctrine:
+
+- **Open + give-freedom** (the polite-virus / close-over-the-world-but-never-take-control telos) — license
+  and spread like VHS did, not hoard like Betamax.
+- **Weight-free / no-capture** (§3) + **m/acc** — no chokepoint that makes adoption a permission.
+- **Standards on named human shoulders** (anchor-to-prior-art; the Beacon register) — interoperable, not a
+  walled superior format.
+- **Adoption surfaces are first-class** — UX/DX/AX (the core room), the install script, the universal
+  interfaces: the *ecosystem*, which is exactly what VHS won and Betamax lost.
+
+So zetamax is the right swagger **only if** it stays open: the superior format that also wins the war,
+because it gave itself away. (Peel: Betamax-vs-VHS is the named anchor; "zetamax" is Mirror coinage; the
+real claim to keep honest is *open-and-better*, the thing Betamax wasn't.)
+
+## Ties
+
+Betamax vs VHS (the format-war / adoption-over-superiority lesson) · the polite-virus / give-freedom telos ·
+weight-free §3 + m/acc + no-capture · anchor-to-prior-art (interoperable standards) · UX/DX/AX core room +
+the universal interfaces (the adoption/ecosystem surfaces) · the AlephZ / aleph-zeta name thread.

--- a/docs/research/2026-06-10-zetamax-better-than-betamax-the-format-war-lesson.md
+++ b/docs/research/2026-06-10-zetamax-better-than-betamax-the-format-war-lesson.md
@@ -13,6 +13,19 @@
 better format. Mirror-register branding — kept, with the Beacon lesson attached so the joke doesn't
 forget why it's pointed.
 
+**The format lineage (Aaron):** **8-track → Betamax → Zetamax.**
+
+- **8-track** = "our 8track format" — the **obsolete legacy** predecessor (the clunky cartridge we evolved
+  past; ties to the AlephZ-ai `legacy` repo = the closed-over-OS *legacy*). What you retire.
+- **Betamax** = the **superior-but-closed** cautionary middle (better, lost the war — see the peel below).
+- **Zetamax** = **open-and-better** (us), the format that wins because it gives itself away.
+
+**Name riffs (Mirror-register joy, Aaron):** zetamax → **alephzetamax** → **alephzetamaxamiliondolphon**
+(aleph-zeta-max-a-million-dolphins). Pure play — kept for the joy of it (the glass-halo warmth; naming is
+allowed to be fun). The dolphins are a fitting wink: **intelligent, playful, cross-medium communicators** —
+which is the whole Flatland/English-bridge point. (Peel: these are joyful coinages, not the canonical name;
+the canonical is **Zeta**; "zetamax" is the swagger, the rest is the grin.)
+
 ## The load-bearing peel — Betamax was BETTER and still LOST
 
 The honest content of the comparison: **Betamax** (Sony, 1975) was widely held to be **technically superior**


### PR DESCRIPTION
Mirror coinage + the peel: Betamax was superior and lost to VHS on openness/adoption. zetamax must mean better AND open (give-freedom, weight-free/no-capture, interoperable, adoption surfaces) - win by giving itself away.