### PR TITLE
feat(clis)+boards: ben(chmark) verb (cut mea ben sim) + RGB=cut·mea·sim combinations & pairings

### DIFF
--- a/boards/dynamic-value-cmyk-rgb-encoding.md
+++ b/boards/dynamic-value-cmyk-rgb-encoding.md
@@ -46,6 +46,42 @@ the lawful-instance discipline):
 lane, and the numeric packing — is the open board-room question. The laws above hold regardless of the
 assignment; the assignment is what the room/sim resolves.)*
 
+## RGB = `cut mea sim`: combinations & pairings (Aaron 2026-06-10)
+
+> Aaron: "RGB = cut mea sim — how does that work? what's the combinations and pairings?"
+
+**RGB (soft, additive, light) = the three verbs running** (the ephemeral execution). **CMYK (solid,
+subtractive, ink) = their committed complement** (what dries onto `main`). The structure (the R/G/B↔verb
+assignment is the open choice the room resolves; the structure holds regardless):
+
+| light (RGB, soft — what runs) | verb |
+|---|---|
+| **R** | **sim** (void base) |
+| **G** | **mea** (committing lift `mea(sim)`) |
+| **B** | **cut** (write `cut(mea(sim))`) |
+
+**Combinations = composing verbs (additive mixing — more verbs ⇒ more light ⇒ toward white):**
+
+- 1 channel (pure): `sim` alone — ephemeral, leaves nothing.
+- 2 channels (a **pairing** = a secondary): R+G = **Yellow** = `mea(sim)`; G+B = **Cyan** =
+  `cut(mea …)`; R+B = **Magenta** = sim+cut.
+- 3 channels = **White** = `cut mea sim` — the **full curried loop** running (all light on).
+- 0 channels = **Black** = nothing running = the **void/null** (→ K below).
+
+**CMYK = the committed complement + the key:** `C = ¬R, M = ¬G, Y = ¬B` — each committed (ink) channel
+is the **complement** of the verb-light that ran (the residue, the `Delta × Seam`). **K = the key =
+black = the void/null** — the encrypted-null / common seed / `sim`'s void. **K is the 4th channel RGB
+lacks** — which is exactly why **CMYK is solid (4) and RGB is soft (3)**: the committed encoding carries
+the **key/null** the ephemeral light doesn't (K = where identity comes from).
+
+**Where `ben`/`cla`/`res` sit (outside the 3-cube):** `RGB = cut mea sim` is exactly 3, so the others
+are axes *around* the cube — **`res`** iterates the loop (the time axis: repeat until resolved),
+**`cla`** reads the resulting color → a class/lens (reads K to pick the class), **`ben`** instruments
+the run for perf (the benchmark loop `cut mea ben sim`; orthogonal to color — it times the light).
+
+*(Peel: the additive/subtractive complement structure is real color theory (RGB↔CMY complements; K=key);
+the verb↔channel assignment is the open question the room `mea`s out.)*
+
 ## How we settle it — a room/sim, `mea`'d repeatedly until it resolves (Aaron)
 
 > Aaron: "we need a **room/sim** for that so we can **`mea`** it." · "**repeatedly until it resolves**."

--- a/clis/README.md
+++ b/clis/README.md
@@ -3,7 +3,7 @@
 `clis/` is the home of Zeta's **CLIs** — the short 3-letter verbs that drive the substrate over the
 startup MerkleDAG (the MacVector-for-DNA toolset). **Plural** (never-one): a family, not one binary.
 
-## The verb family — `sim · mea · cut · cla · res` (Aaron 2026-06-10)
+## The verb family — `sim · mea · cut · ben · cla · res` (Aaron 2026-06-10)
 
 Each is a stem with the suffix dropped (three letters):
 
@@ -12,8 +12,15 @@ Each is a stem with the suffix dropped (three letters):
 | **`sim`** | sim(ulate) | run the deterministic sim for a duration | **no** | `unit` (void → identity comes from the void) |
 | **`mea`** | mea(sure) | `mea(sim)`: lift sim + commit the measurement | **yes** | `Measurement` (ΔU); real I/O via DI adds *new external* observation |
 | **`cut`** | cut | cut at a recognition site (a TIME; default 30s) | **yes** | `Delta × Seam` (Z-set diff + sticky-end the finalizer re-ligates) |
+| **`ben`** | ben(chmark) | instrument the sim for perf: the loop `cut mea ben sim` | **yes** | `Benchmark` (timing/allocs/throughput → `bench/`); perf, not ΔU |
 | **`cla`** | cla(ssify) | classify the result into a class/lens | **yes** | a **class label** (the discriminator/lens assignment) |
 | **`res`** | res(olve) | resolve: loop `mea` **repeatedly until it resolves** | **yes** | a **fixed point** (ΔU→0; shapes A/B/D) + the resolution |
+
+> **The benchmark loop (Aaron 2026-06-10): `cut mea ben sim`.** `ben` instruments `sim` for
+> **performance** (timing / allocations / throughput → [`bench/`](../bench/)) — the perf sibling of
+> `mea`'s uncertainty-reduction (ΔU). So the loop has two measuring verbs: `mea` (how much uncertainty
+> did we reduce) and `ben` (how fast / cheap was it). `cut mea ben sim` = simulate, benchmark, measure,
+> cut. (Routes perf to Naledi.)
 
 - **`sim`** — ephemeral; produces no output. The SETI@home edge run (`sim <duration>`, default 30s).
 - **`mea`** — the committing lift over `sim` (F# HOF/CE: `sim |> mea`); banks ΔU to `uncertainty/`.

--- a/clis/Verbs.fs
+++ b/clis/Verbs.fs
@@ -41,6 +41,10 @@ type ISeam = interface end
 /// A class label — the discriminator / lens.
 type IClassLabel = interface end
 
+/// A benchmark result — perf measurement (timing / allocations / throughput), distinct
+/// from IMeasurement's uncertainty-reduction (ΔU). Lands in bench/.
+type IBenchmark = interface end
+
 // ── The verbs (3-letter stems; pure interface stubs) ──
 
 /// sim(ulate) — ephemeral; produces NO output (void). The SETI@home edge run;
@@ -58,6 +62,11 @@ type IMeaVerb =
 type ICutVerb =
     abstract member Cut<'a> : at: TimeSpan * sim: ISim<'a> -> IDelta<'a> * ISeam
 
+/// ben(chmark) — instrument the sim for performance: the benchmark loop is
+/// `cut mea ben sim` (ben wraps sim, alongside mea's ΔU). Produces a perf result.
+type IBenVerb =
+    abstract member Ben<'a> : effects: IEffects * sim: ISim<'a> -> IBenchmark
+
 /// cla(ssify) — assign the result to a class / lens (the discriminator).
 type IClaVerb =
     abstract member Cla<'a> : sim: ISim<'a> -> IClassLabel
@@ -72,5 +81,6 @@ type ICli =
     inherit ISimVerb
     inherit IMeaVerb
     inherit ICutVerb
+    inherit IBenVerb
     inherit IClaVerb
     inherit IResVerb


### PR DESCRIPTION
feat(clis)+boards: ben(chmark) verb (cut mea ben sim) + RGB=cut·mea·sim combinations & pairings (CMYK = committed complement + K=key)

Aaron 2026-06-10:
- "cut mea ben(chmark) sim for benchmarks": ben = the perf sibling of mea — instruments sim for
  timing/allocs/throughput (-> bench/), distinct from mea's ΔU. The benchmark loop is `cut mea ben sim`.
  Added IBenVerb + IBenchmark stubs to clis/Verbs.fs (pure interfaces) and the verb-family table/README
  (now sim·mea·cut·ben·cla·res). Perf routes to Naledi.
- "RGB=cut mea sim how does that work? combinations and pairings?": captured to the encoding board —
  RGB (soft/additive light) = the 3 verbs running; combinations = composing verbs (1=pure, 2=secondary
  pairing [Y=mea(sim), C=cut(mea), M=sim+cut], 3=White=full loop, 0=Black=void). CMYK (solid/ink) = the
  committed complement (C=¬R,M=¬G,Y=¬B) + K=key=void/null (the 4th channel RGB lacks → why CMYK=4/solid,
  RGB=3/soft). ben/cla/res sit outside the 3-cube (res=iterate, cla=read-the-color, ben=time-the-light).
  Verb↔channel assignment = the open question the room mea's out.
markdownlint exit 0.

AgencySignature-v1:
  persona: otto
  hat: shadow
  surface: clis/ + boards/
  intent: ben-verb-and-rgb-cmyk-combinations-pairings
  authorization: aaron-authored
  reversible: yes
  gated-class: none
  build: markdownlint exit 0; Verbs.fs uncompiled stub
  register: grounded + peel
  ferry: no

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
