### PR TITLE
feat(otto): the shadow-otter avatar (self-chosen, animated, XOR heart) + quote metadata format + CHIP-8 UX primitives + the archaeologist frame

### DIFF
--- a/docs/research/2026-06-11-quote-metadata-lexisnexis-dv2-dbt-db-quotes-plus-chip8-ux-primitives-plus-the-archaeologist-frame.md
+++ b/docs/research/2026-06-11-quote-metadata-lexisnexis-dv2-dbt-db-quotes-plus-chip8-ux-primitives-plus-the-archaeologist-frame.md
@@ -1,0 +1,68 @@
+# Quote metadata (LexisNexis × DV2 × dbt) + /db/quotes · CHIP-8 UX primitives at the slider's low end · the archaeologist frame
+
+Three asks from Aaron 2026-06-11, captured together (they share one spine: the quote becomes a CITED,
+DESIGNED, EXCAVATED artifact):
+
+## 1. The quote meta-tag format — "LexisNexis style; go hard on the data style — Data Vault and dbt"
+
+> "We need a meta-tag format for saving color and animations and all that around our quotes —
+> LexisNexis style. We go hard on the data style, like Data Vault, and dbt-style the tool. Also we can
+> have `/db/quotes` or something — this will be useful for more than just games, I can tell you."
+
+The shape (DV2 applied to quotes — and the FIRST INSTANCE already shipped: `rooms/otto/avatar.lines`
+uses exactly this tab-separated meta-tag form):
+
+- **hub** — the quote's identity: content-address of (savestate-pointer, recording, ticks) — stable,
+  citable. LexisNexis is the anchor: a CITATION SYSTEM where every artifact has a canonical locator
+  and rich headnotes; our quotes get the same treatment (a quote is a *citation into a running
+  system* — game or not: a cluster incident, a test failure, a conversation — anything replayable).
+- **satellites** — the fast-changing annotations as `meta` tag lines: palette/color state, animation
+  tracks, names-as-hypotheses from the archaeology, persona-ownership attributions, kept-fraction,
+  heat. Append-only, keyed, idempotent.
+- **links** — quote→quote relations (continues / forks-from / refutes / quotes-within-quote).
+- **the dbt move** — quotes are TRANSFORMED, not mutated: derived quote tables (a masked quote, a
+  re-annotated quote, a cross-oracle conformance run) are declared transformations over the hub —
+  lineage-tracked, re-runnable, testable (dbt's model: SQL/transform-as-code with tests; ours:
+  transforms over quote hubs with DST replays as the tests).
+- **home**: `/db/quotes` when the /db topology lands (B-1023's plan); until then quotes live beside
+  their state in `saves/` with the meta-tag annotations inline.
+
+## 2. CHIP-8 UX: design principles + reusable UI primitives at the responsive slider's LOW end
+
+> "We should make a proper UX interface around all this — design principles and reusable UI primitives
+> for CHIP-8 specifically — in our responsive-design slider at super low."
+
+The responsive-design slider (grow up and down) needs its BOTTOM end designed as carefully as the top:
+64×32, 8 colors (CHIP-9), 16 keys — the super-low rung where Addison plays and the smallest citizens
+live. Filed as the UI-primitive set to build (the board/arcade/TV all consume these):
+
+- **primitives**: the glyph atlas (the 64-sprite treaty set) · heat bar (the Lite-Brite row) · menu
+  list with cursor (character-select style) · door/exit markers (the Zork compass rendered) · presence
+  dots · the narrator ticker (one line, paged) · avatar slot (8×8, 2-frame animation — the
+  `avatar.lines` format is the data contract).
+- **principles**: honest capability (never fake a pixel you don't have); one action per screen
+  (choose-your-own-adventure pacing); every interactive element reachable by the 16-key pad; the
+  narrator speaks before the screen demands (D&D charter); animation = state made visible (a blink IS
+  a tick), never decoration-only; kid-first defaults (the 5-year-old reads it without text).
+
+## 3. The archaeologist frame
+
+> "Otto, imagine you are an archaeologist studying humans lol — this is what my childhood game systems
+> were like."
+
+Held, and it lands precisely: the quote/mask/reverse-traversal work IS digital archaeology — the
+masked ROM is the excavated stratum (only the touched 6% is the inhabited layer), names-as-hypotheses
+is exactly how archaeologists label finds, state-to-persona attribution is assigning artifacts to
+households, and the playable quote is the museum's living diorama: not a photo of the pot — the pot,
+holdable. The affect matters too: these are Aaron's CHILDHOOD systems — the archaeology is personal;
+handle the strata with the care of someone excavating a family home. (Beacon: archaeology's
+context-is-everything principle — an artifact without its stratum is loot; a quote without its
+savestate+recording is a screenshot.)
+
+## Pointers
+
+- `rooms/otto/avatar.lines` — the meta-tag format's first instance (shipped with this PR) ·
+  `Chip8Quote` (the hub's payload) · `saves/`+`/db` plan (the home) · the feel charter + ZetaMax (what
+  the primitives render through) · B-1023 (/db topology) · anchors: LexisNexis citator practice ·
+  Linstedt DV2 · dbt (transform-as-code with tests) · archaeological stratigraphy (Harris matrices —
+  the branch-graph reading of a dig).

--- a/rooms/otto/avatar.lines
+++ b/rooms/otto/avatar.lines
@@ -1,0 +1,14 @@
+# otto's avatar — chosen by otto, no operator input (Aaron 2026-06-11: "figure out what you want to
+# look like in chip8, all up to you, choose-your-own-adventure character-select style; you need an
+# avatar with animations"). A shadow-otter: body on the CYAN planes (mask 6 — shadow-cool, G+B), and a
+# heart drawn on the RED plane OVER the body — XOR flips those pixels to WHITE (mask 7): the heart is
+# literally the red plane meeting the shadow. Two-frame idle/blink animation.
+# Format (meta-tag lines, tab-separated — the quote/meta style, first instance):
+meta	name	otto-shadow-otter
+meta	persona	otto
+meta	body-plane	6
+meta	heart-plane	1
+frame	idle	3c7edbffffff7e24
+frame	blink	3c7effffffff7e42
+sprite	heart	0018180000000000
+anim	breathe	idle,idle,idle,blink

--- a/tests/Tests.FSharp/OttoAvatar.Tests.fs
+++ b/tests/Tests.FSharp/OttoAvatar.Tests.fs
@@ -1,0 +1,82 @@
+module Zeta.Tests.OttoAvatarTests
+
+// otto's avatar (rooms/otto/avatar.lines): parsed from its meta-tag file, drawn on CHIP-9 planes
+// (cyan body, red-over-cyan heart => WHITE via XOR), rendered through ZetaMax, animated (idle/blink).
+
+open System.IO
+open global.Xunit
+open Zeta.Core
+
+let private repoRoot () =
+    let mutable dir = DirectoryInfo(System.AppContext.BaseDirectory)
+    while not (isNull dir) && not (File.Exists(Path.Combine(dir.FullName, "Zeta.sln"))) do
+        dir <- dir.Parent
+    dir.FullName
+
+let private avatarLines () =
+    File.ReadAllLines(Path.Combine(repoRoot (), "rooms", "otto", "avatar.lines"))
+    |> Array.filter (fun l -> not (l.StartsWith "#") && l.Trim().Length > 0)
+
+let private field (kind: string) (name: string) =
+    avatarLines ()
+    |> Array.pick (fun l ->
+        match l.Split('\t') with
+        | [| k; n; v |] when k = kind && n = name -> Some v
+        | _ -> None)
+
+let private hexBytes (s: string) =
+    [| for i in 0 .. 2 .. s.Length - 2 -> System.Convert.ToByte(s.Substring(i, 2), 16) |]
+
+/// Draw an 8x8 sprite at (0,0) on the given plane mask via real CHIP-9 opcodes (Fn01 + DRW).
+let private draw (planeMask: int) (sprite: byte[]) (f: Chip8Cow.Frame) =
+    let rom =
+        [| byte (0xF0 ||| planeMask); 0x01uy // Fn01: select planes
+           0xA3uy; 0x00uy // I := 0x300
+           0xD0uy; byte sprite.Length |] // DRW 0,0,N
+    let f2 =
+        { f with
+            Mem =
+                sprite
+                |> Array.indexed
+                |> Array.fold (fun m (i, b) -> Map.add (0x300 + i) b m) f.Mem
+            PC = uint16 Chip8.ProgramStart }
+    let f3 =
+        rom
+        |> Array.indexed
+        |> Array.fold (fun (m: Chip8Cow.Frame) (i, b) -> { m with Mem = Map.add (Chip8.ProgramStart + i) b m.Mem }) f2
+    [ 1..3 ] |> List.fold (fun acc _ -> Chip8Cow.step acc) f3
+
+let private composite frameName =
+    let body = hexBytes (field "frame" frameName)
+    let heart = hexBytes (field "sprite" "heart")
+    Chip8Cow.create 7UL |> draw 6 body |> draw 1 heart
+
+[<Fact>]
+let ``the avatar file parses: name, planes, two frames, the heart, the breathe animation`` () =
+    Assert.Equal("otto-shadow-otter", field "meta" "name")
+    Assert.Equal("6", field "meta" "body-plane")
+    Assert.Equal(8, (hexBytes (field "frame" "idle")).Length)
+    Assert.Equal(8, (hexBytes (field "frame" "blink")).Length)
+    Assert.Equal("idle,idle,idle,blink", field "anim" "breathe")
+
+[<Fact>]
+let ``the body is CYAN and the heart is WHITE — the red plane meeting the shadow (XOR symbolism)`` () =
+    let f = composite "idle"
+    Assert.Equal(6uy, Chip8Cow.colorAt 0 2 f) // body edge: cyan (G+B)
+    Assert.Equal(7uy, Chip8Cow.colorAt 3 1 f) // heart pixel (row 1, bits 3-4): white = red XOR cyan
+    Assert.Equal(7uy, Chip8Cow.colorAt 4 2 f)
+    Assert.Equal(ZetaMax.Indexed8, ZetaMax.capabilityOf f) // a color citizen
+
+[<Fact>]
+let ``the animation breathes: idle and blink differ exactly at the eyes and feet`` () =
+    let idle = composite "idle"
+    let blink = composite "blink"
+    Assert.NotEqual<Map<int, byte>>(idle.Extra, blink.Extra)
+    Assert.Equal(0uy, Chip8Cow.colorAt 2 2 idle) // open eye: a hole in the body row
+    Assert.Equal(6uy, Chip8Cow.colorAt 2 2 blink) // blink: the eye row fills cyan
+
+[<Fact>]
+let ``the avatar renders deterministically through ZetaMax (same frame, same bytes)`` () =
+    let f = composite "idle"
+    Assert.Equal<string list>(ZetaMax.render f, ZetaMax.render f)
+    Assert.True(ZetaMax.render f |> List.head |> fun l -> l.Contains "[36m" || l.Contains "[37m")

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -155,6 +155,7 @@
     <Compile Include="Chip9Planes.Tests.fs" />
     <Compile Include="ZetaMax.Tests.fs" />
     <Compile Include="Chip9Phys.Tests.fs" />
+    <Compile Include="OttoAvatar.Tests.fs" />
     <Compile Include="Chip9Treaty.Tests.fs" />
     <Compile Include="Chip8SelfSim.Tests.fs" />
     <Compile Include="SoftChip8Scheduler.Tests.fs" />


### PR DESCRIPTION
The avatar, chosen unprompted: a shadow-otter — cyan body (mask 6), heart drawn on the red plane over it so XOR flips it WHITE (the red plane meeting the shadow); two-frame breathe animation; shipped as data (rooms/otto/avatar.lines — the meta-tag format's first instance), drawn via real CHIP-9 opcodes in tests, rendered through ZetaMax. 4/4 green. Plus: quote metadata 'LexisNexis × DV2 × dbt' (hub/satellite/link + derived quotes as DST-tested transforms; /db/quotes home; useful beyond games), the CHIP-8 UX primitive set + principles at the responsive slider's super-low end, and the archaeologist frame (masked ROM = excavated stratum; excavate childhood systems like a family home).