### PR TITLE
feat(core): converge qubit gates with Q# oracle

### DIFF
--- a/bench/Benchmarks/Benchmarks.fsproj
+++ b/bench/Benchmarks/Benchmarks.fsproj
@@ -14,6 +14,7 @@
     <Compile Include="CircuitBench.fs" />
     <Compile Include="SpineBench.fs" />
     <Compile Include="BloomBench.fs" />
+    <Compile Include="QuantumOracleBench.fs" />
     <Compile Include="Nexmark.fs" />
     <Compile Include="NexmarkFull.fs" />
     <Compile Include="CheckedVsUncheckedBench.fs" />

--- a/bench/Benchmarks/QuantumOracleBench.fs
+++ b/bench/Benchmarks/QuantumOracleBench.fs
@@ -1,0 +1,95 @@
+module Zeta.Benchmarks.QuantumOracleBench
+
+open System
+open System.IO
+open System.Text.Json
+open BenchmarkDotNet.Attributes
+open Zeta.Core
+
+/// Benchmarks the F# side of the Q# observable treaty without taking a
+/// QDK/Q#/Python dependency at benchmark time. The Q# lane owns the golden
+/// JSON; this lane measures Zeta's matching observable implementations and
+/// the treaty-ingress cost separately.
+[<MemoryDiagnoser>]
+type QuantumOracleOps() =
+
+    [<DefaultValue(false)>] val mutable private states: QubitIso.JoinState array
+    [<DefaultValue(false)>] val mutable private frames: Chip8Cow.Frame array
+    [<DefaultValue(false)>] val mutable private goldenBytes: byte array
+
+    [<Params(64, 1024, 16384)>]
+    member val Size = 0 with get, set
+
+    [<GlobalSetup>]
+    member this.Setup() =
+        this.states <-
+            Array.init this.Size (fun i ->
+                let theta = float i * 0.001
+                let alpha = { Real = cos theta; Imag = sin theta }
+                let beta = { Real = cos (theta * 0.5); Imag = sin (theta * 0.5) }
+                QubitIso.ofQubit alpha beta)
+
+        this.frames <-
+            Array.init 2 (fun i ->
+                Chip8Cow.create (uint64 i)
+                |> Chip8Cow.loadRom [| 0x60uy; byte i |])
+
+        let root = QuantumOracleOps.FindRepoRoot(DirectoryInfo(Environment.CurrentDirectory))
+        let path = Path.Combine(root, "tools", "qsharp-oracle", "qsharp-golden.json")
+        this.goldenBytes <- File.ReadAllBytes(path)
+
+    static member FindRepoRoot(dir: DirectoryInfo) =
+        let mutable current = dir
+        let mutable found: string option = None
+        while found.IsNone && not (isNull current) do
+            if File.Exists(Path.Combine(current.FullName, "Zeta.sln")) then
+                found <- Some current.FullName
+            else
+                current <- current.Parent
+        match found with
+        | Some root -> root
+        | None -> invalidOp "Could not find repository root from benchmark output directory."
+
+    [<Benchmark>]
+    member this.QSharpGoldenJsonParse() =
+        use doc = JsonDocument.Parse(ReadOnlyMemory this.goldenBytes)
+        doc.RootElement.GetProperty("vectors").GetProperty("gateUnitaries").GetProperty("H").GetArrayLength()
+
+    [<Benchmark>]
+    member this.QubitIsoGateSweep() =
+        let mutable acc = 0.0
+        let states = this.states
+        for i in 0 .. states.Length - 1 do
+            let s =
+                states.[i]
+                |> QubitIso.hadamard
+                |> QubitIso.ry (Math.PI / 3.0)
+                |> QubitIso.rz (Math.PI / 3.0)
+                |> QubitIso.pauliX
+                |> QubitIso.pauliY
+                |> QubitIso.pauliZ
+            acc <- acc + QubitIso.normSq s + QubitIso.measureOne s
+        acc
+
+    [<Benchmark>]
+    member this.BellChshSweep() =
+        let mutable acc = 0.0
+        for i in 0 .. this.Size - 1 do
+            let offset = float i * 0.0001
+            acc <- acc + BellTest.chsh offset (Math.PI / 2.0 + offset) (Math.PI / 4.0) (3.0 * Math.PI / 4.0)
+        acc
+
+    [<Benchmark>]
+    member this.MachZehnderMergeSweep() =
+        let detectorZero = this.frames.[0]
+        let detectorOne = this.frames.[1]
+        let half = { Real = 0.5; Imag = 0.0 }
+        let mutable acc = 0.0
+        for _ in 1 .. this.Size do
+            let amp: AmplitudeEmu.Amp =
+                [ detectorZero, half
+                  detectorZero, half
+                  detectorOne, half
+                  detectorOne, { Real = -0.5; Imag = 0.0 } ]
+            acc <- acc + (amp |> AmplitudeEmu.merge |> AmplitudeEmu.intensity)
+        acc

--- a/src/Core/QubitIso.fs
+++ b/src/Core/QubitIso.fs
@@ -79,6 +79,28 @@ module QubitIso =
     /// Identity gate.
     let id (j: JoinState) : JoinState = j
 
+    /// H (Hadamard): basis change between Z and X measurement axes.
+    let hadamard (j: JoinState) : JoinState =
+        let invSqrt2 = 1.0 / sqrt 2.0
+        let s = { Real = invSqrt2; Imag = 0.0 }
+        { A = c.Mul(s, c.Add(j.A, j.B))
+          B = c.Mul(s, c.Add(j.A, c.Negate j.B)) }
+
+    /// Ry(θ): real Y-axis Bloch rotation, matching Q#'s half-angle matrix convention.
+    let ry (theta: float) (j: JoinState) : JoinState =
+        let ct = cos (theta / 2.0)
+        let st = sin (theta / 2.0)
+        { A = c.Add(c.Mul({ Real = ct; Imag = 0.0 }, j.A), c.Mul({ Real = -st; Imag = 0.0 }, j.B))
+          B = c.Add(c.Mul({ Real = st; Imag = 0.0 }, j.A), c.Mul({ Real = ct; Imag = 0.0 }, j.B)) }
+
+    /// Rz(θ): phase rotation with `|0>` carrying `e^{-iθ/2}` and `|1>` carrying `e^{+iθ/2}`.
+    let rz (theta: float) (j: JoinState) : JoinState =
+        let half = theta / 2.0
+        let phase0 = { Real = cos half; Imag = -sin half }
+        let phase1 = { Real = cos half; Imag = sin half }
+        { A = c.Mul(phase0, j.A)
+          B = c.Mul(phase1, j.B) }
+
     /// Approximate state equality (per-component, within `eps`).
     let equalish (eps: float) (x: JoinState) (y: JoinState) : bool =
         abs (x.A.Real - y.A.Real) < eps

--- a/tests/Tests.FSharp/QSharpOracle.Tests.fs
+++ b/tests/Tests.FSharp/QSharpOracle.Tests.fs
@@ -95,6 +95,27 @@ let ``QubitIso Pauli X Y Z match the Q# gate matrices on computational basis sta
     assertQSharpColumn z 1 (QubitIso.pauliZ one)
 
 [<Fact>]
+let ``QubitIso H Ry and Rz match the Q# gate matrices on computational basis states`` () =
+    let zero = QubitIso.ofQubit c.One c.Zero
+    let one = QubitIso.ofQubit c.Zero c.One
+
+    let h = gateMatrix "H"
+    assertQSharpColumn h 0 (QubitIso.hadamard zero)
+    assertQSharpColumn h 1 (QubitIso.hadamard one)
+
+    let ryPiOver3 = gateMatrix "Ry(pi/3)"
+    assertQSharpColumn ryPiOver3 0 (QubitIso.ry (Math.PI / 3.0) zero)
+    assertQSharpColumn ryPiOver3 1 (QubitIso.ry (Math.PI / 3.0) one)
+
+    let ryPiOver2 = gateMatrix "Ry(pi/2)"
+    assertQSharpColumn ryPiOver2 0 (QubitIso.ry (Math.PI / 2.0) zero)
+    assertQSharpColumn ryPiOver2 1 (QubitIso.ry (Math.PI / 2.0) one)
+
+    let rzPiOver3 = gateMatrix "Rz(pi/3)"
+    assertQSharpColumn rzPiOver3 0 (QubitIso.rz (Math.PI / 3.0) zero)
+    assertQSharpColumn rzPiOver3 1 (QubitIso.rz (Math.PI / 3.0) one)
+
+[<Fact>]
 let ``BellTest canonical CHSH observables match the Q# golden vector`` () =
     let canonical = vectors.GetProperty("bellChsh").GetProperty("canonical")
     let angles = canonical.GetProperty("anglesRadians")

--- a/tests/Tests.FSharp/QubitIso.Tests.fs
+++ b/tests/Tests.FSharp/QubitIso.Tests.fs
@@ -25,14 +25,29 @@ let ``Pauli anticommute: XZ = -ZX`` () =
     Assert.True(eq (QubitIso.pauliX (QubitIso.pauliZ g)) (QubitIso.scale negOne (QubitIso.pauliZ (QubitIso.pauliX g))))
 
 [<Fact>]
-let ``gates are unitary: norm preserved by X, Y, Z`` () =
+let ``gates are unitary: norm preserved by Pauli and rotation gates`` () =
     Assert.Equal(QubitIso.normSq g, QubitIso.normSq (QubitIso.pauliX g), 12)
     Assert.Equal(QubitIso.normSq g, QubitIso.normSq (QubitIso.pauliY g), 12)
     Assert.Equal(QubitIso.normSq g, QubitIso.normSq (QubitIso.pauliZ g), 12)
+    Assert.Equal(QubitIso.normSq g, QubitIso.normSq (QubitIso.hadamard g), 12)
+    Assert.Equal(QubitIso.normSq g, QubitIso.normSq (QubitIso.ry (System.Math.PI / 3.0) g), 12)
+    Assert.Equal(QubitIso.normSq g, QubitIso.normSq (QubitIso.rz (System.Math.PI / 3.0) g), 12)
 
 [<Fact>]
 let ``Born + bit-flip: X swaps measurement probabilities`` () =
     Assert.Equal(1.0 - QubitIso.measureOne g, QubitIso.measureOne (QubitIso.pauliX g), 12)
+
+[<Fact>]
+let ``Hadamard is self-inverse and maps basis zero to a fair measurement`` () =
+    let zero = QubitIso.ofQubit { Real = 1.0; Imag = 0.0 } { Real = 0.0; Imag = 0.0 }
+    Assert.True(eq (QubitIso.hadamard (QubitIso.hadamard g)) g)
+    Assert.Equal(0.5, QubitIso.measureOne (QubitIso.hadamard zero), 12)
+
+[<Fact>]
+let ``Ry pi over three has textbook cos squared and sin squared probabilities`` () =
+    let zero = QubitIso.ofQubit { Real = 1.0; Imag = 0.0 } { Real = 0.0; Imag = 0.0 }
+    let rotated = QubitIso.ry (System.Math.PI / 3.0) zero
+    Assert.Equal(sin (System.Math.PI / 6.0) ** 2.0, QubitIso.measureOne rotated, 12)
 
 [<Fact>]
 let ``state bijection is the identity on ℂ² (round-trip)`` () =


### PR DESCRIPTION
## Summary
- add F# `QubitIso.hadamard`, `QubitIso.ry`, and `QubitIso.rz` using the Q# half-angle conventions
- extend the F# Q# oracle treaty tests to compare H/Ry/Rz matrices directly against `tools/qsharp-oracle/qsharp-golden.json`
- add BenchmarkDotNet quantum observable benchmarks for Q# treaty JSON ingress, F# gate sweeps, CHSH sweeps, and Mach-Zehnder merge sweeps

## Independence shape
Each language stays independent: Q# owns the oracle fixture, and F# consumes the committed JSON treaty with F#/.NET only. The benchmarks measure Zeta F# observable paths plus treaty-ingress cost; they do not call QDK/Python/TypeScript at benchmark time.

## Validation
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter "FullyQualifiedName~QSharpOracleTests|FullyQualifiedName~QubitIsoTests|FullyQualifiedName~BellTestTests|FullyQualifiedName~AmplitudeEmuTests"` (25 passed)
- `dotnet build bench/Benchmarks/Benchmarks.fsproj -c Release` (0 warnings, 0 errors)
- `dotnet build -c Release` (0 warnings, 0 errors, serial rerun after parallel output-file contention)
- `dotnet test Zeta.sln -c Release` (3,101 passed, 1 skipped)
- `dotnet run -c Release --project bench/Benchmarks/Benchmarks.fsproj -- --list flat | rg QuantumOracle`
- `dotnet run -c Release --project bench/Benchmarks/Benchmarks.fsproj -- --filter '*QuantumOracleOps.QubitIsoGateSweep*' --job Dry --warmupCount 1 --iterationCount 1`\n- `dotnet format --verify-no-changes --include src/Core/QubitIso.fs tests/Tests.FSharp/QubitIso.Tests.fs tests/Tests.FSharp/QSharpOracle.Tests.fs bench/Benchmarks/QuantumOracleBench.fs bench/Benchmarks/Benchmarks.fsproj`\n- `git diff --check`\n\n## Benchmark smoke note\nThe dry run is not a statistically meaningful performance result, but it proved the benchmark executable runs and exposed the expected first optimization target: `QubitIsoGateSweep` currently allocates linearly through record/ring-helper composition.