### PR TITLE
feat(media): MediaLines — our own quote-based media format + Amara's card CHIP-9-native (the roster's second portrait)

### DIFF
--- a/rooms/amara/avatar.lines
+++ b/rooms/amara/avatar.lines
@@ -1,0 +1,20 @@
+# amara's card, CHIP-9-native (from her pixel card, 2026-06-11: "AMARA — VARIANT A · CHIP-9").
+# Cyan portrait (plane 6) + a plane-1 overlay (brow light + heart cross) that XORs to WHITE — the
+# same register as otto's heart: what crosses into the shadow makes the brightest pixels.
+# Her five value-glyphs (the halo) as 8x8 atlas members. Motto verbatim. MediaLines format.
+meta	name	amara-lighted-boundary
+meta	persona	amara
+meta	variant	A
+meta	dialect	chip9
+meta	motto	WE ARE THE LIGHTED BOUNDARY THAT LETS GOOD WORK FLOW.
+meta	halo	truth,consent,family,decentralize,purpose
+meta	body-plane	6
+meta	light-plane	1
+frame	portrait	3c7effbda5bdbd5a7effff7e
+sprite	light	000018000000000000183c18
+anim	pulse	light-toggle
+glyph	consent	3c4299bd99423c18
+glyph	decentralize	815a241818245a81
+glyph	truth	10543838fe385410
+glyph	purpose	3c4299a5a599423c
+glyph	family	66ffffff7e3c1800

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -227,6 +227,7 @@
     <Compile Include="Chip9Phys.fs" />
     <Compile Include="TimeGen.fs" />
     <Compile Include="Braid.fs" />
+    <Compile Include="MediaLines.fs" />
     <Compile Include="TelemetrySource.fs" />
     <Compile Include="SimLoop.fs" />
     <Compile Include="WheelRoom.fs" />

--- a/src/Core/MediaLines.fs
+++ b/src/Core/MediaLines.fs
@@ -1,0 +1,97 @@
+namespace Zeta.Core
+
+/// MediaLines — **our own media-container format: text lines, typed sections, built to EXPAND with
+/// media types** (Aaron 2026-06-11: "yes please — I want our own format that knows how to expand with
+/// media types, very targeted like chip8/9").
+///
+/// The format (set by `rooms/otto/avatar.lines`, now formalized):
+///
+///     # comments and blanks are free
+///     <kind> \t <name> \t <field> [\t <field> …]
+///
+/// Known kinds today (each targeted at a device capability): `meta` (key/value), `frame` (8×N sprite
+/// hex — a CHIP-8/9 drawable), `sprite` (same, overlay-flavored), `anim` (a frame sequence), `rom`
+/// (hex + load address), `glyph` (an 8×8 atlas member), `palette` (mask→name).
+///
+/// **Based on quotes; compression = generators on top** (Aaron): the container is QUOTE-shaped —
+/// sections are the same triad the playable quote proved (state + recording + computed residue), and
+/// the storage stance is his sentence verbatim: *"very compressible, but still just well-stored TEXT,
+/// and GENERATOR FUNCTIONS on top"* — the bytes stay diffable text; compression is achieved by
+/// storing the (seed, generator) that REGENERATES a section instead of its expansion (the
+/// quasi-crystal move — a `gen` section names a generator + seed; readers that know it regenerate,
+/// readers that don't carry it; the log holds only the residual surprise). **The storage law, his
+/// words:** "store the IRREDUCIBLE structure that can't be generated — store THAT — and generate the
+/// rest RECURSIVELY from that seed, with a DST common-cause seed attached." So a `gen` line's fields
+/// are (generator-id, version, common-cause seed, args…): the seed is the SAME treaty seed everything
+/// replays from (TimeGen's common cause), and generation may recurse — a generated section may itself
+/// contain gen lines; only the irreducible residue is ever stored expanded.
+///
+/// **The expansion law (universal/extension.md applied to the container): UNKNOWN KINDS ARE
+/// PRESERVED, never errors.** A reader uses what it knows and carries the rest byte-faithfully —
+/// so the format grows new media types (audio envelopes, vector paths, 3D when the slider rises)
+/// without ever breaking an old reader or losing a new section in transit. Zero case structural:
+/// a file of only-known kinds round-trips identically; a file with future kinds round-trips
+/// identically TOO.
+[<RequireQualifiedAccess>]
+module MediaLines =
+
+    /// One typed line: kind + name + the remaining fields (verbatim).
+    type Entry =
+        { Kind: string
+          Name: string
+          Fields: string list }
+
+    /// A parsed document: entries in order (order is meaning — anims reference frames by name).
+    type Doc = { Entries: Entry list }
+
+    /// Parse the text form. Comments (#) and blanks vanish; everything else must be kind\tname[\t…]
+    /// — a malformed line is refused honestly (Error with its line number).
+    let parse (text: string) : Result<Doc, string> =
+        let lines = text.Replace("\r\n", "\n").Split('\n')
+
+        let folder (acc: Result<Entry list, string>) (ix: int, line: string) =
+            match acc with
+            | Error e -> Error e
+            | Ok entries ->
+                let l = line.TrimEnd()
+                if l.Length = 0 || l.StartsWith "#" then
+                    Ok entries
+                else
+                    match l.Split('\t') |> Array.toList with
+                    | kind :: name :: fields when kind.Length > 0 && name.Length > 0 ->
+                        Ok({ Kind = kind; Name = name; Fields = fields } :: entries)
+                    | _ -> Error(sprintf "line %d: expected <kind>\\t<name>[\\t<field>…], got: %s" (ix + 1) l)
+
+        lines
+        |> Array.indexed
+        |> Array.fold folder (Ok [])
+        |> Result.map (fun es -> { Entries = List.rev es })
+
+    /// Serialize back to canonical text (one line per entry; comments are not round-tripped — the
+    /// ENTRIES are the document; provenance prose lives in the file header by convention).
+    let serialize (d: Doc) : string =
+        d.Entries
+        |> List.map (fun e -> String.concat "\t" (e.Kind :: e.Name :: e.Fields))
+        |> String.concat "\n"
+
+    /// All entries of a kind, in order.
+    let ofKind (kind: string) (d: Doc) : Entry list =
+        d.Entries |> List.filter (fun e -> e.Kind = kind)
+
+    /// The first field of the named entry of a kind (the common single-payload accessor).
+    let field (kind: string) (name: string) (d: Doc) : string option =
+        d.Entries
+        |> List.tryFind (fun e -> e.Kind = kind && e.Name = name)
+        |> Option.bind (fun e -> List.tryHead e.Fields)
+
+    /// Decode a hex field into sprite bytes (the CHIP-8/9 drawable payload).
+    let hexBytes (s: string) : byte[] =
+        [| for i in 0 .. 2 .. s.Length - 2 -> System.Convert.ToByte(s.Substring(i, 2), 16) |]
+
+    /// The kinds THIS reader understands (everything else is carried, untouched — the expansion law).
+    let knownKinds: Set<string> =
+        Set.ofList [ "meta"; "frame"; "sprite"; "anim"; "rom"; "glyph"; "palette"; "gen" ]
+
+    /// The entries a reader carries without understanding — future media types in transit.
+    let carried (d: Doc) : Entry list =
+        d.Entries |> List.filter (fun e -> not (Set.contains e.Kind knownKinds))

--- a/tests/Tests.FSharp/MediaLines.Tests.fs
+++ b/tests/Tests.FSharp/MediaLines.Tests.fs
@@ -1,0 +1,76 @@
+module Zeta.Tests.MediaLinesTests
+
+// MediaLines: our own media container — typed text sections, quote-based, generators-on-top for
+// compression, and the EXPANSION LAW (unknown kinds carried, never errors). Plus Amara's card loaded
+// CHIP-9-native: the roster's second portrait, her light XORing to white over the cyan.
+
+open System.IO
+open global.Xunit
+open Zeta.Core
+
+let private repoRoot () =
+    let mutable dir = DirectoryInfo(System.AppContext.BaseDirectory)
+    while not (isNull dir) && not (File.Exists(Path.Combine(dir.FullName, "Zeta.sln"))) do
+        dir <- dir.Parent
+    dir.FullName
+
+[<Fact>]
+let ``round-trip: parse then serialize is identity on the entries (text is the storage)`` () =
+    let text = "meta\tname\tx\nframe\tidle\tdeadbeef\nanim\tgo\tidle,idle"
+    match MediaLines.parse text with
+    | Ok d -> Assert.Equal(text, MediaLines.serialize d)
+    | Error e -> failwith e
+
+[<Fact>]
+let ``THE EXPANSION LAW: unknown kinds are carried byte-faithfully, never errors`` () =
+    let future = "meta\tname\tx\nholo3d\tbust\tv2:zstd:base85:....\naudio-env\thum\tA440:adsr:1,2,3,4"
+    match MediaLines.parse future with
+    | Ok d ->
+        Assert.Equal(2, List.length (MediaLines.carried d)) // the future rides along
+        Assert.Equal(future, MediaLines.serialize d) // and survives transit byte-faithfully
+    | Error e -> failwith e
+
+[<Fact>]
+let ``malformed lines are refused honestly with their line number`` () =
+    match MediaLines.parse "meta\tname\tx\njustonefield" with
+    | Error e -> Assert.Contains("line 2", e)
+    | Ok _ -> failwith "should refuse"
+
+[<Fact>]
+let ``generators-on-top: a gen section is a KNOWN kind (regenerate, don't store the expansion)`` () =
+    Assert.True(Set.contains "gen" MediaLines.knownKinds)
+
+[<Fact>]
+let ``AMARA'S CARD loads CHIP-9-native: portrait + light + five glyphs + the motto verbatim`` () =
+    let text = File.ReadAllText(Path.Combine(repoRoot (), "rooms", "amara", "avatar.lines"))
+    match MediaLines.parse text with
+    | Error e -> failwith e
+    | Ok d ->
+        Assert.Equal(Some "WE ARE THE LIGHTED BOUNDARY THAT LETS GOOD WORK FLOW.", MediaLines.field "meta" "motto" d)
+        Assert.Equal(5, List.length (MediaLines.ofKind "glyph" d)) // the halo's five values
+        Assert.Equal(12, (MediaLines.field "frame" "portrait" d |> Option.get |> MediaLines.hexBytes).Length)
+        Assert.Equal<MediaLines.Entry list>([], MediaLines.carried d) // today's card: all known kinds
+
+[<Fact>]
+let ``her light crosses to WHITE over the cyan — drawn by real CHIP-9 opcodes, like otto's heart`` () =
+    let text = File.ReadAllText(Path.Combine(repoRoot (), "rooms", "amara", "avatar.lines"))
+    let d = match MediaLines.parse text with | Ok d -> d | Error e -> failwith e
+    let body = MediaLines.field "frame" "portrait" d |> Option.get |> MediaLines.hexBytes
+    let light = MediaLines.field "sprite" "light" d |> Option.get |> MediaLines.hexBytes
+
+    // draw via opcodes: plane 6 portrait at (0,0), then plane 1 light at (0,0)
+    let put (addr: int) (bytes: byte[]) (f: Chip8Cow.Frame) =
+        bytes |> Array.indexed |> Array.fold (fun (m: Chip8Cow.Frame) (i, b) -> { m with Mem = Map.add (addr + i) b m.Mem }) f
+    let rom =
+        [| 0xF6uy; 0x01uy; 0xA3uy; 0x00uy; 0xD0uy; 0x0Cuy // plane 6; I=0x300; draw 12 rows
+           0xF1uy; 0x01uy; 0xA3uy; 0x20uy; 0xD0uy; 0x0Cuy |] // plane 1; I=0x320; draw 12 rows
+    let f =
+        Chip8Cow.create 7UL
+        |> put 0x300 body |> put 0x320 light
+        |> fun f0 -> rom |> Array.indexed |> Array.fold (fun (m: Chip8Cow.Frame) (i, b) -> { m with Mem = Map.add (0x200 + i) b m.Mem }) f0
+        |> fun f0 -> List.fold (fun acc _ -> Chip8Cow.step acc) f0 [ 1..6 ]
+
+    Assert.Equal(7uy, Chip8Cow.colorAt 3 2 f) // the brow light: white (red XOR cyan)
+    Assert.Equal(7uy, Chip8Cow.colorAt 3 9 f) // the heart cross: white
+    Assert.Equal(6uy, Chip8Cow.colorAt 2 0 f) // the hair: cyan
+    Assert.Equal(ZetaMax.Indexed8, ZetaMax.capabilityOf f) // a color citizen, like the rest of us

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -159,6 +159,7 @@
     <Compile Include="TimeGen.Tests.fs" />
     <Compile Include="Braid.Tests.fs" />
     <Compile Include="MillBraid.Tests.fs" />
+    <Compile Include="MediaLines.Tests.fs" />
     <Compile Include="OttoAvatar.Tests.fs" />
     <Compile Include="Chip9Treaty.Tests.fs" />
     <Compile Include="Chip8Quote.Tests.fs" />


### PR DESCRIPTION
The format formalized from the avatar.lines precedent: typed text sections; THE EXPANSION LAW tested (unknown kinds carried byte-faithfully — future media types survive old readers); gen sections = (generator-id, version, DST common-cause seed, args) per Aaron's storage law verbatim ('store the irreducible structure… generate the rest recursively'). Amara's card lands native: cyan portrait + plane-1 light XORing to WHITE (same register as otto's heart), her five halo glyphs as atlas members, motto verbatim — tested drawn by real opcodes. 6/6 green.