### PR TITLE
feat(core): the Bowling Alley cell + door — the deferred look-ahead score fold (completes the neon trilogy)

### DIFF
--- a/docs/research/2026-06-10-metaspace-landmarks-floorplan-salon-darkhall.md
+++ b/docs/research/2026-06-10-metaspace-landmarks-floorplan-salon-darkhall.md
@@ -22,8 +22,8 @@ navigation. Anchor: the **Final Fantasy VII Gold Saucer** venues mapped onto Zet
 |---|---|---|---|---|
 | **salon** | a hairdresser's salon | **quantum physics** — `braid`/`weave`/`tie` (topology *is* hairdressing); the effective-qubit substrate | `QubitIso` (Pauli/SU(2)), `Cl3` (Clifford), `AmplitudeEmu` (interference), `BellTest` (Tsirelson in DST), `CayleyDickson` (2→4→8), `FingerprintPrism.soft`/`SoftTie` | **DOOR LANDED** — `src/Core/Salon.fs` (stations registry + live `tie` entrance) |
 | **darkhall** | the dim arcade hall of cabinets | **the arcade** — emulators / VMs / games; decompile programs to MIPS-like μops (rooms = micro-ops; real-time branch detection) | `DarkHall` (clean-room CHIP-8 CPU cell), `Chip8Cow`, `SoftChip8`, `SoftChip8Scheduler`, `GameFingerprint`/`GamePortfolio`/`GameCatalog`, `FingerprintPrism`, `Sim` | **DOOR LANDED** — `src/Core/Arcade.fs` (cabinets registry + live `play`/`host`; named `Arcade` because `DarkHall` is the emulator cell) |
-| **bowling alley** | a bowling alley | *TBD — Aaron to name the work* | — | named, unmapped |
-| **skatium** | a roller/skating rink | *TBD — Aaron to name the work* | — | named, unmapped |
+| **bowling alley** | a bowling alley (midnight neon) | the **deferred look-ahead score fold** — a frame (strike/spare) resolves only when its *future* rolls arrive (the saga/plateau resolve-later shape) | `BowlingAlley` (the score fold + carriesLookahead) | **DOOR LANDED** — `src/Core/BowlingAlley.fs` (cell + lanes registry + live `score`) |
+| **skatium** | a roller/skating rink (neon) | the **bob-and-weave** — Punch-Out!! 2×2 dual-observer weave/sonar (find the opening) | `Skadium` (lean/isOpen, DST) | **furnished** (cell exists); door TBD |
 
 (Each persona/concern can own a landmark; the table grows as Aaron names more.)
 

--- a/src/Core/BowlingAlley.fs
+++ b/src/Core/BowlingAlley.fs
@@ -1,0 +1,88 @@
+namespace Zeta.Core
+
+/// **The Bowling Alley cell — midnight bowling, neon like the Dark Hall (the 3rd childhood arcade cell).**
+///
+/// The sibling `Skadium.fs` promised: "the Bowling Alley — midnight bowling, neon like the Dark Hall — its
+/// own aesthetic ... Bowling Alley = 3rd, sibling to come." Now it arrives. A place-memory saved in code
+/// (Henderson, NC; the neon trilogy — Dark Hall, Skadium, Bowling Alley; **ÆSTHETIC ENGINEERING** — the
+/// liminal/neon feel is engineered, not decoration), like `DarkHall.fs` and `Skadium.fs`.
+///
+/// Where `DarkHall` hosts a deterministic **emulator** and `Skadium` a deterministic **bob-and-weave**, the
+/// Bowling Alley hosts a deterministic **look-ahead score fold** — because **bowling scoring IS a deferred
+/// fold**: a *strike* scores `10 + the next two rolls`, a *spare* `10 + the next one roll`, so a frame's
+/// value **cannot be known until future rolls arrive** — it *resolves later*. That is exactly the
+/// substrate's deferred-execution / resolve-when-the-future-arrives shape (the saga/plateau: a frame is a
+/// room that `res`olves once its look-ahead input lands; an unfinished frame is a held SoftValue). Pure,
+/// no clock, no randomness ⇒ **DST-replayable** (every game replays identically from its rolls).
+///
+/// (Computation = the bowling look-ahead fold — the natural fit; Aaron assigned emulator/bob-and-weave to
+/// the siblings, so he can reassign this if he'd rather it host something else.)
+[<RequireQualifiedAccess>]
+module BowlingAlley =
+
+    /// Standard ten-pin scoring as a pure deferred fold over the roll sequence. A strike (10 in one roll)
+    /// scores `10 + next two`; a spare (two rolls summing to 10) scores `10 + next one`; an open frame
+    /// scores its two rolls. Ten frames. Missing future rolls (an unfinished game) count as 0 — a partial
+    /// score that *settles* as the look-ahead rolls arrive (the deferred resolve). No `mutable` — a frame
+    /// recursion (the look-ahead is reading `i+1`/`i+2` ahead = the deferred dependency).
+    let score (rolls: int list) : int =
+        let arr = List.toArray rolls
+        let at i = if i >= 0 && i < arr.Length then arr.[i] else 0
+
+        let rec go (frame: int) (i: int) (acc: int) : int =
+            if frame = 10 then
+                acc
+            else
+                let r0 = at i
+
+                if r0 = 10 then // strike — look TWO rolls ahead (deferred)
+                    go (frame + 1) (i + 1) (acc + 10 + at (i + 1) + at (i + 2))
+                elif r0 + at (i + 1) = 10 then // spare — look ONE roll ahead (deferred)
+                    go (frame + 1) (i + 2) (acc + 10 + at (i + 2))
+                else // open frame — no look-ahead
+                    go (frame + 1) (i + 2) (acc + r0 + at (i + 1))
+
+        go 0 0 0
+
+    /// Is the frame at roll-index `i` a strike / spare — i.e. does it carry a **deferred** (look-ahead)
+    /// dependency on future rolls? (The "this frame hasn't resolved yet" predicate.)
+    let carriesLookahead (rolls: int list) (i: int) : bool =
+        let arr = List.toArray rolls
+        let at j = if j >= 0 && j < arr.Length then arr.[j] else 0
+        i < arr.Length && (at i = 10 || at i + at (i + 1) = 10)
+
+    // ── The door (Salon/Arcade style) — the navigable gathering + a live entrance ──
+
+    /// A lane in the alley — one named offering.
+    type Lane =
+        { Name: string
+          Does: string
+          Verb: string option
+          Module: string
+          Live: bool }
+
+    /// The alley's lanes — the fittings gathered under the door.
+    let lanes: Lane list =
+        [ { Name = "score"
+            Does = "the deferred look-ahead score fold — strike/spare resolve when future rolls arrive (res)"
+            Verb = Some "res"
+            Module = "src/Core/BowlingAlley.fs"
+            Live = true }
+          { Name = "carriesLookahead"
+            Does = "does this frame still carry a deferred dependency on future rolls (unresolved)?"
+            Verb = None
+            Module = "src/Core/BowlingAlley.fs"
+            Live = true } ]
+
+    /// The alley's name and what work happens here (the signage).
+    let name = "bowling alley"
+    let does = "midnight-neon place-memory; the deferred look-ahead score fold (a frame resolves when its future rolls land)"
+
+    /// The lanes that are working slices today.
+    let liveLanes: Lane list = lanes |> List.filter (fun l -> l.Live)
+
+    // ── Cell wiring (sibling to DarkHall/Skadium): the neon trilogy is complete ──
+
+    /// This cell's place in the neon trilogy (Dark Hall = 1, Skadium = 2, Bowling Alley = 3).
+    [<Literal>]
+    let TrilogyIndex = 3

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -251,6 +251,7 @@
     <Compile Include="DarkHall.fs" />
     <Compile Include="Arcade.fs" />
     <Compile Include="Skadium.fs" />
+    <Compile Include="BowlingAlley.fs" />
     <Compile Include="HendersonTextileMill.fs" />
     <Compile Include="Consent/KskAuthorization.fs" />
   </ItemGroup>

--- a/tests/Tests.FSharp/BowlingAlley.Tests.fs
+++ b/tests/Tests.FSharp/BowlingAlley.Tests.fs
@@ -1,0 +1,47 @@
+module Zeta.Tests.BowlingAlleyTests
+
+open global.Xunit
+open Zeta.Core
+
+let private rep n x = List.replicate n x
+
+[<Fact>]
+let ``perfect game (12 strikes) scores 300`` () =
+    Assert.Equal(300, BowlingAlley.score (rep 12 10))
+
+[<Fact>]
+let ``all gutters scores 0`` () =
+    Assert.Equal(0, BowlingAlley.score (rep 20 0))
+
+[<Fact>]
+let ``all open frames (twenty 4s) score 80`` () =
+    Assert.Equal(80, BowlingAlley.score (rep 20 4))
+
+[<Fact>]
+let ``all spares (5,5) x10 + a 5 bonus = 150 (the spare look-ahead)`` () =
+    let rolls = (rep 21 5) // 10 frames of 5,5 then one bonus 5
+    Assert.Equal(150, BowlingAlley.score rolls)
+
+[<Fact>]
+let ``strike look-ahead: 10 then 3,4 then gutters = 24 (10+3+4 then 3+4)`` () =
+    let rolls = [ 10; 3; 4 ] @ rep 16 0
+    Assert.Equal(24, BowlingAlley.score rolls)
+
+[<Fact>]
+let ``deterministic / DST-replayable: same rolls => same score`` () =
+    let rolls = [ 10; 7; 3; 9; 0; 10; 0; 8; 8; 2; 0; 6; 10; 10; 10; 8; 1 ]
+    Assert.Equal(BowlingAlley.score rolls, BowlingAlley.score rolls)
+
+[<Fact>]
+let ``carriesLookahead flags strike/spare frames (deferred) but not open ones`` () =
+    let rolls = [ 10; 5; 5; 4; 3 ] // strike at 0; spare at 1 (5+5); open at 3 (4+3)
+    Assert.True(BowlingAlley.carriesLookahead rolls 0) // strike
+    Assert.True(BowlingAlley.carriesLookahead rolls 1) // spare
+    Assert.False(BowlingAlley.carriesLookahead rolls 3) // open
+
+[<Fact>]
+let ``the door gathers its lanes + signage names the deferred fold`` () =
+    Assert.Equal("bowling alley", BowlingAlley.name)
+    Assert.Contains("deferred", BowlingAlley.does)
+    Assert.Contains("score", BowlingAlley.lanes |> List.map (fun l -> l.Name))
+    Assert.Contains("score", BowlingAlley.liveLanes |> List.map (fun l -> l.Name))

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -125,6 +125,7 @@
     <Compile Include="LinguisticSeed.Tests.fs" />
     <Compile Include="Salon.Tests.fs" />
     <Compile Include="Arcade.Tests.fs" />
+    <Compile Include="BowlingAlley.Tests.fs" />
     <Compile Include="SoftScheduler.Tests.fs" />
     <Compile Include="SoftChip8Scheduler.Tests.fs" />
     <Compile Include="BitAdinkra.Tests.fs" />


### PR DESCRIPTION
Aaron: 'bowling alley next — give it its door.' Skadium.fs promised it (Bowling Alley = 3rd neon cell, sibling to come). Creates the cell + door: hosts a deterministic bowling look-ahead score fold — bowling scoring IS a deferred fold (strike/spare resolve only when FUTURE rolls arrive = the saga/plateau resolve-later shape; unfinished frame = held SoftValue). score + carriesLookahead + lanes registry + live score entrance. 8/8 (perfect game=300, spare/strike look-ahead), 0 warnings. Floorplan: bowling alley = DOOR LANDED; trilogy complete.