### PR TITLE
docs(craft): young-learner module — "Crossing the streams" (Ghostbusters proton packs for combining streams)

### DIFF
--- a/docs/craft/README.md
+++ b/docs/craft/README.md
@@ -3,8 +3,11 @@
 **Status:** skeleton landed; multiple Zeta-track modules
 present (`zset-basics`, `retraction-intuition`,
 `operator-composition`, `semiring-basics`) plus an
-initial `production-dotnet` track. The curriculum grows
-tick-by-tick, backwards-chain from current project needs.
+initial `production-dotnet` track, and a **young-learner**
+module (`crossing-the-streams-ghostbusters` — combining
+streams via proton packs; use-the-tool-without-the-how).
+The curriculum grows tick-by-tick, backwards-chain from
+current project needs.
 **Companion curriculum** to `docs/ALIGNMENT.md` per the
 mutual-alignment (yin/yang) discipline — Craft teaches
 humans what the alignment-contract clauses mean in practice.

--- a/docs/craft/subjects/zeta/crossing-the-streams-ghostbusters/module.md
+++ b/docs/craft/subjects/zeta/crossing-the-streams-ghostbusters/module.md
@@ -1,0 +1,145 @@
+# Crossing the streams — combining flows, the Ghostbusters way
+
+**Subject:** zeta
+**Level:** applied (default) — **young-learner scaffolding**
+**Audience:** kids (and anyone who likes Ghostbusters); the
+first, gentlest take on *combining streams*. Grown-up
+version: `subjects/zeta/operator-composition/`.
+
+**Prerequisites:** none. If you know what a stream of water
+is, you're ready.
+
+---
+
+## The anchor — proton packs
+
+In Ghostbusters, each buster has a proton pack that shoots
+a **stream**. One stream catches one ghost. But when they
+need to trap something really big, they do the scary thing:
+they **cross the streams** — they join their streams into
+one. Together the streams are way more powerful than any
+one alone.
+
+There's a rule, though. Egon warns them: *don't* cross the
+streams *carelessly* — it can go BOOM. But by the end of the
+movie they **do** cross them on purpose, carefully, and it
+works. That's the whole secret:
+
+> **You CAN cross the streams. You just have to set the packs
+> up right first.**
+
+---
+
+## What a "stream" is here
+
+A **stream** is just a flow of things arriving over time —
+like a line of train cars going by, or water from a hose, or
+a list of "apples sold today" that keeps getting longer.
+
+In Zeta we have lots of streams: a stream of clicks, a stream
+of scores, a stream of "someone changed their mind" (we can
+even *un*-add something — take it back). Each stream is one
+proton pack.
+
+## Combining streams = crossing the streams
+
+Sometimes you want to put two streams **together** to get
+something more powerful — like "show me kids who scored high
+**and** finished fast." That needs the *score* stream crossed
+with the *time* stream.
+
+Crossing streams is powerful. But just like the movie, there's
+a rule so it doesn't go BOOM:
+
+> **Before you cross two streams, they have to be *tuned to
+> match* — the same size and shape of flow.**
+
+If one stream is a gentle trickle and the other is a firehose,
+crossing them is a mess — too much, too fast, can't tell what
+happened. Tune them to the **same kind of flow** first, and
+crossing them is smooth and safe and even *easy*.
+
+Grown-ups have a fancy name for "tuned to match" — they call
+it *regularizing the big-O*. You do **not** need to know what
+that means to use it. That's the best part. 👇
+
+## The WHY — you use the tool, you don't build the tool
+
+Here's the magic: **you don't have to tune the packs yourself.**
+
+The Ghostbusters had Egon — the smart one who built the packs
+so the others could just *use* them. In Zeta, the **tool does
+the tuning for you.** When you ask it to cross two streams, it
+checks: "do these match? can they cross safely?" If they don't
+match, it stops you *before* the BOOM and says "these don't fit
+yet." If they do, it crosses them for you.
+
+So you get to be the buster who points the pack and catches the
+ghost — you don't have to be the one who builds the pack. You
+learn **when** to cross streams and **why** crossing is
+powerful. The **how** is Egon's job (the tool's job).
+
+That's the rule for *every* good tool:
+
+> You don't have to build a hammer to use a hammer. You don't
+> have to know how a calculator adds to press the `+` button.
+> You don't have to tune a proton pack to cross the streams.
+
+---
+
+## Try it (no computer needed)
+
+1. **Be the streams.** Two friends each tap a steady beat on
+   the table — one slow, one fast. Try to clap *exactly* with
+   *both* at once. Hard, right? The beats don't match — that's
+   un-tuned streams. BOOM.
+2. **Tune them.** Now both friends tap the *same* slow beat.
+   Clap with both. Easy! That's tuned streams — safe to cross.
+3. **The point:** crossing is powerful, and it's *easy once
+   they match*. Matching first is the whole trick — and a good
+   tool does the matching for you.
+
+## Did you get it? (self-check)
+
+- What does "cross the streams" mean here? *(Combine two flows
+  into one more-powerful thing.)*
+- What's the one rule before you cross them? *(Tune them to
+  match first — same size/shape of flow.)*
+- Do **you** have to tune them yourself? *(No — the tool does
+  it, and warns you if they don't fit yet. You decide *when*
+  and *why*; the tool handles the *how*.)*
+
+---
+
+## Grown-up notes (for the teacher / older learner)
+
+- This is the kid-scaffolding of **operator composition** —
+  see `subjects/zeta/operator-composition/` (LEGO-snap anchor,
+  type-match rule, DBSP identities).
+- "Tuned to match" = **regularize the big-O**: combining two
+  incremental streams is cheap and deterministic *iff* their
+  per-change cost is bounded to the same order. Mismatched
+  asymptotics is the "BOOM" (cost blows up / unpredictable).
+  Captured 2026-06-10 in
+  `docs/research/2026-06-10-boundary-flow-architecture-minimal-action-energy-redirection-dataflow-membranes.md`
+  (Aaron's "regularize the big-O and you CAN cross the
+  streams" — Ghostbusters).
+- "The tool tunes for you / use-don't-build" = the Craft
+  pedagogy principle #1 (tool-use first) and the type-checker
+  + operator algebra doing the safety check so the learner
+  reasons about *when/why*, not *how*.
+- Anchor origin: Aaron 2026-06-10 — "perfect for teaching
+  young kids the math WHYs on how to use the TOOLS without
+  needing to understand the HOW; my kids all love
+  Ghostbusters."
+
+---
+
+## Composes with
+
+- `subjects/zeta/operator-composition/` — the grown-up version
+- `subjects/zeta/zset-basics/` — what a single stream carries
+- `subjects/zeta/retraction-intuition/` — the "take it back"
+  stream (un-adding)
+- `docs/craft/README.md` — Craft pedagogy (tool-use first,
+  grounding-point, multi-reading-level)


### PR DESCRIPTION
Saves Aaron's proton-pack metaphor as a kid-facing Craft module: combining streams = crossing the streams; rule = tune-to-match first (big-O regularization, grown-up name only); WHY = the tool tunes for you, you decide when/why not how. No-computer clap exercise + self-check. Ties operator-composition + the big-O capture. Docs only.