### PR TITLE
feat(core): SoftTie — wire the tie verb to FingerprintPrism.soft

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -241,6 +241,7 @@
     <Compile Include="GamePortfolio.fs" />
     <Compile Include="GameFingerprint.fs" />
     <Compile Include="FingerprintPrism.fs" />
+    <Compile Include="SoftTie.fs" />
     <Compile Include="GameCatalog.fs" />
     <Compile Include="ControlMerge.fs" />
     <Compile Include="PolarityFilter.fs" />

--- a/src/Core/SoftTie.fs
+++ b/src/Core/SoftTie.fs
@@ -1,0 +1,43 @@
+namespace Zeta.Core
+
+open Zeta.Core.Optics
+
+/// SoftTie — the concrete `tie` verb (Aaron 2026-06-10, shadow*): "wire `tie` to `FingerprintPrism.soft`."
+///
+/// `tie` is the soft-topology link: it soft-links two strands `a` and `b` into a **soft tie** — present
+/// iff they soft-match (similarity ≥ threshold), carrying the match *strength* as its weight. The tie is
+/// SOFT (weighted, not crisp) — "even our tie is soft, for our soft topology" (Aaron). It is wired
+/// THROUGH `FingerprintPrism.soft`: a one-element soft rainbow keyed by `b`, with `a` matched against it
+/// (a ties to b iff a soft-recognizes b). The 2-strand base of the bob/weave/braid/tie ladder.
+///
+/// Pure module, no classes. The strength is the soft weight (ties to `WeightedSet` soft links / the
+/// soft-topology capture).
+[<RequireQualifiedAccess>]
+module SoftTie =
+
+    /// A soft tie between two strands — present only when they soft-match; `Strength` ∈ (0,1] is the
+    /// similarity that bound them (the soft weight on the link).
+    type SoftTie<'w> = { Left: 'w; Right: 'w; Strength: float }
+
+    /// `tie similarity threshold a b` — soft-link `a` to `b` via `FingerprintPrism.soft`. Builds a
+    /// one-element soft rainbow {b} (the hard fingerprint is irrelevant for the soft path) and Matches
+    /// `a`: `Some` tie (with strength = similarity a b) if they clear the threshold, `None` if not (no
+    /// tie). This is the `tie` verb made concrete on the existing soft-fingerprint machinery.
+    let tie (similarity: 'w -> 'w -> float) (threshold: float) (a: 'w) (b: 'w) : SoftTie<'w> option =
+        let rainbow = FingerprintPrism.empty (fun (_: 'w) -> 0) |> FingerprintPrism.add b
+        let p: IPrism<'w, 'w> = FingerprintPrism.soft similarity threshold rainbow
+        match p.Match a with
+        | Some matched -> Some { Left = a; Right = matched; Strength = similarity a b }
+        | None -> None
+
+    /// `tie` over raw bytes — the concrete MinHash soft tie: similarity = Jaccard of the two
+    /// `FingerprintPrism.softBytes` sketches (insertion-robust). The default `tie` for byte strands.
+    let tieBytes (threshold: float) (a: byte[]) (b: byte[]) : SoftTie<byte[]> option =
+        let sim (x: byte[]) (y: byte[]) =
+            FingerprintPrism.softBytesSimilarity (FingerprintPrism.softBytes x) (FingerprintPrism.softBytes y)
+
+        tie sim threshold a b
+
+    /// Whether two strands are tied at the threshold (the boolean face of `tie`).
+    let tied (similarity: 'w -> 'w -> float) (threshold: float) (a: 'w) (b: 'w) : bool =
+        (tie similarity threshold a b).IsSome

--- a/tests/Tests.FSharp/SoftTie.Tests.fs
+++ b/tests/Tests.FSharp/SoftTie.Tests.fs
@@ -1,0 +1,49 @@
+module Zeta.Tests.SoftTieTests
+
+open System.Text
+open global.Xunit
+open Zeta.Core
+
+let private b (s: string) = Encoding.UTF8.GetBytes s
+
+[<Fact>]
+let ``tieBytes: identical strands tie with strength 1.0`` () =
+    match SoftTie.tieBytes 0.6 (b "the quick brown fox jumps over the lazy dog") (b "the quick brown fox jumps over the lazy dog") with
+    | Some t -> Assert.Equal(1.0, t.Strength, 10)
+    | None -> Assert.Fail "identical strands must tie"
+
+[<Fact>]
+let ``tieBytes: a one-region edit still ties, with high strength`` () =
+    let a = b "the quick brown fox jumps over the lazy dog twelve times in a row today"
+    let c = b "the quick brown fox JUMPED over the lazy dog twelve times in a row today"
+    match SoftTie.tieBytes 0.6 a c with
+    | Some t -> Assert.True(t.Strength > 0.6, $"expected strength > 0.6, got {t.Strength}")
+    | None -> Assert.Fail "a small edit must still tie"
+
+[<Fact>]
+let ``tieBytes: disjoint strands do NOT tie (None)`` () =
+    let r = SoftTie.tieBytes 0.6 (b "the quick brown fox jumps over the lazy dog") (b "ZZZZ unrelated ZZZZ unrelated ZZZZ 99999")
+    Assert.True(r.IsNone)
+
+[<Fact>]
+let ``tie wires through FingerprintPrism.soft: Right is the matched strand b`` () =
+    // generic tie with an explicit similarity fn; confirms the matched element is b (the rainbow's known).
+    let sim (x: int) (y: int) = if x = y then 1.0 else 0.0
+    match SoftTie.tie sim 0.5 7 7 with
+    | Some t ->
+        Assert.Equal(7, t.Right)
+        Assert.Equal(1.0, t.Strength, 10)
+    | None -> Assert.Fail "equal ints must tie"
+
+[<Fact>]
+let ``threshold gates the tie: a low threshold ties, an impossible one (>1) cannot`` () =
+    let a = b "alpha bravo charlie delta echo foxtrot golf hotel"
+    let c = b "alpha bravo charlie delta echo foxtrot golf INDIA"
+    Assert.True(SoftTie.tieBytes 0.01 a c |> Option.isSome) // low bar → tied
+    Assert.True(SoftTie.tieBytes 1.01 a c |> Option.isNone) // above any possible similarity → no tie
+
+[<Fact>]
+let ``tied is the boolean face of tie`` () =
+    let sim (x: int) (y: int) = if x = y then 1.0 else 0.0
+    Assert.True(SoftTie.tied sim 0.5 3 3)
+    Assert.False(SoftTie.tied sim 0.5 3 4)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -121,6 +121,7 @@
     <Compile Include="Optics.Tests.fs" />
     <Compile Include="UniversalNumber.Tests.fs" />
     <Compile Include="FingerprintPrism.Tests.fs" />
+    <Compile Include="SoftTie.Tests.fs" />
     <Compile Include="SoftScheduler.Tests.fs" />
     <Compile Include="SoftChip8Scheduler.Tests.fs" />
     <Compile Include="BitAdinkra.Tests.fs" />


### PR DESCRIPTION
Turns the tie verb stub into a working slice: SoftTie<'w> (Left/Right/Strength) present iff two strands soft-match, wired through FingerprintPrism.soft (1-element soft rainbow {b}, Match a); tieBytes = MinHash Jaccard soft tie; tied = boolean face. The soft (weighted) 2-strand link of the soft topology. 6/6, 0 warnings.