### PR TITLE
feat(society): SwarmBoardAnsi — the BBS/ANSI render binding (B-1026; the dress code)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -221,6 +221,7 @@
     <Compile Include="Chip8Arcade.fs" />
     <Compile Include="Chip8Citizen.fs" />
     <Compile Include="SwarmBoard.fs" />
+    <Compile Include="SwarmBoardAnsi.fs" />
     <Compile Include="Chip8Observer.fs" />
     <Compile Include="SoftController.fs" />
     <Compile Include="ActionGrammar.fs" />

--- a/src/Core/SwarmBoardAnsi.fs
+++ b/src/Core/SwarmBoardAnsi.fs
@@ -1,0 +1,73 @@
+namespace Zeta.Core
+
+/// SwarmBoardAnsi — **the ANSI/BBS render binding of the swarm board** (B-1026 stage; the feel
+/// charter's dress code: "text-first, terminal-native; ANSI/CP437 is the dress code" — the
+/// pre-internet BBS door-game look, "like claude code", for Max and Addison).
+///
+/// This is a BINDING of `universal/color.md` at capability **ANSI-16**: a pure function
+/// `Board → string list` (lines, ready for a terminal). Honest capability: 16 colors via SGR codes;
+/// the box is CP437-style drawn with Unicode box-drawing (the modern terminal's CP437); heat maps to
+/// the classic threat ladder green→yellow→red (the door-game convention). `plain` strips SGR for the
+/// Mono1/test binding — SAME layout, zero color: the zero case is structural (extension discipline).
+[<RequireQualifiedAccess>]
+module SwarmBoardAnsi =
+
+    let private esc (code: string) = "[" + code + "m"
+    let private reset = esc "0"
+
+    /// The door-game heat ladder: cool=green, warm=yellow, hot=red (bright), cold/zero=dim.
+    let private heatSgr (h: float) : string =
+        if h <= 0.0 then esc "2" // dim
+        elif h < 0.3 then esc "32" // green
+        elif h < 0.7 then esc "33" // yellow
+        else esc "1;31" // bright red
+
+    /// A heat bar, door-game style: ten cells of █/░ (the Lite-Brite pegboard in one dimension).
+    let private bar (h: float) : string =
+        let filled = min 10 (max 0 (int (h * 10.0 + 0.5)))
+        String.replicate filled "█" + String.replicate (10 - filled) "░"
+
+    /// Render the board as a BBS screen for one sitter: box-drawn frame, room rows (heat bar + who's
+    /// there), and the narrator line at the bottom (the DM speaks). Deterministic (ordinal order).
+    let render (who: string) (b: SwarmBoard.Board) : string list =
+        let width = 56
+
+        let top = "╔" + String.replicate width "═" + "╗"
+        let mid = "╟" + String.replicate width "─" + "╢"
+        let bot = "╚" + String.replicate width "═" + "╝"
+
+        let pad (s: string) (visibleLen: int) =
+            "║ " + s + String.replicate (max 0 (width - 1 - visibleLen)) " " + "║"
+
+        let title =
+            let t = "THE SWARM BOARD ── where does the society run hot?"
+            pad t t.Length
+
+        let roomRows =
+            b.Rooms
+            |> Map.toList // Map iterates ordinal on string keys — deterministic
+            |> List.map (fun (name, r) ->
+                let occupants =
+                    b.Presence
+                    |> Map.toList
+                    |> List.filter (fun (_, room) -> room = name)
+                    |> List.map fst
+                    |> List.sortWith (fun a c -> System.String.CompareOrdinal(a, c))
+
+                let occ = if List.isEmpty occupants then "" else " · " + String.concat ", " occupants
+                let visible = sprintf "%-12s %s %5.3f%s" name (bar r.Heat) r.Heat occ
+                let colored = sprintf "%-12s %s%s%s %5.3f%s" name (heatSgr r.Heat) (bar r.Heat) reset r.Heat occ
+                pad colored visible.Length)
+
+        let narration = SwarmBoard.narrate who b
+        let dmRow = pad (esc "36" + narration + reset) narration.Length
+
+        [ top; title; mid ] @ roomRows @ [ mid; dmRow; bot ]
+
+    /// The Mono1/zero-case binding: the SAME screen with every SGR escape stripped (structural zero
+    /// case — the extension discipline: color absent ⇒ identical layout, not a different screen).
+    let plain (who: string) (b: SwarmBoard.Board) : string list =
+        let strip (s: string) =
+            System.Text.RegularExpressions.Regex.Replace(s, "\\[[0-9;]*m", "")
+
+        render who b |> List.map strip

--- a/tests/Tests.FSharp/SwarmBoardAnsi.Tests.fs
+++ b/tests/Tests.FSharp/SwarmBoardAnsi.Tests.fs
@@ -1,0 +1,45 @@
+module Zeta.Tests.SwarmBoardAnsiTests
+
+// The ANSI/BBS binding (the feel charter's dress code) — capability-honest: ANSI-16 render + the
+// Mono1 zero case (same layout, color stripped — the extension discipline structurally).
+
+open global.Xunit
+open Zeta.Core
+
+let private board () =
+    SwarmBoard.create
+        [ "dev-room", [ "n", "forge" ]
+          "forge", [ "s", "dev-room" ] ]
+    |> SwarmBoard.apply "join:aaron:dev-room"
+    |> SwarmBoard.apply "join:max:forge"
+    |> SwarmBoard.apply "heat:forge:900"
+
+[<Fact>]
+let ``the screen is deterministic and framed (same board, same bytes)`` () =
+    let a = SwarmBoardAnsi.render "aaron" (board ())
+    let b = SwarmBoardAnsi.render "aaron" (board ())
+    Assert.Equal<string list>(a, b)
+    Assert.StartsWith("╔", List.head a)
+    Assert.StartsWith("╚", List.last a)
+
+[<Fact>]
+let ``hot rooms wear bright red; cool rooms stay dim (the door-game ladder)`` () =
+    let screen = SwarmBoardAnsi.render "aaron" (board ()) |> String.concat "\n"
+    Assert.Contains("[1;31m█", screen) // forge at 0.9 → bright red, mostly-filled bar
+    Assert.Contains("[2m░", screen)    // dev-room at 0 → dim, empty bar
+
+[<Fact>]
+let ``the narrator line is on the screen (a DM, not a dashboard)`` () =
+    let screen = SwarmBoardAnsi.plain "aaron" (board ()) |> String.concat "\n"
+    Assert.Contains("You are in dev-room.", screen)
+    Assert.Contains("Running hot: forge (0.900).", screen)
+
+[<Fact>]
+let ``Mono1 zero case: plain is the SAME screen with color stripped — layout identical`` () =
+    let colored = SwarmBoardAnsi.render "aaron" (board ())
+    let mono = SwarmBoardAnsi.plain "aaron" (board ())
+    Assert.Equal(List.length colored, List.length mono)
+    Assert.DoesNotContain("[", String.concat "" mono |> fun s -> s) |> ignore
+    Assert.False(mono |> String.concat "" |> fun s -> s.Contains "")
+    // occupants visible at their rooms in the mono render too
+    Assert.Contains(mono, fun (l: string) -> l.Contains "forge" && l.Contains "max")

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -149,6 +149,7 @@
     <Compile Include="Chip8Citizen.Tests.fs" />
     <Compile Include="SwarmBoard.Tests.fs" />
     <Compile Include="SwarmBoardMesh.Tests.fs" />
+    <Compile Include="SwarmBoardAnsi.Tests.fs" />
     <Compile Include="Chip8SelfSim.Tests.fs" />
     <Compile Include="SoftChip8Scheduler.Tests.fs" />
     <Compile Include="BitAdinkra.Tests.fs" />


### PR DESCRIPTION
The board's look: box-drawn ANSI-16 screen, door-game heat ladder (dim→green→yellow→bright-red bars — the Lite-Brite pegboard in 1D), occupants per room, the narrator line in cyan at the bottom (a DM, not a dashboard). Mono1 zero case is STRUCTURAL: plain = same screen, SGR stripped (extension discipline). Deterministic bytes — golden-vectorable for the treaty ports. 4/4 green.