### PR TITLE
feat(anim): AnimFlow — our own Rx (observables as pure functions of generated time) + git-native quotes

### DIFF
--- a/src/Core/AnimFlow.fs
+++ b/src/Core/AnimFlow.fs
@@ -1,0 +1,53 @@
+namespace Zeta.Core
+
+/// AnimFlow — **our own Rx for animations** (Aaron 2026-06-11: "we could use our own version of rx for
+/// the animations / what remains; our quotes can be git-native friendly").
+///
+/// The Rx is OURS, meaning: the observable is a **pure function of generated time** (no callbacks, no
+/// ambient clock, no subscription state) — `frameAt` maps a TimeGen tick to a frame name, and
+/// `observe` materializes a bounded window of (tick, frame) events. The four corners carry the flow:
+/// TIn = ticks (from the seeded generator), TOut = frame events, TOutFeedback = the viewer's pacing
+/// (presence slows the SAMPLING, never the math — the presence throttle), TInFeedback = co-owned
+/// drift/phase adjustment (TimeGen.feedback's twist). "What remains" is the persona=owner reading:
+/// the animation's surviving state is just (anim definition, tick) — everything else regenerates.
+///
+/// Git-native quotes (the convention, captured here; plumbing is the runner's): a playable quote's
+/// three parts are ALREADY text files, so a quote IS a git tree — savestate blob + recording blob +
+/// MediaLines meta — addressed by its commit; `refs/quotes/<zetaid>` names it; take-the-controls =
+/// BRANCH from the quote tip; sharing a quote = `git fetch` (no new transport invented — git is the
+/// quote's wire). Diffable, mergeable, citable: LexisNexis over refs.
+[<RequireQualifiedAccess>]
+module AnimFlow =
+
+    /// An animation: named frames cycled in order (parsed from a MediaLines `anim` entry's
+    /// comma-list, e.g. "idle,idle,idle,blink").
+    type Anim = { Name: string; Cycle: string list }
+
+    /// Parse a MediaLines anim entry (None = not an anim / empty cycle — honest refusal).
+    let ofEntry (e: MediaLines.Entry) : Anim option =
+        if e.Kind <> "anim" then None
+        else
+            match e.Fields with
+            | head :: _ ->
+                let cycle = head.Split(',') |> Array.toList |> List.filter (fun s -> s.Length > 0)
+                if List.isEmpty cycle then None else Some { Name = e.Name; Cycle = cycle }
+            | [] -> None
+
+    /// THE OBSERVABLE, our way: the frame at a generated tick — pure, total, replayable. No
+    /// subscription object; time indexes the stream directly (DST is the scheduler).
+    let frameAt (a: Anim) (tick: int) : string =
+        a.Cycle.[((tick % a.Cycle.Length) + a.Cycle.Length) % a.Cycle.Length]
+
+    /// Materialize a bounded window of events [t0, t0+count): the Rx "subscribe" as a value.
+    /// Pacing is the CALLER's corner (TOutFeedback): a present human samples every wallclock-paced
+    /// tick; headless samples as fast as it likes — same events either way.
+    let observe (a: Anim) (t0: int) (count: int) : (int * string) list =
+        [ for t in t0 .. t0 + max 0 count - 1 -> t, frameAt a t ]
+
+    /// Drive the animation from a TimeGen generator: the tick comes from the SEEDED clock, so two
+    /// nodes observing the same generator see the same frame at the same generated instant —
+    /// distributed animation with no coordination (the lockstep property, free).
+    let observeWith (g: TimeGen.Generator) (contributor: uint64) (a: Anim) (steps: int) : (int * string) list =
+        [ for s in 0 .. max 0 steps - 1 ->
+            let t = TimeGen.at g contributor s
+            t.Tick, frameAt a t.Tick ]

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -231,6 +231,7 @@
     <Compile Include="BoundaryLight.fs" />
     <Compile Include="GeneratorRegistry.fs" />
     <Compile Include="ZetaIdViz.fs" />
+    <Compile Include="AnimFlow.fs" />
     <Compile Include="TelemetrySource.fs" />
     <Compile Include="SimLoop.fs" />
     <Compile Include="WheelRoom.fs" />

--- a/tests/Tests.FSharp/AnimFlow.Tests.fs
+++ b/tests/Tests.FSharp/AnimFlow.Tests.fs
@@ -1,0 +1,37 @@
+module Zeta.Tests.AnimFlowTests
+
+// Our own Rx for animations: the observable is a pure function of generated time — no callbacks, no
+// ambient clock; two nodes on the same seeded generator see the same frame at the same instant.
+
+open global.Xunit
+open Zeta.Core
+
+let private breathe =
+    { AnimFlow.Name = "breathe"; AnimFlow.Cycle = [ "idle"; "idle"; "idle"; "blink" ] }
+
+[<Fact>]
+let ``parsed from MediaLines: amara's pulse and otto's breathe are anims; junk refused`` () =
+    let e: MediaLines.Entry = { Kind = "anim"; Name = "breathe"; Fields = [ "idle,idle,idle,blink" ] }
+    Assert.Equal(Some breathe, AnimFlow.ofEntry e)
+    Assert.True(AnimFlow.ofEntry { Kind = "frame"; Name = "x"; Fields = [ "aa" ] } |> Option.isNone)
+    Assert.True(AnimFlow.ofEntry { Kind = "anim"; Name = "x"; Fields = [ "" ] } |> Option.isNone)
+
+[<Fact>]
+let ``the observable is pure time-indexing: cycle order, wraparound, negatives all total`` () =
+    Assert.Equal("idle", AnimFlow.frameAt breathe 0)
+    Assert.Equal("blink", AnimFlow.frameAt breathe 3)
+    Assert.Equal("idle", AnimFlow.frameAt breathe 4) // wraps
+    Assert.Equal("blink", AnimFlow.frameAt breathe -1) // total on all of time
+
+[<Fact>]
+let ``observe materializes the subscription as a VALUE (replayable; same window, same events)`` () =
+    let w = AnimFlow.observe breathe 2 4
+    Assert.Equal<(int * string) list>([ 2, "idle"; 3, "blink"; 4, "idle"; 5, "idle" ], w)
+    Assert.Equal<(int * string) list>(w, AnimFlow.observe breathe 2 4)
+
+[<Fact>]
+let ``DISTRIBUTED FOR FREE: two nodes on the same seeded generator see identical frame streams`` () =
+    let g = TimeGen.mk "anim-clock" 1 0xA11CEUL TimeGen.PhasorTsirelson
+    let nodeA = AnimFlow.observeWith g 7UL breathe 6
+    let nodeB = AnimFlow.observeWith g 7UL breathe 6
+    Assert.Equal<(int * string) list>(nodeA, nodeB) // same common cause, same animation, no coordination

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -163,6 +163,7 @@
     <Compile Include="BoundaryLight.Tests.fs" />
     <Compile Include="GeneratorRegistry.Tests.fs" />
     <Compile Include="ZetaIdViz.Tests.fs" />
+    <Compile Include="AnimFlow.Tests.fs" />
     <Compile Include="OttoAvatar.Tests.fs" />
     <Compile Include="Chip9Treaty.Tests.fs" />
     <Compile Include="Chip8Quote.Tests.fs" />


### PR DESCRIPTION
Aaron: our own Rx for animations; quotes git-native. AnimFlow: no callbacks/subscriptions — the observable IS time-indexing (frameAt total over all time; observe = a subscription as a VALUE); four corners carry the flow; pacing is the viewer's corner (presence slows sampling, never math). Distribution tested: two nodes on one seeded generator see identical frame streams — lockstep animation, zero coordination. Git-native quote convention: a quote IS a git tree (all-text parts), refs/quotes/<zetaid>, take-the-controls = branch, sharing = fetch. 4/4 green.