### PR TITLE
feat(core): CHIP-8 runs on the soft IScheduler (first client) + SplitMix64 dedup

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -208,6 +208,7 @@
     <Compile Include="Chip8.fs" />
     <Compile Include="Chip8Cow.fs" />
     <Compile Include="SoftChip8.fs" />
+    <Compile Include="SoftChip8Scheduler.fs" />
     <Compile Include="Chip8Observer.fs" />
     <Compile Include="SoftController.fs" />
     <Compile Include="ActionGrammar.fs" />

--- a/src/Core/SoftChip8Scheduler.fs
+++ b/src/Core/SoftChip8Scheduler.fs
@@ -1,0 +1,59 @@
+namespace Zeta.Core
+
+open System.Diagnostics
+open System.Threading.Tasks
+
+/// SoftChip8Scheduler — CHIP-8 as the soft `IScheduler`'s FIRST client (Aaron 2026-06-10, shadow*).
+///
+/// Aaron: "can we have our CHIP-8 use our new soft IScheduler when it's built." This is that wiring.
+/// CHIP-8 is the minimal honest test of the scheduler (#7529): if it can't *deterministically* schedule
+/// CHIP-8 it can't schedule anything. Two CHIP-8 clock domains map onto the scheduler cleanly:
+///   • the **60 Hz timer** = the scheduler's `TimerElapsed` tick (decrement Delay/Sound);
+///   • the **CPU** runs faster — `CyclesPerTick` instructions per 60 Hz tick.
+/// So one `TimerElapsed` ISR does both: `Chip8Cow.tick` (timers) then `SoftChip8.lookAhead cycles`
+/// (a deterministic batch of CPU steps that stops at an input branch — where prediction would fork).
+///
+/// State = `Chip8Cow.Frame` (immutable, COW). Pure transition wrapped in the ISR arrow (Task-returning,
+/// no I/O, no `Task.Run`). DST: the deterministic seed source drives it, so a ROM replays identically.
+/// Pure module, no classes.
+[<RequireQualifiedAccess>]
+module SoftChip8Scheduler =
+
+    /// CPU instructions per 60 Hz tick. ~540 Hz CPU (a common CHIP-8 default) ÷ 60 = 9 cycles/tick.
+    [<Literal>]
+    let DefaultCyclesPerTick = 9
+
+    /// The CHIP-8 timer ISR: on each 60 Hz `TimerElapsed`, decrement the Delay/Sound timers, then advance
+    /// the CPU a batch of `cyclesPerTick` instructions (stopping early at an input branch). The scheduler
+    /// only invokes this when the trigger matches, so it always advances exactly one frame's worth.
+    let timerIsr (cyclesPerTick: int) : ISR<Chip8Cow.Frame, Chip8Cow.Frame> =
+        fun _ctx frame ->
+            let ticked = Chip8Cow.tick frame
+            let advanced, _hitBranch = SoftChip8.lookAhead cyclesPerTick ticked
+            Task.FromResult(Ok advanced)
+
+    /// The CHIP-8 60 Hz handler — fires on `TimerElapsed` only (ignores other interrupts so it composes
+    /// with input/CI/etc. handlers in the same scheduler).
+    let timerHandler (cyclesPerTick: int) : SoftScheduler.Handler<Chip8Cow.Frame> =
+        SoftScheduler.handler
+            "chip8-60hz"
+            (function
+            | TimerElapsed _ -> true
+            | _ -> false)
+            (timerIsr cyclesPerTick)
+
+    /// A bare IntrCtx for the deterministic (no-trace-export) path.
+    let private dstCtx: IntrCtx =
+        { Memetic = "chip8"; Prompt = ""; Trust = ""; Log = ""; Otel = ActivityContext() }
+
+    /// Run a ROM on the soft scheduler for `frames` 60 Hz ticks against the deterministic seed source
+    /// (DST — null I/O). Returns the final frame (or the interrupt that stopped it). CHIP-8 = the
+    /// scheduler's first client; identical (seed, rom, frames) replays identically.
+    let run (seed: uint64) (rom: byte[]) (frames: int) : Task<Result<Chip8Cow.Frame, InterruptFeedback>> =
+        let initial = Chip8Cow.create seed |> Chip8Cow.loadRom rom
+        SoftScheduler.runDeterministic [ timerHandler DefaultCyclesPerTick ] dstCtx (int64 seed) initial frames
+
+    /// Run with a custom cycles-per-tick (e.g. for a slower/faster CPU clock).
+    let runWith (cyclesPerTick: int) (seed: uint64) (rom: byte[]) (frames: int) : Task<Result<Chip8Cow.Frame, InterruptFeedback>> =
+        let initial = Chip8Cow.create seed |> Chip8Cow.loadRom rom
+        SoftScheduler.runDeterministic [ timerHandler cyclesPerTick ] dstCtx (int64 seed) initial frames

--- a/src/Core/SoftScheduler.fs
+++ b/src/Core/SoftScheduler.fs
@@ -39,44 +39,18 @@ module SoftScheduler =
     /// room boundary — inject `seedSource` (null/deterministic) for DST, a real-IEffects source for prod.
     type Source = int -> InterruptKind list
 
-    // --- SplitMix64 avalanche constants (Steele/Lea/Flood, "Fast Splittable PRNGs", OOPSLA 2014) ---
-    // Named in hex (their canonical form) so the MEANING survives — a signed-decimal literal is the
-    // compiled form that loses what the number IS. We use SplitMix64 purely as a finalizer/hash: it
-    // avalanches a 64-bit input so every input bit flips ~half the output bits — i.e. low-order seed
-    // differences reach the decision bits. (Hash use only; not seeding a PRNG stream here.)
-
-    /// SplitMix64 increment — 2^64 / φ (the 64-bit fixed-point golden ratio). Odd, so adding it walks
-    /// the whole 64-bit space; used here to fold the tick index into the seed before avalanching.
-    [<Literal>]
-    let private GoldenGamma = 0x9E3779B97F4A7C15UL
-
-    /// SplitMix64 first avalanche multiplier.
-    [<Literal>]
-    let private MixMultiplier1 = 0xBF58476D1CE4E5B9UL
-
-    /// SplitMix64 second avalanche multiplier.
-    [<Literal>]
-    let private MixMultiplier2 = 0x94D049BB133111EBUL
-
-    /// SplitMix64 finalizer — avalanche a 64-bit value to a well-mixed 64-bit hash. Pure, branch-free,
-    /// immutable (let-shadowing, no `mutable`): correctness never depended on single-threading — there
-    /// is no shared state, so it is referentially transparent and safe at any DoP.
-    let private avalanche (x: uint64) : uint64 =
-        let z = x
-        let z = (z ^^^ (z >>> 30)) * MixMultiplier1
-        let z = (z ^^^ (z >>> 27)) * MixMultiplier2
-        z ^^^ (z >>> 31)
-
     /// The DST default — a deterministic null source derived from the seed alone (no I/O), the same way
     /// `Sim.tick` derives its entropy, so the schedule replays identically. Fires the 60Hz `TimerElapsed`
     /// every tick (the CHIP-8 timer) and deterministically raises an occasional `OperatorMessageArrived`
     /// from the avalanched (seed, tick) hash — exercising more than one handler without any real input.
     let seedSource (seed: int64) : Source =
         fun n ->
-            // Fold the tick index into the seed via the golden-ratio increment, then avalanche — so the
-            // WHOLE seed (incl. low bits) reaches the decision bits. (A naive `seed ^^^ n*k` leaves
-            // low-bit seed differences invisible after a right shift — the bug this replaced.)
-            let h = avalanche (uint64 seed + uint64 n * GoldenGamma)
+            // Fold the tick index into the seed via the golden-ratio increment, then run it through the
+            // canonical `SplitMix64.mix` (the ONE place the avalanche constants + their provenance live —
+            // arxiv 1410.0530) so the WHOLE seed (incl. low bits) reaches the decision bits. (A naive
+            // `seed ^^^ n*k` leaves low-bit seed differences invisible after a right shift — the bug this
+            // replaced.) Reusing SplitMix64.mix instead of re-inlining the constants per the DRY rule.
+            let h = SplitMix64.mix (uint64 seed + uint64 n * SplitMix64.GoldenRatio)
             let timer = [ TimerElapsed 17 ] // ~1/60s
             if h &&& 0xFUL = 0UL then
                 timer @ [ OperatorMessageArrived(sprintf "tick-%d" n) ]

--- a/tests/Tests.FSharp/SoftChip8Scheduler.Tests.fs
+++ b/tests/Tests.FSharp/SoftChip8Scheduler.Tests.fs
@@ -1,0 +1,58 @@
+module Zeta.Tests.SoftChip8SchedulerTests
+
+open System.Threading.Tasks
+open global.Xunit
+open Zeta.Core
+
+// ROM at 0x200: 6A 0C (V[A] = 0x0C) ; 12 02 (jump 0x202 — tight infinite loop).
+let private setRegRom = [| 0x6Auy; 0x0Cuy; 0x12uy; 0x02uy |]
+
+// ROM at 0x200: 60 05 (V0=5) ; F0 15 (Delay=V0) ; 12 04 (jump 0x204 — loop, timers keep ticking).
+let private delayRom = [| 0x60uy; 0x05uy; 0xF0uy; 0x15uy; 0x12uy; 0x04uy |]
+
+let private get (r: Result<Chip8Cow.Frame, InterruptFeedback>) =
+    match r with
+    | Ok f -> f
+    | Error e -> failwithf "scheduler errored: %A" e
+
+[<Fact>]
+let ``CHIP-8 runs on the soft scheduler: the CPU steps and sets V[A]`` () =
+    task {
+        let! r = SoftChip8Scheduler.run 1UL setRegRom 5
+        let f = get r
+        Assert.Equal(0x0Cuy, f.V.[0xA])
+    }
+
+[<Fact>]
+let ``deterministic replay: same (seed, rom, frames) => identical frame (DST)`` () =
+    task {
+        let! a = SoftChip8Scheduler.run 42UL setRegRom 30
+        let! b = SoftChip8Scheduler.run 42UL setRegRom 30
+        let fa, fb = get a, get b
+        Assert.Equal(fa.PC, fb.PC)
+        Assert.Equal<byte[]>(fa.V, fb.V)
+        Assert.Equal(fa.Delay, fb.Delay)
+    }
+
+[<Fact>]
+let ``the 60Hz timer interrupt decrements the delay timer to zero over frames`` () =
+    task {
+        // delay set to 5 on frame 1; each subsequent TimerElapsed decrements it. 20 frames => 0.
+        let! r = SoftChip8Scheduler.run 7UL delayRom 20
+        Assert.Equal(0uy, (get r).Delay)
+    }
+
+[<Fact>]
+let ``the delay timer is still counting down partway (proves the timer ISR fires per frame)`` () =
+    task {
+        // frame 1: tick (delay 0->0), then CPU sets Delay=5. frame 2: tick 5->4. ... frame k: 5-(k-1).
+        let! r = SoftChip8Scheduler.run 7UL delayRom 3
+        Assert.Equal(3uy, (get r).Delay) // 5 - (3-1) = 3
+    }
+
+[<Fact>]
+let ``cyclesPerTick governs CPU advance: 0 cycles => CPU never steps (V[A] stays 0)`` () =
+    task {
+        let! r = SoftChip8Scheduler.runWith 0 1UL setRegRom 5
+        Assert.Equal(0uy, (get r).V.[0xA]) // timers tick, but the CPU is held at DoP-of-cycles=0
+    }

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -121,6 +121,7 @@
     <Compile Include="UniversalNumber.Tests.fs" />
     <Compile Include="FingerprintPrism.Tests.fs" />
     <Compile Include="SoftScheduler.Tests.fs" />
+    <Compile Include="SoftChip8Scheduler.Tests.fs" />
     <Compile Include="BitAdinkra.Tests.fs" />
     <Compile Include="ForwardMomentum.Tests.fs" />
     <Compile Include="QubitIso.Tests.fs" />


### PR DESCRIPTION
Wires CHIP-8 into the soft scheduler (#7529): 60Hz TimerElapsed ISR = Chip8Cow.tick + SoftChip8.lookAhead CPU batch; state = Chip8Cow.Frame on the ISR arrow; deterministic ROM replay. CHIP-8 = the scheduler's first client. Also dedups SoftScheduler's avalanche onto the canonical SplitMix64.mix (the module already existed). 10/10 scheduler tests, 0 warnings.