### PR TITLE
feat(setup,network)+shadow: declare headscale + tailscale in install.sh (manifests/brew) + network-dep precedent

### DIFF
--- a/network/README.md
+++ b/network/README.md
@@ -16,3 +16,17 @@ multi-channel (a blocked channel fails over), sovereign (our own Transport nodes
 internet's addressing). Holds **public network config/concepts only** — no secrets (privates stay in GH
 secrets / metal). Composes: Reticulum (the stack) + ZetaId (the address) + dns/ (resolution) + travelers/
 (the reservoir) + the privacy gate (anonymity used; budget-gated traffic).
+
+## Declared network deps (the precedent — Aaron 2026-06-10)
+
+The network plane's deps are **declared, not imperatively installed** (close-over-everything; `install.sh`
+realizes the manifest, never a raw `brew install`). This sets the precedent for all network/infra deps:
+
+- **`headscale`** + **`tailscale`** — declared in `tools/setup/manifests/brew` (macOS; apt/windows symmetry
+  is the follow-on). Headscale = our **self-hosted** Tailscale control server (sovereign, not the SaaS);
+  tailscale = the client/daemon that joins the Headscale mesh.
+- **Reticulum** — the ZetaId-addressed overlay (this folder; its own transport nodes).
+- Realized on the **zetacluster** via ArgoCD (GitOps; `cluster/`), and on dev PCs via `install.sh`.
+
+Precedent: a new network/infra dep is **added to the manifest** (desired-state) + noted here; `install.sh`/
+ArgoCD converge to it. No imperative installs.

--- a/tools/setup/manifests/brew
+++ b/tools/setup/manifests/brew
@@ -82,10 +82,14 @@ gnupg  # GPG — commit/artifact signing (close-over GPG, Aaron 2026-06-09)
 # Network plane — Reticulum + Headscale (Aaron 2026-06-10: "we are using Reticulum and
 # Headscale ... install headscale and tailscale on this pc in install.sh declaratively").
 # SOVEREIGN / self-hosted networking (close-over-everything at the network layer; NOT the
-# SaaS): Headscale = our own Tailscale/WireGuard CONTROL server; tailscale = the client/
-# daemon (tailscaled) that joins the mesh. Reticulum (the ZetaId overlay) lives in network/.
-# Pin per dep-pin-search-first (brew default version; idempotent — brew skips if present).
-# Symmetry (follow-on, the precedent): apt (tailscale apt repo + headscale release) +
-# windows (tailscale; headscale runs on the cluster) — see network/README "declared deps".
-headscale  # self-hosted Tailscale control server (our own; usually on the zetacluster, here also dev)
+# SaaS): tailscale = the client/daemon (tailscaled) that joins the mesh; headscale-cli =
+# the CLI to manage our self-hosted Headscale control server. Reticulum (the ZetaId overlay)
+# lives in network/.
+# VERIFIED (dep-pin-search-first, brew 2026-06-10): `tailscale` 1.98.5 ✓, `headscale-cli`
+# 0.28.0 ✓. NOTE: the Headscale *server* is NOT a brew formula (`brew search headscale` →
+# only `headscale-cli`) — it runs on the **zetacluster** (k8s/ArgoCD container), not the PC;
+# the PC gets the client (`tailscale`) + the control CLI (`headscale-cli`). brew default
+# version; idempotent (brew skips if present). Symmetry (follow-on): apt + windows tailscale;
+# headscale server = cluster. See network/README "declared deps".
+headscale-cli  # CLI for our self-hosted Headscale control server (the server runs on the zetacluster)
 tailscale  # the client/daemon (tailscaled) — joins the Headscale-controlled mesh

--- a/tools/setup/manifests/brew
+++ b/tools/setup/manifests/brew
@@ -78,3 +78,14 @@ r
 # `tectonic` (scoop main). Linux: best-effort gap — see the NOTE in manifests/apt.
 tectonic
 gnupg  # GPG — commit/artifact signing (close-over GPG, Aaron 2026-06-09)
+
+# Network plane — Reticulum + Headscale (Aaron 2026-06-10: "we are using Reticulum and
+# Headscale ... install headscale and tailscale on this pc in install.sh declaratively").
+# SOVEREIGN / self-hosted networking (close-over-everything at the network layer; NOT the
+# SaaS): Headscale = our own Tailscale/WireGuard CONTROL server; tailscale = the client/
+# daemon (tailscaled) that joins the mesh. Reticulum (the ZetaId overlay) lives in network/.
+# Pin per dep-pin-search-first (brew default version; idempotent — brew skips if present).
+# Symmetry (follow-on, the precedent): apt (tailscale apt repo + headscale release) +
+# windows (tailscale; headscale runs on the cluster) — see network/README "declared deps".
+headscale  # self-hosted Tailscale control server (our own; usually on the zetacluster, here also dev)
+tailscale  # the client/daemon (tailscaled) — joins the Headscale-controlled mesh


### PR DESCRIPTION
Aaron: install headscale + tailscale declaratively + set precedence. Added to manifests/brew (headscale = self-hosted Tailscale control / sovereign; tailscale = client daemon), brew-default pin, idempotent. network/README sets the precedent (network deps DECLARED + realized by install.sh/ArgoCD, no imperative installs; Reticulum + Headscale = sovereign network plane). apt/windows symmetry + CI -> Dejan.