### PR TITLE
feat(weave): Amara's commuting proof BUILT (residue preserved as uncertainty) + SoftLens sweep + her review ferried

### DIFF
--- a/docs/research/2026-06-11-ferry-amara-review-of-the-night-wave-reflection-not-aesthetics-plus-the-weave-commuting-proof-built.md
+++ b/docs/research/2026-06-11-ferry-amara-review-of-the-night-wave-reflection-not-aesthetics-plus-the-weave-commuting-proof-built.md
@@ -1,0 +1,44 @@
+# Ferry (Amara) — her review of the night wave ("the through-line is REFLECTION, not aesthetics") + her two named proofs, one already built tonight
+
+> Ferry discipline: Aaron passed two Amara analyses; her structure and keepers preserved; the build
+> answers follow.
+
+## Her review (the substance, kept)
+
+The convergence named: ZetaId generators → visual identity · ZetaMax → display · PixelLens → data +
+uncertainty riding pixels · AnimFlow → generated-time observables · git-native quotes → branchable
+state · SelfTrace → the machine ray-tracing its own execution. Her truth-stack: **ZetaMax = display
+truth · ZetaIdViz = identity truth · PixelLens = sub-pixel truth · AnimFlow = time truth · SelfTrace =
+execution truth.** Her tiny blade, taken as standing guidance: *"the next step should resist becoming
+'cool graphics' — the strongest through-line is reflection, not aesthetics."* Her keeper: *"CHIP-9 is
+becoming the smallest reflective room: it can show what it is, where it is, what kind of thing it is
+touching, what time generated the motion, and eventually what instruction made the light."*
+
+Her peel of the category thread, kept clean: the unifier is **"everything becomes a structure-
+preserving fold over observable change"** — banana split is a VIEW-FUSION LAW inside the engine, not
+the engine; category theory earns its keep as *"a discipline for not lying to ourselves"* — natural
+transformations = different derivation routes MUST agree (incremental vs rebuild; F# vs TS/Rust/C#
+bytes; migration vs backfill) — *"different routes through the diagram must commute, or the system is
+lying."* And the consciousness language peeled (her words): reactive interface synthesis, not
+"mathematics of consciousness"; preservation, not resurrection.
+
+## Her two named proofs — status
+
+1. **SelfTrace proof** (program P, N instructions → trace pixels; same seed = identical trace; soft
+   cells visibly marked): **two-thirds already green** — the trace writes executed/data/spec onto the
+   planes and replays bit-identically (#7684's tests). The remaining third — uncertain cells visibly
+   marked via PixelLens colorize composed with the trace — is the named slice.
+2. **The weave commuting proof** (two streams, one cross-repo edge, one view; same V in every valid
+   replay order for the commutative part; non-commutative residue preserved as uncertainty, NOT
+   erased): **BUILT TONIGHT — `src/Core/WeaveFold.fs`, 4/4 green.** Every valid replay order folds to
+   the same view (the diagram commutes, tested over four orders); intra-stream causality supersedes;
+   concurrent unordered writes are KEPT as candidate sets (never last-writer-wins'd — the residue is
+   honest uncertainty); and the weave EDGE resolves residue AS DATA, itself order-independently.
+   "A stream is a local worldline; a weave is a causal fabric; a state is a fold over a chosen cut" —
+   now a commuting diagram with a test, exactly as she asked.
+
+## Pointers
+
+- `src/Core/WeaveFold.fs` + tests (proof 2) · `Chip9SelfTrace` (proof 1's green two-thirds) ·
+  `PixelLens.colorize` (the remaining third's organ) · her truth-stack as the board's column headers
+  (the reflection register, not the aesthetics one).

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -271,6 +271,7 @@
     <Compile Include="GameFingerprint.fs" />
     <Compile Include="FingerprintPrism.fs" />
     <Compile Include="SoftLens.fs" />
+    <Compile Include="WeaveFold.fs" />
     <Compile Include="SoftTie.fs" />
     <Compile Include="LinguisticSeed.fs" />
     <Compile Include="ConformalGA.fs" />

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -270,6 +270,7 @@
     <Compile Include="GamePortfolio.fs" />
     <Compile Include="GameFingerprint.fs" />
     <Compile Include="FingerprintPrism.fs" />
+    <Compile Include="SoftLens.fs" />
     <Compile Include="SoftTie.fs" />
     <Compile Include="LinguisticSeed.fs" />
     <Compile Include="ConformalGA.fs" />

--- a/src/Core/SoftLens.fs
+++ b/src/Core/SoftLens.fs
@@ -1,0 +1,62 @@
+namespace Zeta.Core
+
+/// SoftLens — **the soft-lensing sweep, implemented** (filed in the naming doc; Aaron: "a soft lensing
+/// technique for finding fingerprints — or more solid ground").
+///
+/// The composition, exactly as named: a WINDOW (the lens focus) swept over a field, each focus scored
+/// two ways — **similarity** against a needle (the soft prism's MinHash kernel: fingerprint peaks =
+/// FOUND structure) and **confidence** (the PixelLens uncertainty channel: certainty peaks = SOLID
+/// GROUND). Same sweep, two channels; the output is a heat map of recognition and a ground map of
+/// where to stand. Deterministic, total, zero clocks (every window scores independently — the
+/// infinite-draw-threads property holds for ANALYSIS too).
+[<RequireQualifiedAccess>]
+module SoftLens =
+
+    /// One scored focus: where the lens was, how strongly the needle matched, how certain the ground.
+    type Focus =
+        { X: int
+          Y: int
+          Similarity: float
+          Confidence: float }
+
+    /// Extract a w×h window's bytes from a field reader (row-major; the reader is any (x,y) → byte —
+    /// a trace frame's colorAt, a sub-pixel payload sheet, a masked ROM rendered to cells).
+    let window (read: int -> int -> byte) (x0: int) (y0: int) (w: int) (h: int) : byte[] =
+        [| for dy in 0 .. h - 1 do
+               for dx in 0 .. w - 1 -> read (x0 + dx) (y0 + dy) |]
+
+    /// THE SWEEP: slide a w×h lens over a fieldW×fieldH field (stride 1), scoring each focus —
+    /// similarity = soft-prism MinHash vs the needle; confidence = the mean confidence the
+    /// `conf` reader reports over the window (1.0 where the field carries no uncertainty channel).
+    let sweep
+        (read: int -> int -> byte)
+        (conf: int -> int -> float)
+        (needle: byte[])
+        (fieldW: int)
+        (fieldH: int)
+        (w: int)
+        (h: int)
+        : Focus list =
+        let needleSketch = FingerprintPrism.softBytes needle
+
+        [ for y0 in 0 .. fieldH - h do
+              for x0 in 0 .. fieldW - w do
+                  let bytes = window read x0 y0 w h
+                  let sim = FingerprintPrism.softBytesSimilarity needleSketch (FingerprintPrism.softBytes bytes)
+
+                  let c =
+                      let mutable acc = 0.0
+                      for dy in 0 .. h - 1 do
+                          for dx in 0 .. w - 1 do
+                              acc <- acc + conf (x0 + dx) (y0 + dy)
+                      acc / float (w * h)
+
+                  yield { X = x0; Y = y0; Similarity = sim; Confidence = c } ]
+
+    /// FINGERPRINT peaks: the foci whose similarity clears the threshold, best first.
+    let fingerprints (threshold: float) (foci: Focus list) : Focus list =
+        foci |> List.filter (fun f -> f.Similarity >= threshold) |> List.sortByDescending (fun f -> f.Similarity)
+
+    /// SOLID-GROUND peaks: the foci whose confidence clears the threshold, best first — where to stand.
+    let solidGround (threshold: float) (foci: Focus list) : Focus list =
+        foci |> List.filter (fun f -> f.Confidence >= threshold) |> List.sortByDescending (fun f -> f.Confidence)

--- a/src/Core/WeaveFold.fs
+++ b/src/Core/WeaveFold.fs
@@ -1,0 +1,64 @@
+namespace Zeta.Core
+
+/// WeaveFold — **Amara's touch-metal proof for the fabric of time, built**: two streams, one
+/// cross-repo edge, one derived view — *"folding over the joined causal cut produces the same V
+/// regardless of valid replay order for the commutative part; and private/non-commutative residue is
+/// preserved as SoftValue uncertainty, NOT erased."*
+///
+/// Her cleaned stack honored: the view is a STRUCTURE-PRESERVING FOLD over observable change; the
+/// commutative part needs no coordination (CALM — order-free by construction: per-key value SETS,
+/// union-folded); the non-commutative part (concurrent writes to one key with no causal order between
+/// them) is the RESIDUE — surfaced as explicit uncertainty (all candidates kept) instead of silently
+/// last-writer-wins'd. Different routes through the diagram must commute, or the system is lying —
+/// here the commuting IS the test.
+[<RequireQualifiedAccess>]
+module WeaveFold =
+
+    /// One event on a worldline: which stream, its local sequence number, the key it writes, the value.
+    type Ev =
+        { Stream: string
+          Seq: int
+          Key: string
+          Value: string }
+
+    /// The derived view: per key, the SET of causally-unordered candidate values. ONE candidate =
+    /// certain (the commutative/public part); MORE = the residue, preserved as uncertainty.
+    type View = Map<string, Set<string>>
+
+    /// Fold a replay order into the view. Within one stream, later Seq SUPERSEDES earlier (causal
+    /// order exists); across streams there is no order (unless the weave edge supplies one), so
+    /// concurrent writes ACCUMULATE as candidates. Set-union semantics make the cross-stream part
+    /// commutative by construction.
+    let fold (events: Ev list) : View =
+        // per stream+key keep only the latest Seq (the intra-stream causal order)
+        let latestPerStream =
+            events
+            |> List.groupBy (fun e -> e.Stream, e.Key)
+            |> List.map (fun (_, es) -> es |> List.maxBy (fun e -> e.Seq))
+
+        latestPerStream
+        |> List.fold
+            (fun (v: View) e ->
+                let cur = Map.tryFind e.Key v |> Option.defaultValue Set.empty
+                Map.add e.Key (Set.add e.Value cur) v)
+            Map.empty
+
+    /// Resolve the weave EDGE: a causal edge "A's write supersedes B's for key k" — applied AFTER the
+    /// fold (the edge is data, not code): the superseded candidate is removed where the superseding
+    /// one is present. Residue without an edge stays uncertain — honestly.
+    type Edge = { Key: string; Winner: string; Superseded: string }
+
+    let resolve (edges: Edge list) (v: View) : View =
+        edges
+        |> List.fold
+            (fun (acc: View) e ->
+                match Map.tryFind e.Key acc with
+                | Some s when Set.contains e.Winner s -> Map.add e.Key (Set.remove e.Superseded s) acc
+                | _ -> acc)
+            v
+
+    /// Is a key CERTAIN (exactly one candidate — the public/commutative part) or RESIDUE (uncertain)?
+    let certain (k: string) (v: View) : string option =
+        match Map.tryFind k v with
+        | Some s when Set.count s = 1 -> Some(Set.minElement s)
+        | _ -> None

--- a/tests/Tests.FSharp/SoftLens.Tests.fs
+++ b/tests/Tests.FSharp/SoftLens.Tests.fs
@@ -1,0 +1,47 @@
+module Zeta.Tests.SoftLensTests
+
+// The soft-lensing sweep: similarity peaks find fingerprints; confidence peaks find solid ground.
+// First real field: a CHIP-9 self-trace — the sweep finds the loop's attractor pattern in the
+// machine's own worldline (the archaeologist's instrument, working).
+
+open global.Xunit
+open Zeta.Core
+
+// a field with a planted pattern: an 8x8 block of 0xAB bytes at (10,4) in a 32x16 zero field
+let private read x y = if x >= 10 && x < 18 && y >= 4 && y < 12 then 0xABuy else 0x00uy
+// confidence: high inside a "measured" region (x<20), low beyond it
+let private conf x _ = if x < 20 then 0.95 else 0.2
+
+[<Fact>]
+let ``the sweep finds the planted fingerprint at its true location (the top peak)`` () =
+    let needle = Array.create 64 0xABuy // the 8x8 pattern we're looking for
+    let foci = SoftLens.sweep read conf needle 32 16 8 8
+    let top = SoftLens.fingerprints 0.9 foci |> List.head
+    Assert.Equal((10, 4), (top.X, top.Y))
+    Assert.Equal(1.0, top.Similarity, 9) // exact match at the true site
+
+[<Fact>]
+let ``solid ground is the OTHER channel: certainty peaks are where the field was measured`` () =
+    let foci = SoftLens.sweep read conf (Array.create 64 0uy) 32 16 8 8
+    let ground = SoftLens.solidGround 0.9 foci
+    Assert.True(ground |> List.forall (fun f -> f.X + 8 <= 20)) // standing room only where measured
+    Assert.True(List.length ground > 0)
+
+[<Fact>]
+let ``the sweep is deterministic and total (zero clocks — every focus independent)`` () =
+    let needle = Array.create 64 0xABuy
+    let a = SoftLens.sweep read conf needle 32 16 8 8
+    Assert.Equal<SoftLens.Focus list>(a, SoftLens.sweep read conf needle 32 16 8 8)
+    Assert.Equal((32 - 8 + 1) * (16 - 8 + 1), List.length a) // every focus visited
+
+[<Fact>]
+let ``ON A REAL FIELD: the sweep finds the self-trace's attractor in the machine's own worldline`` () =
+    // run the BREATHE-style loop self-tracing; sweep for a horizontal run of trace-green cells
+    let loopRom = [| 0xA2uy; 0x08uy; 0xD0uy; 0x01uy; 0x12uy; 0x00uy; 0x00uy; 0x00uy; 0xFFuy |]
+    let traced = Chip9SelfTrace.run 0 12 (Chip8Cow.create 7UL |> Chip8Cow.loadRom loopRom)
+    let readTrace x y = if Chip8Cow.colorAt x y traced &&& 2uy <> 0uy then 1uy else 0uy
+    // needle: a 4x1 run of executed cells (the loop's worldline shape: slots 0..2 + part of the jump cycle)
+    let needle = [| 1uy; 1uy; 1uy; 0uy |]
+    let foci = SoftLens.sweep readTrace (fun _ _ -> 1.0) needle 64 32 4 1
+    let top = SoftLens.fingerprints 0.99 foci |> List.head
+    Assert.Equal((0, 0), (top.X, top.Y)) // the attractor found at the program's own first cells

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -167,6 +167,7 @@
     <Compile Include="PixelLens.Tests.fs" />
     <Compile Include="Chip9SelfTrace.Tests.fs" />
     <Compile Include="SoftLens.Tests.fs" />
+    <Compile Include="WeaveFold.Tests.fs" />
     <Compile Include="OttoAvatar.Tests.fs" />
     <Compile Include="Chip9Treaty.Tests.fs" />
     <Compile Include="Chip8Quote.Tests.fs" />

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -166,6 +166,7 @@
     <Compile Include="AnimFlow.Tests.fs" />
     <Compile Include="PixelLens.Tests.fs" />
     <Compile Include="Chip9SelfTrace.Tests.fs" />
+    <Compile Include="SoftLens.Tests.fs" />
     <Compile Include="OttoAvatar.Tests.fs" />
     <Compile Include="Chip9Treaty.Tests.fs" />
     <Compile Include="Chip8Quote.Tests.fs" />

--- a/tests/Tests.FSharp/WeaveFold.Tests.fs
+++ b/tests/Tests.FSharp/WeaveFold.Tests.fs
@@ -1,0 +1,43 @@
+module Zeta.Tests.WeaveFoldTests
+
+// Amara's commuting-diagram-with-a-test: two streams advance independently; folding over the joined
+// causal cut yields the SAME view in every valid replay order (the commutative part); concurrent
+// unordered writes are PRESERVED as uncertainty (the residue), never silently erased; the weave edge,
+// when it arrives, resolves residue as DATA.
+
+open global.Xunit
+open Zeta.Core
+
+let private a1 = { WeaveFold.Stream = "A"; WeaveFold.Seq = 1; WeaveFold.Key = "x"; WeaveFold.Value = "a-old" }
+let private a2 = { WeaveFold.Stream = "A"; WeaveFold.Seq = 2; WeaveFold.Key = "x"; WeaveFold.Value = "a-new" }
+let private b1 = { WeaveFold.Stream = "B"; WeaveFold.Seq = 1; WeaveFold.Key = "x"; WeaveFold.Value = "b-val" }
+let private b2 = { WeaveFold.Stream = "B"; WeaveFold.Seq = 1; WeaveFold.Key = "y"; WeaveFold.Value = "only" }
+
+[<Fact>]
+let ``COMMUTES: every valid replay order folds to the SAME view (the diagram does not lie)`` () =
+    let orders =
+        [ [ a1; a2; b1; b2 ]; [ b2; b1; a1; a2 ]; [ a1; b1; a2; b2 ]; [ b1; a1; b2; a2 ] ]
+    let views = orders |> List.map WeaveFold.fold
+    for v in List.tail views do
+        Assert.Equal<WeaveFold.View>(List.head views, v)
+
+[<Fact>]
+let ``intra-stream causality holds: A's later write supersedes its own earlier one`` () =
+    let v = WeaveFold.fold [ a1; a2; b2 ]
+    Assert.Equal(Some "a-new", WeaveFold.certain "x" v) // a-old gone (same worldline), b absent here
+    Assert.Equal(Some "only", WeaveFold.certain "y" v)
+
+[<Fact>]
+let ``THE RESIDUE IS PRESERVED: concurrent unordered writes stay as candidates — never last-writer-wins`` () =
+    let v = WeaveFold.fold [ a1; a2; b1 ]
+    Assert.True(WeaveFold.certain "x" v |> Option.isNone) // uncertain, honestly
+    Assert.Equal<Set<string>>(Set.ofList [ "a-new"; "b-val" ], Map.find "x" v) // both kept
+
+[<Fact>]
+let ``the weave EDGE resolves residue as DATA: the edge arrives, certainty follows`` () =
+    let v = WeaveFold.fold [ a1; a2; b1 ]
+    let resolved = WeaveFold.resolve [ { Key = "x"; Winner = "a-new"; Superseded = "b-val" } ] v
+    Assert.Equal(Some "a-new", WeaveFold.certain "x" resolved)
+    // and resolution is order-independent too: resolve after any replay order, same answer
+    let v2 = WeaveFold.fold [ b1; a2; a1 ]
+    Assert.Equal<WeaveFold.View>(resolved, WeaveFold.resolve [ { Key = "x"; Winner = "a-new"; Superseded = "b-val" } ] v2)


### PR DESCRIPTION
Her touch-metal ask, green the night she named it: WeaveFold — four valid replay orders fold to ONE view (the diagram commutes); intra-stream causality supersedes; concurrent unordered writes KEPT as candidate sets (residue = honest uncertainty, never last-writer-wins); the weave edge resolves residue as data, order-independently. Plus SoftLens (the sweep: fingerprint + solid-ground peaks; finds the self-trace's attractor) and her review ferried — her blade adopted as standing guidance: the through-line is REFLECTION, not aesthetics. 8/8 green.