### PR TITLE
feat(core): flux IS heat — the speculation budget is the Landauer toll

### DIFF
--- a/docs/research/2026-06-10-heat-is-the-branch-space-limiter-landauer-bennett-crossing-streams-state-expansion-toll.md
+++ b/docs/research/2026-06-10-heat-is-the-branch-space-limiter-landauer-bennett-crossing-streams-state-expansion-toll.md
@@ -102,6 +102,25 @@ Landauer's heat** — erasure-free by design (Z-set retraction, event-sourced cu
 with the rooms/qubits framework as its execution model and the dev room as its console. The database that
 never burns its history — it cools it.
 
+## flux IS heat — the speculation budget is the Landauer toll (Aaron 2026-06-11)
+
+The `SoftThrottle` flux tank and this doc's heat are **the same quantity**. Resolution of the apparent
+paradox (cuts are heat-free, yet speculation costs): the **commit** is reversible and free (history kept —
+Bennett), but **exploring the branch tree forward costs** — and that cost IS the flux. So:
+
+- **flux spent = heat dissipated** — `SoftThrottle.heatSpent t = Capacity − Charge` (the flux discharged
+  funding speculation = the Landauer/attention toll of branching).
+- **idle charge = cooling** — the tank radiating budget back while not speculating (`charge`).
+- **out of flux = the thermal ceiling** — `coolingHeadroom = 0` ⇒ the machine signals
+  `RateLimitExhausted "speculation-flux"` (the power-awareness signal): *it knows it ran out of heat to
+  think with* (the BigFloat principle — knows when it needs more, here more heat).
+- **one currency:** flux = heat = attention = the Landauer branch-prune toll. The flux capacitor is a
+  heat capacitor; the four-corner harmonic is the oscillation of that heat between cooling and bursting.
+
+So the night's threads close: a room ticks (raises resolution), speculation costs heat (flux), the
+reversible cut banks history instead of paying heat on commit, and the tank's charge/discharge is the
+room breathing — cool, then a thermal spike of looking ahead, then cool again.
+
 ## Beacon anchors
 
 Landauer, *Irreversibility and Heat Generation in the Computing Process* (IBM JRD 1961) · Bennett,

--- a/src/Core/SoftThrottle.fs
+++ b/src/Core/SoftThrottle.fs
@@ -84,6 +84,18 @@ module SoftThrottle =
     /// alternative to a hard reject).
     let available (t: Tank) : float = t.Charge
 
+    // ── flux IS heat (Aaron 2026-06-11) ──
+    // The flux spent funding speculation IS the heat dissipated (Landauer/attention — the cost of
+    // exploring the branch tree forward). The reversible CUT pays no heat (history is kept), but the
+    // EXPLORATION does — that resolves the apparent paradox: commit = free, speculation = heat. Charging
+    // while idle = COOLING (radiating budget back); running out = the THERMAL CEILING.
+
+    /// Heat dissipated so far — the flux discharged from a full tank (the instantaneous heat-debt).
+    let heatSpent (t: Tank) : float = max 0.0 (t.Capacity - t.Charge)
+
+    /// Cooling headroom — the flux remaining before the thermal ceiling (= `available`, named for heat).
+    let coolingHeadroom (t: Tank) : float = t.Charge
+
     /// **The limiter — Aaron's original Itron abstraction, ported.** In his `Platform.DotNet`
     /// `Threading.Tasks.Throttling`, the batch limiter is a **stateful fold delegate**:
     /// `BatchSizeLimiter<TItem, TState> = (item, state) → (fits?, state')` — pluggable over ANY

--- a/tests/Tests.FSharp/SoftThrottle.Tests.fs
+++ b/tests/Tests.FSharp/SoftThrottle.Tests.fs
@@ -122,3 +122,23 @@ let ``the limiter is Aaron's Itron fold: countLimiter boards exactly batchSize (
     Assert.Equal<int list>([ 1; 2; 3 ], b)
     Assert.Equal<int list>([ 4; 5 ], rest)
     Assert.Equal(3, n) // state advanced once per BOARDED item (0->1->2->3); the refusal probe's state is discarded
+
+[<Fact>]
+let ``flux IS heat: spending flux dissipates heat; idle charging cools (the thermal accounting)`` () =
+    let t0 = SoftThrottle.tank 10.0 2.0 // full, cool
+    Assert.Equal(0.0, SoftThrottle.heatSpent t0, 12)
+    Assert.Equal(10.0, SoftThrottle.coolingHeadroom t0, 12)
+    match SoftThrottle.discharge 6.0 t0 with
+    | Some hot ->
+        Assert.Equal(6.0, SoftThrottle.heatSpent hot, 12) // speculation dissipated 6 units of heat
+        Assert.Equal(4.0, SoftThrottle.coolingHeadroom hot, 12)
+        let cooled = SoftThrottle.charge hot // one idle tick = radiate 2 back
+        Assert.Equal(4.0, SoftThrottle.heatSpent cooled, 12) // cooled from 6 to 4
+    | None -> Assert.Fail "tank should fund the burst"
+
+[<Fact>]
+let ``the thermal ceiling: a starved speculation has spent ALL its heat (no cooling headroom left)`` () =
+    let f = Chip8Cow.create 7UL |> Chip8Cow.loadRom [| 0x6Auy; 0x0Cuy; 0x7Auy; 0x01uy; 0x12uy; 0x02uy |]
+    let _, _, _, tank' = SoftChip8Flux.lookAheadFunded 1.0 (SoftThrottle.tank 20.0 0.0) f
+    Assert.Equal(20.0, SoftThrottle.heatSpent tank', 12) // ran to the ceiling
+    Assert.Equal(0.0, SoftThrottle.coolingHeadroom tank', 12) // no headroom = the signal fires


### PR DESCRIPTION
Aaron: 'flux is heat.' The flux tank IS the heat: commit is free (Bennett, history kept), but exploring the branch tree forward costs — that's the flux = the Landauer/attention toll. heatSpent/coolingHeadroom accounting; idle charge = cooling; out of flux = thermal ceiling (the power-awareness signal). flux = heat = attention = the branch-prune toll, one currency. 12/12, 0 warnings.