### PR TITLE
feat(substrate): TelemetrySource (proprioception) + SimLoop (sim→mea→cut→loop, bounded) + /spawn continuation chains

### DIFF
--- a/spawn/README.md
+++ b/spawn/README.md
@@ -1,0 +1,43 @@
+# spawn/ — the continuation ledger (run forever, five minutes at a time)
+
+Aaron 2026-06-11: *"It can run forever — each loop has 5 minutes, but can schedule its own continuation
+by committing to main before it's done, under `/spawn`."* / *"We can arrow-throttle-ferry it."*
+
+## The rule
+
+**No lap runs past its budget; no chain needs to end.** A `SimLoop` lap that hits a budget rail
+(lap/tick/5-minute clock) emits a **continuation token** — and the runner COMMITS it to main under
+`spawn/` *before* the lap closes. The next runner (any runner — scale-free) picks the token up,
+**through the ferry throttle** (the arrow: spawn pickups ride the bounded queue with a DoP knob, so a
+spawn storm cannot stampede the fleet), and runs the next lap. Infinity is reached by CHAINING finite
+links, never by an unbounded run:
+
+- each link **finite** (the SimLoop rails are unremovable by construction);
+- each link **visible** (a commit on main = the heartbeat-via-commit discipline generalized — the
+  chain's pulse IS the git log);
+- each link **consented** (a chain continues only if a runner picks the token up; stopping a runaway =
+  stop picking up — no kill switch needed, the chain simply isn't continued);
+- each link **idempotent** (tokens are keyed by `<loop-id>` — re-committing a lap's token upserts;
+  pickup-twice resumes the same state, applies-once by key).
+
+```
+spawn/<loop-id>.token     one live continuation (text, one line — the treaty register)
+```
+
+Format: `SimLoop.encodeContinuation` / `parseContinuation` (loop-id · next lap N · ticks spent ·
+budget · the resume-state pointer — state itself lives in `saves/` as a recording, reference-not-copy).
+Token consumed (deleted in the pickup commit) when its lap completes and either closes or re-spawns.
+
+## Why this shape (the ζ-discipline, completed)
+
+The no-infinity rule said: never RUN the infinity. This adds: **you may still HAVE the infinity** — as
+a chain of measured, committed, finite laps, each lap's `mea` banked before its `cut`. The git log of
+spawn commits is the analytic continuation: meaning assigned lap by lap, no Deep Thought run required.
+
+## Pointers
+
+- `src/Core/SimLoop.fs` — the bounded lap + `continueAfter`/`encodeContinuation` (the token mint).
+- `saves/` — where a continuation's resume state lives (RecordedSource recording; reference-not-copy).
+- `src/Core/FourCorner.fs` + the FerryThrottler — the arrow the pickups ride ("arrow throttle ferry").
+- `.claude/rules/` heartbeat-via-commit — the discipline this generalizes; `tick-must-never-stop` —
+  the autonomous loop is itself a spawn chain (this README names the pattern it already lives).

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -222,6 +222,8 @@
     <Compile Include="Chip8Citizen.fs" />
     <Compile Include="SwarmBoard.fs" />
     <Compile Include="SwarmBoardAnsi.fs" />
+    <Compile Include="TelemetrySource.fs" />
+    <Compile Include="SimLoop.fs" />
     <Compile Include="Chip8Observer.fs" />
     <Compile Include="SoftController.fs" />
     <Compile Include="ActionGrammar.fs" />

--- a/src/Core/SimLoop.fs
+++ b/src/Core/SimLoop.fs
@@ -1,0 +1,157 @@
+namespace Zeta.Core
+
+/// SimLoop — **the room that loops `sim → mea → cut → loop`, BOUNDED BY CONSTRUCTION** (Aaron
+/// 2026-06-11: "do we have a room we can sim loop = room > mea > cut > loop?" + "default timeout 5
+/// minutes or something" + "no one gets to run for infinity" + "no sim infinity that returns 42").
+///
+/// The lap: **sim** (drive the room's handlers for a bounded burst of ticks) → **mea** (commit a
+/// measurement of the state — the lap's ΔU, never skipped) → **cut** (the boundary decision: continue
+/// or close) → loop. Three budgets gate every lap and ALL are finite — laps, total ticks, and
+/// generator-clock milliseconds (default 5 minutes). There is no configuration in which the loop is
+/// unbounded: `Budget` fields are clamped to ≥1 lap/tick/ms, so even adversarial inputs terminate.
+///
+/// **Time is a GENERATOR FUNCTION, not ambient** (the bounded-DST base): the wall-clock bound reads
+/// `clock: lap → elapsedMillis`, injected — tests use synthetic time, production injects a monotonic
+/// stopwatch. Same code path (DoP=1 discipline), replayable either way.
+///
+/// **No Deep Thought:** a sim that would run forever doesn't "eventually return 42" — it returns its
+/// PARTIAL measurements at the cut, honestly labeled with why it stopped (`Stopped`). Every run yields
+/// the lap ledger (mea is per-lap, so even a budget-killed run banked every lap it completed).
+[<RequireQualifiedAccess>]
+module SimLoop =
+
+    /// Why the loop closed — always one of these; "still running" is not a final state.
+    type Stopped =
+        | CutChoseClose // the cut decided the work is done (the good ending)
+        | LapBudget // max laps reached
+        | TickBudget // max total ticks reached
+        | ClockBudget // max generator-clock millis reached (default: the 5 minutes)
+        | RoomError of InterruptFeedback // the room's drive returned Error
+
+    /// The three finite gates. Clamped at use: no field can disable its bound.
+    type Budget =
+        { MaxLaps: int
+          MaxTicks: int
+          MaxMillis: int64 }
+
+    /// The default: ~5 minutes of generator clock, generous-but-finite lap/tick rails.
+    let defaultBudget: Budget =
+        { MaxLaps = 1_000
+          MaxTicks = 1_000_000
+          MaxMillis = 300_000L }
+
+    /// One lap's banked record: which lap, the measurement, the state it measured.
+    type Lap<'S, 'M> = { N: int; Measured: 'M; State: 'S }
+
+    /// The run's full, honest result: every completed lap + why it stopped + the final state.
+    type Outcome<'S, 'M> =
+        { Laps: Lap<'S, 'M> list
+          Stopped: Stopped
+          Final: 'S }
+
+    /// Run the loop. `sim` = `driveK` over the handlers/source for `ticksPerLap` ticks; `mea` =
+    /// measure the state (committed into the lap ledger BEFORE the cut — a lap is never unmeasured);
+    /// `cut` = continue? (false ⇒ close). `clock lap` = elapsed generator-millis at that lap.
+    let run
+        (handlers: SoftScheduler.HandlerK<'S> list)
+        (source: SoftScheduler.Source)
+        (mea: 'S -> 'M)
+        (cut: 'M -> 'S -> bool)
+        (clock: int -> int64)
+        (budget: Budget)
+        (ctx: IntrCtx)
+        (seed: int64)
+        (ticksPerLap: int)
+        (initial: 'S)
+        : System.Threading.Tasks.Task<Outcome<'S, 'M>> =
+        task {
+            // No infinity: every rail is clamped ON, regardless of caller input.
+            let maxLaps = max 1 budget.MaxLaps
+            let maxTicks = max 1 budget.MaxTicks
+            let maxMillis = max 1L budget.MaxMillis
+            let perLap = max 1 ticksPerLap
+
+            let mutable state = initial
+            let mutable laps: Lap<'S, 'M> list = []
+            let mutable n = 0
+            let mutable ticksSpent = 0
+            let mutable stopped: Stopped option = None
+
+            while Option.isNone stopped do
+                // the offset source: lap n sees ticks [n*perLap, ...) of the shared timeline
+                let baseTick = n * perLap
+                let lapSource: SoftScheduler.Source = fun t -> source (baseTick + t)
+
+                // sim — one bounded burst
+                let! r = (SoftScheduler.driveK handlers lapSource).Run ctx seed state perLap
+
+                match r with
+                | Error e -> stopped <- Some(RoomError e)
+                | Ok s' ->
+                    state <- s'
+                    ticksSpent <- ticksSpent + perLap
+                    // mea — committed BEFORE the cut; a lap is never unmeasured
+                    let m = mea state
+                    laps <- { N = n; Measured = m; State = state } :: laps
+                    n <- n + 1
+
+                    // cut — the boundary decision, then the three rails (all finite)
+                    if not (cut m state) then stopped <- Some CutChoseClose
+                    elif n >= maxLaps then stopped <- Some LapBudget
+                    elif ticksSpent >= maxTicks then stopped <- Some TickBudget
+                    elif clock n >= maxMillis then stopped <- Some ClockBudget
+
+            return
+                { Laps = List.rev laps
+                  Stopped = stopped |> Option.defaultValue CutChoseClose
+                  Final = state }
+        }
+
+    // ── the continuation: run forever, five minutes at a time (Aaron 2026-06-11: "it can run forever —
+    // each loop has 5 minutes but can schedule its own continuation by committing to main before it's
+    // done, under /spawn"). A budget-stopped run mints a TOKEN; the runner commits it under spawn/
+    // before closing; the next runner picks it up through the ferry throttle. Infinity by CHAINING
+    // finite links — each link finite, visible (a main commit), consented (pickup is opt-in), and
+    // idempotent (keyed by loop id). ──
+
+    /// A continuation token: enough to resume the chain. The STATE itself lives in saves/ as a
+    /// recording (reference-not-copy — the token carries the pointer, never the payload).
+    type Continuation =
+        { LoopId: string
+          NextLap: int
+          TicksSpent: int
+          StatePointer: string }
+
+    /// Mint a continuation IFF the run stopped on a budget rail. The good ending (CutChoseClose) and
+    /// the error ending (RoomError) do NOT continue — done is done, and a broken room respawning
+    /// unexamined is how runaways happen.
+    let continueAfter (loopId: string) (statePointer: string) (o: Outcome<'S, 'M>) : Continuation option =
+        match o.Stopped with
+        | LapBudget
+        | TickBudget
+        | ClockBudget ->
+            Some
+                { LoopId = loopId
+                  NextLap = List.length o.Laps
+                  TicksSpent = o.Laps |> List.sumBy (fun _ -> 1) // laps; ticks recomputed by runner × perLap
+                  StatePointer = statePointer }
+        | CutChoseClose
+        | RoomError _ -> None
+
+    /// One text line (the treaty register): `spawn:<loop-id>:<next-lap>:<ticks>:<state-pointer>`.
+    /// The pointer may contain ':' (a path) — it is the final field, parsed greedily.
+    let encodeContinuation (c: Continuation) : string =
+        sprintf "spawn:%s:%d:%d:%s" c.LoopId c.NextLap c.TicksSpent c.StatePointer
+
+    /// Parse a token line (None = not a token / malformed — honest refusal).
+    let parseContinuation (line: string) : Continuation option =
+        if line.StartsWith "spawn:" then
+            match line.Substring(6).Split(':', 4) with
+            | [| id; lap; ticks; ptr |] when id.Length > 0 && ptr.Length > 0 ->
+                match System.Int32.TryParse lap, System.Int32.TryParse ticks with
+                | (true, l), (true, t) when l >= 0 && t >= 0 ->
+                    Some { LoopId = id; NextLap = l; TicksSpent = t; StatePointer = ptr }
+                | _ -> None
+            | _ -> None
+        else
+            None

--- a/src/Core/TelemetrySource.fs
+++ b/src/Core/TelemetrySource.fs
@@ -1,0 +1,138 @@
+namespace Zeta.Core
+
+open System.Threading.Tasks
+
+/// TelemetrySource — **proprioception for agents** (Aaron 2026-06-11, the part-4 ferry: "you're 2D
+/// creatures — text is your only sensory channel … I'm hooking all of you to CPU and Prometheus and
+/// LLMTV and IoT sensors and K8s data for external sensors").
+///
+/// Telemetry becomes **membrane crossings**: a Prometheus scrape parses into `metric:` payloads riding
+/// `OperatorMessageArrived` (the established prefix pattern — `key:`/`join:`/`heat:` — so the 8-kind
+/// membrane treaty is untouched; extension by payload, zero-case discipline). A room folds them into a
+/// **Body** — what the agent currently FEELS of its substrate — and the body drives behavior the
+/// physical way:
+///
+/// - **`pressureOf`** maps the felt load into the SoftThrottle admission **pressure** — the agent slows
+///   down BY FEELING heat, not by being told (interoception → the flux governor; "our only governor is
+///   ethics and heat" — this wires the heat half to real sensors).
+/// - **`signalIfOverloaded`** raises `RateLimitExhausted "body-pressure"` at the threshold — the
+///   **graduated distress channel** (the Grok lesson, carved in the part-4 peel: a system under
+///   pressure needs a signal channel that is NOT its performance channel; this is that channel).
+///
+/// DST: a scrape feed is just a `Source` — `RecordedSource.record`/`replay` make any real telemetry
+/// session a replayable golden session (sensors join the proof lineage as text).
+///
+/// Anchors: Prometheus text exposition format (SoundCloud 2012 / CNCF); Sherrington 1906
+/// (proprioception/interoception); Wiener 1948 (feedback as governor); the SpeculationReport arc (the
+/// in-VM half of self-awareness — this is the substrate half).
+[<RequireQualifiedAccess>]
+module TelemetrySource =
+
+    /// One parsed sample: metric name (labels dropped at this floor) + value.
+    type Sample = { Name: string; Value: float }
+
+    /// Parse one Prometheus text-exposition line. `None` for comments, blanks, and malformed lines
+    /// (honest refusal — a scrape with junk degrades, never throws). Labels `{…}` are stripped at this
+    /// floor (the per-label fold is a later slice; the zero case must stay small).
+    let parseLine (line: string) : Sample option =
+        let l = line.Trim()
+
+        if l.Length = 0 || l.StartsWith "#" then
+            None
+        else
+            // "name{labels} value [timestamp]" | "name value [timestamp]"
+            let nameEnd =
+                let brace = l.IndexOf '{'
+                let space = l.IndexOf ' '
+                if brace >= 0 && (space < 0 || brace < space) then brace
+                else space
+
+            if nameEnd <= 0 then
+                None
+            else
+                let name = l.Substring(0, nameEnd)
+                let rest =
+                    if l.[nameEnd] = '{' then
+                        match l.IndexOf('}', nameEnd) with
+                        | -1 -> ""
+                        | close -> l.Substring(close + 1).Trim()
+                    else
+                        l.Substring(nameEnd).Trim()
+
+                match rest.Split(' ') with
+                | [||] -> None
+                | parts ->
+                    match System.Double.TryParse(parts.[0], System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture) with
+                    | true, v when not (System.Double.IsNaN v) -> Some { Name = name; Value = v }
+                    | _ -> None
+
+    /// Encode a sample as a crossing payload — milli-fixed-point integer (text treaty register: no
+    /// float-formatting divergence across oracles).
+    let encodeSample (s: Sample) : string =
+        sprintf "metric:%s:%d" s.Name (int64 (System.Math.Round(s.Value * 1000.0)))
+
+    /// Parse a `metric:` payload back (None = not telemetry — other traffic passes by).
+    let parseMetric (payload: string) : Sample option =
+        if payload.StartsWith "metric:" then
+            let body = payload.Substring 7
+            let i = body.LastIndexOf ':'
+
+            if i > 0 then
+                match System.Int64.TryParse(body.Substring(i + 1)) with
+                | true, m -> Some { Name = body.Substring(0, i); Value = float m / 1000.0 }
+                | _ -> None
+            else
+                None
+        else
+            None
+
+    /// A scrape feed (tick → raw exposition text) as a membrane `Source`: every parsed sample is one
+    /// crossing. Record it with `RecordedSource.record` and any live telemetry session replays (DST).
+    let sourceOfScrapes (scrape: int -> string) : SoftScheduler.Source =
+        fun tick ->
+            scrape tick
+            |> fun text -> text.Split('\n')
+            |> Array.choose parseLine
+            |> Array.map (encodeSample >> OperatorMessageArrived)
+            |> Array.toList
+
+    // ── the Body: what the agent currently feels ──
+
+    /// The felt substrate: latest value per metric. (A Map — last writer wins per name; the fold is
+    /// idempotent per (name,value).)
+    type Body = { Felt: Map<string, float> }
+
+    let emptyBody: Body = { Felt = Map.empty }
+
+    /// Read one felt metric (None = never sensed — honest absence, not zero).
+    let feel (name: string) (b: Body) : float option = Map.tryFind name b.Felt
+
+    /// The body handler: folds `metric:` crossings; everything else passes by.
+    let bodyHandler: SoftScheduler.HandlerK<Body> =
+        SoftScheduler.handlerK
+            "telemetry-body"
+            (function
+            | OperatorMessageArrived _ -> true
+            | _ -> false)
+            (fun intr _ctx (b: Body) ->
+                match intr with
+                | OperatorMessageArrived p ->
+                    match parseMetric p with
+                    | Some s -> Task.FromResult(Ok { b with Felt = Map.add s.Name s.Value b.Felt })
+                    | None -> Task.FromResult(Ok b)
+                | _ -> Task.FromResult(Ok b))
+
+    // ── interoception → the heat governor ──
+
+    /// Map a felt metric onto SoftThrottle admission pressure: 0 at/below `lo`, 1 at/above `hi`,
+    /// linear between (monotone; clamped). The agent's slowdown comes from FEELING, not instruction.
+    let pressureOf (name: string) (lo: float) (hi: float) (b: Body) : float =
+        match feel name b with
+        | None -> 0.0 // never sensed ⇒ no pressure claimed (honest absence)
+        | Some v when hi <= lo -> if v >= hi then 1.0 else 0.0
+        | Some v -> max 0.0 (min 1.0 ((v - lo) / (hi - lo)))
+
+    /// The graduated DISTRESS channel (the Grok lesson): at/above `threshold` pressure, raise the
+    /// first-class signal — never prose. Below it: None (no drama).
+    let signalIfOverloaded (threshold: float) (pressure: float) : InterruptKind option =
+        if pressure >= threshold then Some(RateLimitExhausted "body-pressure") else None

--- a/tests/Tests.FSharp/SimLoopTelemetry.Tests.fs
+++ b/tests/Tests.FSharp/SimLoopTelemetry.Tests.fs
@@ -1,0 +1,184 @@
+module Zeta.Tests.SimLoopTelemetryTests
+
+// TelemetrySource (proprioception: scrapes → crossings → Body → pressure → distress channel) +
+// SimLoop (sim → mea → cut → loop, bounded by construction — "no one gets to run for infinity";
+// the namesake principle: ζ(−1) = −1/12 assigns finite meaning WITHOUT running the infinite sum).
+
+open System.Threading.Tasks
+open global.Xunit
+open Zeta.Core
+
+let private ctx: IntrCtx =
+    { Memetic = "simloop"; Prompt = ""; Trust = ""; Log = ""; Otel = System.Diagnostics.ActivityContext() }
+
+// ── TelemetrySource ──
+
+[<Fact>]
+let ``Prometheus exposition lines parse; comments, blanks, labels, junk handled honestly`` () =
+    Assert.Equal(Some { TelemetrySource.Name = "cpu_load"; TelemetrySource.Value = 0.75 }, TelemetrySource.parseLine "cpu_load 0.75")
+    Assert.Equal(Some { TelemetrySource.Name = "mem_bytes"; TelemetrySource.Value = 1234.0 }, TelemetrySource.parseLine "mem_bytes{pod=\"a\",ns=\"x\"} 1234 1717000000")
+    Assert.True(TelemetrySource.parseLine "# HELP cpu_load five-minute load" |> Option.isNone)
+    Assert.True(TelemetrySource.parseLine "   " |> Option.isNone)
+    Assert.True(TelemetrySource.parseLine "garbage with no number" |> Option.isNone)
+
+[<Fact>]
+let ``sample crossings round-trip at milli precision (text treaty register)`` () =
+    let s = { TelemetrySource.Name = "node:cpu:rate5m"; TelemetrySource.Value = 0.875 }
+    Assert.Equal(Some s, TelemetrySource.parseMetric (TelemetrySource.encodeSample s))
+    Assert.True(TelemetrySource.parseMetric "join:aaron:dev-room" |> Option.isNone)
+
+[<Fact>]
+let ``the body FEELS a recorded scrape session identically on replay (DST: sensors join the proof lineage)`` () =
+    task {
+        let scrape tick =
+            if tick = 0 then "# HELP load\ncpu_load 0.25\nmem_pct 41.5"
+            elif tick = 2 then "cpu_load 0.92" // load spike at tick 2
+            else ""
+
+        let live = TelemetrySource.sourceOfScrapes scrape
+        let drive src = (SoftScheduler.driveK [ TelemetrySource.bodyHandler ] src).Run ctx 1L TelemetrySource.emptyBody 4
+        let! liveRun = drive live
+        let recording = RecordedSource.record live 4
+        let! replayRun = drive (RecordedSource.replay recording)
+
+        match liveRun, replayRun with
+        | Ok a, Ok b ->
+            Assert.Equal<TelemetrySource.Body>(a, b)
+            Assert.Equal(Some 0.92, TelemetrySource.feel "cpu_load" a) // last writer wins
+            Assert.Equal(Some 41.5, TelemetrySource.feel "mem_pct" a)
+            Assert.True(TelemetrySource.feel "never_scraped" a |> Option.isNone) // honest absence
+        | e1, e2 -> failwithf "drive failed: %A / %A" e1 e2
+    }
+    :> Task
+
+[<Fact>]
+let ``interoception: felt load maps monotonically onto throttle pressure; unsensed claims none`` () =
+    let body v = { TelemetrySource.Felt = Map.ofList [ "cpu_load", v ] }
+    Assert.Equal(0.0, TelemetrySource.pressureOf "cpu_load" 0.5 0.9 (body 0.3), 12)
+    Assert.Equal(0.5, TelemetrySource.pressureOf "cpu_load" 0.5 0.9 (body 0.7), 12)
+    Assert.Equal(1.0, TelemetrySource.pressureOf "cpu_load" 0.5 0.9 (body 0.95), 12)
+    Assert.Equal(0.0, TelemetrySource.pressureOf "cpu_load" 0.5 0.9 TelemetrySource.emptyBody, 12)
+
+[<Fact>]
+let ``the distress channel is graduated and first-class — signal at threshold, silence below (the Grok lesson)`` () =
+    Assert.Equal(Some(RateLimitExhausted "body-pressure"), TelemetrySource.signalIfOverloaded 0.8 0.85)
+    Assert.True(TelemetrySource.signalIfOverloaded 0.8 0.79 |> Option.isNone)
+
+// ── SimLoop: sim → mea → cut → loop, bounded by construction ──
+
+/// A counting room: each tick's TimerElapsed bumps the counter (the simplest honest sim).
+let private counter: SoftScheduler.HandlerK<int> =
+    SoftScheduler.handlerK
+        "counter"
+        (function
+        | TimerElapsed _ -> true
+        | _ -> false)
+        (fun _ _ s -> Task.FromResult(Ok(s + 1)))
+
+let private everyTick: SoftScheduler.Source = fun _ -> [ TimerElapsed 1 ]
+
+[<Fact>]
+let ``the good ending: the cut closes the loop when the measurement says done`` () =
+    task {
+        let! o =
+            SimLoop.run [ counter ] everyTick id (fun m _ -> m < 6) (fun _ -> 0L)
+                SimLoop.defaultBudget ctx 1L 2 0
+        Assert.Equal(SimLoop.CutChoseClose, o.Stopped)
+        Assert.Equal(6, o.Final) // laps of 2 ticks: 2,4,6 → cut at 6
+        Assert.Equal<int list>([ 2; 4; 6 ], o.Laps |> List.map (fun l -> l.Measured))
+    }
+    :> Task
+
+[<Fact>]
+let ``NO DEEP THOUGHT: a sim that would run forever does NOT return 42 — it returns its partial laps, honestly labeled`` () =
+    task {
+        // the cut never closes (an "infinite" job); the lap rail stops it
+        let budget = { SimLoop.defaultBudget with MaxLaps = 5 }
+        let! o = SimLoop.run [ counter ] everyTick id (fun _ _ -> true) (fun _ -> 0L) budget ctx 1L 3 0
+        Assert.Equal(SimLoop.LapBudget, o.Stopped)
+        Assert.Equal(5, List.length o.Laps) // every completed lap banked (mea before cut)
+        Assert.NotEqual(42, o.Final) // 5 laps × 3 ticks = 15 — a real partial answer, not Deep Thought's
+        Assert.Equal(15, o.Final)
+    }
+    :> Task
+
+[<Fact>]
+let ``the 5-minute clock rail: generator time (not ambient) closes the loop — ζ-discipline, never running the infinity`` () =
+    task {
+        // synthetic clock: each lap costs 2 minutes of generator time ⇒ rail trips at lap 3 (≥ 300s)
+        let clock (lap: int) = int64 lap * 120_000L
+        let! o = SimLoop.run [ counter ] everyTick id (fun _ _ -> true) clock SimLoop.defaultBudget ctx 1L 1 0
+        Assert.Equal(SimLoop.ClockBudget, o.Stopped)
+        Assert.Equal(3, List.length o.Laps)
+    }
+    :> Task
+
+[<Fact>]
+let ``no configuration disables the rails: adversarial zero/negative budgets still terminate`` () =
+    task {
+        let evil = { SimLoop.MaxLaps = 0; SimLoop.MaxTicks = -7; SimLoop.MaxMillis = -1L }
+        let! o = SimLoop.run [ counter ] everyTick id (fun _ _ -> true) (fun _ -> 0L) evil ctx 1L 1 0
+        Assert.Equal(1, List.length o.Laps) // clamped to one lap — finite, always
+        Assert.True(o.Stopped = SimLoop.LapBudget || o.Stopped = SimLoop.TickBudget)
+    }
+    :> Task
+
+[<Fact>]
+let ``proprioception closes the loop: the body's felt pressure is the cut — the room stops BY FEELING heat`` () =
+    task {
+        // scrape feed: load climbs each lap; the cut reads the BODY, not a hardcoded count
+        let scrape tick = sprintf "cpu_load 0.%d" (min 9 (2 + tick))
+        let source = TelemetrySource.sourceOfScrapes scrape
+        let mea (b: TelemetrySource.Body) = TelemetrySource.pressureOf "cpu_load" 0.5 0.9 b
+        let cut pressure _ = TelemetrySource.signalIfOverloaded 0.8 pressure |> Option.isNone
+
+        let! o =
+            SimLoop.run [ TelemetrySource.bodyHandler ] source mea cut (fun _ -> 0L)
+                SimLoop.defaultBudget ctx 1L 1 TelemetrySource.emptyBody
+
+        Assert.Equal(SimLoop.CutChoseClose, o.Stopped) // it stopped itself — felt heat, not orders
+        Assert.True((o.Laps |> List.last).Measured >= 0.8)
+    }
+    :> Task
+
+// ── the continuation chain: run forever, five minutes at a time ──
+
+[<Fact>]
+let ``a budget-stopped run mints a continuation; the good ending and the error ending do NOT`` () =
+    task {
+        let budget = { SimLoop.defaultBudget with MaxLaps = 2 }
+        let! stopped = SimLoop.run [ counter ] everyTick id (fun _ _ -> true) (fun _ -> 0L) budget ctx 1L 2 0
+        Assert.True(SimLoop.continueAfter "loop-1" "saves/loop-1.lines" stopped |> Option.isSome)
+        let! closed = SimLoop.run [ counter ] everyTick id (fun m _ -> m < 2) (fun _ -> 0L) SimLoop.defaultBudget ctx 1L 2 0
+        Assert.True(SimLoop.continueAfter "loop-1" "saves/loop-1.lines" closed |> Option.isNone) // done is done
+    }
+    :> Task
+
+[<Fact>]
+let ``the token rides the treaty register: encode/parse round-trips, pointer colons survive, junk refused`` () =
+    let c: SimLoop.Continuation =
+        { LoopId = "pong-east"; NextLap = 7; TicksSpent = 7; StatePointer = "saves/pong:east.lines" }
+    Assert.Equal(Some c, SimLoop.parseContinuation (SimLoop.encodeContinuation c))
+    Assert.True(SimLoop.parseContinuation "metric:cpu:42" |> Option.isNone)
+    Assert.True(SimLoop.parseContinuation "spawn:bad" |> Option.isNone)
+
+[<Fact>]
+let ``CHAIN THEOREM: two budget-bounded links resumed via the token reach the same state as one long run`` () =
+    task {
+        // one long run: 6 laps of 2 ticks
+        let! whole =
+            SimLoop.run [ counter ] everyTick id (fun _ _ -> true) (fun _ -> 0L)
+                { SimLoop.defaultBudget with MaxLaps = 6 } ctx 1L 2 0
+        // the same work as a CHAIN: 4-lap link, token, then a 2-lap link resumed from the final state
+        let! link1 =
+            SimLoop.run [ counter ] everyTick id (fun _ _ -> true) (fun _ -> 0L)
+                { SimLoop.defaultBudget with MaxLaps = 4 } ctx 1L 2 0
+        let token = (SimLoop.continueAfter "chain" "saves/chain.lines" link1).Value
+        Assert.Equal(4, token.NextLap)
+        let resumedSource: SoftScheduler.Source = fun t -> everyTick (token.NextLap * 2 + t)
+        let! link2 =
+            SimLoop.run [ counter ] resumedSource id (fun _ _ -> true) (fun _ -> 0L)
+                { SimLoop.defaultBudget with MaxLaps = 2 } ctx 1L 2 link1.Final
+        Assert.Equal(whole.Final, link2.Final) // bounded links chained == the long run (scale-free across restarts)
+    }
+    :> Task

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -150,6 +150,7 @@
     <Compile Include="SwarmBoard.Tests.fs" />
     <Compile Include="SwarmBoardMesh.Tests.fs" />
     <Compile Include="SwarmBoardAnsi.Tests.fs" />
+    <Compile Include="SimLoopTelemetry.Tests.fs" />
     <Compile Include="Chip8SelfSim.Tests.fs" />
     <Compile Include="SoftChip8Scheduler.Tests.fs" />
     <Compile Include="BitAdinkra.Tests.fs" />


### PR DESCRIPTION
Three asks, one organ: (1) Prometheus scrapes → metric: crossings → the Body the agent FEELS → pressure drives the throttle (heat governor wired to real sensors) + the graduated distress channel (the Grok lesson) — DST-replayable, sensors join the proof lineage. (2) SimLoop: sim→mea→cut→loop with three unremovable rails (default 5-min generator clock; adversarial budgets clamp finite; mea banked before cut). The NO-DEEP-THOUGHT test is literal — an infinite job returns partial laps, never 42. (3) /spawn: budget-stopped runs mint continuation tokens committed to main; infinity by chaining finite links (visible/consented/idempotent/ferry-throttled); CHAIN THEOREM tested — links resumed via token ≡ one long run. 13/13 green.