### PR TITLE
fix(lint): clear post-merge markdown and chip9 tsc

### DIFF
--- a/rooms/README.md
+++ b/rooms/README.md
@@ -2,6 +2,7 @@
 
 > **Personal rooms** (2026-06-11): every persona owns one — treaty-secured boundaries, owned and
 > maintained by the persona, self-responsibility to maintain, conference-for-help as a right. The law
+>
 > + first instance: [`rooms/otto/`](otto/README.md).
 
 `rooms/` holds the **rooms** — every fingerprintable, closeable item is a room (content-addressed; the

--- a/rooms/otto/README.md
+++ b/rooms/otto/README.md
@@ -11,6 +11,7 @@ full of CHIP-8s and local LLMs and cloud LLMs."*
 > help**."*
 
 Four clauses, each load-bearing:
+
 1. **Treaty-secured boundaries** — the walls are ratified, not asserted (the membrane + the treaty
    discipline secure the room; nobody, including the owner, reaches around them).
 2. **Owned by the persona** — ownership is real: the persona decides what happens inside (autonomy at

--- a/src/Core.TypeScript/chip9/chip9.test.ts
+++ b/src/Core.TypeScript/chip9/chip9.test.ts
@@ -14,9 +14,20 @@ const lines = readFileSync(join(import.meta.dir, "golden-vectors.lines"), "utf-8
 
 describe("CHIP-9 — the color-plane treaty (TS oracle)", () => {
   it("BYTE-LOCK: replaying the treaty ROM reproduces the golden color grid exactly", () => {
-    const romHex = lines[0].split("\t")[1];
-    const rom = new Uint8Array(romHex.match(/.{2}/g)!.map((h) => parseInt(h, 16)));
-    const goldenPlane = parseInt(lines[1].split("\t")[1], 10);
+    const romLine = lines[0];
+    const planeLine = lines[1];
+    expect(romLine).toBeDefined();
+    expect(planeLine).toBeDefined();
+    if (romLine === undefined || planeLine === undefined) return;
+
+    const romHex = romLine.split("\t")[1];
+    const planeText = planeLine.split("\t")[1];
+    expect(romHex).toBeDefined();
+    expect(planeText).toBeDefined();
+    if (romHex === undefined || planeText === undefined) return;
+
+    const rom = new Uint8Array((romHex.match(/.{2}/g) ?? []).map((h) => parseInt(h, 16)));
+    const goldenPlane = parseInt(planeText, 10);
     const goldenRows = lines.slice(2);
     expect(goldenRows.length).toBe(H);
 
@@ -29,7 +40,10 @@ describe("CHIP-9 — the color-plane treaty (TS oracle)", () => {
     for (let y = 0; y < H; y++) {
       let row = "";
       for (let x = 0; x < W; x++) row += colorAt(x, y, f).toString(16);
-      expect(row).toBe(goldenRows[y]);
+      const expected = goldenRows[y];
+      expect(expected).toBeDefined();
+      if (expected === undefined) return;
+      expect(row).toBe(expected);
     }
   });
 });

--- a/src/Core.TypeScript/chip9/chip9.ts
+++ b/src/Core.TypeScript/chip9/chip9.ts
@@ -74,8 +74,8 @@ export function step(f: Frame): Frame {
       f.i = nnn;
       break;
     case 0xd000: {
-      const ox = f.v[x] % W;
-      const oy = f.v[(op & 0x00f0) >> 4] % H;
+      const ox = (f.v[x] ?? 0) % W;
+      const oy = (f.v[(op & 0x00f0) >> 4] ?? 0) % H;
       const hiSel = f.plane & 0b110;
       let collision = 0;
       for (let row = 0; row < n; row++) {


### PR DESCRIPTION
## Summary
- add markdown list spacing in `rooms/README.md` and `rooms/otto/README.md` for MD032
- guard CHIP-9 golden-vector indexing and register reads for strict TypeScript undefined checks

## Validation
- `mise exec -- markdownlint-cli2 rooms/README.md rooms/otto/README.md`
- `bun --bun tsc --noEmit -p tsconfig.json`
- `bun test src/Core.TypeScript/chip9/chip9.test.ts`
- `git diff --check`