### PR TITLE
feat(core): SoftThrottle — the soft flux capacitor (gradient + tank), tied into the scheduler

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -140,6 +140,7 @@
     <Compile Include="FourCorner.fs" />
     <Compile Include="IsrLift.fs" />
     <Compile Include="SoftScheduler.fs" />
+    <Compile Include="SoftThrottle.fs" />
     <Compile Include="SagaBuilder.fs" />
     <Compile Include="ChaosEnv.fs" />
     <Compile Include="HigherOrder.fs" />

--- a/src/Core/DevRoom.fs
+++ b/src/Core/DevRoom.fs
@@ -76,3 +76,109 @@ module DevRoom =
 
     /// The landmark names the dev room currently hangs (the navigable index).
     let landmarks: string list = doors |> List.map (fun d -> d.Landmark)
+
+    // ── The TICK (Aaron 2026-06-10, "lets move forward"): the dev room RUNS its rooms, not just lists ──
+    // Each landmark gets a deterministic representative run, driven through the ONE soft scheduler
+    // (`SoftScheduler.runDeterministic` — DoP=1, seed-deterministic, DST-replayable). Entering a room and
+    // ticking it is how a room earns its sign-off (rooms-as-sign-off: run → resolve → report).
+
+    /// The uniform result of ticking a room: which landmark ran, how many 60Hz ticks it was budgeted,
+    /// and a deterministic summary of where it landed (replay-equal for equal (landmark, seed, budget)).
+    type RoomRun =
+        { Landmark: string
+          Ticks: int
+          Summary: string }
+
+    let private dstCtx: IntrCtx =
+        { Memetic = "devroom"
+          Prompt = ""
+          Trust = ""
+          Log = ""
+          Otel = System.Diagnostics.ActivityContext() }
+
+    let private isTimer =
+        function
+        | TimerElapsed _ -> true
+        | _ -> false
+
+    /// One deterministic byte-strand pair for the salon's representative run (a near-match pair, so the
+    /// soft tie genuinely exercises the MinHash similarity, not just identity).
+    let private salonStrands (seed: int64) =
+        let a = System.Text.Encoding.UTF8.GetBytes(sprintf "strand-%d the quick brown fox jumps over the lazy dog" seed)
+        let b = System.Text.Encoding.UTF8.GetBytes(sprintf "strand-%d the quick brown fox JUMPED over the lazy dog" seed)
+        a, b
+
+    /// Tick a landmark's representative workload on the soft scheduler. Deterministic in
+    /// (landmark, seed, budget); `None` for an unknown landmark. Each room's run:
+    ///   salon — tie two near strands each tick; summary = the tie strength (the soft link held).
+    ///   darkhall — play a 2-op clean-room ROM on `SoftChip8Scheduler` (already ON the scheduler).
+    ///   bowling alley — roll deterministically (SplitMix from the seed) each tick; summary = the score.
+    ///   skatium — bob-and-weave; summary = final lean + openings seen.
+    let tick (landmark: string) (seed: int64) (budget: int) : System.Threading.Tasks.Task<Result<RoomRun, InterruptFeedback>> =
+        task {
+            match landmark with
+            | "salon" ->
+                let a, b = salonStrands seed
+                let handler: SoftScheduler.Handler<SoftTie.SoftTie<byte[]> option> =
+                    SoftScheduler.handler "salon-tie" isTimer (fun _ _ ->
+                        System.Threading.Tasks.Task.FromResult(Ok(SoftTie.tieBytes 0.5 a b)))
+                let! r = SoftScheduler.runDeterministic [ handler ] dstCtx seed None budget
+                return
+                    r
+                    |> Result.map (fun tie ->
+                        let s =
+                            match tie with
+                            | Some t -> sprintf "tied (strength %.3f)" t.Strength
+                            | None -> "no tie"
+                        { Landmark = landmark; Ticks = budget; Summary = s })
+            | "darkhall" ->
+                // 6A0C (V[A]=0x0C) ; 1202 (jump loop) — the clean-room 2-op ROM (no copyrighted content).
+                let rom = [| 0x6Auy; 0x0Cuy; 0x12uy; 0x02uy |]
+                let! r = SoftChip8Scheduler.run (uint64 seed) rom budget
+                return
+                    r
+                    |> Result.map (fun f ->
+                        { Landmark = landmark
+                          Ticks = budget
+                          Summary = sprintf "chip8 ran: PC=0x%04X V[A]=0x%02X delay=%d" f.PC f.V.[0xA] f.Delay })
+            | "bowling alley" ->
+                let handler: SoftScheduler.Handler<int list> =
+                    SoftScheduler.handler "bowl" isTimer (fun _ rolls ->
+                        // a deterministic roll 0..10 from the seed + position (SplitMix64 — the one avalanche)
+                        let n = List.length rolls
+                        let h = SplitMix64.mix (uint64 seed + uint64 n * SplitMix64.GoldenRatio)
+                        let roll = int (h % 11UL)
+                        System.Threading.Tasks.Task.FromResult(Ok(rolls @ [ roll ])))
+                let! r = SoftScheduler.runDeterministic [ handler ] dstCtx seed [] budget
+                return
+                    r
+                    |> Result.map (fun rolls ->
+                        { Landmark = landmark
+                          Ticks = budget
+                          Summary = sprintf "rolled %d, score %d" (List.length rolls) (BowlingAlley.score rolls) })
+            | "skatium" ->
+                let handler: SoftScheduler.Handler<int * int> = // (step, openings seen)
+                    SoftScheduler.handler "weave" isTimer (fun _ (step, opens) ->
+                        let opens' = if Skadium.openAt 2 step then opens + 1 else opens
+                        System.Threading.Tasks.Task.FromResult(Ok(step + 1, opens')))
+                let! r = SoftScheduler.runDeterministic [ handler ] dstCtx seed (0, 0) budget
+                return
+                    r
+                    |> Result.map (fun (step, opens) ->
+                        { Landmark = landmark
+                          Ticks = budget
+                          Summary = sprintf "wove %d steps, lean %A, %d openings" step (Skadium.weave 2 step) opens })
+            | _ -> return Error(Failed(sprintf "no such landmark: %s" landmark))
+        }
+
+    /// Tick EVERY room the dev room hangs (the register sweep) — sequentially, deterministically.
+    let tickAll (seed: int64) (budget: int) : System.Threading.Tasks.Task<RoomRun list> =
+        task {
+            let mutable acc = []
+            for lm in landmarks do
+                let! r = tick lm seed budget
+                match r with
+                | Ok run -> acc <- acc @ [ run ]
+                | Error e -> acc <- acc @ [ { Landmark = lm; Ticks = budget; Summary = sprintf "ERROR: %A" e } ]
+            return acc
+        }

--- a/src/Core/SoftThrottle.fs
+++ b/src/Core/SoftThrottle.fs
@@ -1,0 +1,153 @@
+namespace Zeta.Core
+
+/// SoftThrottle — the SOFT throttle knob: "how can we make our throttler soft? then it really will be
+/// the flux capacitor" (Aaron 2026-06-10).
+///
+/// A HARD throttle is a step function: under the ceiling admit, over it reject — a resistor/clipper.
+/// A SOFT throttle replaces the wall with a **gradient + a tank**:
+///   • **admission** is a smooth harmonic function of pressure (a sigmoid — backpressure becomes a
+///     *gradient*, the coupled-oscillator reading of the four-corner feedback, not a binary wall);
+///   • **capacity** is a **capacitor of flux** (the literal flux capacitor): it CHARGES while idle and
+///     DISCHARGES in bursts — an LC-tank shape (the harmonic oscillator of charge), so the throttle can
+///     resonate with the workload's natural rhythm (the time-crystal) instead of clipping it.
+///
+/// **The Y-junction / time-travel reading (why "flux capacitor" is exact, not a joke):** the throttler
+/// sits at the junction of three time-legs — the COMMITTED PAST (the event store), the SPECULATIVE
+/// FUTURE (the branch tree; `SoftChip8.lookAhead` — the throttler already "decides how many timesteps to
+/// batch"), and the PRESENT crossing (input resolving the forks). Throttling speculative depth IS
+/// throttling travel into the future; retraction (the Z-set −1, the antiparticle) is the trip back. The
+/// soft throttle governs the flux between the three legs.
+///
+/// **Look-don't-infer (Aaron's catch):** `FerryThrottler` already throttles AND batches — and its
+/// batching core is *already codenamed* **the Flux Capacitor** (`FerryThrottler.fs`: accumulate queued
+/// items, discharge them as a *boat* the instant a ferry frees). **The batching algorithm is Aaron's own
+/// invention** — his alternative to Nagle: **it never waits, no timeout, ever** — under slow traffic a
+/// boat of one sails immediately (zero added latency); under bursts the boat is simply whatever
+/// accumulated while the ferry was busy. (Independent invention; nearest named kin: Martin Thompson's
+/// "smart batching"; deeper root: Van Jacobson's self-clocking. Nagle waits on a timer — Aaron's never
+/// does.) That is the **hard** flux capacitor: real boats, hard config knobs. THIS module is the **soft**
+/// half that completes the name — the gradient admission + the charged tank — so the throttle "really
+/// will be the flux capacitor": hard boats below, soft flux above.
+///
+/// Pure module, deterministic (DST §7): "probabilistic" admission derives from `SplitMix64.mix (seed,
+/// tick)` — same seed, same decisions, replay-equal. Additive (FerryThrottler untouched — this is the
+/// knob it can consume; per the B-1022 razor, no rewrite).
+[<RequireQualifiedAccess>]
+module SoftThrottle =
+
+    /// Admission probability under `pressure` (0 = idle, 1 = nominal full, >1 = overloaded): a smooth
+    /// logistic gradient centered at pressure = 1 with steepness `k`. At pressure 0 ≈ admit-always; at 1 =
+    /// exactly ½; far above 1 → admit-rarely — but NEVER a hard 0/1 wall (the gradient is the softness).
+    let admissionProbability (k: float) (pressure: float) : float =
+        1.0 / (1.0 + exp (k * (pressure - 1.0)))
+
+    /// The deterministic admission decision at (seed, tick) under `pressure` — soft in distribution, hard
+    /// in replay: `mix(seed, tick)` supplies the deterministic "coin", so the same run admits the same
+    /// ticks (DST), while across ticks the admit-rate tracks `admissionProbability`.
+    let admit (k: float) (seed: int64) (tick: int) (pressure: float) : bool =
+        let p = admissionProbability k pressure
+        let h = SplitMix64.mix (uint64 seed + uint64 tick * SplitMix64.GoldenRatio)
+        // map the top 53 bits to [0,1) — the deterministic uniform draw
+        let u = float (h >>> 11) / float (1UL <<< 53)
+        u < p
+
+    /// The flux tank — the capacitor: charges while idle (up to `Capacity`), discharges on bursts. The
+    /// LC-tank half of the flux capacitor: stored flow-capacity, not a fixed ceiling.
+    type Tank =
+        { Capacity: float // max stored flux
+          Charge: float // current stored flux
+          ChargeRate: float } // flux gained per idle tick
+
+    /// A fresh tank, fully charged.
+    let tank (capacity: float) (chargeRate: float) : Tank =
+        { Capacity = max 0.0 capacity
+          Charge = max 0.0 capacity
+          ChargeRate = max 0.0 chargeRate }
+
+    /// One idle tick: the tank charges toward capacity (never beyond).
+    let charge (t: Tank) : Tank =
+        { t with Charge = min t.Capacity (t.Charge + t.ChargeRate) }
+
+    /// Try to discharge `amount` for a burst: `Some tank'` if the stored flux covers it, else `None`
+    /// (the burst waits — but note this is the TANK's no, not a wall: the caller can take a smaller sip).
+    let discharge (amount: float) (t: Tank) : Tank option =
+        if amount <= t.Charge then Some { t with Charge = t.Charge - amount } else None
+
+    /// The largest burst the tank can serve right now (take a sip instead of being refused — the soft
+    /// alternative to a hard reject).
+    let available (t: Tank) : float = t.Charge
+
+    /// The flux-capacitor step: given pressure and a desired burst, the soft throttle either serves the
+    /// burst from the tank (discharging), serves what it CAN (the sip), or charges (idle). Deterministic.
+    /// Returns (servedAmount, tank').
+    let step (k: float) (seed: int64) (tick: int) (pressure: float) (want: float) (t: Tank) : float * Tank =
+        if want <= 0.0 then
+            0.0, charge t
+        elif admit k seed tick pressure then
+            match discharge want t with
+            | Some t' -> want, t'
+            | None ->
+                let sip = available t
+                sip, { t with Charge = 0.0 }
+        else
+            0.0, charge t
+
+    // ── The scheduler tie-in (Aaron: "and tie it into our scheduler") — additive, the wrap ──
+
+    /// A scheduler state carrying its flux tank + tick counter alongside the inner room state.
+    type Throttled<'S> =
+        { Inner: 'S
+          Tank: Tank
+          Tick: int
+          Served: int // how many matched arrivals actually ran (admitted + funded)
+          Skipped: int } // how many were softly skipped (gradient said no / tank dry)
+
+    /// Wrap a room state for throttled driving.
+    let throttled (inner: 'S) (t: Tank) : Throttled<'S> =
+        { Inner = inner; Tank = t; Tick = 0; Served = 0; Skipped = 0 }
+
+    /// Wrap a `SoftScheduler.Handler<'S>` into a throttled `Handler<Throttled<'S>>`: on each matched
+    /// arrival the flux capacitor decides — the harmonic gradient admits (deterministically from
+    /// (seed, tick)) AND the tank funds `cost`, then the inner ISR runs and the tank discharges;
+    /// otherwise the arrival is *softly skipped* (inner state untouched, tank charges, the room keeps
+    /// breathing). `pressure` reads the current pressure off the inner state. The SCHEDULER IS UNTOUCHED
+    /// — softness arrives by wrapping (the B-1022 razor: instantiation, not refactor).
+    let wrapHandler
+        (k: float)
+        (seed: int64)
+        (cost: float)
+        (pressure: 'S -> float)
+        (h: SoftScheduler.Handler<'S>)
+        : SoftScheduler.Handler<Throttled<'S>> =
+        SoftScheduler.handler (h.Name + "-soft-throttled") h.Matches (fun ctx st ->
+            task {
+                let p = pressure st.Inner
+                if admit k seed st.Tick p then
+                    match discharge cost st.Tank with
+                    | Some tank' ->
+                        let! r = h.Run ctx st.Inner
+                        return
+                            r
+                            |> Result.map (fun inner' ->
+                                { st with
+                                    Inner = inner'
+                                    Tank = tank'
+                                    Tick = st.Tick + 1
+                                    Served = st.Served + 1 })
+                    | None ->
+                        // tank dry — soft skip; charge and move on (no hard failure)
+                        return
+                            Ok
+                                { st with
+                                    Tank = charge st.Tank
+                                    Tick = st.Tick + 1
+                                    Skipped = st.Skipped + 1 }
+                else
+                    // gradient said not-now — soft skip; charge
+                    return
+                        Ok
+                            { st with
+                                Tank = charge st.Tank
+                                Tick = st.Tick + 1
+                                Skipped = st.Skipped + 1 }
+            })

--- a/tests/Tests.FSharp/DevRoomTick.Tests.fs
+++ b/tests/Tests.FSharp/DevRoomTick.Tests.fs
@@ -1,0 +1,65 @@
+module Zeta.Tests.DevRoomTickTests
+
+open global.Xunit
+open Zeta.Core
+
+[<Fact>]
+let ``the salon ticks: the soft tie holds (strength reported)`` () =
+    task {
+        let! r = DevRoom.tick "salon" 7L 5
+        match r with
+        | Ok run ->
+            Assert.Equal("salon", run.Landmark)
+            Assert.Contains("tied", run.Summary)
+        | Error e -> Assert.Fail(sprintf "salon errored: %A" e)
+    }
+
+[<Fact>]
+let ``the darkhall ticks: chip8 runs on the scheduler (V[A] set)`` () =
+    task {
+        let! r = DevRoom.tick "darkhall" 1L 5
+        match r with
+        | Ok run -> Assert.Contains("V[A]=0x0C", run.Summary)
+        | Error e -> Assert.Fail(sprintf "darkhall errored: %A" e)
+    }
+
+[<Fact>]
+let ``the bowling alley ticks: deterministic rolls fold to a score`` () =
+    task {
+        let! r = DevRoom.tick "bowling alley" 42L 21
+        match r with
+        | Ok run ->
+            Assert.Contains("rolled 21", run.Summary)
+            Assert.Contains("score", run.Summary)
+        | Error e -> Assert.Fail(sprintf "bowling errored: %A" e)
+    }
+
+[<Fact>]
+let ``the skatium ticks: the weave steps and finds openings`` () =
+    task {
+        let! r = DevRoom.tick "skatium" 3L 16
+        match r with
+        | Ok run ->
+            Assert.Contains("wove 16 steps", run.Summary)
+            Assert.Contains("openings", run.Summary)
+        | Error e -> Assert.Fail(sprintf "skatium errored: %A" e)
+    }
+
+[<Fact>]
+let ``DST: every room's tick replays identically (same landmark, seed, budget => same summary)`` () =
+    task {
+        for lm in DevRoom.landmarks do
+            let! a = DevRoom.tick lm 99L 12
+            let! b = DevRoom.tick lm 99L 12
+            Assert.Equal<Result<DevRoom.RoomRun, InterruptFeedback>>(a, b)
+    }
+
+[<Fact>]
+let ``unknown landmark errors cleanly; tickAll sweeps the whole register`` () =
+    task {
+        let! bad = DevRoom.tick "casino" 1L 3
+        Assert.True(match bad with Error _ -> true | Ok _ -> false)
+        let! all = DevRoom.tickAll 5L 8
+        Assert.Equal(DevRoom.landmarks.Length, all.Length)
+        Assert.True(all |> List.forall (fun r -> not (r.Summary.StartsWith "ERROR")))
+    }

--- a/tests/Tests.FSharp/SoftThrottle.Tests.fs
+++ b/tests/Tests.FSharp/SoftThrottle.Tests.fs
@@ -1,0 +1,89 @@
+module Zeta.Tests.SoftThrottleTests
+
+open System.Threading.Tasks
+open global.Xunit
+open Zeta.Core
+
+let private isTimer =
+    function
+    | TimerElapsed _ -> true
+    | _ -> false
+
+let private ctx () : IntrCtx =
+    { Memetic = "t"; Prompt = ""; Trust = ""; Log = ""; Otel = System.Diagnostics.ActivityContext() }
+
+[<Fact>]
+let ``admission is a smooth gradient: ~1 when idle, exactly half at nominal, low when overloaded — never a wall`` () =
+    Assert.True(SoftThrottle.admissionProbability 8.0 0.0 > 0.99)
+    Assert.Equal(0.5, SoftThrottle.admissionProbability 8.0 1.0, 12)
+    let p3 = SoftThrottle.admissionProbability 8.0 3.0
+    Assert.True(p3 < 0.01 && p3 > 0.0) // soft: small, never zero
+
+[<Fact>]
+let ``admit is deterministic (DST) and its rate tracks the probability`` () =
+    let admitted pressure =
+        [ 0..999 ] |> List.filter (fun t -> SoftThrottle.admit 8.0 42L t pressure) |> List.length
+    Assert.Equal(admitted 0.5, admitted 0.5) // replay-equal
+    Assert.True(admitted 0.2 > 900) // near-idle ⇒ nearly all
+    Assert.True(admitted 2.0 < 100) // overloaded ⇒ few
+    let half = admitted 1.0
+    Assert.True(half > 400 && half < 600) // ≈ p=0.5
+
+[<Fact>]
+let ``the tank charges while idle, funds bursts, and offers a sip instead of a wall when low`` () =
+    let t = SoftThrottle.tank 10.0 2.0
+    Assert.Equal(10.0, SoftThrottle.available t, 12) // starts charged
+    match SoftThrottle.discharge 7.0 t with
+    | Some t' ->
+        Assert.Equal(3.0, SoftThrottle.available t', 12)
+        Assert.True((SoftThrottle.discharge 7.0 t').IsNone) // can't fund another 7
+        let charged = SoftThrottle.charge t'
+        Assert.Equal(5.0, SoftThrottle.available charged, 12) // +2 per idle tick, capped at 10 later
+    | None -> Assert.Fail "tank should fund the first burst"
+
+[<Fact>]
+let ``step serves, sips, or charges — and replays identically`` () =
+    let run () =
+        let mutable t = SoftThrottle.tank 5.0 1.0
+        let mutable served = []
+        for tick in 0..19 do
+            let s, t' = SoftThrottle.step 8.0 7L tick 0.5 2.0 t
+            served <- served @ [ s ]
+            t <- t'
+        served
+    Assert.Equal<float list>(run (), run ()) // DST
+    Assert.True(run () |> List.sum > 0.0) // it actually serves under mild pressure
+
+[<Fact>]
+let ``scheduler tie-in: a wrapped handler runs throttled — admitted ticks served, the rest softly skipped`` () =
+    task {
+        let inner: SoftScheduler.Handler<int> =
+            SoftScheduler.handler "count" isTimer (fun _ n -> Task.FromResult(Ok(n + 1)))
+        // heavy pressure ⇒ most arrivals softly skipped; tank ample so the gradient is the limiter
+        let wrapped = SoftThrottle.wrapHandler 8.0 42L 1.0 (fun _ -> 2.0) inner
+        let initial = SoftThrottle.throttled 0 (SoftThrottle.tank 1000.0 1.0)
+        let! r = SoftScheduler.runDeterministic [ wrapped ] (ctx ()) 42L initial 100
+        match r with
+        | Ok st ->
+            Assert.Equal(st.Served, st.Inner) // inner ran exactly when served
+            Assert.Equal(100, st.Served + st.Skipped) // every arrival accounted (timer fires each tick)
+            Assert.True(st.Skipped > st.Served) // overloaded ⇒ mostly soft skips
+        | Error e -> Assert.Fail(sprintf "throttled run errored: %A" e)
+    }
+
+[<Fact>]
+let ``scheduler tie-in DST: the throttled run replays identically`` () =
+    task {
+        let inner: SoftScheduler.Handler<int> =
+            SoftScheduler.handler "count" isTimer (fun _ n -> Task.FromResult(Ok(n + 1)))
+        let mk () =
+            SoftScheduler.runDeterministic
+                [ SoftThrottle.wrapHandler 8.0 9L 1.0 (fun _ -> 1.0) inner ]
+                (ctx ())
+                9L
+                (SoftThrottle.throttled 0 (SoftThrottle.tank 50.0 0.5))
+                60
+        let! a = mk ()
+        let! b = mk ()
+        Assert.Equal<Result<SoftThrottle.Throttled<int>, InterruptFeedback>>(a, b)
+    }

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -132,6 +132,7 @@
     <Compile Include="FourCorner.Tests.fs" />
     <Compile Include="FourCornerFusion.Tests.fs" />
     <Compile Include="SoftScheduler.Tests.fs" />
+    <Compile Include="SoftThrottle.Tests.fs" />
     <Compile Include="SoftChip8Scheduler.Tests.fs" />
     <Compile Include="BitAdinkra.Tests.fs" />
     <Compile Include="ForwardMomentum.Tests.fs" />

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -128,6 +128,7 @@
     <Compile Include="BowlingAlley.Tests.fs" />
     <Compile Include="Skadium.Tests.fs" />
     <Compile Include="DevRoom.Tests.fs" />
+    <Compile Include="DevRoomTick.Tests.fs" />
     <Compile Include="FourCorner.Tests.fs" />
     <Compile Include="FourCornerFusion.Tests.fs" />
     <Compile Include="SoftScheduler.Tests.fs" />


### PR DESCRIPTION
Aaron: make the throttler soft → it really becomes the flux capacitor; tie into the scheduler. Look-don't-infer: FerryThrottler's batch core is ALREADY codenamed Flux Capacitor, running Aaron's own zero-wait/no-timeout anti-Nagle batching (attributed; kin: smart batching; root: VJ self-clocking). SoftThrottle = the soft half: harmonic logistic admission (never a wall; DST coin from SplitMix64) + the charged tank (serves/sips/charges) + wrapHandler tying any scheduler Handler into throttled mode (Served/Skipped accounted). 6/6, 0 warnings, all additive.