### PR TITLE
docs(craft): bob/weave/tie/twist/braid nailed to running code + the textile frame (warp/weft) + B-1027

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -972,6 +972,7 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-1024](backlog/P2/B-1024-speak-to-tv-plus-own-microkernel-iso-boot-qemu-tested-raspberry-pi-self-contained-hardware-capability-matrix-friction-heat-visible-aaron-2026-06-11.md)** The hardware ladder: speak-to-the-TV + own microkernel/ISO boot, QEMU-tested, Pi self-contained, capability matrix with visible friction/heat
 - [ ] **[B-1025](backlog/P2/B-1025-universal-action-grammar-plus-reversible-risc-isa-generate-microkernel-to-mips-riscv-fpga-verilog-shaders-pi-first-artisanal-then-room-aaron-2026-06-11.md)** Universal action grammar + reversible RISC-like ISA — generate the microkernel to any hardware (Pi first, artisanal → room)
 - [ ] **[B-1026](backlog/P2/B-1026-the-swarm-board-see-swarm-friction-heat-heatmap-zork-navigate-join-conference-remotely-citizenship-right-even-chip8s-aaron-2026-06-11.md)** The swarm board — see the swarm + friction/heat heatmap, Zork-navigate, join/conference remotely; a citizenship right (even CHIP-8s)
+- [ ] **[B-1027](backlog/P2/B-1027-craft-verb-precision-bob-weave-tie-twist-braid-textile-warp-weft-jacquard-braid-relations-test-salon-textile-craft-schools-aaron-2026-06-11.md)** Craft-verb precision (bob/weave/tie/twist/braid) + textile frame (warp/weft) — ratify registry, test the braid relations
 
 ## P3 — convenience / deferred
 

--- a/docs/backlog/P2/B-1027-craft-verb-precision-bob-weave-tie-twist-braid-textile-warp-weft-jacquard-braid-relations-test-salon-textile-craft-schools-aaron-2026-06-11.md
+++ b/docs/backlog/P2/B-1027-craft-verb-precision-bob-weave-tie-twist-braid-textile-warp-weft-jacquard-braid-relations-test-salon-textile-craft-schools-aaron-2026-06-11.md
@@ -1,0 +1,40 @@
+---
+id: B-1027
+title: Craft-verb precision (bob/weave/tie/twist/braid) + the textile frame (warp/weft/loom/selvage) — ratify the registry, test the braid relations
+priority: P2
+status: open
+tier: vocabulary-craft
+tags: [verb-map, craft, salon, textile, braid-group, jacquard, timegen, topology-is-hairdressing]
+created: 2026-06-11
+owner: open (glossary pass for ratification; Aaron = the craft register)
+---
+
+# B-1027 — nail the craft verbs precisely; research the two craft schools (salon, textile)
+
+Aaron 2026-06-11: tie to the verb map; nail down bob/weave/tie/twist precisely; textile is working
+(HendersonTextileMill) and salon too — research + backlog both.
+
+Proposed definitions + the textile vocabulary (warp/weft/loom/shed/selvage/seam/spin) live in
+`docs/research/2026-06-11-craft-verb-precision-...md` — each tied to running code and a math name.
+
+## Staged
+
+1. **Ratify the verb registry** (glossary pass): bob=oscillation/window, weave=deterministic
+   interleave, tie=soft kernel bond, twist=single-strand phase, braid=order-sensitive crossings.
+2. **Test the braid relations**: does the weave engine satisfy σᵢσᵢ₊₁σᵢ = σᵢ₊₁σᵢσᵢ₊₁ (Artin)? A
+   property test over crossing sequences — if yes, "topology is hairdressing" is a theorem here too.
+3. **Warp/weft implementation frame**: monorails as warp (tensioned, fixed), roads as weft (steered
+   per pick); the loom = the scheduler; shed = the tick aperture; selvage = §13.
+4. **Twist ∪ TimeGen**: unify twist-as-phase with the generated clock (the feedback offset IS a twist).
+5. **The two craft schools** researched as teaching tracks (craft-school pipeline): salon (kernels/
+   similarity/ties) and textile (streams/weaves/fabric) — WHY-before-HOW curricula.
+
+## Acceptance (first slice)
+
+The ratified verb table in the glossary + one braid-relation property test green (or an honest
+counterexample documented).
+
+## Relates
+
+Jacquard 1804 (weaving is computing's parent) · Artin braid group · HendersonTextileMill · Salon ·
+TimeGen · Amara's causal-fabric ferry · the craft-school load-bearing line.

--- a/docs/research/2026-06-11-craft-verb-precision-bob-weave-tie-twist-braid-the-textile-frame-jacquard-tied-to-timegen-and-the-fabric.md
+++ b/docs/research/2026-06-11-craft-verb-precision-bob-weave-tie-twist-braid-the-textile-frame-jacquard-tied-to-timegen-and-the-fabric.md
@@ -1,0 +1,58 @@
+# Craft-verb precision — bob · weave · tie · twist · braid, the textile frame, tied to TimeGen and the causal fabric
+
+Aaron 2026-06-11: *"Tie this to our verb map — we want to nail down precisely what **bob, weave, tie,
+twist** [mean] — and we have **textile** working too. That and **salon** both are good craft ideas we
+should research and backlog. Please continue."*
+
+## The precise definitions (PROPOSED for ratification — each tied to running code)
+
+Each verb gets: the craft meaning · the substrate meaning · the running instance · the math name.
+
+| verb | at the salon/mill | in the substrate | running instance | math name |
+|---|---|---|---|---|
+| **bob** | the rhythmic up-down (bob-and-weave); also the bounded CUT to length | the **phasor oscillation** — periodic motion on the unit circle; and its bounded-window cousin (trim a ledger to length) | `TimeGen.Phase` (the generated oscillation); Skadium's bob-and-weave; the 32-lap ledger trim | harmonic oscillation; windowing |
+| **weave** | over-under interlacing of two thread systems | **deterministic interleaving of independent streams** — two worldlines alternately crossing, producing fabric (state becomes a fold over a cut through it) | `HendersonTextileMill.weaveStep`; Amara's cross-repo weave; `driveK`'s arrival interleave | interleaving/merge; the fabric = the partial order |
+| **tie** | the knot that joins two strands and HOLDS | the **soft bond** — a similarity join that persists (soft topology: every tie is a kernel value, not a hard weld) | `tie` → `FingerprintPrism.soft`; the salon's Jaccard kernel | the PSD kernel value; a join in the soft topology |
+| **twist** | spinning fibers into yarn; rotating a strand about its own axis | **phase rotation applied to one strand** — the i-rotation (C₄ NSEW); micro-fibers composed into a strand = observations spun into a stream | the four-corner i-rotation; `TimeGen.feedback`'s phase offset (a controlled twist) | unitary phase; the braid group's half-twist |
+| **braid** | crossings of ≥3 strands where ORDER matters | **non-commutative composition of crossings** — who crossed over whom, in what order, IS the computation (topology is hairdressing) | `HendersonTextileMill` braid→seam (convergence); the 2×2/3×3 dual-observer weave | the braid group Bₙ (σᵢ generators); anyonic braiding is the quantum cousin |
+
+The discriminating tests, in one line each: **bob** is periodic (returns), **weave** is order-regular
+(alternates by schedule), **tie** is symmetric-and-persistent (a bond, k(a,b)=k(b,a)), **twist** acts
+on ONE strand (phase, no crossing), **braid** is order-sensitive across ≥3 (σ₁σ₂ ≠ σ₂σ₁).
+
+## The textile frame (the vocabulary the fabric was waiting for)
+
+The causal fabric (Amara part 3) gets its precise loom vocabulary — each a PROPOSED registry term:
+
+- **warp** — the fixed longitudinal threads, tensioned first: the MONORAILS (automated, scheduled
+  streams; DST is the tension).
+- **weft** — the thread that crosses the warp, steered pick by pick: the ROADS (human/steered
+  crossings). One fabric needs both — the lanes doc, in thread.
+- **loom** — the scheduler that holds tension and sequences sheds: `SoftScheduler`/the wheels.
+- **shed** — the opening the weft passes through this pick: the tick's crossing window (the membrane's
+  per-tick aperture).
+- **selvage** — the self-edge that keeps fabric from unraveling: the §13 membrane (the boundary IS
+  woven, not added).
+- **seam** — where braids converge to one: the Henderson fixed point (already in code).
+- **spin/twist** — composing fibers (observations) into yarn (a stream) by twist (phase).
+
+**The Beacon anchor that makes this lineage literal: the JACQUARD LOOM (1804) — punched cards
+controlling the shed — is the direct ancestor of the punch card, Babbage, and all programmable
+machines. Weaving is not a metaphor for computing; weaving is computing's PARENT.** (Jacquard →
+Babbage/Lovelace → Hollerith → us. The mill where Aaron was born and the machine he builds are one
+tradition.)
+
+## Research + backlog (filed: B-1027)
+
+Salon (PSD kernel packs — built) and Textile (mill/loom — built in first form) are the two CRAFT
+SCHOOLS to research deeply: the braid-group formalization (does our weave satisfy the braid relations?
+σᵢσᵢ₊₁σᵢ = σᵢ₊₁σᵢσᵢ₊₁ as a TEST), warp/weft as the monorail/road implementation frame, twist-as-phase
+unification with TimeGen, and the verb registry ratification (these definitions are PROPOSALS until
+the glossary pass).
+
+## Pointers
+
+- `src/Core/HendersonTextileMill.fs` (weave/seam, running) · `src/Core/Salon.fs` + LinguisticSeed (tie
+  as kernel) · `TimeGen` (bob/twist as phase) · Amara's weave ferry (the fabric) · the lanes doc
+  (warp/weft = monorail/road) · "topology is hairdressing" (the Craft thread) · Anchors: braid group
+  (Artin 1925) · Jacquard 1804 · Kauffman (knots and physics) · Tsirelson (the bob's bound).


### PR DESCRIPTION
The craft verbs defined precisely, each tied to a running instance and a math name (bob=phasor oscillation, weave=deterministic interleave→causal fabric, tie=soft kernel bond, twist=single-strand phase/i-rotation, braid=order-sensitive crossings/Artin Bₙ) with one-line discriminating tests. The textile frame proposed: warp=monorails, weft=roads, loom=scheduler, shed=tick aperture, selvage=§13, seam=Henderson. Beacon: the Jacquard loom is computing's literal parent — weaving is computing's ancestry, not its metaphor. B-1027 filed: ratify registry + TEST the Artin braid relations + the two craft schools (salon/textile) as curricula. Docs+backlog only.