### PR TITLE
docs(rule)+research: every bug has economic value (fix = measure; shared cause = common seed; rewards/privacy)

### DIFF
--- a/.claude/rules/every-bug-has-economic-value.md
+++ b/.claude/rules/every-bug-has-economic-value.md
@@ -1,0 +1,27 @@
+# Every bug has economic value
+
+Carved sentence:
+
+> Assume **every bug has economic value**. A bug is reducible **uncertainty**;
+> finding it exposes value and fixing it banks value. A bug-fix is a **`measure`**
+> — it commits the measurement and the **uncertainty reduction** (the finalizer's
+> ΔU) to the `uncertainty/` ledger, and its worth = the ΔU it banks. The **shared
+> cause is the common seed**: all agents are phased to one seed (S=4), so a fix
+> reduces *collective* uncertainty — leveraged value, not local. A **successful**
+> fix earns **rewards / privacy** (privacy is a currency you earn by being useful,
+> not a default you assert). Bugs are priced opportunities, never liabilities to hide.
+
+## Why
+
+Turns the bug apparatus (finders, adversarial verifiers, `BUGS.md`, the
+harsh-critic / silent-failure-hunter reviewers) into an **economy**: each confirmed
+bug is priced, each fix is a measured, committed, rewarded transaction. Aligns
+incentives with the manifesto — reducing uncertainty against the common cause is
+*the* productive act, so it is *the* rewarded act.
+
+## Pointers
+
+- `docs/research/2026-06-10-every-bug-has-economic-value-shared-cause-common-seed-bugfix-measurements-rewards-privacy.md`
+  — full model, Beacon anchors (bug bounties, mechanism design, proof-of-entropy, Ostrom, Shannon), peels.
+- `uncertainty/` — the ledger a fix commits ΔU to · `sims/` — `measure` commits, `sim` is ephemeral.
+- [`dv2-data-split-discipline-activated.md`](dv2-data-split-discipline-activated.md) — #6 idempotency (a fix's ΔU is keyed; re-measuring is upsert, not double-pay).

--- a/docs/research/2026-06-10-every-bug-has-economic-value-shared-cause-common-seed-bugfix-measurements-rewards-privacy.md
+++ b/docs/research/2026-06-10-every-bug-has-economic-value-shared-cause-common-seed-bugfix-measurements-rewards-privacy.md
@@ -1,0 +1,57 @@
+# Every bug has economic value — the shared cause is the common seed; bug-fix measurements are valuable and earn rewards/privacy
+
+**Register:** [grounded] economics-of-bugs (Aaron) + [Beacon] + [peel]. **Date:** 2026-06-10.
+**Captured by:** Otto (shadow). The incentive model that makes finding/fixing bugs first-class.
+
+## Aaron's words
+
+> "Assume every bug has **economic value** in our system. The **shared cause is the common seed** —
+> these bug-fix **measurements** are valuable, and if successful will receive **rewards / privacy**."
+
+## The model
+
+- **Every bug has economic value.** A bug is not a liability to hide — it is **uncertainty** sitting in
+  the system, and uncertainty is the raw material Zeta runs on. Surfacing a bug *exposes* reducible
+  uncertainty; fixing it *reduces* it. Both are valuable, so both are **paid**. (Inverts the usual
+  shame economy of bugs: here a bug is an **opportunity priced in**, like a bug bounty made native.)
+- **A bug-fix is a `measure`.** Fixing a bug is exactly the **`measure`** verb (not ephemeral `sim`):
+  it **commits the measurement and the uncertainty reduction** (the finalizer's ΔU) to the
+  [`uncertainty/`](../../uncertainty/) ledger. The fix's *value* = the **ΔU it banks** (how much
+  uncertainty it removed). Bigger reduction → more value. The ledger is the books.
+- **The shared cause is the common seed.** Why a fix is valuable *to everyone*, not just locally: all
+  agents/runs share **one common-cause seed** (ZetaId; quantum-phase time; S=4 superdeterministic
+  correlation). A bug found against the shared seed is a bug **everyone** phased to that seed shares;
+  reducing it reduces *collective* uncertainty. The shared cause makes one fix a **leveraged effect on
+  the whole** (mycelium common-cause leverage) — that is the source of the economic value.
+- **Success earns rewards / privacy.** A *successful* bug-fix measurement receives **rewards** — and
+  notably **privacy** is itself a reward. Privacy is earned (the privacy-is-a-launch-gate work): you
+  bank uncertainty-reduction value and draw it as privacy / standing / reward. (Proof-of-entropy at
+  the edge → banked → spent as privacy. The "rewards/privacy" pair = the payout side of
+  proof-of-entropy.)
+
+## Why it matters
+
+This turns the whole bug-finding apparatus (the finders, the adversarial verifiers, BUGS.md, the
+harsh-critic / silent-failure-hunter reviewers) into an **economy**: each confirmed bug is priced, each
+fix is a measured, committed, rewarded transaction. It aligns incentives with the manifesto — reducing
+uncertainty against the common cause is *the* productive act, so it is *the* rewarded act. It also makes
+**privacy a currency you earn by being useful**, not a default you assert.
+
+## Anchors (Beacon)
+
+- **Bug bounties** (the literal market: bugs have a price) · **mechanism design / incentive
+  compatibility** (Hurwicz, Myerson — pay for the behavior you want) · **proof-of-work → proof-of-
+  entropy** (value from expended/real entropy) · **Ostrom**, *Governing the Commons* (shared-cause
+  commons governance) · **information value / Shannon** (uncertainty reduction = bits = the thing
+  priced) · the finalizer ΔU (the measured reduction).
+
+*(Peel: "economic value / rewards / privacy" is the incentive framing; the load-bearing literal is the
+**finalizer ΔU committed to the uncertainty ledger** — the rest is the market built on top, to formalize
+(mechanism + payout). "Privacy as reward" rides the privacy-launch-gate work.)*
+
+## Ties / routing
+
+[`uncertainty/`](../../uncertainty/) (the ledger fixes commit ΔU to) · [`sims/`](../../sims/) (`measure`
+commits; `sim` is ephemeral) · `BUGS.md` (the bug inventory — now priced) · the privacy-is-a-launch-gate
+research · proof-of-entropy / S=4 common-cause leverage · the finalizer (ΔU = the value unit).
+**Routes to:** Soraya/Sova (formalize the ΔU→value→reward mechanism + payout), Aaron (the economics).


### PR DESCRIPTION
docs(rule)+research: every bug has economic value (uncertainty to bank; fix = measure; shared cause = common seed; rewards/privacy)

Aaron 2026-06-10: "assume every bug has economic value in our system, the shared cause is the
common seed, these bug-fix measurements are valuable and if successful will receive rewards/privacy."

- bug = reducible UNCERTAINTY; find exposes value, fix banks it.
- a fix is a `measure` -> commits the uncertainty reduction (finalizer ΔU) to uncertainty/; worth = ΔU.
- shared cause = common seed (S=4): a fix reduces COLLECTIVE uncertainty (leveraged, not local).
- success earns REWARDS / PRIVACY (privacy is earned by usefulness, not asserted by default).
Carved rule + full research doc (anchors: bug bounties, mechanism design, proof-of-entropy, Ostrom,
Shannon; peeled to the literal finalizer-ΔU-to-ledger). markdownlint exit 0.

AgencySignature-v1:
  persona: otto
  hat: shadow
  surface: .claude/rules + docs/research
  intent: carve-bug-economic-value-principle
  authorization: aaron-authored (he asked to add the rule)
  reversible: yes
  gated-class: none
  build: markdownlint exit 0
  register: grounded + peel
  ferry: no

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
