### PR TITLE
feat(skills,routing)+shadow: /skills (content) + /routing (routing layer) root folders

### DIFF
--- a/routing/README.md
+++ b/routing/README.md
@@ -1,0 +1,18 @@
+# routing/ — the routing layer (content ⟷ router), at root
+
+`routing/` holds the **routing** — how a request finds the right skill/blueprint/traveler (Aaron 2026-06-10:
+"so a skills folder and a routing folder"). A root-level folder. Distinct from `skills/` (the **content**):
+routing **points at** content; it does not hold it.
+
+**Current routing impl:** `.claude/skills/` — the router-facing carved descriptions (broad `description:` =
+the only thing the router sees) that route to the blueprint content. Aaron: "skills/skill-groups in
+`.claude/` are really just for routing." This `routing/` folder is the **root-level home** for that routing
+concept; the exact wiring between `routing/`, `.claude/skills/`, and `skills/` (content) is to be figured out
+later — for now this marks the layer.
+
+Ties: ZetaId addressing (route to a destination) · `dns/` (name → address) · `network/` (the transport
+routing rides) · `same/` (the ctxboundary pair) · the bus (`/bus`, ZetaId-keyed routing).
+
+## Pointers
+
+- `skills/` — the content this routes to. · `.claude/skills/` — the current routing impl.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,21 @@
+# skills/ — our skills (the real content), at root
+
+`skills/` holds **our skills** — the real skill content / know-how (Aaron 2026-06-10: "in /skills at root we
+can do whatever we want; start adding our skills there"). A root-level folder.
+
+**Split (Aaron):** `skills/` (here) = the **content** (the actual skill, whatever shape we want); the
+**routing** to them lives in `routing/` (and, for now, in `.claude/skills/` — the router-facing carved
+descriptions). *Skills/skill-groups in `.claude/` are really just for routing.* The connection between
+`skills/` (content) and `.claude/skills` (routing) is to be wired later — for now we grow the content here.
+
+## Skills so far
+
+- `home-crypto-mining/` — home crypto-mining fleet management (the home-crypto-miner hat's know-how;
+  blueprints; the MyNode td5/td6 nodes). The real content; `.claude/skills/home-crypto-mining/` routes to it.
+
+(More incoming — Aaron: "I have a bunch coming.")
+
+## Pointers
+
+- `routing/` — the routing layer (content ⟷ router). · `.claude/skills/` — the current routing impl.
+- `hats/` — the hats that wear these skills.

--- a/skills/home-crypto-mining/SKILL.md
+++ b/skills/home-crypto-mining/SKILL.md
@@ -1,0 +1,25 @@
+# skill: home-crypto-mining (the real content)
+
+The **home-crypto-mining** skill — managing a fleet of AI agents + mining equipment (rigs/ASICs/GPUs), as
+one's own operation and as a service sold to other home miners. The **content** home (the `.claude/skills/
+home-crypto-mining/` entry is just the *routing* to here; Aaron: ".claude skills are for routing").
+
+Worn by the **home-crypto-miner hat** (`hats/home-crypto-miner/`).
+
+## Know-how / blueprints
+
+- **MyNode BTC nodes (td5, td6)** — see `.claude/skills/home-crypto-mining/blueprint-mynode-nodes.md`
+  (inventory in the `/inventory` website; USB from MyNode "model two"; the Zeta update trigger).
+- **Fleet management** — equipment + AI agents as one fleet (finalizer-runtime tick ops: scale/hold/
+  re-kick/quarantine).
+- **Close-over-the-fleet** — declarative desired-state of all equipment + agents (like close-over-OS).
+- **Sell-to-other-miners** — fleet-management-as-a-service.
+
+## Hard rules
+
+- Security by **clarity** (our own PKI/keyring; keys-in-git sealed, the encrypted null) — not obscurity.
+  Corporate side = keys-in-Vault (Max); research side = keys-in-git (us); meet in the middle.
+
+## Pointers
+
+- `hats/home-crypto-miner/` · `inventory/` · `updates/` + `triggers/` · `cluster/` + `full-ai-cluster/`.


### PR DESCRIPTION
skills/ = our skill content (seeded home-crypto-mining); routing/ = the routing layer (.claude/skills is the current routing impl; wiring TBD). Removed stray empty src/Core/tests-fsx; empty-folder audit clean (only gitignored build artifacts).