### PR TITLE
docs(research): we recover the MEANING — designers think in repeating patterns (=time-crystals=ECS), not assembly

### DIFF
--- a/docs/research/2026-06-10-dotnet-runtime-in-shaders-telos-il-runner-hard-and-soft-shader-memory-and-gc.md
+++ b/docs/research/2026-06-10-dotnet-runtime-in-shaders-telos-il-runner-hard-and-soft-shader-memory-and-gc.md
@@ -75,6 +75,35 @@ engineering) · **tracing JIT** (Bolz/PyPy meta-tracing; LuaJIT; TraceMonkey) ·
 lifting (binary → IR). *(Peel: Cheat Engine = the lensing + JIT + hard↔soft prior art; the shader
 target and time-crystal-as-trace are our generalization, to build.)*
 
+## What we're really recovering: the MEANING (designers think in patterns, not assembly) (Aaron 2026-06-10)
+
+> Aaron: "I'm **reconstructing the meaning** — the thought that went into the compiled instruction — by
+> **finding the structures that repeat**." · "the original designers didn't think in assembly — they
+> thought in **repeating patterns interacting**. Look how **game engines** work today — they optimize
+> for that."
+
+The deepest "why" of the hard→soft lift: **the compiler discarded the meaning, and we reconstruct it.**
+
+- **Compilation is lossy at the meaning layer.** A designer thinks in **repeating patterns interacting**
+  (entities, behaviors, loops, systems) — *not* in assembly. The compiler lowers that intent to
+  instructions and throws the pattern-level meaning away.
+- **The repeating structures ARE the meaning.** Lensing the **quasi-time-crystals** (the repeats over
+  time) recovers exactly the designer's mental model — a recurring structure *is* a concept; a loop *is*
+  an intent. Finding the repeats = reconstructing the thought (decompilation at the *meaning* level, not
+  just syntax; cf. MDL/Solomonoff — repeated = compressible = meaningful).
+- **Game engines already prove this is the right level.** Modern engines optimize for
+  repeating-patterns-interacting: **ECS (Entity-Component-System)** + **data-oriented design** — systems
+  iterate over component arrays (the repeats), data-parallel, cache-friendly, **GPU/shader-friendly**.
+  That is *the same shape* as our time-crystals → shaders. So recovering the pattern-level meaning and
+  running it data-parallel on the GPU isn't exotic — it's how engines are *already* built; we just do it
+  by lensing the meaning out of a compiled artifact first.
+
+Anchors: **Mike Acton — Data-Oriented Design** (CppCon 2014) · **ECS** (Unity DOTS; Bevy; EnTT) + the
+game loop · **decompilation / abstraction recovery** · **MDL/Solomonoff** (repeated structure =
+compression = meaning). *(Peel: "meaning/thought" is the intent layer above instructions; the literal
+is structural-repeat detection (time-crystals) + the ECS/data-oriented correspondence — the recovery
+of designer intent is the aspiration, the repeat-finding is the mechanism.)*
+
 ## Honest scope / peels
 
 [Beacon] **WebAssembly** + **Wasm-GC proposal** (portable bytecode + GC) · **ComputeSharp** (Sergio


### PR DESCRIPTION
Aaron: reverse-engineering reconstructs the meaning the compiler discarded by finding repeating structures; designers think in repeating-patterns-interacting (not assembly); game engines (ECS/data-oriented) optimize for exactly that = data-parallel = GPU = our time-crystals->shaders. Anchors: Acton DOD, ECS, decompilation, MDL/Solomonoff.