### PR TITLE
docs(folders): /saves (resumable save states) + /futures (unfulfilled promises society makes to itself)

### DIFF
--- a/futures/README.md
+++ b/futures/README.md
@@ -1,0 +1,40 @@
+# futures/ — unfulfilled promises society makes to itself (Promise Theory)
+
+`futures/` holds **projected futures** — and Aaron's framing (2026-06-11) makes them precise: *"these
+are unfulfilled promises from society to itself; these need treaties, and discovery of any implicit ones
+that exist."*
+
+A **future is a promise not yet kept** (Promise Theory — Mark Burgess). The substrate already speaks this:
+uncertainty travels *at the promise level* (the rooms-are-IO-packet-wrappers doc); a speculative branch
+(`SoftChip8Flux.conferenceOnFork`) is a future the room is holding open; a treaty (FourCorner / MeshPong /
+MembraneLog) is a promise **ratified** — kept by construction, byte-locked across oracles.
+
+## The two jobs of this folder
+
+1. **Treaty the explicit promises.** Every future society declares to itself — a planned capability, a
+   stated invariant, a "we will…" — is an unfulfilled promise until it is *ratified as a treaty* (made
+   true by construction + cross-oracle byte-lock) or *honestly retracted*. "Everything in Zeta ends up
+   treaty-ratified, little by little" — `futures/` is the ledger of what hasn't been yet.
+2. **Discover the IMPLICIT promises.** The dangerous ones are unstated: a function whose callers *assume*
+   a contract it never declared (the ragged-`dot` "I'm PSD" was an implicit promise that was FALSE until
+   the Math Razor caught it). Surface implicit promises, then either treaty them (declare + enforce) or
+   break them honestly. An implicit promise is a treaty waiting to be discovered.
+
+## The shape
+
+```
+futures/<name>.md     one unfulfilled promise: who promises, to whom, what, and its treaty status
+                      (open | ratified→<treaty> | retracted | implicit-discovered)
+```
+
+A future resolves the way a fork does: when the present arrives, one branch is kept and the others
+retract (`SoftChip8Flux.reconcile`). A promise resolves the same way — kept, or honestly retracted.
+
+## Pointers
+
+- `docs/research/2026-06-10-rooms-are-io-packet-wrappers-uncertainty-at-the-promise-level-*.md` — Promise
+  Theory (Burgess) in the substrate; uncertainty travels with the promise.
+- `src/Core/SoftChip8Flux.fs` — `conferenceOnFork` / `reconcile` (a room holding open its futures, then
+  resolving to the kept one).
+- the treaty board: `src/Core.TypeScript/{four-corner,mesh-pong,recorded-source}/` — promises already kept.
+- [`../saves`](../saves/README.md) — resume a save and *fork* it to project futures.

--- a/saves/README.md
+++ b/saves/README.md
@@ -1,0 +1,32 @@
+# saves/ — named, resumable save states (the FF7 save slots)
+
+`saves/` is where **named save states** live — *"save and resume multiple save states"* (Aaron
+2026-06-11). A save state is a point you can return to and replay forward from, deterministically. Like
+an emulator's save slots: many of them, each named, each resumable.
+
+## The mechanism already exists — this is its home
+
+A save state IS a **recorded membrane log** (`src/Core/RecordedSource.fs`): the crossings that entered a
+room up to a moment. Resume = `RecordedSource.replay` from that recording (DST: the room replays
+byte-identically — proven). So a save slot is a **text recording** here (no binary in the proof lineage;
+the membrane-log treaty already ratifies the format four-oracle).
+
+```
+saves/<name>.lines      one membrane-log recording (a save slot) — diffable, mergeable, replayable
+```
+
+- **Save** = write the room's `RecordedSource.toLines` to `saves/<name>.lines`.
+- **Resume** = `RecordedSource.ofLines` → `replay` → drive the room from that recording.
+- **Multiple** = many named slots; pick any to resume (or fork — see [`../futures`](../futures/README.md)).
+
+Why text + recording (not a binary heap dump): a save state must be *replayable, mergeable, and
+auditable* — the same channel-reliability discipline as everything else. A save you can't diff is a save
+you can't trust.
+
+## Pointers
+
+- `src/Core/RecordedSource.fs` — record/replay (the save/resume mechanism); the membrane-log treaty
+  (`src/Core.TypeScript/recorded-source/golden-vectors.lines`) ratifies the line format four-oracle.
+- `src/Core/Checkpoint.fs` / `src/Core/SagaSnapshot.fs` — snapshot lineage (state-at-a-cadence).
+- `src/Core/SimFramework.fs` — `withSource` swaps a room's membrane to a saved recording's replay.
+- [`../futures`](../futures/README.md) — a save you resume *and fork* projects futures.


### PR DESCRIPTION
Aaron: /saves (save+resume multiple states) + /futures ('unfulfilled promises from society to itself — need treaties and discovery of implicit ones'). saves/ = the FF7 save-slot home over RecordedSource (record=save, replay=resume, DST byte-identical; the membrane-log treaty ratifies the format). futures/ = Promise Theory made a folder: treaty the explicit promises + DISCOVER the implicit ones (the ragged-dot 'I'm PSD' was a false implicit promise the Math Razor caught). Load-bearing root folders + READMEs pointing at existing mechanism. Docs only.