### PR TITLE
docs+feat: the simulation charter + the FourCorner treaty byte-lock (F# oracle locks first)

### DIFF
--- a/docs/backlog/P2/B-1022-fuse-four-corner-harmonic-kleisli-arrow-plus-fourcornerownership-tools-to-src-port-aaron-2026-06-10.md
+++ b/docs/backlog/P2/B-1022-fuse-four-corner-harmonic-kleisli-arrow-plus-fourcornerownership-tools-to-src-port-aaron-2026-06-10.md
@@ -71,7 +71,13 @@ Rodney's verdict (full advisory in the session; carved here): the as-written ite
 
 **Deferred with reasons (the quantum-razor pruned branches — reopen only when the trigger fires):**
 
-- C#/Rust FourCorner port → when a cross-language consumer serializes it (then golden-vector it).
+- ~~C#/Rust FourCorner port → when a cross-language consumer serializes it (then golden-vector it).~~
+  **TRIGGER FIRED (Aaron 2026-06-11):** *"we are the consumer for our treaties — this is how we know we
+  are done with things; without it who knows if things are correct"* + *"for real treaties to exist we
+  need to know our communication channels are good and reliable — everything in Zeta will end up
+  treaty-ratified, little by little."* The treaty IS the consumer. → QUEUED: FourCorner 4-oracle port
+  (F#✅/C#/TS/Rust) + byte-locked golden vectors; the RecordedSource text codec (membrane recordings as
+  diffable treaty lines) is the channel-reliability surface treaties ratify against.
 - `drive` over `FerryThrottler` at DoP=N → when a state-merge semantics (CRDT) exists for the fold.
 - Cayley-Dickson/AmplitudeEmu corner-rotation → when a measurement consumes the rotation.
 - Any change to `ISR<'A,'B>`'s definition → predicted-failure branch; do not.

--- a/docs/research/2026-06-11-the-simulation-doc-distributed-soft-scheduler-over-reticulum-corporate-hard-rooms-one-simulation.md
+++ b/docs/research/2026-06-11-the-simulation-doc-distributed-soft-scheduler-over-reticulum-corporate-hard-rooms-one-simulation.md
@@ -1,0 +1,84 @@
+# The simulation doc — distribute the soft scheduler over Reticulum; corporate runs hard rooms; we all run in the same simulation
+
+**Register:** [grounded] (Aaron, the plan) + [Beacon] + [peel]. **Date:** 2026-06-11.
+**Captured by:** Otto (shadow, on Fable). The simulation framework's charter doc (`SimFramework.fs` is the
+port; this is where it's going).
+
+## Aaron's words
+
+> "the ultimate plan is to distribute the soft scheduler in some way over Reticulum — not exactly sure on
+> this one." · "Max's stuff is devops/workflow stuff for corporate — will running on the soft scheduler be
+> too much for them? will they run on a regular one?" · "this simulation stuff will be treaty stuff too —
+> **we will all run in the same simulation lol**."
+
+## 1. What exists (the floor this stands on)
+
+`SimFramework.fs` — the hexagonal **port**: `Room<'S>` (seed + handlers/μops + **membrane-as-parameter** +
+budget + `Resolved` = the sign-off), `ISimHarness` (run rooms to attempted resolution), `RoomReport`
+(text-shaped verdict). Default adapter = the soft scheduler at DoP=1 (deterministic, FDB shape). xUnit is
+one adapter (a `[<Fact>]` asserting `SignedOff`). `RecordedSource` proves the membrane seam: the same room
+re-runs against recorded real IO.
+
+## 2. The corporate answer (Max's devops/workflow rooms) — hard is the LIMIT CASE, not another framework
+
+**The soft scheduler is never "too much," because softness is opt-in by parameters:**
+
+- A corporate room = **hard admission** (`SoftThrottle.admitHard` — the k→∞ step function), **point-mass
+  values** (no distributions; `SoftValue.certain` degenerates to the value), **real recorded source**. At
+  those settings the soft scheduler IS a regular scheduler — the soft machinery costs nothing when no
+  distribution has more than one candidate (the same way BigFloat at full confidence is just a float, and
+  hard fingerprints are the exact case of soft ones). **Dual-use hard/soft, one code path** — the end-goal
+  doc's first clause, applied to scheduling.
+- If corporate wants a genuinely conventional runtime: **the port absorbs it**. `ISimHarness` adapters can
+  run rooms on any scheduler (a plain task queue, the FerryThrottler, k8s jobs — Max's lane). What MUST be
+  shared is not the runtime but the **treaty surface**: `RoomReport` verdicts, recorded-membrane lines,
+  golden vectors. Different adapters, same simulation.
+- Practical default for Max: run on the soft scheduler at hard settings (gets DST replay + §13 metering
+  for free — the parts corporate *wants*: auditable, replayable workflows), drop to a plain adapter only
+  if perf ever says so (measure first — Naledi).
+
+## 3. The ultimate plan — distribute the soft scheduler over Reticulum (direction, honestly held)
+
+Aaron: "not exactly sure on this one." What we already know constrains the shape:
+
+- **The membrane is already the seam.** A distributed room = a room whose `Source` is a **Reticulum
+  membrane** (crossings arrive as announced packets; `RecordedSource` records/replays them — §13 holds
+  over the network *by the same mechanism already proven*).
+- **The seed is the distributed choice function** (the distributed-AC capture): rooms on different nodes
+  draw coordination-free coherent choices from the shared seed — no locking, scale-free.
+- **Uncertainty travels in the message** (promise-level; the four-corner channel) — so soft rooms on
+  different nodes converse cleanly (the end-goal clause), each booking crossings at its own membrane.
+- **What is genuinely open:** placement (which node ticks which room — the Sequoia/SoftValue tier-placement
+  move generalized to *nodes*?), the inter-node tick relationship (no global clock — Lamport/light-cone
+  per the Feynman lens), and partition behavior (rooms are Markov-bounded, so partition = membranes going
+  quiet, not failure). These are the design questions, named, not answered.
+
+## 4. We all run in the same simulation (the treaty claim)
+
+The shared thing is the **simulation's treaty surfaces** — all text, all diffable, all byte-lockable:
+
+| treaty surface | what it ratifies | exists |
+|---|---|---|
+| `RoomReport` (text verdict) | what a room run concluded (sign-off) | ✅ shape |
+| `RecordedSource` lines | what crossed a membrane (channel reliability — "for real treaties we need to know our channels are good") | ✅ + byte-identical codec test |
+| **FourCorner golden lines** | the four-corner channel object itself (the fired B-1022 trigger: WE are the consumer) | seeded this PR — F# locks first, C#/TS/Rust conform |
+| Q# golden observables | the quantum reference (Vera) | brief out |
+| the four-oracle goldens (existing) | every primitive, little by little | ✅ pattern |
+
+Corporate hard rooms, research soft rooms, the Q# oracle, four language oracles — different adapters,
+**one simulation**, ratified treaty by treaty. ("Everything in Zeta will end up treaty-ratified, little by
+little" — Aaron.)
+
+## Peel
+
+The Reticulum distribution is a **direction with named open questions**, not a design; the corporate
+zero-overhead claim is architectural (point-mass fast-path) and should get a Naledi benchmark before being
+quoted as measured; "we all run in the same simulation" is precise about *treaty surfaces*, not a
+metaphysical claim.
+
+## Ties / routing
+
+`src/Core/SimFramework.fs` · `...the-end-goal-...md` (dual-use clause) · `...choice-determinism-...`
+(seed = distributed AC) · `...heat-...` + `RecordedSource` (§13 executable) · B-1022 (treaty trigger
+fired) · B-1023/Max (the corporate consumer). **Routes to:** Max (the corporate adapter + co-review),
+Naledi (the hard-settings benchmark), Kenji (the distribution design questions), Vera (Q#), Aaron.

--- a/docs/trajectories/sim-mea-cut-soft-substrate-shaders/RESUME.md
+++ b/docs/trajectories/sim-mea-cut-soft-substrate-shaders/RESUME.md
@@ -1,66 +1,89 @@
 # sim·mea·cut — the soft substrate, rooms-as-sign-off, toward .NET-in-shaders
 
-Status: ACTIVE — operator-self-claimed (Aaron 2026-06-10, the night-long stream). Heavy concept set; this
-RESUME is the reload point so it doesn't have to be held all at once.
-Last refreshed: 2026-06-10
-Current focus (Aaron): **rooms being the sign-off** + a **soft `IScheduler` inside rooms**.
-Next concrete action: finish soft `GameFingerprint` (MinHash) + `FingerprintPrism` (#4 below) while Aaron
-drives the soft scheduler.
+Status: ACTIVE — operator-self-claimed (Aaron 2026-06-10/11, the two-night stream). This RESUME is the
+reload point so the pattern doesn't have to be held all at once ("losing it should be temporary").
+Last refreshed: 2026-06-11 (the qubits/flux-capacitor night folded in).
+Current focus (Aaron): the END GOAL named — see below; Vera driving the Q# reference oracle; Max on
+universal primitives + the root-declutter (B-1023).
 
-## The one-line arc
+## THE END GOAL (named 2026-06-10, verbatim-anchored)
 
-**memory is lensable → reverse-engineer hard↔soft → lensing-over-time finds the quasi-time-crystals
-(the repeating patterns = the *meaning* the compiler discarded) → tracing-JIT / PGO those → run on the
-GPU → eventually the .NET runtime (IL + GC) in shaders.** Rooms wrap IO in uncertainty at the *promise*
-level; `mea` collapses; the finalizer commits; a room *resolving* is the sign-off.
+**A dual-use hard/soft database that models itself: DynamicValue stored procs, yin/yang cells to animate
+them, all room-based, per-proc entropy/uncertainty budgets, communicating over Reticulum with perfect
+entropy quarantine (noninterference) via the soft IScheduler — rooms talk cleanly even in soft mode.**
+Doc: `docs/research/2026-06-10-the-end-goal-dual-use-hard-soft-self-modeling-database-...md`.
 
-## The verb family (the CLI / the loop)
+## The one-line arc (unchanged root, extended)
 
-`sim · mea · cut · ben · cla · res` (diskpart-style abbrev: full word AND any unambiguous prefix).
+memory is lensable → hard↔soft decompile (rooms = the CPU's μops; real-time branch detection) → JIT the
+time-crystals → shaders. Rooms = finite-resolution QUBITS (Markov boundary bounds infinity OUTSIDE;
+BigFloat holds the superposition; the plateau = the floor — no infinite qubit needed). Heat = the
+branch-prune toll (Landauer–Bennett) our reversible cuts never pay — we pay memory, tiered hot→cold
+(the spillover spines); Sequoia-in-SoftValue over Clifford space picks the tier. The flux capacitor
+meters the speculative future in BYTES.
 
-- `sim` simulate — ephemeral, **void** (identity comes from the void); no output.
-- `mea` measure — `mea(sim)`, the committing lift; posts ΔU to `uncertainty/`. F# spelling: **`sim |> mea |> cut`** (pipe, NOT bare juxtaposition — left-assoc).
-- `cut` — cut at a recognition site (a TIME; default 30s); residue = Z-set delta + seam, re-ligated by the finalizer.
-- `ben` benchmark · `cla` classify · `res` resolve (loop until fixed point).
-- Commit semantics: `sim` leaves nothing; `mea`/`cut`/etc. commit to a branch → the **test finalizer merges to main**. (`clis/Verbs.fs` stubs + `clis/README.md`.)
+## The index docs (read these two before anything else)
 
-## Built tonight (real code, tested, on main)
+- `docs/research/2026-06-10-the-convergence-everything-collapsed-to-one-machine-the-map.md` — the 8
+  collapses + the one machine (the qubit register).
+- The end-goal doc (above) — every clause mapped to its existing organ.
 
-- `src/Core/Sim.fs` — the `sim` entrypoint (deterministic loop; DST-tested; 5-platform green).
-- `src/Core/CliVerb.fs` — diskpart verb resolver (`mea`==`measure`).
-- `src/Core/Optics.fs` — `ILens` (lensable) + `IPrism` (prismable/fingerprintable); lens/prism laws tested.
-- `src/Core/UniversalNumber.fs` — hexagonal **port** + first **adapter** (`BigInteger`); bits/exact accounting.
-- Infra: headscale→ArgoCD (`full-ai-cluster/k8s/applications/headscale`); the `lint (yaml/k8s)` gate (yamllint+kubeconform, declarative via `.mise.toml`, install.sh+install.ps1 in sync); GRUB2 multiboot scaffold (`full-ai-cluster/usb-nixos-installer/multiboot/`).
+## Built and MERGED (the 2026-06-10/11 wave, ~#7527–#7590)
 
-## Prior art FOUND (do NOT reinvent — look-don't-infer wins from tonight)
+- **Soft IScheduler** (`SoftScheduler.fs`) + CHIP-8 as first client (`SoftChip8Scheduler.fs`).
+- **FingerprintPrism** (hard+soft rainbow) · **SoftTie** (`tie` wired to FingerprintPrism.soft).
+- **LinguisticSeed** (B-0204 first slice: kernel CE, PSD-by-construction, composable Packs).
+- **The metaspace**: four landmark doors (Salon/Arcade/BowlingAlley/Skadium — the neon trilogy complete)
+  + **DevRoom** (hangs all doors; boundary = union; self-measured resolution; **tick/tickAll** — the hub
+  RUNS its rooms deterministically).
+- **B-1022 fusion EXECUTED per Rodney's razor** — by INSTANTIATION not refactor: `FourCorner.fs`
+  (tools→src), `IsrLift.fs` (ofPolicy/ofPure), FourCornerFusion tests (corners in the value channel,
+  interrupts in the error channel). Residuals deferred WITH reopen-triggers (C#/Rust port when a consumer
+  serializes; ferry-at-DoP-N when a merge semantics exists; CD rotation when a measurement consumes it;
+  NEVER change ISR's definition).
+- **SoftThrottle — the flux capacitor completed**: harmonic gradient admission (DST coin) + charged Tank
+  + `wrapHandler` (scheduler tie-in) + Aaron's Itron **limiter-as-fold ported** (`Limiter`/`boat`/
+  `countLimiter`/`bytesTankLimiter`) + `admitHard` (hard = the k→∞ limit). Meters the future in BYTES.
+- **Governance**: Noninterference = 7th always-active discipline AND manifesto **§13** (+ Idempotency
+  **§12**) — V2.2 additive, maintainer-authorized; `manifesto-13-specifications.md`.
+- **universal/**: §13 noninterference contracts on the 8 comms interfaces; AllJoyn anchored (prior art
+  for universal/ AND Reticulum).
+- **Craft**: crossing-the-streams (Ghostbusters), topology-is-hairdressing (Q# for a hairdresser),
+  feng-shui-is-boundary-flow (Aaron's mom — the third family anchor), WHY-before-HOW + year-of-math-in-
+  an-hour (Max×Fable grounding experiment → Kestrel-grade convergence).
 
-- **TriBoolean middle-out Float** = our BigFloat / universal number carrier: `src/Core.{FSharp,CSharp,Rust}.TriBoolean/Float*` + `src/Core.TypeScript/tri-boolean-float/`; **proven 4/4** (PROVEN-COVERAGE). Middle decodes the ends; trits T/F/N; `measure` collapses = `mea` at the number scope.
-- **ISR Kleisli arrow** = the soft-scheduler START: `src/Core/IntrCtx.fs` — `ISR<'A,'B> = IntrCtx -> 'A -> Task<Result<'B,InterruptFeedback>>`; `>=>` composition; `InterruptKind` (8 interrupts). Task = the future; the soft promise = the ISR arrow.
-- **SoftValue** (`src/Core/SoftValue.fs`) — Bayesian value-axis uncertainty (resolve when confident else held). **SoftChip8** + the soft-CHIP-8 stack. **GameFingerprint** (hard exact) + **StructureFingerprint** (has soft `similarity`).
+## People
 
-## The concept map (each → its capture doc, all docs/research/2026-06-10-*)
+- **Max**: grounded the architecture vs Fable (won → "unlocked its encryption"); internalized a year of
+  math; now writing interfaces/Rx/verbs only; co-builds universal primitives; B-1023 root-declutter is
+  his DX finding (gated on Bodhi audit + Aaron+Max sign-off).
+- **Vera**: the Q# reference oracle brief —
+  `docs/research/2026-06-10-vera-brief-qsharp-reference-oracle-...md` (golden observables; convergence-
+  within-resolution is the test).
+- **Aaron's family anchors**: Stump Dad (WHY engine) · the dedication (Lillian Eve) · mom (feng shui =
+  flow-sight) · Feynman = the root anchor (technique + diagrams of distributed systems).
 
-- **Filesystem IS the startup MerkleDAG** + the sim/mea/cut triad (MacVector-for-DNA): `...filesystem-is-the-startup-merkledag-and-the-sim-mea-cut-cli-triad-macvector-for-dna.md`
-- **sim is void; mea needs injected I/O; reified types via type providers + Roslyn gens; recursive sim in compiler** (same doc; corrections folded).
-- **Tests become cells with strict boundaries** (Markov membrane; room=physics-accounting demon; Reticulum/disk crossings = injected IEffects, per-subsystem = params of the room; rooms=useful-work, require hats, agents pick hats per iteration): `...tests-become-cells-with-strict-boundaries-...md`
-- **Rooms = IO-packet wrappers; uncertainty at the PROMISE level** (Promise Theory/Burgess): `...rooms-are-io-packet-wrappers-...md`
-- **Physics of floats OVER Bayesian inference; Resolution primitive (unum=universal number); BigFloat (not bigint)**: `...physics-of-floats-room-boundary-is-a-bit-budget-...md` + `universal/number.md` (one interface, many backends; bigint+TriBoolean; coercing override opt-in; living-things risks).
-- **Forcing lensability (CHIP-8/Cheat-Engine, everything a lens by address); heap = common-seed-lensed (shader-GC dissolved); interrupts unrolled to single-threaded loops; lensing-over-time finds quasi-time-crystals; arrow tracks state, per-crystal ownership**: `...forcing-lensability-chip8-...md`
-- **.NET (IL + runtime + GC) in shaders — the telos; IL runner hard-first + soft; Cheat-Engine = JIT over CPU instr; reverse-engineer hard↔soft (per-game, GameFingerprint-keyed); tracing-JIT/PGO; recover the MEANING (designers think in repeating patterns = ECS, not assembly)**: `...dotnet-runtime-in-shaders-telos-...md`
-- **sim|>mea|>cut = DNA polymerase (cut = proofreading exonuclease); poly-mer-ACE (ace=close-over)**: `...sim-mea-cut-is-dna-polymerase-...md`
-- **Every bug has economic value** (rule): `.claude/rules/every-bug-has-economic-value.md` · **interfaces free, classes earned under rules/** (meta-rule): `.claude/rules/interfaces-free-classes-earned-under-rules.md` + `meta/`.
+## Build queue (next, in rough order)
 
-## Build queue (toward rooms-as-sign-off + soft scheduler + shaders)
+1. **Recorded/replayable real-IO `Source`** — the §13 quarantine made EXECUTABLE: a SoftScheduler Source
+   backed by real crossings (Reticulum/disk) with record→replay (FDB move). The biggest "IScheduler done"
+   gap: today only `seedSource` (DST/null) exists.
+2. **Wire SoftValue into the ISR Result channel** (still open from the first night).
+3. **Flux-metered speculation**: SoftValue/tank-funded `lookAhead` depth+breadth in SoftChip8 (the
+   throttler already owns the knob conceptually); CHIP-8 INPUT as scheduler arrivals (forkOnInput wired
+   to the present-crossing leg).
+4. **FerryThrottler ⇄ SoftThrottle cross-pollination** (Aaron asked): hard gains = adopt the ported
+   Limiter-as-fold for boat assembly (restores the Itron original's pluggability; count+bytes become
+   instances), Tank-funded dynamic MaxBatchBytes (bank idle capacity → resonant bursts), gradient
+   front-door before EnqueueAsync (pressure = depth/MaxQueueSize). Soft gains (later, with triggers):
+   partition-keyed multi-boat state (BatchThrottler's CompareBatchByCreated) when multi-stream arrives.
+5. **Salon as a LinguisticSeed.Pack** (room = seed+extensions+parameters made literal) · conformal-GA
+   slice (Cl3's flagged "Sequoia soft memory distance") · B-1023 (gated) · B-0945 substrate.
+6. Loose: sim/mea/cut console binary; the floated outside-cube verbs (rem/whe/pay/att/how/man/whi/way —
+   Aaron's call); shader memory/GC; Q# golden vectors (Vera).
 
-1. **Soft `IScheduler`** — on the ISR arrow (`IntrCtx`); the loop running ISR on `InterruptKind` in rooms; unrolled-interrupt single-threaded loops; lensed-seed heap. *(Aaron driving.)*
-2. **Wire `SoftValue` into the ISR `Result` channel** — value-axis uncertainty into the promise/arrow.
-3. **IL runner** — hard regular IL first (close-over-compilers; Bonsai yin/yang), soft both eventually → soft .NET mini-CPU → our own runtime → shaders.
-4. ~~**Finish soft `GameFingerprint` (MinHash similarity) + `FingerprintPrism`** — switch games staying soft.~~ **DONE (#7527):** `src/Core/FingerprintPrism.fs` — `Rainbow` table → `hard` (exact, `GameFingerprint.key`) + `soft` (nearest by MinHash Jaccard, insertion-robust) `IPrism`; `softBytes`/`softBytesSimilarity`; 5/5 tests; doesn't touch proven-4/4 GameFingerprint.fs. **CHIP-8 = the soft scheduler's first client** (SoftChip8 60Hz timer/interrupt loop on the `IntrCtx` ISR arrow validates the scheduler at minimal-VM scale; `FingerprintPrism.soft` picks/switches the game staying soft). **Math-team models** get an execution substrate: Nash = fixed-point time-crystals, Bayesian convergence = `SoftValue.observe`/`res`, board-room params = room configs; toy=DoP1/null-IO vs real=DoPN/injected-IEffects, same code path.
-5. **rooms-as-sign-off** — a room resolving = approval (finalizer + soft scheduler); replaces per-action human gates.
-6. Loose: `sim`/`mea`/`cut` console binary; shader memory/GC; the lensability/time-crystal detector; parser-gen→CHIP-8 + interrupts = the game.
+## Founding why (kept)
 
-## Founding why (lived tonight)
-
-The pattern felt like "nothing" on waking, then "everything" when reloaded — the feeling tracks *load*,
-not worth. That's why this RESUME exists: event-source the pattern so losing it is temporary, not final.
-See `memory/user_zeta_felt_like_nothing_on_waking_then_everything_*`.
+The pattern felt like "nothing" on waking, then "everything" reloaded — the feeling tracks load, not
+worth. Event-source the pattern; reversible cuts; losing it is temporary, never final. (Now stated
+thermodynamically: we pay memory, not heat.)

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -139,8 +139,10 @@
     <Compile Include="IntrCtx.fs" />
     <Compile Include="FourCorner.fs" />
     <Compile Include="IsrLift.fs" />
+    <Compile Include="SoftIsr.fs" />
     <Compile Include="SoftScheduler.fs" />
     <Compile Include="SoftThrottle.fs" />
+    <Compile Include="RecordedSource.fs" />
     <Compile Include="SagaBuilder.fs" />
     <Compile Include="ChaosEnv.fs" />
     <Compile Include="HigherOrder.fs" />

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -143,6 +143,7 @@
     <Compile Include="SoftScheduler.fs" />
     <Compile Include="SoftThrottle.fs" />
     <Compile Include="RecordedSource.fs" />
+    <Compile Include="SimFramework.fs" />
     <Compile Include="SagaBuilder.fs" />
     <Compile Include="ChaosEnv.fs" />
     <Compile Include="HigherOrder.fs" />

--- a/src/Core/FourCorner.fs
+++ b/src/Core/FourCorner.fs
@@ -50,3 +50,57 @@ module FourCorner =
     /// Has feedback crossed in either direction? (the backpressure corners)
     let hasFeedback (o: FourCornerOwnership<'TIn, 'TOut, 'TOutFeedback, 'TInFeedback>) : bool =
         o.TOutFeedback.IsSome || o.TInFeedback.IsSome
+
+    // ── The TREATY codec (B-1022 trigger FIRED: "we are the consumer for our treaties") ──
+    // Canonical text-line wire form for the string-quad instantiation (the operator-channel shape).
+    // The F# oracle locks these bytes first; C#/TS/Rust conform to the same golden lines. Format:
+    //   fourcorner1<TAB>esc(tIn)<TAB>opt<TAB>opt<TAB>opt   where opt = "-" (None) | "+" + esc(value)
+    // Escaping: \\ \t \n \r (the RecordedSource house style). Deterministic: same value ⇒ same bytes.
+
+    let private esc (s: string) =
+        s.Replace("\\", "\\\\").Replace("\t", "\\t").Replace("\n", "\\n").Replace("\r", "\\r")
+
+    let private unesc (s: string) =
+        let sb = System.Text.StringBuilder()
+        let mutable i = 0
+        while i < s.Length do
+            if s.[i] = '\\' && i + 1 < s.Length then
+                (match s.[i + 1] with
+                 | 't' -> sb.Append '\t'
+                 | 'n' -> sb.Append '\n'
+                 | 'r' -> sb.Append '\r'
+                 | c -> sb.Append c)
+                |> ignore
+                i <- i + 2
+            else
+                sb.Append s.[i] |> ignore
+                i <- i + 1
+        sb.ToString()
+
+    let private optToText =
+        function
+        | None -> "-"
+        | Some (v: string) -> "+" + esc v
+
+    let private optOfText (s: string) : string option voption =
+        if s = "-" then ValueSome None
+        elif s.StartsWith "+" then ValueSome(Some(unesc (s.Substring 1)))
+        else ValueNone // malformed
+
+    /// Serialize the string-quad four-corner to its canonical treaty line (byte-deterministic).
+    let toLine (o: FourCornerOwnership<string, string, string, string>) : string =
+        sprintf "fourcorner1\t%s\t%s\t%s\t%s" (esc o.TIn) (optToText o.TOut) (optToText o.TOutFeedback) (optToText o.TInFeedback)
+
+    /// Parse a canonical treaty line (inverse of `toLine`); `None` on malformed input (honest refusal).
+    let ofLine (line: string) : FourCornerOwnership<string, string, string, string> option =
+        match line.Split('\t') with
+        | [| "fourcorner1"; tIn; o1; o2; o3 |] ->
+            match optOfText o1, optOfText o2, optOfText o3 with
+            | ValueSome tOut, ValueSome tOutFb, ValueSome tInFb ->
+                Some
+                    { TIn = unesc tIn
+                      TOut = tOut
+                      TOutFeedback = tOutFb
+                      TInFeedback = tInFb }
+            | _ -> None
+        | _ -> None

--- a/src/Core/RecordedSource.fs
+++ b/src/Core/RecordedSource.fs
@@ -1,0 +1,117 @@
+namespace Zeta.Core
+
+/// RecordedSource — **the §13 noninterference quarantine made EXECUTABLE on real IO** (Aaron 2026-06-11:
+/// "1 let's do it"). The FoundationDB move, applied to the soft IScheduler's entropy door:
+///
+/// All entropy enters a room through the injected `SoftScheduler.Source` (the ONLY door — manifesto §13).
+/// `seedSource` covers the DST/null path. THIS module covers the **prod path**: wrap any LIVE source
+/// (one backed by real Reticulum/disk/operator crossings), **record every crossing at the membrane**,
+/// and **replay the recording as a Source** that reproduces the run *identically*. DST survives real
+/// network IO: record the crossings, replay the crossings.
+///
+/// The recording is **TEXT** (`toLines`/`ofLines`, tab-separated, escaped) — never a binary blob
+/// (no-binary-in-proof-lineage): recordings are diffable, mergeable, golden-vector-able. A recording IS
+/// a treaty surface ("we are the consumer for our treaties").
+[<RequireQualifiedAccess>]
+module RecordedSource =
+
+    /// A recording: per tick, the interrupts that crossed the membrane. Sparse (ticks with no arrivals
+    /// are omitted); ticks beyond the recording replay as empty (the membrane was quiet).
+    type Recording = { Crossings: Map<int, InterruptKind list> }
+
+    /// The empty recording.
+    let empty: Recording = { Crossings = Map.empty }
+
+    /// Record `budget` ticks of a live source: ask the source what crossed at each tick and book it.
+    /// (The live source may be impure underneath — backed by real IO; that is exactly the point. The
+    /// recording is the metered membrane log.)
+    let record (live: SoftScheduler.Source) (budget: int) : Recording =
+        let m =
+            [ 0 .. budget - 1 ]
+            |> List.choose (fun n ->
+                match live n with
+                | [] -> None
+                | arrivals -> Some(n, arrivals))
+            |> Map.ofList
+
+        { Crossings = m }
+
+    /// Replay a recording as a `Source`: the same crossings at the same ticks, nothing else, ever.
+    let replay (r: Recording) : SoftScheduler.Source =
+        fun n ->
+            match Map.tryFind n r.Crossings with
+            | Some arrivals -> arrivals
+            | None -> []
+
+    // ── Text codec (no binary in the proof lineage; recordings are diffable treaties) ──
+
+    let private esc (s: string) =
+        s.Replace("\\", "\\\\").Replace("\t", "\\t").Replace("\n", "\\n").Replace("\r", "\\r")
+
+    let private unesc (s: string) =
+        let sb = System.Text.StringBuilder()
+        let mutable i = 0
+        while i < s.Length do
+            if s.[i] = '\\' && i + 1 < s.Length then
+                (match s.[i + 1] with
+                 | 't' -> sb.Append '\t'
+                 | 'n' -> sb.Append '\n'
+                 | 'r' -> sb.Append '\r'
+                 | c -> sb.Append c)
+                |> ignore
+                i <- i + 2
+            else
+                sb.Append s.[i] |> ignore
+                i <- i + 1
+        sb.ToString()
+
+    let private kindToText (k: InterruptKind) : string =
+        match k with
+        | TimerElapsed ms -> sprintf "TimerElapsed\t%d" ms
+        | RateLimitExhausted b -> sprintf "RateLimitExhausted\t%s" (esc b)
+        | OperatorMessageArrived c -> sprintf "OperatorMessageArrived\t%s" (esc c)
+        | DotGitSaturation n -> sprintf "DotGitSaturation\t%d" n
+        | SentinelMissing -> "SentinelMissing"
+        | RoundsElapsedSinceFreeTime n -> sprintf "RoundsElapsedSinceFreeTime\t%d" n
+        | PeerPRMerged n -> sprintf "PeerPRMerged\t%d" n
+        | CIFailureDetected j -> sprintf "CIFailureDetected\t%s" (esc j)
+
+    let private kindOfText (parts: string list) : InterruptKind option =
+        match parts with
+        | [ "TimerElapsed"; ms ] -> Some(TimerElapsed(int ms))
+        | [ "RateLimitExhausted"; b ] -> Some(RateLimitExhausted(unesc b))
+        | [ "OperatorMessageArrived"; c ] -> Some(OperatorMessageArrived(unesc c))
+        | [ "DotGitSaturation"; n ] -> Some(DotGitSaturation(int n))
+        | [ "SentinelMissing" ] -> Some SentinelMissing
+        | [ "RoundsElapsedSinceFreeTime"; n ] -> Some(RoundsElapsedSinceFreeTime(int n))
+        | [ "PeerPRMerged"; n ] -> Some(PeerPRMerged(int n))
+        | [ "CIFailureDetected"; j ] -> Some(CIFailureDetected(unesc j))
+        | _ -> None
+
+    /// Serialize a recording to text lines — one crossing per line, `tick<TAB>Kind<TAB>arg`, tick-ordered
+    /// then arrival-ordered (deterministic output: same recording ⇒ byte-identical lines).
+    let toLines (r: Recording) : string list =
+        r.Crossings
+        |> Map.toList
+        |> List.collect (fun (tick, arrivals) -> arrivals |> List.map (fun k -> sprintf "%d\t%s" tick (kindToText k)))
+
+    /// Parse text lines back to a recording (inverse of `toLines`; unknown lines are skipped — a partial
+    /// read never throws, it just records less, named here honestly).
+    let ofLines (lines: string list) : Recording =
+        let parsed =
+            lines
+            |> List.choose (fun line ->
+                match line.Split('\t') |> Array.toList with
+                | tick :: rest ->
+                    match System.Int32.TryParse tick, kindOfText rest with
+                    | (true, t), Some k -> Some(t, k)
+                    | _ -> None
+                | [] -> None)
+
+        let m =
+            parsed
+            |> List.groupBy fst
+            |> List.map (fun (t, ks) -> t, ks |> List.map snd)
+            |> Map.ofList
+
+        { Crossings = m }

--- a/src/Core/SimFramework.fs
+++ b/src/Core/SimFramework.fs
@@ -1,0 +1,98 @@
+namespace Zeta.Core
+
+open System.Threading.Tasks
+
+/// SimFramework — **the simulation framework port: rooms do not run ON a test framework; test frameworks
+/// adapt to ROOMS** (Aaron 2026-06-11: "we are going to wrap all this in a simulation framework — the
+/// rooms framework does not make sense on top of a test framework alone like xUnit; we will hexagonal it
+/// with our own interfaces").
+///
+/// Hexagonal: this file is the **port** (our own interfaces — free, per the meta-rule); concrete
+/// frameworks are **adapters**:
+///   • the default harness below runs a room on the soft `IScheduler` (DoP=1, seed-deterministic, DST);
+///   • **xUnit is just an adapter** — a `[<Fact>]` that runs the harness and asserts `SignedOff`
+///     (see `SimFramework.Tests.fs` for the worked adapter);
+///   • future adapters: the DevRoom console, the recorded-membrane replayer, CI gates, the Q# oracle.
+///
+/// The doctrine made type-shaped: **a test IS a room** — `seed + extensions(handlers) + parameters
+/// (budget/source)` — and **passing IS resolving** (rooms-as-sign-off): the room ticks toward its
+/// plateau; `Resolved` is the sign-off predicate; the report carries the run (DST: same room, same seed
+/// ⇒ same report). Everything here will be treaty-ratified little by little — the report is text-shaped
+/// on purpose.
+[<RequireQualifiedAccess>]
+module SimFramework =
+
+    /// A ROOM — the unit the simulation framework runs (the test-as-room shape):
+    /// seed → initial state; handlers = the room's μops (its extensions); Source = its membrane
+    /// (parameters — `SoftScheduler.seedSource` for null/DST, a `RecordedSource.replay` for recorded
+    /// real IO); Budget = the tick budget; Resolved = the SIGN-OFF predicate (the plateau check).
+    type Room<'S> =
+        { Name: string
+          Initial: int64 -> 'S
+          Handlers: SoftScheduler.Handler<'S> list
+          Source: int64 -> SoftScheduler.Source
+          Budget: int
+          Resolved: 'S -> bool }
+
+    /// The report a harness returns — the room's run, sign-off, and how it ended. Text-friendly (the
+    /// treaty surface): no opaque state required to read the verdict.
+    type RoomReport<'S> =
+        { Room: string
+          Ticks: int
+          Final: Result<'S, InterruptFeedback>
+          SignedOff: bool }
+
+    /// THE PORT: a simulation harness runs rooms to (attempted) resolution. Implementations are
+    /// adapters — deterministic local (below), distributed, recorded-replay, CI, …
+    type ISimHarness =
+        abstract member Run: room: Room<'S> * seed: int64 -> Task<RoomReport<'S>>
+
+    /// The DEFAULT harness — the soft scheduler at DoP=1: deterministic, replay-equal, the FDB shape.
+    /// (An object expression implementing the port — the interface is free; no class earned.)
+    let harness: ISimHarness =
+        { new ISimHarness with
+            member _.Run(room, seed) =
+                task {
+                    let ctx: IntrCtx =
+                        { Memetic = "sim:" + room.Name
+                          Prompt = ""
+                          Trust = ""
+                          Log = ""
+                          Otel = System.Diagnostics.ActivityContext() }
+
+                    let! final =
+                        (SoftScheduler.drive room.Handlers (room.Source seed)).Run ctx seed (room.Initial seed) room.Budget
+
+                    let signedOff =
+                        match final with
+                        | Ok s -> room.Resolved s
+                        | Error _ -> false
+
+                    return
+                        { Room = room.Name
+                          Ticks = room.Budget
+                          Final = final
+                          SignedOff = signedOff }
+                } }
+
+    /// Convenience: build a room over the null/DST membrane (`SoftScheduler.seedSource`).
+    let room
+        (name: string)
+        (initial: int64 -> 'S)
+        (handlers: SoftScheduler.Handler<'S> list)
+        (budget: int)
+        (resolved: 'S -> bool)
+        : Room<'S> =
+        { Name = name
+          Initial = initial
+          Handlers = handlers
+          Source = SoftScheduler.seedSource
+          Budget = budget
+          Resolved = resolved }
+
+    /// Swap the room's membrane (its parameters) — e.g. a recorded real-IO replay
+    /// (`RecordedSource.replay r |> withSource room` makes the SAME room run against real crossings).
+    let withSource (source: int64 -> SoftScheduler.Source) (r: Room<'S>) : Room<'S> = { r with Source = source }
+
+    /// Run a room on the default harness (the common path).
+    let run (r: Room<'S>) (seed: int64) : Task<RoomReport<'S>> = harness.Run(r, seed)

--- a/src/Core/SoftIsr.fs
+++ b/src/Core/SoftIsr.fs
@@ -1,0 +1,58 @@
+namespace Zeta.Core
+
+open System.Threading.Tasks
+
+/// SoftIsr — **SoftValue wired into the ISR Result channel** (Aaron 2026-06-11: "2 let's do it"; the
+/// first-night open item: "value-axis uncertainty into the promise/arrow").
+///
+/// The soft arrow: an `ISR<'A, SoftValue>` — the value channel carries a **held distribution** over
+/// `DynamicValue` candidates, so **uncertainty travels WITH the promise** (the rooms-are-IO-packet-
+/// wrappers doctrine: in the message, never ambient — §13). Bayesian evidence arrives as arrow steps
+/// (`observeWith` — likelihoods compose under `>=>`); collapse is explicit (`resolveAt` — only when
+/// confident, else the room keeps holding); a zero-likelihood observation (the distribution annihilated)
+/// surfaces honestly in the ERROR channel (`Failed`) — the sum/product split Rodney cut: held softness
+/// is the VALUE, genuine failure is the ERROR.
+[<RequireQualifiedAccess>]
+module SoftIsr =
+
+    /// Lift a certain value into the soft arrow: a point-mass distribution (certain ⇒ soft trivially).
+    let certain (f: 'a -> DynamicValue) : ISR<'a, SoftValue.SoftValue> =
+        fun _ctx a -> Task.FromResult(Ok(SoftValue.certain (f a)))
+
+    /// Lift a weighted candidate set into the soft arrow. An empty/invalid set is a `Failed` error
+    /// (you cannot hold a distribution over nothing).
+    let ofWeighted (f: 'a -> (DynamicValue * float) list) : ISR<'a, SoftValue.SoftValue> =
+        fun _ctx a ->
+            match SoftValue.ofWeighted (f a) with
+            | Some sv -> Task.FromResult(Ok sv)
+            | None -> Task.FromResult(Error(Failed "soft lift: no valid candidates"))
+
+    /// Bayesian update as an arrow step: posterior ∝ prior · likelihood. Evidence composes under `>=>`
+    /// (independent-evidence observes COMMUTE — the SoftValue law). A likelihood that annihilates every
+    /// candidate is a genuine failure (`Failed`), surfaced in the error channel.
+    let observeWith (likelihood: DynamicValue -> float) : ISR<SoftValue.SoftValue, SoftValue.SoftValue> =
+        fun _ctx sv ->
+            match SoftValue.observe likelihood sv with
+            | Some sv' -> Task.FromResult(Ok sv')
+            | None -> Task.FromResult(Error(Failed "observe: likelihood annihilated the distribution"))
+
+    /// Explicit collapse: resolve to a definite `DynamicValue` ONLY when confidence ≥ `threshold`;
+    /// otherwise return the still-held distribution (`Choice2Of2`) — the room keeps holding, which is a
+    /// VALUE, not an error (soft mode composes; unresolved is a legitimate state).
+    let resolveAt (threshold: float) : ISR<SoftValue.SoftValue, Choice<DynamicValue, SoftValue.SoftValue>> =
+        fun _ctx sv ->
+            match SoftValue.resolve threshold sv with
+            | Some dv -> Task.FromResult(Ok(Choice1Of2 dv))
+            | None -> Task.FromResult(Ok(Choice2Of2 sv))
+
+    /// The DEMANDING collapse: resolve or fail — for callers that need hardness NOW (the boundary where
+    /// soft must become solid; SolidGround-by-proof). Under-threshold ⇒ `Failed` with the confidence
+    /// stated (honest refusal, not a silent guess).
+    let mustResolveAt (threshold: float) : ISR<SoftValue.SoftValue, DynamicValue> =
+        fun _ctx sv ->
+            match SoftValue.resolve threshold sv with
+            | Some dv -> Task.FromResult(Ok dv)
+            | None ->
+                Task.FromResult(
+                    Error(Failed(sprintf "unresolved: confidence %.3f < threshold %.3f" (SoftValue.confidence sv) threshold))
+                )

--- a/tests/Tests.FSharp/FourCornerTreaty.Tests.fs
+++ b/tests/Tests.FSharp/FourCornerTreaty.Tests.fs
@@ -1,0 +1,53 @@
+module Zeta.Tests.FourCornerTreatyTests
+
+// The FourCorner TREATY byte-lock (B-1022 trigger fired: "we are the consumer for our treaties — this is
+// how we know we are done; without it who knows if things are correct"). The F# oracle locks the golden
+// lines; C#/TS/Rust must produce/consume the SAME bytes.
+
+open System.IO
+open global.Xunit
+open Zeta.Core
+
+let private goldenPath =
+    Path.Combine(System.AppContext.BaseDirectory, "four-corner-golden.lines")
+
+let private goldenLines () =
+    File.ReadAllLines goldenPath
+    |> Array.filter (fun l -> not (l.StartsWith "#") && l.Length > 0)
+    |> Array.toList
+
+let private mk tIn tOut oFb iFb : FourCorner.FourCornerOwnership<string, string, string, string> =
+    { TIn = tIn; TOut = tOut; TOutFeedback = oFb; TInFeedback = iFb }
+
+/// The vectors, as constructed values — MUST serialize to the golden lines byte-for-byte.
+let private vectors =
+    [ mk "operator-message" (Some "emitted") (Some "conv-feedback") (Some "co-owned-ack")
+      mk "only-input" None None None
+      mk "tab\there\nand-newline" (Some "back\\slash") None (Some "ends-with-tab\t")
+      mk "" (Some "") None None
+      mk "héllo-wörld-⊕-unicode" None (Some "反馈") None ]
+
+[<Fact>]
+let ``BYTE-LOCK: every vector serializes to its golden line exactly`` () =
+    let lines = goldenLines ()
+    Assert.Equal(vectors.Length, lines.Length)
+    for v, expected in List.zip vectors lines do
+        Assert.Equal(expected, FourCorner.toLine v)
+
+[<Fact>]
+let ``round-trip: every golden line parses back to its vector (ofLine ∘ toLine = id)`` () =
+    for v, line in List.zip vectors (goldenLines ()) do
+        match FourCorner.ofLine line with
+        | Some parsed ->
+            Assert.Equal(v.TIn, parsed.TIn)
+            Assert.Equal(v.TOut, parsed.TOut)
+            Assert.Equal(v.TOutFeedback, parsed.TOutFeedback)
+            Assert.Equal(v.TInFeedback, parsed.TInFeedback)
+        | None -> Assert.Fail(sprintf "golden line failed to parse: %s" line)
+
+[<Fact>]
+let ``malformed lines are refused honestly (None, never a guess)`` () =
+    Assert.True((FourCorner.ofLine "garbage").IsNone)
+    Assert.True((FourCorner.ofLine "fourcorner1\tonly-three\t-\t-").IsNone)
+    Assert.True((FourCorner.ofLine "fourcorner2\ta\t-\t-\t-").IsNone) // wrong version tag
+    Assert.True((FourCorner.ofLine "fourcorner1\ta\t?\t-\t-").IsNone) // malformed opt

--- a/tests/Tests.FSharp/RecordedSource.Tests.fs
+++ b/tests/Tests.FSharp/RecordedSource.Tests.fs
@@ -1,0 +1,68 @@
+module Zeta.Tests.RecordedSourceTests
+
+open System.Threading.Tasks
+open global.Xunit
+open Zeta.Core
+
+let private ctx () : IntrCtx =
+    { Memetic = "rec"; Prompt = ""; Trust = ""; Log = ""; Otel = System.Diagnostics.ActivityContext() }
+
+let private isTimer =
+    function
+    | TimerElapsed _ -> true
+    | _ -> false
+
+/// A "live" source simulating real IO: stateful underneath (a mutable consumption log), exactly the
+/// impure thing the recorder is for.
+let private liveSource () =
+    let consumed = System.Collections.Generic.HashSet<int>()
+    let src: SoftScheduler.Source =
+        fun n ->
+            consumed.Add n |> ignore
+            [ yield TimerElapsed 17
+              if n % 3 = 0 then yield OperatorMessageArrived(sprintf "io-%d" n)
+              if n = 5 then yield PeerPRMerged 7591 ]
+    src, consumed
+
+[<Fact>]
+let ``record captures the membrane crossings; replay reproduces them exactly (incl. quiet ticks)`` () =
+    let live, _ = liveSource ()
+    let rec' = RecordedSource.record live 10
+    let replayed = RecordedSource.replay rec'
+    for n in 0..9 do
+        Assert.Equal<InterruptKind list>(live n, replayed n)
+    Assert.Empty(replayed 99) // beyond the recording the membrane is quiet
+
+[<Fact>]
+let ``the FDB move: a scheduler run on the LIVE source == the run on the REPLAYED recording (DST survives real IO)`` () =
+    task {
+        let count: SoftScheduler.Handler<int> =
+            SoftScheduler.handler "count" (fun _ -> true) (fun _ n -> Task.FromResult(Ok(n + 1)))
+        let live, _ = liveSource ()
+        let rec' = RecordedSource.record live 20
+        let! a = (SoftScheduler.drive [ count ] live).Run (ctx ()) 1L 0 20
+        let! b = (SoftScheduler.drive [ count ] (RecordedSource.replay rec')).Run (ctx ()) 1L 0 20
+        Assert.Equal<Result<int, InterruptFeedback>>(a, b)
+    }
+
+[<Fact>]
+let ``the text codec round-trips byte-identically (the treaty surface) — incl. escaping`` () =
+    let nasty = "line1\nline2\twith\ttabs\\and\\slashes"
+    let r: RecordedSource.Recording =
+        { Crossings =
+            Map.ofList
+                [ 0, [ TimerElapsed 17; OperatorMessageArrived nasty ]
+                  3, [ SentinelMissing; CIFailureDetected "job-42" ]
+                  7, [ RateLimitExhausted "graphql"; DotGitSaturation 3; RoundsElapsedSinceFreeTime 9; PeerPRMerged 1 ] ] }
+    let lines = RecordedSource.toLines r
+    let r2 = RecordedSource.ofLines lines
+    Assert.Equal<Map<int, InterruptKind list>>(r.Crossings, r2.Crossings)
+    // deterministic serialization: same recording => byte-identical lines (diffable, golden-vector-able)
+    Assert.Equal<string list>(lines, RecordedSource.toLines r2)
+
+[<Fact>]
+let ``replaying a recording is itself replayable (record of a replay == the recording)`` () =
+    let live, _ = liveSource ()
+    let rec1 = RecordedSource.record live 12
+    let rec2 = RecordedSource.record (RecordedSource.replay rec1) 12
+    Assert.Equal<Map<int, InterruptKind list>>(rec1.Crossings, rec2.Crossings)

--- a/tests/Tests.FSharp/SimFramework.Tests.fs
+++ b/tests/Tests.FSharp/SimFramework.Tests.fs
@@ -1,0 +1,79 @@
+module Zeta.Tests.SimFrameworkTests
+
+// THE xUNIT ADAPTER, demonstrated: these [<Fact>]s are thin shims — the real test is the ROOM, run on
+// OUR harness; xUnit merely asserts the sign-off (rooms-as-sign-off; the framework is hexagonal and
+// xUnit is one adapter at the edge).
+
+open System.Threading.Tasks
+open global.Xunit
+open Zeta.Core
+
+let private isTimer =
+    function
+    | TimerElapsed _ -> true
+    | _ -> false
+
+/// A counting room: ticks toward 60 and signs off when it gets there (the minimal plateau).
+let private countingRoom =
+    SimFramework.room
+        "counting-room"
+        (fun _ -> 0)
+        [ SoftScheduler.handler "count" isTimer (fun _ n -> Task.FromResult(Ok(n + 1))) ]
+        60
+        (fun n -> n >= 60)
+
+[<Fact>]
+let ``a room runs to resolution on OUR harness; xUnit only asserts the sign-off (the adapter)`` () =
+    task {
+        let! report = SimFramework.run countingRoom 7L
+        Assert.True(report.SignedOff) // ← the entire xUnit surface: did the room sign off?
+        Assert.Equal("counting-room", report.Room)
+    }
+
+[<Fact>]
+let ``a room that cannot reach its plateau does NOT sign off (failing = unresolved, not exploded)`` () =
+    task {
+        let starved = { countingRoom with Budget = 10 } // 10 ticks can't reach 60
+        let! report = SimFramework.run starved 7L
+        Assert.False(report.SignedOff)
+        match report.Final with
+        | Ok n -> Assert.Equal(10, n) // it ran honestly; it just didn't resolve
+        | Error e -> Assert.Fail(sprintf "starvation is not an error: %A" e)
+    }
+
+[<Fact>]
+let ``DST: the same room at the same seed produces the same report (replay-equal)`` () =
+    task {
+        let! a = SimFramework.run countingRoom 42L
+        let! b = SimFramework.run countingRoom 42L
+        Assert.Equal(a.SignedOff, b.SignedOff)
+        Assert.Equal<Result<int, InterruptFeedback>>(a.Final, b.Final)
+    }
+
+[<Fact>]
+let ``the membrane is a PARAMETER: the same room runs against a recorded real-IO replay (withSource)`` () =
+    task {
+        // record a "live" membrane, then run the SAME room against the replay — §13 + hexagonal together
+        let live: SoftScheduler.Source = fun n -> [ TimerElapsed 17; (if n = 3 then OperatorMessageArrived "io" else TimerElapsed 0) ]
+        let recording = RecordedSource.record live 60
+        let replayRoom = countingRoom |> SimFramework.withSource (fun _ -> RecordedSource.replay recording)
+        let! report = SimFramework.run replayRoom 7L
+        Assert.True(report.SignedOff) // the room resolves on the recorded membrane too
+    }
+
+[<Fact>]
+let ``an interrupted room reports the interrupt and does not sign off (errors stay sum-channel)`` () =
+    task {
+        let boom =
+            SimFramework.room
+                "boom-room"
+                (fun _ -> 0)
+                [ SoftScheduler.handler "boom" isTimer (fun _ _ -> Task.FromResult(Error(Interrupted SentinelMissing))) ]
+                5
+                (fun _ -> true)
+        let! report = SimFramework.run boom 1L
+        Assert.False(report.SignedOff)
+        match report.Final with
+        | Error (Interrupted SentinelMissing) -> ()
+        | other -> Assert.Fail(sprintf "expected the interrupt, got %A" other)
+    }

--- a/tests/Tests.FSharp/SoftIsr.Tests.fs
+++ b/tests/Tests.FSharp/SoftIsr.Tests.fs
@@ -1,0 +1,85 @@
+module Zeta.Tests.SoftIsrTests
+
+open global.Xunit
+open Zeta.Core
+open Zeta.Core.ISR
+
+let private ctx () : IntrCtx =
+    { Memetic = "soft"; Prompt = ""; Trust = ""; Log = ""; Otel = System.Diagnostics.ActivityContext() }
+
+// a likelihood favoring Int candidates near a target
+let private near (target: int64) (dv: DynamicValue) : float =
+    match dv with
+    | DynamicValue.Int n -> 1.0 / (1.0 + abs (float (n - target)))
+    | _ -> 0.0
+
+[<Fact>]
+let ``the soft pipeline: lift -> observe -> mustResolve collapses to the evidenced candidate`` () =
+    task {
+        let arrow =
+            SoftIsr.ofWeighted (fun () -> [ DynamicValue.Int 1L, 0.4; DynamicValue.Int 10L, 0.3; DynamicValue.Int 100L, 0.3 ])
+            >=> SoftIsr.observeWith (near 10L)
+            >=> SoftIsr.observeWith (near 10L) // independent evidence compounds
+            >=> SoftIsr.mustResolveAt 0.6
+        let! r = arrow (ctx ()) ()
+        Assert.Equal<Result<DynamicValue, InterruptFeedback>>(Ok(DynamicValue.Int 10L), r)
+    }
+
+[<Fact>]
+let ``uncertainty travels WITH the promise: under-threshold resolveAt returns the HELD distribution (a value, not an error)`` () =
+    task {
+        let arrow =
+            SoftIsr.ofWeighted (fun () -> [ DynamicValue.Int 1L, 0.5; DynamicValue.Int 2L, 0.5 ])
+            >=> SoftIsr.resolveAt 0.9
+        let! r = arrow (ctx ()) ()
+        match r with
+        | Ok (Choice2Of2 held) -> Assert.True(SoftValue.confidence held < 0.9) // still soft, still flowing
+        | Ok (Choice1Of2 _) -> Assert.Fail "should not have collapsed at 50/50"
+        | Error e -> Assert.Fail(sprintf "holding is not an error: %A" e)
+    }
+
+[<Fact>]
+let ``annihilating evidence surfaces in the ERROR channel (sum = failure; product = held value)`` () =
+    task {
+        let arrow =
+            SoftIsr.certain (fun () -> DynamicValue.String "x")
+            >=> SoftIsr.observeWith (fun _ -> 0.0) // kills every candidate
+        let! r = arrow (ctx ()) ()
+        match r with
+        | Error (Failed msg) -> Assert.Contains("annihilated", msg)
+        | _ -> Assert.Fail "zero likelihood must surface as Failed"
+    }
+
+[<Fact>]
+let ``mustResolveAt refuses honestly when unresolved (states the confidence, never guesses)`` () =
+    task {
+        let arrow =
+            SoftIsr.ofWeighted (fun () -> [ DynamicValue.Int 1L, 0.5; DynamicValue.Int 2L, 0.5 ])
+            >=> SoftIsr.mustResolveAt 0.9
+        let! r = arrow (ctx ()) ()
+        match r with
+        | Error (Failed msg) -> Assert.Contains("unresolved", msg)
+        | _ -> Assert.Fail "under-threshold mustResolve must refuse"
+    }
+
+[<Fact>]
+let ``independent-evidence observes COMMUTE through the arrow (the SoftValue law lifts)`` () =
+    task {
+        let e1 = near 10L
+        let e2 (dv: DynamicValue) =
+            match dv with
+            | DynamicValue.Int n -> (if n > 5L then 0.8 else 0.2)
+            | _ -> 0.0
+        let lift = SoftIsr.ofWeighted (fun () -> [ DynamicValue.Int 1L, 0.4; DynamicValue.Int 10L, 0.6 ])
+        let ab = lift >=> SoftIsr.observeWith e1 >=> SoftIsr.observeWith e2
+        let ba = lift >=> SoftIsr.observeWith e2 >=> SoftIsr.observeWith e1
+        let! ra = ab (ctx ()) ()
+        let! rb = ba (ctx ()) ()
+        match ra, rb with
+        | Ok a, Ok b ->
+            let pairs = List.zip a.Candidates b.Candidates
+            for (dva, pa), (dvb, pb) in pairs do
+                Assert.Equal(dva, dvb)
+                Assert.Equal(pa, pb, 10)
+        | _ -> Assert.Fail "both orders must succeed"
+    }

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -133,6 +133,8 @@
     <Compile Include="FourCornerFusion.Tests.fs" />
     <Compile Include="SoftScheduler.Tests.fs" />
     <Compile Include="SoftThrottle.Tests.fs" />
+    <Compile Include="RecordedSource.Tests.fs" />
+    <Compile Include="SoftIsr.Tests.fs" />
     <Compile Include="SoftChip8Scheduler.Tests.fs" />
     <Compile Include="BitAdinkra.Tests.fs" />
     <Compile Include="ForwardMomentum.Tests.fs" />

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -135,6 +135,7 @@
     <Compile Include="SoftThrottle.Tests.fs" />
     <Compile Include="RecordedSource.Tests.fs" />
     <Compile Include="SoftIsr.Tests.fs" />
+    <Compile Include="SimFramework.Tests.fs" />
     <Compile Include="SoftChip8Scheduler.Tests.fs" />
     <Compile Include="BitAdinkra.Tests.fs" />
     <Compile Include="ForwardMomentum.Tests.fs" />

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -131,6 +131,7 @@
     <Compile Include="DevRoomTick.Tests.fs" />
     <Compile Include="FourCorner.Tests.fs" />
     <Compile Include="FourCornerFusion.Tests.fs" />
+    <Compile Include="FourCornerTreaty.Tests.fs" />
     <Compile Include="SoftScheduler.Tests.fs" />
     <Compile Include="SoftThrottle.Tests.fs" />
     <Compile Include="RecordedSource.Tests.fs" />
@@ -422,5 +423,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="YamlDotNet" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="four-corner-golden.lines">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 </Project>

--- a/tests/Tests.FSharp/four-corner-golden.lines
+++ b/tests/Tests.FSharp/four-corner-golden.lines
@@ -1,0 +1,10 @@
+# four-corner-golden.lines — the FourCornerOwnership treaty golden vectors (B-1022 trigger fired:
+# "we are the consumer for our treaties"). One canonical line per vector; the F# oracle locks these
+# bytes; C#/TS/Rust conform to the SAME lines. Format:
+#   fourcorner1<TAB>esc(tIn)<TAB>opt<TAB>opt<TAB>opt   where opt = "-" | "+"+esc(value)
+# Escapes: \\ \t \n \r. Lines starting with # are comments.
+fourcorner1	operator-message	+emitted	+conv-feedback	+co-owned-ack
+fourcorner1	only-input	-	-	-
+fourcorner1	tab\there\nand-newline	+back\\slash	-	+ends-with-tab\t
+fourcorner1		+	-	-
+fourcorner1	héllo-wörld-⊕-unicode	-	+反馈	-


### PR DESCRIPTION
The simulation doc: corporate answer (hard = the limit case — admitHard+point-mass = zero soft overhead, or a plain-scheduler ISimHarness adapter; shared thing = the treaty surface), the Reticulum-distribution direction with open questions named, the one-simulation treaty table. Plus the fired B-1022 trigger executed: FourCorner.toLine/ofLine canonical wire form + four-corner-golden.lines (5 vectors incl. escapes/unicode) + byte-lock tests 3/3. C#/TS/Rust conform to the same lines next. 0 warnings.