### PR TITLE
feat(core): SoftChip8Flux — flux-metered speculation + input as a membrane crossing

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -217,6 +217,7 @@
     <Compile Include="Chip8Cow.fs" />
     <Compile Include="SoftChip8.fs" />
     <Compile Include="SoftChip8Scheduler.fs" />
+    <Compile Include="SoftChip8Flux.fs" />
     <Compile Include="Chip8Observer.fs" />
     <Compile Include="SoftController.fs" />
     <Compile Include="ActionGrammar.fs" />

--- a/src/Core/SoftChip8Flux.fs
+++ b/src/Core/SoftChip8Flux.fs
@@ -1,0 +1,106 @@
+namespace Zeta.Core
+
+open System.Threading.Tasks
+
+/// SoftChip8Flux — **flux-metered speculation + input as a membrane crossing** (the RESUME queue's #3;
+/// the flux-capacitor doc's named next slice: "SoftValue/tank-funded lookAhead depth").
+///
+/// Two pieces, both additive over proven code:
+///
+/// 1. **`lookAheadFunded`** — `SoftChip8.lookAhead` with the depth knob replaced by the **flux tank**:
+///    each speculated step must be *funded* (the Bennett/byte budget — "it meters the future in bytes,
+///    literally"). Idle ticks recharge the tank ⇒ after quiet periods the emulator can speculate DEEPER
+///    (banked time-travel capacity discharging in a burst) — the resonant behavior, not a fixed ceiling.
+///    Speculation still stops early at an input branch (the only genuine fork).
+///
+/// 2. **Input as a crossing** — CHIP-8 keys arrive as `OperatorMessageArrived "key:<idx>:<0|1>"` membrane
+///    crossings (arrival-aware `HandlerK`), wired to the frame's `Keys`. This is the **present-crossing
+///    leg of the flux capacitor**: the input arriving is what RESOLVES the speculative forks
+///    (`SoftChip8.branchesOnInput` waits on exactly this). With real players, the same payload rides a
+///    Reticulum packet — the wire shape is identical (the MeshPong pattern).
+[<RequireQualifiedAccess>]
+module SoftChip8Flux =
+
+    // ── 1. Flux-funded speculation ──
+
+    /// Speculate ahead while (a) the tank funds each step at `costPerStep` and (b) no input branch is
+    /// hit. Returns (frame', hitBranch, stepsTaken, tank'). The depth is no longer a constant — it is
+    /// whatever the banked flux affords RIGHT NOW (deep after idle, shallow under load).
+    let lookAheadFunded
+        (costPerStep: float)
+        (tank: SoftThrottle.Tank)
+        (f: Chip8Cow.Frame)
+        : Chip8Cow.Frame * bool * int * SoftThrottle.Tank =
+        let mutable state = f
+        let mutable t = tank
+        let mutable steps = 0
+        let mutable stop = false
+        let mutable hitBranch = false
+
+        while not stop do
+            if SoftChip8.branchesOnInput state then
+                hitBranch <- true
+                stop <- true
+            else
+                match SoftThrottle.discharge costPerStep t with
+                | Some t' ->
+                    state <- Chip8Cow.step state
+                    t <- t'
+                    steps <- steps + 1
+                | None -> stop <- true // out of flux — the future is metered
+
+        state, hitBranch, steps, t
+
+    // ── 2. Input as a membrane crossing ──
+
+    /// Encode a key event as the crossing payload (text — the treaty register).
+    let encodeKey (idx: int) (down: bool) : string =
+        sprintf "key:%d:%d" (idx &&& 0xF) (if down then 1 else 0)
+
+    /// Parse a key-event payload (None = not a key event — honest refusal; other traffic passes by).
+    let parseKey (payload: string) : (int * bool) option =
+        if payload.StartsWith "key:" then
+            match payload.Substring(4).Split(':') with
+            | [| i; d |] ->
+                match System.Int32.TryParse i, System.Int32.TryParse d with
+                | (true, idx), (true, down) when idx >= 0 && idx <= 15 && (down = 0 || down = 1) ->
+                    Some(idx, (down = 1))
+                | _ -> None
+            | _ -> None
+        else
+            None
+
+    /// Apply a key event to a frame (COW — fresh Keys array; parent untouched).
+    let applyKey (idx: int) (down: bool) (f: Chip8Cow.Frame) : Chip8Cow.Frame =
+        let keys = Array.copy f.Keys
+        keys.[idx &&& 0xF] <- down
+        { f with Keys = keys }
+
+    /// The input handler — arrival-AWARE: a key crossing updates the frame's Keys (the present arriving;
+    /// the speculative forks resolve against exactly this). Non-key traffic is skipped unchanged.
+    let inputHandler: SoftScheduler.HandlerK<Chip8Cow.Frame> =
+        SoftScheduler.handlerK
+            "chip8-input"
+            (function
+            | OperatorMessageArrived _ -> true
+            | _ -> false)
+            (fun intr _ctx f ->
+                match intr with
+                | OperatorMessageArrived payload ->
+                    match parseKey payload with
+                    | Some (idx, down) -> Task.FromResult(Ok(applyKey idx down f))
+                    | None -> Task.FromResult(Ok f)
+                | _ -> Task.FromResult(Ok f))
+
+    /// The 60Hz timer handler in arrival-aware form (timers tick + CPU advances a fixed batch) — so a
+    /// full CHIP-8 room can run input + timer on ONE `driveK` loop.
+    let timerHandler (cyclesPerTick: int) : SoftScheduler.HandlerK<Chip8Cow.Frame> =
+        SoftScheduler.handlerK
+            "chip8-60hz"
+            (function
+            | TimerElapsed _ -> true
+            | _ -> false)
+            (fun _ _ctx f ->
+                let ticked = Chip8Cow.tick f
+                let advanced, _ = SoftChip8.lookAhead cyclesPerTick ticked
+                Task.FromResult(Ok advanced))

--- a/tests/Tests.FSharp/SoftChip8Flux.Tests.fs
+++ b/tests/Tests.FSharp/SoftChip8Flux.Tests.fs
@@ -1,0 +1,79 @@
+module Zeta.Tests.SoftChip8FluxTests
+
+// Flux-metered speculation: the tank funds lookAhead depth (the time-travel budget made real);
+// CHIP-8 input arrives as a membrane crossing and resolves the speculative forks.
+
+open System.Threading.Tasks
+open global.Xunit
+open Zeta.Core
+
+// ROM: 6A0C (V[A]=0x0C); 1202 (jump loop) — pure deterministic line, never branches on input.
+let private loopRom = [| 0x6Auy; 0x0Cuy; 0x12uy; 0x02uy |]
+// ROM: EA9E (skip if key V[A] pressed) at 0x200 — branches on input IMMEDIATELY.
+let private inputRom = [| 0xEAuy; 0x9Euy; 0x12uy; 0x00uy |]
+
+let private frameWith (rom: byte[]) =
+    Chip8Cow.create 1UL |> Chip8Cow.loadRom rom
+
+[<Fact>]
+let ``the tank meters the future: speculation depth = what the flux affords, not a constant`` () =
+    let f = frameWith loopRom
+    // 5 units of flux at 1.0/step => exactly 5 speculated steps, then "out of flux"
+    let _, hitBranch, steps, tank' = SoftChip8Flux.lookAheadFunded 1.0 (SoftThrottle.tank 5.0 1.0) f
+    Assert.False(hitBranch)
+    Assert.Equal(5, steps)
+    Assert.Equal(0.0, SoftThrottle.available tank', 12)
+
+[<Fact>]
+let ``idle recharge buys DEEPER speculation (banked time-travel discharging in a burst)`` () =
+    let f = frameWith loopRom
+    let drained = SoftThrottle.tank 3.0 1.5
+    let _, _, steps1, t1 = SoftChip8Flux.lookAheadFunded 1.0 drained f
+    Assert.Equal(3, steps1)
+    // two idle ticks recharge 3.0 (capped at capacity) => the next burst goes deep again
+    let recharged = t1 |> SoftThrottle.charge |> SoftThrottle.charge
+    let _, _, steps2, _ = SoftChip8Flux.lookAheadFunded 1.0 recharged f
+    Assert.Equal(3, steps2)
+
+[<Fact>]
+let ``speculation STOPS at an input branch regardless of remaining flux (the genuine fork)`` () =
+    let f = frameWith inputRom
+    let _, hitBranch, steps, tank' = SoftChip8Flux.lookAheadFunded 1.0 (SoftThrottle.tank 100.0 1.0) f
+    Assert.True(hitBranch)
+    Assert.Equal(0, steps) // branched on the very first opcode
+    Assert.Equal(100.0, SoftThrottle.available tank', 12) // no flux spent on an unresolvable future
+
+[<Fact>]
+let ``input arrives as a crossing and RESOLVES the fork (the present-crossing leg)`` () =
+    task {
+        // a room: input handler + timer handler on one driveK loop; key A pressed at tick 1
+        let source: SoftScheduler.Source =
+            fun tick ->
+                [ yield TimerElapsed 17
+                  if tick = 1 then yield OperatorMessageArrived(SoftChip8Flux.encodeKey 0xC true) ]
+        let ctx: IntrCtx =
+            { Memetic = "flux"; Prompt = ""; Trust = ""; Log = ""; Otel = System.Diagnostics.ActivityContext() }
+        let handlers = [ SoftChip8Flux.inputHandler; SoftChip8Flux.timerHandler 2 ]
+        let! r = (SoftScheduler.driveK handlers source).Run ctx 1L (frameWith loopRom) 5
+        match r with
+        | Ok f ->
+            Assert.True(f.Keys.[0xC]) // the crossing landed in the frame
+            Assert.Equal(0x0Cuy, f.V.[0xA]) // and the CPU still ran
+        | Error e -> Assert.Fail(sprintf "room errored: %A" e)
+    }
+
+[<Fact>]
+let ``the key codec round-trips and refuses non-key traffic honestly`` () =
+    Assert.Equal(Some(0xC, true), SoftChip8Flux.parseKey (SoftChip8Flux.encodeKey 0xC true))
+    Assert.Equal(Some(3, false), SoftChip8Flux.parseKey "key:3:0")
+    Assert.True((SoftChip8Flux.parseKey "pong:1,1").IsNone)
+    Assert.True((SoftChip8Flux.parseKey "key:16:1").IsNone) // out of range
+    Assert.True((SoftChip8Flux.parseKey "key:3:2").IsNone) // bad state
+
+[<Fact>]
+let ``DST: funded speculation replays identically (same frame, same tank => same result)`` () =
+    let f = frameWith loopRom
+    let run () = SoftChip8Flux.lookAheadFunded 1.0 (SoftThrottle.tank 7.0 1.0) f
+    let a = run ()
+    let b = run ()
+    Assert.Equal(a, b)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -141,6 +141,7 @@
     <Compile Include="MeshPong.Tests.fs" />
     <Compile Include="MeshPongTreaty.Tests.fs" />
     <Compile Include="MembraneLogTreaty.Tests.fs" />
+    <Compile Include="SoftChip8Flux.Tests.fs" />
     <Compile Include="SoftChip8Scheduler.Tests.fs" />
     <Compile Include="BitAdinkra.Tests.fs" />
     <Compile Include="ForwardMomentum.Tests.fs" />


### PR DESCRIPTION
Queue #3: lookAheadFunded (the tank funds each speculated step — depth = what the banked flux affords; idle recharge buys deeper bursts; a fork stops speculation with ZERO flux spent) + CHIP-8 keys as OperatorMessageArrived crossings resolving the forks (the present-crossing leg; HandlerK; same wire shape for Reticulum later). 6/6, 0 warnings, all additive.