### PR TITLE
docs(craft): "Topology is hairdressing" — braiding hair is braiding qubits

### DIFF
--- a/docs/craft/subjects/quantum/topology-is-hairdressing/module.md
+++ b/docs/craft/subjects/quantum/topology-is-hairdressing/module.md
@@ -1,0 +1,129 @@
+# Topology is hairdressing — braiding hair is braiding qubits
+
+**Subject:** quantum
+**Level:** applied (default) — **hairdresser + young-learner scaffolding**
+**Audience:** anyone who has ever braided hair (and their kids). The
+gentlest possible door into **topological quantum computing** / Q#.
+Grown-up track at the bottom.
+
+**Prerequisites:** none. If you have ever made a braid, you are already
+doing the hard part.
+
+> **Carved: topology is hairdressing.** (Aaron 2026-06-10: *"I'm creating a
+> language where a hairdresser can understand Q# — and so can my kids."*)
+
+---
+
+## The anchor — you already do this
+
+A hairdresser braids hair every day. To braid, you take strands and cross
+them over and under each other in a pattern, over and over. You also
+**weave**, **tie**, and cut a **bob**. These are not analogies for
+something hard. **They are the hard thing.**
+
+- A **braid** is a real mathematical object — mathematicians study the
+  *braid group*: all the ways you can cross strands.
+- A **weave** and a **tie** (a knot) are the objects of *knot theory* and
+  *topology* — the math of shapes that stay the same when you bend them but
+  change when you cross or tie them.
+
+So when you braid hair, **you are doing topology with your hands.** You are
+an applied topologist. You just never called it that.
+
+---
+
+## Applied track — why this means you already understand qubits
+
+There is a kind of quantum computer that does its work by **braiding**.
+The tiny things it computes with (called *anyons*) are moved around each
+other — crossed over and under — exactly like strands of hair. **Each
+braid pattern is a computation.** Different braid = different answer.
+
+Here is the wonderful part: the *reason* this kind of quantum computer is
+special is the *same reason a braid holds*:
+
+- **A braid is sturdy.** If you nudge the hair a little, the braid is still
+  the same braid — the pattern of crossings didn't change. You'd have to
+  *un-cross* a strand to change it.
+- **That sturdiness is why it's used for computing.** A braided
+  (topological) qubit is hard to mess up by accident, for the *exact same
+  reason* your braid doesn't fall out if the wind blows. The information is
+  in the *pattern of crossings*, not in any one strand.
+
+So you already understand the headline of topological quantum computing:
+**the answer lives in how the strands cross, and crossings are sturdy.**
+That's it. That's the deep idea. You've been doing it since you learned to
+braid.
+
+### The four moves (the verbs you already know)
+
+Zeta's language uses the words you already use at the chair:
+
+| word | at the salon | in the math (what it really is) |
+|---|---|---|
+| **braid** | cross strands over/under in a pattern | a braid-group element = a quantum computation |
+| **weave** | interlace strands together | combining strands into one sturdy structure |
+| **tie** | make a knot / fasten | a knot (knot theory); a *soft* tie = a loose, gentle join |
+| **bob** | a clean cut to a length | a cut — end the pattern at a chosen point |
+
+Learn *when* and *why* to braid, weave, tie, and bob — the **how** (the
+quantum algebra underneath) is the tool's job, not yours. You point; the
+tool braids.
+
+---
+
+## Did you get it? (self-check)
+
+- What carries the information in a braid — a single strand, or the pattern
+  of crossings? *(The pattern of crossings.)*
+- Why is a braid sturdy against a little nudge? *(You'd have to actually
+  un-cross a strand to change the pattern.)*
+- What does that sturdiness give a braided ("topological") qubit?
+  *(Resistance to accidental errors — the same reason your braid stays in.)*
+
+---
+
+## Grown-up / theoretical track — opt-in
+
+*If the above is enough, stop here.*
+
+- **Braid group `Bₙ`** — the strands-crossing math; generators σᵢ (cross
+  strand i over i+1), the Yang–Baxter relation. A braid word = a sequence
+  of crossings.
+- **Anyons & topological quantum computation** — non-abelian anyons in 2D
+  topological order; braiding world-lines implements unitary gates;
+  fault-tolerance because the gate depends only on the *topology* of the
+  braid, not the path details (Kitaev; Freedman; Nayak et al., *Non-Abelian
+  Anyons and Topological Quantum Computation*, RMP 2008).
+- **The n×n / Cayley-Dickson ladder** — 2×2 (SU(2), one qubit) → 4×4 → 8×8;
+  `src/Core/CayleyDickson.fs` (ℝ→ℂ→ℍ→𝕆; ℍ = quaternion = SU(2) = a qubit),
+  `src/Core/QubitIso.fs` (Pauli/SU(2) closes), `src/Core/Cl3.fs` (Clifford
+  Cl(3,0)).
+- **Effective, not physical (peel).** Zeta's qubits are *qubit-shaped linear
+  algebra*, classically simulated and replayable — `src/Core/AmplitudeEmu.fs`
+  (complex amplitudes → interference on merge) and `src/Core/BellTest.fs`
+  (reproduces the CHSH Tsirelson bound 2√2 *in deterministic simulation*).
+  The braid-as-gate layer is the build direction; the algebra + emulation
+  exist now.
+
+---
+
+## Why this module exists (the pedagogy)
+
+This is **Craft principle #2 (grounding-point discipline)** at its purest:
+the anchor isn't an analogy *to* something the learner knows — the thing
+they know (braiding) *is* the thing (topology). And it is the **vernacular
+Beacon test**: if a hairdresser and a six-year-old can both hold the idea,
+the shape is fully public — nothing locked in private notation, not even
+the quantum layer. See
+`docs/research/2026-06-10-vernacular-is-the-real-beacon-test-explaining-shapes-without-the-math.md`.
+
+## Composes with
+
+- `subjects/zeta/crossing-the-streams-ghostbusters/` — the sibling
+  young-learner module (combining streams via proton packs)
+- `docs/craft/README.md` — Craft pedagogy (WHY-before-HOW; grounding-point;
+  tool-use first)
+- `clis/VERB-MAP.md` — the `bob/weave/braid/tie` verbs ↔ the qubit substrate
+- `docs/research/2026-06-10-choice-determinism-attention-distributed-axiom-of-choice-soft-topology.md`
+  — soft ties / soft topology (the *tie* is soft)


### PR DESCRIPTION
Aaron: 'a language where a hairdresser can understand Q# — and so can my kids' + 'topology is hairdressing.' New Craft module: bob/weave/braid/tie are hairdressing words AND topological-QC operations (braid group, anyon braiding, knot theory) — a hairdresser is an applied topologist, so Q# is taught by naming the topology they already do (grounding-point principle at its purest). Verb table + self-check + grown-up track (anyons/Kitaev/Cayley-Dickson/QubitIso). Peeled (effective qubits = simulated; BellTest Tsirelson in DST). Docs only.