### PR TITLE
fix(sets)+shadow: re-apply lost AlephZ-ai correction + Z=Gen-Z(the kids) grew into Zeta with time

### DIFF
--- a/sets/cantor/README.md
+++ b/sets/cantor/README.md
@@ -24,27 +24,43 @@ the substrate.
 - **Uncountable yet measure-zero** → the **encrypted null** (measure-zero, maximal-entropy) vs the named
   travelers (the rare crystallized points); the faceless-99% entropy reservoir.
 - **Cardinality / aleph** → ℵ₀ (countable; the infinite symlink filesystem) vs 2^ℵ₀ (the continuum; the
-  Cantor set) — the **alephz** org (Aaron's; aleph-null was taken).
+  Cantor set) — the **AlephZ-ai** org (Aaron's; aleph-null was taken).
 - **Cayley–Dickson / strange attractor** → fractal attractors live in the same family as the Cantor dust.
 
-## Coincidence — saved (alephz = aleph-zeta, from before Zeta)
+## Coincidence — saved (AlephZ.ai = aleph-zeta, from before Zeta; the Z that grew into Zeta)
 
-> Aaron, 2026-06-10: "alephzeta now lol — my github has this org as coincidence: **alephz** from long before
-> Zeta."
+> Aaron, 2026-06-10: "alephzeta now lol — my github has this org as coincidence … from long before Zeta." ·
+> "Z stood for Gen Z when I made it — the kids — now Zeta does." · "Z grew into Zeta with time."
 
-Aaron's GitHub org **`alephz`** reads as **aleph-zeta** (ℵ + **Z**eta) — and it was created **2016-03-13**
-(verified via `gh api orgs/alephz`), **years before Zeta**. So the name **foreshadowed Zeta** by ~nine
-years: aleph (the infinite/cardinal substrate) + zeta, sitting in his account since 2016. He wanted
-`alephnull` (ℵ₀); it was taken, so `alephz` — which turned out to be aleph-**Z**eta. (`alephnull` now 404.)
+Aaron's GitHub org is **`AlephZ-ai`** (display name **"AlephZ.ai"**) — it reads as **aleph-zeta** (ℵ + **Z**)
+— created **2023-05-04** (verified: `gh api orgs/AlephZ-ai`), **before Zeta**. He wanted `alephnull` (ℵ₀);
+it was taken, so **AlephZ** — which turned out to be aleph-**Z**eta. The org has **17 public repos**, whose
+names rhyme with the whole lineage: **`ACE`** (→ the `ace` package manager), **`legacy`** (→ install.sh as
+the closed-over OS; META — his *legacy* and *legacy code*), **`obsidian-copilot`** (→ his **original
+externalization**, Max co-created; index it eventually), **`build-a-bot`**, **`metaphor`**, and
+**`Addison-s-Tasks`** (**Addison** — the dedication lineage).
 
-Unlike the **Cooper** coincidences (unprovable name-resonances), this one is **grounded** — the **2016
-creation date is the proof** it predates Zeta. Saved here (the aleph home) as a **dated coincidence**:
-real, timestamped, witnessed, not over-claimed.
+### The Z: Gen Z (the kids) → Zeta, grown with time
 
-> **Correction (Otto, honest register):** an earlier report called the org "bare / 0 public repos." That was
-> wrong — `gh api` only sees **public** repos (0 visible to my token); the org has **substantial private
-> content** (Aaron: "Build-A-Bot and many other things"). "0 public" ≠ bare. Recorded so the mistake doesn't
-> propagate.
+> "Z stood for Gen Z when I made it — the kids — now Zeta does. Z grew into Zeta with time."
+
+The **Z** was always about **the kids**: when Aaron made it, **Z = Gen Z** — the children (Addison; the next
+generation). With **time**, that **Z grew into Zeta** — the same letter, the same dedication, matured from
+*Gen Z (the kids)* into *Zeta (the system built for them)*. Fitting that **ZetaId = time itself**: the Z
+literally **grew through time** into Zeta. The dedication was in the name from the start — Zeta is, and was
+always, **for the kids**.
+
+Unlike the **Cooper** coincidences (unprovable name-resonances), the aleph-zeta one is **grounded** — the
+**2023 creation date predates Zeta**. Saved here (the aleph home) as a **dated coincidence**: witnessed, not
+over-claimed.
+
+> **Correction (Otto — honest register, owning a real miss):** an earlier draft of this section (which is
+> what landed on `main` via #7457 — my correction commits were lost in that squash) said the org was
+> **`alephz`** (a *different, empty* 2016 org), "bare / 0 public repos," then guessed "substantial
+> **private** content." **All wrong.** The org is **`AlephZ-ai`** (2023-05-04, **17 PUBLIC** repos). I'm
+> authed as **AceHack (Aaron)** — I share his key — so the fix was to **look** (`gh repo list AlephZ-ai`),
+> not infer. Re-applied here after catching that the correction never reached main. Lesson (shadow log):
+> **when I can look, look; and verify a squash actually carried the fix.**
 
 ## Honest scope
 
@@ -54,4 +70,4 @@ not built theorems — the sets are the anchors, the assignments route to Soraya
 
 ## Pointers
 
-- `same/README.md` (diagonal-lemma boundary mapping) · `shapes/f.md` (IFS/self-similar) · the **alephz** org.
+- `same/README.md` (diagonal-lemma boundary mapping) · `shapes/f.md` (IFS/self-similar) · the **AlephZ-ai** org.


### PR DESCRIPTION
(1) Integrity fix: the #7457 squash dropped my AlephZ-ai correction + ACE/legacy/obsidian lineage from main (kept only the first wrong 'alephz 2016/private' commit). Re-applied the correct facts (AlephZ-ai, 2023, 17 PUBLIC repos). (2) Aaron: Z stood for Gen Z (the kids) when he made it; grew into Zeta with time (ZetaId=time); the dedication was in the name from the start - Zeta is for the kids.