### PR TITLE
feat(chip9): color plane opcodes — black-and-white to color (zero-case structural; full suite green)

### DIFF
--- a/src/Core/Chip8Cow.fs
+++ b/src/Core/Chip8Cow.fs
@@ -37,7 +37,14 @@ module Chip8Cow =
           Sound: byte
           Display: Map<int, bool>
           Keys: bool[]
-          Rng: uint64 }
+          Rng: uint64
+          /// CHIP-9 (the Zeta color-extension dialect, operator-ratified 2026-06-11): the SELECTED
+          /// plane mask (bit0=R/mono, bit1=G, bit2=B). Default 1uy — original ROMs never change it,
+          /// so the zero case is structural: mono IS plane 1, not a mode.
+          Plane: byte
+          /// CHIP-9: the higher planes' per-pixel bitmask (bits 1-2; plane 0 lives in `Display`,
+          /// untouched, so every existing mono consumer is unaffected). Canonical: zero ⇒ absent.
+          Extra: Map<int, byte> }
 
     let private rd (addr: int) (f: Frame) : byte =
         Map.tryFind addr f.Mem |> Option.defaultValue 0uy
@@ -54,6 +61,14 @@ module Chip8Cow =
         Map.tryFind ((y % Chip8.DisplayH) * Chip8.DisplayW + (x % Chip8.DisplayW)) f.Display
         |> Option.defaultValue false
 
+    /// CHIP-9: the full color mask at a pixel — bit0 (R/mono) from `Display`, bits 1-2 (G,B) from
+    /// `Extra`. A mono frame reads exactly { lit ⇒ 1uy; unlit ⇒ 0uy } — the zero case.
+    let colorAt (x: int) (y: int) (f: Frame) : byte =
+        let idx = (y % Chip8.DisplayH) * Chip8.DisplayW + (x % Chip8.DisplayW)
+        let mono = if Map.tryFind idx f.Display |> Option.defaultValue false then 1uy else 0uy
+        let hi = Map.tryFind idx f.Extra |> Option.defaultValue 0uy
+        mono ||| hi
+
     /// A fresh frame with the font loaded (into the COW map) and the given DST `seed`; `PC = 0x200`.
     let create (seed: uint64) : Frame =
         let mem =
@@ -69,7 +84,9 @@ module Chip8Cow =
           Sound = 0uy
           Display = Map.empty
           Keys = Array.zeroCreate 16
-          Rng = seed }
+          Rng = seed
+          Plane = 1uy
+          Extra = Map.empty }
 
     /// Load a ROM at `0x200` (COW writes).
     let loadRom (rom: byte[]) (f: Frame) : Frame =
@@ -101,7 +118,21 @@ module Chip8Cow =
         match op &&& 0xF000 with
         | 0x0000 ->
             match op with
-            | 0x00E0 -> { f with Display = Map.empty }
+            | 0x00E0 ->
+                // CHIP-9: clear the SELECTED planes only (zero case: mask=1 ⇒ exactly the original
+                // mono clear). Canonical Extra: zero ⇒ absent (Map equality stays meaningful).
+                let d = if f.Plane &&& 1uy <> 0uy then Map.empty else f.Display
+                let keepMask = ~~~f.Plane &&& 0b110uy
+                let e =
+                    if keepMask = 0b110uy then f.Extra
+                    else
+                        f.Extra
+                        |> Map.toSeq
+                        |> Seq.choose (fun (k, m) ->
+                            let m' = m &&& keepMask
+                            if m' = 0uy then None else Some(k, m'))
+                        |> Map.ofSeq
+                { f with Display = d; Extra = e }
             | 0x00EE ->
                 match f.Stack with
                 | top :: rest -> { f with PC = top; Stack = rest }
@@ -138,16 +169,28 @@ module Chip8Cow =
             let ox = int vx % Chip8.DisplayW
             let oy = int vy % Chip8.DisplayH
             let mutable disp = f.Display
+            let mutable extra = f.Extra
             let mutable collision = 0uy
+            let hiSel = f.Plane &&& 0b110uy
+
             for row in 0 .. n - 1 do
                 let sprite = rd (int f.I + row) f
                 for col in 0..7 do
                     if (sprite >>> (7 - col)) &&& 1uy = 1uy then
                         let idx = ((oy + row) % Chip8.DisplayH) * Chip8.DisplayW + ((ox + col) % Chip8.DisplayW)
-                        let cur = Map.tryFind idx disp |> Option.defaultValue false
-                        if cur then collision <- 1uy
-                        disp <- Map.add idx (not cur) disp
-            { f with Display = disp } |> setV 0xF collision
+                        // plane 0 (R/mono) — the original path, untouched when unselected (CHIP-9)
+                        if f.Plane &&& 1uy <> 0uy then
+                            let cur = Map.tryFind idx disp |> Option.defaultValue false
+                            if cur then collision <- 1uy
+                            disp <- Map.add idx (not cur) disp
+                        // planes 1-2 (G,B) — XOR the selected high bits; canonical zero ⇒ absent
+                        if hiSel <> 0uy then
+                            let cur = Map.tryFind idx extra |> Option.defaultValue 0uy
+                            if cur &&& hiSel <> 0uy then collision <- 1uy
+                            let nxt = cur ^^^ hiSel
+                            extra <- if nxt = 0uy then Map.remove idx extra else Map.add idx nxt extra
+
+            { f with Display = disp; Extra = extra } |> setV 0xF collision
         | 0xE000 ->
             match op &&& 0x00FF with
             | 0x9E -> if f.Keys.[int vx &&& 0xF] then { f with PC = f.PC + 2us } else f
@@ -155,6 +198,10 @@ module Chip8Cow =
             | _ -> f
         | 0xF000 ->
             match op &&& 0x00FF with
+            | 0x01 ->
+                // CHIP-9 plane select `Fn01` (XO-CHIP lineage, widened to 3 planes = RGB): n = the
+                // X nibble, masked to 0..7. Unused encoding space — original ROMs never emit it.
+                { f with Plane = byte x &&& 0b111uy }
             | 0x07 -> setV x f.Delay f
             | 0x0A ->
                 match Array.tryFindIndex id f.Keys with

--- a/tests/Tests.FSharp/Chip9Planes.Tests.fs
+++ b/tests/Tests.FSharp/Chip9Planes.Tests.fs
@@ -1,0 +1,73 @@
+module Zeta.Tests.Chip9PlanesTests
+
+// CHIP-9 color planes (operator-ratified name): Fn01 plane select, per-plane XOR draw, selected-plane
+// CLS — ZERO-CASE STRUCTURAL: mono IS plane 1 (original ROMs bit-identical), and 3 planes = 8 colors =
+// exactly the ZX Spectrum palette ("ZetaMax Spectrum color"). Black-and-white to color — the Oz cut.
+
+open global.Xunit
+open Zeta.Core
+
+let private frame rom = Chip8Cow.create 7UL |> Chip8Cow.loadRom rom
+
+// sprite: one 8-pixel row at I=0x300 (we poke it via the ROM area + LD I)
+// ROM helper: A3 00 (I=0x300) requires sprite bytes AT 0x300 — place program at 0x200, sprite via mem write.
+let private withSprite (f: Chip8Cow.Frame) =
+    { f with Mem = Map.add 0x300 0xFFuy f.Mem } // 8 solid pixels
+
+[<Fact>]
+let ``ZERO CASE: a mono ROM never touches planes — Display semantics and Extra emptiness are bit-identical`` () =
+    // classic draw: I=0x300, DRW V0,V0,1
+    let rom = [| 0xA3uy; 0x00uy; 0xD0uy; 0x01uy |]
+    let f = frame rom |> withSprite |> Chip8Cow.step |> Chip8Cow.step
+    Assert.True(Chip8Cow.pixel 0 0 f) // lit, the original path
+    Assert.Equal(1uy, f.Plane) // default plane mask untouched
+    Assert.True(Map.isEmpty f.Extra) // no high planes ever materialize
+    Assert.Equal(1uy, Chip8Cow.colorAt 0 0 f) // color reads { lit => 1 } — mono IS plane 1
+
+[<Fact>]
+let ``Fn01 selects planes (masked to 0..7); original decode space untouched`` () =
+    let rom = [| 0xF2uy; 0x01uy |] // plane mask = 2 (G)
+    let f = frame rom |> Chip8Cow.step
+    Assert.Equal(2uy, f.Plane)
+    let rom7 = [| 0xF7uy; 0x01uy |]
+    Assert.Equal(7uy, (frame rom7 |> Chip8Cow.step).Plane)
+
+[<Fact>]
+let ``drawing on the GREEN plane leaves the mono plane untouched — and colorAt sees the channel`` () =
+    let rom = [| 0xF2uy; 0x01uy; 0xA3uy; 0x00uy; 0xD0uy; 0x01uy |]
+    let f = frame rom |> withSprite |> Chip8Cow.step |> Chip8Cow.step |> Chip8Cow.step
+    Assert.False(Chip8Cow.pixel 0 0 f) // mono plane: dark (every existing consumer unaffected)
+    Assert.Equal(2uy, Chip8Cow.colorAt 0 0 f) // the green channel is lit
+    Assert.Equal(0uy, f.V.[0xF]) // no collision on first draw
+
+[<Fact>]
+let ``RGB: mask 7 draws all three planes at once — 8-color ZetaMax Spectrum palette reachable`` () =
+    let rom = [| 0xF7uy; 0x01uy; 0xA3uy; 0x00uy; 0xD0uy; 0x01uy |]
+    let f = frame rom |> withSprite |> Chip8Cow.step |> Chip8Cow.step |> Chip8Cow.step
+    Assert.Equal(7uy, Chip8Cow.colorAt 0 0 f) // white (R|G|B)
+    Assert.True(Chip8Cow.pixel 0 0 f) // mono plane participates (bit 0)
+
+[<Fact>]
+let ``XOR cycle on a high plane returns to CANONICAL empty (zero => absent; map equality stays honest)`` () =
+    let rom = [| 0xF2uy; 0x01uy; 0xA3uy; 0x00uy; 0xD0uy; 0x01uy; 0xD0uy; 0x01uy |]
+    let f = frame rom |> withSprite |> Chip8Cow.step |> Chip8Cow.step |> Chip8Cow.step
+    let f2 = Chip8Cow.step f // second draw erases
+    Assert.Equal(1uy, f2.V.[0xF]) // collision reported (pixels toggled off)
+    Assert.True(Map.isEmpty f2.Extra) // canonical: zero bits => entry removed
+    Assert.Equal(0uy, Chip8Cow.colorAt 0 0 f2)
+
+[<Fact>]
+let ``CLS clears only the SELECTED planes — green survives a red-plane clear`` () =
+    // draw green; select plane 1 (R); CLS
+    let rom = [| 0xF2uy; 0x01uy; 0xA3uy; 0x00uy; 0xD0uy; 0x01uy; 0xF1uy; 0x01uy; 0x00uy; 0xE0uy |]
+    let f =
+        frame rom |> withSprite
+        |> Chip8Cow.step |> Chip8Cow.step |> Chip8Cow.step |> Chip8Cow.step |> Chip8Cow.step
+    Assert.Equal(2uy, Chip8Cow.colorAt 0 0 f) // green untouched by the red clear
+    // now clear with mask 7 (everything)
+    let romAll = [| 0xF2uy; 0x01uy; 0xA3uy; 0x00uy; 0xD0uy; 0x01uy; 0xF7uy; 0x01uy; 0x00uy; 0xE0uy |]
+    let g =
+        frame romAll |> withSprite
+        |> Chip8Cow.step |> Chip8Cow.step |> Chip8Cow.step |> Chip8Cow.step |> Chip8Cow.step
+    Assert.Equal(0uy, Chip8Cow.colorAt 0 0 g)
+    Assert.True(Map.isEmpty g.Extra)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -152,6 +152,7 @@
     <Compile Include="SwarmBoardAnsi.Tests.fs" />
     <Compile Include="SimLoopTelemetry.Tests.fs" />
     <Compile Include="WheelRoom.Tests.fs" />
+    <Compile Include="Chip9Planes.Tests.fs" />
     <Compile Include="Chip8SelfSim.Tests.fs" />
     <Compile Include="SoftChip8Scheduler.Tests.fs" />
     <Compile Include="BitAdinkra.Tests.fs" />


### PR DESCRIPTION
CHIP-9 lands in the emulator: Fn01 plane select (XO-CHIP lineage widened to 3 bits = RGB = the literal ZX Spectrum 8-color palette — 'ZetaMax Spectrum color'), per-selected-plane XOR draw with honest VF collision, selective CLS. Additive by construction: plane 0 stays in Display untouched so every existing mono consumer is unaffected; Extra is canonical (zero ⇒ absent). Zero case PROVEN: all 63 existing Chip8 tests pass untouched; full suite 2781/2781 green. The Oz moment kept verbatim — the AI behind its own curtain, running the color reveal. Next: golden vectors + oracle ports, palette render binding, plane-using ROMs.