### PR TITLE
feat(core): FingerprintPrism — IPrism hook to fingerprints (hard exact + soft MinHash; switch games staying soft)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -238,6 +238,7 @@
     <Compile Include="PrivacyEconomy.fs" />
     <Compile Include="GamePortfolio.fs" />
     <Compile Include="GameFingerprint.fs" />
+    <Compile Include="FingerprintPrism.fs" />
     <Compile Include="GameCatalog.fs" />
     <Compile Include="ControlMerge.fs" />
     <Compile Include="PolarityFilter.fs" />

--- a/src/Core/FingerprintPrism.fs
+++ b/src/Core/FingerprintPrism.fs
@@ -1,0 +1,81 @@
+namespace Zeta.Core
+
+open Zeta.Core.Optics
+
+/// FingerprintPrism — the concrete hook from the optic `IPrism` to a fingerprint primitive (Aaron
+/// 2026-06-10: "prismable ties into our rainbow table primitive for fingerprinting ... soft too not
+/// just hard ... GameFingerprint and we have soft fingerprint lookup so you can switch games while
+/// still staying soft").
+///
+/// A bare fingerprint is one-way (a Getter); a **rainbow table** (the reverse map of known wholes by
+/// fingerprint) makes it a lawful **prism**: `Match` recognizes a known whole, `Build` = id (a known
+/// whole is its own canonical form). Two flavors:
+///   • HARD — exact fingerprint match (the crypto/exact rainbow; e.g. GameFingerprint.key byte-for-byte).
+///   • SOFT — nearest known whole by similarity ≥ threshold (the soft rainbow; switch/recognize games
+///            staying soft). Backed by a MinHash byte-shingle similarity (below) or any sim fn.
+///
+/// Pure (no classes — meta-rule). Generic over the whole 'w and fingerprint 'fp; does not touch the
+/// proven-4/4 GameFingerprint.fs (the cross-language byte-lock stays intact).
+[<RequireQualifiedAccess>]
+module FingerprintPrism =
+
+    /// A rainbow table: known wholes indexed by their (hard) fingerprint — the reverse map that makes a
+    /// one-way fingerprint prism-able.
+    type Rainbow<'w, 'fp when 'fp: comparison> =
+        { Fingerprint: 'w -> 'fp
+          Known: Map<'fp, 'w> }
+
+    /// Empty table over a fingerprint function.
+    let empty (fingerprint: 'w -> 'fp) : Rainbow<'w, 'fp> = { Fingerprint = fingerprint; Known = Map.empty }
+
+    /// Register a known whole (keyed by its fingerprint).
+    let add (w: 'w) (r: Rainbow<'w, 'fp>) : Rainbow<'w, 'fp> =
+        { r with Known = Map.add (r.Fingerprint w) w r.Known }
+
+    /// HARD prism — exact fingerprint match. `Match` returns the known whole with the same fingerprint
+    /// (or None); `Build` = id (a known whole is its own canonical form). Lawful.
+    let hard (r: Rainbow<'w, 'fp>) : IPrism<'w, 'w> =
+        prism (fun w -> Map.tryFind (r.Fingerprint w) r.Known) id
+
+    /// SOFT prism — nearest known whole by `similarity ≥ threshold` (the soft rainbow). `Match` returns
+    /// the most-similar known whole if any clears the threshold; `Build` = id. Lets you recognize /
+    /// switch games while staying soft (no exact hash needed).
+    let soft (similarity: 'w -> 'w -> float) (threshold: float) (r: Rainbow<'w, 'fp>) : IPrism<'w, 'w> =
+        prism
+            (fun w ->
+                r.Known
+                |> Map.toSeq
+                |> Seq.map (fun (_, k) -> k, similarity w k)
+                |> Seq.filter (fun (_, s) -> s >= threshold)
+                |> Seq.sortByDescending snd
+                |> Seq.tryHead
+                |> Option.map fst)
+            id
+
+    /// SOFT byte fingerprint — a MinHash sketch over byte-shingles (Broder MinHash; insertion-robust via
+    /// overlapping shingles). The soft counterpart to GameFingerprint's exact SHA-256 key: near-identical
+    /// byte streams get similar sketches. Reuses GameFingerprint.crc32 for the shingle hash.
+    type SoftBytes = { MinHashes: uint32[] }
+
+    [<Literal>]
+    let private ShingleWidth = 8
+
+    [<Literal>]
+    let private SketchSize = 64
+
+    /// Compute the soft byte sketch (sorted, distinct, ≤ SketchSize smallest shingle hashes).
+    let softBytes (data: byte[]) : SoftBytes =
+        let hashes =
+            if data.Length < ShingleWidth then
+                if data.Length = 0 then Seq.empty else Seq.singleton (GameFingerprint.crc32 data)
+            else
+                seq { for i in 0 .. data.Length - ShingleWidth -> GameFingerprint.crc32 data.[i .. i + ShingleWidth - 1] }
+        { MinHashes = hashes |> Seq.distinct |> Seq.sort |> Seq.truncate SketchSize |> Seq.toArray }
+
+    /// Soft similarity in [0,1] — Jaccard of the two MinHash sketches (1.0 = identical sketch, 0.0 =
+    /// nothing shared). The soft-rainbow distance.
+    let softBytesSimilarity (a: SoftBytes) (b: SoftBytes) : float =
+        let sa = Set.ofArray a.MinHashes
+        let sb = Set.ofArray b.MinHashes
+        let u = Set.union sa sb |> Set.count
+        if u = 0 then 1.0 else float (Set.intersect sa sb |> Set.count) / float u

--- a/tests/Tests.FSharp/FingerprintPrism.Tests.fs
+++ b/tests/Tests.FSharp/FingerprintPrism.Tests.fs
@@ -1,0 +1,56 @@
+module Zeta.Tests.FingerprintPrismTests
+
+open System.Text
+open global.Xunit
+open Zeta.Core
+
+let private bytes (s: string) = Encoding.UTF8.GetBytes s
+
+// A HARD rainbow over the exact SHA-256 key (GameFingerprint.key).
+let private hardTable =
+    FingerprintPrism.empty GameFingerprint.key
+    |> FingerprintPrism.add (bytes "GAME-ALPHA-rom-contents")
+    |> FingerprintPrism.add (bytes "GAME-BETA-rom-contents")
+
+[<Fact>]
+let ``hard prism: exact match recognizes a known game; unknown -> None`` () =
+    let p = FingerprintPrism.hard hardTable
+    Assert.Equal<byte[] option>(Some(bytes "GAME-ALPHA-rom-contents"), p.Match(bytes "GAME-ALPHA-rom-contents"))
+    Assert.Equal<byte[] option>(None, p.Match(bytes "totally-different-rom"))
+
+[<Fact>]
+let ``hard prism law: Build = id; Match (Build w) = Some w for a known w`` () =
+    let p = FingerprintPrism.hard hardTable
+    let w = bytes "GAME-BETA-rom-contents"
+    Assert.Equal<byte[]>(w, p.Build w)
+    Assert.Equal<byte[] option>(Some w, p.Match(p.Build w))
+
+[<Fact>]
+let ``soft byte fingerprint: identical -> 1.0; disjoint -> low`` () =
+    let a = FingerprintPrism.softBytes (bytes "the quick brown fox jumps over the lazy dog")
+    Assert.Equal(1.0, FingerprintPrism.softBytesSimilarity a a, 10)
+    let b = FingerprintPrism.softBytes (bytes "ZZZZZZZZ completely unrelated payload 9999999")
+    Assert.True(FingerprintPrism.softBytesSimilarity a b < 0.2)
+
+[<Fact>]
+let ``soft byte fingerprint: a one-region edit stays HIGHLY similar (insertion-robust)`` () =
+    let orig = bytes "the quick brown fox jumps over the lazy dog twelve times in a row today"
+    let edited = bytes "the quick brown fox JUMPED over the lazy dog twelve times in a row today"
+    let s = FingerprintPrism.softBytesSimilarity (FingerprintPrism.softBytes orig) (FingerprintPrism.softBytes edited)
+    Assert.True(s > 0.6, $"expected high similarity for a small edit, got {s}")
+
+[<Fact>]
+let ``soft prism: recognizes a NEAR game (switch/stay-soft), rejects a far one`` () =
+    // rainbow keyed by the soft sketch's hash set size (any 'fp works; recognition is via similarity)
+    let table =
+        FingerprintPrism.empty (fun (w: byte[]) -> w.Length)
+        |> FingerprintPrism.add (bytes "the quick brown fox jumps over the lazy dog twelve times in a row today")
+    let sim (x: byte[]) (y: byte[]) =
+        FingerprintPrism.softBytesSimilarity (FingerprintPrism.softBytes x) (FingerprintPrism.softBytes y)
+    let p = FingerprintPrism.soft sim 0.6 table
+    // a near-variant resolves to the known game (stay soft across the edit)
+    match p.Match(bytes "the quick brown fox JUMPED over the lazy dog twelve times in a row today") with
+    | Some _ -> ()
+    | None -> Assert.Fail "soft prism should recognize the near-variant"
+    // a far payload does not
+    Assert.Equal<byte[] option>(None, p.Match(bytes "ZZZZ unrelated ZZZZ unrelated ZZZZ unrelated ZZZZ"))

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -119,6 +119,7 @@
     <Compile Include="CliVerb.Tests.fs" />
     <Compile Include="Optics.Tests.fs" />
     <Compile Include="UniversalNumber.Tests.fs" />
+    <Compile Include="FingerprintPrism.Tests.fs" />
     <Compile Include="BitAdinkra.Tests.fs" />
     <Compile Include="ForwardMomentum.Tests.fs" />
     <Compile Include="QubitIso.Tests.fs" />


### PR DESCRIPTION
Aaron: prismable ties to the rainbow table; soft+hard; switch games staying soft. Concrete IPrism over the fingerprint primitives: Rainbow table -> hard (exact) + soft (nearest by MinHash Jaccard, insertion-robust) prisms. Doesn't touch proven-4/4 GameFingerprint.fs. 5/5 tests.