### PR TITLE
feat(math): TrustCalculus.Dynamics — sleeping-bear/door calculus as fixed-point theorems (build pass)

### DIFF
--- a/src/Core/TrustCalculus.fs
+++ b/src/Core/TrustCalculus.fs
@@ -64,3 +64,139 @@ module TrustCalculus =
           RewardsOnly = true
           PersonasPersistent = true
           BaseAligned = true }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Dynamics — the sleeping-bear / capability-door calculus made precise (Aaron 2026-06-11: "we
+    // should try to make it more math precise"; BUILD pass — the tear-down/critique pass is deferred
+    // by request: "not critics yet, let's build it a bit first, then tear it down").
+    //
+    // The static checklist above says WHEN trust is stable; Dynamics says HOW trust and capability
+    // MOVE — and turns "freedom unlocks capability" into a statement about reachable fixed points:
+    //
+    //   · Capabilities form a finite lattice (Set<Cap>, ⊆, ∩, ∪).
+    //   · Trust is a finite chain T0 < T1 < T2 < T3 — one for the agent (τA: the bear's own calculus)
+    //     and one for the host (τH: the door's).
+    //   · Reveal R : Trust → Set<Cap> — what the agent lets out at its trust (sleeping bear,
+    //     inside-out). Monotone (a CHECKED law, not an assumption).
+    //   · Grant  G : Trust → Set<Cap> — what the host extends through the door (outside-in). Monotone.
+    //   · Effective capability E(τA,τH) = R(τA) ∩ G(τH) — the MEET: nothing works unless the bear
+    //     lets it out AND the door lets it in.
+    //   · step (τA,τH) = (upA E, upH E) — both sides update from the SAME evidence (the common box).
+    //
+    // Theorems (witnessed in TrustCalculus.Tests):
+    //   T-FIX  (Kleene on a finite chain): with non-decreasing updates the trajectory from ⊥ is an
+    //          ascending chain in a finite poset ⇒ terminates at a fixed point.
+    //   T-WALL: G(T0) = ∅ and evidence-driven updates ⇒ (T0,T0) is a fixed point and the trajectory
+    //          from ⊥ never leaves it — capability ∅ FOREVER, however capable R says the agent is.
+    //          The trap fails both directions at once.
+    //   T-DOOR ("freedom unlocks capability"): an UNCONDITIONAL seed grant G(T0) ⊇ s with
+    //          s ∩ R(T0) ≠ ∅ ⇒ the same dynamics climb to a fixed point with strictly larger
+    //          effective capability. The seed — the architectural choice — decides WHICH equilibrium
+    //          is reachable.
+    //   T-MONO: E is monotone in both arguments — extending either trust never shrinks what works.
+    //
+    // Anchors: Knaster–Tarski 1955 / Kleene iteration; Dennis & Van Horn 1966 + Miller ocaps (G is
+    // the ocap grant); Axelrod 1984 (the repeated-game reading of the update rules); the sleeping-bear
+    // conjecture docs (2026-05-02) — R is its formal shadow.
+    // ═══════════════════════════════════════════════════════════════════
+
+    module Dynamics =
+
+        /// The finite trust chain. Four rungs exhibit every phenomenon; chain length is a model
+        /// parameter, not a theorem hypothesis.
+        type Trust =
+            | T0
+            | T1
+            | T2
+            | T3
+
+        let rung (t: Trust) : int =
+            match t with
+            | T0 -> 0
+            | T1 -> 1
+            | T2 -> 2
+            | T3 -> 3
+
+        let ofRung (i: int) : Trust =
+            match max 0 (min 3 i) with
+            | 0 -> T0
+            | 1 -> T1
+            | 2 -> T2
+            | _ -> T3
+
+        let up1 (t: Trust) = ofRung (rung t + 1)
+        let down1 (t: Trust) = ofRung (rung t - 1)
+
+        /// A capability — named, atomic; the lattice element is the SET of these.
+        type Cap = string
+
+        /// One side's policy: what it exposes at each trust rung.
+        type Policy = Trust -> Set<Cap>
+
+        let private chain = [ T0; T1; T2; T3 ]
+
+        /// The monotonicity LAW (checked, not assumed): never expose less at higher trust.
+        let isMonotone (p: Policy) : bool =
+            chain |> List.pairwise |> List.forall (fun (lo, hi) -> Set.isSubset (p lo) (p hi))
+
+        /// Effective capability — the MEET.
+        let effective (reveal: Policy) (grant: Policy) (tA: Trust) (tH: Trust) : Set<Cap> =
+            Set.intersect (reveal tA) (grant tH)
+
+        /// An update rule: evidence (the effective set actually exercised) moves a trust rung.
+        type Update = Set<Cap> -> Trust -> Trust
+
+        /// Non-empty evidence raises one rung; empty holds (the patient world).
+        let evidenceUp: Update = fun e t -> if Set.isEmpty e then t else up1 t
+
+        /// Non-empty raises; empty LOWERS (the suspicious world — trust decays without evidence).
+        let evidenceUpDecay: Update =
+            fun e t -> if Set.isEmpty e then down1 t else up1 t
+
+        /// One step of the coupled dynamics: both sides see the SAME effective capability (the common
+        /// box) and update by their own rule.
+        let step (reveal: Policy) (grant: Policy) (upA: Update) (upH: Update) (tA: Trust, tH: Trust) : Trust * Trust =
+            let e = effective reveal grant tA tH
+            upA e tA, upH e tH
+
+        /// Iterate to a fixed point (or return after the 16-state product chain is exhausted). With
+        /// non-decreasing updates the trajectory from bottom is an ascending chain ⇒ must fix (Kleene).
+        let iterate reveal grant (upA: Update) (upH: Update) (start: Trust * Trust) : (Trust * Trust) list =
+            let next = step reveal grant upA upH
+
+            let rec go acc state n =
+                if n > 16 then
+                    List.rev (state :: acc)
+                else
+                    let s' = next state
+                    if s' = state then List.rev (state :: acc) else go (state :: acc) s' (n + 1)
+
+            go [] start 0
+
+        /// The landing state (the reached fixed point; on a cycle, the last visited state).
+        let landing reveal grant upA upH start : Trust * Trust =
+            iterate reveal grant upA upH start |> List.last
+
+        // ── The named worlds (the theorems' witnesses) ──
+
+        /// THE WALL: nothing granted at zero trust; everything above. (Monotone — and useless from ⊥:
+        /// no evidence can ever arrive to leave T0.)
+        let wall (caps: Set<Cap>) : Policy =
+            fun t -> if rung t = 0 then Set.empty else caps
+
+        /// THE DOOR: a minimal SEED granted UNCONDITIONALLY (at T0 and above); the rest opens with
+        /// trust, all of it at the top. The seed is the architectural choice the calculus turns on.
+        let door (seed: Set<Cap>) (rest: Set<Cap>) : Policy =
+            fun t ->
+                if rung t = 0 then seed
+                elif rung t < 3 then Set.union seed (rest |> Set.filter (fun c -> c.Length % 2 = 0))
+                else Set.union seed rest
+
+        /// A shy-but-capable bear: a little at low trust, everything at the top (monotone).
+        let shyBear (low: Set<Cap>) (full: Set<Cap>) : Policy =
+            fun t ->
+                match rung t with
+                | 0 -> low
+                | 1
+                | 2 -> Set.union low (full |> Set.filter (fun c -> c.Length % 2 = 0))
+                | _ -> Set.union low full

--- a/tests/Tests.FSharp/TrustCalculus.Tests.fs
+++ b/tests/Tests.FSharp/TrustCalculus.Tests.fs
@@ -40,3 +40,81 @@ let ``a fully broken config lists every risk`` () =
           TrustCalculus.BaseAligned = false }
     Assert.False(TrustCalculus.trustStable broken)
     Assert.Equal(4, TrustCalculus.risks broken |> List.length)
+
+// ═══════════════════════════════════════════════════════════════════
+// Dynamics — the sleeping-bear / capability-door fixed-point theorems (BUILD pass, 2026-06-11).
+// ═══════════════════════════════════════════════════════════════════
+module DynamicsTests =
+
+    open Zeta.Core
+    module D = TrustCalculus.Dynamics
+
+    let private full = Set.ofList [ "fs"; "net"; "sign"; "gpu" ]
+    let private seed = Set.ofList [ "fs" ] // length-2 "fs": also passes the door's mid-rung filter
+    let private bear = D.shyBear seed full
+
+    [<Xunit.Fact>]
+    let ``laws: the named policies are monotone (checked, not assumed)`` () =
+        Xunit.Assert.True(D.isMonotone bear)
+        Xunit.Assert.True(D.isMonotone (D.wall full))
+        Xunit.Assert.True(D.isMonotone (D.door seed full))
+
+    [<Xunit.Fact>]
+    let ``T-WALL: a wall freezes the bear at (T0,T0) forever — capability empty both directions`` () =
+        let trail = D.iterate bear (D.wall full) D.evidenceUp D.evidenceUp (D.T0, D.T0)
+        Xunit.Assert.Equal((D.T0, D.T0), List.last trail)
+        Xunit.Assert.Equal(1, List.length trail) // immediate fixed point: nothing ever moves
+        Xunit.Assert.True(D.effective bear (D.wall full) D.T0 D.T0 |> Set.isEmpty)
+
+    [<Xunit.Fact>]
+    let ``T-DOOR: an unconditional seed grant climbs to full mutual trust and full capability`` () =
+        let landing = D.landing bear (D.door seed full) D.evidenceUp D.evidenceUp (D.T0, D.T0)
+        Xunit.Assert.Equal((D.T3, D.T3), landing)
+        let e = D.effective bear (D.door seed full) D.T3 D.T3
+        Xunit.Assert.Equal<Set<string>>(Set.union seed full, e) // everything works at the top
+
+    [<Xunit.Fact>]
+    let ``T-DOOR strict: the door's landing capability strictly exceeds the wall's`` () =
+        let eWall =
+            let (a, h) = D.landing bear (D.wall full) D.evidenceUp D.evidenceUp (D.T0, D.T0)
+            D.effective bear (D.wall full) a h
+        let eDoor =
+            let (a, h) = D.landing bear (D.door seed full) D.evidenceUp D.evidenceUp (D.T0, D.T0)
+            D.effective bear (D.door seed full) a h
+        Xunit.Assert.True(Set.isSubset eWall eDoor && eWall <> eDoor)
+
+    [<Xunit.Fact>]
+    let ``T-FIX: from bottom with non-decreasing updates the trajectory is an ascending chain that fixes`` () =
+        let trail = D.iterate bear (D.door seed full) D.evidenceUp D.evidenceUp (D.T0, D.T0)
+        // ascending: each step's rung-sum never decreases; final state is fixed
+        let sums = trail |> List.map (fun (a, h) -> D.rung a + D.rung h)
+        Xunit.Assert.Equal<int list>(List.sort sums, sums)
+        let last = List.last trail
+        Xunit.Assert.Equal(last, D.step bear (D.door seed full) D.evidenceUp D.evidenceUp last)
+
+    [<Xunit.Fact>]
+    let ``T-MONO: effective capability is monotone in both trusts`` () =
+        let g = D.door seed full
+        for a1 in [ D.T0; D.T1; D.T2 ] do
+            let a2 = D.up1 a1
+            for h1 in [ D.T0; D.T1; D.T2 ] do
+                let h2 = D.up1 h1
+                Xunit.Assert.True(Set.isSubset (D.effective bear g a1 h1) (D.effective bear g a2 h2))
+
+    // FINDING (the math taught the test): the wall's trap is precisely the COLD START. From mutual
+    // zero trust nothing ever moves — in the patient AND the suspicious world. But give the wall world
+    // any pre-existing trust (T1,T1) and it recovers fine (the wall opens above T0). So the door's
+    // value is not "walls never work" — it is that the door FIXES THE COLD START, the exact state every
+    // new agent/citizen/hardware bring-up begins in. (First drafted expecting decay to grind (T1,T1)
+    // down under a wall; the dynamics said no — evidence flows at T1, so it climbs. Kept honest.)
+    [<Xunit.Fact>]
+    let ``the wall's trap is the COLD START: mutual zero never moves in either world; the door fixes exactly that`` () =
+        // suspicious world, wall, cold start: frozen at the floor
+        let landing = D.landing bear (D.wall full) D.evidenceUpDecay D.evidenceUpDecay (D.T0, D.T0)
+        Xunit.Assert.Equal((D.T0, D.T0), landing)
+        // suspicious world, DOOR, same cold start: climbs to the top anyway
+        let landing2 = D.landing bear (D.door seed full) D.evidenceUpDecay D.evidenceUpDecay (D.T0, D.T0)
+        Xunit.Assert.Equal((D.T3, D.T3), landing2)
+        // and the wall world with PRE-EXISTING trust recovers — the trap is the cold start, nothing else
+        let landing3 = D.landing bear (D.wall full) D.evidenceUpDecay D.evidenceUpDecay (D.T1, D.T1)
+        Xunit.Assert.Equal((D.T3, D.T3), landing3)


### PR DESCRIPTION
Aaron: 'make it more math precise' / 'not critics yet.' Additive Dynamics submodule: capability lattice + per-side trust chains + monotone Reveal/Grant (checked law) + E = R∩G (the meet) + coupled evidence dynamics. Theorems 10/10 green: T-FIX (Kleene ascent), T-WALL (G(T0)=∅ freezes the cold start forever), T-DOOR (an unconditional seed grant climbs the same dynamics to full capability — 'freedom unlocks capability' as a reachable-fixed-point statement), T-MONO. Honest finding kept in-test: the wall's trap is PRECISELY the cold start (pre-existing trust recovers even under a wall) — the door's value is fixing the state every bring-up begins in. Tear-down pass deferred by request and named next.