### PR TITLE
feat(ace): parse setup manifests for qsharp deps

### DIFF
--- a/tools/ace/qsharp-reference-oracle-package.test.ts
+++ b/tools/ace/qsharp-reference-oracle-package.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { packageHash } from "./package-hash.ts";
 import { contentHash, type AcePackage } from "./store.ts";
+import { pointerFromSetupManifest } from "./setup-manifest.ts";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const packagePath = join(here, "packages", "qsharp-reference-oracle-0.1.0.json");
@@ -12,15 +13,6 @@ const quantumManifestPath = join(here, "..", "setup", "manifests", "quantum");
 
 function readPackage(): AcePackage {
   return JSON.parse(readFileSync(packagePath, "utf8")) as AcePackage;
-}
-
-function manifestSpecs(): string[] {
-  return readFileSync(quantumManifestPath, "utf8")
-    .split(/\r?\n/)
-    .map((line) => line.replace(/#.*$/, "").trim())
-    .filter((line) => line.length > 0)
-    .map((line) => line.split(/\s+/)[0]!)
-    .filter((spec) => !spec.includes("<pin>"));
 }
 
 describe("qsharp-reference-oracle Ace package", () => {
@@ -43,17 +35,18 @@ describe("qsharp-reference-oracle Ace package", () => {
     );
   });
 
-  test("package dependency pointers mirror the install manifest", () => {
+  test("package dependency pointer is generated from the install manifest", () => {
     const pkg = readPackage();
-    const pointer = JSON.parse(pkg.files["qsharp-reference-oracle.deps.json"]!) as {
-      dependencies: Array<{ ecosystem: string; spec: string }>;
-      realizer: string;
-      manifest: string;
-    };
+    const pointer = JSON.parse(pkg.files["qsharp-reference-oracle.deps.json"]!);
+    const expected = pointerFromSetupManifest({
+      text: readFileSync(quantumManifestPath, "utf8"),
+      ecosystem: "pypi",
+      purpose: "QDK/Q# reference oracle for finite-resolution qubits observable golden vectors",
+      realizer: "tools/setup/common/quantum.sh",
+      manifest: "tools/setup/manifests/quantum",
+      optIn: ["ZETA_INSTALL_QUANTUM=1", "ZETA_INSTALL_FULL=1"],
+    });
 
-    expect(pointer.realizer).toBe("tools/setup/common/quantum.sh");
-    expect(pointer.manifest).toBe("tools/setup/manifests/quantum");
-    expect(pointer.dependencies.map((dep) => dep.ecosystem)).toEqual(["pypi", "pypi", "pypi"]);
-    expect(pointer.dependencies.map((dep) => dep.spec)).toEqual(manifestSpecs());
+    expect(pointer).toEqual(expected);
   });
 });

--- a/tools/ace/setup-manifest.test.ts
+++ b/tools/ace/setup-manifest.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { parseSetupManifest, pointerFromSetupManifest } from "./setup-manifest.ts";
+
+describe("setup manifest parser", () => {
+  test("parses specs and key-value attrs while preserving q# values", () => {
+    const entries = parseSetupManifest(`
+# header comment
+qdk[azure]==1.29.1     role=reference-oracle lang=q#
+qsharp==1.29.1         role=reference-oracle lang=q# # trailing comment
+azure-quantum==3.10.0  role=reference-oracle lang=q#
+`);
+
+    expect(entries.map((entry) => entry.spec)).toEqual([
+      "qdk[azure]==1.29.1",
+      "qsharp==1.29.1",
+      "azure-quantum==3.10.0",
+    ]);
+    expect(entries.map((entry) => entry.attrs.lang)).toEqual(["q#", "q#", "q#"]);
+    expect(entries.map((entry) => entry.attrs.role)).toEqual([
+      "reference-oracle",
+      "reference-oracle",
+      "reference-oracle",
+    ]);
+  });
+
+  test("builds package-manager pointer dependencies from a setup manifest", () => {
+    const pointer = pointerFromSetupManifest({
+      text: "qsharp==1.29.1 role=reference-oracle lang=q#\n",
+      ecosystem: "pypi",
+      purpose: "Q# oracle",
+      realizer: "tools/setup/common/quantum.sh",
+      manifest: "tools/setup/manifests/quantum",
+      optIn: ["ZETA_INSTALL_QUANTUM=1"],
+    });
+
+    expect(pointer).toEqual({
+      schema: "zeta.ace.package-manager-pointers.v1",
+      purpose: "Q# oracle",
+      realizer: "tools/setup/common/quantum.sh",
+      manifest: "tools/setup/manifests/quantum",
+      opt_in: ["ZETA_INSTALL_QUANTUM=1"],
+      dependencies: [
+        {
+          ecosystem: "pypi",
+          spec: "qsharp==1.29.1",
+          role: "reference-oracle",
+          lang: "q#",
+        },
+      ],
+    });
+  });
+});

--- a/tools/ace/setup-manifest.ts
+++ b/tools/ace/setup-manifest.ts
@@ -1,0 +1,83 @@
+export interface SetupManifestEntry {
+  readonly line: number;
+  readonly spec: string;
+  readonly attrs: Readonly<Record<string, string>>;
+}
+
+export interface PackageManagerPointerDependency {
+  readonly ecosystem: string;
+  readonly spec: string;
+  readonly role?: string;
+  readonly lang?: string;
+}
+
+export interface PackageManagerPointer {
+  readonly schema: "zeta.ace.package-manager-pointers.v1";
+  readonly purpose: string;
+  readonly realizer: string;
+  readonly manifest: string;
+  readonly opt_in?: ReadonlyArray<string>;
+  readonly dependencies: ReadonlyArray<PackageManagerPointerDependency>;
+}
+
+function stripManifestComment(line: string): string {
+  for (let i = 0; i < line.length; i++) {
+    if (line[i] !== "#") continue;
+    if (i === 0 || /\s/.test(line[i - 1]!)) {
+      return line.slice(0, i);
+    }
+  }
+  return line;
+}
+
+export function parseSetupManifest(text: string): SetupManifestEntry[] {
+  const entries: SetupManifestEntry[] = [];
+  const lines = text.split(/\r?\n/);
+  for (const [index, rawLine] of lines.entries()) {
+    const line = stripManifestComment(rawLine).trim();
+    if (line.length === 0) continue;
+
+    const fields = line.split(/\s+/);
+    const spec = fields[0]!;
+    const attrs: Record<string, string> = {};
+    for (const field of fields.slice(1)) {
+      const equals = field.indexOf("=");
+      if (equals <= 0) continue;
+      attrs[field.slice(0, equals)] = field.slice(equals + 1);
+    }
+    entries.push({ line: index + 1, spec, attrs });
+  }
+  return entries;
+}
+
+export function pointerFromSetupManifest(args: {
+  readonly text: string;
+  readonly ecosystem: string;
+  readonly purpose: string;
+  readonly realizer: string;
+  readonly manifest: string;
+  readonly optIn?: ReadonlyArray<string>;
+}): PackageManagerPointer {
+  const pointer: PackageManagerPointer = {
+    schema: "zeta.ace.package-manager-pointers.v1",
+    purpose: args.purpose,
+    realizer: args.realizer,
+    manifest: args.manifest,
+    dependencies: parseSetupManifest(args.text).map((entry) => {
+      const dep: PackageManagerPointerDependency = {
+        ecosystem: args.ecosystem,
+        spec: entry.spec,
+      };
+      return {
+        ...dep,
+        ...(entry.attrs.role !== undefined ? { role: entry.attrs.role } : {}),
+        ...(entry.attrs.lang !== undefined ? { lang: entry.attrs.lang } : {}),
+      };
+    }),
+  };
+
+  if (args.optIn !== undefined) {
+    return { ...pointer, opt_in: args.optIn };
+  }
+  return pointer;
+}


### PR DESCRIPTION
## Summary
- add an Ace setup-manifest parser for declarative install dependency files
- preserve Q# language tags while stripping real comments
- make the Q# reference-oracle Ace package test derive the expected dependency pointer from tools/setup/manifests/quantum

## Verification
- bun test tools/ace/setup-manifest.test.ts tools/ace/qsharp-reference-oracle-package.test.ts
- bun test tools/ace/
- bunx prettier --check tools/ace/setup-manifest.ts tools/ace/setup-manifest.test.ts tools/ace/qsharp-reference-oracle-package.test.ts
- bun tools/ci/cross-verify-all.ts
- bun test tools/qsharp-oracle/qsharp-golden.test.ts
- bunx tsc --noEmit --pretty false
- dotnet build -c Release
- dotnet test Zeta.sln -c Release --no-build