### PR TITLE
feat(chip9): TypeScript conformer — second oracle ratifies the color-plane treaty (first-run byte-lock)

### DIFF
--- a/src/Core.TypeScript/chip9/chip9.test.ts
+++ b/src/Core.TypeScript/chip9/chip9.test.ts
@@ -1,0 +1,35 @@
+/**
+ * CHIP-9 cross-verify — the TS oracle replays the treaty ROM the F# oracle locked
+ * (./golden-vectors.lines) and must reproduce the 32×64 hex color grid + plane register exactly.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { colorAt, create, H, loadRom, step, W } from "./chip9";
+
+const lines = readFileSync(join(import.meta.dir, "golden-vectors.lines"), "utf-8")
+  .split("\n")
+  .filter((l) => !l.startsWith("#") && l.length > 0);
+
+describe("CHIP-9 — the color-plane treaty (TS oracle)", () => {
+  it("BYTE-LOCK: replaying the treaty ROM reproduces the golden color grid exactly", () => {
+    const romHex = lines[0].split("\t")[1];
+    const rom = new Uint8Array(romHex.match(/.{2}/g)!.map((h) => parseInt(h, 16)));
+    const goldenPlane = parseInt(lines[1].split("\t")[1], 10);
+    const goldenRows = lines.slice(2);
+    expect(goldenRows.length).toBe(H);
+
+    let f = create();
+    f = loadRom(rom, f);
+    f.mem.set(0x300, 0xff); // the treaty sprite (mirrors the F# test setup)
+    for (let s = 0; s < 12; s++) f = step(f);
+
+    expect(f.plane).toBe(goldenPlane);
+    for (let y = 0; y < H; y++) {
+      let row = "";
+      for (let x = 0; x < W; x++) row += colorAt(x, y, f).toString(16);
+      expect(row).toBe(goldenRows[y]);
+    }
+  });
+});

--- a/src/Core.TypeScript/chip9/chip9.ts
+++ b/src/Core.TypeScript/chip9/chip9.ts
@@ -1,0 +1,111 @@
+/**
+ * CHIP-9 (the Zeta color-extension dialect of CHIP-8) — TypeScript conformer oracle.
+ * Mirrors src/Core/Chip8Cow.fs (the F# oracle that LOCKED the treaty): Fn01 plane select (3 bits =
+ * RGB), per-selected-plane XOR draw with VF collision, selective CLS. Zero case structural: plane 0
+ * (mono) lives in `display`; higher planes in `extra` (zero ⇒ absent). Subset sufficient for the
+ * treaty ROM: 00E0, 1NNN-equivalents not needed, ANNN, 6XNN, DXYN, Fn01.
+ * TREATY: replaying ./golden-vectors.lines' rom must reproduce its 32×64 hex color grid exactly.
+ */
+
+export const W = 64;
+export const H = 32;
+const PROGRAM_START = 0x200;
+
+export interface Frame {
+  mem: Map<number, number>;
+  v: Uint8Array;
+  i: number;
+  pc: number;
+  plane: number;
+  display: Map<number, boolean>;
+  extra: Map<number, number>;
+}
+
+export function create(): Frame {
+  return {
+    mem: new Map(),
+    v: new Uint8Array(16),
+    i: 0,
+    pc: PROGRAM_START,
+    plane: 1,
+    display: new Map(),
+    extra: new Map(),
+  };
+}
+
+export function loadRom(rom: Uint8Array, f: Frame): Frame {
+  rom.forEach((b, idx) => f.mem.set(PROGRAM_START + idx, b));
+  return f;
+}
+
+export function colorAt(x: number, y: number, f: Frame): number {
+  const idx = (y % H) * W + (x % W);
+  const mono = f.display.get(idx) ? 1 : 0;
+  return mono | (f.extra.get(idx) ?? 0);
+}
+
+export function step(f: Frame): Frame {
+  const op = ((f.mem.get(f.pc) ?? 0) << 8) | (f.mem.get(f.pc + 1) ?? 0);
+  const x = (op & 0x0f00) >> 8;
+  const n = op & 0x000f;
+  const nn = op & 0x00ff;
+  const nnn = op & 0x0fff;
+  f.pc += 2;
+
+  switch (op & 0xf000) {
+    case 0x0000:
+      if (op === 0x00e0) {
+        // selective CLS: clear only the SELECTED planes; canonical extra (zero ⇒ delete)
+        if (f.plane & 1) f.display.clear();
+        const keep = ~f.plane & 0b110;
+        if (keep !== 0b110) {
+          for (const [k, m] of [...f.extra]) {
+            const m2 = m & keep;
+            if (m2 === 0) f.extra.delete(k);
+            else f.extra.set(k, m2);
+          }
+        }
+      }
+      break;
+    case 0x6000:
+      f.v[x] = nn;
+      break;
+    case 0xa000:
+      f.i = nnn;
+      break;
+    case 0xd000: {
+      const ox = f.v[x] % W;
+      const oy = f.v[(op & 0x00f0) >> 4] % H;
+      const hiSel = f.plane & 0b110;
+      let collision = 0;
+      for (let row = 0; row < n; row++) {
+        const sprite = f.mem.get(f.i + row) ?? 0;
+        for (let col = 0; col < 8; col++) {
+          if (((sprite >> (7 - col)) & 1) === 1) {
+            const idx = ((oy + row) % H) * W + ((ox + col) % W);
+            if (f.plane & 1) {
+              const cur = f.display.get(idx) ?? false;
+              if (cur) collision = 1;
+              f.display.set(idx, !cur);
+            }
+            if (hiSel !== 0) {
+              const cur = f.extra.get(idx) ?? 0;
+              if ((cur & hiSel) !== 0) collision = 1;
+              const nxt = cur ^ hiSel;
+              if (nxt === 0) f.extra.delete(idx);
+              else f.extra.set(idx, nxt);
+            }
+          }
+        }
+      }
+      f.v[0xf] = collision;
+      break;
+    }
+    case 0xf000:
+      if (nn === 0x01) f.plane = x & 0b111; // Fn01: CHIP-9 plane select
+      break;
+    default:
+      break;
+  }
+  return f;
+}


### PR DESCRIPTION
TS oracle mirrors Chip8Cow's CHIP-9 semantics (Fn01, per-plane XOR DRW + VF, selective CLS, canonical extra) and reproduces the F#-locked 32×64 color grid byte-for-byte on the first run. Two oracles ratified; C#/Rust next. bun test green (34 assertions).