### PR TITLE
feat(core): ConformalGA — points are null vectors, distance is ONE inner product; the memory-RBF kernel joins the seed

### DIFF
--- a/docs/trajectories/sim-mea-cut-soft-substrate-shaders/RESUME.md
+++ b/docs/trajectories/sim-mea-cut-soft-substrate-shaders/RESUME.md
@@ -78,8 +78,7 @@ meters the speculative future in BYTES.
    triggers: Limiter-as-fold into boats WHEN a third limiter kind has a consumer; Tank-funded
    MaxBatchBytes WHEN a resonance consumer measures it (Naledi bench first); gradient front-door WHEN a
    queue-depth surface is exposed. Soft side: partition-keyed multi-boat when multi-stream arrives.
-5. ~~Salon as a LinguisticSeed.Pack~~ **DONE 2026-06-11** (Salon.seedPack — Jaccard/min-max kernel is PSD, the Mercer witness holds; Salon.asRoom = seed+extensions+parameters literal; OCP proven: an added pack lifts the room over its threshold without editing it) · conformal-GA
-   slice (Cl3's flagged "Sequoia soft memory distance") · B-1023 (gated) · B-0945 substrate.
+5. ~~Salon as a LinguisticSeed.Pack~~ **DONE 2026-06-11** (Salon.seedPack — Jaccard/min-max kernel is PSD, the Mercer witness holds; Salon.asRoom = seed+extensions+parameters literal; OCP proven: an added pack lifts the room over its threshold without editing it) · ~~conformal-GA slice~~ **DONE 2026-06-11** (`ConformalGA.fs` — null-vector embedding, distance = ONE inner product, cross-checked vs Cl3.distSq; memory-RBF kernel PSD, composes into the seed) · B-1023 (gated) · B-0945 substrate.
 6. Loose: sim/mea/cut console binary; the floated outside-cube verbs (rem/whe/pay/att/how/man/whi/way —
    Aaron's call); shader memory/GC; Q# golden vectors (Vera).
 

--- a/src/Core/ConformalGA.fs
+++ b/src/Core/ConformalGA.fs
@@ -1,0 +1,63 @@
+namespace Zeta.Core
+
+/// ConformalGA — **the conformal-GA slice `Cl3.fs` flagged as its own next step**: *"conformal GA — a
+/// point is a null vector and distance is a single inner product across embedded points — that is the
+/// next slice for 'Sequoia soft memory distance'."* Now built.
+///
+/// The conformal model Cl(4,1) over our Cl(3,0): embed a Euclidean point `x` as the **null vector**
+/// `P = x + ½|x|²·e∞ + e₀` (null basis: `e∞² = e₀² = 0`, `e∞·e₀ = −1`). Then for two embedded points:
+///
+///     P · Q = −½ |x − y|²        — **distance IS one inner product.**
+///
+/// Why this matters for the substrate (the Sequoia/SoftValue placement doc): memory locations become
+/// points in this space; "how far is this memory" is ONE geometric measurement; tiers are distance
+/// shells. And the **soft** half: the Gaussian RBF over this distance, `exp(P·Q/σ²) = exp(−½d²/σ²)`, is
+/// a **PSD kernel** — so *memory distance composes into the seed language* (`LinguisticSeed`) under
+/// Mercer closure, exactly like the salon's Jaccard kernel. Placement similarity is now a kernel the
+/// packs can carry.
+///
+/// Pure module; floats only in the geometry (the placement *decision* stays a SoftValue upstairs).
+[<RequireQualifiedAccess>]
+module ConformalGA =
+
+    /// A conformal point in the null basis: the Euclidean part (X,Y,Z) + the e∞ weight + the e₀ weight.
+    /// An EMBEDDED point (via `embed`) is null: `inner p p = 0`.
+    type CPoint =
+        { X: float
+          Y: float
+          Z: float
+          WInf: float
+          W0: float }
+
+    /// Embed a Euclidean point as a null conformal vector: `P = x + ½|x|² e∞ + e₀`.
+    let embed (x: float) (y: float) (z: float) : CPoint =
+        { X = x
+          Y = y
+          Z = z
+          WInf = 0.5 * (x * x + y * y + z * z)
+          W0 = 1.0 }
+
+    /// Embed a Cl(3,0) grade-1 vector (the existing geospatial carrier) as a conformal point.
+    let embedMv (v: Cl3.Mv) : CPoint = embed v.E1 v.E2 v.E3
+
+    /// The conformal inner product in the null basis: Euclidean dot MINUS the cross terms
+    /// (`e∞·e₀ = e₀·e∞ = −1`; `e∞² = e₀² = 0`).
+    let inner (p: CPoint) (q: CPoint) : float =
+        p.X * q.X + p.Y * q.Y + p.Z * q.Z - (p.WInf * q.W0 + p.W0 * q.WInf)
+
+    /// Squared Euclidean distance, recovered from ONE inner product: `d² = −2 (P·Q)`.
+    let distSq (p: CPoint) (q: CPoint) : float = -2.0 * inner p q
+
+    /// Is this point on the null cone (an honestly embedded point)? `P·P = 0` within `eps`.
+    let isNull (eps: float) (p: CPoint) : bool = abs (inner p p) <= eps
+
+    /// **The Sequoia soft-memory-distance kernel**: Gaussian RBF over conformal distance,
+    /// `exp(−½ d² / σ²) = exp(inner / σ²)` for embedded points — PSD (the Gaussian kernel), so it
+    /// composes into the seed language under Mercer closure. σ is the locality scale (the tier width).
+    let rbfKernel (sigma: float) : LinguisticSeed.Kernel<CPoint> =
+        let s2 = max 1e-12 (sigma * sigma)
+        fun p q -> exp (inner p q / s2)
+
+    /// The memory-distance extension pack — placement similarity, composable into any seed (OCP).
+    let memoryPack (sigma: float) : LinguisticSeed.Pack<CPoint> =
+        LinguisticSeed.pack "conformal" [ "memory-rbf", rbfKernel sigma ]

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -252,6 +252,7 @@
     <Compile Include="FingerprintPrism.fs" />
     <Compile Include="SoftTie.fs" />
     <Compile Include="LinguisticSeed.fs" />
+    <Compile Include="ConformalGA.fs" />
     <Compile Include="Salon.fs" />
     <Compile Include="GameCatalog.fs" />
     <Compile Include="ControlMerge.fs" />

--- a/tests/Tests.FSharp/ConformalGA.Tests.fs
+++ b/tests/Tests.FSharp/ConformalGA.Tests.fs
@@ -1,0 +1,56 @@
+module Zeta.Tests.ConformalGATests
+
+// The conformal-GA slice Cl3.fs flagged: points are null vectors, distance is ONE inner product, and
+// the RBF over it is a PSD kernel — Sequoia soft memory distance joins the seed language.
+
+open global.Xunit
+open Zeta.Core
+
+[<Fact>]
+let ``embedded points are NULL vectors (P·P = 0 — the conformal cone)`` () =
+    for x, y, z in [ 0.0, 0.0, 0.0; 1.0, 2.0, 3.0; -4.5, 0.25, 9.0 ] do
+        Assert.True(ConformalGA.isNull 1e-9 (ConformalGA.embed x y z))
+
+[<Fact>]
+let ``distance IS one inner product: d² = −2(P·Q) matches direct Euclidean computation`` () =
+    let p = ConformalGA.embed 1.0 2.0 3.0
+    let q = ConformalGA.embed 4.0 6.0 3.0
+    Assert.Equal(25.0, ConformalGA.distSq p q, 9) // (3,4,0) => 9+16
+    Assert.Equal(0.0, ConformalGA.distSq p p, 9)
+
+[<Fact>]
+let ``cross-check against the existing Cl3 flat-space metric (the slice composes with its parent)`` () =
+    let a = Cl3.vector 1.0 -2.0 0.5
+    let b = Cl3.vector -3.0 4.0 2.5
+    Assert.Equal(Cl3.distSq a b, ConformalGA.distSq (ConformalGA.embedMv a) (ConformalGA.embedMv b), 9)
+
+[<Fact>]
+let ``translation invariance: shifting both points leaves the conformal distance unchanged`` () =
+    let d1 = ConformalGA.distSq (ConformalGA.embed 1.0 1.0 1.0) (ConformalGA.embed 4.0 5.0 1.0)
+    let d2 = ConformalGA.distSq (ConformalGA.embed 11.0 21.0 31.0) (ConformalGA.embed 14.0 25.0 31.0)
+    Assert.Equal(d1, d2, 9)
+
+[<Fact>]
+let ``the memory-RBF kernel is PSD (the Mercer witness) and composes into the seed (OCP)`` () =
+    let xs =
+        [| ConformalGA.embed 0.0 0.0 0.0
+           ConformalGA.embed 1.0 0.0 0.0
+           ConformalGA.embed 0.0 2.0 0.0
+           ConformalGA.embed 5.0 5.0 5.0
+           ConformalGA.embed -3.0 1.0 2.0 |]
+    let vs =
+        [| [| 1.0; 1.0; 1.0; 1.0; 1.0 |]
+           [| 1.0; -1.0; 1.0; -1.0; 1.0 |]
+           [| 2.0; -3.0; 0.5; 1.0; -2.0 |] |]
+    let k = LinguisticSeed.composePacks [ ConformalGA.memoryPack 2.0 ]
+    for v in vs do
+        Assert.True(LinguisticSeed.quadForm k xs v >= -1e-9)
+    Assert.Equal<string list>([ "conformal.memory-rbf" ], LinguisticSeed.packNames [ ConformalGA.memoryPack 2.0 ])
+
+[<Fact>]
+let ``locality scale behaves: near memories similar (~1), far memories dissimilar (~0)`` () =
+    let k = ConformalGA.rbfKernel 1.0
+    let origin = ConformalGA.embed 0.0 0.0 0.0
+    Assert.Equal(1.0, k origin origin, 9)
+    Assert.True(k origin (ConformalGA.embed 0.1 0.0 0.0) > 0.99)
+    Assert.True(k origin (ConformalGA.embed 10.0 10.0 10.0) < 1e-10)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -143,6 +143,7 @@
     <Compile Include="MembraneLogTreaty.Tests.fs" />
     <Compile Include="SoftChip8Flux.Tests.fs" />
     <Compile Include="SalonPack.Tests.fs" />
+    <Compile Include="ConformalGA.Tests.fs" />
     <Compile Include="SoftChip8Scheduler.Tests.fs" />
     <Compile Include="BitAdinkra.Tests.fs" />
     <Compile Include="ForwardMomentum.Tests.fs" />


### PR DESCRIPTION
The slice Cl3.fs flagged for 'Sequoia soft memory distance': null-vector embedding (P·P=0 proven), d²=−2(P·Q) cross-checked against Cl3.distSq, translation-invariant, and the Gaussian RBF over conformal distance is PSD (Mercer witness) — memory/placement similarity now composes into the seed language as a pack (σ = the tier width). 6/6 first try, 0 warnings.