### PR TITLE
docs(craft): solid ground as Spectrum tiles (Alexa's channel) + zero clocks = the image format IS the parallel program

### DIFF
--- a/docs/research/2026-06-11-soft-lensing-sweep-the-soft-prism-to-find-fingerprints-or-solid-ground.md
+++ b/docs/research/2026-06-11-soft-lensing-sweep-the-soft-prism-to-find-fingerprints-or-solid-ground.md
@@ -1,0 +1,52 @@
+# Soft lensing — sweep the soft prism over a field to find fingerprints, or solid ground
+
+Aaron 2026-06-11 (right after the self-trace landed): *"We also have a **soft lensing** technique for
+finding fingerprints — **or more solid ground**."*
+
+## The technique, named precisely (every organ already exists)
+
+**Soft lensing = a LENS swept over a field, scoring each focus with the SOFT PRISM's kernel.** The
+gravitational-lensing reading is exact and earns the name: lensing reveals mass you cannot see directly
+by how it bends what you CAN see — soft lensing reveals STRUCTURE you can't read directly (a game in a
+quote, an attractor in a self-trace, a generator in a byte field) by how strongly the soft fingerprint
+kernel responds as the focus sweeps.
+
+The sweep has two distinct finds, his two words:
+
+1. **Fingerprints** — similarity peaks: where `FingerprintPrism.soft` (the MinHash/kernel similarity ≥
+   threshold) lights up against the known-wholes table, you've FOUND a thing (which game, which loop,
+   which persona's state — the recognition direction).
+2. **Solid ground** — certainty peaks: where the field's own uncertainty is LOW (`PixelLens.uncertainty`
+   per cell; the SoftValue confidence), the sweep marks ground you can BUILD on — SolidGround in the
+   lifetime sense (static, load-bearing) found empirically rather than declared. The same sweep, the
+   other channel: peak similarity finds WHAT it is; peak confidence finds WHERE to stand.
+
+## The composition (mechanical, organ by organ)
+
+```
+sweep:    Optics.ILens focus  ×  PixelLens.shift (the overlay slide)
+score:    FingerprintPrism.soft (MinHash / any kernel — the PSD discipline applies)
+field:    a self-trace's planes · a quote's masked ROM · a sub-pixel payload sheet · any MediaLines doc
+output:   (focus, score, confidence) triples — a HEAT MAP of recognition and a GROUND MAP of certainty
+render:   the two maps on the CHIP-9 planes (found-structure on one channel, solid-ground on another —
+          the board shows where the swarm can stand and what it is standing on)
+```
+
+The self-trace makes this immediately useful: sweep the soft lens over a machine's OWN execution trace
+and the peaks name its attractors (the archaeology arc's "name things" step gets its instrument); sweep
+it over a quote's masked ROM and the peaks say which game family the quote cites (LexisNexis gains a
+similarity citator).
+
+## Honest scope
+
+The organs exist (soft prism, lenses, shift, uncertainty cells, ZetaMax render); the SWEEP COMPOSITION
+is the named buildable — small, but today closed with the self-trace and this is its instrument panel:
+filed as the next slice rather than rushed at day's end. Beacon: gravitational lensing (Eddington 1919 —
+the inference-from-bending move) · MinHash (Broder 1997) · perceptual hashing · matched filtering
+(the signal-processing name for sweep-and-score).
+
+## Pointers
+
+- `FingerprintPrism` (the soft rainbow — the score) · `Optics.ILens` + `PixelLens.shift` (the sweep) ·
+  `PixelLens.uncertainty`/`softRead` (the ground channel) · `Chip9SelfTrace` (the first field to sweep)
+  · `Chip8Quote` (the second) · the archaeology arc ("name things" — this is the namer's instrument).

--- a/docs/research/2026-06-11-solid-ground-as-spectrum-attribute-tiles-alexas-8bit-entry-plus-zero-clocks-infinite-draw-threads.md
+++ b/docs/research/2026-06-11-solid-ground-as-spectrum-attribute-tiles-alexas-8bit-entry-plus-zero-clocks-infinite-draw-threads.md
@@ -1,0 +1,51 @@
+# Solid ground as Spectrum-attribute tiles (Alexa's 8-bit entry) + zero clocks, infinite draw threads — in the image format itself
+
+Aaron 2026-06-11, two beats on the soft-lensing close:
+
+> "We should be able to represent **solid ground in some Tetris-style, some tiling style — like the
+> Spectrum but 8-bit style**. This will let **Alexa get her 8-bit style in** too."
+> / "And the no-clocks is awesome — **0 clocks, infinite draw threads, in an image format**."
+
+## 1. Solid ground as tiles — the Spectrum attribute system, repurposed
+
+The ZX Spectrum's signature constraint: the screen is 8×8 ATTRIBUTE CELLS, each carrying one color
+pair for all its pixels — the look every Spectrum game wears. Repurposed as the GROUND MAP's render:
+
+- the soft-lens sweep yields per-cell confidence; quantize the field into 8×8 attribute tiles;
+- a tile whose cells are uniformly high-confidence becomes a SOLID tile (full attribute color — ground
+  you can stand on); mixed tiles render as the Spectrum's classic attribute-clash texture (the
+  honesty: uncertainty at tile granularity LOOKS like clash — the constraint becomes the indicator);
+- **Tetris-style**: solid tiles PACK — contiguous certain regions tile into tetromino-like solids
+  (the eye reads load-bearing ground the way a Tetris player reads a settled stack: gaps are exactly
+  where you cannot stand). Filling ground = clearing lines = the bug-economy's ΔU made visible.
+- **Alexa's entry**: this tiling register is HERS — her pixel-card aesthetic (the 8-bit portrait
+  lineage) becomes a first-class render binding (`tiles.spectrum-attr` in the registry when built),
+  joining the board's ANSI, the lens's Mono1, and ZetaMax's palette as a peer style. Her style, her
+  channel — the persona register growing the way the roster did.
+
+## 2. Zero clocks, infinite draw threads — a property of the FORMAT, not just the renderer
+
+The clock-free discipline (TimeGen + pure generators) lands its sharpest consequence: every cell of a
+generated image is a PURE FUNCTION of (stored text, seed, coordinates[, tick]) — no sequencing, no
+shared state, **zero clocks** — so ANY number of draw threads can each compute ANY subset
+independently: tile-parallel, scanline-parallel, lens-window-parallel, machine-parallel (the GPU rung,
+the FPGA rung, a swarm of CHIP-9s each owning a tile). And because the generators live IN the file
+(MediaLines `gen` lines with their ZetaIds + common-cause seed), **the image format itself is the
+parallel program** — shipping a picture ships the means to draw it at any width of parallelism, with
+byte-identical output at every width (determinism is per-cell, so thread count cannot change the
+picture — the scale-free spec, met by a file format).
+
+## Honest scope
+
+Both are RENDER BINDINGS over built organs (the ground map from soft lensing; the pure generators from
+BoundaryLight/TimeGen) — the tile binding and the parallel scheduler are named slices, filed with this
+capture. Beacon: ZX Spectrum attribute cells (the 1982 constraint-as-aesthetic); Tetris (Pajitnov
+1984 — settled-stack legibility); embarrassingly-parallel rendering (the raytracing tradition);
+map-reduce over pure functions.
+
+## Pointers
+
+- the soft-lensing doc (the ground map this renders) · PixelLens (per-cell confidence) · ZetaMax +
+  universal/color.md (the binding family this joins) · GeneratorRegistry (tiles.spectrum-attr when
+  built) · rooms/amara + the Alexa register flag (the persona styles, each earning a channel) ·
+  BoundaryLight/TimeGen (why zero clocks holds).


### PR DESCRIPTION
Solid ground rendered ZX-Spectrum-attribute style: solid 8×8 tiles where confidence is uniform, attribute-clash texture where it's mixed (the constraint becomes the honesty indicator), tetromino packing for settled-stack legibility — and the tiling register is Alexa's 8-bit entry, a peer binding to ANSI/Mono1/ZetaMax. Plus the zero-clock consequence: every generated cell is pure (text, seed, coords) → infinite draw threads, byte-identical at any width — and with gen lines in the file, the image format itself is the parallel program. Docs only; bindings filed as slices.