### PR TITLE
governance: promote Idempotency (§12) + Noninterference (§13) into the manifesto (V2.2 additive)

### DIFF
--- a/.claude/rules/async-all-the-way-truthful-signatures.md
+++ b/.claude/rules/async-all-the-way-truthful-signatures.md
@@ -50,7 +50,7 @@ thread.
 
 ## Pointers
 
-- [`manifesto-11-specifications.md`](manifesto-11-specifications.md) §1 scale-free, §2 lock/wait-free, §7 DST
+- [`manifesto-13-specifications.md`](manifesto-13-specifications.md) §1 scale-free, §2 lock/wait-free, §7 DST
 - [`dv2-data-split-discipline-activated.md`](dv2-data-split-discipline-activated.md) — #1 scale-free, #2 lock/wait-free, #4 DST
 - [`anchor-to-human-prior-art.md`](anchor-to-human-prior-art.md) — why the anchors above are load-bearing
 - B-0969 — `ConfigureAwait(false)` cross-cutting default

--- a/.claude/rules/dv2-data-split-discipline-activated.md
+++ b/.claude/rules/dv2-data-split-discipline-activated.md
@@ -60,7 +60,7 @@ this discipline's load-bearing guards.
 - `memory/feedback_aaron_data_vault_2_is_source_of_repo_split_smell_intuitions_needs_reactivation_alongside_scale_free_lock_free_weight_free_dst_2026_05_13.md` — re-activation disclosure (PR #2912)
 - `memory/feedback_skills_as_carved_sentences_knowledge_in_docs_datavault_2_0_pattern_aaron_2026_05_03.md` — DV2.0 at skill-design scope
 - `memory/feedback_aaron_ontology_hkt_applies_directly_to_master_data_every_company_has_one_human_lineage_2026_05_13.md` — HKT-MDM universality (PR #2913)
-- [`manifesto-11-specifications.md`](manifesto-11-specifications.md) — disciplines 1,2,3,4,5 are also manifesto specs (idempotency and noninterference are not among the 11)
+- [`manifesto-13-specifications.md`](manifesto-13-specifications.md) — ALL seven disciplines are now also manifesto specs (idempotency = §12, noninterference = §13; promoted 2026-06-10, maintainer-authorized)
 - `docs/research/2026-06-10-the-end-goal-dual-use-hard-soft-self-modeling-database-dynamicvalue-stored-procs-entropy-quarantine-over-reticulum.md` — noninterference origin (entropy quarantine; the end-goal doc) + the formalization route (Soraya/Sova)
 - [`async-all-the-way-truthful-signatures.md`](async-all-the-way-truthful-signatures.md) — noninterference's load-bearing guards (no ambient entropy paths)
 - DST deeper treatment (archived): `.claude/rules.bak/dst-plus-persist-plus-generator-time-plus-feedback-equals-computational-omniscience-over-simulation-substrate.md`

--- a/.claude/rules/interfaces-free-classes-earned-under-rules.md
+++ b/.claude/rules/interfaces-free-classes-earned-under-rules.md
@@ -27,7 +27,7 @@ generate CHIP-8 asm + reified types **from the F# itself** (pure interfaces).
 ## Pointers
 
 - `meta/` — this rule recognized as a meta-rule (rules about rules).
-- [`manifesto-11-specifications.md`](manifesto-11-specifications.md) — §3 weight-free (class state = weight).
+- [`manifesto-13-specifications.md`](manifesto-13-specifications.md) — §3 weight-free (class state = weight).
 - `gen/` — generators read pure interfaces, no classes · `universal/` — interfaces = universal shapes.
 - `docs/research/2026-06-10-parser-generator-emits-chip8-assembly-for-the-cut-mea-sim-loop-then-interrupts-thats-our-game.md`
   — "from the F# itself — pure interface, no class."

--- a/.claude/rules/manifesto-13-specifications.md
+++ b/.claude/rules/manifesto-13-specifications.md
@@ -1,0 +1,45 @@
+# The 13 Root Discipline Specifications (Zeta building codes)
+
+Carved sentence:
+
+> Zeta-shaped systems are built under thirteen specifications — the
+> operational floor. A design that violates any of them does not belong
+> in Zeta unless an explicit, substrate-honest exception is on file.
+> Full prose for each lives in the manifesto; this rule is the index.
+
+## The thirteen (names + where the detail lives)
+
+Source of truth: [`docs/governance/MANIFESTO.md`](../../docs/governance/MANIFESTO.md) §1–§13.
+
+1. **Scale-free** — no central point of control/coordination/failure
+2. **Lock/Wait-free** — no blocking or coordination via shared mutable state
+3. **Weight-free** — no permanent/irreversible authority (weight creates capture)
+4. **Bounded Mobility** — compute/data may relocate only within safety bounds
+5. **Memory Preservation Guarantee** — identity transitions never silently destroy memory
+6. **Consent-First Design** — ongoing, granular, revocable consent on every observation surface
+7. **Deterministic Simulation Testing (DST)** — every critical path replays deterministically
+8. **Data Vault 2.0** — partition substrate by change rate (hub/link/satellite)
+9. **Recursive** — same rules at every scale, no special cases
+10. **Self-similar** — shape stays recognizable at every magnification
+11. **Default Moral Regard (Default Oracle)** — highest regard for morally-relevant entities absent a chosen oracle
+12. **Idempotency** — apply-N-times == apply-once effect (V2.2 addition, 2026-06-10)
+13. **Noninterference (Entropy Quarantine)** — entropy/influence only through declared, metered channels (V2.2 addition, 2026-06-10)
+
+Orientation: **m/acc** + **Multi-Oracle Principle** (no single mandatory
+morality; #11 is the default oracle). See the manifesto.
+
+## Overlap with the always-active engineering disciplines
+
+All SEVEN always-active engineering disciplines are now also manifesto specs
+(1, 2, 3, 7, 8, 12, 13 — idempotency and noninterference were promoted to the
+manifesto 2026-06-10, maintainer-authorized). The manifesto additionally carries
+the value floor (4, 5, 6, 9, 10, 11) that is not a per-commit engineering ask.
+Full discipline checklist: [`dv2-data-split-discipline-activated.md`](dv2-data-split-discipline-activated.md).
+
+## Pointers for detail
+
+- Full prose, m/acc, derivation chain, lock status: [`docs/governance/MANIFESTO.md`](../../docs/governance/MANIFESTO.md)
+- Six always-active disciplines + master data: [`dv2-data-split-discipline-activated.md`](dv2-data-split-discipline-activated.md)
+- DST deeper treatment (archived): `.claude/rules.bak/dst-plus-persist-plus-generator-time-plus-feedback-equals-computational-omniscience-over-simulation-substrate.md`
+
+> Manifesto is at PARTIAL LOCK — specs 5 & 6 carry `[RECONSTRUCTION NOTE]` markers; it is the canonical surface for any change.

--- a/docs/SEED-VOCABULARY.md
+++ b/docs/SEED-VOCABULARY.md
@@ -85,7 +85,7 @@ rules are one harness's restatement, not the source of truth.*
   `.claude/**` is Claude-specific). The base-frame disciplines are restated for any agent here.
 - **`docs/GLOSSARY.md`** — full prose for every term in this kernel (Tier-3, on-demand).
 
-> `.claude/rules/manifesto-11-specifications.md` is a Claude-harness *pointer* to the manifesto; the durable source is
+> `.claude/rules/manifesto-13-specifications.md` is a Claude-harness *pointer* to the manifesto; the durable source is
 > `docs/governance/MANIFESTO.md`. A non-Claude traveler reads the docs, never the `.claude/` folder.
 
 ## Why this file

--- a/docs/governance/MANIFESTO.md
+++ b/docs/governance/MANIFESTO.md
@@ -110,6 +110,18 @@ We treat every entity that has the potential to become morally relevant with the
 
 Zeta's substrate does not model value through cash or monetary units. Instead, it tracks the relativity of relations between irreducible elements — such as attention, care, memory, physical resources, compute, and relational investment. When no specific moral invariant or oracle has been explicitly chosen, this highest regard for entities with moral potential serves as the system's default moral position. It is the baseline against which relational value is understood and respected.
 
+### 12. Idempotency
+
+> *[V2.2 ADDITIVE CONSTRAINT — added 2026-06-10, maintainer-authorized ("we should add both of those to the 11 too"). Not part of the V2 locked prose; promoted from the always-active engineering disciplines, where it has been active since 2026-05-30.]*
+
+Applying an operation N times has the same effect as applying it once: `f(f(x)) = f(x)`. Every critical-path operation is idempotent by construction (set-union, max/min, upsert-by-key, CAS, content-address) or carries an explicit idempotency key naming its non-idempotence. Idempotency is what makes retry, replay, redelivery, and merge safe — it is the precondition under which deterministic simulation (constraint 7) and coordination-free merge survive a lossy, repeating world.
+
+### 13. Noninterference (Entropy Quarantine)
+
+> *[V2.2 ADDITIVE CONSTRAINT — added 2026-06-10, maintainer-authorized ("elevate that noninterference invariant to wherever we have weight-free"). Not part of the V2 locked prose; promoted from the always-active engineering disciplines the day it was named.]*
+
+Entropy and influence enter a bounded context ONLY through declared, metered channels (Goguen–Meseguer noninterference). A room's injected effects are the only doors; every crossing is metered at the membrane and accounted to the ledger; no ambient channel (clock, threadpool, allocator, unthrottled spawn) may carry unaccounted influence. Noninterference is the sibling of weight-free (constraint 3): weight-free forbids captured *authority*; noninterference forbids unaccounted *influence*. It is what lets deterministic simulation survive real network I/O (record and replay the crossings), lets soft contexts compose without smearing uncertainty into each other, and makes entropy budgets enforceable rather than estimated.
+
 ---
 
 ## Moral Accelerationism (m/acc)


### PR DESCRIPTION
Aaron: 'we should add both of those to the 11 too' (explicit human authorization for the gated manifesto change). Additive V2.2 constraints with provenance markers; locked V2 prose untouched; index rule renamed manifesto-13-specifications + links fixed. All seven always-active disciplines are now also manifesto specs; the manifesto additionally carries the value floor. Docs/rules only.