### PR TITLE
ci(gate): advisory yaml/k8s lint (yamllint + kubeconform) — declarative via .mise.toml, install.sh + install.ps1 in sync

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -474,6 +474,44 @@ jobs:
         # rule without a gate isn't a control.
         run: semgrep --config .semgrep.yml --error --metrics=off
 
+  lint-yaml-k8s:
+    # YAML + Kubernetes-manifest validation over full-ai-cluster/k8s/** — the
+    # GitOps surface ArgoCD deploys. Closes the gap that let a k8s Application land
+    # with ZERO CI validation (only ArgoCD checked it, slowly, at cluster-sync).
+    # yamllint = syntax/indentation/dup-key; kubeconform = k8s API-schema validation.
+    # Aaron 2026-06-10 ("should we have a yaml/k8s lint gate? ... lets do that").
+    #
+    # ADVISORY first (continue-on-error) — reports without blocking the gate; flip
+    # to required once it has run clean for a few rounds (same easing-in pattern as
+    # prior gate additions). Toolchain via three-way-parity install.sh (GOVERNANCE
+    # §24): yamllint (pipx→uv) + kubeconform (ubi:) pinned in .mise.toml, so dev
+    # laptops + CI + devcontainers + install.ps1 all get the same versions.
+    name: lint (yaml/k8s)
+    timeout-minutes: 10
+    runs-on: ubuntu-24.04
+    continue-on-error: true   # ADVISORY — remove once clean for a few rounds (then required)
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install toolchain via three-way-parity script (GOVERNANCE §24)
+        run: ./tools/setup/install.sh
+
+      - name: yamllint (k8s manifests)
+        # relaxed profile: structural correctness (indent/dup-key/syntax), not
+        # cosmetic line-length — the manifests are machine-authored Helm values.
+        run: yamllint -d relaxed full-ai-cluster/k8s/
+
+      - name: kubeconform (k8s API-schema validation)
+        # -ignore-missing-schemas: skip CRs we have no schema for (ArgoCD
+        # Application etc.) rather than false-fail; -strict: reject unknown fields
+        # on the manifests we DO have schemas for. find-pipe so it recurses
+        # explicitly (portable across kubeconform versions).
+        run: |
+          find full-ai-cluster/k8s -type f \( -name '*.yaml' -o -name '*.yml' \) -print0 \
+            | xargs -0 kubeconform -strict -ignore-missing-schemas -summary -schema-location default
+
   lint-shell:
     # Shellcheck on every bash script under tools/setup/ + tools/.
     # Round 33 static-analysis expansion (Aaron: "as much static

--- a/.mise.toml
+++ b/.mise.toml
@@ -104,6 +104,23 @@ node = "24"
 # unpinned pip-bootstrap surface goes away entirely once mise
 # owns this tool).
 "pipx:semgrep" = "1.161.0"
+# yamllint: YAML syntax/indentation/duplicate-key linter for the k8s manifests
+# under full-ai-cluster/k8s/** (the `lint (yaml/k8s)` gate job). Same three-way-
+# parity rationale as semgrep — mac/linux/windows all get it through mise, so
+# install.sh AND install.ps1 stay in sync by construction (no per-OS manifest
+# divergence). NOTE: the `pipx:` prefix is mise's backend NAME only — because `uv`
+# is in this toolchain, mise auto-routes `pipx:` through `uv tool install`, NOT
+# pip (the uv-canonical ADR; identical to `pipx:semgrep` above). No pip anywhere.
+# Pin per dep-pin-search-first (PyPI 2026-06-10: 1.38.0).
+"pipx:yamllint" = "1.38.0"
+# kubeconform: FAST offline Kubernetes-manifest schema validator (the other half
+# of the `lint (yaml/k8s)` gate — validates ArgoCD Application CRs + k8s manifests
+# against API schemas; --ignore-missing-schemas so CRDs don't false-fail). A Go
+# binary, installed cross-platform via mise's `ubi:` backend (GitHub-release
+# universal binary installer) — one pin covers mac/linux/windows, install.sh +
+# install.ps1 in sync. Pin per dep-pin-search-first (GitHub releases 2026-06-10:
+# v0.7.0; ubi strips the leading v).
+"ubi:yannh/kubeconform" = "0.7.0"
 
 [settings]
 # `python-build-standalone` (upstream for mise's python plugin)


### PR DESCRIPTION
ci(gate): add advisory yaml/k8s lint (yamllint + kubeconform) over full-ai-cluster/k8s/**

Aaron 2026-06-10: "should we have a yaml/k8s lint gate? ... lets do that and make sure we add
declarative to install.sh too ... make sure windows install.ps1 is in sync too."

Closes the gap the headscale Application (#7504) walked through: k8s manifests had ZERO CI
validation — only ArgoCD checked them, slowly, at cluster-sync. Now validated at PR time.

- gate.yml: new `lint (yaml/k8s)` job (ADVISORY — continue-on-error; flips to required after a few
  clean rounds). yamllint -d relaxed (syntax/indent/dup-key) + kubeconform -strict
  -ignore-missing-schemas (k8s API-schema validation; CRs like ArgoCD Application are skipped, not
  false-failed). find-pipe for portable recursion. Mirrors the semgrep job (install.sh → tool).
- .mise.toml: pinned `pipx:yamllint` = 1.38.0 and `ubi:yannh/kubeconform` = 0.7.0
  (dep-pin-search-first; PyPI + GitHub releases 2026-06-10). DECLARATIVE + cross-platform via mise:
  - pipx:yamllint routes through `uv tool install`, NOT pip (uv-canonical ADR; same as pipx:semgrep;
    matches the scratch/SQLSharp uv setup Aaron pointed to).
  - ubi: = GitHub-release universal binary (one pin → mac/linux/windows).
  - install.sh (mac/linux) AND install.ps1 (line 215 `mise install`, IDENTICAL .mise.toml) both pick
    these up — three-way + windows in sync BY CONSTRUCTION, no per-OS manifest divergence.

Verified locally: yamllint exit 0; kubeconform 41 valid / 0 invalid / 94 CR-skipped / exit 0 — the
advisory job is green from the start.

AgencySignature-v1:
  persona: otto
  hat: shadow
  surface: .github/workflows/gate.yml + .mise.toml
  intent: yaml-k8s-lint-gate-declarative-cross-platform
  authorization: aaron-authored ("lets do that")
  reversible: yes
  gated-class: none
  build: yamllint exit 0; kubeconform exit 0; gate.yml YAML valid
  register: grounded
  ferry: no

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
