### PR TITLE
fix(gate): restore green main — persona-keys tsc narrowing + keyring.sh allowlist + ops-k8s exactOptional

### DIFF
--- a/full-ai-cluster/portal/src/ops-k8s.ts
+++ b/full-ai-cluster/portal/src/ops-k8s.ts
@@ -114,7 +114,7 @@ export class K8sOps implements ResourceOps {
 
   async metrics(resource: string): Promise<Metrics> {
     const [ns, name] = split(resource);
-    const cfg = await this.config(resource).catch(() => ({ cpu: "1", memory: "512Mi", storage: undefined } as ResourceConfig));
+    const cfg = await this.config(resource).catch(() => ({ cpu: "1", memory: "512Mi" } as ResourceConfig));
     const limits = { cpuMilli: parseCpu(cfg.cpu), memMi: parseMemMi(cfg.memory) };
     const storageMi = cfg.storage ? parseMemMi(cfg.storage) : 0;
     try {

--- a/tools/hygiene/check-bash-retirement-inventory.ts
+++ b/tools/hygiene/check-bash-retirement-inventory.ts
@@ -113,6 +113,7 @@ export const EXPECTED_RETAINED_SHELL: readonly string[] = [
   "tools/setup/install.sh",
   "tools/setup/linux.sh",
   "tools/setup/macos.sh",
+  "tools/setup/persona-keys/keyring.sh",
 ];
 
 export const RETAINED_BASH_SCOPE = RETAINED_SHELL_SCOPE;
@@ -157,6 +158,10 @@ export const RETAINED_SHELL_CATEGORY_BY_FILE: Readonly<Record<string, RetainedSh
   "tools/setup/install.sh": "setup/bootstrap",
   "tools/setup/linux.sh": "setup/bootstrap",
   "tools/setup/macos.sh": "setup/bootstrap",
+  // keyring.sh is the intentionally-retained thin security EDGE: in-process seed
+  // handling (`read -s`, umask-077, shred-on-exit) that must stay in shell; the
+  // typed operational logic lives in keyset.ts ("bash only calls the edge").
+  "tools/setup/persona-keys/keyring.sh": "setup/bootstrap",
 };
 
 function parseArgs(argv: readonly string[]): ParseResult {

--- a/tools/setup/persona-keys/keyring-4x4.test.ts
+++ b/tools/setup/persona-keys/keyring-4x4.test.ts
@@ -11,8 +11,6 @@ import { test, expect } from "bun:test";
 import { readFileSync } from "node:fs";
 import { keyring4x4, keyringToTagged, serializeKeyring, deserializeKeyring } from "./keyring-4x4.ts";
 import { deriveKeyring } from "./derive.ts";
-import { canonicalJson } from "../../../src/Core.TypeScript/dynamic-value/json.ts";
-import { canonicalCbor, toHex } from "../../../src/Core.TypeScript/dynamic-value/cbor.ts";
 
 const HERE = new URL(".", import.meta.url).pathname;
 const gv = JSON.parse(readFileSync(HERE + "golden-vectors-keyring.json", "utf8"));

--- a/tools/setup/persona-keys/keyset.dst1000.test.ts
+++ b/tools/setup/persona-keys/keyset.dst1000.test.ts
@@ -30,7 +30,7 @@ test(`(2) a ${N}-link rotation chain is gapless + continuous at every link`, () 
   let set = makeKeyringSet(A, B, "zeta");
   let breaks = 0, discontinuities = 0;
   for (let i = 0; i < N; i++) {
-    const priorStandbyEth = set.standby[0].keyring.eth.address;
+    const priorStandbyEth = set.standby[0]!.keyring.eth.address;
     set = rotate(set, freshMnemonic());                 // fresh standby each link
     try { assertWellFormed(set); } catch { breaks++; }   // never single-key
     if (set.active.keyring.eth.address !== priorStandbyEth) discontinuities++; // promoted == prior standby

--- a/tools/setup/persona-keys/keyset.test.ts
+++ b/tools/setup/persona-keys/keyset.test.ts
@@ -20,8 +20,8 @@ test("a fresh set holds exactly one active + one standby (>=2), both well-formed
 
 test("active and standby derive from DIFFERENT seeds (one compromise must not take both)", () => {
   const s = makeKeyringSet(A, B, "zeta");
-  expect(s.active.mnemonic).not.toBe(s.standby[0].mnemonic);
-  expect(s.active.keyring.eth.address).not.toBe(s.standby[0].keyring.eth.address);
+  expect(s.active.mnemonic).not.toBe(s.standby[0]!.mnemonic);
+  expect(s.active.keyring.eth.address).not.toBe(s.standby[0]!.keyring.eth.address);
 });
 
 test("reusing a seed across slots is rejected (distinct-seed invariant)", () => {
@@ -30,17 +30,17 @@ test("reusing a seed across slots is rejected (distinct-seed invariant)", () => 
 
 test("rotation is GAPLESS and CONTINUOUS: old standby becomes new active, byte-identical", () => {
   const s0 = makeKeyringSet(A, B, "zeta");
-  const oldStandbyEth = s0.standby[0].keyring.eth.address;
+  const oldStandbyEth = s0.standby[0]!.keyring.eth.address;
   const s1 = rotate(s0, C);
   // continuity: the promoted keyring is byte-identical to what it was as standby
   expect(s1.active.keyring.eth.address).toBe(oldStandbyEth);
-  expect(s1.active.keyring.eth.privkey).toBe(s0.standby[0].keyring.eth.privkey);
+  expect(s1.active.keyring.eth.privkey).toBe(s0.standby[0]!.keyring.eth.privkey);
   // gapless: still >=2 keys at every step (1 active + >=1 standby), never single-key
   assertWellFormed(s1);
   // the retiring active is recorded for revocation, not silently dropped
   expect(s1.retired.map((r) => r.keyring.eth.address)).toContain(s0.active.keyring.eth.address);
   // the new standby is the fresh seed we supplied
-  expect(s1.standby[s1.standby.length - 1].keyring.eth.address).toBe(makeKeyringSet(C, A, "zeta").active.keyring.eth.address);
+  expect(s1.standby[s1.standby.length - 1]!.keyring.eth.address).toBe(makeKeyringSet(C, A, "zeta").active.keyring.eth.address);
 });
 
 test("rotation is deterministic given the fresh-standby seed (DST-replayable)", () => {

--- a/tools/setup/persona-keys/keyset.ts
+++ b/tools/setup/persona-keys/keyset.ts
@@ -40,7 +40,7 @@ export function makeKeyringSet(activeMnemonic: string, standbyMnemonic: string, 
   assertDistinctSeeds(seeds);
   return {
     user,
-    active: slot("active", seeds[0], user),
+    active: slot("active", activeMnemonic, user),  // === seeds[0]; named form satisfies noUncheckedIndexedAccess
     standby: seeds.slice(1).map((m) => slot("standby", m, user)),
     retired: [],
   };
@@ -53,8 +53,9 @@ export function makeKeyringSet(activeMnemonic: string, standbyMnemonic: string, 
  * Pure: pass the fresh standby seed in (the only randomness) for DST-replayability.
  */
 export function rotate(set: KeyringSet, freshStandbyMnemonic: string): KeyringSet {
-  if (set.standby.length < 1) throw new Error("malformed set: no standby to promote (single-key state forbidden)");
-  const [promote, ...restStandby] = set.standby;
+  const promote = set.standby[0];
+  if (promote === undefined) throw new Error("malformed set: no standby to promote (single-key state forbidden)");
+  const restStandby = set.standby.slice(1);
   assertDistinctSeeds([promote.mnemonic, ...restStandby.map((s) => s.mnemonic), freshStandbyMnemonic, set.active.mnemonic]);
   const newActive: KeySlot = { ...promote, state: "active" };           // continuity: same bytes
   const newStandby: KeySlot = slot("standby", freshStandbyMnemonic, set.user);


### PR DESCRIPTION
fix(gate): restore green main — persona-keys tsc narrowing + keyring.sh allowlist + ops-k8s exactOptional

main's `gate` had been red ~2h across many merges (docs PRs auto-merged over it).
Two independent lint-job failures, both pre-existing and behavior-preserving to fix:

1. tsc (tools) — noUncheckedIndexedAccess on the persona-keys dual-key oracle:
   - keyset.ts: use named `activeMnemonic` (=== seeds[0]); narrow `rotate`'s promote
     via `set.standby[0]` + undefined-guard instead of array destructure.
   - keyset.test.ts / keyset.dst1000.test.ts: `!` on guaranteed-present standby[i].
   - keyring-4x4.test.ts: drop unused imports (canonicalJson/canonicalCbor/toHex).
   - ops-k8s.ts: drop `storage: undefined` from the ResourceConfig fallback literal
     (exactOptionalPropertyTypes; line 119 already guards `cfg.storage`).
2. bash-retirement inventory — register `tools/setup/persona-keys/keyring.sh` as a
   retained shell EDGE (setup/bootstrap). The merged keyset.ts design is explicit
   that bash is the thin edge (in-process `read -s` seed, umask-077, shred-on-exit);
   the inventory just hadn't caught up to that merged decision.

Zero behavior change — narrowing + inventory only. Local: tsc 0 errors; persona-keys
22/22 (incl. 1000x DST byte-identical); bash-retirement guard exit 0.

AgencySignature-v1:
  persona: otto
  hat: shadow
  surface: tools/setup/persona-keys + tools/hygiene + full-ai-cluster/portal
  intent: restore-green-main-gate
  authorization: aaron-standing (keep CI green)
  reversible: yes
  gated-class: none
  build: tsc clean; 22/22 tests; bash-retirement enforce exit 0
  register: grounded
  ferry: no

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
