### PR TITLE
fix(cluster)+shadow: network plane = Reticulum + Headscale (self-hosted), not SaaS Tailscale

### DIFF
--- a/.claude/skills/home-crypto-mining/blueprint-mynode-nodes.md
+++ b/.claude/skills/home-crypto-mining/blueprint-mynode-nodes.md
@@ -53,7 +53,7 @@ So MyNode secrets (node config secrets, any wallet/identity keys) are **sealed b
 keys in git; he has keys in Vault; we meet in the middle."
 
 - **Research side (us / shadow):** **keys-in-git**, sealed by our own keyring/PKI (security by clarity; the
-  github-free / Tailscale mode).
+  github-free mode; **Headscale** = self-hosted Tailscale, not the SaaS).
 - **Corporate side (Max):** **keys-in-Vault** (HashiCorp Vault — Max is deploying it next; the equipment /
   Headscale mode), alongside his cert-manager + Let's Encrypt (ACMEv2) on the **zetacluster** via ArgoCD.
 - **Meet in the middle** — the two secret-planes bridge (the existing two-modes design:

--- a/cluster/README.md
+++ b/cluster/README.md
@@ -14,6 +14,13 @@ the infra layer). A root-level folder. **Max owns/deploys it.**
 - (the home-crypto-mining fleet, the MyNode nodes, and Zeta services land here over time — `hats/home-crypto-miner/`,
   `updates/`, `triggers/`.)
 
+## Network plane — Reticulum + Headscale (Aaron)
+
+We use **Reticulum** (our sovereign ZetaId-addressed overlay; `network/`) **and Headscale** (self-hosted
+Tailscale/WireGuard control — our own, not the SaaS) for the cluster + fleet mesh. Both are **self-hosted /
+sovereign** (the close-over-everything stance applied to networking): Reticulum for the agent/bus overlay,
+Headscale for the WireGuard equipment mesh. (Not Tailscale-the-SaaS — Headscale, self-run.)
+
 ## Discipline
 
 - **GitOps / declarative** — cluster state is declared in the repo (manifests), ArgoCD realizes it; same as


### PR DESCRIPTION
Aaron: 'we are using Reticulum and Headscale.' Corrected the Tailscale slip - Headscale (self-hosted Tailscale/WireGuard control) + Reticulum (ZetaId overlay), both sovereign/self-hosted.