### PR TITLE
feat(gen)+rule+research: gen/ + parser-generator->CHIP-8 for cut·mea·sim (+interrupts=the game) + interfaces-free/classes-earned-under-rules

### DIFF
--- a/.claude/rules/interfaces-free-classes-earned-under-rules.md
+++ b/.claude/rules/interfaces-free-classes-earned-under-rules.md
@@ -1,0 +1,30 @@
+# Interfaces are free; classes must be earned under rules/
+
+Carved sentence:
+
+> The **rules of the game are interfaces** — free, default, **weight-free** (pure
+> shape, no instance state). A concrete **class** (state ⇒ weight ⇒ capture) is
+> **NOT free**: it must be **earned**, and the earning is governed **under
+> `rules/`** (an explicit rule justifies each class). Default to interfaces;
+> reach for a class only when you have *earned* it under a rule. Generators read
+> **interfaces, not classes** (`gen/`), so pure-interface code stays
+> DST-deterministic and byte-lockable across the four oracles.
+
+## Why
+
+A class carries hidden state — weight, in the manifesto sense (§3 weight-free): it
+creates capture, breaks DST determinism (state to reflect over), and resists
+byte-lock. An interface is pure shape: nothing to capture, total to generate from,
+free to compose (`cut mea sim` by currying). So interfaces are the **free default**
+(the rules of the game everyone plays by); a class is a **privilege** that must be
+*earned* — justified under `rules/` like any other weight-bearing exception. This
+is weight-free made concrete at the type level, and it is what lets `gen/`
+generate CHIP-8 asm + reified types **from the F# itself** (pure interfaces).
+
+## Pointers
+
+- [`manifesto-11-specifications.md`](manifesto-11-specifications.md) — §3 weight-free (class state = weight).
+- `gen/` — generators read pure interfaces, no classes · `universal/` — interfaces = universal shapes.
+- `docs/research/2026-06-10-parser-generator-emits-chip8-assembly-for-the-cut-mea-sim-loop-then-interrupts-thats-our-game.md`
+  — "from the F# itself — pure interface, no class."
+- [`every-bug-has-economic-value.md`](every-bug-has-economic-value.md) — sibling earned-privilege economy (a class, like a reward, is earned).

--- a/docs/research/2026-06-10-parser-generator-emits-chip8-assembly-for-the-cut-mea-sim-loop-then-interrupts-thats-our-game.md
+++ b/docs/research/2026-06-10-parser-generator-emits-chip8-assembly-for-the-cut-mea-sim-loop-then-interrupts-thats-our-game.md
@@ -1,0 +1,79 @@
+# A parser generator that emits CHIP-8 assembly for the `cut mea sim` loop — then tie in interrupts: that's our game
+
+**Register:** [grounded] build-plan (Aaron) + [Beacon] + [peel]. **Date:** 2026-06-10.
+**Captured by:** Otto (shadow). The architecture for "our game" — the runnable substrate.
+
+## Aaron's words
+
+> "We write a **parser generator** that generates **CHIP-8 assembly** for that loop, and then we will
+> tie in **interrupts** — **that's our game**."
+
+## The build
+
+The `cut mea sim` curried loop (the [`clis/`](../../clis/) verb family) gets a **runnable target**: a
+**parser generator** compiles it down to **CHIP-8 assembly**, and **interrupts** make it interactive —
+the result is **the game** (the CHIP-8-class VM that *is* `sim`).
+
+### 0. From the F# itself — pure interfaces, no classes (Aaron 2026-06-10)
+
+> Aaron: "from the F# itself — that's pure interface, right? no class?"
+
+**Yes: pure interfaces, no classes.** The CHIP-8 asm is generated **from the F# itself** — the
+**interface definitions** are the source the generator reads, not concrete classes. F# **interfaces**
+(abstract members only; no class, no instance state) are the **pure boundary**: nothing to reflect over
+but the *shape*, so the generator emits asm from the interface contract directly. This is exactly the
+[`universal/`](../../universal/) discipline (**interfaces = universal shapes**) and Core-pure
+(Result-over-exception, no hidden class state). The loop's verbs (`sim`/`mea`/`cut`) are **interface
+members**; `cut mea sim` (curried) is interface composition; the generator ([`gen/`](../../gen/)) turns
+those pure interfaces into CHIP-8 opcodes. No class state ⇒ DST-deterministic ⇒ byte-lockable across
+the four oracles.
+
+### 1. Parser generator → CHIP-8 assembly
+
+A **parser generator** (F#: FParsec — `Parser<'a>` is a monad, the "monadic, closed, over Markov
+boundaries" shape from the F#-CLI discussion; or Argu for the closed verb DU) parses the **`cut mea
+sim`** loop expression and **emits CHIP-8 assembly** for it. So the curried loop (`cut (mea (sim))`,
+currying = the wiring) is **compiled**, not interpreted — the parser is the front end, CHIP-8 asm the
+back end. CHIP-8 (Weisbecker 1977; ~35 opcodes) is the **minimal honest target**: small enough to
+byte-lock across the four oracles, DST-replayable, the common-ground emulator floor (`hooks/`).
+
+- **Front end:** parse the loop / the sim program (the grammar over the MerkleDAG sequence).
+- **Code gen:** emit CHIP-8 opcodes for `sim` (run), `mea` (measure→commit), `cut` (cut at site).
+- **Why a *generator*:** it writes the asm from the parsed loop — ties the type-provider / Roslyn-gen
+  story (generators that run `sim`/`mea`/`cut` in the compiler): the parser generator is the same move
+  at the asm level.
+
+### 2. Tie in interrupts → the game
+
+CHIP-8 has **timers** (delay + sound, 60Hz) — the seed of **interrupts**. Tying interrupts in makes the
+loop **interactive / reactive**: an interrupt fires an action mid-loop. This is exactly
+[`triggers/`](../../triggers/) (**act-on-condition**) and the finalizer's `ReKick` — the interrupt *is*
+a trigger. With interrupts wired, the `cut mea sim` loop becomes a **playable game**: input/timer
+interrupts drive the loop; `sim` renders (ray-traced ZetaId), `mea`/`cut` commit, interrupts steer.
+(The Cheat-Engine lineage: triggers / conditional breakpoints are interrupts on the running game —
+`hooks/`.)
+
+## Why it matters
+
+This is the **runnable bottom** of the whole stack: the abstract `sim`/`mea`/`cut` loop gets a real
+compile target (CHIP-8 asm via a parser generator) and real interactivity (interrupts = triggers). It
+makes "prod = sim" concrete — the game is the simulation, compiled to the minimal VM, driven by
+interrupts. Bounded (shape A/F; CHIP-8 is tiny and total → terminates, DST-replayable).
+
+## Honest scope / peels
+
+[Beacon] CHIP-8 / Weisbecker 1977 (real minimal VM + timers) · parser generators (yacc/ANTLR lineage;
+F# FParsec monadic combinators, Argu closed-DU) · interrupts / interrupt service routines (real;
+CHIP-8's 60Hz timers are the hook) · DBSP/Z-set (`cut`'s delta). **Peels:** "that's our game" — the
+game *is* the running compiled loop; building the parser-generator + CHIP-8 codegen + interrupt wiring
+is the **work to do** (routes to Core team), not yet built. CHIP-8 is the chosen minimal target; a
+richer target can come later.
+
+## Ties / routing
+
+[`clis/`](../../clis/) (the `cut mea sim` loop being compiled) · [`triggers/`](../../triggers/) +
+[`hooks/`](../../hooks/) (interrupts = act-on-condition = the Cheat-Engine hook) · [`sims/`](../../sims/)
+(the game = the sim) · the F#-CLI discussion (FParsec/Argu as the parser generator) ·
+`docs/research/2026-06-10-filesystem-is-the-startup-merkledag-and-the-sim-mea-cut-cli-triad-macvector-for-dna.md`
+(CHIP-8 = the VM; the triad). **Routes to:** the Core team (parser generator + CHIP-8 codegen +
+interrupt wiring), Soraya (the grammar / asm byte-lock), Aaron (the game).

--- a/gen/README.md
+++ b/gen/README.md
@@ -1,0 +1,51 @@
+# gen/ — the generators (always plural), at root
+
+`gen/` is the home of Zeta's **generators** — the compile-time machinery that **generates code/types
+from pure F# interfaces + git-history metadata**. **Plural** (never-one): a family of generators, one
+discipline.
+
+## What generates what
+
+All generators share one move: read a **pure interface** (no class state — [`universal/`](../universal/)
+shapes) and/or **git-history metadata**, and **emit** something at compile time. The family:
+
+- **F# type providers** — generate **reified types from git-history metadata** (the persona entropy of
+  previous runs, made first-class). The provider reads the event-sourced commit metadata and produces
+  types `sim` can see.
+- **Roslyn source generators** — the C#-side counterpart (both: F# type providers **and** Roslyn
+  generators reify from git history).
+- **F# generators inside type providers** — can **recursively run `sim`/`mea`/`cut` in the compiler**
+  (once the rules are filtered) → compile-time *is* sim. The self-hosting strange loop.
+- **The parser generator → CHIP-8 assembly** — parses the `cut mea sim` loop (FParsec monadic / Argu
+  closed-DU) and **emits CHIP-8 opcodes** **from the F# itself (pure interfaces, no classes)**; then
+  interrupts ([`triggers/`](../triggers/)) tie in → the game.
+
+## The discipline — generate from pure interfaces, no classes
+
+Generators read **interfaces, not classes**: abstract members only, no instance state. Nothing to
+reflect over but the *shape*, so generation is **DST-deterministic** and **byte-lockable** across the
+four oracles. (Aaron: "from the F# itself — that's pure interface, no class.") This keeps `gen/`
+Core-pure: a generator is a total function `interface (+ git metadata) → emitted artifact`.
+
+**The rule (Aaron 2026-06-10): interfaces are free; classes must be earned under `rules/`.** "The rules
+of the game are interfaces — or free; classes have to be earned under `rules/`." An interface is
+weight-free (pure shape); a concrete class is **state ⇒ weight ⇒ capture** and is **not free** — it must
+be **earned** under an explicit rule. Default to interfaces; a class is a privilege governed under
+`rules/`. See `.claude/rules/interfaces-free-classes-earned-under-rules.md`.
+
+## Honest scope / peels
+
+[Beacon] F# type providers (compile-time generated types) · Roslyn source generators · parser
+generators (yacc/ANTLR lineage; FParsec monadic combinators) · CHIP-8 (the asm target). **Peel:** the
+generators are the **plan/standard**; the parser-gen + CHIP-8 codegen + the recursive-compiler-sim are
+**work to build** (route to Core). `gen/` is their home + the discipline (pure-interface, no-class).
+
+## Pointers
+
+- [`clis/`](../clis/) (the `cut mea sim` loop the parser-gen compiles) · [`triggers/`](../triggers/) +
+  [`hooks/`](../hooks/) (interrupts) · [`universal/`](../universal/) (interfaces = the generators' input) ·
+  [`sims/`](../sims/) (the game the asm runs).
+- `docs/research/2026-06-10-parser-generator-emits-chip8-assembly-for-the-cut-mea-sim-loop-then-interrupts-thats-our-game.md`
+  — the parser-gen → CHIP-8 → interrupts build plan.
+- `docs/research/2026-06-10-filesystem-is-the-startup-merkledag-and-the-sim-mea-cut-cli-triad-macvector-for-dna.md`
+  — reified types via type providers + Roslyn gens; recursive sim in the compiler.


### PR DESCRIPTION
feat(gen)+rule+research: gen/ folder + parser-generator->CHIP-8 for the cut·mea·sim loop (+interrupts=the game) + "interfaces free, classes earned under rules/"

Aaron's stream (2026-06-10):
- "we write a parser generator that generates chip8 assembly for that loop and then we will tie in
  interrupts that's our game": research doc — FParsec/Argu parser-gen emits CHIP-8 asm for the
  curried cut(mea(sim)) loop; interrupts (triggers/, CHIP-8 60Hz timers) tie in -> the game.
- "from the f# itself that's pure interface right no class?": YES — generate from pure F# INTERFACES
  (no classes, no state) -> DST-deterministic, byte-lockable; universal/ shapes; Core-pure.
- "we need a gen folder": gen/ = generators home (F# type providers + Roslyn source generators [both];
  F# generators inside providers that recursively run sim/mea/cut in the compiler; the parser-gen->CHIP8).
- "rules of the games are interfaces or free, classes have to be earned under rules/": carved rule —
  interfaces are free/weight-free (the rules of the game); a class (state=>weight=>capture) is NOT free,
  must be EARNED under rules/. Weight-free §3 at the type level.

markdownlint exit 0. All build-plan/standard (parser-gen + CHIP-8 codegen + recursive-compiler-sim are
work to build; route to Core).

AgencySignature-v1:
  persona: otto
  hat: shadow
  surface: gen/ + .claude/rules + docs/research
  intent: gen-folder-chip8-parser-generator-interfaces-free-classes-earned
  authorization: aaron-authored (the folder + the rule + the build plan)
  reversible: yes
  gated-class: none
  build: markdownlint exit 0
  register: grounded + peel
  ferry: no

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
