### PR TITLE
feat(clis): sim·mea·cut·cla·res pure-interface stubs (Verbs.fs) + cut-mea-sim homoiconic across F#/CLI/filesystem

### DIFF
--- a/clis/README.md
+++ b/clis/README.md
@@ -56,6 +56,28 @@ takes the measured value and writes the delta — `cut (mea (sim))`, written poi
 until it resolves (ΔU→0; shape A/B/D). No glue code — currying *is* the wiring. (`cla` slots in where a
 class is needed; the core engine loop is `cut mea sim`.)
 
+The interface stubs for the five verbs live in [`Verbs.fs`](Verbs.fs) — pure interfaces, no classes
+(the meta-rule).
+
+### Homoiconic across F# · CLI · filesystem — the `fs` pun (Aaron 2026-06-10)
+
+> Aaron: "`cut mea sim` works on the CLI too, like currying — homoiconic to **fs**: **F#** /
+> **filesystem** homoiconicity."
+
+`cut mea sim` is **the same expression in three registers** — code = data = tree (homoiconicity, the
+Lisp property: program and data share one representation). The pun is **`fs`**:
+
+- **F# code** — `cut mea sim` as curried functions (point-free composition).
+- **the CLI** — `cut mea sim` on the command line: the **shell** curries too (partial application /
+  composition of the verb commands). Same expression, run as a command.
+- **the filesystem** — the startup **MerkleDAG** (the `fs`) *is* that structure: folders/paths are the
+  same tree the F# and the CLI walk. The filesystem is the code.
+
+So **F# ≅ CLI ≅ filesystem** — one homoiconic structure. Writing `cut mea sim` in F#, typing it at the
+shell, and walking the MerkleDAG are the *same act* over the *same representation*. (This is why the
+folder structure is load-bearing: the filesystem is not a container for the code — it **is** the code,
+homoiconically.)
+
 ## Honest scope
 
 [Beacon] MacVector (the DNA-CLI shape lineage) · CHIP-8 (the minimal VM `sim` runs) · DBSP/Z-set (the

--- a/clis/Verbs.fs
+++ b/clis/Verbs.fs
@@ -1,0 +1,76 @@
+namespace Zeta.Clis
+
+open System
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The CLI verb family — sim · mea · cut · cla · res — as PURE INTERFACE STUBS.
+//
+// Meta-rule (.claude/rules/interfaces-free-classes-earned-under-rules.md): the rules
+// of the game are interfaces — free, weight-free, no instance state. A concrete class
+// must be EARNED under rules/. So the verb contracts are interfaces only.
+//
+// STUB: not yet wired into a project (clis/ is a root folder). The supporting types
+// are opaque interfaces too — to be reified from git-history metadata via gen/ (F#
+// type providers + Roslyn generators). The loop is `cut mea sim` by currying; res
+// iterates it (the finalizer) until it resolves.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ── Supporting types (opaque stubs; reified later via gen/) ──
+
+/// The 128-bit common-cause seed.
+type ISeed = interface end
+
+/// Injected effects: null (DST) or real I/O (prod). Real I/O adds NEW external
+/// observation; its absence does NOT make a measurement empty — sim carries
+/// intrinsic persona entropy (git history, reified types) it can always measure.
+type IEffects = interface end
+
+/// An ephemeral simulation computation — the VOID base every verb lifts.
+/// `sim` returns this as unit/void; identity comes from that (full) void.
+type ISim<'a> = interface end
+
+/// A committed measurement: the uncertainty reduction (the finalizer's ΔU).
+type IMeasurement = interface end
+
+/// A Z-set delta (DBSP: +1 assertions / −1 retractions) — the excised/inserted change.
+type IDelta<'a> = interface end
+
+/// The sticky-end cut boundary the finalizer re-ligates to main (the same/ ctxboundary).
+type ISeam = interface end
+
+/// A class label — the discriminator / lens.
+type IClassLabel = interface end
+
+// ── The verbs (3-letter stems; pure interface stubs) ──
+
+/// sim(ulate) — ephemeral; produces NO output (void). The SETI@home edge run;
+/// `sim <duration>` (bare = 30s). Identity comes from the void.
+type ISimVerb =
+    abstract member Sim: seed: ISeed * duration: TimeSpan -> unit
+
+/// mea(sure) — `mea(sim)`: the committing lift over sim. Commits ΔU to the ledger.
+/// Real I/O via DI (effects) adds new external observation.
+type IMeaVerb =
+    abstract member Mea<'a> : effects: IEffects * sim: ISim<'a> -> IMeasurement
+
+/// cut — cut at a recognition site that is a TIME (default 30s): `mea(sim)` cuts at
+/// 30s by default. Residue = a Z-set delta + a sticky-end seam (re-ligated to main).
+type ICutVerb =
+    abstract member Cut<'a> : at: TimeSpan * sim: ISim<'a> -> IDelta<'a> * ISeam
+
+/// cla(ssify) — assign the result to a class / lens (the discriminator).
+type IClaVerb =
+    abstract member Cla<'a> : sim: ISim<'a> -> IClassLabel
+
+/// res(olve) — loop `mea` repeatedly until it resolves (a fixed point; finalizer-
+/// iterated; shapes A/B/D). "Resolves" = converges (ΔU→0) AND gains resolution.
+type IResVerb =
+    abstract member Res<'a> : effects: IEffects * sim: ISim<'a> -> IMeasurement
+
+/// The full family. `cut mea sim` by currying IS the loop; `res` iterates it.
+type ICli =
+    inherit ISimVerb
+    inherit IMeaVerb
+    inherit ICutVerb
+    inherit IClaVerb
+    inherit IResVerb


### PR DESCRIPTION
feat(clis): sim·mea·cut·cla·res pure-interface stubs (Verbs.fs) + cut-mea-sim is homoiconic across F#/CLI/filesystem (the fs pun)

Aaron: "sim cut mea res cla as interface stubs in clis/" + "cut mea sim works on cli too like currying
homoiconic to fs — fsharp filesystem homoiconicity."

- clis/Verbs.fs: the five verbs as PURE INTERFACES (no classes — the meta-rule), with the established
  type shapes (sim: ISeed*TimeSpan->unit (void); mea<'a>: IEffects*ISim<'a>->IMeasurement (the
  committing lift); cut<'a>: TimeSpan*ISim<'a>->IDelta<'a>*ISeam (cut at 30s default); cla<'a>->
  IClassLabel; res<'a> the resolve loop). Supporting types are opaque interface stubs (reified later
  via gen/). Stub: not yet in a project (clis/ is a root folder; uncompiled — no build risk).
- README: cut mea sim is HOMOICONIC across three registers — F# code, the CLI (the shell curries too),
  and the filesystem (the startup MerkleDAG IS the tree). The `fs` pun = F# / filesystem. One
  representation; the filesystem is the code (why folder structure is load-bearing).
markdownlint exit 0.

AgencySignature-v1:
  persona: otto
  hat: shadow
  surface: clis/
  intent: verb-interface-stubs-and-fs-homoiconicity
  authorization: aaron-authored (asked for the stubs)
  reversible: yes
  gated-class: none
  build: markdownlint exit 0; Verbs.fs is an uncompiled stub (not in any fsproj)
  register: grounded + peel
  ferry: no

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
