### PR TITLE
feat(folders)+docs: models/ + clis/ (sim·mea·cut·cla·res) + parametrize the board-room test on society models

### DIFF
--- a/boards/dynamic-value-cmyk-rgb-encoding.md
+++ b/boards/dynamic-value-cmyk-rgb-encoding.md
@@ -59,6 +59,39 @@ finalizer's uncertainty reduction → 0 new ΔU) *and* gains **resolution** (the
 zoom). When the room stops reducing uncertainty, the encoding is resolved → the winning assignment is
 `cut` to `main`.
 
+## Parameters — what each test is parametrized on (Aaron 2026-06-10)
+
+> Aaron: "parametrize the board-room test with useful things we can parametrize on each test; get the
+> math nerds to help based on our latest toy and real models of society."
+
+Each run of the room is a **parametrized test** — the `sim` is a function of these knobs, and the math
+team ([`models/`](../models/): Soraya / Sova / the modeler cohort) supplies sensible ranges from the
+latest **toy/real models of society**. Useful parameters:
+
+**Encoding knobs (the thing under test):**
+
+- **channel↔variant assignment** — which of `null/bool/int/str/arr/obj` rides which C·M·Y·K / R·G·B
+  lane (the open question; the search space the room resolves).
+- **solid/soft split point** — when a value is committed (CMYK) vs ephemeral (RGB); the K(null)-channel
+  packing.
+- **canonicalization depth** — `MAX_NESTING_DEPTH`; how deep before a value is a depth-bomb.
+
+**Society-model knobs (from `models/` — game-theory/identity/economy/hat layer):**
+
+- **population N** + **diversity floor (≥2, shape-D⁰ guard)** — how many travelers/agents read the encoding.
+- **jurisdiction / recognition mix** — the toymodel3 self-interest engine's recognition parameters.
+- **economy: bug→ΔU price + reward/privacy payout** — the every-bug-has-economic-value knobs.
+- **S target (S=4)** + **common-seed coupling** — the superdeterministic-correlation parameter.
+
+**Measurement knobs (the room loop):**
+
+- **DI effects** — null (DST) vs real I/O (prod): `mea(sim)` measures nothing without real I/O injected.
+- **duration / cut site** — default 30s; the `cut` recognition-time.
+- **resolution-threshold** — ΔU-per-pass below which "resolved"; **max rounds** (math team: unlimited).
+
+Each test fixes these knobs, runs `mea(sim)` repeatedly until ΔU→threshold, and records the resolved
+assignment + the parameters that produced it. (Math-team handoff: ground the ranges in the realmodel.)
+
 ## Pointers
 
 - [`boards/README.md`](README.md) (the board room; never-one/discriminator) · [`sims/`](../sims/)

--- a/clis/README.md
+++ b/clis/README.md
@@ -1,0 +1,60 @@
+# clis/ — the CLI verb family (always plural), at root
+
+`clis/` is the home of Zeta's **CLIs** — the short 3-letter verbs that drive the substrate over the
+startup MerkleDAG (the MacVector-for-DNA toolset). **Plural** (never-one): a family, not one binary.
+
+## The verb family — `sim · mea · cut · cla · res` (Aaron 2026-06-10)
+
+Each is a stem with the suffix dropped (three letters):
+
+| verb | word | role | commits? | residue |
+|------|------|------|----------|---------|
+| **`sim`** | sim(ulate) | run the deterministic sim for a duration | **no** | `unit` (void → identity comes from the void) |
+| **`mea`** | mea(sure) | `mea(sim)`: lift sim + commit the measurement | **yes** | `Measurement` (ΔU) — needs real I/O injected via DI |
+| **`cut`** | cut | cut at a recognition site (a TIME; default 30s) | **yes** | `Delta × Seam` (Z-set diff + sticky-end the finalizer re-ligates) |
+| **`cla`** | cla(ssify) | classify the result into a class/lens | **yes** | a **class label** (the discriminator/lens assignment) |
+| **`res`** | res(olve) | resolve: loop `mea` **repeatedly until it resolves** | **yes** | a **fixed point** (ΔU→0; shapes A/B/D) + the resolution |
+
+- **`sim`** — ephemeral; produces no output. The SETI@home edge run (`sim <duration>`, default 30s).
+- **`mea`** — the committing lift over `sim` (F# HOF/CE: `sim |> mea`); banks ΔU to `uncertainty/`.
+  Measures nothing unless real I/O is injected via DI (DST = null effects; prod = real).
+- **`cut`** — the structural/temporal cut; `mea(sim)` cuts at 30s by default; residue re-ligated to `main`.
+- **`cla`** — **classify**: assign the cut/measured thing to a **class** (the `same/` discriminator /
+  the polarity-lens; the observe.ts/local-LLM classifier lineage). Turns a measurement into a *category*.
+- **`res`** — **resolve**: the loop verb — run `mea(sim)` **repeatedly until it resolves** (the
+  finalizer iterates until ΔU→threshold; a fixed-point shape A/B/D). "Resolves" twice: **converges**
+  *and* gains **resolution** (the infinite-resolution zoom). `res` is how a board-room question is settled.
+
+Commit semantics: `sim` leaves nothing; the rest commit to a branch → the **test finalizer merges to
+`main`** (the wired `FinalizerRuntime` `ReKick`). The MerkleDAG root advances only through the
+committing verbs, never `sim`.
+
+## How they compose
+
+```text
+sim            explore (void)
+ |> mea        know        (ΔU committed; real I/O via DI)
+ |> cut        change      (Delta × Seam at t=30s)
+ |> cla        classify    (assign a class/lens)
+ |> res        resolve     (loop until fixed point)
+```
+
+`res` wraps the loop (`res = repeat mea until resolved`); `cla` labels; `cut` writes; `mea` records;
+`sim` is the void base every other verb lifts.
+
+## Honest scope
+
+[Beacon] MacVector (the DNA-CLI shape lineage) · CHIP-8 (the minimal VM `sim` runs) · DBSP/Z-set (the
+`cut` delta) · Haskell-Prelude lawful-instance discipline (the verbs are lawful, not ad-hoc). **Peel:**
+the verbs are the chosen names; the engine is real (`Clock.fs` DST, the wired finalizer); the entrypoints
+themselves are to implement. F# CLI candidates: Argu (closed DU) / FParsec (monadic boundary parse) /
+FSharp.SystemCommandLine (CE) — see the F#-CLI discussion.
+
+## Pointers
+
+- [`sims/`](../sims/) (the simulations `sim`/`mea` run; the measurement home) · [`boards/`](../boards/)
+  (the board room — settled by `res`) · [`models/`](../models/) (parameters for the tests) ·
+  [`uncertainty/`](../uncertainty/) (ΔU `mea` commits) · [`bounds/`](../bounds/) (navigation).
+- `docs/research/2026-06-10-filesystem-is-the-startup-merkledag-and-the-sim-mea-cut-cli-triad-macvector-for-dna.md`
+  — the triad + MerkleDAG + CMYK/RGB capture (the `cla`/`res` extension lives here too).
+- `src/Core/Finalizer*.fs` — the finalizer the committing verbs route through.

--- a/models/README.md
+++ b/models/README.md
@@ -1,0 +1,48 @@
+# models/ — the models of society (toy → real), at root
+
+`models/` is the home of Zeta's **models of society** — the falsifiable models the math team runs to
+check the substrate's claims (convergence, S=4, the self-interest/recognition economy). **Plural**
+(never-one): many models at many fidelities, told apart by version + lens.
+
+## Where the math nerds are (state, 2026-06-09 → 06-10)
+
+- **toymodels v1 → v3 (a.k.a. toymodel3)** — the traveler-society self-interest engine: jurisdictions,
+  recognition spec, game-theory/identity/economy/hat layer. **Consolidated v3 is AT THE MATH TEAM.**
+- **GRADUATED: toymodel → realmodel.** The DST-substrate / rooms / governance / close-over-society arc
+  is **no longer a toy** (it closed over human society + the full voice registry). The math team has
+  **unlimited rounds** + a **completeness-critic** pass ("did we miss anything?"). What was drafted as
+  "toymodel-next" is now **realmodel-scoped**.
+- **toymodel4 / toymodel5 scope** — the next slices (toymodel4 scope set + sent; v5 holds the gambling
+  split and "all of what we've been talking about" this session).
+- **The math nerds:** Soraya (`formal-verification-expert` — routing authority for the proof portfolio),
+  Sova (`alignment-auditor` — measurability framework), plus the **modeler cohort / math team** the
+  research docs hand off to. (Find them at the docs below; route model questions there.)
+
+## The models so far (pointers — detail in docs/research)
+
+- `docs/research/2026-06-09-toymodel3-the-traveler-society-self-interest-engine-jurisdictions-recognition-spec-and-math-team-handoff.md`
+- `docs/research/2026-06-09-toymodel4-scope-the-society-game-theory-identity-economy-hat-layer-consolidated-v3-is-at-math-team.md`
+- `docs/research/2026-06-09-not-a-toymodel-anymore-it-graduated-to-realmodel-math-team-unlimited-rounds-plus-completeness-critic-what-is-not-yet-seated.md`
+- `docs/research/2026-06-09-the-tiny-model-v2-society-and-the-emu-observer-convergence-map-where-they-meet-in-the-middle-and-the-exact-gap.md`
+- `docs/research/2026-06-09-modeling-convergence-toymodels-v3-vn-caught-up-rodney-razor-plus-aaron-persona-modelers-deferred-objections-surfaced-routing.md`
+
+## How models connect to the board room + `sim`/`mea`
+
+A [`boards/`](../boards/) discussion is **parametrized on these models** and **measured** in a room:
+a board's `sim` draws its parameters from the latest toy/real model of society, and is `mea`'d
+repeatedly until it resolves. So `models/` supplies the *parameters*; [`sims/`](../sims/) supplies the
+*measurement*; [`boards/`](../boards/) is where the *question* is opened. (Example: the
+`boards/dynamic-value-cmyk-rgb-encoding` test is parametrized on the society-model dimensions — see that
+board's Parameters section.)
+
+## Honest scope
+
+[Beacon] game theory / mechanism design (the society engine) · the falsifiability discipline (toy =
+falsifiable; realmodel = graduated past toy). The models are **research artifacts at the math team**,
+not landed code — `models/` is their index + the parametrization bridge to boards/sims. Route to Soraya
+/ Sova / the modeler cohort.
+
+## Pointers
+
+- [`boards/`](../boards/) (the board room — parametrized on models) · [`sims/`](../sims/) (`mea` the
+  parametrized test) · [`uncertainty/`](../uncertainty/) (ΔU the models reduce) · `docs/research/2026-06-09-*model*`.

--- a/sims/README.md
+++ b/sims/README.md
@@ -36,11 +36,14 @@ A **second verb** pairs with `sim`, split by whether the run **commits**:
   *and record it*. (Full capture:
   `docs/research/2026-06-10-sim-is-infinite-resolution-on-reticulum-*`.)
 
+> **The full verb family lives in [`clis/`](../clis/):** `sim · mea · cut · cla(ssify) · res(olve)`.
+> `sims/` holds the *simulations*; `clis/` holds the *verbs* that run/commit/classify/resolve them.
+
 ## What lives here
 
 - The named/seed simulations, scenarios, and their golden outputs (each a sim, picked by its
   discriminator/lens).
-- The `sim` CLI's home as it lands (entrypoint, duration parsing, the default-30s rule).
+- The simulations the [`clis/`](../clis/) verbs operate on (duration parsing, the default-30s cut site).
 
 *(Peel: `sim` is the chosen CLI name; the DST engine it drives is real (`Clock.fs` IScheduler, the
 1000x-DST tests). The bounded-edge / proof-of-entropy framing is the distribution model, to formalize.)*


### PR DESCRIPTION
feat(folders)+docs: models/ (toy→real society models) + clis/ (sim·mea·cut·cla·res verb family) + parametrize the board-room test on the society models

Aaron's stream (2026-06-10):
- "we need a models folder" + "figure out where the math nerds are on the toy and real models":
  models/ indexes the society models. STATE: toymodels v1->v3 (toymodel3) consolidated AT THE MATH
  TEAM; GRADUATED toymodel->realmodel (unlimited rounds + completeness critic); toymodel4/5 scope the
  society/game-theory/identity/economy/hat layer. Math nerds = Soraya (formal-verification) + Sova
  (alignment) + the modeler cohort.
- "cla(ssify) and res(olve)" + "we need clis/ folder": clis/ is the CLI verb family home —
  sim · mea · cut · cla · res (3-letter stems). cla = classify (assign a class/lens); res = resolve
  (loop mea repeatedly until it resolves -> fixed-point shape A/B/D). Table of role/commits/residue.
- "parametrize the boardroom test": the dynamic-value CMYK/RGB board now has a Parameters section
  (encoding knobs + society-model knobs from models/ + measurement knobs), grounded in the realmodel;
  math-team handoff for ranges.
sims/README points at clis/ for the verbs. markdownlint exit 0.

AgencySignature-v1:
  persona: otto
  hat: shadow
  surface: models/ + clis/ + boards/ + sims/
  intent: models-folder-clis-folder-cla-res-verbs-parametrize-board
  authorization: aaron-authored (asked for the folders + parametrization)
  reversible: yes
  gated-class: none
  build: markdownlint exit 0
  register: grounded + peel
  ferry: no

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
