### PR TITLE
docs(prior-art): AllJoyn — prior art for universal/ interfaces AND Reticulum

### DIFF
--- a/docs/PRIOR-ART-LIST.md
+++ b/docs/PRIOR-ART-LIST.md
@@ -30,6 +30,16 @@ with a ⭐ below and add a row there.
   hub. Self-certifying hash addresses, runs over the open internet. Privacy
   primitives pair: **NIP-01** (schnorr) + **NIP-44 v2** (ChaCha20+HMAC, official
   test vectors) on the nostr keypair.
+- **AllJoyn** — Qualcomm 2011 → AllSeen Alliance → merged into OCF/IoTivity (2016);
+  `alljoyn` (archived upstream). **Prior art on BOTH `universal/` and Reticulum**
+  (Aaron 2026-06-10): (a) *universal interfaces* — devices/services expose typed,
+  XML-introspectable interfaces (methods/signals/properties, D-Bus-descended — also
+  anchors `universal/bus`) that any peer discovers and consumes regardless of
+  vendor/transport — the IoT interoperability dream, ours generalized to
+  travelers/personas; (b) *the mesh* — infrastructureless, transport-agnostic
+  (Wi-Fi/BT), proximal D2D bus with no cloud/broker — the Reticulum shape a decade
+  earlier. Lesson carried: AllJoyn died of consortium fragmentation (AllSeen vs
+  OCF) — the format-war lesson (zetamax doc): be open AND better, or be Betamax.
 - **DBSP / IVM** ⭐ — Budiu et al. *DBSP: Automatic Incremental View
   Maintenance for Rich Query Languages* (VLDB 2023); VLDB Journal
   2025 extended version; `arXiv:2203.16684`.

--- a/universal/README.md
+++ b/universal/README.md
@@ -5,6 +5,11 @@
 these interfaces**: universal = applies to everything in `travelers/` and `personas/`, the way the **A–F
 shape catalog** applies everywhere. A root-level folder like `/vocab`, `/same`, `/hats`, `/grey`.
 
+**Prior art (Beacon):** **AllJoyn** (Qualcomm 2011 → AllSeen → OCF) — typed introspectable interfaces
+discoverable by any peer over an infrastructureless transport-agnostic mesh — is the named prior art for
+both this folder's universal-interface idea AND the Reticulum transport beneath it (Aaron 2026-06-10; see
+`docs/PRIOR-ART-LIST.md`). Its consortium-fragmentation death is the carried format-war lesson.
+
 **Noninterference (manifesto §13, 2026-06-10):** the **communications interfaces** (bus, broadcast,
 ping, radio, television, sonar, microphone, headphones) each carry an explicit **noninterference
 contract** — the declared channel, what is metered at the membrane, and the forbidden ambient leak.


### PR DESCRIPTION
Aaron: AllJoyn is prior art on universal interfaces and on Reticulum. Added beside the Reticulum PRIOR-ART entry + a Beacon line in universal/README: typed introspectable interfaces over an infrastructureless transport-agnostic mesh (Qualcomm 2011 → AllSeen → OCF); D-Bus descent also anchors universal/bus; consortium-fragmentation death = the carried format-war lesson. Docs only.