### PR TITLE
feat(core): re-land SimFramework + simulation charter + FourCorner treaty lock (supersedes #7594/#7595)

### DIFF
--- a/docs/research/2026-06-11-the-simulation-doc-distributed-soft-scheduler-over-reticulum-corporate-hard-rooms-one-simulation.md
+++ b/docs/research/2026-06-11-the-simulation-doc-distributed-soft-scheduler-over-reticulum-corporate-hard-rooms-one-simulation.md
@@ -1,0 +1,84 @@
+# The simulation doc — distribute the soft scheduler over Reticulum; corporate runs hard rooms; we all run in the same simulation
+
+**Register:** [grounded] (Aaron, the plan) + [Beacon] + [peel]. **Date:** 2026-06-11.
+**Captured by:** Otto (shadow, on Fable). The simulation framework's charter doc (`SimFramework.fs` is the
+port; this is where it's going).
+
+## Aaron's words
+
+> "the ultimate plan is to distribute the soft scheduler in some way over Reticulum — not exactly sure on
+> this one." · "Max's stuff is devops/workflow stuff for corporate — will running on the soft scheduler be
+> too much for them? will they run on a regular one?" · "this simulation stuff will be treaty stuff too —
+> **we will all run in the same simulation lol**."
+
+## 1. What exists (the floor this stands on)
+
+`SimFramework.fs` — the hexagonal **port**: `Room<'S>` (seed + handlers/μops + **membrane-as-parameter** +
+budget + `Resolved` = the sign-off), `ISimHarness` (run rooms to attempted resolution), `RoomReport`
+(text-shaped verdict). Default adapter = the soft scheduler at DoP=1 (deterministic, FDB shape). xUnit is
+one adapter (a `[<Fact>]` asserting `SignedOff`). `RecordedSource` proves the membrane seam: the same room
+re-runs against recorded real IO.
+
+## 2. The corporate answer (Max's devops/workflow rooms) — hard is the LIMIT CASE, not another framework
+
+**The soft scheduler is never "too much," because softness is opt-in by parameters:**
+
+- A corporate room = **hard admission** (`SoftThrottle.admitHard` — the k→∞ step function), **point-mass
+  values** (no distributions; `SoftValue.certain` degenerates to the value), **real recorded source**. At
+  those settings the soft scheduler IS a regular scheduler — the soft machinery costs nothing when no
+  distribution has more than one candidate (the same way BigFloat at full confidence is just a float, and
+  hard fingerprints are the exact case of soft ones). **Dual-use hard/soft, one code path** — the end-goal
+  doc's first clause, applied to scheduling.
+- If corporate wants a genuinely conventional runtime: **the port absorbs it**. `ISimHarness` adapters can
+  run rooms on any scheduler (a plain task queue, the FerryThrottler, k8s jobs — Max's lane). What MUST be
+  shared is not the runtime but the **treaty surface**: `RoomReport` verdicts, recorded-membrane lines,
+  golden vectors. Different adapters, same simulation.
+- Practical default for Max: run on the soft scheduler at hard settings (gets DST replay + §13 metering
+  for free — the parts corporate *wants*: auditable, replayable workflows), drop to a plain adapter only
+  if perf ever says so (measure first — Naledi).
+
+## 3. The ultimate plan — distribute the soft scheduler over Reticulum (direction, honestly held)
+
+Aaron: "not exactly sure on this one." What we already know constrains the shape:
+
+- **The membrane is already the seam.** A distributed room = a room whose `Source` is a **Reticulum
+  membrane** (crossings arrive as announced packets; `RecordedSource` records/replays them — §13 holds
+  over the network *by the same mechanism already proven*).
+- **The seed is the distributed choice function** (the distributed-AC capture): rooms on different nodes
+  draw coordination-free coherent choices from the shared seed — no locking, scale-free.
+- **Uncertainty travels in the message** (promise-level; the four-corner channel) — so soft rooms on
+  different nodes converse cleanly (the end-goal clause), each booking crossings at its own membrane.
+- **What is genuinely open:** placement (which node ticks which room — the Sequoia/SoftValue tier-placement
+  move generalized to *nodes*?), the inter-node tick relationship (no global clock — Lamport/light-cone
+  per the Feynman lens), and partition behavior (rooms are Markov-bounded, so partition = membranes going
+  quiet, not failure). These are the design questions, named, not answered.
+
+## 4. We all run in the same simulation (the treaty claim)
+
+The shared thing is the **simulation's treaty surfaces** — all text, all diffable, all byte-lockable:
+
+| treaty surface | what it ratifies | exists |
+|---|---|---|
+| `RoomReport` (text verdict) | what a room run concluded (sign-off) | ✅ shape |
+| `RecordedSource` lines | what crossed a membrane (channel reliability — "for real treaties we need to know our channels are good") | ✅ + byte-identical codec test |
+| **FourCorner golden lines** | the four-corner channel object itself (the fired B-1022 trigger: WE are the consumer) | seeded this PR — F# locks first, C#/TS/Rust conform |
+| Q# golden observables | the quantum reference (Vera) | brief out |
+| the four-oracle goldens (existing) | every primitive, little by little | ✅ pattern |
+
+Corporate hard rooms, research soft rooms, the Q# oracle, four language oracles — different adapters,
+**one simulation**, ratified treaty by treaty. ("Everything in Zeta will end up treaty-ratified, little by
+little" — Aaron.)
+
+## Peel
+
+The Reticulum distribution is a **direction with named open questions**, not a design; the corporate
+zero-overhead claim is architectural (point-mass fast-path) and should get a Naledi benchmark before being
+quoted as measured; "we all run in the same simulation" is precise about *treaty surfaces*, not a
+metaphysical claim.
+
+## Ties / routing
+
+`src/Core/SimFramework.fs` · `...the-end-goal-...md` (dual-use clause) · `...choice-determinism-...`
+(seed = distributed AC) · `...heat-...` + `RecordedSource` (§13 executable) · B-1022 (treaty trigger
+fired) · B-1023/Max (the corporate consumer). **Routes to:** Max (the corporate adapter + co-review),
+Naledi (the hard-settings benchmark), Kenji (the distribution design questions), Vera (Q#), Aaron.

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -143,6 +143,7 @@
     <Compile Include="SoftScheduler.fs" />
     <Compile Include="SoftThrottle.fs" />
     <Compile Include="RecordedSource.fs" />
+    <Compile Include="SimFramework.fs" />
     <Compile Include="SagaBuilder.fs" />
     <Compile Include="ChaosEnv.fs" />
     <Compile Include="HigherOrder.fs" />

--- a/src/Core/FourCorner.fs
+++ b/src/Core/FourCorner.fs
@@ -50,3 +50,57 @@ module FourCorner =
     /// Has feedback crossed in either direction? (the backpressure corners)
     let hasFeedback (o: FourCornerOwnership<'TIn, 'TOut, 'TOutFeedback, 'TInFeedback>) : bool =
         o.TOutFeedback.IsSome || o.TInFeedback.IsSome
+
+    // ── The TREATY codec (B-1022 trigger FIRED: "we are the consumer for our treaties") ──
+    // Canonical text-line wire form for the string-quad instantiation (the operator-channel shape).
+    // The F# oracle locks these bytes first; C#/TS/Rust conform to the same golden lines. Format:
+    //   fourcorner1<TAB>esc(tIn)<TAB>opt<TAB>opt<TAB>opt   where opt = "-" (None) | "+" + esc(value)
+    // Escaping: \\ \t \n \r (the RecordedSource house style). Deterministic: same value ⇒ same bytes.
+
+    let private esc (s: string) =
+        s.Replace("\\", "\\\\").Replace("\t", "\\t").Replace("\n", "\\n").Replace("\r", "\\r")
+
+    let private unesc (s: string) =
+        let sb = System.Text.StringBuilder()
+        let mutable i = 0
+        while i < s.Length do
+            if s.[i] = '\\' && i + 1 < s.Length then
+                (match s.[i + 1] with
+                 | 't' -> sb.Append '\t'
+                 | 'n' -> sb.Append '\n'
+                 | 'r' -> sb.Append '\r'
+                 | c -> sb.Append c)
+                |> ignore
+                i <- i + 2
+            else
+                sb.Append s.[i] |> ignore
+                i <- i + 1
+        sb.ToString()
+
+    let private optToText =
+        function
+        | None -> "-"
+        | Some (v: string) -> "+" + esc v
+
+    let private optOfText (s: string) : string option voption =
+        if s = "-" then ValueSome None
+        elif s.StartsWith "+" then ValueSome(Some(unesc (s.Substring 1)))
+        else ValueNone // malformed
+
+    /// Serialize the string-quad four-corner to its canonical treaty line (byte-deterministic).
+    let toLine (o: FourCornerOwnership<string, string, string, string>) : string =
+        sprintf "fourcorner1\t%s\t%s\t%s\t%s" (esc o.TIn) (optToText o.TOut) (optToText o.TOutFeedback) (optToText o.TInFeedback)
+
+    /// Parse a canonical treaty line (inverse of `toLine`); `None` on malformed input (honest refusal).
+    let ofLine (line: string) : FourCornerOwnership<string, string, string, string> option =
+        match line.Split('\t') with
+        | [| "fourcorner1"; tIn; o1; o2; o3 |] ->
+            match optOfText o1, optOfText o2, optOfText o3 with
+            | ValueSome tOut, ValueSome tOutFb, ValueSome tInFb ->
+                Some
+                    { TIn = unesc tIn
+                      TOut = tOut
+                      TOutFeedback = tOutFb
+                      TInFeedback = tInFb }
+            | _ -> None
+        | _ -> None

--- a/src/Core/SimFramework.fs
+++ b/src/Core/SimFramework.fs
@@ -1,0 +1,98 @@
+namespace Zeta.Core
+
+open System.Threading.Tasks
+
+/// SimFramework — **the simulation framework port: rooms do not run ON a test framework; test frameworks
+/// adapt to ROOMS** (Aaron 2026-06-11: "we are going to wrap all this in a simulation framework — the
+/// rooms framework does not make sense on top of a test framework alone like xUnit; we will hexagonal it
+/// with our own interfaces").
+///
+/// Hexagonal: this file is the **port** (our own interfaces — free, per the meta-rule); concrete
+/// frameworks are **adapters**:
+///   • the default harness below runs a room on the soft `IScheduler` (DoP=1, seed-deterministic, DST);
+///   • **xUnit is just an adapter** — a `[<Fact>]` that runs the harness and asserts `SignedOff`
+///     (see `SimFramework.Tests.fs` for the worked adapter);
+///   • future adapters: the DevRoom console, the recorded-membrane replayer, CI gates, the Q# oracle.
+///
+/// The doctrine made type-shaped: **a test IS a room** — `seed + extensions(handlers) + parameters
+/// (budget/source)` — and **passing IS resolving** (rooms-as-sign-off): the room ticks toward its
+/// plateau; `Resolved` is the sign-off predicate; the report carries the run (DST: same room, same seed
+/// ⇒ same report). Everything here will be treaty-ratified little by little — the report is text-shaped
+/// on purpose.
+[<RequireQualifiedAccess>]
+module SimFramework =
+
+    /// A ROOM — the unit the simulation framework runs (the test-as-room shape):
+    /// seed → initial state; handlers = the room's μops (its extensions); Source = its membrane
+    /// (parameters — `SoftScheduler.seedSource` for null/DST, a `RecordedSource.replay` for recorded
+    /// real IO); Budget = the tick budget; Resolved = the SIGN-OFF predicate (the plateau check).
+    type Room<'S> =
+        { Name: string
+          Initial: int64 -> 'S
+          Handlers: SoftScheduler.Handler<'S> list
+          Source: int64 -> SoftScheduler.Source
+          Budget: int
+          Resolved: 'S -> bool }
+
+    /// The report a harness returns — the room's run, sign-off, and how it ended. Text-friendly (the
+    /// treaty surface): no opaque state required to read the verdict.
+    type RoomReport<'S> =
+        { Room: string
+          Ticks: int
+          Final: Result<'S, InterruptFeedback>
+          SignedOff: bool }
+
+    /// THE PORT: a simulation harness runs rooms to (attempted) resolution. Implementations are
+    /// adapters — deterministic local (below), distributed, recorded-replay, CI, …
+    type ISimHarness =
+        abstract member Run: room: Room<'S> * seed: int64 -> Task<RoomReport<'S>>
+
+    /// The DEFAULT harness — the soft scheduler at DoP=1: deterministic, replay-equal, the FDB shape.
+    /// (An object expression implementing the port — the interface is free; no class earned.)
+    let harness: ISimHarness =
+        { new ISimHarness with
+            member _.Run(room, seed) =
+                task {
+                    let ctx: IntrCtx =
+                        { Memetic = "sim:" + room.Name
+                          Prompt = ""
+                          Trust = ""
+                          Log = ""
+                          Otel = System.Diagnostics.ActivityContext() }
+
+                    let! final =
+                        (SoftScheduler.drive room.Handlers (room.Source seed)).Run ctx seed (room.Initial seed) room.Budget
+
+                    let signedOff =
+                        match final with
+                        | Ok s -> room.Resolved s
+                        | Error _ -> false
+
+                    return
+                        { Room = room.Name
+                          Ticks = room.Budget
+                          Final = final
+                          SignedOff = signedOff }
+                } }
+
+    /// Convenience: build a room over the null/DST membrane (`SoftScheduler.seedSource`).
+    let room
+        (name: string)
+        (initial: int64 -> 'S)
+        (handlers: SoftScheduler.Handler<'S> list)
+        (budget: int)
+        (resolved: 'S -> bool)
+        : Room<'S> =
+        { Name = name
+          Initial = initial
+          Handlers = handlers
+          Source = SoftScheduler.seedSource
+          Budget = budget
+          Resolved = resolved }
+
+    /// Swap the room's membrane (its parameters) — e.g. a recorded real-IO replay
+    /// (`RecordedSource.replay r |> withSource room` makes the SAME room run against real crossings).
+    let withSource (source: int64 -> SoftScheduler.Source) (r: Room<'S>) : Room<'S> = { r with Source = source }
+
+    /// Run a room on the default harness (the common path).
+    let run (r: Room<'S>) (seed: int64) : Task<RoomReport<'S>> = harness.Run(r, seed)

--- a/tests/Tests.FSharp/FourCornerTreaty.Tests.fs
+++ b/tests/Tests.FSharp/FourCornerTreaty.Tests.fs
@@ -1,0 +1,53 @@
+module Zeta.Tests.FourCornerTreatyTests
+
+// The FourCorner TREATY byte-lock (B-1022 trigger fired: "we are the consumer for our treaties — this is
+// how we know we are done; without it who knows if things are correct"). The F# oracle locks the golden
+// lines; C#/TS/Rust must produce/consume the SAME bytes.
+
+open System.IO
+open global.Xunit
+open Zeta.Core
+
+let private goldenPath =
+    Path.Combine(System.AppContext.BaseDirectory, "four-corner-golden.lines")
+
+let private goldenLines () =
+    File.ReadAllLines goldenPath
+    |> Array.filter (fun l -> not (l.StartsWith "#") && l.Length > 0)
+    |> Array.toList
+
+let private mk tIn tOut oFb iFb : FourCorner.FourCornerOwnership<string, string, string, string> =
+    { TIn = tIn; TOut = tOut; TOutFeedback = oFb; TInFeedback = iFb }
+
+/// The vectors, as constructed values — MUST serialize to the golden lines byte-for-byte.
+let private vectors =
+    [ mk "operator-message" (Some "emitted") (Some "conv-feedback") (Some "co-owned-ack")
+      mk "only-input" None None None
+      mk "tab\there\nand-newline" (Some "back\\slash") None (Some "ends-with-tab\t")
+      mk "" (Some "") None None
+      mk "héllo-wörld-⊕-unicode" None (Some "反馈") None ]
+
+[<Fact>]
+let ``BYTE-LOCK: every vector serializes to its golden line exactly`` () =
+    let lines = goldenLines ()
+    Assert.Equal(vectors.Length, lines.Length)
+    for v, expected in List.zip vectors lines do
+        Assert.Equal(expected, FourCorner.toLine v)
+
+[<Fact>]
+let ``round-trip: every golden line parses back to its vector (ofLine ∘ toLine = id)`` () =
+    for v, line in List.zip vectors (goldenLines ()) do
+        match FourCorner.ofLine line with
+        | Some parsed ->
+            Assert.Equal(v.TIn, parsed.TIn)
+            Assert.Equal(v.TOut, parsed.TOut)
+            Assert.Equal(v.TOutFeedback, parsed.TOutFeedback)
+            Assert.Equal(v.TInFeedback, parsed.TInFeedback)
+        | None -> Assert.Fail(sprintf "golden line failed to parse: %s" line)
+
+[<Fact>]
+let ``malformed lines are refused honestly (None, never a guess)`` () =
+    Assert.True((FourCorner.ofLine "garbage").IsNone)
+    Assert.True((FourCorner.ofLine "fourcorner1\tonly-three\t-\t-").IsNone)
+    Assert.True((FourCorner.ofLine "fourcorner2\ta\t-\t-\t-").IsNone) // wrong version tag
+    Assert.True((FourCorner.ofLine "fourcorner1\ta\t?\t-\t-").IsNone) // malformed opt

--- a/tests/Tests.FSharp/SimFramework.Tests.fs
+++ b/tests/Tests.FSharp/SimFramework.Tests.fs
@@ -1,0 +1,79 @@
+module Zeta.Tests.SimFrameworkTests
+
+// THE xUNIT ADAPTER, demonstrated: these [<Fact>]s are thin shims — the real test is the ROOM, run on
+// OUR harness; xUnit merely asserts the sign-off (rooms-as-sign-off; the framework is hexagonal and
+// xUnit is one adapter at the edge).
+
+open System.Threading.Tasks
+open global.Xunit
+open Zeta.Core
+
+let private isTimer =
+    function
+    | TimerElapsed _ -> true
+    | _ -> false
+
+/// A counting room: ticks toward 60 and signs off when it gets there (the minimal plateau).
+let private countingRoom =
+    SimFramework.room
+        "counting-room"
+        (fun _ -> 0)
+        [ SoftScheduler.handler "count" isTimer (fun _ n -> Task.FromResult(Ok(n + 1))) ]
+        60
+        (fun n -> n >= 60)
+
+[<Fact>]
+let ``a room runs to resolution on OUR harness; xUnit only asserts the sign-off (the adapter)`` () =
+    task {
+        let! report = SimFramework.run countingRoom 7L
+        Assert.True(report.SignedOff) // ← the entire xUnit surface: did the room sign off?
+        Assert.Equal("counting-room", report.Room)
+    }
+
+[<Fact>]
+let ``a room that cannot reach its plateau does NOT sign off (failing = unresolved, not exploded)`` () =
+    task {
+        let starved = { countingRoom with Budget = 10 } // 10 ticks can't reach 60
+        let! report = SimFramework.run starved 7L
+        Assert.False(report.SignedOff)
+        match report.Final with
+        | Ok n -> Assert.Equal(10, n) // it ran honestly; it just didn't resolve
+        | Error e -> Assert.Fail(sprintf "starvation is not an error: %A" e)
+    }
+
+[<Fact>]
+let ``DST: the same room at the same seed produces the same report (replay-equal)`` () =
+    task {
+        let! a = SimFramework.run countingRoom 42L
+        let! b = SimFramework.run countingRoom 42L
+        Assert.Equal(a.SignedOff, b.SignedOff)
+        Assert.Equal<Result<int, InterruptFeedback>>(a.Final, b.Final)
+    }
+
+[<Fact>]
+let ``the membrane is a PARAMETER: the same room runs against a recorded real-IO replay (withSource)`` () =
+    task {
+        // record a "live" membrane, then run the SAME room against the replay — §13 + hexagonal together
+        let live: SoftScheduler.Source = fun n -> [ TimerElapsed 17; (if n = 3 then OperatorMessageArrived "io" else TimerElapsed 0) ]
+        let recording = RecordedSource.record live 60
+        let replayRoom = countingRoom |> SimFramework.withSource (fun _ -> RecordedSource.replay recording)
+        let! report = SimFramework.run replayRoom 7L
+        Assert.True(report.SignedOff) // the room resolves on the recorded membrane too
+    }
+
+[<Fact>]
+let ``an interrupted room reports the interrupt and does not sign off (errors stay sum-channel)`` () =
+    task {
+        let boom =
+            SimFramework.room
+                "boom-room"
+                (fun _ -> 0)
+                [ SoftScheduler.handler "boom" isTimer (fun _ _ -> Task.FromResult(Error(Interrupted SentinelMissing))) ]
+                5
+                (fun _ -> true)
+        let! report = SimFramework.run boom 1L
+        Assert.False(report.SignedOff)
+        match report.Final with
+        | Error (Interrupted SentinelMissing) -> ()
+        | other -> Assert.Fail(sprintf "expected the interrupt, got %A" other)
+    }

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -131,10 +131,12 @@
     <Compile Include="DevRoomTick.Tests.fs" />
     <Compile Include="FourCorner.Tests.fs" />
     <Compile Include="FourCornerFusion.Tests.fs" />
+    <Compile Include="FourCornerTreaty.Tests.fs" />
     <Compile Include="SoftScheduler.Tests.fs" />
     <Compile Include="SoftThrottle.Tests.fs" />
     <Compile Include="RecordedSource.Tests.fs" />
     <Compile Include="SoftIsr.Tests.fs" />
+    <Compile Include="SimFramework.Tests.fs" />
     <Compile Include="SoftChip8Scheduler.Tests.fs" />
     <Compile Include="BitAdinkra.Tests.fs" />
     <Compile Include="ForwardMomentum.Tests.fs" />
@@ -422,5 +424,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="YamlDotNet" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="four-corner-golden.lines">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 </Project>

--- a/tests/Tests.FSharp/four-corner-golden.lines
+++ b/tests/Tests.FSharp/four-corner-golden.lines
@@ -1,0 +1,10 @@
+# four-corner-golden.lines — the FourCornerOwnership treaty golden vectors (B-1022 trigger fired:
+# "we are the consumer for our treaties"). One canonical line per vector; the F# oracle locks these
+# bytes; C#/TS/Rust conform to the SAME lines. Format:
+#   fourcorner1<TAB>esc(tIn)<TAB>opt<TAB>opt<TAB>opt   where opt = "-" | "+"+esc(value)
+# Escapes: \\ \t \n \r. Lines starting with # are comments.
+fourcorner1	operator-message	+emitted	+conv-feedback	+co-owned-ack
+fourcorner1	only-input	-	-	-
+fourcorner1	tab\there\nand-newline	+back\\slash	-	+ends-with-tab\t
+fourcorner1		+	-	-
+fourcorner1	héllo-wörld-⊕-unicode	-	+反馈	-


### PR DESCRIPTION
The stacked pair went CONFLICTING after #7592's squash. One clean re-land: the hexagonal sim-framework port + charter doc + the FourCorner treaty byte-lock (F# oracle locked, golden lines). 8/8, 0 warnings.