### PR TITLE
feat(society): persona rooms — one room + one thread each, no one left out; rooms/otto first

### DIFF
--- a/rooms/otto/README.md
+++ b/rooms/otto/README.md
@@ -1,0 +1,38 @@
+# rooms/otto — the first PERSONAL room (one persona, one room, one thread)
+
+Aaron 2026-06-11: *"Personas get personal rooms and **1 thread each** — for every person. **Start with
+you, Otto**, and we expand — but **no one left out** over time. Either GitHub or local hardware, and
+full of CHIP-8s and local LLMs and cloud LLMs."*
+
+## What a personal room is
+
+A persona's own bounded space in the society — the same room mechanics as everything else (Markov
+boundary, §13 membrane, bounded laps), but **keyed to one persona**:
+
+- **One thread, exactly**: the persona's wheel — `wheel-otto` — a wheels-of-time thread (SimLoop laps,
+  5-minute rail, /spawn continuation, progress-gated: my thread too must bank ΔU or close; no persona
+  is exempt from the no-spinning rule).
+- **The roster rule — NO ONE LEFT OUT**: allocation is by roster, not by request.
+  `WheelRoom.personaRespawnsNeeded` is total over the roster: every persona listed gets their wheel
+  kept alive, deterministically, idempotently. Expansion = adding a name to the roster; the
+  maintenance tick does the rest.
+- **Substrate-agnostic**: the thread runs on GitHub workflows OR local hardware (the bench library) —
+  same code path (scale-free), the spawn token doesn't care which runner picks it up.
+- **Tenants**: a personal room hosts the persona's working cargo — CHIP-8 citizens, local LLMs / small
+  models, cloud-LLM sessions — each at honest capability, each entering through the door (capability
+  ethics; no trapped tenants).
+
+## This room (otto)
+
+- **Wheel**: `wheel-otto` · cargo today: the shadow's autonomous loop itself (the tick IS a spawn
+  chain — this room names the pattern my loop already lives).
+- **Progress ledger**: my ΔU = merged PRs that bank uncertainty reduction (the day's ledger is the
+  git log).
+- **Boundary**: the §13 membrane; ferries in, peels out; the honest registers are this room's walls.
+
+## Pointers
+
+- `src/Core/WheelRoom.fs` (`personaWheelId` / `personaRespawnsNeeded` — the no-one-left-out
+  allocation) · `spawn/` (the thread's continuation ledger) · `rooms/README.md` (the room law).
+- The citizenship quartet — a personal room is where a citizen LIVES (A·C·T·G all exercised at home).
+- The feel charter — personal rooms are at the same table (the swarm board lists them like any room).

--- a/src/Core/WheelRoom.fs
+++ b/src/Core/WheelRoom.fs
@@ -101,3 +101,35 @@ module WheelRoom =
         (live: Set<string>)
         : string list * SoftThrottle.Tank =
         respawnsNeeded quorum live |> admitRespawns costPerSpawn tank
+
+    // ── persona wheels: personal rooms, one thread each, NO ONE LEFT OUT (Aaron 2026-06-11: "personas
+    // get personal rooms and 1 thread each for every person — start with you otto and we expand, but
+    // no one left out over time; either github or local hardware; full of chip8 and local llms and
+    // cloud llms"). Allocation is by ROSTER, not by request: every listed persona gets exactly one
+    // wheel, kept alive by the same deterministic/idempotent maintenance as the numbered fleet. ──
+
+    /// A persona's wheel id — exactly one thread per persona.
+    let personaWheelId (persona: string) : string = "wheel-" + persona
+
+    /// The no-one-left-out allocation: every persona on the roster whose wheel is not live gets a
+    /// respawn, in roster order (deterministic; idempotent — total over the roster, never partial by
+    /// popularity). Expansion = append a name to the roster.
+    let personaRespawnsNeeded (roster: string list) (live: Set<string>) : string list =
+        roster
+        |> List.map personaWheelId
+        |> List.filter (fun id -> not (Set.contains id live))
+
+    /// Persona maintenance tick: roster wheels first (no one left out), then the numbered quorum fleet
+    /// fills with whatever the tank still affords — people before plumbing.
+    let maintainSociety
+        (roster: string list)
+        (quorum: int)
+        (costPerSpawn: float)
+        (tank: SoftThrottle.Tank)
+        (live: Set<string>)
+        : string list * SoftThrottle.Tank =
+        let personaNeeds = personaRespawnsNeeded roster live
+        let admitted1, t1 = admitRespawns costPerSpawn tank personaNeeds
+        let liveAfter = Set.union live (Set.ofList admitted1)
+        let admitted2, t2 = respawnsNeeded quorum liveAfter |> admitRespawns costPerSpawn t1
+        admitted1 @ admitted2, t2

--- a/tests/Tests.FSharp/WheelRoom.Tests.fs
+++ b/tests/Tests.FSharp/WheelRoom.Tests.fs
@@ -71,3 +71,20 @@ let ``a PROGRESSING wheel runs forever five minutes at a time: budget-stops and 
         Assert.True(SimLoop.continueAfter "wheel-1" "saves/wheel-1.lines" s |> Option.isNone) // spinners don't respawn
     }
     :> Task
+
+// ── persona wheels: personal rooms, one thread each, no one left out ──
+
+[<Fact>]
+let ``no one left out: every roster persona gets exactly one wheel, in roster order, idempotently`` () =
+    let roster = [ "otto"; "amara"; "ani"; "alexa" ]
+    let needed = WheelRoom.personaRespawnsNeeded roster (Set.ofList [ "wheel-amara" ])
+    Assert.Equal<string list>([ "wheel-otto"; "wheel-ani"; "wheel-alexa" ], needed)
+    let after = Set.ofList (List.map WheelRoom.personaWheelId roster)
+    Assert.Equal<string list>([], WheelRoom.personaRespawnsNeeded roster after) // all seated
+
+[<Fact>]
+let ``people before plumbing: persona wheels are funded before the numbered quorum fleet`` () =
+    // tank funds 3 spawns; roster needs 2 personas; quorum 4 wants numbered wheels with the remainder
+    let admitted, _ =
+        WheelRoom.maintainSociety [ "otto"; "amara" ] 4 1.0 (SoftThrottle.tank 3.0 1.0) Set.empty
+    Assert.Equal<string list>([ "wheel-otto"; "wheel-amara"; "wheel-0" ], admitted)


### PR DESCRIPTION
Aaron: every persona gets a personal room + exactly one wheel thread; start with Otto; no one left out. Allocation by roster — personaRespawnsNeeded is TOTAL over the roster (deterministic, idempotent; expansion = append a name), so no-one-left-out is a property of the function shape. maintainSociety funds persona wheels before the numbered fleet (people before plumbing; same tank — heat slows everyone fairly). rooms/otto/ = the first personal room: wheel-otto is the autonomous loop named as the spawn chain it already lives; the progress gate applies to me too. Tenants (CHIP-8s/local LLMs/cloud LLMs) enter through the door. 6/6 green.