### PR TITLE
feat(craft): Braid — the Artin relations TESTED ('topology is hairdressing' is now a law, not a slogan)

### DIFF
--- a/src/Core/Braid.fs
+++ b/src/Core/Braid.fs
@@ -1,0 +1,84 @@
+namespace Zeta.Core
+
+/// Braid — **the braid group made executable, so "topology is hairdressing" can be TESTED** (B-1027's
+/// falsifiable item: do the Artin relations hold?).
+///
+/// Representation: **Artin's action on the free group Fₙ** — faithful (Artin 1925), exact, integer-only
+/// (byte-lockable; no floats). A strand-crossing σᵢ acts as the automorphism
+///
+///     σᵢ:  xᵢ ↦ xᵢ xᵢ₊₁ xᵢ⁻¹,   xᵢ₊₁ ↦ xᵢ,   others fixed
+///
+/// and a braid word (a sequence of crossings, sign = over/under) acts by composition. Because the
+/// action is faithful, two braid words are EQUAL iff they act identically on the generators — so the
+/// braid relations become executable equalities:
+///
+///   - **Artin relation:**      σᵢ σᵢ₊₁ σᵢ  =  σᵢ₊₁ σᵢ σᵢ₊₁          (the hairdresser's move)
+///   - **far commutativity:**   σᵢ σⱼ = σⱼ σᵢ            for |i−j| ≥ 2 (distant strands don't care)
+///   - **NOT the symmetric group:** σᵢ² ≠ identity — crossing twice is not un-crossing: WHO crossed
+///     OVER WHOM is remembered. (This is the whole point: a braid is a permutation PLUS history —
+///     order-sensitivity is what makes it computation, not shuffling.)
+///
+/// A free-group element is a reduced word of (generator, ±1) letters; reduction (xx⁻¹ ⇒ ε) is the only
+/// rewriting needed, and it is confluent — equality is literal list equality after reduction.
+[<RequireQualifiedAccess>]
+module Braid =
+
+    /// A letter: generator index (0-based strand) with exponent sign (+1 / −1).
+    type Letter = int * int
+
+    /// A reduced free-group word (no adjacent x·x⁻¹ pairs).
+    type Word = Letter list
+
+    /// Reduce a word (cancel adjacent inverse pairs until none remain) — confluent, terminating.
+    let reduce (w: Word) : Word =
+        let push (acc: Word) (l: Letter) =
+            match acc, l with
+            | (g1, e1) :: rest, (g2, e2) when g1 = g2 && e1 + e2 = 0 -> rest
+            | _ -> l :: acc
+
+        w |> List.fold push [] |> List.rev
+
+    /// Concatenate and reduce.
+    let mul (a: Word) (b: Word) : Word = reduce (a @ b)
+
+    /// The inverse word.
+    let inv (w: Word) : Word =
+        w |> List.rev |> List.map (fun (g, e) -> g, -e)
+
+    /// One generator as a word.
+    let gen (i: int) : Word = [ i, 1 ]
+
+    /// Apply ONE crossing's automorphism to ONE letter. `c` > 0 means σ_{c−1}; `c` < 0 its inverse
+    /// (1-based in the sign-carrying int so 0 is never ambiguous).
+    let private applyCrossingToLetter (c: int) (g: int, e: int) : Word =
+        let i = abs c - 1 // the crossing acts on strands i, i+1
+
+        let image =
+            if c > 0 then
+                // σᵢ: xᵢ ↦ xᵢ xᵢ₊₁ xᵢ⁻¹ ; xᵢ₊₁ ↦ xᵢ
+                if g = i then [ i, 1; i + 1, 1; i, -1 ]
+                elif g = i + 1 then [ i, 1 ]
+                else [ g, 1 ]
+            else
+                // σᵢ⁻¹: xᵢ ↦ xᵢ₊₁ ; xᵢ₊₁ ↦ xᵢ₊₁⁻¹ xᵢ xᵢ₊₁
+                if g = i then [ i + 1, 1 ]
+                elif g = i + 1 then [ i + 1, -1; i, 1; i + 1, 1 ]
+                else [ g, 1 ]
+
+        if e = 1 then image else inv image
+
+    /// Apply one crossing to a word (homomorphic extension), reduced.
+    let applyCrossing (c: int) (w: Word) : Word =
+        w |> List.collect (applyCrossingToLetter c) |> reduce
+
+    /// Apply a braid word (crossings left-to-right) to a free-group word.
+    let act (braid: int list) (w: Word) : Word =
+        braid |> List.fold (fun acc c -> applyCrossing c acc) w
+
+    /// Are two braid words EQUAL as braids? (Faithful action ⇒ equal iff they act identically on
+    /// every generator of Fₙ.)
+    let equal (n: int) (b1: int list) (b2: int list) : bool =
+        [ 0 .. n - 1 ] |> List.forall (fun i -> act b1 (gen i) = act b2 (gen i))
+
+    /// The identity test.
+    let isIdentity (n: int) (b: int list) : bool = equal n b []

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -226,6 +226,7 @@
     <Compile Include="ZetaMax.fs" />
     <Compile Include="Chip9Phys.fs" />
     <Compile Include="TimeGen.fs" />
+    <Compile Include="Braid.fs" />
     <Compile Include="TelemetrySource.fs" />
     <Compile Include="SimLoop.fs" />
     <Compile Include="WheelRoom.fs" />

--- a/tests/Tests.FSharp/Braid.Tests.fs
+++ b/tests/Tests.FSharp/Braid.Tests.fs
@@ -1,0 +1,51 @@
+module Zeta.Tests.BraidTests
+
+// "Topology is hairdressing" — TESTED (B-1027): the Artin relations hold for our braid engine, far
+// strands commute, and the braid REMEMBERS who crossed over whom (it is NOT the symmetric group).
+// Exact integers via the faithful free-group action; FsCheck sweeps random words.
+
+open global.Xunit
+open FsCheck
+open FsCheck.FSharp
+open FsCheck.Xunit
+open Zeta.Core
+
+let private N = 5 // strands (generators sigma_1..sigma_4 as ints 1..4)
+
+[<Fact>]
+let ``THE ARTIN RELATION: s1 s2 s1 = s2 s1 s2 — the hairdresser's move is a law`` () =
+    Assert.True(Braid.equal N [ 1; 2; 1 ] [ 2; 1; 2 ])
+    Assert.True(Braid.equal N [ 2; 3; 2 ] [ 3; 2; 3 ])
+    Assert.True(Braid.equal N [ 3; 4; 3 ] [ 4; 3; 4 ])
+
+[<Fact>]
+let ``FAR COMMUTATIVITY: distant strands don't care — s1 s3 = s3 s1; s1 s4 = s4 s1`` () =
+    Assert.True(Braid.equal N [ 1; 3 ] [ 3; 1 ])
+    Assert.True(Braid.equal N [ 1; 4 ] [ 4; 1 ])
+    Assert.True(Braid.equal N [ 2; 4 ] [ 4; 2 ])
+
+[<Fact>]
+let ``NOT THE SYMMETRIC GROUP: crossing twice is not un-crossing — the braid remembers the over/under`` () =
+    Assert.False(Braid.isIdentity N [ 1; 1 ]) // sigma_1^2 != id: history is kept
+    Assert.True(Braid.isIdentity N [ 1; -1 ]) // ...but a crossing and its true inverse cancel
+    Assert.False(Braid.equal N [ 1; 2 ] [ 2; 1 ]) // adjacent crossings do NOT commute (order matters)
+
+[<Fact>]
+let ``the free-group reduction is sound: w * inv w = identity`` () =
+    let w = [ 0, 1; 1, -1; 2, 1 ]
+    Assert.Equal<Braid.Word>([], Braid.mul w (Braid.inv w))
+
+type private BraidArbs =
+    static member Crossing() =
+        Arb.fromGen (Gen.elements [ 1; -1; 2; -2; 3; -3; 4; -4 ])
+    static member BraidWord() =
+        Arb.fromGen (Gen.listOf (Gen.elements [ 1; -1; 2; -2; 3; -3; 4; -4 ]) |> Gen.map (List.truncate 8))
+
+[<Property(Arbitrary = [| typeof<BraidArbs> |])>]
+let ``property: every braid word composed with its inverse is the identity (random words)`` (b: int list) =
+    let binv = b |> List.rev |> List.map (~-)
+    Braid.isIdentity N (b @ binv)
+
+[<Property(Arbitrary = [| typeof<BraidArbs> |])>]
+let ``property: the Artin relation holds INSIDE any context — u·(s1 s2 s1)·v = u·(s2 s1 s2)·v`` (u: int list) (v: int list) =
+    Braid.equal N (u @ [ 1; 2; 1 ] @ v) (u @ [ 2; 1; 2 ] @ v)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -157,6 +157,7 @@
     <Compile Include="Chip9Phys.Tests.fs" />
     <Compile Include="ZetaBreathe.Tests.fs" />
     <Compile Include="TimeGen.Tests.fs" />
+    <Compile Include="Braid.Tests.fs" />
     <Compile Include="OttoAvatar.Tests.fs" />
     <Compile Include="Chip9Treaty.Tests.fs" />
     <Compile Include="Chip8Quote.Tests.fs" />


### PR DESCRIPTION
B-1027's falsifiable item, green: the braid group executable via Artin's faithful free-group action (exact integers). The Artin relation σᵢσᵢ₊₁σᵢ = σᵢ₊₁σᵢσᵢ₊₁ holds at every adjacent pair AND inside arbitrary FsCheck contexts; far strands commute; σ² ≠ id — the braid remembers who crossed over whom (history, not shuffling — why a braid is computation). Honest scope: mill-weave-as-fold-over-braid-word is the remaining B-1027 step. 6/6 green.