### PR TITLE
feat(core): add result computation expression

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="Result.fs" />
     <Compile Include="Finalizer.fs" />
     <Compile Include="Algebra.fs" />
     <Compile Include="Collation.fs" />

--- a/src/Core/Result.fs
+++ b/src/Core/Result.fs
@@ -1,0 +1,28 @@
+namespace Zeta.Core
+
+/// Computation expression for the repo's F# `Result<'T, 'Feedback>` convention.
+/// The feedback channel stays authored by the called function; `Bind` only
+/// propagates it without translating, throwing, or collapsing it to strings.
+[<AutoOpen>]
+module ResultComputation =
+
+    type ResultBuilder() =
+        member _.Return(value: 'T) : Result<'T, 'Feedback> = Ok value
+
+        member _.ReturnFrom(result: Result<'T, 'Feedback>) : Result<'T, 'Feedback> = result
+
+        member _.Bind(result: Result<'T, 'Feedback>, next: 'T -> Result<'U, 'Feedback>) : Result<'U, 'Feedback> =
+            Result.bind next result
+
+        member _.Zero() : Result<unit, 'Feedback> = Ok()
+
+        member _.Delay(thunk: unit -> Result<'T, 'Feedback>) : unit -> Result<'T, 'Feedback> = thunk
+
+        member _.Run(thunk: unit -> Result<'T, 'Feedback>) : Result<'T, 'Feedback> = thunk()
+
+        member _.Combine(first: Result<unit, 'Feedback>, next: unit -> Result<'T, 'Feedback>) : Result<'T, 'Feedback> =
+            match first with
+            | Ok() -> next()
+            | Error feedback -> Error feedback
+
+    let result = ResultBuilder()

--- a/src/Core/ReticulumQuantum.fs
+++ b/src/Core/ReticulumQuantum.fs
@@ -82,8 +82,6 @@ module ReticulumQuantum =
         | Some value -> Ok value
         | None -> Error(PacketError.Malformed(sprintf "missing %s" name))
 
-    let private bind f r = Result.bind f r
-
     let private parseFloat name (value: string) =
         match Double.TryParse(value, NumberStyles.Float, inv) with
         | true, value -> Ok value
@@ -114,32 +112,28 @@ module ReticulumQuantum =
                     | _ -> None)
                 |> Map.ofSeq
 
-            field "room" fields
-            |> bind (fun room ->
-                field "source" fields
-                |> bind (fun source ->
-                    field "name" fields
-                    |> bind (fun name ->
-                        field "value" fields
-                        |> bind (parseFloat "value")
-                        |> bind (fun value ->
-                            field "norm" fields
-                            |> bind (parseFloat "norm")
-                            |> bind (fun norm ->
-                                field "support" fields
-                                |> bind (parseInt "support")
-                                |> bind (fun support ->
-                                    field "sequence" fields
-                                    |> bind (parseInt64 "sequence")
-                                    |> bind (fun sequence ->
-                                        Ok
-                                            { Room = dec room
-                                              Source = dec source
-                                              Name = dec name
-                                              Value = value
-                                              Norm = norm
-                                              Support = support
-                                              Sequence = sequence })))))))
+            result {
+                let! room = field "room" fields
+                let! source = field "source" fields
+                let! name = field "name" fields
+                let! valueRaw = field "value" fields
+                let! value = parseFloat "value" valueRaw
+                let! normRaw = field "norm" fields
+                let! norm = parseFloat "norm" normRaw
+                let! supportRaw = field "support" fields
+                let! support = parseInt "support" supportRaw
+                let! sequenceRaw = field "sequence" fields
+                let! sequence = parseInt64 "sequence" sequenceRaw
+
+                return
+                    { Room = dec room
+                      Source = dec source
+                      Name = dec name
+                      Value = value
+                      Norm = norm
+                      Support = support
+                      Sequence = sequence }
+            }
 
     /// Send one observable over an established deterministic link.
     let send

--- a/tests/Tests.FSharp/Core/Result.Tests.fs
+++ b/tests/Tests.FSharp/Core/Result.Tests.fs
@@ -1,0 +1,49 @@
+module Zeta.Tests.ResultTests
+
+open global.Xunit
+open Zeta.Core
+
+type private Feedback =
+    | MissingInput
+    | BadNumber
+
+let private parseInt (s: string) =
+    match System.Int32.TryParse s with
+    | true, value -> Ok value
+    | false, _ -> Error BadNumber
+
+[<Fact>]
+let ``result computation expression composes the success value channel`` () =
+    let actual =
+        result {
+            let! a = parseInt "2"
+            let! b = parseInt "40"
+            return a + b
+        }
+
+    Assert.Equal<Result<int, Feedback>>(Ok 42, actual)
+
+[<Fact>]
+let ``result computation expression short-circuits on the authored feedback channel`` () =
+    let mutable ranAfterError = false
+
+    let actual =
+        result {
+            let! _ = Error MissingInput
+            ranAfterError <- true
+            let! n = parseInt "40"
+            return n
+        }
+
+    Assert.False(ranAfterError)
+    Assert.Equal<Result<int, Feedback>>(Error MissingInput, actual)
+
+[<Fact>]
+let ``result computation expression propagates return-from feedback without translation`` () =
+    let actual =
+        result {
+            let! _ = parseInt "nope"
+            return! Ok 1
+        }
+
+    Assert.Equal<Result<int, Feedback>>(Error BadNumber, actual)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -52,6 +52,7 @@
     <Compile Include="SocietyUnbounded.Tests.fs" />
     <Compile Include="TriBoolean/TriBoolean.Tests.fs" />
     <Compile Include="TriBoolean/Float.Tests.fs" />
+    <Compile Include="Core/Result.Tests.fs" />
     <Compile Include="Bonsai/Bonsai.Tests.fs" />
     <Compile Include="Bonsai/Resume.Tests.fs" />
     <Compile Include="Bonsai/IntrCtx.Tests.fs" />


### PR DESCRIPTION
## Summary

- Adds a shared F# `result {}` computation expression over the existing `Result<_, _>` / feedback-channel convention.
- Converts `ReticulumQuantum.decode` from local `Result.bind` plumbing to the shared computation expression.
- Adds tests proving success composition, early feedback short-circuiting, and `return!` propagation without feedback translation.

## Validation

- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter "FullyQualifiedName~ResultTests|FullyQualifiedName~ReticulumQuantumTests"` — 6 passed
- `dotnet build -c Release` — 0 warnings, 0 errors
- `dotnet test Zeta.sln -c Release` — 3,082 passed, 1 skipped, 0 failed
- `git diff --check` — passed
- `dotnet format --verify-no-changes --include src/Core/Result.fs src/Core/ReticulumQuantum.fs src/Core/Core.fsproj tests/Tests.FSharp/Core/Result.Tests.fs tests/Tests.FSharp/Tests.FSharp.fsproj` — passed
