### PR TITLE
feat(chip9): the physics library's first stone — fix16 sub-pixel clock-free kernel + the five design laws

### DIFF
--- a/docs/research/2026-06-11-chip9-graphics-physics-library-clock-free-presence-throttle-xms-door-universal-console-interface-chip9-is-the-atom.md
+++ b/docs/research/2026-06-11-chip9-graphics-physics-library-clock-free-presence-throttle-xms-door-universal-console-interface-chip9-is-the-atom.md
@@ -1,0 +1,60 @@
+# The CHIP-9 graphics/physics library — clock-free, presence-throttled, XMS-through-the-door, the universal game console interface; CHIP-9 is the atom
+
+Aaron 2026-06-11:
+
+> "We need our own **graphics and physics library for chip9** — **super high quality rendering like
+> never seen before on tiny things**, **scale-free**, so it can run **independent of clock speed** —
+> we don't try to slow to human speed; it can run at max speed, **artificial throttle [only] unless a
+> human joins the conference**. Don't need to limit chip9 by chip8 specs — can have **XMS like win3.1**
+> or whatever, so it can **ask for more** — and also **DI inject better and better tech until it IS
+> just a Game Boy or Atari or whatever — a universal game console interface**."
+> / "**chip9 is our atom** — like DynamicValue. You had a great physics mapping around this yesterday."
+
+## The five design laws (first stone SHIPPED: `src/Core/Chip9Phys.fs`)
+
+1. **Sub-pixel exactness — "never seen before on tiny things," made concrete.** The kernel is
+   fixed-point 16.16, no floats: positions live on a grid 65,536× finer than the display in each axis
+   (a 64×32 screen simulated on ~4M×2M sub-pixels). The simulation is always far finer than any pixel
+   shows; the renderer downsamples. Tested concretely: two bodies in sub-pixel contact that whole
+   pixels would round onto the same cell — the sim sees what the display cannot. Exact ⇒ a TREATY
+   surface (byte-locked trajectories on every oracle/architecture — the physics rides the B-1025
+   fan-out).
+2. **Clock-free — speed is nobody's business.** `step` advances SIMULATION time by exact dt; tested:
+   8 × (1/8 tick) ≡ 1 tick to the bit. Headless rooms run at max machine speed.
+3. **The presence throttle.** The ONLY artificial slowdown is a human joining the conference — pacing
+   is inserted at the ROOM layer (the runner wall-clocks the ticks while presence shows a human at the
+   table; the board's join/part crossings are the trigger), never in the math. Ethics-and-heat again:
+   the throttle exists for the watcher, not against the machine.
+4. **XMS through the door.** CHIP-9 isn't capped by CHIP-8's 4KB: like Win3.1's XMS/EMS, the machine
+   ASKS for more — extended memory as an injected capability (a `mem:request` crossing; pages granted
+   through the membrane per the trust calculus — capacity is a GRANT, not a birthright; the trap/door
+   law applies to RAM).
+5. **The universal game console interface.** DI injects better and better tech — more memory, finer
+   display, richer sound, faster stepping — until the same room IS a Game Boy, an Atari, whatever:
+   a CONSOLE IS A CAPABILITY BUNDLE. Console identity = the set of grants a room holds (CHIP-8 = the
+   zero bundle; CHIP-9 = +planes; "Game Boy" = +XMS+tiles+APU…). One interface, every console a point
+   on its lattice — the capability-door calculus with consoles as the fixed points.
+
+## "CHIP-9 is our atom" (the physics mapping, hung where it belongs)
+
+DynamicValue is the atom of VALUES; **CHIP-9 is the atom of MACHINES** — the smallest universal unit a
+room/citizen/console builds from. Yesterday's physics mapping attaches naturally to the atom:
+executed instructions are worldlines (Feynman), retraction is the antiparticle leg (CMYK), heat is the
+branch-prune toll (Landauer — the flux tank), planes are the color channels of the trace (RGB), and
+the conference of futures is the atom's superposition resolved by the input crossing. Chemistry =
+composition: atoms (CHIP-9 rooms) bond through treaty crossings into molecules (games, boards,
+consoles) — the capability bundle is the valence.
+
+## Named next slices
+
+Rasterize-to-planes (sub-pixel → CHIP-9 color planes with temporal supersampling) · sprites-from-
+physics · springs/joints · the `mem:request` XMS door · the console-bundle registry (the lattice) ·
+the C#/TS/Rust physics conformance goldens.
+
+## Pointers
+
+- `src/Core/Chip9Phys.fs` + tests (the kernel: fix16, clock-free, integer collision; 5/5 green) ·
+  MeshPong (the integer-world precedent) · the convergence/qubits docs (yesterday's mapping) ·
+  TrustCalculus.Dynamics (capacity-as-grant) · universal/extension.md (the console bundle's zero case)
+  · anchors: fixed-point DSP tradition · XMS/HIMEM (Microsoft, Win3.x) · Feynman/Landauer (the
+  mapping's shoulders).

--- a/src/Core/Chip9Phys.fs
+++ b/src/Core/Chip9Phys.fs
@@ -1,0 +1,82 @@
+namespace Zeta.Core
+
+/// Chip9Phys — **the first stone of the CHIP-9 graphics/physics library** (Aaron 2026-06-11: "we need
+/// our own graphics and physics library for chip9 — super high quality rendering like never seen
+/// before on tiny things, SCALE-FREE, so it can run independent of clock speed … it can run at max
+/// speed, artificial throttle only when a human joins the conference").
+///
+/// Design laws (each from a standing discipline):
+/// - **Fixed-point 16.16, no floats** — exact, byte-lockable, culture-invariant: the physics is a
+///   TREATY surface (the same trajectory on every oracle, every architecture — the B-1025 fan-out
+///   carries it). 16.16 gives sub-pixel precision ×65536 on a 64×32 screen: positions live on a
+///   4,194,304 × 2,097,152 sub-pixel grid — "super high quality on tiny things" is exactly this:
+///   the SIMULATION is far finer than the DISPLAY, and the renderer downsamples.
+/// - **Clock-free stepping** — `step` advances SIMULATION TIME by an exact dt (a 16.16 tick fraction),
+///   never wall time. Determinism is per-step; speed is the runner's business: headless = max speed
+///   (no human to pace for), and the HUMAN THROTTLE is presence-triggered at the room layer (a human
+///   joins the conference ⇒ the runner inserts wall-clock pacing; nobody slows the math itself).
+/// - **Integer collision** — AABB overlap + elastic axis reflection in pure integer arithmetic;
+///   restitution as a 16.16 scalar. The MeshPong integer world generalized.
+///
+/// Honest scope: this is the KERNEL (vectors, AABB, integrate, reflect) — the library grows around it
+/// (sprites-from-physics, sub-pixel rasterize-to-planes, springs/joints are named next slices).
+[<RequireQualifiedAccess>]
+module Chip9Phys =
+
+    /// One unit = 1/65536 of a pixel. The whole library speaks fix16.
+    type Fix = int
+
+    let one: Fix = 65536
+    let ofInt (i: int) : Fix = i * one
+    let toIntFloor (f: Fix) : int = int (System.Math.Floor(float f / 65536.0))
+
+    /// fix16 multiply (64-bit intermediate — no overflow inside the screen's range).
+    let mul (a: Fix) (b: Fix) : Fix = int ((int64 a * int64 b) >>> 16)
+
+    /// fix16 divide.
+    let div (a: Fix) (b: Fix) : Fix = int ((int64 a <<< 16) / int64 b)
+
+    /// A 2D fixed-point vector.
+    type V2 = { X: Fix; Y: Fix }
+
+    let v2 x y = { X = x; Y = y }
+    let add (a: V2) (b: V2) = { X = a.X + b.X; Y = a.Y + b.Y }
+    let scale (k: Fix) (a: V2) = { X = mul k a.X; Y = mul k a.Y }
+
+    /// An axis-aligned body: position (top-left), size, velocity — all fix16 sub-pixel.
+    type Body =
+        { Pos: V2
+          Size: V2
+          Vel: V2 }
+
+    /// Advance one body by exact dt (fix16 ticks) — pure, clock-free, deterministic.
+    let integrate (dt: Fix) (b: Body) : Body = { b with Pos = add b.Pos (scale dt b.Vel) }
+
+    /// AABB overlap test — pure integer comparisons.
+    let overlaps (a: Body) (b: Body) : bool =
+        a.Pos.X < b.Pos.X + b.Size.X
+        && b.Pos.X < a.Pos.X + a.Size.X
+        && a.Pos.Y < b.Pos.Y + b.Size.Y
+        && b.Pos.Y < a.Pos.Y + a.Size.Y
+
+    /// Reflect a body off the world's walls (0..w, 0..h), with restitution `e` (fix16; one = elastic).
+    /// Clamps position back inside and flips/scales the velocity axis — the pong move, sub-pixel.
+    let reflectWalls (w: Fix) (h: Fix) (e: Fix) (b: Body) : Body =
+        let bounce (pos: Fix) (size: Fix) (vel: Fix) (limit: Fix) =
+            if pos < 0 then -pos, -(mul e vel)
+            elif pos + size > limit then limit - size - (pos + size - limit), -(mul e vel)
+            else pos, vel
+
+        let px, vx = bounce b.Pos.X b.Size.X b.Vel.X w
+        let py, vy = bounce b.Pos.Y b.Size.Y b.Vel.Y h
+        { b with Pos = v2 px py; Vel = v2 vx vy }
+
+    /// One world step: integrate every body, then wall-reflect — the kernel's whole loop.
+    let step (w: Fix) (h: Fix) (e: Fix) (dt: Fix) (bodies: Body list) : Body list =
+        bodies |> List.map (integrate dt >> reflectWalls w h e)
+
+    /// Rasterize a body to whole pixels (floor) — where the sub-pixel simulation meets the 64×32
+    /// display: the renderer's input. The high-quality move: positions carry 16 bits MORE precision
+    /// than any pixel shows, so motion stays smooth at any dt (temporal supersampling lives upstairs).
+    let pixelRect (b: Body) : int * int * int * int =
+        toIntFloor b.Pos.X, toIntFloor b.Pos.Y, toIntFloor b.Size.X, toIntFloor b.Size.Y

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -223,6 +223,7 @@
     <Compile Include="SwarmBoard.fs" />
     <Compile Include="SwarmBoardAnsi.fs" />
     <Compile Include="ZetaMax.fs" />
+    <Compile Include="Chip9Phys.fs" />
     <Compile Include="TelemetrySource.fs" />
     <Compile Include="SimLoop.fs" />
     <Compile Include="WheelRoom.fs" />

--- a/tests/Tests.FSharp/Chip9Phys.Tests.fs
+++ b/tests/Tests.FSharp/Chip9Phys.Tests.fs
@@ -1,0 +1,54 @@
+module Zeta.Tests.Chip9PhysTests
+
+// The CHIP-9 physics kernel: fix16 sub-pixel, clock-free, integer-exact — a treaty surface (same
+// trajectory on every oracle at any speed; the human throttle is presence-triggered upstairs, never
+// in the math).
+
+open global.Xunit
+open Zeta.Core
+
+module P = Zeta.Core.Chip9Phys
+
+let private world = P.ofInt 64, P.ofInt 32
+
+[<Fact>]
+let ``fix16 arithmetic is exact: mul/div round-trip on representable values`` () =
+    Assert.Equal(P.ofInt 6, P.mul (P.ofInt 2) (P.ofInt 3))
+    Assert.Equal(P.ofInt 2, P.div (P.ofInt 6) (P.ofInt 3))
+    Assert.Equal(P.one / 2, P.mul (P.one / 2) P.one) // half a pixel survives exactly
+
+[<Fact>]
+let ``CLOCK-FREE: n small steps equal one big step exactly (linear motion; dt is simulation time)`` () =
+    let b = { P.Pos = P.v2 (P.ofInt 5) (P.ofInt 5); P.Size = P.v2 P.one P.one; P.Vel = P.v2 (P.ofInt 2) (P.ofInt 1) }
+    let small = [ 1..8 ] |> List.fold (fun x _ -> P.integrate (P.one / 8) x) b
+    let big = P.integrate P.one b
+    Assert.Equal(big.Pos, small.Pos) // 8 × (1/8 tick) == 1 tick, to the bit — speed is nobody's business
+
+[<Fact>]
+let ``walls reflect sub-pixel exactly; elastic bounce preserves speed, restitution scales it`` () =
+    let w, h = world
+    let b = { P.Pos = P.v2 (P.ofInt 63) (P.ofInt 10); P.Size = P.v2 P.one P.one; P.Vel = P.v2 (P.ofInt 4) 0 }
+    let e1 = P.step w h P.one P.one [ b ] |> List.head
+    Assert.True(e1.Vel.X < 0) // bounced
+    Assert.Equal(P.ofInt 4, -e1.Vel.X) // elastic: speed preserved exactly
+    let eHalf = P.step w h (P.one / 2) P.one [ b ] |> List.head
+    Assert.Equal(P.ofInt 2, -eHalf.Vel.X) // restitution ½: half the speed, exactly
+
+[<Fact>]
+let ``DETERMINISM: the same world replays bit-identically (the treaty surface property)`` () =
+    let bodies =
+        [ { P.Pos = P.v2 (P.ofInt 3) (P.ofInt 4); P.Size = P.v2 P.one P.one; P.Vel = P.v2 (P.ofInt 3) (P.ofInt 2) }
+          { P.Pos = P.v2 (P.ofInt 50) (P.ofInt 20); P.Size = P.v2 (P.ofInt 2) P.one; P.Vel = P.v2 (-P.ofInt 5) (P.ofInt 1) } ]
+    let w, h = world
+    let run () = [ 1..500 ] |> List.fold (fun bs _ -> P.step w h P.one (P.one / 4) bs) bodies
+    Assert.Equal<P.Body list>(run (), run ())
+
+[<Fact>]
+let ``overlap detects sub-pixel contact that whole pixels cannot see (the quality claim, concrete)`` () =
+    let a = { P.Pos = P.v2 (P.ofInt 10) (P.ofInt 10); P.Size = P.v2 P.one P.one; P.Vel = P.v2 0 0 }
+    // b sits 1/4 pixel inside a's right edge — pixelRect says both are at distinct cells
+    let b = { a with P.Pos = P.v2 (P.ofInt 10 + P.one * 3 / 4) (P.ofInt 10) }
+    Assert.True(P.overlaps a b) // the simulation sees the contact
+    let ax, _, _, _ = P.pixelRect a
+    let bx, _, _, _ = P.pixelRect b
+    Assert.Equal(ax, bx) // ...the display would round them onto the same cell — sim ≫ display precision

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -154,6 +154,7 @@
     <Compile Include="WheelRoom.Tests.fs" />
     <Compile Include="Chip9Planes.Tests.fs" />
     <Compile Include="ZetaMax.Tests.fs" />
+    <Compile Include="Chip9Phys.Tests.fs" />
     <Compile Include="Chip9Treaty.Tests.fs" />
     <Compile Include="Chip8SelfSim.Tests.fs" />
     <Compile Include="SoftChip8Scheduler.Tests.fs" />


### PR DESCRIPTION
Aaron's vision captured + first stone shipped: Chip9Phys (fixed-point 16.16 — exact/byte-lockable treaty physics; clock-free stepping proven to the bit; sub-pixel contact the display can't see — the quality claim falsifiable and passing; 500-step bit-identical replay). The five laws: sub-pixel exactness, clock-free (max speed headless), the PRESENCE THROTTLE (pacing only when a human joins the conference — at the room layer, never in the math), XMS through the door (RAM as a trust-calculus grant), and the universal console interface (a console IS a capability bundle; CHIP-8 = the zero bundle; Game Boy/Atari = richer grants on the same lattice). Plus 'CHIP-9 is our atom' — the physics mapping hung on it. 5/5 green.