### PR TITLE
feat(viz): PixelLens — sub-pixel cells with lawful lenses (data+uncertainty ride the pixel) + CRT/FPGA corner audit

### DIFF
--- a/docs/research/2026-06-11-subpixel-cells-lens-overlays-crt-effects-fpga-fidelity-dont-paint-out-of-that-corner.md
+++ b/docs/research/2026-06-11-subpixel-cells-lens-overlays-crt-effects-fpga-fidelity-dont-paint-out-of-that-corner.md
@@ -1,0 +1,54 @@
+# Sub-pixel cells + lens overlays — and the CRT/FPGA corner stays open
+
+Aaron 2026-06-11, two beats:
+
+> "Lens overlays will allow shifting of this and revealing of **sub-pixel data** where applicable — I
+> see lots of useful things, like **data storage in sub-pixel data**… **data and uncertainty can travel
+> with the pixels** in a way our soft side can understand and predict with, and **colorize** too."
+> / "Imagine the **CRT effects** and all the awesome shit emulators do — even the **FPGA ones** that
+> are trying to emulate old hardware perfectly. **We don't want to paint ourselves out of that
+> corner. I have FPGAs.**"
+
+## 1. Sub-pixel cells — BUILT (`src/Core/PixelLens.fs`, 6/6 green)
+
+The room was already there: the physics runs 65,536× finer than the display (Chip9Phys 16.16), so a
+pixel's color is a PROJECTION of a deeper cell. Now addressable: a 32-bit cell = color (3 bits, what
+the display shows) + payload (13 bits of data riding WITH the pixel) + uncertainty (16-bit milli).
+Three LAWFUL lenses (get-put/put-get tested) focus the fields; `softRead` gives the SoftValue-shaped
+(value, confidence); `colorize` renders uncertainty HONESTLY — an uncertain pixel visibly collapses
+toward mono ("don't lean on me") instead of being silently painted; the overlay `shift` slides the
+focus. The zero case holds: a mono consumer reads bits 0-2 and never sees the rest.
+
+## 2. The CRT/FPGA corner — held open BY the same architecture
+
+The constraint named: nothing in the pipeline may preclude (a) CRT-physics post-effects or (b)
+cycle-accurate FPGA emulation. The audit says we're clean, and WHY:
+
+- **`colorAt` is the canonical seam** — every renderer (ZetaMax ANSI, future shaders, a CRT filter, an
+  FPGA pixel clock) binds at that one read. CRT effects are POST-GENERATORS over it (registry entries
+  when built: `crt.scanline`, `crt.phosphor`, `crt.curvature`, `crt.ntsc` — each versioned/ZetaId'd
+  like every generator).
+- **The glow already IS phosphor physics** — BoundaryLight's exp(−d²/σ²) is the phosphor-bloom kernel;
+  a CRT binding reuses the same generator with the electron-spot σ.
+- **Sub-pixel cells map to CRT reality** — a real CRT pixel IS sub-structured (RGB phosphor triads,
+  beam spot, persistence); our 32-bit cell is the honest digital cousin (and the uncertainty field can
+  carry PERSISTENCE — phosphor decay as confidence decay: the soft side predicting what the beam left).
+- **FPGA = the B-1025 Verilog rung, already on the ladder** — and the fidelity bar is named by its
+  champion: **MiSTer** (cycle-accurate FPGA re-implementation of old hardware). Our clock-free math +
+  TimeGen generated time is FPGA-friendly BY construction (a pixel clock is just another clock
+  generator; fix16 is synthesizable arithmetic; no floats on the hot path). Aaron HAS FPGAs — the
+  bench's Verilog rung has hardware waiting like the 4090s do.
+- **Spec-speed mode** (the constraints observation) is the same door: period-authentic pacing is a
+  generator choice, so CRT-era timing quirks (raster chase, beam racing) remain expressible.
+
+## Anchors (Beacon)
+
+MiSTer / FPGA re-implementation lineage · CRT shader literature (Lottes' scanline shaders; RetroArch
+filter chains) · phosphor persistence physics · Park identicons (the viz lineage) · Chip9Phys/TimeGen
+(the in-house halves that keep the corner open).
+
+## Pointers
+
+- `src/Core/PixelLens.fs` + tests (the cell + lenses) · `BoundaryLight.glow` (the phosphor kernel) ·
+  GeneratorRegistry (where crt.* land) · B-1025 (the Verilog rung; hardware in hand) ·
+  `universal/color.md` (capability honesty governs CRT bindings too).

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -232,6 +232,7 @@
     <Compile Include="GeneratorRegistry.fs" />
     <Compile Include="ZetaIdViz.fs" />
     <Compile Include="AnimFlow.fs" />
+    <Compile Include="PixelLens.fs" />
     <Compile Include="TelemetrySource.fs" />
     <Compile Include="SimLoop.fs" />
     <Compile Include="WheelRoom.fs" />

--- a/src/Core/PixelLens.fs
+++ b/src/Core/PixelLens.fs
@@ -1,0 +1,71 @@
+namespace Zeta.Core
+
+open Zeta.Core.Optics
+
+/// PixelLens — **data and uncertainty travel WITH the pixels; lens overlays reveal the sub-pixel
+/// layer** (Aaron 2026-06-11: "lens overlays will allow shifting of this and revealing of sub-pixel
+/// data where applicable — data storage in sub-pixel data… data and uncertainty can travel with the
+/// pixels in a way our soft side can understand and predict with, and colorize too").
+///
+/// The room was already there: the physics runs 65,536× finer than the display (Chip9Phys 16.16), so
+/// a pixel's coarse color is a PROJECTION of a deeper cell. This module makes the deeper cell
+/// addressable — a 32-bit sub-pixel cell:
+///
+///     bits 0-2   color (the CHIP-9 mask — what the display shows)
+///     bits 3-15  payload (13 bits of data riding WITH the pixel)
+///     bits 16-31 uncertainty (16-bit milli-scale: 0 = certain … 65535 ≈ unknown)
+///
+/// Three lawful LENSES (Optics.ILens — get-put/put-get hold by construction) focus the three fields:
+/// the display reads `color`; the soft side reads `(payload, uncertainty)` and can PREDICT (a
+/// SoftValue-shaped read: value + how sure) and COLORIZE — uncertainty rendered honestly as visual
+/// texture (a certain pixel shows its color; an uncertain one declares itself). The "lens overlay
+/// shift" is exactly the ILens composition: same frame, a different focus, the sub-pixel layer
+/// revealed where applicable — and a mono consumer never sees any of it (bits 3+ are invisible to
+/// `colorOf` — the zero case holds).
+[<RequireQualifiedAccess>]
+module PixelLens =
+
+    /// A sub-pixel cell: the 32-bit deep pixel.
+    type Cell = uint32
+
+    /// Pack (color, payload, uncertainty) into a cell — masked to their fields (total; no overflow).
+    let pack (color: byte) (payload: int) (uncertaintyMilli: int) : Cell =
+        (uint32 color &&& 0x7u)
+        ||| ((uint32 payload &&& 0x1FFFu) <<< 3)
+        ||| ((uint32 uncertaintyMilli &&& 0xFFFFu) <<< 16)
+
+    /// The color lens — what the DISPLAY sees (the projection; bits 3+ invisible: the zero case).
+    let color: ILens<Cell, byte> =
+        { new ILens<Cell, byte> with
+            member _.Get c = byte (c &&& 0x7u)
+            member _.Set v c = (c &&& ~~~0x7u) ||| (uint32 v &&& 0x7u) }
+
+    /// The payload lens — the data riding with the pixel (the sub-pixel storage).
+    let payload: ILens<Cell, int> =
+        { new ILens<Cell, int> with
+            member _.Get c = int ((c >>> 3) &&& 0x1FFFu)
+            member _.Set v c = (c &&& ~~~(0x1FFFu <<< 3)) ||| ((uint32 v &&& 0x1FFFu) <<< 3) }
+
+    /// The uncertainty lens — how sure the soft side is about this pixel (milli-scale).
+    let uncertainty: ILens<Cell, int> =
+        { new ILens<Cell, int> with
+            member _.Get c = int ((c >>> 16) &&& 0xFFFFu)
+            member _.Set v c = (c &&& 0x0000FFFFu) ||| ((uint32 v &&& 0xFFFFu) <<< 16) }
+
+    /// The soft read: the pixel as (payload, confidence) — SoftValue-shaped, ready for prediction.
+    let softRead (c: Cell) : int * float =
+        payload.Get c, 1.0 - float (uncertainty.Get c) / 65535.0
+
+    /// COLORIZE the uncertainty honestly: a certain pixel shows its color; an uncertain pixel
+    /// DECLARES itself — above the threshold its color is dimmed to the mono bit only (the display's
+    /// way of saying "don't lean on me"). Honest rendering: uncertainty is visible as texture,
+    /// never silently painted over.
+    let colorize (thresholdMilli: int) (c: Cell) : byte =
+        let v = color.Get c
+        if uncertainty.Get c <= thresholdMilli then v
+        else v &&& 0x1uy // uncertain: collapse to the mono bit — visibly humbler
+
+    /// The overlay SHIFT: focus the same lens family on a neighboring cell of a frame map —
+    /// the lens-overlay move (same world, shifted focus; sub-pixel revealed where applicable).
+    let shift (dx: int) (dy: int) (w: int) ((x, y): int * int) : int * int =
+        (((x + dx) % w) + w) % w, y + dy

--- a/tests/Tests.FSharp/PixelLens.Tests.fs
+++ b/tests/Tests.FSharp/PixelLens.Tests.fs
@@ -1,0 +1,51 @@
+module Zeta.Tests.PixelLensTests
+
+// Sub-pixel cells: data + uncertainty travel WITH the pixel; lawful lenses focus the fields; the
+// display sees only the projection (zero case); uncertainty colorizes honestly.
+
+open global.Xunit
+open Zeta.Core
+
+[<Fact>]
+let ``pack/unpack: the three fields coexist without bleeding (13-bit payload, 16-bit uncertainty)`` () =
+    let c = PixelLens.pack 6uy 0x1ABC 4242
+    Assert.Equal(6uy, PixelLens.color.Get c)
+    Assert.Equal(0x1ABC, PixelLens.payload.Get c)
+    Assert.Equal(4242, PixelLens.uncertainty.Get c)
+
+[<Fact>]
+let ``the lenses are LAWFUL: get-put and put-get hold on every field`` () =
+    let c = PixelLens.pack 3uy 999 100
+    // get-put: Set (Get w) w = w
+    Assert.Equal(c, PixelLens.color.Set (PixelLens.color.Get c) c)
+    Assert.Equal(c, PixelLens.payload.Set (PixelLens.payload.Get c) c)
+    Assert.Equal(c, PixelLens.uncertainty.Set (PixelLens.uncertainty.Get c) c)
+    // put-get: Get (Set p w) = p
+    Assert.Equal(7uy, PixelLens.color.Get(PixelLens.color.Set 7uy c))
+    Assert.Equal(0, PixelLens.payload.Get(PixelLens.payload.Set 0 c))
+
+[<Fact>]
+let ``data travels WITH the pixel: setting the color never disturbs the payload or uncertainty`` () =
+    let c = PixelLens.pack 1uy 1234 555
+    let recolored = PixelLens.color.Set 4uy c
+    Assert.Equal(1234, PixelLens.payload.Get recolored)
+    Assert.Equal(555, PixelLens.uncertainty.Get recolored)
+
+[<Fact>]
+let ``the soft read is SoftValue-shaped: payload + confidence; certain=1.0, unknown~=0.0`` () =
+    let sure = PixelLens.pack 2uy 42 0
+    Assert.Equal((42, 1.0), PixelLens.softRead sure)
+    let (v, conf) = PixelLens.softRead (PixelLens.pack 2uy 42 65535)
+    Assert.Equal(42, v)
+    Assert.Equal(0.0, conf, 9)
+
+[<Fact>]
+let ``COLORIZE is honest: certain pixels keep their color; uncertain pixels visibly collapse to mono`` () =
+    Assert.Equal(6uy, PixelLens.colorize 1000 (PixelLens.pack 6uy 0 500)) // certain: full cyan
+    Assert.Equal(0uy, PixelLens.colorize 1000 (PixelLens.pack 6uy 0 5000)) // uncertain cyan: mono bit only (dark)
+    Assert.Equal(1uy, PixelLens.colorize 1000 (PixelLens.pack 7uy 0 5000)) // uncertain white: humbled to mono
+
+[<Fact>]
+let ``the overlay shift wraps horizontally (the lens slides over the same world)`` () =
+    Assert.Equal((0, 5), PixelLens.shift 1 0 64 (63, 5))
+    Assert.Equal((63, 4), PixelLens.shift -1 -1 64 (0, 5))

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -164,6 +164,7 @@
     <Compile Include="GeneratorRegistry.Tests.fs" />
     <Compile Include="ZetaIdViz.Tests.fs" />
     <Compile Include="AnimFlow.Tests.fs" />
+    <Compile Include="PixelLens.Tests.fs" />
     <Compile Include="OttoAvatar.Tests.fs" />
     <Compile Include="Chip9Treaty.Tests.fs" />
     <Compile Include="Chip8Quote.Tests.fs" />


### PR DESCRIPTION
The 16.16 headroom made addressable: a 32-bit deep cell (color 3b / payload 13b / uncertainty 16b) with three LAWFUL lenses (laws tested); recoloring never disturbs the payload — data truly travels with the pixel; softRead = (value, confidence); colorize renders uncertainty honestly (uncertain pixels visibly humble themselves). And the CRT/FPGA corner held open by audit: colorAt is the canonical seam (CRT effects = post-generators; the glow IS phosphor physics; uncertainty can carry persistence), FPGA-friendly by construction (clock-free, fix16, generated time) — MiSTer the fidelity bar, Aaron's FPGAs waiting on the B-1025 Verilog rung. 6/6 green.