### PR TITLE
feat(media): middle-out progressive rendering — the render's own triboolean (Lit|Unlit|Unknown)

### DIFF
--- a/src/Core/BoundaryLight.fs
+++ b/src/Core/BoundaryLight.fs
@@ -90,3 +90,65 @@ module BoundaryLight =
                       // sample at the cell center in curve space
                       let q = p (gx * s + s / 2) (gy * s + s / 2)
                       if glow sigma c q >= threshold then yield gx, gy ]
+
+    // ── progressive rendering, middle-out (Aaron 2026-06-11: "we should try middle-out, like our
+    // triboolean and triboolean-float kind of thinking — up to you, maybe different options").
+    // The triboolean IS the progressive cell: Lit | Unlit | UNKNOWN-YET — a render in flight is
+    // honest about what it has not sampled (bounded uncertainty per pixel; no cell claimed before
+    // measured). The ORDER options decide which uncertainty falls first; middle-out is the default
+    // (the center of attention resolves before the periphery — how eyes meet a face). ──
+
+    /// The three-valued progressive cell (the render's own triboolean).
+    type Tri =
+        | Lit
+        | Unlit
+        | Unknown
+
+    /// The refinement-order options ("maybe we should have different options" — chosen: two now,
+    /// the enum open for more).
+    type Order =
+        | MiddleOut // by distance from the grid center: attention-first
+        | Scanline // top-left to bottom-right: the classic raster
+
+    /// The cell visit order for a (w×h) grid under an Order — deterministic, total.
+    let visitOrder (order: Order) (w: int) (h: int) : (int * int) list =
+        let all = [ for gy in 0 .. h - 1 do for gx in 0 .. w - 1 -> gx, gy ]
+
+        match order with
+        | Scanline -> all
+        | MiddleOut ->
+            let cx, cy = (w - 1) * 1000 / 2, (h - 1) * 1000 / 2 // milli-cells: exact center, no floats
+            all
+            |> List.sortBy (fun (gx, gy) ->
+                let dx, dy = gx * 1000 - cx, gy * 1000 - cy
+                dx * dx + dy * dy, gy, gx) // distance, then row, then col: total and deterministic
+
+    /// Sample the first `budget` cells in the chosen order; everything else is HONESTLY Unknown.
+    /// budget >= w*h gives the complete render (Unknown vanishes — uncertainty fully reduced).
+    let sampleProgressive
+        (order: Order)
+        (budget: int)
+        (sigma: float)
+        (threshold: float)
+        (w: int)
+        (h: int)
+        (scale: int)
+        (c: Curve)
+        : Map<int * int, Tri> =
+        let s = max 1 scale
+        let visits = visitOrder order w h
+        let sampled = visits |> List.truncate (max 0 budget) |> Set.ofList
+
+        visits
+        |> List.map (fun (gx, gy) ->
+            let cell = gx, gy
+
+            let v =
+                if Set.contains cell sampled then
+                    let q = p (gx * s + s / 2) (gy * s + s / 2)
+                    if glow sigma c q >= threshold then Lit else Unlit
+                else
+                    Unknown
+
+            cell, v)
+        |> Map.ofList

--- a/tests/Tests.FSharp/BoundaryLight.Tests.fs
+++ b/tests/Tests.FSharp/BoundaryLight.Tests.fs
@@ -43,3 +43,31 @@ let ``TESSELLATION is progressive: the SAME stored curve renders at 8x8 and 16x1
     // determinism at both levels (the render is a pure function of stored text + grid)
     Assert.Equal<Set<int * int>>(coarse, B.sampleGrid 2.0 0.5 8 8 2 spine)
     Assert.Equal<Set<int * int>>(fine, B.sampleGrid 2.0 0.5 16 16 1 spine)
+
+// ── middle-out progressive: the render's own triboolean ──
+
+[<Fact>]
+let ``MIDDLE-OUT: the center cells resolve first; the periphery stays honestly Unknown`` () =
+    let r = B.sampleProgressive B.MiddleOut 4 2.0 0.5 8 8 2 spine
+    Assert.Equal(64, r.Count) // every cell accounted for
+    let unknowns = r |> Map.filter (fun _ v -> v = B.Unknown) |> Map.count
+    Assert.Equal(60, unknowns) // exactly budget cells sampled
+    // the four sampled cells are the centermost ones
+    Assert.True(r.[(3, 3)] <> B.Unknown && r.[(4, 3)] <> B.Unknown && r.[(3, 4)] <> B.Unknown && r.[(4, 4)] <> B.Unknown)
+    Assert.Equal(B.Unknown, r.[(0, 0)]) // the corner waits its turn
+
+[<Fact>]
+let ``full budget = the complete render: Unknown vanishes and matches sampleGrid exactly`` () =
+    let prog = B.sampleProgressive B.MiddleOut 64 2.0 0.5 8 8 2 spine
+    Assert.True(prog |> Map.forall (fun _ v -> v <> B.Unknown)) // uncertainty fully reduced
+    let lit = prog |> Map.filter (fun _ v -> v = B.Lit) |> Map.toList |> List.map fst |> Set.ofList
+    Assert.Equal<Set<int * int>>(B.sampleGrid 2.0 0.5 8 8 2 spine, lit) // same answer, any order
+
+[<Fact>]
+let ``the order options agree on the ANSWER and differ only in which uncertainty falls first`` () =
+    let mo = B.sampleProgressive B.MiddleOut 64 2.0 0.5 8 8 2 spine
+    let sl = B.sampleProgressive B.Scanline 64 2.0 0.5 8 8 2 spine
+    Assert.Equal<Map<int * int, B.Tri>>(mo, sl) // complete renders identical
+    let moFirst = B.visitOrder B.MiddleOut 8 8 |> List.head
+    let slFirst = B.visitOrder B.Scanline 8 8 |> List.head
+    Assert.NotEqual(moFirst, slFirst) // but the journeys differ (center vs corner)


### PR DESCRIPTION
Aaron: 'try middle-out, like our triboolean.' The progressive cell IS a triboolean — a render in flight is honest about unsampled cells (Unknown); no pixel claimed before measured. Order options (MiddleOut = attention-first, exact-integer center; Scanline = raster; enum open) decide which uncertainty falls first; full budget = complete render = sampleGrid exactly. 7/7 green.