### PR TITLE
feat(core): Universal Number port + BigInteger adapter (hexagonal ports & adapters; first concrete backend)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -49,6 +49,7 @@
     <Compile Include="Sim.fs" />
     <Compile Include="CliVerb.fs" />
     <Compile Include="Optics.fs" />
+    <Compile Include="UniversalNumber.fs" />
     <Compile Include="TravelerFrame.fs" />
     <Compile Include="FrameDelta.fs" />
     <Compile Include="UncertainClock.fs" />

--- a/src/Core/UniversalNumber.fs
+++ b/src/Core/UniversalNumber.fs
@@ -1,0 +1,45 @@
+namespace Zeta.Core
+
+open System.Numerics
+
+/// Universal Number — our PORT (hexagonal architecture: ports & adapters, Cockburn). One interface,
+/// many backends behind it (Aaron 2026-06-10: "this is just us hexagonaling our interfaces ... we
+/// should have an interface we can pull prior art in behind, all the same interface").
+///
+/// The port carries the value ops PLUS resolution accounting (`BitsUsed`/`IsExact`) — the bit-budget
+/// the `Resolution` primitive reads (physics-of-floats). Adapters plug in:
+///   • `bigint` (this file — first concrete adapter; arbitrary-precision INTEGER, always exact)
+///   • IEEE float/double, the TriBoolean middle-out Float (arbitrary-precision FLOAT / BigFloat)
+///   • prior art (MPFR / GMP / BigDecimal / posit) — and prior art doubles as the TEST ORACLE:
+///     differential-test OUR backends' ACCURACY against MPFR/BigDecimal, and benchmark their SPEED
+///     against IEEE/MPFR (Aaron: "use prior art to test the speed and accuracy of our own").
+///
+/// Pure interface, no classes (the interfaces-free / classes-earned meta-rule). The port ops are TOTAL
+/// (exact backends); the Result-typed decline-don't-coerce discipline stays at the DynamicValue edge,
+/// and the coercing INumberBase override is opt-in (never default) — see universal/number.md.
+[<RequireQualifiedAccess>]
+module UniversalNumber =
+
+    /// The port. 'T = the carrier number (bigint, float, TriBoolean.Float, ...).
+    type IUniversalNumber<'T> =
+        abstract Zero: 'T
+        abstract One: 'T
+        abstract Add: 'T -> 'T -> 'T
+        abstract Mul: 'T -> 'T -> 'T
+        /// Significant bits currently carrying information (the resolution accounting input).
+        abstract BitsUsed: 'T -> int
+        /// True if the value is represented exactly (no ULP / precision loss). Integers: always true.
+        abstract IsExact: 'T -> bool
+
+    /// The BigInteger adapter — first concrete backend (arbitrary-precision integer; the bigint corner
+    /// of the universal number, the integer analog of our BigFloat). Always exact; resolution = bit
+    /// length. .NET `BigInteger` is itself `INumberBase`, so this adapter bridges it to our port.
+    let bigInt: IUniversalNumber<BigInteger> =
+        { new IUniversalNumber<BigInteger> with
+            member _.Zero = BigInteger.Zero
+            member _.One = BigInteger.One
+            member _.Add a b = a + b
+            member _.Mul a b = a * b
+            member _.BitsUsed v =
+                if v.IsZero then 0 else int (BigInteger.Abs(v).GetBitLength())
+            member _.IsExact _ = true }

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -118,6 +118,7 @@
     <Compile Include="Sim.Tests.fs" />
     <Compile Include="CliVerb.Tests.fs" />
     <Compile Include="Optics.Tests.fs" />
+    <Compile Include="UniversalNumber.Tests.fs" />
     <Compile Include="BitAdinkra.Tests.fs" />
     <Compile Include="ForwardMomentum.Tests.fs" />
     <Compile Include="QubitIso.Tests.fs" />

--- a/tests/Tests.FSharp/UniversalNumber.Tests.fs
+++ b/tests/Tests.FSharp/UniversalNumber.Tests.fs
@@ -1,0 +1,39 @@
+module Zeta.Tests.UniversalNumberTests
+
+open System.Numerics
+open global.Xunit
+open Zeta.Core
+
+let private n = UniversalNumber.bigInt
+
+[<Fact>]
+let ``bigint adapter: zero/one identities`` () =
+    Assert.Equal(BigInteger.Zero, n.Zero)
+    Assert.Equal(BigInteger.One, n.One)
+    let x = BigInteger 42
+    Assert.Equal(x, n.Add x n.Zero) // additive identity
+    Assert.Equal(x, n.Mul x n.One) // multiplicative identity
+    Assert.Equal(BigInteger.Zero, n.Mul x n.Zero) // annihilator
+
+[<Fact>]
+let ``bigint adapter: add and mul are exact + arbitrary precision`` () =
+    let big = BigInteger.Pow(BigInteger 2, 200) // way past int64
+    Assert.Equal(BigInteger.Pow(BigInteger 2, 201), n.Add big big) // 2^200 + 2^200 = 2^201
+    Assert.Equal(BigInteger.Pow(BigInteger 2, 400), n.Mul big big) // 2^200 * 2^200 = 2^400
+
+[<Fact>]
+let ``bigint adapter: BitsUsed = bit length (resolution accounting)`` () =
+    Assert.Equal(0, n.BitsUsed BigInteger.Zero)
+    Assert.Equal(1, n.BitsUsed BigInteger.One)
+    Assert.Equal(8, n.BitsUsed (BigInteger 255)) // 0b1111_1111
+    Assert.Equal(9, n.BitsUsed (BigInteger 256)) // 0b1_0000_0000
+    Assert.Equal(201, n.BitsUsed (BigInteger.Pow(BigInteger 2, 200))) // 2^200 → 201 bits
+
+[<Fact>]
+let ``bigint adapter: BitsUsed handles negatives by magnitude`` () =
+    Assert.Equal(8, n.BitsUsed (BigInteger -255))
+
+[<Fact>]
+let ``bigint adapter: integers are always exact (no ULP loss)`` () =
+    Assert.True(n.IsExact BigInteger.Zero)
+    Assert.True(n.IsExact (BigInteger.Pow(BigInteger 2, 500)))


### PR DESCRIPTION
feat(core): Universal Number PORT + first concrete adapter (BigInteger) — hexagonal ports & adapters

Aaron 2026-06-10: "this is just us hexagonaling our interfaces ... we should have an interface we can
pull prior art in behind, all the same interface" + "we should make a big int adapter now" + "does
bigint fit into universal number too?" (yes).

src/Core/UniversalNumber.fs (pure interface, no classes — meta-rule):
- IUniversalNumber<'T> = the PORT (Cockburn hexagonal): Zero/One/Add/Mul + resolution accounting
  (BitsUsed/IsExact, the input the Resolution primitive reads). Total ops (exact backends); the
  Result-typed decline + coercing-override discipline stays at the DynamicValue edge / opt-in.
- UniversalNumber.bigInt = first concrete ADAPTER: BigInteger (arbitrary-precision INTEGER; the bigint
  corner / integer analog of our BigFloat). Always exact; BitsUsed = GetBitLength. Bridges .NET's
  INumberBase<BigInteger> to our port. Prior art doubles as the test ORACLE (accuracy vs MPFR/
  BigDecimal; speed vs IEEE/MPFR).

tests/Tests.FSharp/UniversalNumber.Tests.fs (5 cases): zero/one identities + annihilator, exact
arbitrary-precision add/mul (2^200, 2^400 — past int64), BitsUsed = bit length (0/1/255->8/256->9/
2^200->201), negatives by magnitude, integers always exact.

Build gate: Core 0 warnings; tests 5/5 pass. First adapter proving the port+adapter pattern; next
adapters: IEEE float, TriBoolean middle-out Float (BigFloat), MPFR.

AgencySignature-v1:
  persona: otto
  hat: shadow
  surface: src/Core (UniversalNumber.fs) + tests
  intent: universal-number-port-and-bigint-adapter
  authorization: aaron-authored ("make a big int adapter now")
  reversible: yes
  gated-class: none
  build: dotnet build Core 0/0; UniversalNumber tests 5/5
  register: grounded
  ferry: no

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
