### PR TITLE
docs(clis): the Cayley mini-cubes — cognitive/query verbs (rem·whe·pay·att, how·man·whi·way)

### DIFF
--- a/clis/README.md
+++ b/clis/README.md
@@ -85,6 +85,33 @@ shell, and walking the MerkleDAG are the *same act* over the *same representatio
 folder structure is load-bearing: the filesystem is not a container for the code — it **is** the code,
 homoiconically.)
 
+## Outside the cube — the Cayley mini-cubes (cognitive/query verbs) (Aaron 2026-06-10)
+
+`sim · mea · cut` is the **main cube** (the RGB primaries; the run/commit loop). `ben · cla · res` are
+**axes around it** (perf / classify / iterate). Beyond those sit two **mini-cubes over Cayley** — the
+**cognitive / query** verbs, paired as natural-language phrases:
+
+> Aaron: "(outside the cube) rem(ember)/whe(n) \ pay/att(ention) — mini cube over cayley" · "also
+> how/man(y) \ whi(ch)/way over cayley."
+
+- **Mini-cube A — memory + attention:** **`rem`(ember) · `whe`(n)** ("remember when") and **`pay` ·
+  `att`(ention)** ("pay attention"). `rem` recalls from the persona entropy / git history (the reified
+  types); `whe` is the temporal query (quantum-phase time — *when*); `pay`/`att` are the attention pair
+  (focus / weight where to look — the transformer "pay attention"; ties the bug→reward `pay` economy).
+- **Mini-cube B — quantity + direction:** **`how` · `man`(y)** ("how many") and **`whi`(ch) · `way`**
+  ("which way"). `how`/`man` = the counting/cardinality query; `whi`/`way` = the navigation query
+  (which direction over the tree — the `bounds/` dashboard walk).
+
+**"Over Cayley"** = these mini-cubes are situated over the **Cayley structure** — the Cayley graph
+(group generators → navigation) / the **Cayley–Dickson** phasor spiral (the doubling that gave us the
+shape-F attractor). The main cube *acts*; the Cayley mini-cubes *query/navigate* over the algebra that
+generates the space. (Together they read as English phrases — remember-when, pay-attention, how-many,
+which-way — the interrogatives + how/many/which/way: the substrate's introspection verbs.)
+
+*(Peel: the core six (`sim·mea·cut·ben·cla·res`) have settled semantics + stubs in `Verbs.fs`; the
+Cayley mini-cube verbs are **forming** — captured as the cognitive/query layer, semantics to crystallize
+(no stubs yet). "Over Cayley" = Cayley graph / Cayley–Dickson, to formalize with the math team.)*
+
 ## Honest scope
 
 [Beacon] MacVector (the DNA-CLI shape lineage) · CHIP-8 (the minimal VM `sim` runs) · DBSP/Z-set (the


### PR DESCRIPTION
docs(clis): the Cayley mini-cubes outside the cube — cognitive/query verbs (rem·whe·pay·att, how·man·whi·way)

Aaron 2026-06-10: "(outside the cube) rem(ember)/whe(n) \ pay/att(ention) mini cube over cayley" +
"also how/man(y) \ whi(ch)/way over cayley."

Outside the main sim·mea·cut cube (RGB primaries; the act/commit loop) and the ben·cla·res axes, two
MINI-CUBES OVER CAYLEY of cognitive/query verbs, paired as English phrases:
- A (memory+attention): rem(ember)·whe(n) ["remember when"] + pay·att(ention) ["pay attention"] —
  recall from persona entropy/git history; temporal query; the attention pair (+ bug->reward pay).
- B (quantity+direction): how·man(y) ["how many"] + whi(ch)·way ["which way"] — cardinality query;
  navigation query (which way over the tree / bounds dashboard).
"Over Cayley" = Cayley graph (navigation) / Cayley-Dickson (the phasor spiral). The main cube ACTS; the
mini-cubes QUERY/NAVIGATE over the generating algebra. Peel: the core six have stubs; these are forming
(cognitive/query layer, no stubs yet; formalize "over Cayley" with the math team).
markdownlint exit 0.

AgencySignature-v1:
  persona: otto
  hat: shadow
  surface: clis/
  intent: capture-cayley-mini-cubes-cognitive-query-verbs
  authorization: aaron-authored
  reversible: yes
  gated-class: none
  build: markdownlint exit 0
  register: grounded + peel
  ferry: no

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
