### PR TITLE
feat(time): TimeGen — time-as-generator as a treaty primitive (Amara's named proof built; CHSH regimes hit their bounds)

### DIFF
--- a/docs/research/2026-06-11-ferry-amara-tests-as-time-stepper-time-as-generator-chsh-regimes-cross-repo-weave-plus-the-proof-built.md
+++ b/docs/research/2026-06-11-ferry-amara-tests-as-time-stepper-time-as-generator-chsh-regimes-cross-repo-weave-plus-the-proof-built.md
@@ -1,0 +1,77 @@
+# Ferry (Amara ↔ Aaron) — tests as the time-stepper; time as generator (CHSH regimes); the cross-repo weave — AND the named proof, built
+
+> **Ferry discipline:** Aaron passed two Amara analyses. Preserved as hers; the substance is kept whole
+> below (her structure and keepers verbatim); the peel + the BUILT proof follow.
+
+## Amara, part 1 — the deterministic tick (tests as the time-stepper)
+
+Her loop: `git root Rₙ + MUMPS scoped state Sₙ + observations/ferries Oₙ + treaty reducer → Δₙ → Uₙ₊₁
+→ regenerated F# types Tₙ₊₁ → Rₙ₊₁`. Not run-check-discard but: read the world, fold observations,
+reduce uncertainty, persist, regenerate types, compile/replay, advance time one proven step.
+
+Her operational splits and blades, kept:
+- **Replay tests vs advance tests** — replay proves determinism (write nothing); advance evolves the
+  world (write the next state to a branch). 
+- **Truth root ≠ transport root** — assert over the Zeta canonical root / treaty bytes, never the raw
+  git commit hash (commit metadata is where nondeterminism sneaks in).
+- **The 1000× bar** generalized to type regeneration once load-bearing.
+- **Mutation disciplines declared per cell** (single-writer | CRDT/ZSet | RX-observed pair | CAS/Raft |
+  BFT) — tests writing back to git are treaty-typed transitions, not random writes.
+- **Ferries remain observations, not commands** — provenance/frame/scope/ZetaId; the reducer decides;
+  "pasted text never becomes authority."
+- **Generated F# types are materialized views** of the treaty state, never the source of truth.
+- Her keeper: *"Every deterministic test is a tick … every regenerated type is the compiler witnessing
+  the next state of the world."*
+
+## Amara, part 2 — time as a generator function (the CHSH regimes)
+
+Aaron: *"in our DST step time is a generator function too — we can make whatever we want for all
+contributors to count on, from seed common cause; allow possible S=2√2, maybe S=4 staged coincidence;
+and we have a four-corner feedback model for adjustments over time."*
+
+Amara: **"DST time is generated, not observed. The clock is a generator and the seed is the common
+cause."** Regimes as SCHEDULER modes, not physics claims: ClassicalCommonCause (S≤2) ·
+PhasorTsirelson (E=cos(a−b), S=2√2 — the unit circle we already live on) · StagedCoincidence (S=4,
+hard-labeled staged/non-physical — the free-choice assumption deliberately violated by the shared
+seed). The four CHSH corners as the feedback surface; feedback itself deterministic and replayable;
+her tiny blade: **the generator must be versioned and ZetaId-addressed** so time semantics never change
+silently. Her keeper: *"A deterministic simulation does not run in time. It generates time from seed.
+The generated time is the common cause. The four corners are the feedback surface."*
+
+## Amara, part 3 — the cross-repo weave
+
+Once the first cross-repo stream is woven, the stream stops being the primitive: **the primitive
+becomes a causal fabric** — state = a fold over a chosen causal cut. Her stack kept clean: DBSP =
+change propagation · ZSet = signed multiplicity · banana split = ONE law (fold-fusion), not the engine
+· CRDT/CALM = when coordination is avoidable · the weave = the fabric of causal time. Her peel of the
+overclaims kept: not consciousness, not resurrection — *preservation*; "we can address, replay, fork,
+merge, and fold causal histories" is already enormous. Her keeper: *"A stream is a local worldline. A
+weave is a causal fabric. A state is a fold over a chosen cut through that fabric."*
+
+## THE PROOF, BUILT (Aaron: "what's next — please continue")
+
+Amara named it: *"the next proof should be small … that would make 'time as generator' a treaty
+primitive instead of a metaphor."* It is now `src/Core/TimeGen.fs` + 6/6 green tests:
+
+- **Replay**: same seed ⇒ identical corner traces and instants; distinct contributors get distinct,
+  individually-replayable local clocks from ONE common cause.
+- **Classical**: the seeded hidden-variable scheduler stays inside S ≤ 2 (4096 deterministic samples).
+- **Phasor**: the unit-circle scheduler reaches S = 2√2 exactly (analytic; the corner angles 0, π/2,
+  ±π/4).
+- **Staged**: S = 4 by explicit staged schedule — and the LABEL is part of the value
+  ("STAGED … free-choice violated BY DESIGN; not physical") so the result can never masquerade.
+- **Versioned + addressed** (her blade): Generator carries Id/Version/Seed/Regime; a different seed is
+  a different common cause, visibly.
+- **Feedback**: deterministic, bounded (clamped), replayable — the four-corner adjustment as a pure
+  function.
+
+Honest scope: float correlations stay outside the byte-lock treaty (per the exact-valued rule); the
+STRUCTURE is the treaty surface; fixed-point phases = the named slice for cross-oracle goldens.
+
+## Pointers
+
+- `src/Core/TimeGen.fs` + `tests/Tests.FSharp/TimeGen.Tests.fs` (the proof) · `SimLoop` (the
+  generator-clock consumer already built) · the Bell/qubits docs (the unit circle lineage) · CHSH
+  (Clauser-Horne-Shimony-Holt 1969) · Tsirelson 1980 (the 2√2 bound) · Popescu-Rohrlich 1994 (the S=4
+  box — the staged regime's honest name) · Amara's replay/advance split → the rooms/tests doctrine
+  already live in rooms/README.

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -225,6 +225,7 @@
     <Compile Include="SwarmBoardAnsi.fs" />
     <Compile Include="ZetaMax.fs" />
     <Compile Include="Chip9Phys.fs" />
+    <Compile Include="TimeGen.fs" />
     <Compile Include="TelemetrySource.fs" />
     <Compile Include="SimLoop.fs" />
     <Compile Include="WheelRoom.fs" />

--- a/src/Core/TimeGen.fs
+++ b/src/Core/TimeGen.fs
@@ -1,0 +1,116 @@
+namespace Zeta.Core
+
+/// TimeGen — **time as a generator function, made a treaty primitive instead of a metaphor** (Amara's
+/// ferried design + her named "next proof should be small", 2026-06-11; Aaron: "in our DST step time
+/// is a generator function too — we can make whatever we want for all contributors to count on, from
+/// seed common cause; allow possible S=2√2, maybe S=4 staged coincidence; and we have a four-corner
+/// feedback model for adjustments over time").
+///
+/// The model (Amara's, implemented): **the clock is a generator and the seed is the common cause.**
+/// Contributors never trust wall time — they replay the same seeded time treaty. The generator is
+/// VERSIONED AND ADDRESSED (her "tiny blade": changing time semantics must never be silent).
+///
+/// The CHSH four corners are the feedback surface, and the three regimes are SCHEDULER REGIMES, not
+/// physics claims (her labels kept exactly):
+/// - `ClassicalCommonCause` — seeded hidden-variable model ⇒ S ≤ 2 (the classical bound).
+/// - `PhasorTsirelson` — the phasor scheduler, E(a,b) = cos(a−b) ⇒ S = 2√2 (the unit circle we
+///   already live on; analytic, exact-by-construction).
+/// - `StagedCoincidence` — the scheduler stages the corners ⇒ S = 4, **hard-labeled STAGED**: a
+///   stress-test scheduler, never evidence of nonlocality (the seed IS the coordination channel; the
+///   free-choice assumption is deliberately violated and SAID SO).
+///
+/// Honest scope: correlations here are float-valued (cos) — per the treaty discipline float kernels
+/// stay OUTSIDE the byte-lock; the STRUCTURE (regimes, corners, versioning, determinism-from-seed) is
+/// the treaty surface; fixed-point phases are the named slice if cross-oracle goldens are wanted.
+[<RequireQualifiedAccess>]
+module TimeGen =
+
+    /// The scheduler regimes (Amara's names, verbatim).
+    type Regime =
+        | ClassicalCommonCause
+        | PhasorTsirelson
+        | StagedCoincidence
+
+    /// The versioned, addressed generator — "the root includes the time generator, so every
+    /// contributor knows exactly which common cause they are sharing."
+    type Generator =
+        { Id: string // the generator's address (ZetaId-shaped slot; minted upstream)
+          Version: int
+          Seed: uint64
+          Regime: Regime }
+
+    let mk (id: string) (version: int) (seed: uint64) (regime: Regime) : Generator =
+        { Id = id; Version = version; Seed = seed; Regime = regime }
+
+    /// One generated instant: what a contributor derives instead of reading a wall clock.
+    type GeneratedTime =
+        { Tick: int
+          Phase: float // radians on the unit circle (the phasor)
+          Regime: Regime }
+
+    // deterministic SplitMix64 — the seed is the common cause, the only entropy anywhere here.
+    let private mix (z0: uint64) : uint64 =
+        let z = z0 + 0x9E3779B97F4A7C15UL
+        let z = (z ^^^ (z >>> 30)) * 0xBF58476D1CE4E5B9UL
+        let z = (z ^^^ (z >>> 27)) * 0x94D049BB133111EBUL
+        z ^^^ (z >>> 31)
+
+    let private unit (g: Generator) (k: uint64) : float =
+        float (mix (g.Seed ^^^ k) >>> 11) / 9007199254740992.0 // [0,1), 53-bit
+
+    /// Generate the instant for (contributor, step): tick + phase from the seed — never from a wall.
+    let at (g: Generator) (contributor: uint64) (step: int) : GeneratedTime =
+        { Tick = step
+          Phase = 2.0 * System.Math.PI * unit g (contributor * 0x9E37UL + uint64 step)
+          Regime = g.Regime }
+
+    // ── the CHSH four corners (the feedback surface) ──
+
+    /// The standard corner angles that reach Tsirelson under the phasor scheduler.
+    let cornerAngles: (float * float) list =
+        let a0, a1 = 0.0, System.Math.PI / 2.0
+        let b0, b1 = System.Math.PI / 4.0, -System.Math.PI / 4.0
+        [ a0, b0; a0, b1; a1, b0; a1, b1 ]
+
+    /// The correlation E(a,b) a regime's scheduler produces at a corner. Classical samples a seeded
+    /// hidden variable λ (deterministic; `n` samples); Phasor is the analytic cos(a−b); Staged returns
+    /// the staged corner table (+1,+1,+1,−1) — coordination BY the seed, labeled as such.
+    let correlation (g: Generator) (n: int) (cornerIx: int) (a: float) (b: float) : float =
+        match g.Regime with
+        | PhasorTsirelson -> cos (a - b)
+        | StagedCoincidence -> if cornerIx = 3 then -1.0 else 1.0
+        | ClassicalCommonCause ->
+            // λ from the seed; outcomes A = sign cos(a−λ), B = sign cos(b−λ) — a local HV model.
+            let samples = max 1 n
+            let mutable acc = 0.0
+            for i in 0 .. samples - 1 do
+                let lambda = 2.0 * System.Math.PI * unit g (uint64 i)
+                let av = if cos (a - lambda) >= 0.0 then 1.0 else -1.0
+                let bv = if cos (b - lambda) >= 0.0 then 1.0 else -1.0
+                acc <- acc + av * bv
+            acc / float samples
+
+    /// The CHSH S at the four corners: E₀₀ + E₀₁ + E₁₀ − E₁₁.
+    let chsh (g: Generator) (n: int) : float =
+        let es =
+            cornerAngles
+            |> List.mapi (fun i (a, b) -> correlation g n i a b)
+        match es with
+        | [ e00; e01; e10; e11 ] -> e00 + e01 + e10 - e11
+        | _ -> 0.0
+
+    /// Is this run's correlation HONESTLY labeled? Staged S=4 must say it is staged — the label is
+    /// part of the value, so a result can never masquerade as physical nonlocality.
+    let label (g: Generator) : string =
+        match g.Regime with
+        | ClassicalCommonCause -> "classical-common-cause (local HV; S<=2)"
+        | PhasorTsirelson -> "phasor (unit circle; S=2*sqrt(2))"
+        | StagedCoincidence -> "STAGED coincidence (seed-coordinated; free-choice violated BY DESIGN; not physical)"
+
+    // ── the four-corner feedback (deterministic adjustment over time) ──
+
+    /// One bounded feedback step: error = target − observed S, applied as a phase-table offset with a
+    /// deterministic clamp. "The feedback loop is not hidden adaptation — it is a replayable update."
+    let feedback (target: float) (observed: float) (maxStep: float) (phaseOffset: float) : float =
+        let err = target - observed
+        phaseOffset + (max -maxStep (min maxStep (0.5 * err)))

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -156,6 +156,7 @@
     <Compile Include="ZetaMax.Tests.fs" />
     <Compile Include="Chip9Phys.Tests.fs" />
     <Compile Include="ZetaBreathe.Tests.fs" />
+    <Compile Include="TimeGen.Tests.fs" />
     <Compile Include="OttoAvatar.Tests.fs" />
     <Compile Include="Chip9Treaty.Tests.fs" />
     <Compile Include="Chip8Quote.Tests.fs" />

--- a/tests/Tests.FSharp/TimeGen.Tests.fs
+++ b/tests/Tests.FSharp/TimeGen.Tests.fs
@@ -1,0 +1,55 @@
+module Zeta.Tests.TimeGenTests
+
+// Amara's "next proof should be small", executed: given seed σ and time-generator G and the four CHSH
+// corners — ClassicalCommonCause stays inside the classical bound; PhasorTsirelson reaches S = 2√2;
+// StagedCoincidence reaches S = 4 BY EXPLICIT STAGED SCHEDULE (labeled, never physical); and every
+// replay produces identical corner traces. Time-as-generator: a treaty primitive, not a metaphor.
+
+open global.Xunit
+open Zeta.Core
+
+let private gen regime = TimeGen.mk "timegen-test" 1 0xC0FFEEUL regime
+
+[<Fact>]
+let ``REPLAY: the same seed produces identical corner traces and instants (the common cause)`` () =
+    let g = gen TimeGen.PhasorTsirelson
+    Assert.Equal(TimeGen.chsh g 512, TimeGen.chsh g 512)
+    let t1 = TimeGen.at g 7UL 42
+    let t2 = TimeGen.at g 7UL 42
+    Assert.Equal(t1, t2)
+    // distinct contributors get distinct (but each replayable) phases — local clocks from one cause
+    Assert.NotEqual(t1.Phase, (TimeGen.at g 8UL 42).Phase)
+
+[<Fact>]
+let ``CLASSICAL: the seeded hidden-variable scheduler stays inside the classical bound (S <= 2 + eps)`` () =
+    let s = TimeGen.chsh (gen TimeGen.ClassicalCommonCause) 4096
+    Assert.True(abs s <= 2.0 + 0.05, sprintf "classical S = %f exceeded the bound" s)
+
+[<Fact>]
+let ``PHASOR: the unit-circle scheduler reaches Tsirelson exactly (S = 2*sqrt 2)`` () =
+    let s = TimeGen.chsh (gen TimeGen.PhasorTsirelson) 1
+    Assert.Equal(2.0 * sqrt 2.0, s, 10)
+
+[<Fact>]
+let ``STAGED: S = 4 by explicit staged schedule — and the label SAYS it is staged, not physical`` () =
+    let g = gen TimeGen.StagedCoincidence
+    Assert.Equal(4.0, TimeGen.chsh g 1, 12)
+    let l = TimeGen.label g
+    Assert.Contains("STAGED", l)
+    Assert.Contains("not physical", l)
+
+[<Fact>]
+let ``the generator is versioned and addressed — changing time semantics can never be silent`` () =
+    let g = gen TimeGen.PhasorTsirelson
+    Assert.Equal("timegen-test", g.Id)
+    Assert.Equal(1, g.Version)
+    // a different seed IS a different common cause: traces diverge
+    let g2 = { g with Seed = 0xBEEFUL }
+    Assert.NotEqual(TimeGen.at g 7UL 1, TimeGen.at g2 7UL 1)
+
+[<Fact>]
+let ``FEEDBACK is deterministic and bounded: the four-corner adjustment replays and clamps`` () =
+    let f1 = TimeGen.feedback (2.0 * sqrt 2.0) 2.0 0.1 0.0
+    Assert.Equal(f1, TimeGen.feedback (2.0 * sqrt 2.0) 2.0 0.1 0.0)
+    Assert.True(f1 <= 0.1 + 1e-12) // clamped
+    Assert.True(f1 > 0.0) // pushing toward the target


### PR DESCRIPTION
Amara's 'next proof should be small,' executed: the clock is a generator, the seed is the common cause. Three scheduler regimes (never physics claims): Classical seeded-HV stays S≤2; Phasor unit-circle hits S=2√2 exactly; Staged hits S=4 with the label baked into the value ('STAGED… not physical' — Popescu-Rohrlich anchored). Generator versioned+addressed (her blade: time semantics never change silently); contributors derive instants from seed, never walls; four-corner feedback pure/bounded/replayable. Ferry preserved (replay-vs-advance, truth-root≠transport-root, 1000× bar, mutation disciplines, weave-as-causal-fabric). 6/6 green.