### PR TITLE
feat(core): the salon as a LinguisticSeed.Pack — room = seed+extensions+parameters made literal

### DIFF
--- a/docs/trajectories/sim-mea-cut-soft-substrate-shaders/RESUME.md
+++ b/docs/trajectories/sim-mea-cut-soft-substrate-shaders/RESUME.md
@@ -72,12 +72,13 @@ meters the speculative future in BYTES.
 3. **Flux-metered speculation**: SoftValue/tank-funded `lookAhead` depth+breadth in SoftChip8 (the
    throttler already owns the knob conceptually); CHIP-8 INPUT as scheduler arrivals (forkOnInput wired
    to the present-crossing leg).
-4. **FerryThrottler ⇄ SoftThrottle cross-pollination** (Aaron asked): hard gains = adopt the ported
-   Limiter-as-fold for boat assembly (restores the Itron original's pluggability; count+bytes become
-   instances), Tank-funded dynamic MaxBatchBytes (bank idle capacity → resonant bursts), gradient
-   front-door before EnqueueAsync (pressure = depth/MaxQueueSize). Soft gains (later, with triggers):
-   partition-keyed multi-boat state (BatchThrottler's CompareBatchByCreated) when multi-stream arrives.
-5. **Salon as a LinguisticSeed.Pack** (room = seed+extensions+parameters made literal) · conformal-GA
+4. ~~FerryThrottler ⇄ SoftThrottle cross-pollination~~ **DEFERRED-WITH-TRIGGERS (Rodney verdict
+   2026-06-11):** the boat loop already IMPLEMENTS Aaron's count+bytes limiter pair, tight and proven —
+   generalizing the hot path with no third limiter kind demanding it = accidental complexity. Reopen
+   triggers: Limiter-as-fold into boats WHEN a third limiter kind has a consumer; Tank-funded
+   MaxBatchBytes WHEN a resonance consumer measures it (Naledi bench first); gradient front-door WHEN a
+   queue-depth surface is exposed. Soft side: partition-keyed multi-boat when multi-stream arrives.
+5. ~~Salon as a LinguisticSeed.Pack~~ **DONE 2026-06-11** (Salon.seedPack — Jaccard/min-max kernel is PSD, the Mercer witness holds; Salon.asRoom = seed+extensions+parameters literal; OCP proven: an added pack lifts the room over its threshold without editing it) · conformal-GA
    slice (Cl3's flagged "Sequoia soft memory distance") · B-1023 (gated) · B-0945 substrate.
 6. Loose: sim/mea/cut console binary; the floated outside-cube verbs (rem/whe/pay/att/how/man/whi/way —
    Aaron's call); shader memory/GC; Q# golden vectors (Vera).

--- a/src/Core/Salon.fs
+++ b/src/Core/Salon.fs
@@ -71,3 +71,37 @@ module Salon =
 
     /// The stations that are working slices today (Live = true) — what you can actually use at the salon now.
     let liveStations: Station list = stations |> List.filter (fun s -> s.Live)
+
+    // ── The salon as a LinguisticSeed.Pack (room = seed + extensions + parameters, made literal) ──
+    // The salon's soft-tie similarity IS a kernel: Jaccard over MinHash sketches is the min-max kernel,
+    // PSD (Gärtner; the min-max/Jaccard kernel literature) — so the salon's offerings compose into the
+    // seed language under Mercer closure, and a salon ROOM is literally seed + extensions(Pack) +
+    // parameters(budget/threshold), ticking to its sign-off.
+
+    /// The Jaccard (min-max) kernel over byte strands — the soft tie's similarity, kernel-shaped. PSD.
+    let jaccardKernel: LinguisticSeed.Kernel<byte[]> =
+        fun a b -> FingerprintPrism.softBytesSimilarity (FingerprintPrism.softBytes a) (FingerprintPrism.softBytes b)
+
+    /// The salon's extension pack — its kernels, composable into any seed (OCP: add, never edit).
+    let seedPack: LinguisticSeed.Pack<byte[]> =
+        LinguisticSeed.pack
+            "salon"
+            [ "tie-jaccard", jaccardKernel
+              "exact", LinguisticSeed.indicator ]
+
+    /// A salon ROOM, literally `seed + extensions + parameters`: state = the running kernel evaluation
+    /// of two strands under the COMPOSED pack (seed ∪ salon extensions); parameters = budget + the
+    /// sign-off threshold; resolves when the composed kernel clears it.
+    let asRoom (extraPacks: LinguisticSeed.Pack<byte[]> list) (a: byte[]) (b: byte[]) (budget: int) (threshold: float) : SimFramework.Room<float> =
+        let kernel = LinguisticSeed.composePacks (seedPack :: extraPacks)
+        SimFramework.room
+            "salon-room"
+            (fun _ -> 0.0)
+            [ SoftScheduler.handler
+                  "salon-kernel"
+                  (function
+                  | TimerElapsed _ -> true
+                  | _ -> false)
+                  (fun _ _ -> System.Threading.Tasks.Task.FromResult(Ok(kernel a b))) ]
+            budget
+            (fun v -> v >= threshold)

--- a/tests/Tests.FSharp/SalonPack.Tests.fs
+++ b/tests/Tests.FSharp/SalonPack.Tests.fs
@@ -1,0 +1,63 @@
+module Zeta.Tests.SalonPackTests
+
+// The salon as a LinguisticSeed.Pack — room = seed + extensions + parameters, made literal.
+// The soft tie's Jaccard similarity IS a PSD kernel (the min-max kernel), so the salon composes into
+// the seed language under Mercer closure, and a salon room runs to sign-off on the harness.
+
+open System.Text
+open global.Xunit
+open Zeta.Core
+
+let private b (s: string) = Encoding.UTF8.GetBytes s
+
+// byte-strand samples + test vectors for the PSD (Mercer) witness
+let private xs =
+    [| b "the quick brown fox jumps over the lazy dog"
+       b "the quick brown fox JUMPED over the lazy dog"
+       b "completely unrelated payload 99999 zzzz"
+       b "the quick brown fox"
+       b "" |]
+
+let private vs =
+    [| [| 1.0; 1.0; 1.0; 1.0; 1.0 |]
+       [| 1.0; -1.0; 1.0; -1.0; 1.0 |]
+       [| 2.0; -3.0; 0.5; 1.0; -2.0 |]
+       [| -1.0; 2.0; 0.0; -2.0; 1.0 |] |]
+
+let private isPSD (k: LinguisticSeed.Kernel<byte[]>) =
+    vs |> Array.forall (fun v -> LinguisticSeed.quadForm k xs v >= -1e-9)
+
+[<Fact>]
+let ``the Jaccard (min-max) kernel is PSD over byte strands (the Mercer witness holds)`` () =
+    Assert.True(isPSD Salon.jaccardKernel)
+
+[<Fact>]
+let ``the salon pack composes into the seed under Mercer closure and stays PSD`` () =
+    let composed = LinguisticSeed.composePacks [ Salon.seedPack ]
+    Assert.True(isPSD composed)
+    Assert.Equal<string list>([ "salon.tie-jaccard"; "salon.exact" ], LinguisticSeed.packNames [ Salon.seedPack ])
+
+[<Fact>]
+let ``a salon ROOM = seed + extensions + parameters: near strands resolve, far strands hold`` () =
+    task {
+        let near = Salon.asRoom [] (b "the quick brown fox jumps over the lazy dog twelve times") (b "the quick brown fox JUMPED over the lazy dog twelve times") 5 0.5
+        let! r1 = SimFramework.run near 1L
+        Assert.True(r1.SignedOff) // jaccard(near) + exact(0) clears 0.5
+        let far = Salon.asRoom [] (b "the quick brown fox") (b "zzzz unrelated 9999") 5 0.5
+        let! r2 = SimFramework.run far 1L
+        Assert.False(r2.SignedOff) // far strands: the room holds (unresolved, not exploded)
+    }
+
+[<Fact>]
+let ``OCP: an extra pack EXTENDS the salon room without editing it (the composed kernel grows)`` () =
+    task {
+        // a constant-boost pack: adds 0.6 to every comparison (PSD: constant kernel)
+        let boost = LinguisticSeed.pack "boost" [ "c", LinguisticSeed.constant 0.6 ]
+        let a, c = b "the quick brown fox", b "zzzz unrelated 9999"
+        let without = Salon.asRoom [] a c 5 0.5
+        let withBoost = Salon.asRoom [ boost ] a c 5 0.5
+        let! r1 = SimFramework.run without 1L
+        let! r2 = SimFramework.run withBoost 1L
+        Assert.False(r1.SignedOff)
+        Assert.True(r2.SignedOff) // the added pack lifted the composed kernel over the threshold
+    }

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -142,6 +142,7 @@
     <Compile Include="MeshPongTreaty.Tests.fs" />
     <Compile Include="MembraneLogTreaty.Tests.fs" />
     <Compile Include="SoftChip8Flux.Tests.fs" />
+    <Compile Include="SalonPack.Tests.fs" />
     <Compile Include="SoftChip8Scheduler.Tests.fs" />
     <Compile Include="BitAdinkra.Tests.fs" />
     <Compile Include="ForwardMomentum.Tests.fs" />


### PR DESCRIPTION
Queue #5: Salon.jaccardKernel (the soft tie IS a PSD kernel — min-max/Jaccard, Mercer witness proven over byte strands) + Salon.seedPack (composable under Mercer closure) + Salon.asRoom (literally seed+extensions+parameters; near strands resolve, far strands hold; OCP proven live — an added pack lifts the room over threshold without editing it). Queue #4 deferred-with-triggers (Rodney verdict: the boat loop already implements the count+bytes limiter pair; no third kind demands generalizing the hot path). 4/4, 0 warnings.