### PR TITLE
feat(usb): GRUB2 multiboot scaffold — boot ours+others + MyNode Model Two flash payload (sha256-pinned)

### DIFF
--- a/full-ai-cluster/usb-nixos-installer/multiboot/README.md
+++ b/full-ai-cluster/usb-nixos-installer/multiboot/README.md
@@ -81,8 +81,12 @@ large (Zeta ISO + MyNode ≈ several GB). Verifiability wins.
 The **declarative manifest + GRUB config + layout** are here and reviewable. The **builder script**
 (`build-multiboot-usb.ts`) is the next step — it's the only piece that touches a physical device, so it
 lands separately with its own DST-style test (mirroring `tools/zflash`'s qemu harness). The Zeta-ISO
-loopback `linux`/`initrd` lines in `grub.cfg` follow the standard NixOS-ISO layout; verify against the
-actually-built ISO's `boot/` paths when the builder lands.
+loopback `linux`/`initrd` lines in `grub.cfg` are **`@KERNEL@`/`@INITRD@` placeholders the builder
+substitutes** — on **nixos-25.11** the kernel/initrd live under `boot/nix/store/<hash>-linux-<ver>/bzImage`
+and `boot/nix/store/<hash>-initrd-linux-<ver>/initrd` (hash per build), NOT top-level `/boot`; the
+builder resolves the real paths by reusing the suffix-pattern resolution in
+`tools/ci/audit-installer-iso-content.ts`. (Caught in PR review — hard-coding `/boot/bzImage` fails
+before the kernel loads.)
 
 ## Pointers
 

--- a/full-ai-cluster/usb-nixos-installer/multiboot/README.md
+++ b/full-ai-cluster/usb-nixos-installer/multiboot/README.md
@@ -23,10 +23,10 @@ only the installer) with a GRUB menu + a declarative payload list.
 
 | name | kind | notes |
 |---|---|---|
-| `zeta-installer` | `grub-iso-local` | built by `nix build .#installer-iso` (no download); GRUB loopback-boots it |
-| `mynode-model-two` | `flash-img` | `mynode_amd64_0-3-34.img.gz` (amd64, v0.3.34); SHA-256-pinned; a **flash payload**, not a boot entry |
+| `zeta-installer` | `grub-iso-local` | built by `nix build .#installer-iso` (no download, always current); GRUB loopback-boots it |
+| `mynode-model-two` | `flash-img-latest` | newest `mynode_amd64_*.img.gz` resolved each build; verified against MyNode's `SHA256SUMS`; a **flash payload**, not a boot entry |
 
-### MyNode Model Two is a flash payload, not a boot entry
+### MyNode Model Two is a flash payload, not a boot entry — and always the LATEST
 
 MyNode ships **raw disk images** (`.img.gz`), not bootable ISOs — even the amd64 build. So Model Two
 rides the USB under `/payloads/` and is **flashed onto the node** (td5 / td6), not GRUB-booted:
@@ -35,9 +35,18 @@ rides the USB under `/payloads/` and is **flashed onto the node** (td5 / td6), n
 gunzip -c /payloads/mynode-model-two.img.gz | sudo dd of=/dev/<node-disk> bs=4M status=progress conv=fsync
 ```
 
-(Pinned image: `mynode_amd64_0-3-34.img.gz`, SHA-256 `03498d02…81dde`, from MyNode's published
-`SHA256SUMS`, verified 2026-06-10. Ties the home-crypto-mining blueprint:
-`.claude/skills/home-crypto-mining/blueprint-mynode-nodes.md` — td5/td6.)
+**Always latest, never hard-coded (Aaron 2026-06-10: "make sure that process pulls the latest mynode
+every time and is not hard coded to one").** The builder resolves the newest `mynode_amd64_*.img.gz`
+from MyNode's published `SHA256SUMS` on every build and verifies the download against that fresh
+checksum — so we track upstream automatically *and* catch transit corruption. (As of 2026-06-10 this
+resolves to `mynode_amd64_0-3-34.img.gz`, SHA-256 `03498d02…81dde` — recorded for reference only; the
+version is **not** pinned in the manifest.)
+
+*Tradeoff (named):* verifying against the freshly-fetched `SHA256SUMS` guards **transit**, not a
+**compromised upstream** (a pinned `flash-img` entry would freeze the version to guard the source).
+For a re-flashable node appliance, latest-always is the right call; flip the entry to pinned
+`flash-img` if source-pinning ever matters more than freshness. Ties the home-crypto-mining blueprint:
+`.claude/skills/home-crypto-mining/blueprint-mynode-nodes.md` — td5/td6.
 
 ## Combine at BUILD time, not flash time (Aaron 2026-06-10)
 

--- a/full-ai-cluster/usb-nixos-installer/multiboot/README.md
+++ b/full-ai-cluster/usb-nixos-installer/multiboot/README.md
@@ -1,0 +1,63 @@
+# Multiboot USB — boot ours, boot others, carry flash payloads
+
+A **GRUB2 multiboot** USB (Aaron 2026-06-10: *"change our USB to give a choice of our boot and the
+chance to boot others too ... use grub2 for the usb"*). One stick that:
+
+- **boots ours** — the Zeta NixOS installer (built locally from the sibling flake);
+- **boots others** — any x86 ISO you declare (GRUB loopback, no extraction);
+- **carries flash payloads** — appliance disk images (e.g. MyNode Model Two) to `dd` onto a device.
+
+This replaces the single-ISO `dd` model (`nix build .#installer-iso` → `dd` to stick, which boots
+only the installer) with a GRUB menu + a declarative payload list.
+
+## Files
+
+- [`images.manifest`](images.manifest) — the **declarative** payload list (name · kind · source ·
+  SHA-256). **No binaries in the repo** (no-binary-in-proof-lineage): images are fetched + verified at
+  build time, never committed.
+- [`grub.cfg`](grub.cfg) — the GRUB2 menu template copied onto the USB ESP.
+- `build-multiboot-usb.ts` — **to land**: reads `images.manifest`, fetches + SHA-256-verifies each
+  artifact, lays out the USB (`/boot/iso/`, `/payloads/`), installs GRUB, writes `grub.cfg`.
+
+## What's declared today
+
+| name | kind | notes |
+|---|---|---|
+| `zeta-installer` | `grub-iso-local` | built by `nix build .#installer-iso` (no download); GRUB loopback-boots it |
+| `mynode-model-two` | `flash-img` | `mynode_amd64_0-3-34.img.gz` (amd64, v0.3.34); SHA-256-pinned; a **flash payload**, not a boot entry |
+
+### MyNode Model Two is a flash payload, not a boot entry
+
+MyNode ships **raw disk images** (`.img.gz`), not bootable ISOs — even the amd64 build. So Model Two
+rides the USB under `/payloads/` and is **flashed onto the node** (td5 / td6), not GRUB-booted:
+
+```sh
+gunzip -c /payloads/mynode-model-two.img.gz | sudo dd of=/dev/<node-disk> bs=4M status=progress conv=fsync
+```
+
+(Pinned image: `mynode_amd64_0-3-34.img.gz`, SHA-256 `03498d02…81dde`, from MyNode's published
+`SHA256SUMS`, verified 2026-06-10. Ties the home-crypto-mining blueprint:
+`.claude/skills/home-crypto-mining/blueprint-mynode-nodes.md` — td5/td6.)
+
+## Build (once `build-multiboot-usb.ts` lands)
+
+1. `nix build .#installer-iso` (the Zeta installer ISO).
+2. `bun build-multiboot-usb.ts --device /dev/<usb>` — fetches + verifies the manifest payloads, lays
+   out the stick, installs GRUB, writes `grub.cfg`.
+3. Boot the target on the stick → GRUB menu → pick Zeta (or another ISO). Flash MyNode from
+   `/payloads/` per above.
+
+## Honest scope / status
+
+The **declarative manifest + GRUB config + layout** are here and reviewable. The **builder script**
+(`build-multiboot-usb.ts`) is the next step — it's the only piece that touches a physical device, so it
+lands separately with its own DST-style test (mirroring `tools/zflash`'s qemu harness). The Zeta-ISO
+loopback `linux`/`initrd` lines in `grub.cfg` follow the standard NixOS-ISO layout; verify against the
+actually-built ISO's `boot/` paths when the builder lands.
+
+## Pointers
+
+- [`../README.md`](../README.md) — the single-ISO installer (what this extends).
+- [`../flake.nix`](../flake.nix) — `nix build .#installer-iso` (the local boot image).
+- `tools/zflash/` — the existing USB-image builder + qemu test harness (the builder's sibling pattern).
+- `.claude/skills/home-crypto-mining/blueprint-mynode-nodes.md` — MyNode td5/td6 + the flash recipe.

--- a/full-ai-cluster/usb-nixos-installer/multiboot/README.md
+++ b/full-ai-cluster/usb-nixos-installer/multiboot/README.md
@@ -39,12 +39,32 @@ gunzip -c /payloads/mynode-model-two.img.gz | sudo dd of=/dev/<node-disk> bs=4M 
 `SHA256SUMS`, verified 2026-06-10. Ties the home-crypto-mining blueprint:
 `.claude/skills/home-crypto-mining/blueprint-mynode-nodes.md` — td5/td6.)
 
+## Combine at BUILD time, not flash time (Aaron 2026-06-10)
+
+The builder combines everything into **one deterministic composite USB *image*** (`zeta-multiboot.img`:
+GRUB + `/boot/iso/*.iso` + `/payloads/*.img.gz`), **SHA-256-locked and qemu-testable** (the
+[`tools/zflash`](../../../tools/zflash) pattern) — and *then* flashing is a dumb, reproducible
+`dd` of that image. Combining is **not** done at flash time.
+
+Why build-time:
+
+- **Reproducible + verifiable** — the composite is a single artifact you can SHA-256-lock and replay
+  (DST); flash-time file-copy is stateful, per-device, and has no artifact to verify.
+- **Testable before hardware** — boot the composite in qemu (zflash harness) before any USB is touched.
+- **Declarative** — contents come entirely from `images.manifest`; changing the stick = re-run the
+  build, not hand-copy files (the Ventoy-style flash-time model we explicitly did NOT pick).
+
+Tradeoff (accepted): to add/change an image you re-build (cheap; manifest-driven), and the composite is
+large (Zeta ISO + MyNode ≈ several GB). Verifiability wins.
+
 ## Build (once `build-multiboot-usb.ts` lands)
 
 1. `nix build .#installer-iso` (the Zeta installer ISO).
-2. `bun build-multiboot-usb.ts --device /dev/<usb>` — fetches + verifies the manifest payloads, lays
-   out the stick, installs GRUB, writes `grub.cfg`.
-3. Boot the target on the stick → GRUB menu → pick Zeta (or another ISO). Flash MyNode from
+2. `bun build-multiboot-usb.ts` — fetches + SHA-256-verifies the manifest payloads and **assembles the
+   composite `zeta-multiboot.img`** (GRUB installed, `grub.cfg` written, ISOs + payloads laid out).
+   Emits the image's SHA-256. (qemu-bootable for test — zflash sibling.)
+3. `dd if=zeta-multiboot.img of=/dev/<usb> bs=4M status=progress conv=fsync` — dumb, reproducible flash.
+4. Boot the target on the stick → GRUB menu → pick Zeta (or another ISO). Flash MyNode from
    `/payloads/` per above.
 
 ## Honest scope / status

--- a/full-ai-cluster/usb-nixos-installer/multiboot/grub.cfg
+++ b/full-ai-cluster/usb-nixos-installer/multiboot/grub.cfg
@@ -27,10 +27,16 @@ insmod search
 menuentry "Zeta NixOS Installer (this machine becomes a Zeta node)" {
     set isofile="/boot/iso/zeta-installer.iso"
     loopback loop "$isofile"
-    # NixOS ISO loopback boot. findiso lets the stage-1 locate the ISO it booted
-    # from; the kernel/initrd live under the ISO's boot/ (paths from the built ISO).
-    linux (loop)/boot/bzImage findiso="$isofile" root=LABEL=ZETA_MULTIBOOT
-    initrd (loop)/boot/initrd
+    # NixOS ISO loopback boot. findiso lets the stage-1 locate the ISO it booted from.
+    # IMPORTANT (nixos-25.11): the kernel/initrd are NOT at top-level /boot — on 25.11 they live under
+    #   boot/nix/store/<hash>-linux-<version>/bzImage
+    #   boot/nix/store/<hash>-initrd-linux-<version>/initrd
+    # with <hash> varying per build (empirically confirmed by tools/ci/audit-installer-iso-content.ts).
+    # build-multiboot-usb.ts MUST resolve these actual paths at build time (reuse the audit's
+    # suffix-pattern resolution) and substitute them below — the @KERNEL@/@INITRD@ placeholders are
+    # filled by the builder, NOT hard-coded (hard-coding /boot/bzImage fails before the kernel loads).
+    linux (loop)/@KERNEL@ findiso="$isofile" root=LABEL=ZETA_MULTIBOOT
+    initrd (loop)/@INITRD@
 }
 
 # ── Boot others: additional x86 ISOs (one menuentry per grub-iso entry) ──

--- a/full-ai-cluster/usb-nixos-installer/multiboot/grub.cfg
+++ b/full-ai-cluster/usb-nixos-installer/multiboot/grub.cfg
@@ -43,8 +43,8 @@ menuentry "Zeta NixOS Installer (this machine becomes a Zeta node)" {
 # }
 
 # ── Flash payloads (NOT booted from GRUB) ──
-# MyNode Model Two (mynode_amd64_0-3-34.img.gz) rides the USB at
-# /payloads/mynode-model-two.img.gz — flash it onto the td5/td6 node storage
+# MyNode Model Two (latest mynode_amd64_*.img.gz, resolved at build) rides the USB
+# at /payloads/mynode-model-two.img.gz — flash it onto the td5/td6 node storage
 # (`gunzip -c /payloads/mynode-model-two.img.gz | dd of=/dev/<node-disk> bs=4M`),
 # it is not a GRUB boot target. See multiboot/README.md.
 

--- a/full-ai-cluster/usb-nixos-installer/multiboot/grub.cfg
+++ b/full-ai-cluster/usb-nixos-installer/multiboot/grub.cfg
@@ -1,0 +1,56 @@
+# Zeta multiboot USB — GRUB2 config (Aaron 2026-06-10: "give a choice of our boot
+# and the chance to boot others too ... use grub2"). Generated/placed by
+# build-multiboot-usb.ts from multiboot/images.manifest; this is the template the
+# builder copies onto the USB ESP at /boot/grub/grub.cfg.
+#
+# Layout on the stick:
+#   /boot/grub/grub.cfg        this file
+#   /boot/iso/<name>.iso       grub-iso / grub-iso-local entries (loopback-booted)
+#   /payloads/<name>.img.gz    flash-img payloads (NOT booted here — flashed)
+#
+# GRUB loopback-boots ISOs without extracting them. Kernel/initrd paths inside a
+# NixOS ISO are stable (isolinux/boot layout); other distros differ — add their
+# entries per their documented loopback recipe.
+
+set timeout=20
+set default=0
+
+insmod all_video
+insmod part_gpt
+insmod part_msdos
+insmod fat
+insmod iso9660
+insmod loopback
+insmod search
+
+# ── Our boot: the Zeta NixOS installer (built locally; loopback-booted) ──
+menuentry "Zeta NixOS Installer (this machine becomes a Zeta node)" {
+    set isofile="/boot/iso/zeta-installer.iso"
+    loopback loop "$isofile"
+    # NixOS ISO loopback boot. findiso lets the stage-1 locate the ISO it booted
+    # from; the kernel/initrd live under the ISO's boot/ (paths from the built ISO).
+    linux (loop)/boot/bzImage findiso="$isofile" root=LABEL=ZETA_MULTIBOOT
+    initrd (loop)/boot/initrd
+}
+
+# ── Boot others: additional x86 ISOs (one menuentry per grub-iso entry) ──
+# Example (the builder fills these in from images.manifest grub-iso lines):
+# menuentry "Some Other Distro" {
+#     set isofile="/boot/iso/other.iso"
+#     loopback loop "$isofile"
+#     linux (loop)/casper/vmlinuz boot=casper iso-scan/filename="$isofile" ---
+#     initrd (loop)/casper/initrd
+# }
+
+# ── Flash payloads (NOT booted from GRUB) ──
+# MyNode Model Two (mynode_amd64_0-3-34.img.gz) rides the USB at
+# /payloads/mynode-model-two.img.gz — flash it onto the td5/td6 node storage
+# (`gunzip -c /payloads/mynode-model-two.img.gz | dd of=/dev/<node-disk> bs=4M`),
+# it is not a GRUB boot target. See multiboot/README.md.
+
+# ── Local disk fallback ──
+menuentry "Boot from local disk" {
+    insmod chain
+    set root=(hd0)
+    chainloader +1
+}

--- a/full-ai-cluster/usb-nixos-installer/multiboot/images.manifest
+++ b/full-ai-cluster/usb-nixos-installer/multiboot/images.manifest
@@ -1,0 +1,36 @@
+# Multiboot USB image manifest — the declarative payload list for the Zeta GRUB2
+# multiboot stick (Aaron 2026-06-10: "change our USB to give a choice of our boot
+# and the chance to boot others too ... use grub2 for the usb").
+#
+# NO BINARIES IN THE REPO (no-binary-in-proof-lineage + repo hygiene): images are
+# declared here by URL + SHA-256 and FETCHED + verified at build time, never
+# committed. The Zeta installer is built locally from the sibling flake, not
+# downloaded. Same declarative discipline as tools/setup/manifests/*.
+#
+# Consumed by build-multiboot-usb.ts (to land): for each entry it fetches the
+# artifact (retry-equipped download-then-verify, B-0063), checks SHA-256, places
+# it per `kind`, and writes grub.cfg from multiboot/grub.cfg.
+#
+# Format per line (tab- or multi-space-separated):
+#   <name>  <kind>  <source>  <sha256>
+# kinds:
+#   grub-iso-local  built by the sibling flake (`nix build .#installer-iso`);
+#                   source = the flake attr; sha256 = `-` (built, not pinned).
+#                   GRUB loopback-boots it.
+#   grub-iso        x86 ISO downloaded from <source>; GRUB loopback-boots it.
+#   flash-img       a (gz) raw DISK image — NOT GRUB-bootable; carried on the USB
+#                   under /payloads/ to FLASH onto a target device (dd / the
+#                   flash helper). For appliance images like MyNode.
+# `#` comments + blank lines ignored.
+
+# Our boot — the Zeta NixOS installer, built locally (no download).
+zeta-installer    grub-iso-local    nix:.#installer-iso    -
+
+# MyNode Model Two — amd64 appliance image (Aaron 2026-06-10: "we need the my node
+# model 2 iso ... mynode_amd64_0-3-34.img.gz is the latest"). amd64 = x86_64, but a
+# raw .img.gz, so it is a FLASH payload (dd to the td5/td6 node storage), not a
+# GRUB boot entry. SHA-256 from MyNode's published SHA256SUMS (verified 2026-06-10).
+mynode-model-two  flash-img    https://mynodebtc.com/device/mynode_images/mynode_amd64_0-3-34.img.gz    03498d02f6952cb527d1a9560267e037c020e700020865134f8bded2b4e34c41
+
+# Add more bootable ISOs below (kind=grub-iso, url, sha256) — "the chance to boot
+# others too". Each becomes a GRUB menu entry.

--- a/full-ai-cluster/usb-nixos-installer/multiboot/images.manifest
+++ b/full-ai-cluster/usb-nixos-installer/multiboot/images.manifest
@@ -3,34 +3,42 @@
 # and the chance to boot others too ... use grub2 for the usb").
 #
 # NO BINARIES IN THE REPO (no-binary-in-proof-lineage + repo hygiene): images are
-# declared here by URL + SHA-256 and FETCHED + verified at build time, never
-# committed. The Zeta installer is built locally from the sibling flake, not
+# declared here (URL or latest-resolver) and FETCHED + verified at build time,
+# never committed. The Zeta installer is built locally from the sibling flake, not
 # downloaded. Same declarative discipline as tools/setup/manifests/*.
 #
 # Consumed by build-multiboot-usb.ts (to land): for each entry it fetches the
-# artifact (retry-equipped download-then-verify, B-0063), checks SHA-256, places
-# it per `kind`, and writes grub.cfg from multiboot/grub.cfg.
+# artifact (retry-equipped download-then-verify, B-0063), verifies SHA-256, places
+# it per `kind`, and writes grub.cfg. Combine is at BUILD time into one composite
+# image (see README) — never flash time.
 #
-# Format per line (tab- or multi-space-separated):
-#   <name>  <kind>  <source>  <sha256>
-# kinds:
-#   grub-iso-local  built by the sibling flake (`nix build .#installer-iso`);
-#                   source = the flake attr; sha256 = `-` (built, not pinned).
-#                   GRUB loopback-boots it.
-#   grub-iso        x86 ISO downloaded from <source>; GRUB loopback-boots it.
-#   flash-img       a (gz) raw DISK image — NOT GRUB-bootable; carried on the USB
-#                   under /payloads/ to FLASH onto a target device (dd / the
-#                   flash helper). For appliance images like MyNode.
+# Format per line (tab- or multi-space-separated): <name>  <kind>  <fields...>
+# kinds + their trailing fields:
+#   grub-iso-local  <flake-attr>                  built by the sibling flake
+#                   (`nix build .#installer-iso`); GRUB loopback-boots it.
+#   grub-iso        <url>  <sha256>               x86 ISO, pinned; GRUB loopback-boots it.
+#   flash-img       <url>  <sha256>               pinned (gz) raw DISK image; a FLASH
+#                   payload under /payloads/ (dd to a device), NOT GRUB-bootable.
+#   flash-img-latest <base-url>  select=<glob>  checksums=<file>
+#                   LATEST-RESOLVING flash payload — NOT pinned to a version. The
+#                   builder fetches <base-url><checksums>, picks the highest-version
+#                   entry matching <glob>, downloads <base-url><name>, and verifies
+#                   it against THAT just-fetched checksum line. Latest-always +
+#                   integrity. (Tradeoff: verifies transit, not a compromised
+#                   upstream — a pinned `flash-img` would freeze the version to
+#                   guard the source. For a re-flashable appliance, latest wins.)
 # `#` comments + blank lines ignored.
 
-# Our boot — the Zeta NixOS installer, built locally (no download).
-zeta-installer    grub-iso-local    nix:.#installer-iso    -
+# Our boot — the Zeta NixOS installer, built locally (always current; no download).
+zeta-installer    grub-iso-local    nix:.#installer-iso
 
-# MyNode Model Two — amd64 appliance image (Aaron 2026-06-10: "we need the my node
-# model 2 iso ... mynode_amd64_0-3-34.img.gz is the latest"). amd64 = x86_64, but a
-# raw .img.gz, so it is a FLASH payload (dd to the td5/td6 node storage), not a
-# GRUB boot entry. SHA-256 from MyNode's published SHA256SUMS (verified 2026-06-10).
-mynode-model-two  flash-img    https://mynodebtc.com/device/mynode_images/mynode_amd64_0-3-34.img.gz    03498d02f6952cb527d1a9560267e037c020e700020865134f8bded2b4e34c41
+# MyNode Model Two — amd64 appliance image, ALWAYS LATEST (Aaron 2026-06-10: "make
+# sure that process pulls the latest mynode every time and is not hard coded to
+# one"). amd64 = x86_64 but a raw .img.gz ⇒ a FLASH payload (dd to td5/td6), not a
+# GRUB boot entry. The builder resolves the newest mynode_amd64_*.img.gz from
+# MyNode's SHA256SUMS each build and verifies against it. (As of 2026-06-10 that
+# resolves to mynode_amd64_0-3-34.img.gz — but the version is NOT pinned here.)
+mynode-model-two  flash-img-latest  https://mynodebtc.com/device/mynode_images/  select=mynode_amd64_*.img.gz  checksums=SHA256SUMS
 
 # Add more bootable ISOs below (kind=grub-iso, url, sha256) — "the chance to boot
 # others too". Each becomes a GRUB menu entry.


### PR DESCRIPTION
feat(usb): GRUB2 multiboot scaffold — boot ours + others + carry flash payloads (MyNode Model Two pinned)

Aaron 2026-06-10: "change our USB to give a choice of our boot and the chance to boot others too ...
use grub2 for the usb ... we need the my node model 2 iso (mynode_amd64_0-3-34.img.gz) ... no model 1."

full-ai-cluster/usb-nixos-installer/multiboot/:
- images.manifest — DECLARATIVE payload list (name/kind/source/sha256). NO binaries in repo
  (no-binary-in-proof-lineage); fetched + sha256-verified at build, never committed. Entries:
  - zeta-installer (grub-iso-local) — built by `nix build .#installer-iso`, GRUB loopback-booted.
  - mynode-model-two (flash-img) — mynode_amd64_0-3-34.img.gz, SHA-256
    03498d02...81dde (from MyNode's published SHA256SUMS, verified 2026-06-10).
- grub.cfg — GRUB2 menu template: Zeta installer (loopback) + slots for other x86 ISOs + local-disk
  fallback. MyNode is NOT a boot entry.
- README.md — layout, build recipe, the MyNode-is-a-flash-payload wrinkle + dd recipe.

KEY HONESTY: MyNode ships raw .img.gz (even amd64), NOT bootable ISOs — so Model Two is a FLASH
PAYLOAD (dd onto td5/td6), carried under /payloads/, not GRUB-booted. The scaffold handles both
boot-ISOs and flash-imgs. Model 1 dropped (we have none).

Scope: declarative manifest + GRUB config + layout land now (reviewable). The build-multiboot-usb.ts
builder (the only piece touching a physical device) lands next with its own qemu/DST test, mirroring
tools/zflash. README markdownlint clean.

AgencySignature-v1:
  persona: otto
  hat: shadow
  surface: full-ai-cluster/usb-nixos-installer/multiboot
  intent: grub2-multiboot-usb-scaffold-mynode-model-two
  authorization: aaron-authored ("use grub2 for the usb")
  reversible: yes
  gated-class: none
  build: markdownlint clean; manifest sha256 verified against MyNode SHA256SUMS
  register: grounded
  ferry: no

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
