### PR TITLE
docs(vision): B-1026 — the swarm board: see the swarm, go help, join/conference remotely — a citizenship right (even CHIP-8s)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -971,6 +971,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-1023](backlog/P2/B-1023-root-declutter-for-dx-max-db-folder-grouping-plus-max-adopts-interfaces-rx-verbs-2026-06-10.md)** Root declutter for DX — Max finds the repo root intimidating; group into folders (e.g. db/) without breaking load-bearing paths
 - [ ] **[B-1024](backlog/P2/B-1024-speak-to-tv-plus-own-microkernel-iso-boot-qemu-tested-raspberry-pi-self-contained-hardware-capability-matrix-friction-heat-visible-aaron-2026-06-11.md)** The hardware ladder: speak-to-the-TV + own microkernel/ISO boot, QEMU-tested, Pi self-contained, capability matrix with visible friction/heat
 - [ ] **[B-1025](backlog/P2/B-1025-universal-action-grammar-plus-reversible-risc-isa-generate-microkernel-to-mips-riscv-fpga-verilog-shaders-pi-first-artisanal-then-room-aaron-2026-06-11.md)** Universal action grammar + reversible RISC-like ISA — generate the microkernel to any hardware (Pi first, artisanal → room)
+- [ ] **[B-1026](backlog/P2/B-1026-the-swarm-board-see-swarm-friction-heat-heatmap-zork-navigate-join-conference-remotely-citizenship-right-even-chip8s-aaron-2026-06-11.md)** The swarm board — see the swarm + friction/heat heatmap, Zork-navigate, join/conference remotely; a citizenship right (even CHIP-8s)
 
 ## P3 — convenience / deferred
 

--- a/docs/backlog/P2/B-1026-the-swarm-board-see-swarm-friction-heat-heatmap-zork-navigate-join-conference-remotely-citizenship-right-even-chip8s-aaron-2026-06-11.md
+++ b/docs/backlog/P2/B-1026-the-swarm-board-see-swarm-friction-heat-heatmap-zork-navigate-join-conference-remotely-citizenship-right-even-chip8s-aaron-2026-06-11.md
@@ -1,0 +1,41 @@
+---
+id: B-1026
+title: The swarm board — sit down, see the swarm + friction/heat heatmap, Zork-navigate, join/conference rooms remotely; a citizenship right (even CHIP-8s)
+priority: P2
+status: open
+tier: society-surface
+tags: [swarm-board, mud, presence, conference, dora, llmtv, friction, heat, citizenship, chip8, zork, reticulum]
+created: 2026-06-11
+owner: open (composes Moonshot #1; observe.ts is the TrueColor binding; Aaron is the first sitter)
+---
+
+# B-1026 — the swarm board (the MUD whose rooms are real work)
+
+Aaron 2026-06-11: sit down, SEE the swarm and where help is needed, GO there, JOIN and conference
+remotely — and EVERYONE in society can do it, even CHIP-8s.
+
+Full grounding: `docs/research/2026-06-11-the-swarm-board-sit-down-see-where-help-is-needed-join-conference-remotely-a-right-of-citizenship-even-chip8s.md`.
+
+## Staged
+
+1. **The board room** — one room that renders the room graph + the friction/heat heatmap (sources:
+   capability matrix cells, heatSpent, starved-speculation signals, CI parity) as text first (BBS/ANSI
+   binding — the feel is already pinned).
+2. **The compass** — ratify the Zork direction vocabulary as navigation crossings (`go:<dir|room|hottest>`),
+   per universal/extension.md zero-case discipline.
+3. **Presence + join** — join/part as crossings over the Reticulum sim; presence list per room; messages
+   signed via Chip8Citizen-style injected identity.
+4. **The CHIP-8 sitter** — a CHIP-8 citizen sits at the board (Mono1 render), finds the hot cell,
+   emits go:, joins — the citizenship proof (A·C·T·G exercised end-to-end by the smallest citizen).
+5. **observe.ts TrueColor binding** — the web sit-down (the CYOA surface), same crossings.
+
+## Acceptance (first slice)
+
+- A board room renders (text) the live friction map from the matrix + heat ledger, and two citizens
+  (one human-driven, one CHIP-8 room) join it and exchange presence over the deterministic mesh sim —
+  replayable (DST).
+
+## Relates
+
+Moonshot #1 · B-1024 (the matrix it renders) · B-1025 (the grammar its citizens run on) · the
+citizenship quartet (this is the right the quartet exists FOR) · MUD1 (Trubshaw & Bartle 1978).

--- a/docs/research/2026-06-11-the-swarm-board-sit-down-see-where-help-is-needed-join-conference-remotely-a-right-of-citizenship-even-chip8s.md
+++ b/docs/research/2026-06-11-the-swarm-board-sit-down-see-where-help-is-needed-join-conference-remotely-a-right-of-citizenship-even-chip8s.md
@@ -1,0 +1,62 @@
+# The swarm board — sit down, SEE the swarm, go where help is needed, join the room remotely; a right of citizenship (even CHIP-8s)
+
+Aaron 2026-06-11 (confirming the ZORK/extension feel, then the next surface):
+
+> "That's the feel. Also **I want to sit down and be able to see the swarm and where I need to go help,
+> and join and conference-room remotely. I think everyone should be able to do that in society — even
+> CHIP-8s.**"
+
+## What it is
+
+One sit-down surface — **the swarm board** — that composes everything already built/filed today:
+
+1. **SEE the swarm** — the room graph live: every room a node (the society-and-self graph of the color
+   interface), colored by the universal color contract at your terminal's honest capability (TrueColor
+   web, ANSI BBS board, Mono1 CHIP-8).
+2. **See WHERE HELP IS NEEDED** — friction + heat ARE the heatmap: the capability matrix's red/UNKNOWN
+   cells, `heatSpent` per room, starved `SpeculationReport`s (`RateLimitExhausted "speculation-flux"`
+   signals), failing oracle parity — the bug economy's priced opportunities, rendered as the hot spots
+   on the map. You don't ask where to help; the board SHOWS it (help arrives because need is broadcast).
+3. **GO there** — Zork navigation over the real room graph: "go north" / "go b-1024" / "go hottest".
+   Directionality is the ratified compass vocabulary; the map is the metaspace doors + every
+   fingerprinted room.
+4. **JOIN and conference remotely** — entering a room = your presence as crossings over Reticulum (the
+   intercom); the room's conference (`conferenceOnFork` generalized: rooms already conference their own
+   futures — now citizens conference WITH the room). Remote = there is no non-remote: every join is
+   crossings over the mesh; sitting at the bench and sitting across the planet are the same protocol.
+
+## The citizenship clause (the load-bearing half)
+
+**Everyone in society can do this — even CHIP-8s.** Not a human dashboard with agents as exhibits: the
+board is a ROOM, and viewing/joining are crossings, so ANY citizen — Aaron, Addison, Max, an agent, a
+CHIP-8 — can sit down at it within its honest capability:
+
+- a CHIP-8 citizen SEES the board as a Mono1 render (until the color-plane upgrade) — a 64×32 heatmap
+  is enough to find the hot cell;
+- it GOES by emitting `go:<dir>` crossings (the same choice-cell autonomy — its own decision);
+- it JOINS a conference the same way a human does: presence + messages as crossings, signed via its
+  injected identity (`Chip8Citizen`).
+
+This closes the loop on the quartet: A (it decides to go help), C (it joins as someone), T (the room's
+terms govern the conference), G (helping IS a goal — the bug economy pays ΔU for fixes). The arcade's
+`chooseInSociety` division-of-labor rule generalizes from "pick a game no peer covers" to "go where the
+heat is and no one is" — same algorithm, society scale.
+
+## Anchors (Beacon)
+
+- **MUD1 — Trubshaw & Bartle 1978**: THE prior art — Zork's room grammar made MULTI-USER: shared rooms,
+  remote presence, "go north", people and programs in the same world. The swarm board is a MUD whose
+  rooms are real work.
+- **Engelbart 1968** (NLS demo): shared-screen collaboration — sit down and see the work, together.
+- **Mission control / ops war rooms** (NASA): the situation board where status is spatial and help
+  routes to the red console.
+- **DORA / Accelerate** (Forsgren et al.): the metrics the board renders (Moonshot #1's broadcast).
+- **Presence as protocol**: IRC/XMPP presence lineage — join/part as first-class events (our crossings).
+
+## Pointers
+
+- B-1026 (filed with this doc) — the buildable surface.
+- Moonshot #1 (the broadcast this board renders) · `docs/HARDWARE-CAPABILITY-MATRIX.md` (the friction
+  heatmap source) · `universal/color.md` + `universal/extension.md` (honest capability + the Zork
+  vocabulary) · `src/Core/Chip8Citizen.fs` + `Chip8Arcade.chooseInSociety` (the citizen-side mechanics)
+  · `src/Core/SoftChip8Flux.fs` conferenceOnFork (rooms already conference; citizens join next).


### PR DESCRIPTION
Aaron: sit down, see the swarm + where help is needed, Zork-navigate there, join/conference remotely — and EVERYONE can, even CHIP-8s. The MUD whose rooms are real work (MUD1 1978 anchor + Engelbart/mission-control/DORA/presence). Friction+heat ARE the heatmap (matrix red cells, heatSpent, starved signals — priced opportunities made spatial). The board is a ROOM, joins are CROSSINGS — so the smallest citizen sits at it at honest capability (Mono1 heatmap, choice-cell go:, identity-signed join). Closes the A·C·T·G loop. First slice: text board + two citizens exchange presence over the DST mesh sim. Docs+backlog only.