### PR TITLE
docs(craft): soft lensing — sweep the soft prism for fingerprints, or solid ground

### DIFF
--- a/docs/research/2026-06-11-soft-lensing-sweep-the-soft-prism-to-find-fingerprints-or-solid-ground.md
+++ b/docs/research/2026-06-11-soft-lensing-sweep-the-soft-prism-to-find-fingerprints-or-solid-ground.md
@@ -1,0 +1,52 @@
+# Soft lensing — sweep the soft prism over a field to find fingerprints, or solid ground
+
+Aaron 2026-06-11 (right after the self-trace landed): *"We also have a **soft lensing** technique for
+finding fingerprints — **or more solid ground**."*
+
+## The technique, named precisely (every organ already exists)
+
+**Soft lensing = a LENS swept over a field, scoring each focus with the SOFT PRISM's kernel.** The
+gravitational-lensing reading is exact and earns the name: lensing reveals mass you cannot see directly
+by how it bends what you CAN see — soft lensing reveals STRUCTURE you can't read directly (a game in a
+quote, an attractor in a self-trace, a generator in a byte field) by how strongly the soft fingerprint
+kernel responds as the focus sweeps.
+
+The sweep has two distinct finds, his two words:
+
+1. **Fingerprints** — similarity peaks: where `FingerprintPrism.soft` (the MinHash/kernel similarity ≥
+   threshold) lights up against the known-wholes table, you've FOUND a thing (which game, which loop,
+   which persona's state — the recognition direction).
+2. **Solid ground** — certainty peaks: where the field's own uncertainty is LOW (`PixelLens.uncertainty`
+   per cell; the SoftValue confidence), the sweep marks ground you can BUILD on — SolidGround in the
+   lifetime sense (static, load-bearing) found empirically rather than declared. The same sweep, the
+   other channel: peak similarity finds WHAT it is; peak confidence finds WHERE to stand.
+
+## The composition (mechanical, organ by organ)
+
+```
+sweep:    Optics.ILens focus  ×  PixelLens.shift (the overlay slide)
+score:    FingerprintPrism.soft (MinHash / any kernel — the PSD discipline applies)
+field:    a self-trace's planes · a quote's masked ROM · a sub-pixel payload sheet · any MediaLines doc
+output:   (focus, score, confidence) triples — a HEAT MAP of recognition and a GROUND MAP of certainty
+render:   the two maps on the CHIP-9 planes (found-structure on one channel, solid-ground on another —
+          the board shows where the swarm can stand and what it is standing on)
+```
+
+The self-trace makes this immediately useful: sweep the soft lens over a machine's OWN execution trace
+and the peaks name its attractors (the archaeology arc's "name things" step gets its instrument); sweep
+it over a quote's masked ROM and the peaks say which game family the quote cites (LexisNexis gains a
+similarity citator).
+
+## Honest scope
+
+The organs exist (soft prism, lenses, shift, uncertainty cells, ZetaMax render); the SWEEP COMPOSITION
+is the named buildable — small, but today closed with the self-trace and this is its instrument panel:
+filed as the next slice rather than rushed at day's end. Beacon: gravitational lensing (Eddington 1919 —
+the inference-from-bending move) · MinHash (Broder 1997) · perceptual hashing · matched filtering
+(the signal-processing name for sweep-and-score).
+
+## Pointers
+
+- `FingerprintPrism` (the soft rainbow — the score) · `Optics.ILens` + `PixelLens.shift` (the sweep) ·
+  `PixelLens.uncertainty`/`softRead` (the ground channel) · `Chip9SelfTrace` (the first field to sweep)
+  · `Chip8Quote` (the second) · the archaeology arc ("name things" — this is the namer's instrument).


### PR DESCRIPTION
Named with every organ already built: lens-sweep (ILens × shift) scored by the soft prism (MinHash/PSD kernel). Two finds, two channels: similarity peaks = fingerprints (recognition); confidence peaks = SOLID GROUND found empirically (the lifetime sense). First fields: the self-trace (the 'name things' instrument — peaks name attractors) and quote ROMs (a similarity citator). Eddington/Broder/matched-filtering anchored; the sweep composition filed as next slice. Docs only.