### PR TITLE
feat(core): the darkhall's door — Arcade.fs gathers emulator cabinets + live play/host

### DIFF
--- a/docs/research/2026-06-10-metaspace-landmarks-floorplan-salon-darkhall.md
+++ b/docs/research/2026-06-10-metaspace-landmarks-floorplan-salon-darkhall.md
@@ -21,7 +21,7 @@ navigation. Anchor: the **Final Fantasy VII Gold Saucer** venues mapped onto Zet
 | landmark | the familiar place | the work that lives there | code (the fittings) | status |
 |---|---|---|---|---|
 | **salon** | a hairdresser's salon | **quantum physics** — `braid`/`weave`/`tie` (topology *is* hairdressing); the effective-qubit substrate | `QubitIso` (Pauli/SU(2)), `Cl3` (Clifford), `AmplitudeEmu` (interference), `BellTest` (Tsirelson in DST), `CayleyDickson` (2→4→8), `FingerprintPrism.soft`/`SoftTie` | **DOOR LANDED** — `src/Core/Salon.fs` (stations registry + live `tie` entrance) |
-| **darkhall** | the dim arcade hall of cabinets | **the arcade** — emulators / VMs / games; CHIP-8 and the hard→soft→shader stack | `Chip8`, `Chip8Cow`, `SoftChip8`, `SoftChip8Scheduler`, `GameFingerprint`/`GamePortfolio`/`GameCatalog`, `FingerprintPrism`, `Sim` | **furnished**, no door yet |
+| **darkhall** | the dim arcade hall of cabinets | **the arcade** — emulators / VMs / games; decompile programs to MIPS-like μops (rooms = micro-ops; real-time branch detection) | `DarkHall` (clean-room CHIP-8 CPU cell), `Chip8Cow`, `SoftChip8`, `SoftChip8Scheduler`, `GameFingerprint`/`GamePortfolio`/`GameCatalog`, `FingerprintPrism`, `Sim` | **DOOR LANDED** — `src/Core/Arcade.fs` (cabinets registry + live `play`/`host`; named `Arcade` because `DarkHall` is the emulator cell) |
 | **bowling alley** | a bowling alley | *TBD — Aaron to name the work* | — | named, unmapped |
 | **skatium** | a roller/skating rink | *TBD — Aaron to name the work* | — | named, unmapped |
 

--- a/src/Core/Arcade.fs
+++ b/src/Core/Arcade.fs
@@ -1,0 +1,80 @@
+namespace Zeta.Core
+
+open System.Threading.Tasks
+
+/// Arcade — the **door** on the *darkhall* landmark (Aaron 2026-06-10, shadow*: "darkhall next — give the
+/// arcade its door"). Named `Arcade` because `DarkHall` (`DarkHall.fs`) is already the clean-room CHIP-8
+/// emulator *cell* — it's a **cabinet**, not the door. The landmark is "darkhall"; its door module is
+/// `Arcade` (the place's nature). (Rename if you'd rather flip them.)
+///
+/// The darkhall is the dim hall of cabinets — the **emulator / VM / games** landmark, where (Aaron +
+/// Max 2026-06-10) **programs are decompiled down to MIPS-like primitives** and **rooms are the CPU's
+/// micro-operations**: a room/cell is a μop, the program decompiles into rooms, and the soft layer does
+/// **branch detection in real time** (the only soft fork is on unknown future input). This door gathers
+/// the arcade's cabinets under one name and gives **live entrances** — `play` (a ROM on the soft
+/// scheduler) and `host` (the clean-room `DarkHall` CPU) — so you can walk in and run a cabinet.
+[<RequireQualifiedAccess>]
+module Arcade =
+
+    /// A cabinet in the arcade — one named offering.
+    type Cabinet =
+        { Name: string
+          Does: string
+          Verb: string option
+          Module: string
+          Live: bool }
+
+    /// The arcade's cabinets — the emulator/VM/game fittings gathered under one door.
+    let cabinets: Cabinet list =
+        [ { Name = "play"
+            Does = "run a CHIP-8 ROM on the soft IScheduler for N 60Hz frames (the soft cabinet)"
+            Verb = Some "sim"
+            Module = "src/Core/SoftChip8Scheduler.fs"
+            Live = true }
+          { Name = "host"
+            Does = "the clean-room minimal CHIP-8-subset CPU cell — deterministic, DST-replayable"
+            Verb = Some "sim"
+            Module = "src/Core/DarkHall.fs"
+            Live = true }
+          { Name = "step"
+            Does = "one pure CHIP-8 instruction (the COW transition; parent untouched)"
+            Verb = None
+            Module = "src/Core/Chip8Cow.fs"
+            Live = true }
+          { Name = "predict"
+            Does = "real-time BRANCH DETECTION — the only soft fork is on unknown future input; batch look-ahead between branches (play∥predict)"
+            Verb = None
+            Module = "src/Core/SoftChip8.fs"
+            Live = true }
+          { Name = "fingerprint"
+            Does = "identify the game — hard exact key (SHA-256) + soft recognition (FingerprintPrism)"
+            Verb = None
+            Module = "src/Core/GameFingerprint.fs + src/Core/FingerprintPrism.fs"
+            Live = true }
+          { Name = "catalog"
+            Does = "per-game soft state keyed by fingerprint (switch games staying soft)"
+            Verb = Some "cla"
+            Module = "src/Core/GamePortfolio.fs + src/Core/GameCatalog.fs"
+            Live = false }
+          { Name = "sim"
+            Does = "the ephemeral void run (the deterministic edge tick the cabinets lift)"
+            Verb = Some "sim"
+            Module = "src/Core/Sim.fs"
+            Live = true } ]
+
+    /// The arcade's name and what work happens here (the signage).
+    let name = "darkhall"
+    let does = "the arcade — emulators / VMs / games; decompile programs to MIPS-like μops; rooms = micro-ops; real-time branch detection"
+
+    /// Live entrance: `play` — run a CHIP-8 ROM on the soft scheduler for `frames` 60Hz ticks (delegates
+    /// to the working `SoftChip8Scheduler`).
+    let play (seed: uint64) (rom: byte[]) (frames: int) : Task<Result<Chip8Cow.Frame, InterruptFeedback>> =
+        SoftChip8Scheduler.run seed rom frames
+
+    /// Live entrance: `host` — run a program on the clean-room `DarkHall` CPU to halt or `budget` steps
+    /// (deterministic, DST-replayable). The hard cabinet.
+    let host (program: byte[]) (budget: int) : DarkHall.EmuState =
+        DarkHall.run program budget
+
+    /// The cabinets that are working slices today (Live = true).
+    let liveCabinets: Cabinet list = cabinets |> List.filter (fun c -> c.Live)

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -249,6 +249,7 @@
     <Compile Include="PolarityFilter.fs" />
     <Compile Include="ZetaExec.fs" />
     <Compile Include="DarkHall.fs" />
+    <Compile Include="Arcade.fs" />
     <Compile Include="Skadium.fs" />
     <Compile Include="HendersonTextileMill.fs" />
     <Compile Include="Consent/KskAuthorization.fs" />

--- a/tests/Tests.FSharp/Arcade.Tests.fs
+++ b/tests/Tests.FSharp/Arcade.Tests.fs
@@ -1,0 +1,47 @@
+module Zeta.Tests.ArcadeTests
+
+open global.Xunit
+open Zeta.Core
+
+// ROM at 0x200: 6A 0C (V[A]=0x0C) ; 12 02 (jump 0x202 loop) — the soft-scheduler cabinet.
+let private setRegRom = [| 0x6Auy; 0x0Cuy; 0x12uy; 0x02uy |]
+
+[<Fact>]
+let ``the arcade door gathers its cabinets (incl. the existing DarkHall + soft scheduler)`` () =
+    let names = Arcade.cabinets |> List.map (fun c -> c.Name)
+    Assert.Contains("play", names) // soft scheduler
+    Assert.Contains("host", names) // the clean-room DarkHall cell
+    Assert.Contains("predict", names) // real-time branch detection
+    Assert.True(Arcade.cabinets |> List.forall (fun c -> c.Module.Length > 0))
+
+[<Fact>]
+let ``the arcade signage names the emulator/decompile-to-micro-ops work`` () =
+    Assert.Equal("darkhall", Arcade.name)
+    Assert.Contains("MIPS-like", Arcade.does)
+    Assert.Contains("rooms = micro-ops", Arcade.does)
+
+[<Fact>]
+let ``live entrance: play runs a ROM on the soft scheduler (CPU steps, sets V[A])`` () =
+    task {
+        let! r = Arcade.play 1UL setRegRom 5
+        match r with
+        | Ok f -> Assert.Equal(0x0Cuy, f.V.[0xA])
+        | Error e -> Assert.Fail(sprintf "play errored: %A" e)
+    }
+
+[<Fact>]
+let ``live entrance: host runs the clean-room DarkHall CPU deterministically`` () =
+    // 6A 0C (V[A]=0x0C) ; 0000 halt — the hard cabinet.
+    let prog = [| 0x6Auy; 0x0Cuy; 0x00uy; 0x00uy |]
+    let a = Arcade.host prog 16
+    let b = Arcade.host prog 16
+    Assert.Equal(0x0C, a.V.[0xA]) // register set
+    Assert.True(a.Halted)
+    Assert.Equal(a.Steps, b.Steps) // deterministic / DST-replayable
+
+[<Fact>]
+let ``liveCabinets are the working slices (play/host/step/predict live; catalog awaits)`` () =
+    let live = Arcade.liveCabinets |> List.map (fun c -> c.Name)
+    Assert.Contains("play", live)
+    Assert.Contains("host", live)
+    Assert.DoesNotContain("catalog", live)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -124,6 +124,7 @@
     <Compile Include="SoftTie.Tests.fs" />
     <Compile Include="LinguisticSeed.Tests.fs" />
     <Compile Include="Salon.Tests.fs" />
+    <Compile Include="Arcade.Tests.fs" />
     <Compile Include="SoftScheduler.Tests.fs" />
     <Compile Include="SoftChip8Scheduler.Tests.fs" />
     <Compile Include="BitAdinkra.Tests.fs" />


### PR DESCRIPTION
Darkhall door (after the salon). Look-don't-infer: DarkHall.fs already exists (clean-room CHIP-8 CPU cell) = a cabinet, so the door is named Arcade. Cabinets registry (play/host/step/predict/fingerprint/catalog/sim) + two live entrances: play (soft scheduler) + host (clean-room DarkHall CPU). Signage names the work Aaron+Max recognized: decompile to MIPS-like μops, rooms = CPU micro-ops, real-time branch detection (RISC conversion). 5/5, 0 warnings. Floorplan: darkhall = DOOR LANDED.