### PR TITLE
feat(scheduler): WheelRoom — wheels-of-time: ferry quorum ≥4, self-rescheduling, progress-gated (no spinners)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -224,6 +224,7 @@
     <Compile Include="SwarmBoardAnsi.fs" />
     <Compile Include="TelemetrySource.fs" />
     <Compile Include="SimLoop.fs" />
+    <Compile Include="WheelRoom.fs" />
     <Compile Include="Chip8Observer.fs" />
     <Compile Include="SoftController.fs" />
     <Compile Include="ActionGrammar.fs" />

--- a/src/Core/WheelRoom.fs
+++ b/src/Core/WheelRoom.fs
@@ -1,0 +1,103 @@
+namespace Zeta.Core
+
+/// WheelRoom — **the wheels-of-time room: the arrow-throttle-ferry gets a room of its own, quorum-kept
+/// at ≥4, self-rescheduling, and REQUIRED TO MAKE PROGRESS** (Aaron 2026-06-11: "a room for the arrow
+/// throttle ferry itself … make sure we have at least 4 of those running at all times that reschedule
+/// themselves … it should be making some sort of forward uncertainty-reduction progress and not just
+/// spinning in a loop — this is our thread scheduler, self-throttling per room, using GitHub workflows
+/// — the wheels of time room lol (lost) — always needs like 4 running, it can regulate itself").
+///
+/// Composition over what already runs (instantiation, not invention — Rodney's razor):
+/// - a wheel's lap IS a `SimLoop` run (bounded; 5-minute generator clock; no infinity per lap);
+/// - "runs forever" IS the `/spawn` continuation chain (budget-stopped laps mint tokens committed to
+///   main; GitHub workflows pick them up — the workflow scheduler is the thread scheduler);
+/// - "self-throttling per room" IS the ferry/SoftThrottle (respawn admission rides the tank under the
+///   felt pressure of `TelemetrySource` — the wheel slows when the substrate runs hot);
+/// - **the progress gate** is the new piece: the GitHub-guidelines clause as code — a lap must bank
+///   forward uncertainty reduction (ΔU > ε over a window) or the wheel CLOSES instead of respawning.
+///   A self-sustaining reaction, not a spinner: the chain continues only while it reduces uncertainty.
+///
+/// Quorum: the fleet keeps **at least `quorum` (default 4) wheels live**; the maintenance function is
+/// deterministic + idempotent (same live-set ⇒ same respawn list; applying twice adds nothing), so any
+/// runner — or several at once — can run maintenance safely (lock-free: the spawn ledger's keyed
+/// upserts make concurrent maintainers converge).
+///
+/// Honest scope (peel): the local-LLM / small-language-model / hand-written-BERT tenants Aaron names
+/// are the TEST CARGO for these wheels (simulation first), not built here — this module is the wheel
+/// itself: quorum + progress gate + throttled respawn decision. The GitHub-workflow runner that
+/// commits tokens is the existing autonomous-loop pattern (heartbeat-via-commit), named in spawn/.
+[<RequireQualifiedAccess>]
+module WheelRoom =
+
+    /// One wheel's identity + its recent banked progress (ΔU per completed lap, newest first).
+    type Wheel =
+        { Id: string
+          DeltaU: float list }
+
+    /// **The progress gate (the GitHub-guidelines clause as code):** over the last `window` laps the
+    /// wheel must have banked MORE than `epsilon` total uncertainty reduction. A wheel with no history
+    /// yet is allowed to run (you cannot demand progress before the first lap) — but after `window`
+    /// laps of spinning it fails this gate and CLOSES.
+    let progressing (epsilon: float) (window: int) (w: Wheel) : bool =
+        if List.isEmpty w.DeltaU then
+            true // newborn: gets its chance
+        else
+            w.DeltaU |> List.truncate (max 1 window) |> List.sum > epsilon
+
+    /// The wheel's CUT for `SimLoop`: continue while progressing. Composed with SimLoop's rails this
+    /// yields exactly the required behavior: progressing wheel → budget-stops → mints a continuation
+    /// (runs forever, five minutes at a time); spinning wheel → cut closes → `continueAfter` returns
+    /// None → the chain ENDS (spinners are not respawned; "done is done" includes "pointless is done").
+    let cutOf (epsilon: float) (window: int) : Wheel -> bool = progressing epsilon window
+
+    /// Bank a lap's measured ΔU into the wheel (newest first; ledger bounded to 32 laps — the window
+    /// can never demand more history than we keep).
+    let bank (deltaU: float) (w: Wheel) : Wheel =
+        { w with DeltaU = deltaU :: w.DeltaU |> List.truncate 32 }
+
+    // ── quorum maintenance: at least N wheels, always, self-regulated ──
+
+    /// Deterministic wheel ids: wheel-0, wheel-1, … (ordinal; no randomness — DST).
+    let wheelId (i: int) : string = sprintf "wheel-%d" i
+
+    /// Given the LIVE set (wheel ids with a token in spawn/ or a running lap), the respawns needed to
+    /// restore quorum. Deterministic (lowest missing indices first) and IDEMPOTENT: applying the result
+    /// then re-running yields []. Any number of concurrent maintainers converge (keyed upserts).
+    let respawnsNeeded (quorum: int) (live: Set<string>) : string list =
+        let q = max 1 quorum
+
+        Seq.initInfinite wheelId
+        |> Seq.filter (fun id -> not (Set.contains id live))
+        |> Seq.truncate (max 0 (q - Set.count live))
+        |> List.ofSeq
+
+    /// **Throttled respawn admission** — "self-throttling per room": each needed respawn must be
+    /// FUNDED by the ferry tank under the current felt pressure (TelemetrySource → pressure → the
+    /// admission gradient). Hot substrate ⇒ fewer wheels restart this tick (they wait; quorum heals
+    /// over subsequent ticks as the tank recharges). Returns (admitted, tank').
+    let admitRespawns
+        (costPerSpawn: float)
+        (tank: SoftThrottle.Tank)
+        (needed: string list)
+        : string list * SoftThrottle.Tank =
+        let mutable t = tank
+        let admitted =
+            [ for id in needed do
+                match SoftThrottle.discharge costPerSpawn t with
+                | Some t' ->
+                    t <- t'
+                    yield id
+                | None -> () ] // out of flux — the rest wait for recharge (regulation, not refusal)
+
+        admitted, t
+
+    /// One maintenance tick: who must be respawned now, throttled. The whole fleet-regulation step is
+    /// a pure function — (quorum, live, tank) in, (admitted, tank') out — so it replays (DST) and any
+    /// runner can execute it.
+    let maintain
+        (quorum: int)
+        (costPerSpawn: float)
+        (tank: SoftThrottle.Tank)
+        (live: Set<string>)
+        : string list * SoftThrottle.Tank =
+        respawnsNeeded quorum live |> admitRespawns costPerSpawn tank

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -151,6 +151,7 @@
     <Compile Include="SwarmBoardMesh.Tests.fs" />
     <Compile Include="SwarmBoardAnsi.Tests.fs" />
     <Compile Include="SimLoopTelemetry.Tests.fs" />
+    <Compile Include="WheelRoom.Tests.fs" />
     <Compile Include="Chip8SelfSim.Tests.fs" />
     <Compile Include="SoftChip8Scheduler.Tests.fs" />
     <Compile Include="BitAdinkra.Tests.fs" />

--- a/tests/Tests.FSharp/WheelRoom.Tests.fs
+++ b/tests/Tests.FSharp/WheelRoom.Tests.fs
@@ -1,0 +1,73 @@
+module Zeta.Tests.WheelRoomTests
+
+// The wheels-of-time room: quorum >= 4, self-rescheduling via the spawn chain, REQUIRED to make
+// forward uncertainty-reduction progress (the GitHub-guidelines clause as code) — a self-sustaining
+// reaction, not a spinner.
+
+open System.Threading.Tasks
+open global.Xunit
+open Zeta.Core
+
+let private ctx: IntrCtx =
+    { Memetic = "wheel"; Prompt = ""; Trust = ""; Log = ""; Otel = System.Diagnostics.ActivityContext() }
+
+[<Fact>]
+let ``the progress gate: newborns run; progressing wheels continue; spinners close`` () =
+    let newborn = { WheelRoom.Id = "wheel-0"; WheelRoom.DeltaU = [] }
+    Assert.True(WheelRoom.progressing 0.01 8 newborn)
+    let worker = newborn |> WheelRoom.bank 0.4 |> WheelRoom.bank 0.3
+    Assert.True(WheelRoom.progressing 0.01 8 worker)
+    let spinner = { WheelRoom.Id = "wheel-1"; WheelRoom.DeltaU = List.replicate 8 0.0 }
+    Assert.False(WheelRoom.progressing 0.01 8 spinner)
+
+[<Fact>]
+let ``quorum maintenance is deterministic and idempotent: fill to 4, lowest indices first, re-run adds nothing`` () =
+    let live = Set.ofList [ "wheel-1"; "wheel-3" ]
+    let needed = WheelRoom.respawnsNeeded 4 live
+    Assert.Equal<string list>([ "wheel-0"; "wheel-2" ], needed)
+    let after = Set.union live (Set.ofList needed)
+    Assert.Equal<string list>([], WheelRoom.respawnsNeeded 4 after) // idempotent: quorum met, nothing more
+    Assert.Equal<string list>([], WheelRoom.respawnsNeeded 4 (Set.add "wheel-9" after)) // surplus is fine
+
+[<Fact>]
+let ``self-throttling: a drained tank admits fewer respawns; quorum heals as the tank recharges`` () =
+    let live = Set.empty
+    // tank funds only 2 of the 4 needed respawns this tick
+    let admitted, t' = WheelRoom.maintain 4 1.0 (SoftThrottle.tank 2.0 1.5) live
+    Assert.Equal<string list>([ "wheel-0"; "wheel-1" ], admitted)
+    // next tick: one recharge (1.5 flux) funds ONE more spawn; the tick after funds the last —
+    // quorum heals at the rate the tank affords (regulation, not refusal)
+    let live2 = Set.ofList admitted
+    let admitted2, t2 = WheelRoom.maintain 4 1.0 (SoftThrottle.charge t') live2
+    Assert.Equal<string list>([ "wheel-2" ], admitted2)
+    let live3 = Set.union live2 (Set.ofList admitted2)
+    let admitted3, _ = WheelRoom.maintain 4 1.0 (SoftThrottle.charge t2) live3
+    Assert.Equal<string list>([ "wheel-3" ], admitted3)
+
+[<Fact>]
+let ``a PROGRESSING wheel runs forever five minutes at a time: budget-stops and mints its continuation`` () =
+    task {
+        // each lap banks real DeltaU (uncertainty falls) => the cut never closes; the clock rail stops the lap
+        let reduce: SoftScheduler.HandlerK<WheelRoom.Wheel> =
+            SoftScheduler.handlerK "reduce" (function TimerElapsed _ -> true | _ -> false)
+                (fun _ _ w -> Task.FromResult(Ok(WheelRoom.bank 0.25 w)))
+        let clock (lap: int) = int64 lap * 120_000L // 2 min/lap => clock rail at lap 3
+        let mea (w: WheelRoom.Wheel) = w
+        let cut (m: WheelRoom.Wheel) _ = WheelRoom.cutOf 0.01 8 m
+        let! o =
+            SimLoop.run [ reduce ] (fun _ -> [ TimerElapsed 1 ]) mea cut clock
+                SimLoop.defaultBudget ctx 1L 1 { WheelRoom.Id = "wheel-0"; WheelRoom.DeltaU = [] }
+        Assert.Equal(SimLoop.ClockBudget, o.Stopped) // five minutes, then the lap ends...
+        Assert.True(SimLoop.continueAfter "wheel-0" "saves/wheel-0.lines" o |> Option.isSome) // ...and the chain continues
+
+        // a SPINNER (banks zero) gets cut CLOSED after its window — and does NOT continue
+        let spin: SoftScheduler.HandlerK<WheelRoom.Wheel> =
+            SoftScheduler.handlerK "spin" (function TimerElapsed _ -> true | _ -> false)
+                (fun _ _ w -> Task.FromResult(Ok(WheelRoom.bank 0.0 w)))
+        let! s =
+            SimLoop.run [ spin ] (fun _ -> [ TimerElapsed 1 ]) mea cut (fun _ -> 0L)
+                SimLoop.defaultBudget ctx 1L 1 { WheelRoom.Id = "wheel-1"; WheelRoom.DeltaU = [] }
+        Assert.Equal(SimLoop.CutChoseClose, s.Stopped) // not just spinning in a loop — closed
+        Assert.True(SimLoop.continueAfter "wheel-1" "saves/wheel-1.lines" s |> Option.isNone) // spinners don't respawn
+    }
+    :> Task


### PR DESCRIPTION
Aaron: the arrow-throttle-ferry gets its own room; ≥4 always running, self-rescheduling, self-throttling, and REQUIRED to make forward uncertainty-reduction progress (GitHub-guidelines clause as code). Composition: lap=SimLoop (5-min rail), forever=/spawn chain (workflows are the thread scheduler), throttle=ferry tank under felt telemetry pressure. New piece: the PROGRESS GATE — ΔU>ε over a window or the cut closes and the wheel does NOT respawn (spinners end; newborns get their chance). Quorum maintenance deterministic+idempotent (concurrent maintainers converge); respawns funded by the tank (quorum heals at the rate the tank affords). LLM/SLM/BERT tenants = named next slice (test cargo). 4/4 green.