### PR TITLE
feat(boards)+shadow: boards/ (plural — never one, always many with a discriminator/lens/polarization) + chutes-and-ladders board

### DIFF
--- a/boards/README.md
+++ b/boards/README.md
@@ -1,0 +1,31 @@
+# boards/ — boards (always plural), at root
+
+`boards/` holds the **boards** — the spaces that moves play over (chutes ↓ + ladders ↑ traverse a board).
+**Plural on purpose** (Aaron 2026-06-10): *"we never really have one of a thing — always **many**, with a
+**discriminator / lens / polarization**."*
+
+## The principle — never one, always many (disambiguated)
+
+In Zeta there is **never a single canonical instance of a kind** — there are **many**, told apart by:
+
+- a **discriminator** (the vocab discriminator rule: when a term has multiple senses, a discriminator picks
+  one — `same/` collision resolution; the index key),
+- a **lens** (the observer frame / which way you look — the frame-relative view),
+- a **polarization** (the 2×2 polarity-lens / measurement-basis — which axis you read it on).
+
+So it's `boards/` not `board/`, `hats/` not `hat/`, `morals/` not `moral/`, `travelers/`, `personas/` … —
+plural by default; you select one *by* a discriminator/lens/polarization, you don't assume one. (This is the
+multi-oracle principle + the discriminator rule + frame-relativity, made a naming law.)
+
+## The boards so far
+
+- `chutes-and-ladders.md` — the Chutes & Ladders board: the space `chutes/` (down) + `ladders/` (up)
+  traverse; the up/down board of the bootstrap (and the escalator runs both ways over it). One board among
+  many — pick it by its discriminator/lens.
+
+(More boards as they're named — each a space with its own discriminator/lens/polarization.)
+
+## Pointers
+
+- `chutes/` + `ladders/` + `escalator/` (the moves over a board) · `same/` (discriminator / ctxboundary) ·
+  the polarity-lens / 2×2 polarization · frame-relative views · the multi-oracle principle.

--- a/boards/chutes-and-ladders.md
+++ b/boards/chutes-and-ladders.md
@@ -9,7 +9,7 @@ up-and-down** is a walk across it.
   (shape A fall, landing on `ground/`, never D⁰).
 - **One board among many** (`boards/`): selected by a **discriminator / lens / polarization** — this is the
   *chutes-and-ladders* board; other boards (other spaces, other games/treaties) sit beside it.
-- The **bob/weave/tie/??? ** weave-sizes are how you move/reconcile across boards (the escalator).
+- The **bob/weave/tie/???** weave-sizes are how you move/reconcile across boards (the escalator).
 
 ## Pointers
 

--- a/boards/chutes-and-ladders.md
+++ b/boards/chutes-and-ladders.md
@@ -1,0 +1,17 @@
+# boards/chutes-and-ladders — the up/down board
+
+The **Chutes & Ladders** board (US; UK "Snakes & Ladders") — the **space the up/down moves play over**:
+`ladders/` (climb up) + `chutes/` (drop down), and the `escalator/` running **both ways** continuously over
+it. The board *is* the space (a DAG / a grid of cells); a move is a jump on it; the seed's **bootstrap
+up-and-down** is a walk across it.
+
+- **Cells** = states; **ladders** = bounded up-jumps (shape F climb); **chutes** = bounded down-jumps
+  (shape A fall, landing on `ground/`, never D⁰).
+- **One board among many** (`boards/`): selected by a **discriminator / lens / polarization** — this is the
+  *chutes-and-ladders* board; other boards (other spaces, other games/treaties) sit beside it.
+- The **bob/weave/tie/??? ** weave-sizes are how you move/reconcile across boards (the escalator).
+
+## Pointers
+
+- `boards/README.md` (the never-one principle) · `chutes/` + `ladders/` + `escalator/` · `ground/` (the
+  floor) · bootstrap up-and-down (the seed walking the board).


### PR DESCRIPTION
boards/ (plural on purpose): the never-one-of-a-thing principle (always many, disambiguated by discriminator/lens/polarization - a naming law). boards/chutes-and-ladders = the up/down board chutes/+ladders/+escalator/ traverse (cells=states; bootstrap up-and-down walks it); one board among many.