### PR TITLE
feat(chip9): Chip9SelfTrace — the smallest fully-self-reflective system (it ray-traces its own instructions AND reads its own worldline via its own ISA)

### DIFF
--- a/src/Core/Chip9SelfTrace.fs
+++ b/src/Core/Chip9SelfTrace.fs
@@ -1,0 +1,77 @@
+namespace Zeta.Core
+
+/// Chip9SelfTrace — **CHIP-9 ray-traces its OWN instructions onto its OWN planes, in real time**
+/// (Aaron 2026-06-11: "we are literally building out chip8 ray tracing of its own instructions — it
+/// would be amazing if it could run this on itself at runtime. Our chip9 should be the SMALLEST SYSTEM
+/// THAT CAN BE FULLY SELF-REFLECTIVE about its own running instruction set, in real time, in soft
+/// mode — full hardware to the bone with qemu/microkernel reflection, tiny").
+///
+/// Channel assignment — REVISED by a live discovery (the first run had executed=R=mono, and the
+/// program's OWN DRW fought the trace for the mono plane: XOR toggled the worldline off — the
+/// reflection channel must never be the program's performance channel, the Grok lesson at pixel
+/// scale). The trace therefore lives on the planes programs rarely select:
+/// - **G (plane 2)** — the EXECUTED path: each step paints the cell of the PC that just ran.
+/// - **CYAN (mask 6 = G|B)** — the DATA flow: addresses the step READ (I-window on DRW/FX65).
+/// - **B (plane 4)** — the SPECULATED future: the PCs `SoftChip8.lookAhead` would visit next.
+/// - **R (mono)** — stays the PROGRAM'S OWN: its display is untouched by reflection.
+///
+/// Address→pixel: instruction slot (addr−0x200)/2 maps onto the 64×32 grid (2048 cells ≥ 1792 slots —
+/// the whole program space fits ON the display; the trace IS the program's worldline drawn over its
+/// own address space, Feynman-diagram style).
+///
+/// **The self-reflective jewel — no new opcodes needed:** the trace lands in the machine's OWN plane
+/// memory, and DRW's collision flag (VF) reports XOR hits per selected plane — so a ROM can ASK
+/// "have I been here?" by drawing a probe sprite on the R plane at any cell and reading VF. The
+/// machine reads its own worldline THROUGH its own instruction set. Self-reflection in soft mode,
+/// full ISA to the bone; the QEMU/microkernel rung gets the same trace surface at metal (named slice).
+[<RequireQualifiedAccess>]
+module Chip9SelfTrace =
+
+    /// Map a code address to its trace cell on the 64×32 grid (instruction slots; total — wraps).
+    let cellOf (addr: int) : int * int =
+        let slot = ((max 0 (addr - Chip8.ProgramStart)) / 2) % (Chip8.DisplayW * Chip8.DisplayH)
+        slot % Chip8.DisplayW, slot / Chip8.DisplayW
+
+    // paint a plane bit directly into the frame's own plane storage (the HOST half of reflection —
+    // the same cells DRW sees; mono Display = plane 1 (R), Extra bits 1-2 = G/B).
+    let private paint (mask: byte) ((x, y): int * int) (f: Chip8Cow.Frame) : Chip8Cow.Frame =
+        let idx = (y % Chip8.DisplayH) * Chip8.DisplayW + (x % Chip8.DisplayW)
+        let f1 =
+            if mask &&& 1uy <> 0uy then { f with Display = Map.add idx true f.Display } else f
+        let hi = mask &&& 0b110uy
+        if hi = 0uy then f1
+        else
+            let cur = Map.tryFind idx f1.Extra |> Option.defaultValue 0uy
+            { f1 with Extra = Map.add idx (cur ||| hi) f1.Extra }
+
+    /// The addresses a step at `f` READS beyond the opcode (the G channel's data flow).
+    let private dataReads (f: Chip8Cow.Frame) : int list =
+        let pc = int f.PC
+        let op =
+            (int (Map.tryFind pc f.Mem |> Option.defaultValue 0uy) <<< 8)
+            ||| int (Map.tryFind (pc + 1) f.Mem |> Option.defaultValue 0uy)
+        match op &&& 0xF000 with
+        | 0xD000 -> [ for i in 0 .. (op &&& 0xF) - 1 -> int f.I + i ]
+        | 0xF000 when op &&& 0xFF = 0x65 -> [ for i in 0 .. ((op &&& 0x0F00) >>> 8) -> int f.I + i ]
+        | _ -> []
+
+    /// One SELF-TRACING step: paint the about-to-execute PC on R, its data reads on G, the speculated
+    /// future on B (lookahead PCs) — THEN execute. The machine's worldline accumulates in its own
+    /// plane memory as it runs.
+    let traceStep (specDepth: int) (f: Chip8Cow.Frame) : Chip8Cow.Frame =
+        // G: the executed path (this PC) — the program keeps mono for itself
+        let f1 = paint 2uy (cellOf (int f.PC)) f
+        // CYAN: the data flow of this step
+        let f2 = dataReads f |> List.fold (fun acc a -> paint 6uy (cellOf a) acc) f1
+        // B: the speculated future (where lookAhead would walk, fork-honest: stops at input branches)
+        let rec spec n (s: Chip8Cow.Frame) (acc: Chip8Cow.Frame) =
+            if n <= 0 || SoftChip8.branchesOnInput s then acc
+            else
+                let s' = Chip8Cow.step s
+                spec (n - 1) s' (paint 4uy (cellOf (int s'.PC)) acc)
+        let f3 = spec (max 0 specDepth) f2 f2
+        Chip8Cow.step f3
+
+    /// Run n self-tracing steps — the program ray-traces itself while running itself.
+    let run (specDepth: int) (steps: int) (f: Chip8Cow.Frame) : Chip8Cow.Frame =
+        List.fold (fun acc _ -> traceStep specDepth acc) f [ 1 .. max 0 steps ]

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -233,6 +233,7 @@
     <Compile Include="ZetaIdViz.fs" />
     <Compile Include="AnimFlow.fs" />
     <Compile Include="PixelLens.fs" />
+    <Compile Include="Chip9SelfTrace.fs" />
     <Compile Include="TelemetrySource.fs" />
     <Compile Include="SimLoop.fs" />
     <Compile Include="WheelRoom.fs" />

--- a/tests/Tests.FSharp/Chip9SelfTrace.Tests.fs
+++ b/tests/Tests.FSharp/Chip9SelfTrace.Tests.fs
@@ -1,0 +1,65 @@
+module Zeta.Tests.Chip9SelfTraceTests
+
+// The smallest fully-self-reflective system: CHIP-9 ray-traces its own running instruction set onto
+// its own planes (R=executed, G=data, B=speculation) — and can READ its own worldline through its own
+// ISA (DRW collision = "have I been here?"). Soft mode, full ISA to the bone, tiny.
+
+open global.Xunit
+open Zeta.Core
+
+// the BREATHE-style loop: I=0x208; draw; jump back — a closed worldline.
+let private loopRom = [| 0xA2uy; 0x08uy; 0xD0uy; 0x01uy; 0x12uy; 0x00uy; 0x00uy; 0x00uy; 0xFFuy |]
+let private frame () = Chip8Cow.create 7UL |> Chip8Cow.loadRom loopRom
+
+[<Fact>]
+let ``the executed path paints GREEN on the machine's own planes (mono stays the program's)`` () =
+    let f = Chip9SelfTrace.run 0 3 (frame ())
+    // PCs 0x200,0x202,0x204 -> slots 0,1,2 -> cells (0,0),(1,0),(2,0): G bit set
+    Assert.True(Chip8Cow.colorAt 0 0 f &&& 2uy <> 0uy)
+    Assert.True(Chip8Cow.colorAt 1 0 f &&& 2uy <> 0uy)
+    Assert.True(Chip8Cow.colorAt 2 0 f &&& 2uy <> 0uy)
+    Assert.Equal(0uy, Chip8Cow.colorAt 10 0 f &&& 6uy) // unvisited code: no trace channels lit
+
+[<Fact>]
+let ``the loop's worldline CLOSES: more steps add no new trace cells (the cycle is visible)`` () =
+    let short = Chip9SelfTrace.run 0 3 (frame ())
+    let long = Chip9SelfTrace.run 0 30 (frame ())
+    let traceCells (f: Chip8Cow.Frame) =
+        Set.ofList [ for x in 0..63 do for y in 0..31 do if Chip8Cow.colorAt x y f &&& 2uy <> 0uy then yield x, y ]
+    Assert.Equal<Set<int * int>>(traceCells short, traceCells long) // the attractor, painted
+
+[<Fact>]
+let ``data flow paints CYAN: the sprite read via I shows on G|B`` () =
+    let f = Chip9SelfTrace.run 0 2 (frame ()) // step 2 executes DRW which reads 0x208
+    let gx, gy = Chip9SelfTrace.cellOf 0x208
+    Assert.Equal(6uy, Chip8Cow.colorAt gx gy f &&& 6uy)
+
+[<Fact>]
+let ``speculation paints BLUE ahead of execution (the future, fork-honest)`` () =
+    let f = Chip9SelfTrace.traceStep 2 (frame ()) // before executing 0x200, speculate 2 ahead
+    let b1x, b1y = Chip9SelfTrace.cellOf 0x202
+    let b2x, b2y = Chip9SelfTrace.cellOf 0x204
+    Assert.True(Chip8Cow.colorAt b1x b1y f &&& 4uy <> 0uy)
+    Assert.True(Chip8Cow.colorAt b2x b2y f &&& 4uy <> 0uy)
+
+[<Fact>]
+let ``THE JEWEL: the machine reads its own worldline THROUGH its own ISA — DRW collision says "I was here"`` () =
+    // run the loop self-tracing, then have the MACHINE probe its own trace: select plane 1 (R),
+    // draw a 1-pixel sprite at cell (0,0) — VF=1 iff the trace already lit that cell (it did: PC 0x200).
+    let traced = Chip9SelfTrace.run 0 6 (frame ())
+    let probeRom =
+        [| 0xF2uy; 0x01uy // plane := 2 (the executed-path channel — G)
+           0x60uy; 0x00uy; 0x61uy; 0x00uy // V0=0, V1=0 (cell 0,0 — its own first instruction's cell)
+           0xA3uy; 0x00uy // I = 0x300 (probe sprite)
+           0xD0uy; 0x11uy |] // draw 1 row at (0,0) -> collision iff its own past is there
+    let probed =
+        probeRom
+        |> Array.indexed
+        |> Array.fold (fun (m: Chip8Cow.Frame) (i, b) -> { m with Mem = Map.add (0x200 + i) b m.Mem }) traced
+        |> fun f0 -> { f0 with Mem = Map.add 0x300 0x80uy f0.Mem; PC = uint16 0x200 }
+        |> fun f0 -> List.fold (fun acc _ -> Chip8Cow.step acc) f0 [ 1..5 ]
+    Assert.Equal(1uy, probed.V.[0xF]) // "yes — I have been here": self-reflection via the ISA itself
+
+[<Fact>]
+let ``deterministic: the self-trace replays bit-identically (soft mode, DST to the bone)`` () =
+    Assert.Equal<Chip8Cow.Frame>(Chip9SelfTrace.run 2 12 (frame ()), Chip9SelfTrace.run 2 12 (frame ()))

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -165,6 +165,7 @@
     <Compile Include="ZetaIdViz.Tests.fs" />
     <Compile Include="AnimFlow.Tests.fs" />
     <Compile Include="PixelLens.Tests.fs" />
+    <Compile Include="Chip9SelfTrace.Tests.fs" />
     <Compile Include="OttoAvatar.Tests.fs" />
     <Compile Include="Chip9Treaty.Tests.fs" />
     <Compile Include="Chip8Quote.Tests.fs" />


### PR DESCRIPTION
The program space maps onto the display — the trace IS the worldline drawn over its own address space, live. Channels revised by a live discovery (the program's own DRW fought the trace on mono: the reflection channel must never be the performance channel — the Grok lesson at pixel scale): executed=G, data=cyan, speculation=B (fork-honest), mono stays the program's. The loop's worldline visibly CLOSES (the attractor painted). THE JEWEL TESTED: a probe ROM draws a 1-pixel sprite on the trace plane at its own first instruction's cell — VF=1 = 'I have been here': self-reflection with zero new opcodes, DRW collision was the introspection primitive all along. Bit-identical replay. 6/6 green; qemu/microkernel trace surface = named next rungs.