### PR TITLE
feat(core): save optic interfaces — ILens (lensable) + IPrism (prismable/fingerprintable, soft+hard rainbow)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -48,6 +48,7 @@
     <Compile Include="FinalizerRuntimeLive.fs" />
     <Compile Include="Sim.fs" />
     <Compile Include="CliVerb.fs" />
+    <Compile Include="Optics.fs" />
     <Compile Include="TravelerFrame.fs" />
     <Compile Include="FrameDelta.fs" />
     <Compile Include="UncertainClock.fs" />

--- a/src/Core/Optics.fs
+++ b/src/Core/Optics.fs
@@ -1,0 +1,47 @@
+namespace Zeta.Core
+
+/// Optics — the **lensable** and **prismable (fingerprintable)** focus interfaces (Aaron 2026-06-10:
+/// "save the lensable and prismable (fingerprintable) interfaces in code so we don't lose them").
+///
+/// Two kinds of focus, chosen by the shape of the whole (see
+/// docs/research/2026-06-10-forcing-lensability-*):
+///   • LENS  — a part that is ALWAYS present: a *product* factor (`whole ≅ part × rest`).
+///   • PRISM — a part that MAY be present: a *sum* case. Prism = **fingerprint**: `Match` identifies
+///             whether the whole is this case and extracts it; `Build` injects it back. The
+///             fingerprinting ties our rainbow-table / content-derived-identity primitives
+///             (`GameFingerprint`, `StructureFingerprint`): `Match` = fingerprint-then-lookup.
+///
+/// Pure interfaces, no classes (the interfaces-free / classes-earned meta-rule). Optics compose.
+module Optics =
+
+    /// A **LENS** onto a part that is always present (a product factor). Lawful iff:
+    ///   get-put: `Set (Get w) w = w` · put-get: `Get (Set p w) = p` · put-put: last write wins.
+    /// `PolarityFilter` (a color/component read) is a lens at the meaning layer.
+    type ILens<'whole, 'part> =
+        abstract Get: 'whole -> 'part
+        abstract Set: 'part -> 'whole -> 'whole
+
+    /// A **PRISM** onto a part that may be present (a sum case) — the **fingerprintable** optic.
+    /// `Match` is the fingerprint (is the whole this case? → extract it); `Build` reconstructs the
+    /// whole from the part. Lawful iff:
+    ///   build-match: `Match (Build p) = Some p` · match-build: `Match w = Some p ⇒ Build p = w`.
+    /// Ties the rainbow-table fingerprinting primitive: `Match` = content-fingerprint → case lookup.
+    /// The rainbow table has a HARD form (exact crypto reversal — the hash→preimage hacking/decrypting
+    /// use) AND a SOFT form (Aaron 2026-06-10): approximate / similarity fingerprinting — perceptual
+    /// hash / locality-sensitive lookup → nearest case, not exact. So `Match` is either exact
+    /// (hard / CMYK-solid) or fuzzy (soft / RGB) — same soft-vs-solid duality as the encoding.
+    type IPrism<'whole, 'part> =
+        abstract Match: 'whole -> 'part option
+        abstract Build: 'part -> 'whole
+
+    /// Build a lens from a getter + setter (the common constructor).
+    let lens (get: 'whole -> 'part) (set: 'part -> 'whole -> 'whole) : ILens<'whole, 'part> =
+        { new ILens<'whole, 'part> with
+            member _.Get(w) = get w
+            member _.Set p w = set p w }
+
+    /// Build a prism from a matcher (fingerprint) + builder.
+    let prism (matcher: 'whole -> 'part option) (build: 'part -> 'whole) : IPrism<'whole, 'part> =
+        { new IPrism<'whole, 'part> with
+            member _.Match(w) = matcher w
+            member _.Build p = build p }

--- a/tests/Tests.FSharp/Optics.Tests.fs
+++ b/tests/Tests.FSharp/Optics.Tests.fs
@@ -1,0 +1,46 @@
+module Zeta.Tests.OpticsTests
+
+open global.Xunit
+open Zeta.Core
+open Zeta.Core.Optics
+
+// A sample LENS: focus the first element of a pair (always present = product factor).
+let private fstLens : ILens<int * string, int> =
+    lens fst (fun p (_, b) -> (p, b))
+
+// A sample PRISM (fingerprintable): focus the Choice1Of2 case of a sum (may not be present).
+let private firstPrism : IPrism<Choice<int, string>, int> =
+    prism
+        (function
+            | Choice1Of2 i -> Some i
+            | Choice2Of2 _ -> None)
+        Choice1Of2
+
+[<Fact>]
+let ``lens law get-put: Set (Get w) w = w`` () =
+    let w = (7, "x")
+    Assert.Equal<int * string>(w, fstLens.Set (fstLens.Get w) w)
+
+[<Fact>]
+let ``lens law put-get: Get (Set p w) = p`` () =
+    Assert.Equal(42, fstLens.Get(fstLens.Set 42 (7, "x")))
+
+[<Fact>]
+let ``lens law put-put: last write wins`` () =
+    let w = (7, "x")
+    Assert.Equal<int * string>(fstLens.Set 2 w, fstLens.Set 2 (fstLens.Set 1 w))
+
+[<Fact>]
+let ``prism law build-match: Match (Build p) = Some p (fingerprint round-trips)`` () =
+    Assert.Equal<int option>(Some 5, firstPrism.Match(firstPrism.Build 5))
+
+[<Fact>]
+let ``prism law match-build: Match w = Some p => Build p = w`` () =
+    let w = Choice1Of2 9
+    match firstPrism.Match w with
+    | Some p -> Assert.Equal<Choice<int, string>>(w, firstPrism.Build p)
+    | None -> Assert.Fail "expected a match"
+
+[<Fact>]
+let ``prism Match fingerprints the case: the OTHER case does not match (None)`` () =
+    Assert.Equal<int option>(None, firstPrism.Match(Choice2Of2 "not-an-int"))

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -117,6 +117,7 @@
     <Compile Include="CoincidenceClock.Tests.fs" />
     <Compile Include="Sim.Tests.fs" />
     <Compile Include="CliVerb.Tests.fs" />
+    <Compile Include="Optics.Tests.fs" />
     <Compile Include="BitAdinkra.Tests.fs" />
     <Compile Include="ForwardMomentum.Tests.fs" />
     <Compile Include="QubitIso.Tests.fs" />


### PR DESCRIPTION
Aaron: save the lensable + prismable interfaces. ILens (Get/Set, product) + IPrism (Match/Build, sum = fingerprintable; Match = rainbow-table fingerprint lookup, hard exact OR soft similarity). Pure interfaces (meta-rule); lens+prism laws tested 6/6.