### PR TITLE
docs(hardware): NVIDIA GPUs in hand and ready — shader rung jumps the queue (matrix + B-1025/B-1026)

### DIFF
--- a/docs/HARDWARE-CAPABILITY-MATRIX.md
+++ b/docs/HARDWARE-CAPABILITY-MATRIX.md
@@ -23,6 +23,7 @@ replay). Idempotent upsert by (target, surface). No aspirational greens.
 | **raspberry-pi-4/5** (metal) | UNKNOWN (arm64 .NET exists upstream) | UNKNOWN | UNKNOWN | UNKNOWN | UNKNOWN | UNKNOWN (RNS upstream supports Pi) | UNKNOWN | Aaron has the hardware; nothing recorded |
 | **microcontroller class** (RNode-ish) | ❌ honest-no (no .NET) | ❌ | UNKNOWN (no_std uninvestigated) | UNKNOWN (a C CHIP-8 fits the class) | ❌ (sim is .NET) | UNKNOWN (RNode firmware proves the radio layer) | ❌ | class analysis only — the honest-capability probe is B-1024 rung 5 |
 | **nixos-x64** | UNKNOWN | UNKNOWN | UNKNOWN | UNKNOWN | UNKNOWN | UNKNOWN | UNKNOWN | named in the 6×6×6 room axis; no recorded run |
+| **nvidia-gpu (CUDA, small AND large)** | UNKNOWN (ILGPU/.NET-CUDA exists upstream) | UNKNOWN | UNKNOWN (cudarc) | UNKNOWN (a shader CHIP-8 is the lens-on-GPU probe) | UNKNOWN | n/a | n/a | **hardware IN HAND — Aaron: "tons hooked up right now, ready" (2026-06-11); B-0725 lineage; the B-1025 shader rung jumps the queue** |
 
 Legend: ✅ proven green · ❌ honest-no (class can't carry it — declared, like Mono1) · UNKNOWN = no
 evidence either way (NOT a no; a cell waiting for its first run).
@@ -37,6 +38,9 @@ evidence either way (NOT a no; a cell waiting for its first run).
    has looked (cheap to scout).
 4. **RNS daemon real-wire** — the sim is proven; the `rnsd` integration is the FinalizerRuntimeLive
    named follow-up. Friction unknown until tried.
+5. **NVIDIA GPU bring-up** — hardware READY NOW (Aaron's bench, "tons hooked up"); "go small and large"
+   = both a minimal kernel probe (one room loop on one SM) and the large fan-out (the swarm board's
+   society graph as GPGPU). The waiting-on-nothing cell: first green is a bench session away.
 
 ## Heat
 

--- a/docs/backlog/P2/B-1025-universal-action-grammar-plus-reversible-risc-isa-generate-microkernel-to-mips-riscv-fpga-verilog-shaders-pi-first-artisanal-then-room-aaron-2026-06-11.md
+++ b/docs/backlog/P2/B-1025-universal-action-grammar-plus-reversible-risc-isa-generate-microkernel-to-mips-riscv-fpga-verilog-shaders-pi-first-artisanal-then-room-aaron-2026-06-11.md
@@ -29,7 +29,7 @@ Full grounding + anchors: `docs/research/2026-06-11-universal-action-grammar-rev
    room forever).
 4. **Reversible RISC-V profile** (the novel seam, named as novelty): Pendulum/PISA-class reversibility
    on RISC-V's open opcode space; the un-instruction = ISA-level retraction.
-5. **Fan out**: MIPS (Max) · FPGA Verilog (Aaron) · SPIR-V shaders — each a backend of the SAME grammar.
+5. **Fan out**: MIPS (Max) · FPGA Verilog (Aaron) · **NVIDIA GPU first among shader targets — hardware in hand NOW** (Aaron 2026-06-11: "tons hooked up, ready"; "go small and large" = minimal one-SM room-loop probe AND the large society-graph GPGPU) · SPIR-V — each a backend of the SAME grammar.
 
 ## Acceptance (first slice)
 

--- a/docs/backlog/P2/B-1026-the-swarm-board-see-swarm-friction-heat-heatmap-zork-navigate-join-conference-remotely-citizenship-right-even-chip8s-aaron-2026-06-11.md
+++ b/docs/backlog/P2/B-1026-the-swarm-board-see-swarm-friction-heat-heatmap-zork-navigate-join-conference-remotely-citizenship-right-even-chip8s-aaron-2026-06-11.md
@@ -28,6 +28,7 @@ Full grounding: `docs/research/2026-06-11-the-swarm-board-sit-down-see-where-hel
 4. **The CHIP-8 sitter** — a CHIP-8 citizen sits at the board (Mono1 render), finds the hot cell,
    emits go:, joins — the citizenship proof (A·C·T·G exercised end-to-end by the smallest citizen).
 5. **observe.ts TrueColor binding** — the web sit-down (the CYOA surface), same crossings.
+6. **Deploy wide** (Aaron 2026-06-11): "then we do the dotnet version and raspberry pi too and all our treaty languages, and we go small and large on NVIDIA GPUs — I have tons hooked up right now, ready" — the board itself ports across the treaty oracles (.NET/TS/Rust/C#), runs on the Pi rung, and renders/computes small-and-large on the in-hand NVIDIA bench.
 
 ## Acceptance (first slice)
 


### PR DESCRIPTION
Aaron: 'we do the dotnet version and raspberry pi too and all our treaty languages, and we go small and large on NVIDIA GPUs — tons hooked up right now, ready.' Matrix gains the nvidia-gpu row (cells honest UNKNOWN; the changed fact is hardware availability) + friction-map entry: the waiting-on-nothing cell. B-1025 reorders NVIDIA first among shader targets; B-1026 gains the deploy-wide stage (treaty oracles + Pi + GPU small-and-large). Docs only.