### PR TITLE
perf(core): add raw qubit gate kernels

### DIFF
--- a/bench/Benchmarks/QuantumOracleBench.fs
+++ b/bench/Benchmarks/QuantumOracleBench.fs
@@ -14,6 +14,7 @@ open Zeta.Core
 type QuantumOracleOps() =
 
     [<DefaultValue(false)>] val mutable private states: QubitIso.JoinState array
+    [<DefaultValue(false)>] val mutable private rawStates: QubitIso.RawState array
     [<DefaultValue(false)>] val mutable private frames: Chip8Cow.Frame array
     [<DefaultValue(false)>] val mutable private goldenBytes: byte array
 
@@ -28,6 +29,8 @@ type QuantumOracleOps() =
                 let alpha = { Real = cos theta; Imag = sin theta }
                 let beta = { Real = cos (theta * 0.5); Imag = sin (theta * 0.5) }
                 QubitIso.ofQubit alpha beta)
+
+        this.rawStates <- this.states |> Array.map QubitIso.toRaw
 
         this.frames <-
             Array.init 2 (fun i ->
@@ -69,6 +72,22 @@ type QuantumOracleOps() =
                 |> QubitIso.pauliY
                 |> QubitIso.pauliZ
             acc <- acc + QubitIso.normSq s + QubitIso.measureOne s
+        acc
+
+    [<Benchmark>]
+    member this.QubitIsoRawGateSweep() =
+        let mutable acc = 0.0
+        let states = this.rawStates
+        for i in 0 .. states.Length - 1 do
+            let s =
+                states.[i]
+                |> QubitIso.Raw.hadamard
+                |> QubitIso.Raw.ry (Math.PI / 3.0)
+                |> QubitIso.Raw.rz (Math.PI / 3.0)
+                |> QubitIso.Raw.pauliX
+                |> QubitIso.Raw.pauliY
+                |> QubitIso.Raw.pauliZ
+            acc <- acc + QubitIso.normSqRaw s + QubitIso.measureOneRaw s
         acc
 
     [<Benchmark>]

--- a/src/Core/QubitIso.fs
+++ b/src/Core/QubitIso.fs
@@ -51,9 +51,28 @@ module QubitIso =
     /// A two-stream join state = a qubit. `A` = stream-A / `|0⟩` amplitude, `B` = stream-B / `|1⟩` amplitude.
     type JoinState = { A: Complex; B: Complex }
 
+    /// Allocation-conscious twin of `JoinState` for hot observable loops. The algebraic surface stays
+    /// `JoinState`; this struct is the benchmark/data-plane carrier for the same Q#-locked gate convention.
+    [<Struct>]
+    type RawState =
+        { AReal: float
+          AImag: float
+          BReal: float
+          BImag: float }
+
     /// Qubit `α|0⟩ + β|1⟩` ↔ join `(A,B)` — the state bijection is the identity on `ℂ²`.
     let ofQubit (alpha: Complex) (beta: Complex) : JoinState = { A = alpha; B = beta }
     let toQubit (j: JoinState) : Complex * Complex = j.A, j.B
+
+    let toRaw (j: JoinState) : RawState =
+        { AReal = j.A.Real
+          AImag = j.A.Imag
+          BReal = j.B.Real
+          BImag = j.B.Imag }
+
+    let ofRaw (r: RawState) : JoinState =
+        { A = { Real = r.AReal; Imag = r.AImag }
+          B = { Real = r.BReal; Imag = r.BImag } }
 
     /// `|z|²`.
     let private magSq (z: Complex) : float = z.Real * z.Real + z.Imag * z.Imag
@@ -65,6 +84,13 @@ module QubitIso =
     let measureOne (j: JoinState) : float =
         let n = normSq j
         if n = 0.0 then 0.0 else magSq j.B / n
+
+    let normSqRaw (r: RawState) : float =
+        r.AReal * r.AReal + r.AImag * r.AImag + r.BReal * r.BReal + r.BImag * r.BImag
+
+    let measureOneRaw (r: RawState) : float =
+        let n = normSqRaw r
+        if n = 0.0 then 0.0 else (r.BReal * r.BReal + r.BImag * r.BImag) / n
 
     // ── Pauli gates as stream operations ──────────────────────────────────────────────────────────────────
     /// X (bit-flip) = swap the two streams.
@@ -100,6 +126,51 @@ module QubitIso =
         let phase1 = { Real = cos half; Imag = sin half }
         { A = c.Mul(phase0, j.A)
           B = c.Mul(phase1, j.B) }
+
+    module Raw =
+
+        let id (r: RawState) : RawState = r
+
+        let pauliX (r: RawState) : RawState =
+            { AReal = r.BReal
+              AImag = r.BImag
+              BReal = r.AReal
+              BImag = r.AImag }
+
+        let pauliY (r: RawState) : RawState =
+            { AReal = r.BImag
+              AImag = -r.BReal
+              BReal = -r.AImag
+              BImag = r.AReal }
+
+        let pauliZ (r: RawState) : RawState =
+            { r with
+                BReal = -r.BReal
+                BImag = -r.BImag }
+
+        let hadamard (r: RawState) : RawState =
+            let invSqrt2 = 1.0 / sqrt 2.0
+            { AReal = (r.AReal + r.BReal) * invSqrt2
+              AImag = (r.AImag + r.BImag) * invSqrt2
+              BReal = (r.AReal - r.BReal) * invSqrt2
+              BImag = (r.AImag - r.BImag) * invSqrt2 }
+
+        let ry (theta: float) (r: RawState) : RawState =
+            let ct = cos (theta / 2.0)
+            let st = sin (theta / 2.0)
+            { AReal = ct * r.AReal - st * r.BReal
+              AImag = ct * r.AImag - st * r.BImag
+              BReal = st * r.AReal + ct * r.BReal
+              BImag = st * r.AImag + ct * r.BImag }
+
+        let rz (theta: float) (r: RawState) : RawState =
+            let half = theta / 2.0
+            let ct = cos half
+            let st = sin half
+            { AReal = ct * r.AReal + st * r.AImag
+              AImag = ct * r.AImag - st * r.AReal
+              BReal = ct * r.BReal - st * r.BImag
+              BImag = ct * r.BImag + st * r.BReal }
 
     /// Approximate state equality (per-component, within `eps`).
     let equalish (eps: float) (x: JoinState) (y: JoinState) : bool =

--- a/tests/Tests.FSharp/QSharpOracle.Tests.fs
+++ b/tests/Tests.FSharp/QSharpOracle.Tests.fs
@@ -116,6 +116,24 @@ let ``QubitIso H Ry and Rz match the Q# gate matrices on computational basis sta
     assertQSharpColumn rzPiOver3 1 (QubitIso.rz (Math.PI / 3.0) one)
 
 [<Fact>]
+let ``QubitIso raw kernels match Q# gate matrices on computational basis states`` () =
+    let zero = QubitIso.ofQubit c.One c.Zero |> QubitIso.toRaw
+    let one = QubitIso.ofQubit c.Zero c.One |> QubitIso.toRaw
+
+    let assertRaw name op =
+        let matrix = gateMatrix name
+        assertQSharpColumn matrix 0 (zero |> op |> QubitIso.ofRaw)
+        assertQSharpColumn matrix 1 (one |> op |> QubitIso.ofRaw)
+
+    assertRaw "X" QubitIso.Raw.pauliX
+    assertRaw "Y" QubitIso.Raw.pauliY
+    assertRaw "Z" QubitIso.Raw.pauliZ
+    assertRaw "H" QubitIso.Raw.hadamard
+    assertRaw "Ry(pi/3)" (QubitIso.Raw.ry (Math.PI / 3.0))
+    assertRaw "Ry(pi/2)" (QubitIso.Raw.ry (Math.PI / 2.0))
+    assertRaw "Rz(pi/3)" (QubitIso.Raw.rz (Math.PI / 3.0))
+
+[<Fact>]
 let ``BellTest canonical CHSH observables match the Q# golden vector`` () =
     let canonical = vectors.GetProperty("bellChsh").GetProperty("canonical")
     let angles = canonical.GetProperty("anglesRadians")

--- a/tests/Tests.FSharp/QubitIso.Tests.fs
+++ b/tests/Tests.FSharp/QubitIso.Tests.fs
@@ -50,6 +50,21 @@ let ``Ry pi over three has textbook cos squared and sin squared probabilities`` 
     Assert.Equal(sin (System.Math.PI / 6.0) ** 2.0, QubitIso.measureOne rotated, 12)
 
 [<Fact>]
+let ``Raw kernels match the algebraic gate surface`` () =
+    let raw = QubitIso.toRaw g
+    let assertSame expected actual =
+        Assert.True(eq expected (QubitIso.ofRaw actual))
+
+    assertSame (QubitIso.pauliX g) (QubitIso.Raw.pauliX raw)
+    assertSame (QubitIso.pauliY g) (QubitIso.Raw.pauliY raw)
+    assertSame (QubitIso.pauliZ g) (QubitIso.Raw.pauliZ raw)
+    assertSame (QubitIso.hadamard g) (QubitIso.Raw.hadamard raw)
+    assertSame (QubitIso.ry (System.Math.PI / 3.0) g) (QubitIso.Raw.ry (System.Math.PI / 3.0) raw)
+    assertSame (QubitIso.rz (System.Math.PI / 3.0) g) (QubitIso.Raw.rz (System.Math.PI / 3.0) raw)
+    Assert.Equal(QubitIso.normSq g, QubitIso.normSqRaw raw, 12)
+    Assert.Equal(QubitIso.measureOne g, QubitIso.measureOneRaw raw, 12)
+
+[<Fact>]
 let ``state bijection is the identity on ℂ² (round-trip)`` () =
     let a, b = QubitIso.toQubit g
     Assert.True(eq (QubitIso.ofQubit a b) g)


### PR DESCRIPTION
## Summary
- add `QubitIso.RawState`, a struct carrier for hot observable loops
- add raw Pauli/H/Ry/Rz kernels plus raw norm and Born measurement helpers
- lock raw kernels against the readable F# `JoinState` gate surface and the Q# golden matrix treaty
- add `QubitIsoRawGateSweep` to the quantum BenchmarkDotNet suite

## Independence shape
Q# still owns the oracle fixture. F# validates and benchmarks against the committed JSON treaty with F#/.NET only; no QDK, Python, or TS runtime dependency is introduced.

## Validation
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter "FullyQualifiedName~QSharpOracleTests|FullyQualifiedName~QubitIsoTests|FullyQualifiedName~BellTestTests|FullyQualifiedName~AmplitudeEmuTests"` (27 passed)
- `dotnet build bench/Benchmarks/Benchmarks.fsproj -c Release` (0 warnings, 0 errors; SDK emitted a non-warning MVID note)
- `dotnet build -c Release` (0 warnings, 0 errors)
- `dotnet test Zeta.sln -c Release` (3,255 passed, 1 skipped)
- `dotnet run -c Release --project bench/Benchmarks/Benchmarks.fsproj -- --filter '*QuantumOracleOps.QubitIso*GateSweep*' --job Dry --warmupCount 1 --iterationCount 1`\n- `dotnet format --verify-no-changes --include src/Core/QubitIso.fs tests/Tests.FSharp/QubitIso.Tests.fs tests/Tests.FSharp/QSharpOracle.Tests.fs bench/Benchmarks/QuantumOracleBench.fs`\n- `git diff --check`\n\n## Benchmark smoke note\nDry-run numbers are not statistically meaningful, but they prove the shape: at Size=16384, readable `QubitIsoGateSweep` reported ~11.164 ms and ~15.2 MB allocated; raw `QubitIsoRawGateSweep` reported ~1.645 ms and 0 B allocated.