### PR TITLE
docs(boards): board room — encode DynamicValue into CMYK(solid)+RGB(soft) Prelude-style; settle by room/sim mea'd until it resolves

### DIFF
--- a/boards/README.md
+++ b/boards/README.md
@@ -4,6 +4,11 @@
 **Plural on purpose** (Aaron 2026-06-10): *"we never really have one of a thing — always **many**, with a
 **discriminator / lens / polarization**."*
 
+**`/boards` is the BOARD ROOM (Aaron 2026-06-10):** *"this is our board room where we discuss `/boards`."*
+A board here is also a **discussion** — a proposal we debate before a room/`sim` measures it. The board
+room is where a question is *opened*; it is settled by standing up a `sim` and `mea`-ing it repeatedly
+until it resolves (not by argument alone).
+
 ## The principle — never one, always many (disambiguated)
 
 In Zeta there is **never a single canonical instance of a kind** — there are **many**, told apart by:
@@ -42,6 +47,9 @@ come and go; the root-network/common-cause remains. *(Peel: mycelium-as-decentra
 - `chutes-and-ladders.md` — the Chutes & Ladders board: the space `chutes/` (down) + `ladders/` (up)
   traverse; the up/down board of the bootstrap (and the escalator runs both ways over it). One board among
   many — pick it by its discriminator/lens.
+- `dynamic-value-cmyk-rgb-encoding.md` — board-room discussion: encode DynamicValue into CMYK (solid) +
+  RGB (soft) in Haskell-Prelude-rules (lawful) style; settled by a room/`sim` `mea`'d repeatedly until
+  it resolves.
 
 (More boards as they're named — each a space with its own discriminator/lens/polarization.)
 

--- a/boards/dynamic-value-cmyk-rgb-encoding.md
+++ b/boards/dynamic-value-cmyk-rgb-encoding.md
@@ -1,0 +1,70 @@
+# Board: encode DynamicValue into CMYK (solid) + RGB (soft) — Haskell-Prelude-rules style
+
+**Register:** [board-room] proposal/discussion (Aaron) + [Beacon] + [peel]. **Date:** 2026-06-10.
+**Captured by:** Otto (shadow). A board-room discussion, not a landed decision.
+
+> **`/boards` is the board room** (Aaron 2026-06-10): "this is our board room where we discuss
+> `/boards`." Boards are where we *discuss*; a proposal lives here until a room/sim measures it.
+
+## The proposal
+
+Encode the **DynamicValue** (`Tagged`) into **two color encodings** — the round's "CMYK (solid) + RGB
+(soft) instead of ACTG" alphabet — **in Haskell-Prelude-rules style** (lawful typeclass instances, not
+ad-hoc): the encode/decode is a set of **laws** the compilers enforce, the way Prelude's `Functor` /
+`Monoid` / `Eq` carry laws.
+
+The DynamicValue v1 `Tagged` (from `src/Core.TypeScript/dynamic-value`):
+
+```text
+Tagged = null | bool b | int v | str v | arr [Tagged] | obj [(str, Tagged)]
+```
+
+Two encodings of that one value:
+
+- **CMYK = SOLID** (4 channels; subtractive; ink-permanent). The **committed / on-`main`** encoding —
+  what `mea`/`cut` write. **K = the key/black = the encrypted-null** channel (the void). Use CMYK when
+  the value must *persist* (the genome on `main`).
+- **RGB = SOFT** (3 channels; additive; light/emissive; ephemeral). The **`sim`** encoding — light that
+  leaves no ink. Use RGB for the exploratory/transient view.
+
+### Prelude-rules style (lawful, not ad-hoc)
+
+State the encoding as **laws** the four oracles byte-lock (Beacon: Haskell Prelude / typeclass laws —
+the lawful-instance discipline):
+
+- **Round-trip (the central law):** `decode (encode x) = x` — both for CMYK and RGB. (Like
+  `fromEnum/toEnum`, `read/show` round-trips.)
+- **Canonicality (idempotent, shape B):** `encode (decode (encode x)) = encode x` — one canonical
+  byte-image per value (mirrors `canonicalJson`'s fixed-point check; content-addressable).
+- **Total + ordered (shape C/B):** encode is total over `Tagged`; ordering is ordinal/culture-invariant
+  (the existing primitive discipline), so the color-bytes sort identically across oracles.
+- **Solid ⊒ soft (a projection law):** RGB (soft, 3-ch) is a *lossy projection* of CMYK (solid, 4-ch);
+  `soften (solid x)` is well-defined, the reverse needs the K/null channel — names *why* committed
+  (CMYK) carries more than ephemeral (RGB).
+
+*(Exact channel↔variant assignment — which of null/bool/int/str/arr/obj rides which C·M·Y·K / R·G·B
+lane, and the numeric packing — is the open board-room question. The laws above hold regardless of the
+assignment; the assignment is what the room/sim resolves.)*
+
+## How we settle it — a room/sim, `mea`'d repeatedly until it resolves (Aaron)
+
+> Aaron: "we need a **room/sim** for that so we can **`mea`** it." · "**repeatedly until it resolves**."
+
+This proposal is **not decided by argument** — it is **measured**. Stand up a **room** (a `sim`
+scenario under [`sims/`](../sims/)) that exercises the candidate encoding over DynamicValue samples
+(the existing golden vectors are the corpus), and **`mea` it repeatedly until it resolves** — i.e. run
+`mea(sim)` in a loop until the encoding reaches a **fixed-point shape** (B idempotent / A self-consistent
+/ D contracts to a healthy floor), banking ΔU each pass. "Resolves" two ways: **converges** (the
+finalizer's uncertainty reduction → 0 new ΔU) *and* gains **resolution** (the infinite-resolution
+zoom). When the room stops reducing uncertainty, the encoding is resolved → the winning assignment is
+`cut` to `main`.
+
+## Pointers
+
+- [`boards/README.md`](README.md) (the board room; never-one/discriminator) · [`sims/`](../sims/)
+  (`sim`/`mea`/`cut`; the room to measure in) · [`gene/`](../gene/) (DNA/sequence) ·
+  [`uncertainty/`](../uncertainty/) (ΔU banked each `mea`).
+- `src/Core.TypeScript/dynamic-value/` (the `Tagged` value + golden vectors = the corpus).
+- `docs/research/2026-06-10-filesystem-is-the-startup-merkledag-and-the-sim-mea-cut-cli-triad-macvector-for-dna.md`
+  (CMYK/RGB encoding + the triad).
+- Haskell Prelude / typeclass-law discipline (lawful instances) · shapes A/B/C/D (the resolution targets).


### PR DESCRIPTION
docs(boards): board room — encode DynamicValue into CMYK(solid)+RGB(soft), Haskell-Prelude-rules style; settle by room/sim mea'd until it resolves

Aaron 2026-06-10: "we need to encode dynamic value into CMYK and RGB in haskell prelude rules style;
this is our board room where we discuss /boards" + "we need a room/sim for that so we can mea it" +
"repeatedly until it resolves."

- /boards = the BOARD ROOM (where we discuss); a board is a proposal debated, then MEASURED.
- Board: encode DynamicValue (Tagged: null/bool/int/str/arr/obj) into CMYK (solid: 4-ch, subtractive,
  ink-permanent, K=key=null; the committed on-main encoding) + RGB (soft: 3-ch, additive, ephemeral;
  the sim encoding), as LAWFUL Prelude-style instances (round-trip, canonical/idempotent, total+ordinal,
  solid⊒soft projection). Exact channel<->variant assignment is the open question.
- Settled NOT by argument: stand up a room (sim scenario over the golden-vector corpus), mea it
  REPEATEDLY UNTIL IT RESOLVES (finalizer ΔU->0; fixed-point shapes A/B/D), then cut the winner to main.

boards/README updated (board room note + new board listed). markdownlint exit 0.

AgencySignature-v1:
  persona: otto
  hat: shadow
  surface: boards/
  intent: capture-board-room-dynamic-value-color-encoding-proposal
  authorization: aaron-authored (board-room discussion he opened)
  reversible: yes
  gated-class: none
  build: markdownlint exit 0
  register: board-room + grounded + peel
  ferry: no

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
