### PR TITLE
rules: elevate noninterference to the always-active base frame (7th discipline, beside weight-free)

### DIFF
--- a/.claude/rules/dv2-data-split-discipline-activated.md
+++ b/.claude/rules/dv2-data-split-discipline-activated.md
@@ -1,14 +1,15 @@
-# Six always-active substrate-engineering disciplines
+# Seven always-active substrate-engineering disciplines
 
 Carved sentence:
 
-> Apply six disciplines to every substrate-engineering decision, always:
-> scale-free, lock-free/wait-free, weight-free, DST, Data Vault 2.0, and
-> idempotency. They apply simultaneously. DV2.0 partitions substrate by
-> change rate (hub/link/satellite) and is the lens for repo-split, skill
-> design, master-data, and where-does-this-substrate-go decisions.
+> Apply seven disciplines to every substrate-engineering decision, always:
+> scale-free, lock-free/wait-free, weight-free, DST, Data Vault 2.0,
+> idempotency, and noninterference. They apply simultaneously. DV2.0
+> partitions substrate by change rate (hub/link/satellite) and is the lens
+> for repo-split, skill design, master-data, and where-does-this-substrate-go
+> decisions.
 
-## The six (checklist)
+## The seven (checklist)
 
 | # | Discipline | Ask |
 |---|---|---|
@@ -18,8 +19,9 @@ Carved sentence:
 | 4 | DST | Replays deterministically? |
 | 5 | **DV2.0** | What changes at what rate; how is substrate partitioned? |
 | 6 | **Idempotency** (added 2026-05-30) | Apply-N-times == apply-once *effect*? If not, add a natural/dedup key or name the non-idempotence. |
+| 7 | **Noninterference** (added 2026-06-10) | Does entropy/influence enter ONLY through declared, metered channels (the injected `Source`/IEffects)? If not, name the ambient leak. |
 
-All six apply at once — see [`default-to-both.md`](default-to-both.md).
+All seven apply at once — see [`default-to-both.md`](default-to-both.md).
 
 ## DV2.0 in one line
 
@@ -40,11 +42,26 @@ is why it composes with DST (safe redelivery/partial replay) and CRDT/G-Set
 merge (idempotent by construction; the git-as-event-store fold depends on it).
 Note: Z-set retraction (+1 then −1) is *correction*, not a duplicate-guard.
 
+## Noninterference in one line
+
+Entropy/influence flows ONLY through declared, metered channels (Goguen–Meseguer
+1982): the soft `IScheduler`'s injected `Source` / the room's injected IEffects are
+the *only* doors; every crossing is metered at the membrane and posted to the
+ledger — no ambient clock, threadpool, allocator, or `Task.Run` leak. It is the
+sibling of weight-free (weight-free = no captured *authority*; noninterference =
+no unaccounted *influence/entropy*), and it is what makes DST survive real network
+IO (record/replay the crossings), soft rooms compose cleanly (uncertainty travels
+in the message, never ambiently), and entropy budgets enforceable (refuse a
+crossing that blows the budget). The `async-all-the-way` / no-`Task.Run` rules are
+this discipline's load-bearing guards.
+
 ## Pointers (detail lives here)
 
 - `memory/feedback_aaron_data_vault_2_is_source_of_repo_split_smell_intuitions_needs_reactivation_alongside_scale_free_lock_free_weight_free_dst_2026_05_13.md` — re-activation disclosure (PR #2912)
 - `memory/feedback_skills_as_carved_sentences_knowledge_in_docs_datavault_2_0_pattern_aaron_2026_05_03.md` — DV2.0 at skill-design scope
 - `memory/feedback_aaron_ontology_hkt_applies_directly_to_master_data_every_company_has_one_human_lineage_2026_05_13.md` — HKT-MDM universality (PR #2913)
-- [`manifesto-11-specifications.md`](manifesto-11-specifications.md) — disciplines 1,2,3,4,5 are also manifesto specs (idempotency is not one of the 11)
+- [`manifesto-11-specifications.md`](manifesto-11-specifications.md) — disciplines 1,2,3,4,5 are also manifesto specs (idempotency and noninterference are not among the 11)
+- `docs/research/2026-06-10-the-end-goal-dual-use-hard-soft-self-modeling-database-dynamicvalue-stored-procs-entropy-quarantine-over-reticulum.md` — noninterference origin (entropy quarantine; the end-goal doc) + the formalization route (Soraya/Sova)
+- [`async-all-the-way-truthful-signatures.md`](async-all-the-way-truthful-signatures.md) — noninterference's load-bearing guards (no ambient entropy paths)
 - DST deeper treatment (archived): `.claude/rules.bak/dst-plus-persist-plus-generator-time-plus-feedback-equals-computational-omniscience-over-simulation-substrate.md`
 - Repo-split substrate: B-0424 · B-0425 · B-0426 · B-0427 (ruleset-divergence smell = DV2.0 on repo topology)

--- a/.claude/rules/manifesto-11-specifications.md
+++ b/.claude/rules/manifesto-11-specifications.md
@@ -29,7 +29,10 @@ morality; #11 is the default oracle). See the manifesto.
 ## Overlap with the always-active engineering disciplines
 
 Specs 1, 2, 3, 7, 8 are *also* always-active engineering disciplines.
-**Idempotency** is a 6th always-active discipline but is NOT one of the 11.
+**Idempotency** (6th) and **Noninterference** (7th, 2026-06-10 — entropy/influence
+enters only through declared, metered channels; the weight-free sibling: weight-free
+= no captured authority, noninterference = no unaccounted influence) are
+always-active disciplines but NOT among the 11.
 Full discipline checklist: [`dv2-data-split-discipline-activated.md`](dv2-data-split-discipline-activated.md).
 
 ## Pointers for detail


### PR DESCRIPTION
Aaron: elevate the noninterference invariant to wherever weight-free lives in the base frame. Done via the idempotency precedent (6th discipline, no manifesto edit): Seven always-active disciplines; #7 Noninterference = entropy/influence only through declared metered channels (Goguen-Meseguer; the weight-free sibling — authority vs influence); async-all-the-way = its load-bearing guards. Manifesto PARTIAL LOCK untouched. Rules only.