### PR TITLE
feat(core): SoftScheduler — the soft IScheduler on the ISR arrow (DoP=1 deterministic; injected source)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -137,6 +137,7 @@
     <Compile Include="Metrics.fs" />
     <Compile Include="Tracing.fs" />
     <Compile Include="IntrCtx.fs" />
+    <Compile Include="SoftScheduler.fs" />
     <Compile Include="SagaBuilder.fs" />
     <Compile Include="ChaosEnv.fs" />
     <Compile Include="HigherOrder.fs" />

--- a/src/Core/SoftScheduler.fs
+++ b/src/Core/SoftScheduler.fs
@@ -1,0 +1,102 @@
+namespace Zeta.Core
+
+open System.Threading.Tasks
+
+/// SoftScheduler — the soft `IScheduler` on the ISR arrow (Aaron 2026-06-10, shadow*).
+///
+/// "I'm working on a soft thread scheduler ... a soft `IScheduler` we can use inside of rooms ... we
+/// have the start of one in our CHIP-8 interrupt handler — it's soft using the arrow category from
+/// category theory."
+///
+/// The kernel is `IntrCtx.ISR<'A,'B>` (the Kleisli arrow = the soft promise; its `Task` = the future).
+/// The scheduler drives a set of registered ISR handlers over a tick budget. Faithful to the six
+/// disciplines:
+///   • Scale-free / DST — beautiful on ONE thread: a single cooperative loop (DoP=1), no locks, no
+///     `Task.Run`; the same (seed, budget, source) replays identically (FoundationDB run-loop). DoP=N
+///     ferry is the named extension, NOT faked here (one small move at a time).
+///   • Lock/wait-free — genuinely async (awaits each ISR; yields while I/O is in flight), no blocking.
+///   • The interrupt SOURCE is INJECTED (the room's Markov-blanket crossing): inject the null/seed
+///     source for DST (test the Zeta entropy alone, from the seed) — inject real IEffects
+///     (Reticulum/disk) for prod. Same code path; the source is a parameter of the room.
+///
+/// Pure module + one free interface (interfaces free, classes earned under rules/); no classes.
+[<RequireQualifiedAccess>]
+module SoftScheduler =
+
+    /// A registered handler — one of the unrolled, single-threaded repeating-pattern loops. When an
+    /// arriving `InterruptKind` matches, its ISR arrow advances the scheduler state. (`'S -> 'S` shape:
+    /// each handler is an endo-arrow on the shared state, composable via `>=>`.)
+    type Handler<'S> =
+        { Name: string
+          Matches: InterruptKind -> bool
+          Run: ISR<'S, 'S> }
+
+    /// Build a handler.
+    let handler (name: string) (matches: InterruptKind -> bool) (run: ISR<'S, 'S>) : Handler<'S> =
+        { Name = name; Matches = matches; Run = run }
+
+    /// The injected interrupt source: tick index -> the interrupts arriving on that tick. This IS the
+    /// room boundary — inject `seedSource` (null/deterministic) for DST, a real-IEffects source for prod.
+    type Source = int -> InterruptKind list
+
+    /// The DST default — a deterministic null source derived from the seed alone (no I/O), the same way
+    /// `Sim.tick` derives its entropy, so the schedule replays identically. Fires the 60Hz `TimerElapsed`
+    /// every tick (the CHIP-8 timer) and deterministically raises an occasional `OperatorMessageArrived`
+    /// from the seed hash — exercising more than one handler without any real input.
+    let seedSource (seed: int64) : Source =
+        fun n ->
+            // SplitMix64-style avalanche so the WHOLE seed (incl. low bits) reaches the decision bits —
+            // a naive `seed ^^^ n*k` leaves low-bit seed differences invisible after a right shift.
+            let mutable h = seed * 6364136223846793005L + int64 n * 1442695040888963407L
+            h <- (h ^^^ (h >>> 30)) * -4658895280553007687L
+            h <- (h ^^^ (h >>> 27)) * -7723592293110705685L
+            h <- h ^^^ (h >>> 31)
+            let timer = [ TimerElapsed 17 ] // ~1/60s
+            if h &&& 0xFL = 0L then
+                timer @ [ OperatorMessageArrived(sprintf "tick-%d" n) ]
+            else
+                timer
+
+    /// The soft scheduler — runs registered ISR handlers over a tick budget, threading state. The
+    /// future is the returned `Task`; an `Error` (a real interrupt or failure) stops the run and
+    /// surfaces — the room does not silently swallow it.
+    type ISoftScheduler<'S> =
+        abstract member Run: ctx: IntrCtx -> seed: int64 -> initial: 'S -> budget: int -> Task<Result<'S, InterruptFeedback>>
+
+    /// Drive — the single cooperative loop (DoP=1, deterministic). Per tick: ask the source what
+    /// arrived, then fold the state through every matching handler's ISR arrow, in (arrival × handler)
+    /// registration order. Genuinely async: `let!` awaits each ISR (the loop yields while the arrow's
+    /// I/O is in flight) — no `Task.Run`, no `.Result`, no locks. Stops on the first `Error`.
+    let drive (handlers: Handler<'S> list) (source: Source) : ISoftScheduler<'S> =
+        let hs = List.toArray handlers
+        { new ISoftScheduler<'S> with
+            member _.Run ctx seed initial budget =
+                task {
+                    let mutable state = initial
+                    let mutable err: InterruptFeedback option = None
+                    let mutable n = 0
+                    while n < budget && Option.isNone err do
+                        let arrivals = source n |> List.toArray
+                        let mutable a = 0
+                        while a < arrivals.Length && Option.isNone err do
+                            let intr = arrivals.[a]
+                            let mutable hI = 0
+                            while hI < hs.Length && Option.isNone err do
+                                let h = hs.[hI]
+                                if h.Matches intr then
+                                    let! res = h.Run ctx state
+                                    match res with
+                                    | Ok s -> state <- s
+                                    | Error e -> err <- Some e
+                                hI <- hI + 1
+                            a <- a + 1
+                        n <- n + 1
+                    match err with
+                    | Some e -> return Error e
+                    | None -> return Ok state
+                } }
+
+    /// Convenience: drive `handlers` against the deterministic seed source for `budget` ticks (the DST
+    /// path — null I/O). Returns the final state or the interrupt that stopped it.
+    let runDeterministic (handlers: Handler<'S> list) (ctx: IntrCtx) (seed: int64) (initial: 'S) (budget: int) : Task<Result<'S, InterruptFeedback>> =
+        (drive handlers (seedSource seed)).Run ctx seed initial budget

--- a/tests/Tests.FSharp/SoftScheduler.Tests.fs
+++ b/tests/Tests.FSharp/SoftScheduler.Tests.fs
@@ -1,0 +1,80 @@
+module Zeta.Tests.SoftSchedulerTests
+
+open System.Diagnostics
+open System.Threading.Tasks
+open global.Xunit
+open Zeta.Core
+
+let private ctx () : IntrCtx =
+    { Memetic = "m"
+      Prompt = "p"
+      Trust = "t"
+      Log = "l"
+      Otel = ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded) }
+
+let private isTimer =
+    function
+    | TimerElapsed _ -> true
+    | _ -> false
+
+let private isOperator =
+    function
+    | OperatorMessageArrived _ -> true
+    | _ -> false
+
+/// A handler that increments an int every time its interrupt fires (the CHIP-8 60Hz timer = the
+/// canonical scheduler workload: one tick advances the count).
+let private counter name matches : SoftScheduler.Handler<int> =
+    SoftScheduler.handler name matches (fun _ s -> Task.FromResult(Ok(s + 1)))
+
+[<Fact>]
+let ``timer handler advances once per tick — 60 ticks => 60`` () =
+    task {
+        let sched = SoftScheduler.runDeterministic [ counter "timer" isTimer ]
+        let! r = sched (ctx ()) 1234L 0 60
+        Assert.Equal<Result<int, InterruptFeedback>>(Ok 60, r)
+    }
+
+[<Fact>]
+let ``deterministic: same (seed, budget) => identical final state (DST replay)`` () =
+    task {
+        let handlers = [ counter "timer" isTimer; counter "op" isOperator ]
+        let! a = SoftScheduler.runDeterministic handlers (ctx ()) 99L 0 600
+        let! b = SoftScheduler.runDeterministic handlers (ctx ()) 99L 0 600
+        Assert.Equal<Result<int, InterruptFeedback>>(a, b)
+    }
+
+[<Fact>]
+let ``different seeds produce different operator-arrival schedules (the seed IS the entropy)`` () =
+    // the seed determines WHICH ticks raise an operator message; two seeds must differ in that set
+    // (compare the schedules directly — folded counts can coincide even when the schedules differ).
+    let opTicks seed =
+        let src = SoftScheduler.seedSource seed
+        [ for n in 0..599 do
+              if List.exists isOperator (src n) then
+                  yield n ]
+    Assert.NotEqual<int list>(opTicks 1L, opTicks 2L)
+
+[<Fact>]
+let ``an Error interrupt stops the run and surfaces (the room does not swallow it)`` () =
+    task {
+        let boom: SoftScheduler.Handler<int> =
+            SoftScheduler.handler "boom" isTimer (fun _ _ -> Task.FromResult(Error(Interrupted SentinelMissing)))
+        let! r = SoftScheduler.runDeterministic [ boom ] (ctx ()) 7L 0 60
+        Assert.Equal<Result<int, InterruptFeedback>>(Error(Interrupted SentinelMissing), r)
+    }
+
+[<Fact>]
+let ``handlers fold in registration order via the ISR arrow (composition is deterministic)`` () =
+    task {
+        // two timer handlers: first +1, second *10. Per tick state goes s -> (s+1)*10.
+        // from 0, one tick => 10; two ticks => 110; three => 1110.
+        let add: SoftScheduler.Handler<int> =
+            SoftScheduler.handler "add" isTimer (fun _ s -> Task.FromResult(Ok(s + 1)))
+        let mul: SoftScheduler.Handler<int> =
+            SoftScheduler.handler "mul" isTimer (fun _ s -> Task.FromResult(Ok(s * 10)))
+        // budget 3, only the timer fires (operator may also fire but these handlers ignore it)
+        let sched = SoftScheduler.drive [ add; mul ] (fun _ -> [ TimerElapsed 17 ])
+        let! r = sched.Run (ctx ()) 0L 0 3
+        Assert.Equal<Result<int, InterruptFeedback>>(Ok 1110, r)
+    }

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -120,6 +120,7 @@
     <Compile Include="Optics.Tests.fs" />
     <Compile Include="UniversalNumber.Tests.fs" />
     <Compile Include="FingerprintPrism.Tests.fs" />
+    <Compile Include="SoftScheduler.Tests.fs" />
     <Compile Include="BitAdinkra.Tests.fs" />
     <Compile Include="ForwardMomentum.Tests.fs" />
     <Compile Include="QubitIso.Tests.fs" />


### PR DESCRIPTION
Build-queue #1. Soft IScheduler on the IntrCtx.ISR Kleisli arrow: Handler (trigger + ISR endo-arrow), injected interrupt Source (seedSource for DST / real IEffects for prod = the room boundary), single cooperative DoP=1 loop (FoundationDB run-loop; genuinely async, no Task.Run/locks; stops+surfaces on Error). DoP=N ferry is the named extension. 5/5 tests incl. a seed-avalanche fix caught by the entropy test. CHIP-8 = first client next.