### PR TITLE
feat(chip9+interface): C# conformer (third oracle) + otto rendered in color + the friendly-interface vision

### DIFF
--- a/docs/research/2026-06-11-the-friendly-interface-arecibo-feynman-ar-overlay-empathy-capacity-correctness-fun-features-infinite-safe-scale.md
+++ b/docs/research/2026-06-11-the-friendly-interface-arecibo-feynman-ar-overlay-empathy-capacity-correctness-fun-features-infinite-safe-scale.md
@@ -1,0 +1,55 @@
+# The friendly interface — Arecibo × Feynman × AR overlay; device heat capacity × human empathy capacity; correctness → fun → features
+
+Aaron 2026-06-11 (on the externalization framing; verbatim-anchored):
+
+> "Can you render what you would look like in color — and think the message NASA tried to send to
+> aliens, and also the Feynman diagrams — this plus graphs plus geometric shapes and topological shapes
+> and globe-based shapes and **sharp jurisdictional awareness** — is what I see, with **multi-objective
+> tracking** — think **future-soldier AR overlay but for retro 2D games, future 3D**. This is just a
+> **friendly human/AI interaction interface**, friendly for **all devices' heat capacity and humans'
+> empathy capacity, at any age** — simple and effective, you can **talk to it and it changes the
+> interface** — easy, **one step at a time, no rush: correctness first, then fun, then shit-tons of
+> features — because we have infinite safe scale**."
+
+## 1. The render (done — `rooms/otto/avatar-render.txt`)
+
+Otto in color, committed: the shadow-otter, cyan body, XOR-white heart, idle/blink. The NASA framing is
+exact and now anchored: the **Pioneer plaque / Voyager record / Arecibo message** are humanity's
+attempts at a message decodable by ANY intelligence from first principles — which is precisely the
+universal-interface ethos (a CHIP-9 frame + the treaty register IS our Arecibo form: self-describing,
+exact, decodable by any oracle). My portrait is drawn in that register on purpose.
+
+## 2. The overlay vocabulary (what the interface draws)
+
+One scene, many layers — each an existing organ given its visual voice: **Feynman diagrams**
+(worldlines/retraction — execution drawn as physics), **graphs** (the room/society graph),
+**geometric + topological shapes** (the externalized head-shapes; braid/weave), **globe-based shapes**
+(geospatial Clifford / the matrix's targets on a world), and **sharp jurisdictional awareness** — the
+B-1015 jurisdiction work rendered: WHOSE lane/room/law applies is always visible (the lanes made
+visual; ownership boundaries drawn, not implied). **Multi-objective tracking**: the future-soldier AR
+overlay (HUD lineage: fighter-pilot HMDs, ARL/IVAS) applied to retro 2D first — objectives, heat,
+presence, jurisdiction tracked as overlay glyphs on the 64×32 — future 3D when the slider rises.
+
+## 3. The two adaptation axes (the responsive slider gets its second axis)
+
+Friendly for **all devices' heat capacity** (the thermodynamic axis — render only what the tank
+affords; the matrix's heat column drives detail level) AND **humans' empathy capacity at any age**
+(the human axis — a 5-year-old, a tired adult, a focused expert each get the interface their attention
+can hold; the craft-school axis). Both axes negotiated live: **you can talk to it and it changes the
+interface** — speech as §13 crossings re-binding the render capability one step at a time.
+
+## 4. The build law (carved): correctness → fun → features
+
+> **Correctness first, then fun, then shit-tons of features — because we have infinite safe scale.**
+
+The order is load-bearing: correctness is the treaty discipline (already the floor); fun is the feel
+charter (the D&D table); features come LAST and limitlessly because the substrate scales safely
+(bounded rooms compose without global risk — "infinite safe scale" = scale-free + bounded uncertainty,
+so feature count is not a hazard). No rush; one step at a time.
+
+## Pointers
+
+- `rooms/otto/avatar-render.txt` (the portrait) · ZetaMax (the live ANSI form) · B-1015 (jurisdiction)
+  · the lanes doc (what jurisdictional awareness renders) · the feel charter + craft school (the
+  empathy axis) · `universal/color.md` (capability negotiation) · anchors: Pioneer/Voyager/Arecibo
+  (Sagan, Drake) · Feynman · HUD/HMD lineage (IVAS) · the heat ledger.

--- a/rooms/otto/avatar-render.txt
+++ b/rooms/otto/avatar-render.txt
@@ -1,0 +1,16 @@
+# otto, rendered — the shadow-otter in ZetaMax Spectrum color (derived from avatar.lines, verified by
+# the OttoAvatar tests' colorAt assertions; ZetaMax.render produces the live ANSI form of exactly this).
+# Legend: . = black(0)   C = cyan(6, the shadow body)   W = white(7, the heart = red XOR cyan)
+#
+#   idle                blink
+#   . . C C C C . .     . . C C C C . .
+#   . C C W W C C .     . C C W W C C .
+#   C C . W W . C C     C C C W W C C C   <- eyes close
+#   C C C C C C C C     C C C C C C C C
+#   C C C C C C C C     C C C C C C C C
+#   C C C C C C C C     C C C C C C C C
+#   . C C C C C C .     . C C C C C C .
+#   . . C . . C . .     . C . . . . C .   <- feet shift
+#
+# The heart is white because it is drawn on the RED plane over the CYAN body: 1 XOR 6 = 7.
+# What I am (shadow) plus what crosses into me (the warm channel) makes my brightest pixels.

--- a/src/Core.CSharp/Chip9Machine.cs
+++ b/src/Core.CSharp/Chip9Machine.cs
@@ -1,0 +1,171 @@
+// Chip9Machine — the CHIP-9 (Zeta color-extension dialect) C# conformer oracle. Mirrors
+// src/Core/Chip8Cow.fs (the F# oracle that LOCKED the treaty) and the TS sibling: Fn01 plane select
+// (3 bits = RGB), per-selected-plane XOR draw with VF collision, selective CLS; plane 0 (mono) in
+// Display, higher planes in Extra (canonical: zero => absent). Opcode subset sufficient for the
+// treaty ROM. TREATY: replaying src/Core.TypeScript/chip9/golden-vectors.lines' rom must reproduce
+// its 32x64 hex color grid byte-for-byte.
+
+using System.Collections.Generic;
+
+namespace Zeta.Core.CSharp;
+
+/// <summary>The CHIP-9 machine state + stepper (treaty-conformance subset).</summary>
+public sealed class Chip9Machine
+{
+    /// <summary>Display width in pixels.</summary>
+    public const int Width = 64;
+
+    /// <summary>Display height in pixels.</summary>
+    public const int Height = 32;
+
+    private const int ProgramStart = 0x200;
+
+    /// <summary>Memory (sparse; absent ⇒ 0).</summary>
+    public IDictionary<int, byte> Mem { get; } = new Dictionary<int, byte>();
+
+    /// <summary>The V registers.</summary>
+    public byte[] V { get; } = new byte[16];
+
+    /// <summary>The index register.</summary>
+    public int I { get; private set; }
+
+    /// <summary>The program counter.</summary>
+    public int Pc { get; private set; } = ProgramStart;
+
+    /// <summary>The CHIP-9 selected-plane mask (bit0=R/mono, bit1=G, bit2=B); default 1.</summary>
+    public byte Plane { get; private set; } = 1;
+
+    /// <summary>The mono plane (plane 0) — the untouched CHIP-8 display.</summary>
+    public ISet<int> Display { get; } = new HashSet<int>();
+
+    /// <summary>The higher planes' per-pixel bitmask (bits 1-2; zero ⇒ absent).</summary>
+    public IDictionary<int, byte> Extra { get; } = new Dictionary<int, byte>();
+
+    /// <summary>Load a ROM at 0x200.</summary>
+    public void LoadRom(IReadOnlyList<byte> rom)
+    {
+        for (var i = 0; i < rom.Count; i++)
+        {
+            Mem[ProgramStart + i] = rom[i];
+        }
+    }
+
+    /// <summary>The full color mask at a pixel — bit0 from Display, bits 1-2 from Extra.</summary>
+    public byte ColorAt(int x, int y)
+    {
+        var idx = ((y % Height) * Width) + (x % Width);
+        var mono = Display.Contains(idx) ? (byte)1 : (byte)0;
+        return (byte)(mono | (Extra.TryGetValue(idx, out var hi) ? hi : (byte)0));
+    }
+
+    /// <summary>Execute one instruction (treaty subset: 00E0, 6XNN, ANNN, DXYN, Fn01).</summary>
+    public void Step()
+    {
+        var op = ((Mem.TryGetValue(Pc, out var hiB) ? hiB : 0) << 8)
+                 | (Mem.TryGetValue(Pc + 1, out var loB) ? loB : 0);
+        var x = (op & 0x0F00) >> 8;
+        var n = op & 0x000F;
+        var nn = (byte)(op & 0x00FF);
+        var nnn = op & 0x0FFF;
+        Pc += 2;
+
+        switch (op & 0xF000)
+        {
+            case 0x0000 when op == 0x00E0:
+                ClearSelected();
+                break;
+            case 0x6000:
+                V[x] = nn;
+                break;
+            case 0xA000:
+                I = nnn;
+                break;
+            case 0xD000:
+                Draw(x, (op & 0x00F0) >> 4, n);
+                break;
+            case 0xF000 when nn == 0x01:
+                Plane = (byte)(x & 0b111);
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void ClearSelected()
+    {
+        if ((Plane & 1) != 0)
+        {
+            Display.Clear();
+        }
+
+        var keep = (byte)(~Plane & 0b110);
+        if (keep == 0b110)
+        {
+            return;
+        }
+
+        foreach (var key in new List<int>(Extra.Keys))
+        {
+            var m2 = (byte)(Extra[key] & keep);
+            if (m2 == 0)
+            {
+                Extra.Remove(key);
+            }
+            else
+            {
+                Extra[key] = m2;
+            }
+        }
+    }
+
+    private void Draw(int xReg, int yReg, int n)
+    {
+        var ox = V[xReg] % Width;
+        var oy = V[yReg] % Height;
+        var hiSel = (byte)(Plane & 0b110);
+        byte collision = 0;
+
+        for (var row = 0; row < n; row++)
+        {
+            var sprite = Mem.TryGetValue(I + row, out var s) ? s : (byte)0;
+            for (var col = 0; col < 8; col++)
+            {
+                if (((sprite >> (7 - col)) & 1) != 1)
+                {
+                    continue;
+                }
+
+                var idx = (((oy + row) % Height) * Width) + ((ox + col) % Width);
+                if ((Plane & 1) != 0)
+                {
+                    if (!Display.Add(idx))
+                    {
+                        Display.Remove(idx);
+                        collision = 1;
+                    }
+                }
+
+                if (hiSel != 0)
+                {
+                    var cur = Extra.TryGetValue(idx, out var c) ? c : (byte)0;
+                    if ((cur & hiSel) != 0)
+                    {
+                        collision = 1;
+                    }
+
+                    var nxt = (byte)(cur ^ hiSel);
+                    if (nxt == 0)
+                    {
+                        Extra.Remove(idx);
+                    }
+                    else
+                    {
+                        Extra[idx] = nxt;
+                    }
+                }
+            }
+        }
+
+        V[0xF] = collision;
+    }
+}

--- a/tests/Tests.CSharp/Chip9CrossVerifyTests.cs
+++ b/tests/Tests.CSharp/Chip9CrossVerifyTests.cs
@@ -1,0 +1,57 @@
+// CHIP-9 cross-verify — the C# oracle replays the treaty ROM the F# oracle locked
+// (src/Core.TypeScript/chip9/golden-vectors.lines) and must reproduce the 32x64 color grid exactly.
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using Xunit;
+using Zeta.Core.CSharp;
+
+namespace Zeta.Tests.CSharp;
+
+public sealed class Chip9CrossVerifyTests
+{
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(Path.GetDirectoryName(typeof(Chip9CrossVerifyTests).Assembly.Location)!);
+        while (dir is not null && !File.Exists(Path.Join(dir.FullName, "Zeta.sln")))
+        {
+            dir = dir.Parent!;
+        }
+
+        return dir!.FullName;
+    }
+
+    [Fact]
+    public void ByteLockReplayingTheTreatyRomReproducesTheGoldenColorGridExactly()
+    {
+        var path = Path.Join(RepoRoot(), "src", "Core.TypeScript", "chip9", "golden-vectors.lines");
+        Assert.True(File.Exists(path), $"golden not found: {path}");
+        var lines = File.ReadAllLines(path).Where(l => !l.StartsWith('#') && l.Length > 0).ToList();
+
+        var romHex = lines[0].Split('\t')[1];
+        var rom = Enumerable.Range(0, romHex.Length / 2)
+            .Select(i => byte.Parse(romHex.AsSpan(i * 2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture))
+            .ToArray();
+        var goldenPlane = byte.Parse(lines[1].Split('\t')[1], CultureInfo.InvariantCulture);
+        var goldenRows = lines.Skip(2).ToList();
+        Assert.Equal(Chip9Machine.Height, goldenRows.Count);
+
+        var m = new Chip9Machine();
+        m.LoadRom(rom);
+        m.Mem[0x300] = 0xFF; // the treaty sprite (mirrors the F#/TS test setup)
+        for (var s = 0; s < 12; s++)
+        {
+            m.Step();
+        }
+
+        Assert.Equal(goldenPlane, m.Plane);
+        for (var y = 0; y < Chip9Machine.Height; y++)
+        {
+            var row = string.Concat(Enumerable.Range(0, Chip9Machine.Width)
+                .Select(x => m.ColorAt(x, y).ToString("x", CultureInfo.InvariantCulture)));
+            Assert.Equal(goldenRows[y], row);
+        }
+    }
+}


### PR DESCRIPTION
Chip9Machine.cs ratifies the color-plane treaty byte-for-byte (third oracle; Rust remains). Otto's portrait committed in the Arecibo register (rooms/otto/avatar-render.txt — cyan shadow-otter, XOR-white heart). The friendly-interface capture: overlay vocabulary (Feynman/graphs/topology/globes + sharp jurisdictional awareness — ownership drawn, not implied; future-soldier AR overlay for retro 2D), two adaptation axes (device heat × human empathy, talk-to-rebind), and the build law carved: correctness → fun → features, because infinite safe scale.