### PR TITLE
chore(setup): close over Q# oracle deps

### DIFF
--- a/docs/INSTALLED.md
+++ b/docs/INSTALLED.md
@@ -7,81 +7,89 @@ be able to recreate the environment from this doc.
 
 ## Runtime SDKs (installed before project started — reused)
 
-| Tool | Version | Why | How installed |
-|---|---|---|---|
-| **.NET SDK** | 10.0.203 | Primary build runtime for F# + C# projects | mise-managed via `.mise.toml` + `global.json`; installed by `tools/setup/install.sh` (the canonical update path — see `memory/feedback_install_script_is_preferred_update_method_2026_04_24.md`). Older Homebrew / system installs (`/usr/local/share/dotnet`, `/opt/homebrew/Cellar/dotnet/`) MAY remain on personal machines but are NOT used for the build — `mise exec -- dotnet` resolves to the pinned SDK. |
-| **Java** | OpenJDK 21.0.1 LTS | Required by TLA+ `tla2tools.jar` and Alloy `alloy.jar` | Pre-installed (Oracle JDK) |
-| **Rust / cargo** | rustc 1.94.1 (Homebrew) | Building Feldera (apples-to-apples benchmark) | Pre-installed via Homebrew |
-| **Python 3** | 3.14 (mise-pinned) | Package-audit script JSON parsing + helper scripts; uv venv auto-source per `.mise.toml` | mise-managed via `.mise.toml` (`python = "3.14"`); resolved through `mise exec -- python3` for dev/CI parity. System Python may remain on personal machines but is not used for the build. |
-| **bash / awk / curl / git** | system default | `tools/*.sh` helper scripts | Pre-installed |
+| Tool                        | Version                 | Why                                                                                      | How installed                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --------------------------- | ----------------------- | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **.NET SDK**                | 10.0.203                | Primary build runtime for F# + C# projects                                               | mise-managed via `.mise.toml` + `global.json`; installed by `tools/setup/install.sh` (the canonical update path — see `memory/feedback_install_script_is_preferred_update_method_2026_04_24.md`). Older Homebrew / system installs (`/usr/local/share/dotnet`, `/opt/homebrew/Cellar/dotnet/`) MAY remain on personal machines but are NOT used for the build — `mise exec -- dotnet` resolves to the pinned SDK. |
+| **Java**                    | OpenJDK 21.0.1 LTS      | Required by TLA+ `tla2tools.jar` and Alloy `alloy.jar`                                   | Pre-installed (Oracle JDK)                                                                                                                                                                                                                                                                                                                                                                                        |
+| **Rust / cargo**            | rustc 1.94.1 (Homebrew) | Building Feldera (apples-to-apples benchmark)                                            | Pre-installed via Homebrew                                                                                                                                                                                                                                                                                                                                                                                        |
+| **Python 3**                | 3.14 (mise-pinned)      | Package-audit script JSON parsing + helper scripts; uv venv auto-source per `.mise.toml` | mise-managed via `.mise.toml` (`python = "3.14"`); resolved through `mise exec -- python3` for dev/CI parity. System Python may remain on personal machines but is not used for the build.                                                                                                                                                                                                                        |
+| **bash / awk / curl / git** | system default          | `tools/*.sh` helper scripts                                                              | Pre-installed                                                                                                                                                                                                                                                                                                                                                                                                     |
 
 ## System CLI tools (declared through install manifests)
 
-| Tool | Version | Why | How installed |
-|---|---|---|---|
-| **QEMU / qemu-img** | OS package manager version | USB/ISO boot, full-install, and B-0891 retention QEMU proofs | `tools/setup/install.sh` via `tools/setup/manifests/{apt,brew}`; Windows via `tools/setup/manifests/windows`; Nix dev/cluster surfaces via `full-ai-cluster/**/flake.nix` and `full-ai-cluster/nixos/modules/common.nix` |
-| **mtools / mcopy** | OS package manager version | File-backed zflash ESP writes into raw QEMU boot images without mounting physical USB devices | `tools/setup/install.sh` via `tools/setup/manifests/{apt,brew}`; Nix dev/cluster surfaces via `full-ai-cluster/**/flake.nix` and NixOS package lists |
-| **k3d** | 5.8.3 | Local K3S/Cilium parity substrate for B-0967 Kubernetes + ArgoCD health tests | mise-managed via `.mise.toml`; installed by `tools/setup/install.sh` |
-| **kind** | 0.31.0 | Conservative Docker/Podman Kubernetes substrate for B-0967 CI smoke tests | mise-managed via `.mise.toml`; installed by `tools/setup/install.sh` |
-| **kubectl** | 1.36.1 | Kubernetes control-plane inspection and ArgoCD Application health assertions | mise-managed via `.mise.toml`; installed by `tools/setup/install.sh` |
-| **helm** | 4.2.0 | Installs bootstrap ArgoCD/Cilium charts for local cluster health tests | mise-managed via `.mise.toml`; installed by `tools/setup/install.sh` |
+| Tool                | Version                    | Why                                                                                           | How installed                                                                                                                                                                                                            |
+| ------------------- | -------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **QEMU / qemu-img** | OS package manager version | USB/ISO boot, full-install, and B-0891 retention QEMU proofs                                  | `tools/setup/install.sh` via `tools/setup/manifests/{apt,brew}`; Windows via `tools/setup/manifests/windows`; Nix dev/cluster surfaces via `full-ai-cluster/**/flake.nix` and `full-ai-cluster/nixos/modules/common.nix` |
+| **mtools / mcopy**  | OS package manager version | File-backed zflash ESP writes into raw QEMU boot images without mounting physical USB devices | `tools/setup/install.sh` via `tools/setup/manifests/{apt,brew}`; Nix dev/cluster surfaces via `full-ai-cluster/**/flake.nix` and NixOS package lists                                                                     |
+| **k3d**             | 5.8.3                      | Local K3S/Cilium parity substrate for B-0967 Kubernetes + ArgoCD health tests                 | mise-managed via `.mise.toml`; installed by `tools/setup/install.sh`                                                                                                                                                     |
+| **kind**            | 0.31.0                     | Conservative Docker/Podman Kubernetes substrate for B-0967 CI smoke tests                     | mise-managed via `.mise.toml`; installed by `tools/setup/install.sh`                                                                                                                                                     |
+| **kubectl**         | 1.36.1                     | Kubernetes control-plane inspection and ArgoCD Application health assertions                  | mise-managed via `.mise.toml`; installed by `tools/setup/install.sh`                                                                                                                                                     |
+| **helm**            | 4.2.0                      | Installs bootstrap ArgoCD/Cilium charts for local cluster health tests                        | mise-managed via `.mise.toml`; installed by `tools/setup/install.sh`                                                                                                                                                     |
+
+## Python reference-oracle libraries
+
+| Package           | Version | Why                                                                                                                      | How installed                                                                                                                                                                                                                                     |
+| ----------------- | ------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **qdk[azure]**    | 1.29.1  | Microsoft QDK Python entrypoint for Q# reference-oracle tests over finite-resolution qubits observables                  | Optional install through `ZETA_INSTALL_QUANTUM=1 tools/setup/install.sh` or `ZETA_INSTALL_FULL=1 tools/setup/install.sh`; realized by `tools/setup/common/quantum.sh` from `tools/setup/manifests/quantum` into repo `.venv` via `uv pip install` |
+| **qsharp**        | 1.29.1  | Direct Q# package pin for `qsharp` / `%%qsharp` parity when producing `qsharp-golden.json` observables                   | Same optional quantum path as above                                                                                                                                                                                                               |
+| **azure-quantum** | 3.10.0  | Explicit pin for the optional Azure backend edge owned by `qdk[azure]`; local simulation remains the default oracle path | Same optional quantum path as above                                                                                                                                                                                                               |
 
 ## Project-specific binary artifacts (downloaded by `tools/setup/install.sh`)
 
-| Artifact | Version | Path | Why | Install command |
-|---|---|---|---|---|
-| **TLA+ / TLC** | tla2tools.jar v1.8.0 | `tools/tla/tla2tools.jar` | Model-check every `docs/*.tla` spec in CI | `curl -sL -o tools/tla/tla2tools.jar https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar` |
-| **Alloy** | v6.2.0 dist jar | `tools/alloy/alloy.jar` | Bounded-model structural invariants (Spine sizeDoubling) | `curl -sL -o tools/alloy/alloy.jar https://github.com/AlloyTools/org.alloytools.alloy/releases/download/v6.2.0/org.alloytools.alloy.dist.jar` |
-| **Feldera (cloned)** | `main` branch | `references/prior-art/feldera/` | Apples-to-apples Nexmark benchmarks | `git clone --depth 1 https://github.com/feldera/feldera.git` |
-| **CTFP book (Milewski)** | v1.3.0 PDF | `docs/category-theory/ctfp-milewski.pdf` | Required-reading category theory reference | `curl -sL -o ... https://github.com/hmemcpy/milewski-ctfp-pdf/.../category-theory-for-programmers.pdf` |
-| **CTFP .NET (Bouderaux)** | archived snapshot | `docs/category-theory/ctfp-dotnet/` | F#/C# CT examples (no upstream tracking, .git stripped) | `git clone ... && rm -rf .git .github` |
+| Artifact                  | Version              | Path                                     | Why                                                      | Install command                                                                                                                               |
+| ------------------------- | -------------------- | ---------------------------------------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| **TLA+ / TLC**            | tla2tools.jar v1.8.0 | `tools/tla/tla2tools.jar`                | Model-check every `docs/*.tla` spec in CI                | `curl -sL -o tools/tla/tla2tools.jar https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar`                               |
+| **Alloy**                 | v6.2.0 dist jar      | `tools/alloy/alloy.jar`                  | Bounded-model structural invariants (Spine sizeDoubling) | `curl -sL -o tools/alloy/alloy.jar https://github.com/AlloyTools/org.alloytools.alloy/releases/download/v6.2.0/org.alloytools.alloy.dist.jar` |
+| **Feldera (cloned)**      | `main` branch        | `references/prior-art/feldera/`          | Apples-to-apples Nexmark benchmarks                      | `git clone --depth 1 https://github.com/feldera/feldera.git`                                                                                  |
+| **CTFP book (Milewski)**  | v1.3.0 PDF           | `docs/category-theory/ctfp-milewski.pdf` | Required-reading category theory reference               | `curl -sL -o ... https://github.com/hmemcpy/milewski-ctfp-pdf/.../category-theory-for-programmers.pdf`                                        |
+| **CTFP .NET (Bouderaux)** | archived snapshot    | `docs/category-theory/ctfp-dotnet/`      | F#/C# CT examples (no upstream tracking, .git stripped)  | `git clone ... && rm -rf .git .github`                                                                                                        |
 
 ## dotnet global tools
 
-| Tool | Version | Why | Install |
-|---|---|---|---|
-| **dotnet-stryker** | latest | Mutation testing against `Zeta.Core.fsproj` | `dotnet tool install -g dotnet-stryker` |
+| Tool                   | Version                                                                                          | Why                                                                     | Install                                                                                            |
+| ---------------------- | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| **dotnet-stryker**     | latest                                                                                           | Mutation testing against `Zeta.Core.fsproj`                             | `dotnet tool install -g dotnet-stryker`                                                            |
 | **elan / lean / lake** | elan-installed, toolchain `leanprover/lean4:v4.30.0-rc1` at `/opt/homebrew/bin/{elan,lean,lake}` | Lean 4 version manager + compiler + build tool; drives chain-rule proof | `tools/setup/install.sh` runs the elan installer; toolchain pinned by `tools/lean4/lean-toolchain` |
 
 ## NuGet packages (pinned in `Directory.Packages.props`)
 
 See `Directory.Packages.props` for the authoritative list. Current pins:
 
-| Package | Version | Purpose |
-|---|---|---|
-| FSharp.Core | 10.1.202 | F# runtime |
-| G-Research.FSharp.Analyzers | 0.22.0 | F# static analysis |
-| Ionide.Analyzers | 0.15.0 | F# static analysis |
-| FSharp.Analyzers.Build | 0.5.0 | Analyzer build hook |
-| Meziantou.Analyzer | 3.0.48 | C# static analysis (shim project) |
-| xunit.v3 | 3.2.2 | Test framework |
-| xunit.runner.visualstudio | 3.1.5 | VS test runner |
-| Microsoft.NET.Test.Sdk | 18.4.0 | dotnet test host |
-| FsCheck | 3.3.2 | Property-based testing |
-| FsCheck.Xunit.v3 | 3.3.2 | FsCheck × xUnit v3 glue |
-| FsUnit.Xunit | 7.1.0 | F# test DSL |
-| Unquote | 7.0.1 | F# assertion debugger |
-| BenchmarkDotNet | 0.15.8 | Perf harness |
-| coverlet.collector | 10.0.0 | Code-coverage collector |
-| coverlet.msbuild | 10.0.0 | MSBuild coverage target |
-| Microsoft.Z3 | 4.12.2 | SMT-prover for pointwise axioms |
-| System.IO.Hashing | 10.0.6 | XxHash + CRC32 |
-| System.Reactive | 6.1.0 | Rx .NET |
-| System.Numerics.Tensors | 10.0.6 | SIMD Tensor ops |
-| FsPickler | 5.3.2 | Canonical F# binary pickler |
-| Apache.Arrow | 22.1.0 | Arrow IPC wire format |
+| Package                     | Version  | Purpose                           |
+| --------------------------- | -------- | --------------------------------- |
+| FSharp.Core                 | 10.1.202 | F# runtime                        |
+| G-Research.FSharp.Analyzers | 0.22.0   | F# static analysis                |
+| Ionide.Analyzers            | 0.15.0   | F# static analysis                |
+| FSharp.Analyzers.Build      | 0.5.0    | Analyzer build hook               |
+| Meziantou.Analyzer          | 3.0.48   | C# static analysis (shim project) |
+| xunit.v3                    | 3.2.2    | Test framework                    |
+| xunit.runner.visualstudio   | 3.1.5    | VS test runner                    |
+| Microsoft.NET.Test.Sdk      | 18.4.0   | dotnet test host                  |
+| FsCheck                     | 3.3.2    | Property-based testing            |
+| FsCheck.Xunit.v3            | 3.3.2    | FsCheck × xUnit v3 glue           |
+| FsUnit.Xunit                | 7.1.0    | F# test DSL                       |
+| Unquote                     | 7.0.1    | F# assertion debugger             |
+| BenchmarkDotNet             | 0.15.8   | Perf harness                      |
+| coverlet.collector          | 10.0.0   | Code-coverage collector           |
+| coverlet.msbuild            | 10.0.0   | MSBuild coverage target           |
+| Microsoft.Z3                | 4.12.2   | SMT-prover for pointwise axioms   |
+| System.IO.Hashing           | 10.0.6   | XxHash + CRC32                    |
+| System.Reactive             | 6.1.0    | Rx .NET                           |
+| System.Numerics.Tensors     | 10.0.6   | SIMD Tensor ops                   |
+| FsPickler                   | 5.3.2    | Canonical F# binary pickler       |
+| Apache.Arrow                | 22.1.0   | Arrow IPC wire format             |
 
 Run `tools/audit-packages.sh` to diff pins against NuGet's latest. The
 audit is idempotent; `⚠ bump available` lines are actionable.
 
 ## Still required but NOT yet installed on this box
 
-| Tool | Reason deferred | When to install |
-|---|---|---|
-| **CodeQL CLI** | 500 MB; skipped pending concrete rules-authoring session | `brew install codeql` on macOS |
-| **Semgrep** | Not installed on this box; rules in `.semgrep.yml` run wherever Semgrep is invoked from (CI or dev laptop) | `brew install semgrep` or `pip3 install --user semgrep` |
-| **Infer.NET F# wrapper native libs** | Only needed if `Zeta.Bayesian` ever grows a full graphical-model operator (roadmap P2); current conjugate-prior impl has zero native deps | Install on-demand per that task |
-| **Feldera build** | Cloned but not `cargo build`-ed yet — ~15 min build | `cd references/prior-art/feldera && cargo build --release` when apples-to-apples run is scheduled |
+| Tool                                 | Reason deferred                                                                                                                           | When to install                                                                                   |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| **CodeQL CLI**                       | 500 MB; skipped pending concrete rules-authoring session                                                                                  | `brew install codeql` on macOS                                                                    |
+| **Semgrep**                          | Not installed on this box; rules in `.semgrep.yml` run wherever Semgrep is invoked from (CI or dev laptop)                                | `brew install semgrep` or `pip3 install --user semgrep`                                           |
+| **Infer.NET F# wrapper native libs** | Only needed if `Zeta.Bayesian` ever grows a full graphical-model operator (roadmap P2); current conjugate-prior impl has zero native deps | Install on-demand per that task                                                                   |
+| **Feldera build**                    | Cloned but not `cargo build`-ed yet — ~15 min build                                                                                       | `cd references/prior-art/feldera && cargo build --release` when apples-to-apples run is scheduled |
 
 ## How to recreate this environment from scratch
 
@@ -121,13 +129,13 @@ The working Lean project lives at `tools/lean4/`. Build with:
 cd tools/lean4 && lake build
 ```
 
-| Path | Contents |
-|---|---|
-| `tools/lean4/lakefile.toml` | Declares `[[require]] name = "mathlib" scope = "leanprover-community" rev = "v4.30.0-rc1"`; library target `Lean4` |
-| `tools/lean4/lean-toolchain` | Pins `leanprover/lean4:v4.30.0-rc1` (matches Mathlib rev) |
-| `tools/lean4/Lean4/Basic.lean` | Template sanity stub (`def hello := "world"`) |
+| Path                                   | Contents                                                                                                                                                          |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tools/lean4/lakefile.toml`            | Declares `[[require]] name = "mathlib" scope = "leanprover-community" rev = "v4.30.0-rc1"`; library target `Lean4`                                                |
+| `tools/lean4/lean-toolchain`           | Pins `leanprover/lean4:v4.30.0-rc1` (matches Mathlib rev)                                                                                                         |
+| `tools/lean4/Lean4/Basic.lean`         | Template sanity stub (`def hello := "world"`)                                                                                                                     |
 | `tools/lean4/Lean4/DbspChainRule.lean` | Current chain-rule scaffold; namespace `Dbsp.ChainRule`, 7 outstanding `sorry` obligations. Supersedes the older `proofs/lean/ChainRule.lean` on the v4.12.0 pin. |
-| `tools/lean4/.lake/packages/mathlib/` | Pre-warmed Mathlib checkout (aesop, batteries, Cli, LeanSearchClient, Qq, importGraph, plausible, proofwidgets siblings) |
+| `tools/lean4/.lake/packages/mathlib/`  | Pre-warmed Mathlib checkout (aesop, batteries, Cli, LeanSearchClient, Qq, importGraph, plausible, proofwidgets siblings)                                          |
 
 The older scaffold at `proofs/lean/ChainRule.lean` (Mathlib v4.12.0
 dep; unbuilt) is superseded and slated for deletion once the migrated
@@ -135,10 +143,10 @@ file builds green. See DEBT.md.
 
 ## Reference material (non-executable, cited in docs/papers)
 
-| Artifact | Source | Path | Why |
-|---|---|---|---|
-| **Lamport *Specifying Systems*** | Lamport's personal site (PDF) | `references/tla-book/specifying-systems.pdf` | Canonical TLA+ textbook; cited in `docs/SPEC-CAUGHT-A-BUG.md` |
-| **Adam Shostack EoP card game** | `elevationofprivilege.com` | upstream only (not vendored) | Teaching tool for threat modelling (CC-BY-3.0) |
+| Artifact                         | Source                        | Path                                         | Why                                                           |
+| -------------------------------- | ----------------------------- | -------------------------------------------- | ------------------------------------------------------------- |
+| **Lamport _Specifying Systems_** | Lamport's personal site (PDF) | `references/tla-book/specifying-systems.pdf` | Canonical TLA+ textbook; cited in `docs/SPEC-CAUGHT-A-BUG.md` |
+| **Adam Shostack EoP card game**  | `elevationofprivilege.com`    | upstream only (not vendored)                 | Teaching tool for threat modelling (CC-BY-3.0)                |
 
 ## Changelog
 

--- a/docs/craft/README.md
+++ b/docs/craft/README.md
@@ -180,6 +180,7 @@ piece of the philosophy is already in it:
 > not-knowing.** This is the root the whole
 > choice-architecture grows from (weight-free §3,
 > consent-first §6, no-directives).
+
 - **They choose.** It is a game they *want* to play —
   attention given, never forced. Freedom of choice of rooms,
   at the dinner table.

--- a/tools/ace/ace.test.ts
+++ b/tools/ace/ace.test.ts
@@ -793,7 +793,7 @@ describe("install --frozen (slice 5.3)", () => {
 
   // Builds an inline root->A graph in a temp dir, installs it once with --lockfile to
   // generate the lock (the lock's node url points at the temp A.json — registry never used),
-  // then returns paths so a --frozen run can replay it against an EMPTY registry.
+  // then returns paths so a --frozen run can replay it without consulting the user registry.
   function buildInlineGraph() {
     const dir = mkdtempSync(join(tmpdir(), "ace-frozen-pkgs-"));
     const A = { manifest: { format_version:1, name:"A", version:"1.0.0", content_hash: h({ "a.txt":"a" }) }, files: { "a.txt":"a" } };
@@ -810,9 +810,10 @@ describe("install --frozen (slice 5.3)", () => {
     // 1. Generate the lock via a normal install (inline graph; no registry add ever happens).
     expect(await main(["install", g.rootPath, "--store", genStore, "--allow-no-signature", "--lockfile", g.lockPath])).toBe(0);
     expect(existsSync(g.lockPath)).toBe(true);
-    // 2. Replay into a fresh store with --frozen. Registry is empty (no registry add); the
-    //    replay must install entirely from the lock's pinned url, never consulting the registry.
-    expect(loadRegistry().size).toBe(0);
+    // 2. Replay into a fresh store with --frozen. The user registry is empty (no registry add);
+    //    the bundled registry may carry unrelated packages. Frozen replay must install entirely
+    //    from the lock's pinned url, never consulting registry entries for the inline graph.
+    expect(loadRegistry(join(g.dir, "missing-bundled-registry.json")).size).toBe(0);
     const frozenStore = mkdtempSync(join(tmpdir(), "ace-frozen-replay-"));
     const code = await main(["install", g.rootPath, "--store", frozenStore, "--allow-no-signature", "--lockfile", g.lockPath, "--frozen"]);
     expect(code).toBe(0);

--- a/tools/ace/packages/qsharp-reference-oracle-0.1.0.json
+++ b/tools/ace/packages/qsharp-reference-oracle-0.1.0.json
@@ -1,0 +1,12 @@
+{
+  "manifest": {
+    "format_version": 1,
+    "name": "qsharp-reference-oracle",
+    "version": "0.1.0",
+    "description": "Declarative QDK/Q# Python dependency set for Zeta finite-resolution qubits reference-oracle tests.",
+    "content_hash": "sha256:07f5b7448ffd93c07b69c122ec8360ce2dddf235b43121982389ec9dfd00415d"
+  },
+  "files": {
+    "qsharp-reference-oracle.deps.json": "{\n  \"schema\": \"zeta.ace.package-manager-pointers.v1\",\n  \"purpose\": \"QDK/Q# reference oracle for finite-resolution qubits observable golden vectors\",\n  \"realizer\": \"tools/setup/common/quantum.sh\",\n  \"manifest\": \"tools/setup/manifests/quantum\",\n  \"opt_in\": [\"ZETA_INSTALL_QUANTUM=1\", \"ZETA_INSTALL_FULL=1\"],\n  \"dependencies\": [\n    {\n      \"ecosystem\": \"pypi\",\n      \"spec\": \"qdk[azure]==1.29.1\",\n      \"role\": \"reference-oracle\",\n      \"lang\": \"q#\"\n    },\n    {\n      \"ecosystem\": \"pypi\",\n      \"spec\": \"qsharp==1.29.1\",\n      \"role\": \"reference-oracle\",\n      \"lang\": \"q#\"\n    },\n    {\n      \"ecosystem\": \"pypi\",\n      \"spec\": \"azure-quantum==3.10.0\",\n      \"role\": \"reference-oracle\",\n      \"lang\": \"q#\"\n    }\n  ]\n}\n"
+  }
+}

--- a/tools/ace/qsharp-reference-oracle-package.test.ts
+++ b/tools/ace/qsharp-reference-oracle-package.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { packageHash } from "./package-hash.ts";
+import { contentHash, type AcePackage } from "./store.ts";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const packagePath = join(here, "packages", "qsharp-reference-oracle-0.1.0.json");
+const registryPath = join(here, "registry.json");
+const quantumManifestPath = join(here, "..", "setup", "manifests", "quantum");
+
+function readPackage(): AcePackage {
+  return JSON.parse(readFileSync(packagePath, "utf8")) as AcePackage;
+}
+
+function manifestSpecs(): string[] {
+  return readFileSync(quantumManifestPath, "utf8")
+    .split(/\r?\n/)
+    .map((line) => line.replace(/#.*$/, "").trim())
+    .filter((line) => line.length > 0)
+    .map((line) => line.split(/\s+/)[0]!)
+    .filter((spec) => !spec.includes("<pin>"));
+}
+
+describe("qsharp-reference-oracle Ace package", () => {
+  test("content_hash matches packaged dependency pointers", () => {
+    const pkg = readPackage();
+    const actual = contentHash(new TextEncoder().encode(JSON.stringify(pkg.files)));
+    expect(pkg.manifest.content_hash).toBe(actual);
+  });
+
+  test("bundled registry pins the package identity", () => {
+    const pkg = readPackage();
+    const registry = JSON.parse(readFileSync(registryPath, "utf8")) as {
+      "qsharp-reference-oracle": { "0.1.0": { package_hash: string; url: string } };
+    };
+
+    const entry = registry["qsharp-reference-oracle"]["0.1.0"];
+    expect(entry.package_hash).toBe(packageHash(pkg));
+    expect(entry.url).toBe(
+      "https://raw.githubusercontent.com/Lucent-Financial-Group/Zeta/main/tools/ace/packages/qsharp-reference-oracle-0.1.0.json",
+    );
+  });
+
+  test("package dependency pointers mirror the install manifest", () => {
+    const pkg = readPackage();
+    const pointer = JSON.parse(pkg.files["qsharp-reference-oracle.deps.json"]!) as {
+      dependencies: Array<{ ecosystem: string; spec: string }>;
+      realizer: string;
+      manifest: string;
+    };
+
+    expect(pointer.realizer).toBe("tools/setup/common/quantum.sh");
+    expect(pointer.manifest).toBe("tools/setup/manifests/quantum");
+    expect(pointer.dependencies.map((dep) => dep.ecosystem)).toEqual(["pypi", "pypi", "pypi"]);
+    expect(pointer.dependencies.map((dep) => dep.spec)).toEqual(manifestSpecs());
+  });
+});

--- a/tools/ace/registry.json
+++ b/tools/ace/registry.json
@@ -1,1 +1,8 @@
-{}
+{
+  "qsharp-reference-oracle": {
+    "0.1.0": {
+      "url": "https://raw.githubusercontent.com/Lucent-Financial-Group/Zeta/main/tools/ace/packages/qsharp-reference-oracle-0.1.0.json",
+      "package_hash": "sha256:8dc33e29da029ea104fbecb55a01f1663690cfb72cb2c93fcc68f1f79997d02c"
+    }
+  }
+}

--- a/tools/setup/common/quantum.sh
+++ b/tools/setup/common/quantum.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# tools/setup/common/quantum.sh — optional quantum-reference-oracle Python deps.
+#
+# The dependencies in tools/setup/manifests/quantum are imported libraries,
+# not standalone CLI tools, so this script realizes them into the project
+# Python environment via `uv pip install` instead of `uv tool install`.
+# Default-skip keeps ordinary install.sh / CI paths light; opt in with
+# ZETA_INSTALL_QUANTUM=1 or the existing heavy-path switch ZETA_INSTALL_FULL=1.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+MANIFEST="$REPO_ROOT/tools/setup/manifests/quantum"
+VENV="$REPO_ROOT/.venv"
+PY_BIN="$VENV/bin/python"
+
+if [ ! -f "$MANIFEST" ]; then
+  echo "✓ no quantum manifest at $MANIFEST; skipping"
+  exit 0
+fi
+
+if [ "${ZETA_INSTALL_QUANTUM:-0}" != "1" ] && [ "${ZETA_INSTALL_FULL:-0}" != "1" ]; then
+  echo "✓ skipping quantum oracle deps (set ZETA_INSTALL_QUANTUM=1 or ZETA_INSTALL_FULL=1)"
+  exit 0
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "warn: uv not on PATH; skipping quantum oracle deps" >&2
+  exit 0
+fi
+UV_BIN="$(command -v uv)"
+
+SPECS="$(awk '
+  { sub(/#.*$/, ""); gsub(/^[[:space:]]+|[[:space:]]+$/, "") }
+  NF > 0 { print $1 }
+' "$MANIFEST")"
+
+if [ -z "$SPECS" ]; then
+  echo "✓ quantum manifest empty; skipping"
+  exit 0
+fi
+
+echo "↓ ensuring project Python env at .venv for quantum oracle deps..."
+if ! "$UV_BIN" venv "$VENV" >/dev/null; then
+  echo "warn: uv venv failed; skipping quantum oracle deps" >&2
+  exit 0
+fi
+
+echo "↓ installing quantum oracle deps from $(basename "$MANIFEST")..."
+while IFS= read -r spec; do
+  [ -z "$spec" ] && continue
+  echo "  uv pip install $spec"
+  if ! "$UV_BIN" pip install --python "$PY_BIN" "$spec"; then
+    echo "warn: failed to install quantum oracle dep '$spec'; continuing" >&2
+    exit 0
+  fi
+done <<< "$SPECS"
+
+if "$PY_BIN" - <<'PY'
+import importlib
+
+importlib.import_module("qdk")
+try:
+    from qdk import qsharp  # noqa: F401
+except Exception:
+    importlib.import_module("qsharp")
+PY
+then
+  echo "✓ quantum oracle deps ready"
+else
+  echo "warn: quantum deps installed but QDK/Q# import probe failed; continuing" >&2
+fi

--- a/tools/setup/linux.sh
+++ b/tools/setup/linux.sh
@@ -9,19 +9,21 @@
 #                           per .mise.toml
 #   4. common/python-tools.sh — uv-managed Python CLI tools
 #                              (ruff, etc.) from manifests/uv-tools
-#   5. common/elan.sh     — Lean toolchain
-#   6. common/dotnet-tools.sh — dotnet global tools from
+#   5. common/quantum.sh  — optional Q# reference-oracle deps from
+#                           manifests/quantum (opt-in)
+#   6. common/elan.sh     — Lean toolchain
+#   7. common/dotnet-tools.sh — dotnet global tools from
 #                              manifests/dotnet-tools
-#   7. common/verifiers.sh    — TLA+ + Alloy jars from manifests/verifiers
-#   7b. common/tlaps.sh       — TLAPS (tlapm) opam source-build, gated on
+#   8. common/verifiers.sh    — TLA+ + Alloy jars from manifests/verifiers
+#   8b. common/tlaps.sh       — TLAPS (tlapm) opam source-build, gated on
 #                              ZETA_INSTALL_FULL (heavy OCaml build)
-#   8. common/agent-clis.sh   — agent/peer CLIs (bun-global) from manifests/agent-clis
-#   9. common/one-liner-tools.sh — non-package-manager CLIs (download-then-exec installers)
+#   9. common/agent-clis.sh   — agent/peer CLIs (bun-global) from manifests/agent-clis
+#  10. common/one-liner-tools.sh — non-package-manager CLIs (download-then-exec installers)
 #                                  from manifests/one-liner-tools
-#  10. common/local-llm.sh   — local-LLM core primitive (ollama + pinned tiny model) from
+#  11. common/local-llm.sh   — local-LLM core primitive (ollama + pinned tiny model) from
 #                              manifests/local-llm
-#  11. common/shellenv.sh    — managed PATH file
-#  12. common/profile-edit.sh — append the managed-PATH source line to the shell profile
+#  12. common/shellenv.sh    — managed PATH file
+#  13. common/profile-edit.sh — append the managed-PATH source line to the shell profile
 #
 # Non-Debian Linuxes (RHEL/Fedora/Arch/Alpine) are deferred — the
 # install-script layering supports adding them alongside apt.
@@ -209,6 +211,7 @@ for shim_dir in \
 done
 
 "$SETUP_DIR/common/python-tools.sh"
+"$SETUP_DIR/common/quantum.sh"
 
 # Make ~/.dotnet/tools available for the remainder of this install.sh
 # process so dotnet-tools.sh can install globals (semgrep / stryker)

--- a/tools/setup/macos.sh
+++ b/tools/setup/macos.sh
@@ -12,19 +12,21 @@
 #                           per .mise.toml
 #   6. common/python-tools.sh — uv-managed Python CLI tools
 #                              (ruff, etc.) from manifests/uv-tools
-#   7. common/elan.sh     — Lean toolchain (no mise plugin yet)
-#   8. common/dotnet-tools.sh — dotnet global tools (semgrep,
+#   7. common/quantum.sh  — optional Q# reference-oracle deps from
+#                           manifests/quantum (opt-in)
+#   8. common/elan.sh     — Lean toolchain (no mise plugin yet)
+#   9. common/dotnet-tools.sh — dotnet global tools (semgrep,
 #                              stryker, etc.) from manifests/dotnet-tools
-#   9. common/verifiers.sh    — TLA+ + Alloy jars from manifests/verifiers
-#   9b. common/tlaps.sh       — TLAPS (tlapm) opam source-build, gated on
+#  10. common/verifiers.sh    — TLA+ + Alloy jars from manifests/verifiers
+#  10b. common/tlaps.sh       — TLAPS (tlapm) opam source-build, gated on
 #                              ZETA_INSTALL_FULL (heavy OCaml build)
-#  10. common/agent-clis.sh   — agent/peer CLIs (bun-global) from manifests/agent-clis
-#  11. common/one-liner-tools.sh — non-package-manager CLIs (download-then-exec installers)
+#  11. common/agent-clis.sh   — agent/peer CLIs (bun-global) from manifests/agent-clis
+#  12. common/one-liner-tools.sh — non-package-manager CLIs (download-then-exec installers)
 #                                  from manifests/one-liner-tools
-#  12. common/local-llm.sh   — local-LLM core primitive (ollama via brew above + pinned
+#  13. common/local-llm.sh   — local-LLM core primitive (ollama via brew above + pinned
 #                              tiny model from manifests/local-llm)
-#  13. common/shellenv.sh    — managed PATH file
-#  14. common/profile-edit.sh — append the managed-PATH source line to the shell profile
+#  14. common/shellenv.sh    — managed PATH file
+#  15. common/profile-edit.sh — append the managed-PATH source line to the shell profile
 
 set -euo pipefail
 
@@ -141,6 +143,7 @@ for shim_dir in \
 done
 
 "$SETUP_DIR/common/python-tools.sh"
+"$SETUP_DIR/common/quantum.sh"
 
 # Make ~/.dotnet/tools available for the remainder of this install.sh
 # process so dotnet-tools.sh can install globals (semgrep / stryker)

--- a/tools/setup/manifests/quantum
+++ b/tools/setup/manifests/quantum
@@ -1,36 +1,37 @@
-# tools/setup/manifests/quantum — the quantum-language toolchain (desired-state, declarative).
-# Q# is the TOY-MODEL validator that grounds F#'s physics-flavoured claims (S=4, CHSH,
-# common cause, topological stability) in a real toy quantum model; the other free quantum
-# languages are the rest of the 4×4 quantum-language ORACLE convened in the UN room (shape G)
-# — same byte-lock discipline as the 4-language (F#/C#/TS/Rust) oracle, but for quantum.
+# tools/setup/manifests/quantum — quantum-language oracle deps (desired-state).
+# Q# is the reference oracle for the finite-resolution qubits framework: Zeta
+# computes measurable observables with finite BigFloat precision; QDK/Q# supplies
+# the textbook continuous-amplitude reference values for convergence checks.
 #
-# DECLARATIVE DESIRED-STATE ONLY — never imperative (Aaron 2026-06-08): install.sh REALIZES
-# this; there is no bare `pip install`. Consumed by `common/quantum.sh` (to be wired by Dejan,
-# GOVERNANCE §24 — the one install script), mirroring `common/local-llm.sh`: BEST-EFFORT +
-# GRACEFUL (a registry/network failure WARNS and continues; must never brick install.sh).
-# DEFAULT-SKIP in generic CI / scripted runs (heavyweight); opt in with ZETA_INSTALL_FULL=1.
-# All are free + open + easy to use (Aaron). Tests skip-if-absent (exceptions-as-signals).
+# DECLARATIVE DESIRED-STATE ONLY: install.sh realizes this through
+# common/quantum.sh; no one-off bare pip command. Best-effort + graceful
+# (network/registry failure warns and continues; must never brick install.sh).
+# Default-skip in generic CI / scripted runs; opt in with ZETA_INSTALL_QUANTUM=1
+# or ZETA_INSTALL_FULL=1.
 #
 # These are LIBRARIES (imported), not `uv tool install` CLIs — so they install into the
 # project's Python env via uv (`uv pip install`), NOT `uv tool install`. The `common/quantum.sh`
 # consumer handles that distinction (see the script header).
 #
-# Format per line:
+# Format per line (the installer consumes the first field as the pip spec):
 #   <pip-package-id>[==X.Y.Z]   [role=<toy-validator|oracle>]  [lang=<q#|qiskit|cirq|...>]
-# Pins: dep-pin-search-first (WebSearch before landing real pins — placeholders below are
-# UNPINNED and MUST be pinned by Dejan before this is wired; left unpinned on purpose so the
-# manifest is the spec, not an unverified install).
+# Pins verified 2026-06-10 against Microsoft Learn QDK setup guidance and PyPI:
+# qdk 1.29.1, qsharp 1.29.1, azure-quantum 3.10.0.
 #
-# Q# — the toy-model validator (Microsoft Quantum; modern Q# ships as the `qsharp` Python
-# package + VS Code ext; grounds F# physics claims in a toy quantum model):
-qsharp                 role=toy-validator   lang=q#
-azure-quantum          role=toy-validator   lang=q#     # optional cloud backends; local sim is default
+# Q# — reference oracle for H/Ry measurement stats, gate-set observables,
+# Bell/CHSH, and interference visibility. qdk[azure] owns the supported
+# Microsoft QDK Python entrypoint; qsharp is pinned directly so %%qsharp /
+# import qsharp parity stays explicit; azure-quantum is pinned to close the
+# optional-cloud-backend transitive edge.
+qdk[azure]==1.29.1     role=reference-oracle lang=q#
+qsharp==1.29.1         role=reference-oracle lang=q#
+azure-quantum==3.10.0  role=reference-oracle lang=q#
 #
-# The rest of the 4×4 quantum-language oracle (free, easy; the UN-room byte-lock cells):
-qiskit                 role=oracle          lang=qiskit       # IBM
-cirq                   role=oracle          lang=cirq         # Google
-pennylane              role=oracle          lang=pennylane    # Xanadu (differentiable)
+# The rest of the quantum-language oracle remains intentionally deferred until
+# the Q# reference vectors exist; uncomment with verified pins when those cells
+# become active.
+# qiskit==<pin>         role=oracle          lang=qiskit       # IBM
+# cirq==<pin>           role=oracle          lang=cirq         # Google
+# pennylane==<pin>      role=oracle          lang=pennylane    # Xanadu
 #
-# NOTE: roster is the SPEC; which cells seat in the 4×4 is the UN-room (Max) + math-team call.
-# Real version pins + the `common/quantum.sh` wiring + the `ace` registry publish (signed) are
-# routed to Dejan — see docs/research/2026-06-10-quantum-language-oracle-*.md.
+# See docs/research/2026-06-10-vera-brief-qsharp-reference-oracle-for-the-finite-resolution-qubits-framework.md.


### PR DESCRIPTION
## Summary
- wires `tools/setup/manifests/quantum` into macOS/Linux `install.sh` through opt-in `tools/setup/common/quantum.sh`
- pins the Q# reference-oracle Python set: `qdk[azure]==1.29.1`, `qsharp==1.29.1`, `azure-quantum==3.10.0`
- adds an Ace package + bundled registry entry for the same Q# oracle dependency surface, with hash/manifest sync tests
- updates `docs/INSTALLED.md` with the opt-in quantum install path

## Verification
- `bash -n tools/setup/common/quantum.sh tools/setup/macos.sh tools/setup/linux.sh`
- `ZETA_INSTALL_QUANTUM=0 bash tools/setup/common/quantum.sh`
- `ZETA_INSTALL_QUANTUM=1 mise exec -- bash tools/setup/common/quantum.sh`
- `bun test tools/ace`
- `bun run typecheck`
- `dotnet build -c Release`
- `dotnet test Zeta.sln -c Release --no-build`
- `bunx prettier --check docs/INSTALLED.md tools/ace/registry.json tools/ace/packages/qsharp-reference-oracle-0.1.0.json tools/ace/qsharp-reference-oracle-package.test.ts`

## Note
- `dotnet format --verify-no-changes` still reports pre-existing C# formatting/analyzer drift in unrelated files (for example `src/Core.Abstractions/*`, `src/Core.CSharp.DynamicValue/DynamicValues.cs`, `src/Core.CSharp.Yaml/YamlReader.cs`, and `tests/Tests.CSharp/Yaml/*`). I left that drift out of this installer PR.