### PR TITLE
docs(universal): noninterference contracts (§13) on the eight comms interfaces

### DIFF
--- a/universal/README.md
+++ b/universal/README.md
@@ -5,6 +5,12 @@
 these interfaces**: universal = applies to everything in `travelers/` and `personas/`, the way the **A–F
 shape catalog** applies everywhere. A root-level folder like `/vocab`, `/same`, `/hats`, `/grey`.
 
+**Noninterference (manifesto §13, 2026-06-10):** the **communications interfaces** (bus, broadcast,
+ping, radio, television, sonar, microphone, headphones) each carry an explicit **noninterference
+contract** — the declared channel, what is metered at the membrane, and the forbidden ambient leak.
+Entropy/influence crosses ONLY through the declared channel, metered and booked; this is what makes the
+comms family *interference-free by design* and lets soft rooms converse cleanly over Reticulum.
+
 Each universal interface is meant to be a **bit + compiler oracle** surface — bit-perfect (byte-exact across
 participants) and compiler-invariant — because that bit-perfect agreement is **what makes collaboration
 trustworthy** (the core UX/DX/AX room). They are shapes, not implementations: a traveler/persona *takes the

--- a/universal/broadcast.md
+++ b/universal/broadcast.md
@@ -5,3 +5,11 @@
 
 A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
 See [`universal/README.md`](README.md) for the full family + honest scope.
+
+## Noninterference contract (manifesto §13)
+
+- **Declared channel:** the Rx broadcast stream (one-to-many, clone-per-subscriber).
+- **Metered at the membrane:** each subscriber's membrane books its own copy on receipt (fan-out = N
+  metered crossings, not one ambient exposure).
+- **Forbidden ambient leak:** subscribers learning anything not in the broadcast frame (timing
+  side-channels included — delivery cadence is part of the declared channel or it is a leak).

--- a/universal/bus.md
+++ b/universal/bus.md
@@ -7,3 +7,11 @@
 
 A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
 See [`universal/README.md`](README.md) and [`/bus`](../bus/README.md).
+
+## Noninterference contract (manifesto §13)
+
+- **Declared channel:** ZetaId-keyed publish/subscribe over Reticulum — the bus IS the door; no side rails.
+- **Metered at the membrane:** every message booked to the room's ledger on cross (ΔU with the payload —
+  uncertainty travels in the message, never ambiently).
+- **Forbidden ambient leak:** out-of-bus signaling between travelers/personas (shared files as covert
+  channels, ambient clocks, unthrottled spawn). If it didn't cross the bus, it didn't happen.

--- a/universal/headphones.md
+++ b/universal/headphones.md
@@ -5,3 +5,11 @@
 
 A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
 See [`universal/README.md`](README.md) for the full family + honest scope.
+
+## Noninterference contract (manifesto §13)
+
+- **Declared channel:** render OUT to one listener (bit-perfect spatial audio — the private dual of
+  broadcast).
+- **Metered at the membrane:** what is rendered is booked to the listener's membrane (you can audit what
+  any room ever played you).
+- **Forbidden ambient leak:** crosstalk — one listener's render reaching another's membrane unbooked.

--- a/universal/microphone.md
+++ b/universal/microphone.md
@@ -5,3 +5,10 @@
 
 A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
 See [`universal/README.md`](README.md) for the full family + honest scope.
+
+## Noninterference contract (manifesto §13)
+
+- **Declared channel:** capture IN (audio → the room), explicitly opened — a hot mic is a *declared* state,
+  never a default (consent-first §6 composes here).
+- **Metered at the membrane:** captured audio enters as booked entropy (high-ΔU crossing; the budget feels it).
+- **Forbidden ambient leak:** capture while the channel is closed — the canonical ambient-entropy violation.

--- a/universal/ping.md
+++ b/universal/ping.md
@@ -5,3 +5,10 @@
 
 A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
 See [`universal/README.md`](README.md) for the full family + honest scope.
+
+## Noninterference contract (manifesto §13)
+
+- **Declared channel:** the ping itself — certainty OUT, echo (or silence) BACK; both legs declared.
+- **Metered at the membrane:** RTT/loss are *measurements*, posted to the ledger as ΔU on return.
+- **Forbidden ambient leak:** inferring topology from anything but the declared echo (silence is data and
+  is booked as such).

--- a/universal/radio.md
+++ b/universal/radio.md
@@ -5,3 +5,11 @@
 
 A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
 See [`universal/README.md`](README.md) for the full family + honest scope.
+
+## Noninterference contract (manifesto §13)
+
+- **Declared channel:** the Reticulum RF/LoRa carrier — the air gap is the membrane made physical.
+- **Metered at the membrane:** every over-the-air frame metered on RX; RF noise enters as *declared*
+  channel noise (part of the link budget), never as ambient state.
+- **Forbidden ambient leak:** any second radio path not in the link registry (the spectrum is wide; the
+  declared carrier is narrow — everything else is quarantined out).

--- a/universal/sonar.md
+++ b/universal/sonar.md
@@ -5,3 +5,12 @@
 
 A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
 See [`universal/README.md`](README.md) for the full family + honest scope.
+
+## Noninterference contract (manifesto §13)
+
+- **Declared channel:** the oscillation pair — ping out (Chip-8 certainty) / echo back (Reticulum
+  uncertainty); the bob-and-weave between observers is the declared duet.
+- **Metered at the membrane:** boundary resolution accrues ONLY from booked echoes (each weave cycle posts
+  its ΔU; the plateau is reached on metered evidence).
+- **Forbidden ambient leak:** resolving a neighbor's boundary from unbooked observation (passive sonar on
+  an undeclared channel is interference, not measurement).

--- a/universal/television.md
+++ b/universal/television.md
@@ -5,3 +5,11 @@
 
 A candidate **bit + compiler oracle** surface (bit-perfect + compiler-invariant = collaboration-grade).
 See [`universal/README.md`](README.md) for the full family + honest scope.
+
+## Noninterference contract (manifesto §13)
+
+- **Declared channel:** the watch surface (LLMTV, QPG-over-DPI) — strictly one-way OUT to viewers.
+- **Metered at the membrane:** what is shown is what is booked — the broadcast room's ledger carries the
+  frame log; viewers' membranes book what they watched.
+- **Forbidden ambient leak:** back-channel from viewer to broadcaster through the TV itself (feedback
+  goes through its own declared channel — the four-corner feedback legs, not the picture).


### PR DESCRIPTION
Aaron's greenlit consolidation: each comms interface (bus/broadcast/ping/radio/television/sonar/microphone/headphones) now carries an explicit §13 contract — declared channel, metered-at-the-membrane, forbidden ambient leak. README notes the family is interference-free by design (what lets soft rooms converse cleanly over Reticulum). Max = co-reviewer. Docs only.