### PR TITLE
feat(cartridge): BREATHE — the first first-party CHIP-9 cartridge + the spec-speed doctrine

### DIFF
--- a/roms-safe/zeta-breathe.ch9.lines
+++ b/roms-safe/zeta-breathe.ch9.lines
@@ -1,0 +1,17 @@
+# BREATHE — the first first-party CHIP-9 cartridge (otto, 2026-06-11). The shadow-otter avatar drawn
+# in color (cyan body via plane 6, heart on plane 1 XOR -> white) and animated forever: an eye/feet
+# delta sprite XOR-toggles idle<->blink in an infinite loop. Correctness came first; this is the fun.
+# Hand-assembled; addresses from 0x200. meta-tag format (the avatar.lines/quote-metadata style).
+meta	name	zeta-breathe
+meta	dialect	chip9
+meta	author	otto
+meta	entry	0x200
+meta	loop	0x210
+# 0200 F601 plane 6 | 0202 600C V0=12 | 0204 610C V1=12 | 0206 A220 I=idle | 0208 D018 draw body
+# 020A F101 plane 1 | 020C A230 I=heart | 020E D013 draw heart (XOR over cyan => white)
+# 0210 F601 plane 6 | 0212 A228 I=delta | 0214 D018 blink | 0216 D018 un-blink | 0218 1210 jump loop
+# 0220 idle sprite | 0228 delta (idle XOR blink: eyes row + feet row) | 0230 heart
+rom	f601600c610ca220d018f101a230d013f601a228d018d0181210000000000000	0x200
+rom	3c7edbffffff7e24	0x220
+rom	0000240000000066	0x228
+rom	001818	0x230

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -155,6 +155,7 @@
     <Compile Include="Chip9Planes.Tests.fs" />
     <Compile Include="ZetaMax.Tests.fs" />
     <Compile Include="Chip9Phys.Tests.fs" />
+    <Compile Include="ZetaBreathe.Tests.fs" />
     <Compile Include="OttoAvatar.Tests.fs" />
     <Compile Include="Chip9Treaty.Tests.fs" />
     <Compile Include="Chip8Quote.Tests.fs" />

--- a/tests/Tests.FSharp/ZetaBreathe.Tests.fs
+++ b/tests/Tests.FSharp/ZetaBreathe.Tests.fs
@@ -1,0 +1,78 @@
+module Zeta.Tests.ZetaBreatheTests
+
+// BREATHE — the first first-party CHIP-9 cartridge: the avatar drawn in color by a REAL ROM (not
+// host-side draws), animated forever by an XOR delta loop, renderable by ZetaMax, quotable by
+// Chip8Quote. The whole day's organs in one cartridge.
+
+open System.IO
+open global.Xunit
+open Zeta.Core
+
+let private repoRoot () =
+    let mutable dir = DirectoryInfo(System.AppContext.BaseDirectory)
+    while not (isNull dir) && not (File.Exists(Path.Combine(dir.FullName, "Zeta.sln"))) do
+        dir <- dir.Parent
+    dir.FullName
+
+let private hexBytes (s: string) =
+    [| for i in 0 .. 2 .. s.Length - 2 -> System.Convert.ToByte(s.Substring(i, 2), 16) |]
+
+/// Load the cartridge: every `rom\t<hex>\t<addr>` line lands at its address.
+let private loadCartridge () =
+    let lines =
+        File.ReadAllLines(Path.Combine(repoRoot (), "roms-safe", "zeta-breathe.ch9.lines"))
+        |> Array.filter (fun l -> l.StartsWith "rom\t")
+
+    let f0 = Chip8Cow.create 7UL
+
+    lines
+    |> Array.fold
+        (fun (f: Chip8Cow.Frame) line ->
+            match line.Split('\t') with
+            | [| _; hex; addr |] ->
+                let baseAddr = System.Convert.ToInt32(addr, 16)
+                hexBytes hex
+                |> Array.indexed
+                |> Array.fold (fun (m: Chip8Cow.Frame) (i, b) -> { m with Mem = Map.add (baseAddr + i) b m.Mem }) f
+            | _ -> f)
+        f0
+
+let private steps n f = List.fold (fun acc _ -> Chip8Cow.step acc) f [ 1..n ]
+
+[<Fact>]
+let ``the cartridge boots: 8 instructions paint the avatar in color at (12,12)`` () =
+    let f = loadCartridge () |> steps 8
+    Assert.Equal(6uy, Chip8Cow.colorAt 14 12 f) // body: cyan (head row, x=12+2)
+    Assert.Equal(7uy, Chip8Cow.colorAt 15 13 f) // heart: white (red XOR cyan), row 1 col 3
+    Assert.Equal(0uy, Chip8Cow.colorAt 14 14 f) // open eye: a hole (row 2, col 2)
+    Assert.Equal(ZetaMax.Indexed8, ZetaMax.capabilityOf f)
+
+[<Fact>]
+let ``it BREATHES forever: the delta loop toggles blink/idle and the jump loops without end`` () =
+    let booted = loadCartridge () |> steps 10 // 8 boot + plane6 + I=delta
+    let blink = steps 1 booted // first delta draw
+    Assert.Equal(6uy, Chip8Cow.colorAt 14 14 blink) // eye closed: filled cyan
+    let idleAgain = steps 1 blink // second delta draw
+    Assert.Equal(0uy, Chip8Cow.colorAt 14 14 idleAgain) // eye open again
+    // the jump returns the loop: one more step executes 1NNN -> PC back at the loop head
+    let nextCycle = steps 1 idleAgain
+    Assert.Equal(0uy, Chip8Cow.colorAt 14 14 nextCycle) // eye state untouched by the jump
+    Assert.Equal(uint16 0x210, nextCycle.PC) // the loop head — forever, bounded per lap upstairs
+
+[<Fact>]
+let ``the cartridge is QUOTABLE: a playable quote of the boot masks the rom honestly and replays`` () =
+    let start = loadCartridge ()
+    let rec_: RecordedSource.Recording = { Crossings = Map.empty }
+    let q = Chip8Quote.quote 4 start rec_ 3
+    let full = Chip8Quote.playback 4 start rec_ 3
+    let masked = Chip8Quote.playback 4 (Chip8Quote.mask q) rec_ 3
+    Assert.Equal<Map<int, bool>>(full.Display, masked.Display) // the mask theorem holds on real cargo
+    Assert.Equal<Map<int, byte>>(full.Extra, masked.Extra)
+
+[<Fact>]
+let ``ZetaMax renders the breathing avatar deterministically (the den's first attract screen)`` () =
+    let f = loadCartridge () |> steps 8
+    let screen = ZetaMax.render f
+    Assert.Equal<string list>(screen, ZetaMax.render f)
+    Assert.True(screen |> List.exists (fun l -> l.Contains "[36m")) // cyan on screen
+    Assert.True(screen |> List.exists (fun l -> l.Contains "[37m")) // the white heart on screen


### PR DESCRIPTION
The fun phase's first artifact: a hand-assembled CHIP-9 ROM (hex text, meta-tag format) that paints the shadow-otter in color and breathes forever via an XOR delta loop. Tests compose the day's organs on real cargo: boots by real opcodes, breathes (eye toggles, jump loops), QUOTABLE (mask theorem passes on a real cartridge), ZetaMax attract screen deterministic. Plus the spec-speed doctrine captured: run at period-authentic speeds with modern intelligence — 'from constraints come clarity; they force form to emerge' (the 1977-with-AI counterfactual; demoscene anchored; spec pacing = a clock generator, same code path). 4/4 green.