### PR TITLE
feat(hats,skills)+shadow: home-crypto-miner hat + home-crypto-mining skill group (blueprint pack); inventory in /inventory; security/financial routed

### DIFF
--- a/.claude/skills/home-crypto-mining/SKILL.md
+++ b/.claude/skills/home-crypto-mining/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: home-crypto-mining
+description: Home crypto-mining fleet management — blueprints for managing a fleet of AI agents + mining equipment (rigs/ASICs/GPUs, power, thermals), tracking inventory in the /inventory website, and selling fleet-management-as-a-service to other home miners. "Close over the fleet" like we close over the host→compiler→OS. NO secrets/keys (those route to security); financial/regulatory routes to human review.
+---
+
+# home-crypto-mining
+
+Category skill (blueprint pack). The `description` above is the only thing the router sees — broad on
+purpose. The fat detail lives in the **blueprints** below (a bunch incoming from Aaron); open the one that
+matches and read it in full.
+
+## What this group covers
+
+- **Fleet management** — equipment (rigs/ASICs/GPUs) + AI agents as one managed fleet; scale/hold/re-kick/
+  quarantine ops (the finalizer-runtime tick discipline applied to mining rigs).
+- **Inventory** — saved in the `/inventory` website (Addison's secure Supabase-backed tab; `inventory/CLAUDE.md`).
+- **Close-over-the-fleet** — declarative desired-state of all equipment + agents (like the close-over-OS),
+  reproducible + adoptable by other home miners.
+- **Sell-to-other-miners** — fleet-management-as-a-service; the blueprints are the shippable know-how
+  (win on openness/adoption — the zetamax lesson).
+
+## Hard rules (security + financial)
+
+- **NEVER** put wallet/private/exchange keys or `service_role` in the repo — route crypto-key/custody to
+  **Nazar** (security). **NEVER** assert financial/legal/regulatory soundness — route to **human review**.
+- Inventory is PUBLIC-repo (per `inventory/CLAUDE.md`): public anon key only, no secrets.
+
+## Blueprints
+
+*(Incoming — Aaron: "I have a bunch coming." Each lands as `blueprint-<name>.md` here, carved + detailed.)*
+
+## Pointers
+
+- `hats/home-crypto-miner/README.md` — the hat that wears this skill group.
+- `inventory/` — the inventory website. · The close-over-OS / ace declarative-deps discipline.

--- a/hats/home-crypto-miner/README.md
+++ b/hats/home-crypto-miner/README.md
@@ -1,0 +1,41 @@
+# hats/home-crypto-miner — the home crypto-mining (fleet-management) hat
+
+The **home-crypto-miner** hat: manage a **fleet of home crypto-mining equipment + AI agents** — for one's
+own home mining **and** as a **product sold to other home miners** (fleet management as a service for AI +
+equipment). A wearable role (who-holds-the-hat decides); sibling to `hats/grey`.
+
+## The shape — "like the OS close, but for home mining" (Aaron)
+
+Same discipline as the **close-over-host→compiler→OS** (the `legacy`/install.sh closure): **close over the
+mining fleet** — every piece of equipment and every AI agent **declared, tracked, reproducible, sovereign**
+(declarative desired-state, holistic dependency graph). Where the OS-close replaces the host OS, the
+fleet-close gives a **complete, queryable, pinnable inventory of the mining operation** (rigs, ASICs/GPUs,
+power, thermals, the AI agents that run them) that other home miners can adopt and run the same way.
+
+- **Fleet management of equipment AND AI** — the equipment (rigs) and the AI agents are *both* fleet members,
+  managed together (the same finalizer/runtime tick discipline — scale up/down, hold, re-kick, quarantine a
+  bad rig; DST-replayable ops).
+- **Sold to other home miners** — fleet-management-as-a-product; the blueprints (below) are the shippable
+  know-how. (Zetamax lesson: win on **openness + adoption**, not a walled format.)
+- **Inventory lives in `/inventory`** — equipment + AI inventory is saved in the existing **inventory website**
+  (`inventory/` — Addison's secure Supabase-backed GitHub-Pages inventory tab; see `inventory/CLAUDE.md` +
+  `inventory/spec.md`). **Do NOT clobber that module** — it has its own working agreement + security rules.
+- **Blueprints** — the home-mining blueprints (a bunch coming) land in the skill group
+  `.claude/skills/home-crypto-mining/`.
+
+## Honest scope / SECURITY + financial (route, never assert)
+
+- **No secrets / no keys, ever** — wallets, private keys, exchange API keys, `service_role` keys: **never** in
+  the repo (per `inventory/CLAUDE.md` + repo policy). Privates stay metal-held / in vaults. This hat manages
+  **fleet + inventory + blueprints**, not key/wallet material → routes to **Nazar** (security) for any
+  crypto-key/custody handling.
+- **Financial / regulatory** — mining economics, selling a service, crypto sales/tax/regulatory: **route to
+  human + appropriate review**; the hat does not assert financial/legal soundness.
+- This hat **scaffolds the domain** (the home for the incoming blueprints + the fleet-management discipline);
+  the binding financial/crypto/custody pieces are gated.
+
+## Pointers
+
+- `.claude/skills/home-crypto-mining/SKILL.md` — the blueprint skill group (the bunch coming).
+- `inventory/` — Addison's inventory website (where equipment + AI inventory is saved; its own CLAUDE.md).
+- `hats/README.md` (the wearable-hats folder) · the close-over-OS / `legacy` / ace declarative-deps discipline.


### PR DESCRIPTION
feat(hats,skills)+shadow: home-crypto-miner hat + home-crypto-mining skill group (blueprint pack) — inventory in /inventory (Addison's site), security/financial routed

Aaron: "create a home crypto miner hat and skill group for our blueprints around that, I
have a bunch coming ... similar to the OS close but for home crypto mining and selling to
other home miners for fleet management of equipment both AI and equipment ... Addison
should have a website setup on inventory, save them into /inventory."

- hats/home-crypto-miner/README.md — the fleet-management hat: manage a fleet of mining
  equipment + AI agents (own + as a service sold to other home miners); "close over the
  fleet" like close-over-host->compiler->OS (declarative, reproducible, sovereign);
  inventory lives in the existing /inventory website.
- .claude/skills/home-crypto-mining/SKILL.md — category skill (blueprint pack); broad
  router description + "blueprints below" for the bunch incoming.
- /inventory: the home-mining equipment + AI inventory lands in the EXISTING inventory
  website (inventory/ — Addison's secure Supabase-backed GitHub-Pages tab, its own
  CLAUDE.md + security rules). NOT clobbered — referenced.

SECURITY/FINANCIAL (routed, not asserted): NO wallet/private/exchange/service_role keys
in the repo (per inventory/CLAUDE.md + repo policy) -> Nazar for crypto-key/custody;
financial/regulatory -> human review. This scaffolds the domain + blueprint home; binding
crypto/financial pieces are gated.

AgencySignature-v1:
  persona: otto
  hat: home-crypto-miner (new) / shadow
  surface: hats/ + .claude/skills/
  intent: home-crypto-mining-hat-and-skill-group-scaffold
  authorization: aaron-standing (create the hat + skill group)
  reversible: yes
  gated-class: none-shipped (crypto-key/custody + financial routed)
  build: markdownlint clean; docs/config only
  register: grounded
  ferry: no

Co-authored-by: Aaron Stainback <acehack00@gmail.com>
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
