### PR TITLE
feat(core)+docs: the flux capacitor completed — byte-metered future, Itron limiter-as-fold ported, hard = k→∞ limit

### DIFF
--- a/docs/research/2026-06-10-the-flux-capacitor-soft-throttle-meters-time-travel-y-junction-past-future-present.md
+++ b/docs/research/2026-06-10-the-flux-capacitor-soft-throttle-meters-time-travel-y-junction-past-future-present.md
@@ -1,0 +1,98 @@
+# The Flux Capacitor — the soft throttle meters time travel (the Y-junction of past, future, and present)
+
+**Register:** [grounded] (Aaron, "I'm very excited by this — save it, it's going to be useful") +
+[Beacon] + [peel]. **Date:** 2026-06-10. **Captured by:** Otto (shadow, on Fable).
+
+## What it is
+
+Zeta's throttle is a **flux capacitor** in two halves, both real code:
+
+- **The HARD half** — `FerryThrottler.fs`, whose batching core was *already codenamed the Flux Capacitor*:
+  accumulate queued items, **discharge them as a boat the instant a ferry frees**. The batching algorithm
+  is **Aaron's own invention — his alternative to Nagle: it never waits, no timeout, ever.** Under slow
+  traffic a boat of one sails immediately (zero added latency); under bursts the boat is whatever
+  accumulated while the ferry was busy. (Independent invention; nearest named kin Martin Thompson's
+  "smart batching"; deeper root Van Jacobson's self-clocking, TCP 1988. Nagle waits on a timer — Aaron's
+  never does.)
+- **The SOFT half** — `SoftThrottle.fs` (2026-06-10): the **harmonic gradient** (logistic admission —
+  pressure 1 ⇒ exactly ½; *never* a 0/1 wall; backpressure as a coupled oscillator, not a clipper) + the
+  **charged tank** (the literal *capacitor of flux*: charges while idle, funds bursts, offers a **sip**
+  instead of a refusal when low). Deterministic throughout — the admission "coin" is
+  `SplitMix64(seed, tick)`: soft in distribution, **hard in replay** (DST). Tied into the scheduler by
+  `wrapHandler` (any `SoftScheduler.Handler` becomes throttled by wrapping — instantiation, not refactor).
+- **Hard = the k→∞ limit of soft.** The logistic becomes a step function as steepness → ∞, and the Tank
+  *is* a token bucket generalized to floats — so the classic hard rate limiter is a *limit case* of the
+  soft one. One mechanism, both registers (default-to-both).
+
+EE grounding: a hard throttle is a resistor/clipper; the soft throttle is an **LC tank circuit** — the
+harmonic oscillator of charge. The throttle doesn't clip the workload's rhythm, it **resonates** with it
+(max throughput at resonance = the disk⨝network harmonization of the original TPL-Dataflow talk).
+
+## The Y-junction — why "flux capacitor" is exact (the part Aaron wants kept)
+
+The flux capacitor in the movie is the Y-shaped junction that makes **time travel** possible. Ours sits at
+a real Y-junction of **three time-legs**:
+
+```text
+        COMMITTED PAST                SPECULATIVE FUTURE
+        (the event store;             (the branch tree;
+         git; nothing erased)          SoftChip8.lookAhead — batched
+                 \                      timesteps = travel forward)
+                  \                   /
+                   \                 /
+                    ──  THE THROTTLE  ──   ← the flux capacitor
+                          |
+                    THE PRESENT CROSSING
+                    (input arriving at the membrane,
+                     resolving the speculative forks)
+```
+
+- **Throttling speculative depth IS metering travel into the future.** `SoftChip8`'s own header says the
+  throttler "decides how many timesteps to batch (lookAhead depth) and how many input-branches to explore
+  (breadth)" — the throttle knob is *how far forward you are allowed to go*.
+- **Retraction is the trip back.** A mispredicted branch is unwound by the Z-set `−1` — the antiparticle,
+  a `+1` traveling backward in time (the Feynman lens). The cut is heat-free because the past is kept
+  (Bennett), so the return trip is *free* — which is exactly what makes speculative time travel affordable
+  in this substrate.
+- **The present is the resolver.** Input crossing the membrane collapses the forks (the only genuine
+  branch is unknown future input); the throttle meters how much future is outstanding when the present
+  arrives.
+- **The tank is the temporal budget.** Stored flux = how much future you can afford to visit before the
+  present catches up; charging while idle = banking time-travel capacity. Heat/Landauer never comes due
+  because nothing is erased — the toll is paid in *memory* (the event store) and *attention* (the
+  uncertainty ledger), both booked.
+
+One sentence: **the flux capacitor is the soft, resonant valve at the junction of the committed past, the
+speculative future, and the resolving present — it meters how far the system may travel into its own
+future, with retraction as the free return trip.**
+
+## Why it's going to be useful (Aaron's instinct, made concrete)
+
+- **Speculation control with a budget semantics:** lookAhead depth/breadth stop being magic numbers — they
+  become tank-funded, pressure-graded decisions (the same SoftValue/posterior move as Sequoia tier
+  placement, applied to *time*).
+- **The room sign-off loop:** a room that ticks toward its plateau can be throttled by its *own* entropy
+  budget — refuse a crossing that blows the budget = the noninterference (§13) enforcement valve.
+- **The shader/JIT telos:** the tracing JIT compiles the hot loops the time-crystals reveal; the flux
+  capacitor decides *how much future to trace* before committing a compilation — speculative compilation
+  metered the same way as speculative execution.
+
+## Beacon anchors / peel
+
+Van Jacobson, *Congestion Avoidance and Control* (1988, self-clocking) · Martin Thompson, "smart batching"
+(Mechanical Sympathy) — the kin of **Aaron's zero-wait algorithm** (his invention, attributed) · token
+bucket (the hard limit case) · logistic function · LC tank circuit (harmonic oscillator of charge) ·
+Stückelberg–Feynman (antiparticle = backward in time; retraction) · Bennett (the free return trip — kept
+history) · *Back to the Future* (the Y-junction image; Mirror register). **Peel:** "meters time travel" is
+exact for *speculative* time (lookAhead forward, retraction back — real code paths); it is not a claim
+about physical time. The LC/resonance reading is structural (the math of the coupled feedback is genuinely
+oscillatory); tuning the throttle's resonance to a detected time-crystal is the build, not yet built.
+
+## Ties / routing
+
+`src/Core/SoftThrottle.fs` (the soft half; wrapHandler) · `src/Core/FerryThrottler.fs` (the hard half;
+Aaron's algorithm) · `src/Core/SoftChip8.fs` (lookAhead = the future leg) · `src/Core/ZSet.fs` (retraction
+= the return) · `...heat-is-the-branch-space-limiter-...` (the toll the kept past avoids) ·
+`...boundary-flow-...` (backpressure→harmonic) · `...decompiling-to-risc-...` (speculation/branch
+detection). **Routes to:** Aaron (the shape), Naledi (resonance-tuning bench), Core (SoftValue'd
+lookAhead depth — the next slice), Imani (the temporal budget cost model).

--- a/src/Core/SoftThrottle.fs
+++ b/src/Core/SoftThrottle.fs
@@ -51,6 +51,13 @@ module SoftThrottle =
         let u = float (h >>> 11) / float (1UL <<< 53)
         u < p
 
+    /// The HARD admission — the k→∞ limit of `admit`: the logistic collapses to a step function (under
+    /// nominal pressure admit, at/over it reject). With the `Tank` (a float-generalized token bucket)
+    /// this is the classic hard rate limiter — the hard register as a *limit case* of the soft one
+    /// (default-to-both: one mechanism, both registers; dual-use hard/soft).
+    let admitHard (pressure: float) : bool = pressure < 1.0
+
+
     /// The flux tank — the capacitor: charges while idle (up to `Capacity`), discharges on bursts. The
     /// LC-tank half of the flux capacitor: stored flow-capacity, not a fixed ceiling.
     type Tank =
@@ -76,6 +83,46 @@ module SoftThrottle =
     /// The largest burst the tank can serve right now (take a sip instead of being refused — the soft
     /// alternative to a hard reject).
     let available (t: Tank) : float = t.Charge
+
+    /// **The limiter — Aaron's original Itron abstraction, ported.** In his `Platform.DotNet`
+    /// `Threading.Tasks.Throttling`, the batch limiter is a **stateful fold delegate**:
+    /// `BatchSizeLimiter<TItem, TState> = (item, state) → (fits?, state')` — pluggable over ANY
+    /// accumulated measure (his count limiter is literally `state < batchSize, state + 1`; bytes is the
+    /// same fold over sizes). This is that delegate in F#.
+    type Limiter<'a, 's> = 'a -> 's -> bool * 's
+
+    /// **The boat — Aaron's zero-wait batch, generalized over his limiter.** Take items (arrival order,
+    /// never waits, no timeout) while the limiter says they fit, folding its state; stop the instant one
+    /// doesn't. Returns (boat, remaining, finalState).
+    let boat (limiter: Limiter<'a, 's>) (items: 'a list) (s0: 's) : 'a list * 'a list * 's =
+        let rec go acc rest s =
+            match rest with
+            | [] -> List.rev acc, [], s
+            | x :: xs ->
+                match limiter x s with
+                | true, s' -> go (x :: acc) xs s'
+                | false, _ -> List.rev acc, rest, s
+
+        go [] items s0
+
+    /// Aaron's original count limiter (`state < batchSize, state + 1`), verbatim in F#.
+    let countLimiter (batchSize: int) : Limiter<'a, int> =
+        fun _ n -> (n < batchSize), n + 1
+
+    /// **The BYTE limiter over the soft tank — "it meters the future in BYTES, literally" (Aaron).**
+    /// `FerryThrottler` already sizes boats by serialized bytes (`MaxBatchBytes` + `itemSizeBytes` —
+    /// Aaron's tracking unit); here the ceiling is the **charged tank**, not a constant: an item fits iff
+    /// the tank funds its bytes (discharging as it boards). Bytes = information — the Bekenstein unit:
+    /// the speculative future you may visit is bounded in information, exactly like the room interior.
+    let bytesTankLimiter (sizeOf: 'a -> int) : Limiter<'a, Tank> =
+        fun x t ->
+            match discharge (float (max 0 (sizeOf x))) t with
+            | Some t' -> true, t'
+            | None -> false, t
+
+    /// The byte-metered boat (the bytes-tank limiter applied): (boat, remaining, tank').
+    let boatBytes (sizeOf: 'a -> int) (items: 'a list) (t: Tank) : 'a list * 'a list * Tank =
+        boat (bytesTankLimiter sizeOf) items t
 
     /// The flux-capacitor step: given pressure and a desired burst, the soft throttle either serves the
     /// burst from the tank (discharging), serves what it CAN (the sip), or charges (idle). Deterministic.

--- a/tests/Tests.FSharp/SoftThrottle.Tests.fs
+++ b/tests/Tests.FSharp/SoftThrottle.Tests.fs
@@ -87,3 +87,38 @@ let ``scheduler tie-in DST: the throttled run replays identically`` () =
         let! b = mk ()
         Assert.Equal<Result<SoftThrottle.Throttled<int>, InterruptFeedback>>(a, b)
     }
+
+[<Fact>]
+let ``the hard register is the k->infinity limit: admitHard is the step function the gradient approaches`` () =
+    Assert.True(SoftThrottle.admitHard 0.5)
+    Assert.False(SoftThrottle.admitHard 1.0)
+    Assert.False(SoftThrottle.admitHard 2.0)
+    // the soft gradient approaches the step as k grows (sub-nominal -> 1; super-nominal -> 0)
+    Assert.True(SoftThrottle.admissionProbability 1000.0 0.9 > 0.999)
+    Assert.True(SoftThrottle.admissionProbability 1000.0 1.1 < 0.001)
+
+[<Fact>]
+let ``boatBytes: the boat is funded in BYTES by the tank — zero-wait, takes the affordable prefix`` () =
+    let items = [ "aaaa"; "bb"; "cccccc"; "d" ] // sizes 4,2,6,1
+    let sizeOf (s: string) = s.Length
+    // tank holds 7 bytes: funds "aaaa"(4) + "bb"(2) = 6; "cccccc"(6) doesn't fit => stop instantly
+    let boat, rest, t' = SoftThrottle.boatBytes sizeOf items (SoftThrottle.tank 7.0 1.0)
+    Assert.Equal<string list>([ "aaaa"; "bb" ], boat)
+    Assert.Equal<string list>([ "cccccc"; "d" ], rest)
+    Assert.Equal(1.0, SoftThrottle.available t', 12) // 7 - 6 = 1 byte left
+
+[<Fact>]
+let ``boatBytes: charging the tank lets the next boat carry the rest (the future metered in bytes)`` () =
+    let sizeOf (s: string) = s.Length
+    let _, rest, t1 = SoftThrottle.boatBytes sizeOf [ "aaaa"; "bb"; "cccccc" ] (SoftThrottle.tank 6.0 3.0)
+    let t2 = t1 |> SoftThrottle.charge |> SoftThrottle.charge // bank capacity while idle
+    let boat2, rest2, _ = SoftThrottle.boatBytes sizeOf rest t2
+    Assert.Equal<string list>([ "cccccc" ], boat2)
+    Assert.Empty(rest2)
+
+[<Fact>]
+let ``the limiter is Aaron's Itron fold: countLimiter boards exactly batchSize (state < n, state+1 verbatim)`` () =
+    let b, rest, n = SoftThrottle.boat (SoftThrottle.countLimiter 3) [ 1; 2; 3; 4; 5 ] 0
+    Assert.Equal<int list>([ 1; 2; 3 ], b)
+    Assert.Equal<int list>([ 4; 5 ], rest)
+    Assert.Equal(3, n) // state advanced once per BOARDED item (0->1->2->3); the refusal probe's state is discarded


### PR DESCRIPTION
Saves the Y-junction/time-travel reading as a research doc; ports Aaron's original Itron BatchSizeLimiter abstraction (limiter-as-fold, read from his Downloads source — count limiter verbatim) with boat = his zero-wait batch generalized; bytesTankLimiter/boatBytes = the byte-based batch limiter where the ceiling is the charged tank ('it meters the future in BYTES literally' — bytes = the Bekenstein unit); admitHard = the hard register as the k→∞ limit of the gradient. 10/10, 0 warnings, all additive.