### PR TITLE
feat(core): MeshPong — pong over the mesh; lockstep treaty + anti-cheat demonstrated

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -145,6 +145,7 @@
     <Compile Include="SoftThrottle.fs" />
     <Compile Include="RecordedSource.fs" />
     <Compile Include="SimFramework.fs" />
+    <Compile Include="MeshPong.fs" />
     <Compile Include="SagaBuilder.fs" />
     <Compile Include="ChaosEnv.fs" />
     <Compile Include="HigherOrder.fs" />

--- a/src/Core/MeshPong.fs
+++ b/src/Core/MeshPong.fs
@@ -1,0 +1,148 @@
+namespace Zeta.Core
+
+open System.Threading.Tasks
+
+/// MeshPong — **pong over the mesh: the first playable integration artifact** (the demo named in the
+/// game-physics-over-Reticulum doc).
+///
+/// The **lockstep model** (Age of Empires "1500 archers" / GGPO's core trick), on our substrate: **only
+/// INPUTS travel as membrane crossings; the seed carries the world.** Two rooms each replay the SAME
+/// recorded input crossings (`RecordedSource`) and independently simulate the WHOLE game. Because the
+/// physics is a pure **integer** fold (no floats ⇒ byte-stable), their final states must agree exactly —
+/// **agreement = the treaty holding; divergence = desync = a treaty violation, detected by comparison**.
+/// A tampered crossing is caught the same way: **anti-cheat = noninterference, demonstrated in a test.**
+///
+/// This demo also EARNED a substrate improvement: lockstep needs the crossing's PAYLOAD, which exposed
+/// that `SoftScheduler.Handler` never received the arrival — hence the additive `HandlerK`/`driveK` +
+/// `SimFramework.RoomK` (arrival-aware rooms). Pure module; deterministic; DST throughout. The integer
+/// game is portable to the other three oracles (a future game-state treaty).
+[<RequireQualifiedAccess>]
+module MeshPong =
+
+    [<Literal>]
+    let Width = 16
+
+    [<Literal>]
+    let Height = 9
+
+    [<Literal>]
+    let PaddleLen = 3
+
+    /// The whole game — small, integer, byte-stable.
+    type Game =
+        { BallX: int
+          BallY: int
+          VX: int
+          VY: int
+          PaddleA: int // top row of paddle A (left wall)
+          PaddleB: int // top row of paddle B (right wall)
+          ScoreA: int
+          ScoreB: int }
+
+    /// Center serve, heading right-down.
+    let create () : Game =
+        { BallX = Width / 2
+          BallY = Height / 2
+          VX = 1
+          VY = 1
+          PaddleA = Height / 2 - 1
+          PaddleB = Height / 2 - 1
+          ScoreA = 0
+          ScoreB = 0 }
+
+    let private clampPaddle (p: int) = max 0 (min (Height - PaddleLen) p)
+
+    let private serve (vx: int) (g: Game) =
+        { g with BallX = Width / 2; BallY = Height / 2; VX = vx; VY = 1 }
+
+    /// One lockstep tick: both players' inputs (each clamped to {-1,0,+1}) + the pure physics fold.
+    let step (inputA: int) (inputB: int) (g: Game) : Game =
+        let g =
+            { g with
+                PaddleA = clampPaddle (g.PaddleA + max -1 (min 1 inputA))
+                PaddleB = clampPaddle (g.PaddleB + max -1 (min 1 inputB)) }
+
+        let nx = g.BallX + g.VX
+        let nyRaw = g.BallY + g.VY
+        // bounce top/bottom
+        let vy, ny =
+            if nyRaw < 0 || nyRaw >= Height then -g.VY, g.BallY - g.VY else g.VY, nyRaw
+
+        if nx <= 0 then
+            if ny >= g.PaddleA && ny < g.PaddleA + PaddleLen then
+                { g with BallX = 1; BallY = ny; VX = 1; VY = vy } // A saves
+            else
+                serve -1 { g with ScoreB = g.ScoreB + 1 } // B scores; serve toward A
+        elif nx >= Width - 1 then
+            if ny >= g.PaddleB && ny < g.PaddleB + PaddleLen then
+                { g with BallX = Width - 2; BallY = ny; VX = -1; VY = vy } // B saves
+            else
+                serve 1 { g with ScoreA = g.ScoreA + 1 } // A scores; serve toward B
+        else
+            { g with BallX = nx; BallY = ny; VY = vy }
+
+    // ── The mesh wiring: inputs are the ONLY crossings ──
+
+    /// Deterministic input pair for a tick (each ∈ {-1,0,+1}) — the stand-in "controllers"; with real
+    /// players the wire shape is identical (a Reticulum packet carrying the same payload).
+    let inputsAt (seed: int64) (tick: int) : int * int =
+        let h = SplitMix64.mix (uint64 seed + uint64 tick * SplitMix64.GoldenRatio)
+        (int (h % 3UL)) - 1, (int ((h >>> 8) % 3UL)) - 1
+
+    /// Encode a tick's input pair as the crossing payload (text — the treaty register).
+    let encodeInputs (a: int) (b: int) : string = sprintf "pong:%d,%d" a b
+
+    /// Parse a crossing payload back to the input pair (None = not a pong input — honest refusal).
+    let parseInputs (payload: string) : (int * int) option =
+        if payload.StartsWith "pong:" then
+            match payload.Substring(5).Split(',') with
+            | [| a; b |] ->
+                match System.Int32.TryParse a, System.Int32.TryParse b with
+                | (true, ia), (true, ib) -> Some(ia, ib)
+                | _ -> None
+            | _ -> None
+        else
+            None
+
+    /// The "controllers" membrane: each tick, both players' inputs cross as ONE message.
+    let inputsSource (seed: int64) : SoftScheduler.Source =
+        fun tick ->
+            let a, b = inputsAt seed tick
+            [ OperatorMessageArrived(encodeInputs a b) ]
+
+    /// The lockstep handler — arrival-AWARE: reads the crossing's payload, steps the pure physics.
+    /// A non-pong payload is skipped (state unchanged) — the membrane may carry other traffic.
+    let lockstepHandler: SoftScheduler.HandlerK<Game> =
+        SoftScheduler.handlerK
+            "pong-lockstep"
+            (function
+            | OperatorMessageArrived _ -> true
+            | _ -> false)
+            (fun intr _ctx g ->
+                match intr with
+                | OperatorMessageArrived payload ->
+                    match parseInputs payload with
+                    | Some (a, b) -> Task.FromResult(Ok(step a b g))
+                    | None -> Task.FromResult(Ok g)
+                | _ -> Task.FromResult(Ok g))
+
+    /// A pong room over a given membrane. Resolves (signs off) when anyone scores `toWin` points.
+    let room (name: string) (source: int64 -> SoftScheduler.Source) (budget: int) (toWin: int) : SimFramework.RoomK<Game> =
+        { Name = name
+          Initial = fun _ -> create ()
+          HandlersK = [ lockstepHandler ]
+          Source = source
+          Budget = budget
+          Resolved = fun g -> g.ScoreA >= toWin || g.ScoreB >= toWin }
+
+    /// **Play a match over the mesh**: record the input crossings once (the "network session"), then TWO
+    /// rooms each replay the same recording and simulate independently. Returns (recording, reportA,
+    /// reportB) — the lockstep treaty check is `reportA.Final = reportB.Final` (byte-equal worlds).
+    let playMatch (seed: int64) (budget: int) (toWin: int) =
+        task {
+            let recording = RecordedSource.record (inputsSource seed) budget
+            let replay = fun (_: int64) -> RecordedSource.replay recording
+            let! reportA = SimFramework.runK (room "pong-room-A" replay budget toWin) seed
+            let! reportB = SimFramework.runK (room "pong-room-B" replay budget toWin) seed
+            return recording, reportA, reportB
+        }

--- a/src/Core/SimFramework.fs
+++ b/src/Core/SimFramework.fs
@@ -96,3 +96,38 @@ module SimFramework =
 
     /// Run a room on the default harness (the common path).
     let run (r: Room<'S>) (seed: int64) : Task<RoomReport<'S>> = harness.Run(r, seed)
+
+    // ── Arrival-aware rooms (additive, 2026-06-11) — for rooms that fold crossing PAYLOADS (lockstep) ──
+
+    /// A room whose handlers receive the matched crossing itself (`SoftScheduler.HandlerK`).
+    type RoomK<'S> =
+        { Name: string
+          Initial: int64 -> 'S
+          HandlersK: SoftScheduler.HandlerK<'S> list
+          Source: int64 -> SoftScheduler.Source
+          Budget: int
+          Resolved: 'S -> bool }
+
+    /// Run an arrival-aware room on the default deterministic harness shape (driveK at DoP=1).
+    let runK (r: RoomK<'S>) (seed: int64) : Task<RoomReport<'S>> =
+        task {
+            let ctx: IntrCtx =
+                { Memetic = "sim:" + r.Name
+                  Prompt = ""
+                  Trust = ""
+                  Log = ""
+                  Otel = System.Diagnostics.ActivityContext() }
+
+            let! final = (SoftScheduler.driveK r.HandlersK (r.Source seed)).Run ctx seed (r.Initial seed) r.Budget
+
+            let signedOff =
+                match final with
+                | Ok s -> r.Resolved s
+                | Error _ -> false
+
+            return
+                { Room = r.Name
+                  Ticks = r.Budget
+                  Final = final
+                  SignedOff = signedOff }
+        }

--- a/src/Core/SoftScheduler.fs
+++ b/src/Core/SoftScheduler.fs
@@ -100,3 +100,49 @@ module SoftScheduler =
     /// path — null I/O). Returns the final state or the interrupt that stopped it.
     let runDeterministic (handlers: Handler<'S> list) (ctx: IntrCtx) (seed: int64) (initial: 'S) (budget: int) : Task<Result<'S, InterruptFeedback>> =
         (drive handlers (seedSource seed)).Run ctx seed initial budget
+
+    // ── Arrival-AWARE handlers (additive, 2026-06-11; discovered by the MeshPong lockstep demo) ──
+    // `Handler.Run` never sees the arrival itself, so a room cannot read a crossing's PAYLOAD (e.g. an
+    // input message). `HandlerK` passes the matched `InterruptKind` to the arrow — needed by any room
+    // that folds message contents (lockstep inputs, operator messages). `Handler`/`drive` untouched.
+
+    /// An arrival-aware handler: `RunK` receives the matched crossing (its content), then the state.
+    type HandlerK<'S> =
+        { Name: string
+          Matches: InterruptKind -> bool
+          RunK: InterruptKind -> ISR<'S, 'S> }
+
+    /// Build an arrival-aware handler.
+    let handlerK (name: string) (matches: InterruptKind -> bool) (runK: InterruptKind -> ISR<'S, 'S>) : HandlerK<'S> =
+        { Name = name; Matches = matches; RunK = runK }
+
+    /// Drive arrival-aware handlers — same single cooperative loop as `drive` (DoP=1, deterministic,
+    /// stops on first Error), but the matched arrival is handed to the arrow.
+    let driveK (handlers: HandlerK<'S> list) (source: Source) : ISoftScheduler<'S> =
+        let hs = List.toArray handlers
+        { new ISoftScheduler<'S> with
+            member _.Run ctx seed initial budget =
+                task {
+                    let mutable state = initial
+                    let mutable err: InterruptFeedback option = None
+                    let mutable n = 0
+                    while n < budget && Option.isNone err do
+                        let arrivals = source n |> List.toArray
+                        let mutable a = 0
+                        while a < arrivals.Length && Option.isNone err do
+                            let intr = arrivals.[a]
+                            let mutable hI = 0
+                            while hI < hs.Length && Option.isNone err do
+                                let h = hs.[hI]
+                                if h.Matches intr then
+                                    let! res = h.RunK intr ctx state
+                                    match res with
+                                    | Ok s -> state <- s
+                                    | Error e -> err <- Some e
+                                hI <- hI + 1
+                            a <- a + 1
+                        n <- n + 1
+                    match err with
+                    | Some e -> return Error e
+                    | None -> return Ok state
+                } }

--- a/tests/Tests.FSharp/MeshPong.Tests.fs
+++ b/tests/Tests.FSharp/MeshPong.Tests.fs
@@ -1,0 +1,81 @@
+module Zeta.Tests.MeshPongTests
+
+// Pong over the mesh — the integration artifact: rooms + scheduler + recorded membranes + the lockstep
+// treaty. Two rooms replay the same crossings and must agree byte-for-byte; a tampered crossing is
+// CAUGHT as desync (anti-cheat = noninterference, demonstrated).
+
+open global.Xunit
+open Zeta.Core
+
+[<Fact>]
+let ``lockstep parity: two rooms replaying the same crossings produce BYTE-EQUAL worlds (the treaty holds)`` () =
+    task {
+        let! _, a, b = MeshPong.playMatch 42L 400 1
+        Assert.Equal<Result<MeshPong.Game, InterruptFeedback>>(a.Final, b.Final)
+    }
+
+[<Fact>]
+let ``the match resolves: someone scores and both rooms sign off together`` () =
+    task {
+        let! _, a, b = MeshPong.playMatch 42L 400 1
+        Assert.True(a.SignedOff)
+        Assert.Equal(a.SignedOff, b.SignedOff)
+        match a.Final with
+        | Ok g -> Assert.True(g.ScoreA + g.ScoreB >= 1)
+        | Error e -> Assert.Fail(sprintf "match errored: %A" e)
+    }
+
+[<Fact>]
+let ``DST: the same match replays identically (same seed => same recording => same world)`` () =
+    task {
+        let! rec1, a1, _ = MeshPong.playMatch 7L 200 99
+        let! rec2, a2, _ = MeshPong.playMatch 7L 200 99
+        Assert.Equal<Map<int, InterruptKind list>>(rec1.Crossings, rec2.Crossings)
+        Assert.Equal<Result<MeshPong.Game, InterruptFeedback>>(a1.Final, a2.Final)
+    }
+
+[<Fact>]
+let ``ANTI-CHEAT: a tampered crossing causes detectable desync (the treaty violation surfaces)`` () =
+    task {
+        let recording = RecordedSource.record (MeshPong.inputsSource 42L) 300
+        // the cheat: from tick 10 on, player A's input is doctored in ONE room's copy of the session
+        // (a sustained aimbot-style cheat; a single-tick nudge can wash out under paddle clamping —
+        // honest physics — so the test uses a cheat that actually pays, which is the kind worth catching)
+        let tampered: RecordedSource.Recording =
+            { Crossings =
+                recording.Crossings
+                |> Map.map (fun tick arrivals ->
+                    if tick >= 10 then
+                        match arrivals with
+                        | [ OperatorMessageArrived payload ] ->
+                            match MeshPong.parseInputs payload with
+                            | Some (_, b) -> [ OperatorMessageArrived(MeshPong.encodeInputs 1 b) ]
+                            | None -> arrivals
+                        | _ -> arrivals
+                    else
+                        arrivals) }
+        let honest = MeshPong.room "honest" (fun _ -> RecordedSource.replay recording) 300 99
+        let cheated = MeshPong.room "cheated" (fun _ -> RecordedSource.replay tampered) 300 99
+        let! ra = SimFramework.runK honest 42L
+        let! rb = SimFramework.runK cheated 42L
+        // the worlds diverge — desync detected by the lockstep comparison = the cheat is CAUGHT
+        Assert.NotEqual<Result<MeshPong.Game, InterruptFeedback>>(ra.Final, rb.Final)
+    }
+
+[<Fact>]
+let ``physics sanity: the ball stays in bounds and paddles stay clamped over a long rally`` () =
+    let mutable g = MeshPong.create ()
+    for t in 0..999 do
+        let a, b = MeshPong.inputsAt 5L t
+        g <- MeshPong.step a b g
+        Assert.InRange(g.BallX, 0, MeshPong.Width - 1)
+        Assert.InRange(g.BallY, 0, MeshPong.Height - 1)
+        Assert.InRange(g.PaddleA, 0, MeshPong.Height - MeshPong.PaddleLen)
+        Assert.InRange(g.PaddleB, 0, MeshPong.Height - MeshPong.PaddleLen)
+
+[<Fact>]
+let ``the payload codec round-trips and refuses non-pong traffic honestly`` () =
+    Assert.Equal(Some(1, -1), MeshPong.parseInputs (MeshPong.encodeInputs 1 -1))
+    Assert.Equal(Some(0, 0), MeshPong.parseInputs "pong:0,0")
+    Assert.True((MeshPong.parseInputs "chat:hello").IsNone)
+    Assert.True((MeshPong.parseInputs "pong:x,y").IsNone)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -138,6 +138,7 @@
     <Compile Include="RecordedSource.Tests.fs" />
     <Compile Include="SoftIsr.Tests.fs" />
     <Compile Include="SimFramework.Tests.fs" />
+    <Compile Include="MeshPong.Tests.fs" />
     <Compile Include="SoftChip8Scheduler.Tests.fs" />
     <Compile Include="BitAdinkra.Tests.fs" />
     <Compile Include="ForwardMomentum.Tests.fs" />


### PR DESCRIPTION
The named demo, built: lockstep (only inputs travel; the seed carries the world) — two rooms replay the same recorded crossings and produce byte-equal worlds (treaty holds); a sustained doctored-input cheat causes detectable desync (anti-cheat = noninterference, executable). Earned substrate: arrival-aware HandlerK/driveK + RoomK (Handler.Run never saw the crossing payload — found by integration). Integer physics, portable to the other oracles. 6/6, 0 warnings.