### PR TITLE
feat(viz): ZetaIdViz — every ZetaId category visible (color = kind, pattern = which)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -230,6 +230,7 @@
     <Compile Include="MediaLines.fs" />
     <Compile Include="BoundaryLight.fs" />
     <Compile Include="GeneratorRegistry.fs" />
+    <Compile Include="ZetaIdViz.fs" />
     <Compile Include="TelemetrySource.fs" />
     <Compile Include="SimLoop.fs" />
     <Compile Include="WheelRoom.fs" />

--- a/src/Core/GeneratorRegistry.fs
+++ b/src/Core/GeneratorRegistry.fs
@@ -48,7 +48,8 @@ module GeneratorRegistry =
           register "boundary.grid" 1
           register "boundary.rotorCurve" 1
           register "kernel.rbf" 1
-          register "timegen.phasor" 1 ]
+          register "timegen.phasor" 1
+          register "zetaid.glyph" 1 ]
 
     /// Look a generator up by its ZetaId (the filetype's reverse direction: id -> what it is).
     let byId (zetaId: string) : Entry option =

--- a/src/Core/ZetaIdViz.fs
+++ b/src/Core/ZetaIdViz.fs
@@ -1,0 +1,54 @@
+namespace Zeta.Core
+
+open Zeta.Core.FSharp.ZetaId
+
+/// ZetaIdViz — **every ZetaId category gets a way to be SEEN** (Aaron 2026-06-11: "every zetaid
+/// category should have a way to visualize it — they are all generators anyway").
+///
+/// "They are all generators anyway" is the design: a ZetaId is already a deterministic mint, so its
+/// visualization is just ONE MORE GENERATOR — `glyphOf` derives an 8×8 identicon-style glyph from the
+/// id's own bits (mirror-symmetric: the left half comes from the bits, the right half is the mirror —
+/// the BoundaryLight `mirror` move, which is also why every glyph reads as a "face"), and the
+/// CATEGORY picks the CHIP-9 plane color — so WHAT KIND of thing an id is, is visible at a glance
+/// (safety/jurisdiction at a glance, extended to identity), and WHICH thing it is, is the pattern.
+///
+/// Deterministic end-to-end: same id ⇒ same glyph ⇒ same pixels on every node (the glyph is registered
+/// in GeneratorRegistry as `zetaid.glyph` v1 — referenceable by its own ZetaId, shape A and proud).
+/// Anchors: identicons (Park's visual hash, 2007 — gravatar lineage); our mirror/glyph primitives.
+[<RequireQualifiedAccess>]
+module ZetaIdViz =
+
+    /// The CHIP-9 color mask for a category — the at-a-glance channel. Total over the registered
+    /// categories; Extended/unknown render white (7: "all channels — tell me more").
+    let colorOf (c: Category) : byte =
+        match c with
+        | Category.Observation -> 6uy // cyan — what crosses in (the shadow register)
+        | Category.Emission -> 1uy // red — what goes out
+        | Category.Workflow -> 2uy // green — work in motion
+        | Category.Heartbeat -> 5uy // magenta — the pulse
+        | Category.Batch -> 3uy // yellow — bulk transport
+        | Category.FrictionTelemetry -> 1uy // red family — friction runs hot
+        | Category.Bus -> 4uy // blue — the wire
+        | Category.Spawn -> 2uy // green family — new life
+        | Category.WorkItem -> 3uy // yellow family — the board
+        | Category.ContentAddress -> 6uy // cyan family — content is observed, not commanded
+        | _ -> 7uy // Extended / future: white until they earn a channel
+
+    /// The glyph: 8 rows of 8 bits, mirror-symmetric, derived from the id's low 32 bits (4 bits per
+    /// row → the left half; the right half mirrors). Deterministic; the id IS the picture.
+    let glyphOf (id: System.UInt128) : byte[] =
+        [| for row in 0..7 ->
+               let nibble = byte ((id >>> (row * 4)) &&& System.UInt128.op_Implicit 0xFUL) &&& 0xFuy
+               // left half = the nibble; right half = its bit-reverse (the mirror)
+               let mutable rev = 0uy
+               for b in 0..3 do
+                   if nibble &&& (1uy <<< b) <> 0uy then rev <- rev ||| (1uy <<< (3 - b))
+               (nibble <<< 4) ||| rev |]
+
+    /// Render an id + category as MediaLines entries (a `glyph` row + a `palette` row) — the artifact
+    /// form every surface (board, card, TV) consumes; the filetype refers to THIS generator by its
+    /// registered ZetaId.
+    let toMediaLines (name: string) (category: Category) (id: System.UInt128) : MediaLines.Entry list =
+        let hex = glyphOf id |> Array.map (sprintf "%02x") |> String.concat ""
+        [ { Kind = "glyph"; Name = name; Fields = [ hex ] }
+          { Kind = "palette"; Name = name; Fields = [ string (colorOf category) ] } ]

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -162,6 +162,7 @@
     <Compile Include="MediaLines.Tests.fs" />
     <Compile Include="BoundaryLight.Tests.fs" />
     <Compile Include="GeneratorRegistry.Tests.fs" />
+    <Compile Include="ZetaIdViz.Tests.fs" />
     <Compile Include="OttoAvatar.Tests.fs" />
     <Compile Include="Chip9Treaty.Tests.fs" />
     <Compile Include="Chip8Quote.Tests.fs" />

--- a/tests/Tests.FSharp/ZetaIdViz.Tests.fs
+++ b/tests/Tests.FSharp/ZetaIdViz.Tests.fs
@@ -1,0 +1,52 @@
+module Zeta.Tests.ZetaIdVizTests
+
+// Every ZetaId category is visible: category -> CHIP-9 color (the at-a-glance channel), id bits ->
+// a mirror-symmetric identicon glyph (the id IS the picture). Deterministic everywhere; registered
+// as a generator (zetaid.glyph) so filetypes reference the visualizer by ZetaId too.
+
+open global.Xunit
+open Zeta.Core
+open Zeta.Core.FSharp.ZetaId
+
+[<Fact>]
+let ``every registered category has a color — none invisible (total, at a glance)`` () =
+    let cats =
+        [ Category.Observation; Category.Emission; Category.Workflow; Category.Heartbeat
+          Category.Batch; Category.FrictionTelemetry; Category.Bus; Category.Spawn
+          Category.WorkItem; Category.ContentAddress; Category.Extended ]
+    for c in cats do
+        let m = ZetaIdViz.colorOf c
+        Assert.True(m >= 1uy && m <= 7uy) // a real CHIP-9 color, never black/invisible
+
+[<Fact>]
+let ``the glyph is deterministic and mirror-symmetric (the id IS the picture; the face reads as a face)`` () =
+    let id = System.UInt128.op_Implicit 0xDEADBEEFCAFEUL
+    let g1 = ZetaIdViz.glyphOf id
+    Assert.Equal<byte[]>(g1, ZetaIdViz.glyphOf id)
+    Assert.Equal(8, g1.Length)
+    // mirror symmetry: bit i of the left half equals bit (7-i) overall
+    for row in g1 do
+        for b in 0..7 do
+            let l = (row >>> (7 - b)) &&& 1uy
+            let r = (row >>> b) &&& 1uy
+            Assert.Equal(l, r)
+
+[<Fact>]
+let ``distinct ids draw distinct glyphs (the discriminating pair)`` () =
+    Assert.NotEqual<byte[]>(
+        ZetaIdViz.glyphOf (System.UInt128.op_Implicit 0x12345678UL),
+        ZetaIdViz.glyphOf (System.UInt128.op_Implicit 0x87654321UL))
+
+[<Fact>]
+let ``the visualizer is itself a registered generator — referenceable by ZetaId (shape A)`` () =
+    let e = GeneratorRegistry.byName "zetaid.glyph" |> Option.get
+    Assert.Equal(32, e.ZetaId.Length)
+    Assert.Equal(Some e, GeneratorRegistry.byId e.ZetaId)
+
+[<Fact>]
+let ``toMediaLines emits the consumable artifact: a glyph row + the category's palette row`` () =
+    let entries = ZetaIdViz.toMediaLines "bus-7" Category.Bus (System.UInt128.op_Implicit 0xC0FFEEUL)
+    Assert.Equal(2, List.length entries)
+    Assert.Equal("glyph", entries.[0].Kind)
+    Assert.Equal(16, entries.[0].Fields.Head.Length) // 8 bytes hex
+    Assert.Equal("4", entries.[1].Fields.Head) // Bus = blue


### PR DESCRIPTION
Aaron: every category should have a way to visualize it — they're all generators anyway. So the viz IS a generator: 8×8 mirror-symmetric identicon from the id's own bits + a CHIP-9 color per category (all 11 covered — none invisible; Extended stays white until it earns a channel). toMediaLines emits glyph+palette rows; registered as zetaid.glyph v1 — the visualizer referenceable by its own ZetaId (shape A). 5/5 green.