### PR TITLE
docs(universal): Extension Interface + ZORK/Z-machine support path + Etch-a-Sketch/Lite-Brite display lineage

### DIFF
--- a/docs/research/2026-06-11-etch-a-sketch-lite-brite-zork-zmachine-nsew-directionality-support-the-format-extension-interface.md
+++ b/docs/research/2026-06-11-etch-a-sketch-lite-brite-zork-zmachine-nsew-directionality-support-the-format-extension-interface.md
@@ -1,0 +1,63 @@
+# Etch-a-Sketch, Lite-Brite, ZORK — the display lineage + supporting the Z-machine format
+
+Aaron 2026-06-11 (extending the colorspace/BBS grounding):
+
+> "Also think **Etch-a-Sketch** and/or **Lite-Brite with LEDs**, and BBS games, CYOA, and **text-based
+> adventures like ZORK — it had consistent directionality, NSEW and others. We should probably support
+> his format too.** Have some **interface for extensions** and we can move forward with whatever."
+
+## The display lineage (the TV's aesthetic ancestors, each an honest capability)
+
+| ancestor | what it teaches the TV | capability class |
+|---|---|---|
+| **Etch-a-Sketch** (Cassagnes 1960) | ONE continuous line, two knobs, erase-by-shake — drawing as a *path*, reset as a *gesture*; the mono single-plane aesthetic | Mono1, vector-path |
+| **Lite-Brite** (Hasbro 1967) | colored POINTS on a dark grid — pixels as physical pegs; the indexed-palette aesthetic (and literal LEDs on the Pi/microcontroller rung) | Indexed⟨palette⟩, point grid |
+| **BBS / CP437 ANSI** | the board aesthetic (already pinned for DORA) | ANSI-16/256 |
+| **ZORK / text adventure** | the room graph SPOKEN: consistent directionality — NSEW + up/down/in/out — as the navigation contract | text, the CYOA's ancestor |
+
+These aren't nostalgia: each is a *binding* of `universal/color.md` at a real capability, and Lite-Brite
+is literally the Pi-with-LEDs rung of B-1024.
+
+## ZORK's directionality IS our four corners
+
+Zork's compass (N/S/E/W + NE/NW/SE/SW + up/down/in/out — Infocom 1980) is a **consistent spatial
+algebra over a room graph** — exactly our substrate: rooms with doors (the metaspace), NSEW as the C₄
+rotation (the four-corner i-rotation), `enterAny`/doors as exits. A text adventure is a **room graph
+rendered in prose with a treaty-stable direction vocabulary**. The dev-room with its doors already IS a
+Zork map; speaking to the TV (B-1024 rung 6) in Zork grammar ("go north", "look", "open door") is the
+conversational interface with 45 years of proven UX.
+
+## "Support his format too" — the Z-machine
+
+ZORK's format is the **Z-machine** (Berez & Blank, Infocom 1979): the original portable story VM —
+story files (`.z3/.z5/.z8`) run unchanged on interpreters for every platform since 1980 (Frotz et al.;
+Inform — Nelson 1993 — still targets it). It is the **prior-art champion of exactly our thesis**: a
+tiny, well-specified VM as the universal portable substrate (CHIP-8's sibling — CHIP-8 for
+games/graphics 1977, Z-machine for narrative/rooms 1979; the same era, the same move).
+
+Support path (capability-honest, additive):
+1. **Direction vocabulary first** (cheap): adopt Zork's compass as the treaty vocabulary for room
+   navigation crossings (`go:north` etc.) — the metaspace doors + MeshPong NSEW already speak it in
+   spirit; ratify the words.
+2. **Z-machine room as oracle** (the real support): a Z-machine interpreter room (spec is public,
+   v3 is small) — story files become rooms; the membrane discipline holds (input crossings in, prose
+   out). Our extensions live in undefined opcode/header space per `universal/extension.md`.
+3. **The TV binding**: text-adventure prose IS the text-capability render of any room graph — the
+   chronovisor's text channel ("you are in the dev-room; exits are N, E, and SELF").
+
+## The extension interface (carved)
+
+`universal/extension.md` (this PR): extensions live in unused encoding space; the original is the ZERO
+CASE (not a mode); hosts probe honestly; every extension ships golden vectors. XO-CHIP generalized —
+the same law that lets original CHIP-8 ROMs run under color planes lets standard Z-machine stories run
+under ours. "We can move forward with whatever" = the interface makes EVERY format extensible without
+betraying its installed base.
+
+## Pointers
+
+- `universal/extension.md` · `universal/color.md` — the two sibling contracts.
+- Anchors: Z-machine (Berez/Blank 1979; Nelson's Inform; Frotz) · ZIL · Cassagnes (Etch-a-Sketch 1960) ·
+  Hasbro Lite-Brite 1967 · Infocom ZORK 1980 (Anderson/Blank/Daniels/Lebling, the MIT lineage) ·
+  XO-CHIP (Earnest).
+- `docs/research/2026-06-11-universal-color-interface-grounding-...md` (BBS/CYOA — the same stream) ·
+  the metaspace doors / DevRoom.selfDoor (the Zork map we already have).

--- a/universal/extension.md
+++ b/universal/extension.md
@@ -1,0 +1,42 @@
+# universal/extension — the Extension Interface (grow a system without breaking its zero case)
+
+> **Universal Extension Interface** — how ANY closed format/VM/protocol grows: extensions live in
+> **unused encoding space**, the **original behavior is the zero case** (not a mode), and every
+> extension ratifies with **golden vectors** like any treaty surface. An extension never changes what
+> existing artifacts mean; a host that lacks the extension binds honestly at its zero case ("not yet").
+
+Aaron 2026-06-11: *"have some interface for extensions and we can move forward with whatever."* The
+XO-CHIP move (bit-plane color in unused CHIP-8 opcodes; every original ROM unchanged) generalized to a
+universal shape.
+
+## The contract (pure shape)
+
+- **`Space`** — where extensions may live: encoding points the base spec never assigns (unused opcodes,
+  reserved fields, undefined tags). NEVER repurpose assigned space.
+- **`Zero`** — the base behavior IS the degenerate case of the extended behavior (mono = 1 plane;
+  no-extension = identity). Compatibility is structural, not a compatibility *mode*.
+- **`Probe`** — a host can be asked what it supports (honest capability, `universal/color.md` rule);
+  absent = zero case, never a crash.
+- **`Vectors`** — each extension ships golden vectors (text, hex-in-JSON where binary) proving the zero
+  case unchanged AND the extension deterministic across oracles.
+
+## Instances (running + planned)
+
+| system | zero case | extension space | status |
+|---|---|---|---|
+| CHIP-8 → color planes | Mono1 (original ROMs) | unused opcodes (XO-CHIP precedent) | planned ("until we upgrade") |
+| RISC-V → reversible profile | standard RV | the open custom-opcode space | B-1025 seam |
+| InterruptKind / membrane log | the 8 ratified kinds | new kinds = new lines; old logs parse unchanged | running |
+| Z-machine support | a standard story file runs | our extensions in undefined opcode/header space | proposed (the ZORK doc) |
+| LinguisticSeed packs | the bare seed | added packs (OCP — composition is the extension) | running |
+
+## Anchors (Beacon)
+
+XO-CHIP (Earnest) · Super-CHIP (Bryntse) · RISC-V custom-extension discipline (Asanović & Patterson) ·
+TLV/"ignore unknown tags" protocol lineage (ASN.1, protobuf unknown fields) · Meyer OCP 1988 (the same
+law at the type level) · HTML's "unknown elements render as inline" (the web's zero case).
+
+## Pointers
+
+- `universal/color.md` (honest capability — the sibling rule) · `gen/action-grammar.md` (backends bind
+  at declared capability) · the ZORK/Z-machine doc (`docs/research/2026-06-11-etch-a-sketch-lite-brite-zork-zmachine-...md`).


### PR DESCRIPTION
Aaron's stream: universal/extension.md carves the XO-CHIP move as a universal contract (unused encoding space, zero-case compatibility, honest Probe, golden vectors — instances: CHIP-8 planes, RISC-V reversible, InterruptKind log, Z-machine, seed packs). ZORK: the compass IS our four-corner C₄ over the room graph (the dev-room already is a Zork map; 'go north' = speak-to-the-TV grammar); 'his format' = the Z-machine (Berez & Blank 1979) — CHIP-8's narrative sibling; support path = ratify direction vocabulary → Z-machine v3 interpreter room → the TV's text channel. Etch-a-Sketch/Lite-Brite as honest capability bindings (Lite-Brite = literal LEDs on the Pi rung). Docs only.