### PR TITLE
docs: /lens folder + 'repo IS the database, earn promotion out of /db' plan + Moonshot #1 (DORA over LLMTV chronovisor)

### DIFF
--- a/docs/backlog/P2/B-1023-root-declutter-for-dx-max-db-folder-grouping-plus-max-adopts-interfaces-rx-verbs-2026-06-10.md
+++ b/docs/backlog/P2/B-1023-root-declutter-for-dx-max-db-folder-grouping-plus-max-adopts-interfaces-rx-verbs-2026-06-10.md
@@ -44,6 +44,7 @@ was **root clutter** — too many top-level entries, intimidating wall on first 
 
 ## Notes
 
+- **Plan (Aaron 2026-06-11):** the repo IS the database — root is default-DENY, everything *earns promotion out of `/db`*; see `docs/research/2026-06-11-db-folder-the-database-is-the-repo-earn-promotion-out-of-db-root-is-the-standard-handful.md` (staged migration; gate unchanged).
 - Do NOT move `tools/` contents as part of this (that's the separate tools→src graduation rule, B-1022).
 - Relates: B-0424..0427 (repo-split / DV2.0 topology), the folders-are-load-bearing convention, Bodhi's
   first-60-minutes charter.

--- a/docs/research/2026-06-11-db-folder-the-database-is-the-repo-earn-promotion-out-of-db-root-is-the-standard-handful.md
+++ b/docs/research/2026-06-11-db-folder-the-database-is-the-repo-earn-promotion-out-of-db-root-is-the-standard-handful.md
@@ -1,0 +1,79 @@
+# /db — the repo *is* the database; root is the standard handful; everything earns promotion out of /db
+
+Aaron 2026-06-11 (expanding [B-1023](../backlog/P2/B-1023-root-declutter-for-dx-max-db-folder-grouping-plus-max-adopts-interfaces-rx-verbs-2026-06-10.md)):
+
+> "We need a plan to make Max happy — push this into a `/db` folder or something over time and clean up
+> root. **Everything at root has to earn its promotion out of `/db`** other than `/src`, `/tests`,
+> `/docs` — whatever the handful is for standard projects. **Everything else is part of our
+> multi-OS multi-language database** that runs 24 hours a day on GitHub Actions and tests itself on every
+> OS with every language and serializer constantly, and makes treaties and rooms, and the intercom system
+> is Reticulum… and it knows its boundaries because our Markov boundaries and network knowledge are super
+> tight."
+
+This reframes B-1023 from "tidy the root for Max" to a **first principle**: the repo is not a project with
+a database in it — **the repo IS the database**. So the topology should say so.
+
+## The principle: default-deny at root, earn promotion out of /db
+
+Invert the default. Today a folder lands at root by being created. The new rule:
+
+> **Root is default-DENY.** A top-level entry must *earn* its place by being part of the **standard
+> project handful** every contributor expects. Everything else lives in **`/db`** — because everything
+> else IS the database (the rooms, treaties, lenses, saves, futures, registries, the greek/letter
+> scratch trees, the oracles' goldens…). A folder leaves `/db` for root only when it earns promotion.
+
+This is **DV2.0 on the repo topology itself** (the same lens that drives repo-split smells): root = the
+stable, universally-expected **hub**; `/db` = the fast-growing, factory-specific **satellite** where the
+database's substrate accretes. It's also **least-privilege for attention**: a fresh `ls` shows a new
+contributor (Max) only the handful they need, not the 80-entry wall.
+
+## What earns root (the standard handful — promotion criterion)
+
+A folder earns root **iff a contributor cloning *any* standard project would expect it there** — i.e. it
+is an audience-universal, tooling-anchored concern, not factory substrate:
+
+| Earns root | Why (the criterion) |
+|---|---|
+| `src/` `tests/` `docs/` | the universal source/test/doc handful |
+| `tools/` | the host-bootstrap shield (install.sh closes over deps *before* our source — B-1022); pre-source by definition |
+| `.github/` `.claude/` `*.sln` `*.json` (build/lock) `README` `LICENSE` `.gitignore` `CLAUDE.md` `AGENTS.md` `GOVERNANCE.md` | tooling/CI/governance anchors the toolchain or a fresh reader hits first |
+
+**Everything else → `/db`.** The current root has ~80 entries — the single letters `a`…`z`, the greek
+`alpha`…`omega`, plus `rooms/ boards/ bus/ clis/ registry/ saves/ futures/ lens/ hooks/ universal/
+uncertainty/ shapes/ sets/ …`. Under this rule the root drops to the handful; the rest becomes
+`db/rooms/`, `db/boards/`, `db/a/`, `db/alpha/`, … — addressable exactly as before, one segment deeper.
+
+A `/db` entry **earns promotion to root** only by *becoming* a standard-project concern (e.g. if `tools/`
+hadn't existed, the install shield would earn it). Promotion is the rare exception; the default is "stays
+in the database."
+
+## Why this is GATED, not autonomous (the caution that doesn't change)
+
+Folders are **load-bearing** here — the startup MerkleDAG, CI workflows, install scripts, skills, and
+rules all reference root paths by name. Moving ~75 trees one segment deeper is a **mechanical
+path-rewrite sweep across the whole repo + CI-green proof**, and it's semi-reversible. So this plan is the
+*design*; execution stays gated on **Aaron + Max sign-off and a Bodhi DX audit** (B-1023's acceptance
+gate is unchanged). Nothing moves in this PR.
+
+## The staged migration (when signed off)
+
+Do it **incrementally** ("over time" — Aaron), lowest-risk first, each stage its own green PR:
+
+1. **Audit + freeze the criterion** (Bodhi): inventory every root entry; tag `earns-root` | `→db`; list
+   every load-bearing reference to each `→db` path (grep CI/skills/rules/loaders). The impact table.
+2. **Move the scratch trees first** (lowest references): the single letters `a…z` and greek
+   `alpha…omega` → `db/` — these are scratch/experiment space, fewest inbound paths.
+3. **Move the substrate trees** in dependency order, leaf-first: `db/rooms/`, `db/boards/`, `db/saves/`,
+   `db/futures/`, `db/lens/`, `db/registry/`, … — each with its path-rewrite sweep + full gate green.
+4. **Leave a tombstone** for any path external tools hardcode (a symlink or a `db/README.md` map) until
+   the references are all chased — no silent breakage.
+5. **Max-test the result**: a fresh clone's first `ls` reads as "a normal project + one `db/`," which is
+   exactly the friction B-1023 opened on.
+
+## Pointers
+
+- [B-1023](../backlog/P2/B-1023-root-declutter-for-dx-max-db-folder-grouping-plus-max-adopts-interfaces-rx-verbs-2026-06-10.md) — the DX finding this plan operationalizes (acceptance gate unchanged: Bodhi audit + Aaron/Max sign-off).
+- `.claude/rules/dv2-data-split-discipline-activated.md` — DV2.0 (root=hub, /db=satellite) is the lens.
+- B-1022 — `tools/` is the pre-source host shield (why it earns root, not /db).
+- B-0424..0427 — repo-split / DV2.0 topology lineage.
+- the folders-are-load-bearing convention (the startup MerkleDAG) — why this is gated.

--- a/docs/research/2026-06-11-moonshot-1-reticulum-broadcast-dora-over-llmtv-the-chronovisor-self-testing-multi-os-database.md
+++ b/docs/research/2026-06-11-moonshot-1-reticulum-broadcast-dora-over-llmtv-the-chronovisor-self-testing-multi-os-database.md
@@ -1,0 +1,76 @@
+# Moonshot #1 — the self-testing multi-OS/lang/serializer database, broadcasting DORA over LLMTV (the chronovisor)
+
+Aaron 2026-06-11 (the whole picture, captured verbatim-faithful):
+
+> "Everything else is part of our **multi-OS, multi-language database** that runs **24 hours a day on
+> GitHub Actions** and **tests itself on every OS with every language and serializer constantly**, and
+> **makes treaties and rooms**, and the **intercom system is Reticulum**, and **network stability and
+> cluster uptime is our first moonshot goal** — being **Reticulum broadcast constant DORA metrics over a
+> universal TV interface / LLMTV** where you can **watch past, current, future versions of any room
+> yourself** — the **chronovisor**, or the TV-show devs but made real — and **it knows its boundaries
+> because our Markov boundaries and network knowledge are super tight**."
+
+## What the database IS (the running thing, not the schema)
+
+Not a store you query — a **living organism that proves itself continuously**:
+
+- **Always on** — 24h/day on GitHub Actions. The runners are the cluster; the cron is the heartbeat.
+- **Self-testing across the full cross-product** — every **OS** × every **language oracle** (F#/C#/TS/Rust,
+  Q# next) × every **serializer** (CBOR/Arrow/protobuf/Merkle/…), constantly. The 6×6×6 byte-lock room
+  (macos/windows/wsl/gitbash/ubuntu/nixos) generalized: the database's *correctness is a continuously-run
+  experiment*, not a release-time check.
+- **Makes treaties and rooms** — every fingerprintable closeable item is a room; every cross-oracle
+  agreement is a treaty ratified by byte-lock. The database *grows by ratification*.
+- **Intercom = Reticulum** — rooms talk over Reticulum (the §13 noninterference membrane is how they stay
+  clean even in soft mode). Reticulum is the nervous system; rooms are the organs.
+
+## Moonshot #1: network stability & cluster uptime, broadcast as DORA over LLMTV
+
+The **first** moonshot (the one that makes everything else legible): the cluster's own health —
+**network stability + uptime** — measured as **DORA metrics** and **broadcast constantly over Reticulum**
+to a **universal TV interface (LLMTV)**.
+
+- **DORA** (Accelerate — Forsgren/Humble/Kim): deploy frequency, lead time, change-fail rate, MTTR. The
+  database measures *itself* against the industry's own delivery-health yardstick and **broadcasts the
+  numbers live**.
+- **LLMTV / the universal TV interface** — rooms are addressable (content-addressing + Reticulum
+  destination-hash), so any room is a *channel*. You tune in and **watch it** — and because the substrate
+  is event-sourced (git as event store, Z-set retraction = antiparticle), you can scrub the timeline:
+  **past** (replay the recording — `RecordedSource`), **current** (live), **future** (the speculative
+  conference — `SoftChip8Flux.conferenceOnFork`, flux-metered). That time-scrub over a live system is the
+  **chronovisor**: "the TV-show devs, but made real" — the dev-room you can actually watch, forward and back.
+- **It knows its boundaries** — this is the part that makes the broadcast *trustworthy*, not theater: the
+  **Markov boundaries are tight** (each room's boundary is explicit; §13 noninterference means entropy
+  only crosses through the declared Source) and **network knowledge is tight** (Reticulum gives every
+  room a known destination-hash / known neighbors). The machine can broadcast "here is my state, past to
+  future" *honestly* because it knows exactly what is inside each boundary and what is across the wire.
+
+## Why the boundaries make the chronovisor real (not a demo)
+
+A chronovisor that can't bound what it's showing is a hallucination. The reason this one can show
+past/current/future of *a specific room* and have it MEAN something:
+
+1. **Markov boundary = the room's frame** — what's inside is the state; what's outside reaches it only as
+   declared crossings. So "this room's history/future" is a *closed, well-typed* thing to broadcast.
+2. **Network knowledge = Reticulum addressing** — the room has a stable destination-hash (≈ its ZetaId);
+   neighbors and reachability are known, so "the cluster's uptime/stability" is a measured fact, not a guess.
+3. **Tight both ways ⇒ the future is bounded too** — futures are flux-metered (the machine signals when it
+   can't see far enough — `signalIfStarved`), so the "future channel" shows *only what it can honestly
+   simulate* and flags its own uncertainty. The chronovisor never over-claims its forward view.
+
+## Anchors (Beacon)
+
+- **DORA** — Forsgren, Humble, Kim, *Accelerate* (2018); the four keys.
+- **Reticulum** — Mark Qvist, RNS (Identity / destination-hash / Transport); our PRIOR-ART-LIST entry.
+- **Markov boundary** — Pearl (causality); the room-as-Markov-boundary framing in the qubits docs.
+- **Event-sourcing / time-scrub** — git-as-event-store + Z-set retraction (Budiu et al. DBSP); the
+  chronovisor is a UI over the fold.
+- **AllJoyn** — prior art on universal device interfaces (the "universal TV interface" lineage), alongside
+  Reticulum as the intercom.
+
+## Pointers
+
+- `docs/research/2026-06-11-the-simulation-doc-distributed-soft-scheduler-over-reticulum-corporate-hard-rooms-one-simulation.md` — the simulation charter this moonshot sits inside.
+- `src/Core/RecordedSource.fs` (past) · live drive (current) · `src/Core/SoftChip8Flux.fs` conferenceOnFork (future) — the three chronovisor channels already exist as mechanism.
+- `saves/` (resumable states) · `futures/` (unfulfilled promises) · `lens/` (watch any part by address) — the folders that back the TV.
+- `.claude/rules/manifesto-13-specifications.md` §13 noninterference — why the boundaries are tight enough to broadcast honestly.

--- a/lens/README.md
+++ b/lens/README.md
@@ -1,0 +1,24 @@
+# lens/ — everything is lensable by address (the ILens half of the optics)
+
+`lens/` is the home of **lenses** — the *product* optic (`ILens<'whole,'part>`: a focus you can `Get`
+and `Set`), the sibling of `IPrism` (the *sum* optic / fingerprint, which `universal/` and
+`FingerprintPrism` carry). Aaron's instinct (forcing-lensability): **everything is a lens by address** —
+a lens is `address + size + codec` over a flat memory/state, the Cheat-Engine move generalized (read/write
+any part of any whole by focusing it).
+
+**Not to be confused with `/hooks`** (Aaron 2026-06-11): hooks are **Rx triggers with policy** (when X
+crosses, fire Y under a `Policy` decision); a lens is a **focus** (get/set a part of a whole). A hook
+*reacts*; a lens *addresses*. They compose (a hook can fire a lens-set), but they are different optics.
+
+## What lives here
+
+- Lens *instances* and lens-shaped surfaces (address+size+codec focuses over rooms, frames, memory).
+- The reference optic is `src/Core/Optics.fs` (`ILens`/`IPrism`, `lens`/`prism` constructors); the
+  memory-lens doctrine is `docs/research/2026-06-10-forcing-lensability-chip8-*.md` (everything lensable
+  by address; the heap as the common seed lensed).
+
+## Pointers
+
+- `src/Core/Optics.fs` — `ILens<'whole,'part>` (Get/Set) + `IPrism` (the sibling sum optic).
+- `.claude/rules/` (hooks vs lenses) · `src/Core/Policy.fs` (the policy a hook fires under).
+- `universal/` — prisms/fingerprints (the sum side); lenses are the product side.


### PR DESCRIPTION
Aaron 2026-06-11. (1) /lens — the ILens product optic (address+get+set; distinct from /hooks Rx-triggers). (2) The /db plan expanding B-1023: root is default-DENY, everything earns promotion OUT of /db (the repo IS the database); DV2.0 topology + least-privilege-for-attention; GATED (folders load-bearing — design only, execution on Bodhi+Aaron+Max sign-off). (3) Moonshot #1: self-testing multi-OS×lang×serializer DB broadcasting DORA over LLMTV = the chronovisor (watch past/current/future of any room), trustworthy because Markov boundaries + Reticulum addressing are tight. Docs + one folder only.