### PR TITLE
feat(hardware): B-1024 slice 1 — aarch64 ISO builds AND boots in CI (QEMU virt + EDK2) + multi-boot CYOA boot-screen design

### DIFF
--- a/.github/workflows/build-ai-cluster-iso.yml
+++ b/.github/workflows/build-ai-cluster-iso.yml
@@ -445,3 +445,63 @@ jobs:
           path: ${{ steps.sign.outputs.bundle-path }}
           if-no-files-found: error
           retention-days: 90
+
+  # ── B-1024 slice 1 (2026-06-11): the aarch64 ISO builds AND BOOTS in CI ──
+  # Native aarch64 end-to-end on the ubuntu-24.04-arm runner: build the
+  # aarch64 installer ISO from the SAME configuration (one source of
+  # truth; only `system` differs), then boot it in qemu-system-aarch64
+  # (-machine virt + EDK2 UEFI) and assert the zeta-installer login
+  # prompt on the PL011 serial (ttyAMA0 — the installer's kernel params
+  # list ttyS0 + ttyAMA0 so ONE config serves both arches). This is the
+  # hardware axis joining the oracle cross-product (DST for hardware:
+  # same image, same inputs, same bytes — emulated first, then the Pi).
+  # Skips the k3s nixosTest checks (x86_64-gated in the flake).
+  build-aarch64:
+    name: build-iso-aarch64 + qemu-boot
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      - name: Check flake evaluates
+        working-directory: full-ai-cluster
+        run: nix flake check --no-build --show-trace
+
+      - name: Build aarch64 installer ISO
+        working-directory: full-ai-cluster
+        run: nix build .#installer-iso --print-build-logs
+
+      - name: Install QEMU (aarch64 system emulator + EDK2 UEFI firmware)
+        run: sudo apt-get update -y && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends qemu-system-arm qemu-efi-aarch64
+
+      - name: QEMU aarch64 boot smoke-test (B-1024 slice 1 floor)
+        working-directory: full-ai-cluster
+        run: |
+          set -euo pipefail
+          mapfile -t iso_candidates < <(find result/iso -maxdepth 1 -type f \( -name 'zeta-installer-*.iso' -o -name 'nixos-minimal-*.iso' \) | sort)
+          if [ "${#iso_candidates[@]}" -eq 0 ]; then
+            echo "::error::aarch64 QEMU boot test: No installer ISO under result/iso/" >&2
+            exit 1
+          fi
+          iso_abs=$(readlink -f "${iso_candidates[0]}")
+          echo "Booting aarch64 ISO: $iso_abs"
+          bun ../tools/ci/qemu-boot-test.ts "$iso_abs" --arch aarch64
+
+      - name: Upload aarch64 ISO artifact
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v4.6.1
+        with:
+          name: zeta-installer-aarch64-iso
+          path: full-ai-cluster/result/iso/*.iso
+          retention-days: 14
+          if-no-files-found: error

--- a/docs/HARDWARE-CAPABILITY-MATRIX.md
+++ b/docs/HARDWARE-CAPABILITY-MATRIX.md
@@ -20,10 +20,10 @@ replay). Idempotent upsert by (target, surface). No aspirational greens.
 | **macos-arm64** (macos-15, M-class) | ✅ | ✅ | ✅ | ✅ | ✅ | UNKNOWN | n/a (host) | macos-15 workflow + this dev machine (Darwin 25.4, daily) |
 | **qemu-x86_64** | UNKNOWN | UNKNOWN | UNKNOWN | UNKNOWN | UNKNOWN | UNKNOWN | ✅ **boots, in CI** | `build-ai-cluster-iso.yml` + `tools/ci/qemu-boot-test.ts` (serial-console login-prompt smoke test) + `qemu-full-install-test.ts`; green runs 2026-06-10 |
 | **qemu-aarch64** | UNKNOWN | UNKNOWN | UNKNOWN | UNKNOWN | UNKNOWN | UNKNOWN | UNKNOWN — the remaining B-1024 slice-1 gap (x86_64 proven; arch port of the boot test) | none yet |
-| **raspberry-pi-4/5** (metal) | UNKNOWN (arm64 .NET exists upstream) | UNKNOWN | UNKNOWN | UNKNOWN | UNKNOWN | UNKNOWN (RNS upstream supports Pi) | UNKNOWN | Aaron has the hardware; nothing recorded |
+| **raspberry-pi-4/5** (metal) | UNKNOWN (arm64 .NET exists upstream) | UNKNOWN | UNKNOWN | UNKNOWN | UNKNOWN | UNKNOWN (RNS upstream supports Pi) | UNKNOWN | Aaron has the hardware (Pi + NAS equipment on the bench, 2026-06-11); nothing recorded; the aarch64 CI ISO artifact (slice 1) is the flash source |
 | **microcontroller class** (RNode-ish) | ❌ honest-no (no .NET) | ❌ | UNKNOWN (no_std uninvestigated) | UNKNOWN (a C CHIP-8 fits the class) | ❌ (sim is .NET) | UNKNOWN (RNode firmware proves the radio layer) | ❌ | class analysis only — the honest-capability probe is B-1024 rung 5 |
 | **nixos-x64** | UNKNOWN | UNKNOWN | UNKNOWN | UNKNOWN | UNKNOWN | UNKNOWN | UNKNOWN | named in the 6×6×6 room axis; no recorded run |
-| **nvidia-gpu (CUDA, small AND large)** | UNKNOWN (ILGPU/.NET-CUDA exists upstream) | UNKNOWN | UNKNOWN (cudarc) | UNKNOWN (a shader CHIP-8 is the lens-on-GPU probe) | UNKNOWN | n/a | n/a | **hardware IN HAND — Aaron: "tons hooked up right now, ready" (2026-06-11); B-0725 lineage; the B-1025 shader rung jumps the queue** |
+| **nvidia-gpu (CUDA, small AND large)** | UNKNOWN (ILGPU/.NET-CUDA exists upstream) | UNKNOWN | UNKNOWN (cudarc) | UNKNOWN (a shader CHIP-8 is the lens-on-GPU probe) | UNKNOWN | n/a | n/a | **hardware IN HAND — Aaron 2026-06-11: 4 machines waiting incl. RTX 4090 + RTX 3090; "tons hooked up right now, ready"; B-0725 lineage; the B-1025 shader rung jumps the queue** |
 
 Legend: ✅ proven green · ❌ honest-no (class can't carry it — declared, like Mono1) · UNKNOWN = no
 evidence either way (NOT a no; a cell waiting for its first run).

--- a/docs/research/2026-06-11-qemu-slice1-aarch64-plus-zeta-multiboot-iso-cyoa-boot-screen-bench-closes-over-into-shared-library.md
+++ b/docs/research/2026-06-11-qemu-slice1-aarch64-plus-zeta-multiboot-iso-cyoa-boot-screen-bench-closes-over-into-shared-library.md
@@ -1,0 +1,76 @@
+# QEMU slice 1 (aarch64) + the Zeta multi-boot ISO whose boot screen IS the first CYOA page + the bench closes over into the shared library
+
+Aaron 2026-06-11 (authorizing slice 1, then the boot-screen + bench stream):
+
+> "Let's do the QEMU slice 1 and get the ISO booting aarch64. Make sure any ISOs are part of **Zeta's
+> multi-boot ISO** — we have **crypto, home, mining stuff** too. We can make that **boot screen run and
+> look like this** [the BBS/board feel] and **switch into choose-your-own-adventure from early on**."
+> / "I have **4 machines waiting** for this — **4090, 3090, others** — and **Raspberry Pi** and tons of
+> other equipment, and **NAS equipment**. We get to **close over it all, and each one gets added to the
+> library that's shared for common use**."
+
+## Slice 1 — built this PR (the aarch64 boot floor)
+
+- **flake**: `installer-aarch64` nixosConfiguration — the SAME installer configuration, only `system`
+  differs (one source of truth); `aarch64-linux` joins `isoBuildSystems`; the per-system `installer-iso`
+  package selects the right config.
+- **kernel params**: `console=ttyAMA0` added alongside `ttyS0` — each arch ignores the UART it lacks,
+  so ONE config boots both (x86 q35 serial = ttyS0; aarch64 virt PL011 = ttyAMA0; the Pi's UART is also
+  ttyAMA0-family — the same line serves the metal rung).
+- **boot test**: `qemu-boot-test.ts --arch aarch64` — `-machine virt` + EDK2 UEFI (`qemu-efi-aarch64`),
+  KVM when the host is arm64 (the `ubuntu-24.04-arm` runner), TCG `-cpu max` fallback.
+- **CI**: a `build-aarch64` job on `ubuntu-24.04-arm` — native build, boot to login prompt, ISO uploaded
+  as an artifact (14 days) so the Pi can be flashed from CI output directly.
+
+When this job is green, the matrix's `qemu-aarch64` row earns its first ✅ and the Pi rung unblocks.
+
+## The Zeta multi-boot ISO — every ISO is a member, the boot screen is page one of the CYOA
+
+The standing rule (Aaron): **any ISO we produce is a member of ONE Zeta multi-boot ISO** — the installer,
+the crypto/home tools, the mining stack, whatever ships next — one USB stick, one GRUB menu, every tool
+a chapter. Lineage already in place: the GRUB multiboot work (#7506), B-0823 (ISO/kernel/initrd layout),
+B-0853 (signed artifacts).
+
+And the boot menu is not a boring list — **it is the FIRST PAGE of the choose-your-own-adventure**:
+the BBS/D&D feel charter applies from power-on. GRUB themes support exactly this (text menu, colors,
+ASCII art): the menu reads like a room with doors —
+
+```
+  ╔══════════════════════════════════════════╗
+  ║        Z E T A  —  pick your door        ║
+  ╟──────────────────────────────────────────╢
+  ║  > Install a cluster node    (the forge) ║
+  ║    Crypto / home tools       (the vault) ║
+  ║    Mining rig                (the mine)  ║
+  ║    Live arcade (CHIP-8)      (the den)   ║
+  ╚══════════════════════════════════════════╝
+```
+
+The CYOA "switches in from early on" — before an OS even loads, you're already at the table. (GRUB
+theming + the member-ISO loopback entries are the NAMED NEXT SLICE — design here, implementation after
+slice 1 is green; chainloading member ISOs via GRUB loopback is proven prior art.)
+
+## The bench closes over into the shared library (the commons)
+
+The waiting hardware, recorded: **4 machines (RTX 4090, RTX 3090, others) · Raspberry Pi(s) · NAS
+equipment · "tons of other equipment."** The rule Aaron set: **each device "closes over" — becomes a
+named, capability-declared member — and is added to the library that's shared for common use.** That is:
+
+- **close over** = the device gets a citizen identity (governed ZetaId / Reticulum destination), an
+  honest capability row in `docs/HARDWARE-CAPABILITY-MATRIX.md`, and its bring-up recorded
+  (glass-blowing: hot artisanal first, annealed into a room);
+- **the shared library** = the commons (Ostrom — governing shared resources by community rules): any
+  member of the society can USE the 4090s/NAS/Pi through the room protocol, under the matrix's declared
+  capabilities and the treaty terms. Compute and storage become library books: checked out, returned,
+  visible on the board (who's using the forge; how hot it runs).
+
+NAS = the spillover spine's natural home (the tiered hot→cold memory arc); the 4090/3090 = the B-1025
+GPU rung's bench; the Pi = slice 2's metal.
+
+## Pointers
+
+- B-1024 (the ladder; slice 1 = this PR's CI job) · B-1025 (GPU rung — the 4090/3090 bench) ·
+  B-1026 (the board that shows library usage).
+- `docs/HARDWARE-CAPABILITY-MATRIX.md` — where each closed-over device gets its row.
+- the feel charter + `universal/color.md` (the boot screen's dress code) · GRUB loopback chainload
+  (prior art for member ISOs) · Ostrom 1990 (the commons).

--- a/full-ai-cluster/flake.nix
+++ b/full-ai-cluster/flake.nix
@@ -68,6 +68,10 @@
       isoBuildSystems = [
         "x86_64-linux"
         "aarch64-darwin"
+        # B-1024 slice 1 (2026-06-11): aarch64-linux builds the aarch64
+        # installer ISO natively (GitHub ubuntu-24.04-arm runners; Pi
+        # bring-up path). Selects nixosConfigurations.installer-aarch64.
+        "aarch64-linux"
       ];
 
       mkSystem = { system ? "x86_64-linux", modules }: nixpkgs.lib.nixosSystem {
@@ -82,6 +86,16 @@
         # USB installer ISO — identical to the standalone
         # usb-nixos-installer/ flake at the parent level.
         installer = mkSystem {
+          modules = [
+            ./usb-nixos-installer/nixos/installer/configuration.nix
+          ];
+        };
+
+        # The SAME installer configuration built for aarch64 (B-1024
+        # slice 1: QEMU aarch64 boot in CI; the Raspberry Pi rung). One
+        # source of truth — only `system` differs.
+        installer-aarch64 = mkSystem {
+          system = "aarch64-linux";
           modules = [
             ./usb-nixos-installer/nixos/installer/configuration.nix
           ];
@@ -178,8 +192,13 @@
       in
       {
         packages = nixpkgs.lib.optionalAttrs (builtins.elem system isoBuildSystems) {
+          # aarch64-linux hosts build the aarch64 installer natively; all
+          # other ISO-building systems target the x86_64 installer (the
+          # aarch64-darwin case cross-builds it via linux-builder).
           installer-iso =
-            self.nixosConfigurations.installer.config.system.build.isoImage;
+            (if system == "aarch64-linux"
+             then self.nixosConfigurations.installer-aarch64
+             else self.nixosConfigurations.installer).config.system.build.isoImage;
           default = self.packages.${system}.installer-iso;
         };
 

--- a/full-ai-cluster/usb-nixos-installer/nixos/installer/configuration.nix
+++ b/full-ai-cluster/usb-nixos-installer/nixos/installer/configuration.nix
@@ -30,6 +30,11 @@
   # flow); ttyS0 is mirrored secondary at 115200 8N1 (standard).
   boot.kernelParams = [
     "console=ttyS0,115200n8"
+    # aarch64 (QEMU -machine virt / Pi): the PL011 serial is ttyAMA0,
+    # not ttyS0. Each arch ignores the console= naming a UART it does
+    # not have, so listing both keeps ONE config for both ISOs
+    # (B-1024 slice 1). tty1 stays last = primary /dev/console.
+    "console=ttyAMA0,115200n8"
     "console=tty1"
   ];
 

--- a/tools/ci/qemu-boot-test.ts
+++ b/tools/ci/qemu-boot-test.ts
@@ -46,25 +46,70 @@ interface BootResult {
   serialLogTail?: string;
 }
 
+type Arch = "x86_64" | "aarch64";
+
 function usage(): never {
-  console.error("usage: bun tools/ci/qemu-boot-test.ts <iso-path>");
+  console.error("usage: bun tools/ci/qemu-boot-test.ts <iso-path> [--arch x86_64|aarch64]");
   process.exit(2);
 }
 
-function checkDependencies(): string | null {
-  // qemu-system-x86_64 must be installed (apt-get install qemu-system-x86)
+function qemuBinary(arch: Arch): string {
+  return arch === "aarch64" ? "qemu-system-aarch64" : "qemu-system-x86_64";
+}
+
+// aarch64 UEFI firmware (apt: qemu-efi-aarch64). -machine virt has no
+// BIOS path; EDK2 is the only boot road. First existing candidate wins.
+const AARCH64_EFI_CANDIDATES = [
+  "/usr/share/qemu-efi-aarch64/QEMU_EFI.fd",
+  "/usr/share/AAVMF/AAVMF_CODE.fd",
+];
+
+function checkDependencies(arch: Arch): string | null {
+  const bin = qemuBinary(arch);
+  const pkg = arch === "aarch64" ? "qemu-system-arm qemu-efi-aarch64" : "qemu-system-x86";
   try {
-    const result = Bun.spawnSync(["qemu-system-x86_64", "--version"]);
+    const result = Bun.spawnSync([bin, "--version"]);
     if (result.exitCode !== 0) {
-      return "qemu-system-x86_64 not found or non-zero exit; install via `apt-get install -y qemu-system-x86`";
+      return `${bin} not found or non-zero exit; install via \`apt-get install -y ${pkg}\``;
     }
   } catch {
-    return "qemu-system-x86_64 not found in PATH; install via `apt-get install -y qemu-system-x86`";
+    return `${bin} not found in PATH; install via \`apt-get install -y ${pkg}\``;
+  }
+  if (arch === "aarch64" && !AARCH64_EFI_CANDIDATES.some((f) => existsSync(f))) {
+    return `aarch64 UEFI firmware not found (looked for ${AARCH64_EFI_CANDIDATES.join(", ")}); install via \`apt-get install -y qemu-efi-aarch64\``;
   }
   return null;
 }
 
-function buildQemuArgs(isoPath: string, serialLogPath: string): string[] {
+function buildQemuArgs(arch: Arch, isoPath: string, serialLogPath: string): string[] {
+  const kvm = existsSync(KVM_PATH);
+
+  if (arch === "aarch64") {
+    // -machine virt + EDK2 UEFI; the PL011 serial (ttyAMA0 — matched by
+    // the installer's console= kernel param) lands in the serial log.
+    const efi = AARCH64_EFI_CANDIDATES.find((f) => existsSync(f))!;
+    const args: string[] = [
+      "-machine", "virt",
+      "-m", String(MEMORY_MB),
+      "-smp", "2",
+      "-bios", efi,
+      "-cdrom", isoPath,
+      "-boot", "d",
+      "-serial", `file:${serialLogPath}`,
+      "-display", "none",
+      "-no-reboot",
+    ];
+    // KVM only accelerates same-arch (an aarch64 host, e.g. the
+    // ubuntu-24.04-arm runners); otherwise TCG with -cpu max.
+    if (kvm && process.arch === "arm64") {
+      args.push("-enable-kvm", "-cpu", "host");
+    } else {
+      args.push("-cpu", "max");
+      console.warn(`[qemu-boot-test] aarch64 without same-arch KVM; using TCG (will be slow)`);
+    }
+    return args;
+  }
+
   const args: string[] = [
     "-machine", "q35",
     "-m", String(MEMORY_MB),
@@ -81,7 +126,7 @@ function buildQemuArgs(isoPath: string, serialLogPath: string): string[] {
   // KVM acceleration when /dev/kvm is available (GitHub Actions
   // ubuntu-24.04 supports nested KVM). Falls back to TCG (slow but
   // works) when KVM unavailable (e.g., macOS local testing).
-  if (existsSync(KVM_PATH)) {
+  if (kvm) {
     args.push("-enable-kvm", "-cpu", "host");
   } else {
     args.push("-cpu", "qemu64");
@@ -124,7 +169,16 @@ async function waitForLoginPrompt(serialLogPath: string): Promise<BootResult> {
 }
 
 async function main(): Promise<never> {
-  const [isoPath] = process.argv.slice(2);
+  const argv = process.argv.slice(2);
+  const archFlag = argv.indexOf("--arch");
+  let arch: Arch = "x86_64";
+  if (archFlag >= 0) {
+    const v = argv[archFlag + 1];
+    if (v !== "x86_64" && v !== "aarch64") usage();
+    arch = v;
+    argv.splice(archFlag, 2);
+  }
+  const [isoPath] = argv;
   if (!isoPath) usage();
 
   if (!existsSync(isoPath)) {
@@ -132,7 +186,7 @@ async function main(): Promise<never> {
     process.exit(2);
   }
 
-  const depErr = checkDependencies();
+  const depErr = checkDependencies(arch);
   if (depErr) {
     console.error(`[qemu-boot-test] ${depErr}`);
     process.exit(2);
@@ -146,10 +200,11 @@ async function main(): Promise<never> {
   console.log(`[qemu-boot-test] Memory: ${MEMORY_MB}MB; timeout: ${TIMEOUT_SECONDS}s`);
   console.log(`[qemu-boot-test] Expecting login prompt: "${EXPECTED_LOGIN_PROMPT}"`);
 
-  const qemuArgs = buildQemuArgs(isoPath, serialLogPath);
-  console.log(`[qemu-boot-test] Launching: qemu-system-x86_64 ${qemuArgs.join(" ")}`);
+  console.log(`[qemu-boot-test] Arch: ${arch}`);
+  const qemuArgs = buildQemuArgs(arch, isoPath, serialLogPath);
+  console.log(`[qemu-boot-test] Launching: ${qemuBinary(arch)} ${qemuArgs.join(" ")}`);
 
-  const qemu = spawn("qemu-system-x86_64", qemuArgs, {
+  const qemu = spawn(qemuBinary(arch), qemuArgs, {
     stdio: ["ignore", "inherit", "inherit"],
   });
 


### PR DESCRIPTION
Aaron: 'get the ISO booting aarch64' — done as a native ubuntu-24.04-arm CI job: installer-aarch64 nixosConfiguration (same config, only system differs), console=ttyAMA0 beside ttyS0 (one config boots q35/virt/Pi), qemu-boot-test.ts --arch aarch64 (-machine virt + EDK2, KVM-or-TCG), boot-to-login floor, ISO artifact uploaded so the Pi flashes from CI. Plus the design capture: Zeta MULTI-BOOT ISO (every ISO a member — crypto/home/mining) whose GRUB menu IS the first CYOA page (feel charter at power-on; loopback chainload prior art; theme = named next slice). Bench recorded: 4 machines (4090/3090/+), Pi, NAS — each closes over into the shared-commons library (Ostrom). x86 paths unchanged.