### PR TITLE
feat(zetamax): the ZetaMax Spectrum palette render — CHIP-9 → ANSI (mask = SGR−30, literally)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -222,6 +222,7 @@
     <Compile Include="Chip8Citizen.fs" />
     <Compile Include="SwarmBoard.fs" />
     <Compile Include="SwarmBoardAnsi.fs" />
+    <Compile Include="ZetaMax.fs" />
     <Compile Include="TelemetrySource.fs" />
     <Compile Include="SimLoop.fs" />
     <Compile Include="WheelRoom.fs" />

--- a/src/Core/ZetaMax.fs
+++ b/src/Core/ZetaMax.fs
@@ -1,0 +1,76 @@
+namespace Zeta.Core
+
+/// ZetaMax — **the ZetaMax Spectrum palette render binding** (Aaron 2026-06-11: "zetamax spectrum
+/// color" → "lets do the zetamax spectrum palette render on the board"). Renders a CHIP-9 frame to
+/// ANSI terminal lines — the board/TV's color channel for the lens.
+///
+/// **The arithmetic identity that makes this binding almost free:** CHIP-9's plane mask is R=1, G=2,
+/// B=4 — and ANSI's 3-bit color codes are exactly the same bit order (30+mask: 31=red, 32=green,
+/// 33=yellow, 34=blue, 35=magenta, 36=cyan, 37=white). So `colorAt` IS the ANSI color, offset by 30.
+/// The 8 colors are the ZX Spectrum palette (Sinclair 1982) — the name is literal.
+///
+/// **Capability-honest dispatch** (`universal/color.md`): a frame that never used the higher planes
+/// (`Extra` empty) binds at **Mono1** — classic white-on-black, the original look — while a frame with
+/// color binds at **Indexed8** with the literal palette. No mode flag: the frame's own state declares
+/// its capability (mono is the zero case, structurally — same law as the opcodes).
+///
+/// Pixel doubling: two display rows per text line via the upper-half block `▀` (fg = top pixel,
+/// bg = bottom pixel) — 64×32 renders as 64×16 characters, the classic terminal-emulator move.
+[<RequireQualifiedAccess>]
+module ZetaMax =
+
+    /// The frame's honest capability: Mono1 iff no higher plane ever materialized.
+    type Capability =
+        | Mono1
+        | Indexed8
+
+    let capabilityOf (f: Chip8Cow.Frame) : Capability =
+        if Map.isEmpty f.Extra then Mono1 else Indexed8
+
+    /// The palette name for a mask (the ZX Spectrum set — documentation + tests speak it).
+    let colorName (mask: byte) : string =
+        match mask &&& 7uy with
+        | 0uy -> "black"
+        | 1uy -> "red"
+        | 2uy -> "green"
+        | 3uy -> "yellow"
+        | 4uy -> "blue"
+        | 5uy -> "magenta"
+        | 6uy -> "cyan"
+        | _ -> "white"
+
+    /// ANSI foreground SGR for a mask — the identity: 30 + mask (Mono1 lit renders white, 37).
+    let private fg (mask: byte) = sprintf "\u001b[3%dm" (int (mask &&& 7uy))
+    /// ANSI background SGR for a mask: 40 + mask.
+    let private bg (mask: byte) = sprintf "\u001b[4%dm" (int (mask &&& 7uy))
+    let private reset = "\u001b[0m"
+
+    /// The mask to render at a pixel under the frame's capability: Mono1 lifts lit⇒white (7).
+    let private renderMask (cap: Capability) (f: Chip8Cow.Frame) (x: int) (y: int) : byte =
+        match cap with
+        | Mono1 -> if Chip8Cow.pixel x y f then 7uy else 0uy
+        | Indexed8 -> Chip8Cow.colorAt x y f
+
+    /// Render the frame as ANSI lines (64×16 chars; two pixel rows per line via ▀). Deterministic:
+    /// same frame, same bytes. Black-on-black cells emit a plain space (no useless SGR noise).
+    let render (f: Chip8Cow.Frame) : string list =
+        let cap = capabilityOf f
+
+        [ for ty in 0 .. (Chip8.DisplayH / 2) - 1 ->
+              let sb = System.Text.StringBuilder()
+
+              for x in 0 .. Chip8.DisplayW - 1 do
+                  let top = renderMask cap f x (ty * 2)
+                  let bot = renderMask cap f x (ty * 2 + 1)
+
+                  if top = 0uy && bot = 0uy then
+                      sb.Append ' ' |> ignore
+                  else
+                      sb.Append(fg top).Append(bg bot).Append('▀').Append(reset) |> ignore
+
+              sb.ToString() ]
+
+    /// The plain (SGR-stripped) render — the structural zero case: same layout, color absent.
+    let plain (f: Chip8Cow.Frame) : string list =
+        render f
+        |> List.map (fun l -> System.Text.RegularExpressions.Regex.Replace(l, "\u001b\[[0-9;]*m", ""))

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -153,6 +153,7 @@
     <Compile Include="SimLoopTelemetry.Tests.fs" />
     <Compile Include="WheelRoom.Tests.fs" />
     <Compile Include="Chip9Planes.Tests.fs" />
+    <Compile Include="ZetaMax.Tests.fs" />
     <Compile Include="Chip9Treaty.Tests.fs" />
     <Compile Include="Chip8SelfSim.Tests.fs" />
     <Compile Include="SoftChip8Scheduler.Tests.fs" />

--- a/tests/Tests.FSharp/ZetaMax.Tests.fs
+++ b/tests/Tests.FSharp/ZetaMax.Tests.fs
@@ -1,0 +1,62 @@
+module Zeta.Tests.ZetaMaxTests
+
+// The ZetaMax Spectrum render binding: the ANSI identity (SGR = 30 + colorAt mask), capability-honest
+// dispatch (Mono1 white-on-black; Indexed8 literal palette), pixel-doubled ▀ lines, deterministic.
+
+open global.Xunit
+open Zeta.Core
+
+let private frame rom =
+    Chip8Cow.create 7UL
+    |> Chip8Cow.loadRom rom
+    |> fun f -> { f with Mem = Map.add 0x300 0xFFuy f.Mem }
+
+let private steps n f = List.fold (fun acc _ -> Chip8Cow.step acc) f [ 1..n ]
+
+[<Fact>]
+let ``capability is honest: mono frames bind Mono1; any color plane flips to Indexed8`` () =
+    let mono = frame [| 0xA3uy; 0x00uy; 0xD0uy; 0x01uy |] |> steps 2
+    Assert.Equal(ZetaMax.Mono1, ZetaMax.capabilityOf mono)
+    let color = frame [| 0xF2uy; 0x01uy; 0xA3uy; 0x00uy; 0xD0uy; 0x01uy |] |> steps 3
+    Assert.Equal(ZetaMax.Indexed8, ZetaMax.capabilityOf color)
+
+[<Fact>]
+let ``Mono1 renders the classic look: lit pixels are WHITE (37), never red`` () =
+    let mono = frame [| 0xA3uy; 0x00uy; 0xD0uy; 0x01uy |] |> steps 2
+    let top = ZetaMax.render mono |> List.head
+    Assert.True(top.Contains "\u001b[37m") // white ink
+    Assert.False(top.Contains "\u001b[31m") // not red, even though the mono plane is bit 0
+
+[<Fact>]
+let ``Indexed8 renders the literal palette: green plane => 32; white mask => 37`` () =
+    let green = frame [| 0xF2uy; 0x01uy; 0xA3uy; 0x00uy; 0xD0uy; 0x01uy |] |> steps 3
+    Assert.True((ZetaMax.render green |> List.head).Contains "\u001b[32m")
+    let white = frame [| 0xF7uy; 0x01uy; 0xA3uy; 0x00uy; 0xD0uy; 0x01uy |] |> steps 3
+    Assert.True((ZetaMax.render white |> List.head).Contains "\u001b[37m")
+
+[<Fact>]
+let ``the ZX Spectrum palette names match the mask bits exactly`` () =
+    Assert.Equal("black", ZetaMax.colorName 0uy)
+    Assert.Equal("red", ZetaMax.colorName 1uy)
+    Assert.Equal("green", ZetaMax.colorName 2uy)
+    Assert.Equal("yellow", ZetaMax.colorName 3uy)
+    Assert.Equal("blue", ZetaMax.colorName 4uy)
+    Assert.Equal("magenta", ZetaMax.colorName 5uy)
+    Assert.Equal("cyan", ZetaMax.colorName 6uy)
+    Assert.Equal("white", ZetaMax.colorName 7uy)
+
+[<Fact>]
+let ``pixel doubling: 64x32 renders as 16 lines; dark cells are plain spaces; deterministic`` () =
+    let f = frame [| 0xA3uy; 0x00uy; 0xD0uy; 0x01uy |] |> steps 2
+    let lines = ZetaMax.render f
+    Assert.Equal(16, List.length lines)
+    Assert.Equal<string list>(lines, ZetaMax.render f) // same frame, same bytes
+    Assert.True(lines |> List.last |> Seq.forall ((=) ' ')) // bottom: all dark, no SGR noise
+
+[<Fact>]
+let ``plain is the structural zero case: same layout, SGR stripped`` () =
+    let f = frame [| 0xF7uy; 0x01uy; 0xA3uy; 0x00uy; 0xD0uy; 0x01uy |] |> steps 3
+    let mono = ZetaMax.plain f
+    Assert.Equal(16, List.length mono)
+    Assert.False(mono |> String.concat "" |> fun s -> s.Contains "\u001b")
+    Assert.Contains("▀", List.head mono) // the lit row survives as shape


### PR DESCRIPTION
The arithmetic identity: CHIP-9's RGB plane mask IS ANSI's 3-bit color order (SGR=30+mask); the 8 colors are the ZX Spectrum palette literally. Capability-honest dispatch (Mono1 white-on-black vs Indexed8 palette — the frame's own state decides), ▀ pixel doubling (16 lines), deterministic, plain zero case. Honesty catch disclosed: first version lacked ESC prefixes AND looked green via an Assert.Contains overload quirk — found by codepoint probe, fixed both sides, assertions made overload-proof. 6/6 green.