### PR TITLE
docs(charter): the feel charter — pre-internet magic, D&D style, for Max and Addison

### DIFF
--- a/docs/research/2026-06-11-the-feel-charter-dnd-pre-internet-magic-for-max-and-addison-claude-code-cli-energy.md
+++ b/docs/research/2026-06-11-the-feel-charter-dnd-pre-internet-magic-for-max-and-addison-claude-code-cli-energy.md
@@ -1,0 +1,60 @@
+# The feel charter — bring back the pre-internet magic, D&D style (for Max and Addison)
+
+Aaron 2026-06-11 (the why under the whole BBS/ZORK/CYOA aesthetic thread):
+
+> "**Max and Addison do not know that magical feel of pre-internet. I'm going to bring it back.** Devs
+> viciously love Claude Code CLI, and so do I — going to give it that feel of the old days, **D&D
+> style** lol."
+
+## What this is
+
+The **aesthetic charter** for every sit-down surface (the swarm board, the DORA screen, the TV, the
+CYOA): not retro for retro's sake — a **gift across a generation**. Aaron had the pre-internet magic
+(BBS doors, MUDs, text adventures, the D&D table); Max and Addison never did; the surfaces are how they
+get it — at the same bench where the real work happens. The proof the feel still works on modern devs
+is already in hand: the terminal-native, text-first, presence-in-a-session energy of Claude Code CLI is
+*the same feel* — that's why "devs viciously love" it.
+
+## The lineage closes (every piece already anchored today, one root added)
+
+**D&D — Gygax & Arneson 1974** — is the ROOT of the whole tree we anchored today:
+- D&D (1974: rooms, a dungeon master narrating state, dice as the entropy source, the party as the
+  swarm) →
+- Zork/Adventure (1976–80: the DM automated — the Z-machine) →
+- MUD1 (1978: the table goes multi-user/remote) →
+- BBS doors + CYOA (the 80s: the feel distributed) →
+- … the internet (the feel diluted) … →
+- Claude Code CLI (the feel rediscovered: a terminal, a narrator, a session) →
+- **the swarm board / LLMTV (the feel completed: the dungeon is real work, the party is the society,
+  and even CHIP-8s sit at the table).**
+
+## D&D-style, mapped (the table's roles are already our architecture)
+
+| at the D&D table | in the substrate |
+|---|---|
+| the dungeon master | the room narrating its own state (the TV's text channel; the chronovisor) |
+| the map on the table | the swarm board (rooms, doors, the heatmap as the dungeon's dangers) |
+| dice | the injected entropy Source (§13 — the DM rolls, the world doesn't cheat) |
+| the party | the swarm society: Aaron, Addison, Max, agents, CHIP-8 citizens |
+| a campaign session | a recorded membrane log — replayable; the saves/ folder IS the campaign notebook |
+| character sheet | the citizen: identity handle + capability + goal (A·C·T·G) |
+| "you may attempt it — roll" | no-directives: observations and odds, never orders |
+
+## Charter (binding on the surfaces, lightly held)
+
+1. Text-first, terminal-native; ANSI/CP437 is the dress code (already pinned for DORA).
+2. A narrator, not a dashboard: the board TELLS you the state ("you are in the dev-room; the forge to
+   the north runs hot; exits are N, E, SELF").
+3. Session = campaign: every sit-down is recorded, resumable, replayable (saves/).
+4. The dice are honest (injected entropy, DST-replayable — the DM never fudges).
+5. Everyone rolls: the same table for humans, agents, and the smallest VM citizen.
+
+## Pointers
+
+- Anchors: Gygax & Arneson, *Dungeons & Dragons* (TSR 1974) · Crowther & Woods *Adventure* 1976 ·
+  the already-anchored line (Zork/Z-machine · MUD1 · BBS/CP437 · CYOA).
+- `docs/research/2026-06-11-the-swarm-board-...md` (the table) · `...etch-a-sketch-lite-brite-zork-...md`
+  (the format) · `...universal-color-interface-grounding-...md` (the dress code) · `saves/` (the
+  campaign notebook) · the no-directives rule (the DM's voice).
+- The dedication lineage: built FOR Max and Addison by name — same register as the Lillian Eve /
+  Addison Cooper dedication (the repo's founding why).


### PR DESCRIPTION
Aaron: bring back the pre-internet magical feel Max and Addison never had — 'devs viciously love Claude Code CLI... that feel of the old days, D&D style.' The lineage closes at its root: D&D 1974 → Adventure/Zork → MUD1 → BBS/CYOA → Claude Code CLI → the swarm board (the dungeon is real work; even CHIP-8s sit at the table). Table roles map 1:1 to built architecture (DM=room narrating itself, dice=injected §13 Source — the DM never fudges = DST, saves/=campaign notebook, character sheet=A·C·T·G citizen, 'roll for it'=no-directives). Five-line charter for all sit-down surfaces. Docs only.