### PR TITLE
feat(core): add Q#-locked Bell state prep

### DIFF
--- a/src/Core/BellState.fs
+++ b/src/Core/BellState.fs
@@ -1,0 +1,55 @@
+namespace Zeta.Core
+
+/// Two-qubit Bell-state preparation on the same complex amplitude substrate as `QubitIso`.
+[<RequireQualifiedAccess>]
+module BellState =
+
+    let private c = ImaginaryStack.complex
+
+    /// Basis order is `|00>`, `|01>`, `|10>`, `|11>`, matching the Q# oracle fixture.
+    type State =
+        { ZeroZero: Complex
+          ZeroOne: Complex
+          OneZero: Complex
+          OneOne: Complex }
+
+    let zeroZero: State =
+        { ZeroZero = c.One
+          ZeroOne = c.Zero
+          OneZero = c.Zero
+          OneOne = c.Zero }
+
+    let private scale (factor: float) (z: Complex) : Complex =
+        c.Mul({ Real = factor; Imag = 0.0 }, z)
+
+    let private magSq (z: Complex) : float = z.Real * z.Real + z.Imag * z.Imag
+
+    let normSq (state: State) : float =
+        magSq state.ZeroZero + magSq state.ZeroOne + magSq state.OneZero + magSq state.OneOne
+
+    let probabilities (state: State) : float[] =
+        let n = normSq state
+        if n = 0.0 then
+            [| 0.0; 0.0; 0.0; 0.0 |]
+        else
+            [| magSq state.ZeroZero / n
+               magSq state.ZeroOne / n
+               magSq state.OneZero / n
+               magSq state.OneOne / n |]
+
+    /// Apply H to the first qubit.
+    let hadamardFirst (state: State) : State =
+        let invSqrt2 = 1.0 / sqrt 2.0
+        { ZeroZero = c.Add(state.ZeroZero, state.OneZero) |> scale invSqrt2
+          ZeroOne = c.Add(state.ZeroOne, state.OneOne) |> scale invSqrt2
+          OneZero = c.Add(state.ZeroZero, c.Negate state.OneZero) |> scale invSqrt2
+          OneOne = c.Add(state.ZeroOne, c.Negate state.OneOne) |> scale invSqrt2 }
+
+    /// Apply CNOT with the first qubit as control and the second as target.
+    let cnot01 (state: State) : State =
+        { state with
+            OneZero = state.OneOne
+            OneOne = state.OneZero }
+
+    /// Prepare `|Φ+> = (|00> + |11>) / sqrt(2)` from `|00>` via `H(0); CNOT(0,1)`.
+    let phiPlus () : State = zeroZero |> hadamardFirst |> cnot01

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -212,6 +212,7 @@
     <Compile Include="ForwardMomentum.fs" />
     <Compile Include="QubitIso.fs" />
     <Compile Include="BellTest.fs" />
+    <Compile Include="BellState.fs" />
     <Compile Include="FeedbackThrottle.fs" />
     <Compile Include="Chip8.fs" />
     <Compile Include="Chip8Cow.fs" />

--- a/tests/Tests.FSharp/QSharpOracle.Tests.fs
+++ b/tests/Tests.FSharp/QSharpOracle.Tests.fs
@@ -49,6 +49,9 @@ let private gateMatrix (name: string) =
 let private matrixEntry (matrix: JsonElement) row col =
     matrix[row][col] |> jsonComplex
 
+let private jsonFloatArray (element: JsonElement) =
+    element.EnumerateArray() |> Seq.map _.GetDouble() |> Seq.toArray
+
 let private singleQubitCase (id: string) =
     vectors.GetProperty("singleQubitMeasurement").EnumerateArray()
     |> Seq.find (fun item -> item.GetProperty("id").GetString() = id)
@@ -64,6 +67,12 @@ let private probabilities (case: JsonElement) =
 let private assertQSharpColumn (matrix: JsonElement) col (state: QubitIso.JoinState) =
     complexCloseTo (matrixEntry matrix 0 col) state.A
     complexCloseTo (matrixEntry matrix 1 col) state.B
+
+let private assertQSharpBellColumn (matrix: JsonElement) col (state: BellState.State) =
+    complexCloseTo (matrixEntry matrix 0 col) state.ZeroZero
+    complexCloseTo (matrixEntry matrix 1 col) state.ZeroOne
+    complexCloseTo (matrixEntry matrix 2 col) state.OneZero
+    complexCloseTo (matrixEntry matrix 3 col) state.OneOne
 
 let private probabilityFor frame probabilities =
     probabilities
@@ -165,6 +174,22 @@ let ``BellTest canonical CHSH observables match the Q# golden vector`` () =
     closeTo (correlators.GetProperty("E(aPrime,bPrime)").GetDouble()) (BellTest.correlation a' b')
     closeTo (canonical.GetProperty("s").GetDouble()) (BellTest.chsh a a' b b')
     closeTo (canonical.GetProperty("tsirelson").GetDouble()) BellTest.TsirelsonBound
+
+[<Fact>]
+let ``BellState PhiPlus preparation matches the Q# two-qubit oracle`` () =
+    let bell = vectors.GetProperty("bellChsh")
+    let prepared = BellState.phiPlus ()
+
+    assertQSharpBellColumn (gateMatrix "BellPhiPlusPrep") 0 prepared
+
+    let expectedProbabilities = bell.GetProperty("preparation").GetProperty("probabilities") |> jsonFloatArray
+    let actualProbabilities = BellState.probabilities prepared
+    Assert.Equal(expectedProbabilities.Length, actualProbabilities.Length)
+
+    Array.zip expectedProbabilities actualProbabilities
+    |> Array.iter (fun (expected, actual) -> closeTo expected actual)
+
+    closeTo 1.0 (BellState.normSq prepared)
 
 [<Fact>]
 let ``single-qubit probability formulas match the Q# observable treaty`` () =


### PR DESCRIPTION
## Summary
- add `BellState` two-qubit amplitude state in Q# basis order (`|00>`, `|01>`, `|10>`, `|11>`)
- implement `H(0)`, `CNOT(0,1)`, Born probabilities, and `PhiPlus` preparation
- pin `BellState.phiPlus()` to the committed Q# `BellPhiPlusPrep` vector and Q# Bell preparation probabilities

## Context
Otto is moving the CHIP-9/self-trace lane forward on main; this keeps Vera on the Q# oracle path and closes the two-qubit Bell-prep gap already present in `qsharp-golden.json`.

## Verification
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter 'FullyQualifiedName~QSharpOracleTests|FullyQualifiedName~BellTestTests'` (13 passed)\n- `dotnet build -c Release` (0 warnings, 0 errors)\n- `dotnet test Zeta.sln -c Release` (3,299 passed, 1 skipped)\n- `dotnet format --verify-no-changes --include src/Core/BellState.fs src/Core/Core.fsproj tests/Tests.FSharp/QSharpOracle.Tests.fs`\n- `git diff --check`