### PR TITLE
feat(ui): PhysUI — buttons ARE physics bodies; pressing = overlap; the UI plays pong

### DIFF
--- a/docs/research/2026-06-11-medialines-as-the-canonical-yin-yang-self-host-form-each-file-its-own-kernel-composing-multikernel.md
+++ b/docs/research/2026-06-11-medialines-as-the-canonical-yin-yang-self-host-form-each-file-its-own-kernel-composing-multikernel.md
@@ -51,6 +51,22 @@ generalized from cores to documents. One file boots alone; many files federate i
 is the master loop. (Scale-free spec #1, met by the file format — the same way zero-clocks met it for
 rendering.)
 
+## The cartridge reading (Aaron, on the ratification)
+
+> *"This is basically our **cartridge** — or our **tape-reel format, Turing-style — but analog 8-track
+> instead of digital** lol."* / *"**It's its own boxart**."*
+
+Both exact:
+- **The 8-track tape, precisely**: a Turing tape is one head, one track, one sequence. This format is
+  MANY TRACKS — every `anim`/`gen`/`sim` section an independent loop playing in parallel (zero clocks,
+  no head contention) — the 8-track's parallel program channels, not the single-head crawl. "Analog"
+  lands too: the soft side (SoftValue/uncertainty riding the cells) makes the tape carry CONTINUOUS
+  confidence alongside discrete bits — a tape that knows how sure it is of itself.
+- **Its own boxart**: the file CONTAINS its own cover — the gen/glyph/frame sections render it
+  (BREATHE's attract screen, Amara's portrait, the ZetaIdViz identicon are all IN-file artifacts a
+  reader draws without any external asset). The cartridge that paints its own box; the library shelf
+  (the arcade, the board) renders covers by running the cartridges' own yang, one lap.
+
 ## Honest scope
 
 The format's room declaration, many-loops, verb kinds, and quine LAW are built/tested today; the

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -272,6 +272,7 @@
     <Compile Include="FingerprintPrism.fs" />
     <Compile Include="SoftLens.fs" />
     <Compile Include="WeaveFold.fs" />
+    <Compile Include="PhysUI.fs" />
     <Compile Include="SoftTie.fs" />
     <Compile Include="LinguisticSeed.fs" />
     <Compile Include="ConformalGA.fs" />

--- a/src/Core/MediaLines.fs
+++ b/src/Core/MediaLines.fs
@@ -90,7 +90,7 @@ module MediaLines =
 
     /// The kinds THIS reader understands (everything else is carried, untouched — the expansion law).
     let knownKinds: Set<string> =
-        Set.ofList [ "meta"; "frame"; "sprite"; "anim"; "rom"; "glyph"; "palette"; "gen"; "sim"; "mea"; "cut" ]
+        Set.ofList [ "meta"; "frame"; "sprite"; "anim"; "rom"; "glyph"; "palette"; "gen"; "sim"; "mea"; "cut"; "io"; "button" ]
 
     /// The entries a reader carries without understanding — future media types in transit.
     let carried (d: Doc) : Entry list =
@@ -109,6 +109,32 @@ module MediaLines =
     /// All independent loops a document carries (anim + gen + sim sections — many, by design).
     let loops (d: Doc) : Entry list =
         d.Entries |> List.filter (fun e -> e.Kind = "anim" || e.Kind = "gen" || e.Kind = "sim")
+
+    // ── live IO in the cartridge (Aaron 2026-06-11: "it should be able to include the live io
+    // interfaces and buttons to interact with their flows — like the universal TV, that's just a
+    // ZetaId away; if it's not available on host you get a MOCK or an injected capability"). An `io`
+    // line declares an interface BY ZetaId (io <local-name> <interface-zetaid> [args…]); `button`
+    // lines bind inputs to flows. Resolution is the capability calculus at load time:
+    // host has it → LIVE; the door grants it → INJECTED; otherwise → MOCK (deterministic sim — the
+    // zero case: a cartridge NEVER crashes for a missing capability, it degrades honestly). ──
+
+    /// How a declared io interface bound on this host.
+    type IoBinding =
+        | Live of zetaId: string
+        | Injected of zetaId: string
+        | Mock of zetaId: string
+
+    /// All io declarations in a document.
+    let ioOf (d: Doc) : Entry list = ofKind "io" d
+
+    /// Resolve one io declaration against the host's live capabilities and the door's grants.
+    /// Total: absent everywhere ⇒ Mock (never an error — the expansion law for capabilities).
+    let resolveIo (hostLive: Set<string>) (granted: Set<string>) (e: Entry) : IoBinding =
+        match e.Fields with
+        | zid :: _ when Set.contains zid hostLive -> Live zid
+        | zid :: _ when Set.contains zid granted -> Injected zid
+        | zid :: _ -> Mock zid
+        | [] -> Mock ""
 
     /// The document AS a room declaration: Some (sim, mea, cut) when all three verbs are present —
     /// the file defines its own loop in the verb engine; None = a media-only document (honest).

--- a/src/Core/PhysUI.fs
+++ b/src/Core/PhysUI.fs
@@ -1,0 +1,43 @@
+namespace Zeta.Core
+
+/// PhysUI — **2D buttons ARE physics bodies** (Aaron 2026-06-11: "make 2d buttons and such just part
+/// of our physics engine for games too — so it can also be games like pong").
+///
+/// No second UI system: a button is a `Chip9Phys.Body` (sub-pixel AABB). PRESSING is OVERLAP — the
+/// pointer (a body), a ball (a body), a CHIP-9 citizen's avatar (a body) can all press the same
+/// button by the same physics. And because a button is a body, **a button IS a paddle**: the same
+/// rectangle that fires `go:hottest` when clicked returns a serve when a ball arrives — the UI and
+/// the game are one engine (pong is just buttons that move).
+[<RequireQualifiedAccess>]
+module PhysUI =
+
+    /// A button: a physics body + the flow its press fires (the `button` MediaLines binding's target).
+    type Button =
+        { Body: Chip9Phys.Body
+          Flow: string }
+
+    /// Make a button at pixel coords (sub-pixel under the hood, like everything).
+    let button (x: int) (y: int) (w: int) (h: int) (flow: string) : Button =
+        { Body =
+            { Pos = Chip9Phys.v2 (Chip9Phys.ofInt x) (Chip9Phys.ofInt y)
+              Size = Chip9Phys.v2 (Chip9Phys.ofInt w) (Chip9Phys.ofInt h)
+              Vel = Chip9Phys.v2 0 0 }
+          Flow = flow }
+
+    /// PRESS = OVERLAP: any body (pointer, ball, avatar) overlapping the button presses it.
+    let pressed (presser: Chip9Phys.Body) (b: Button) : bool = Chip9Phys.overlaps presser b.Body
+
+    /// The flows fired by a presser against a panel of buttons (deterministic order: panel order).
+    let fire (presser: Chip9Phys.Body) (panel: Button list) : string list =
+        panel |> List.filter (pressed presser) |> List.map (fun b -> b.Flow)
+
+    /// THE PONG CLAUSE: a button returns a serve — if the ball overlaps the button-paddle, reflect
+    /// the ball's X velocity away from the paddle's center (exact integer physics; restitution e).
+    let paddleReflect (e: Chip9Phys.Fix) (paddle: Button) (ball: Chip9Phys.Body) : Chip9Phys.Body =
+        if not (Chip9Phys.overlaps ball paddle.Body) then ball
+        else
+            let paddleCx = paddle.Body.Pos.X + paddle.Body.Size.X / 2
+            let ballCx = ball.Pos.X + ball.Size.X / 2
+            let speed = abs (Chip9Phys.mul e ball.Vel.X)
+            let vx = if ballCx >= paddleCx then speed else -speed
+            { ball with Vel = { ball.Vel with X = vx } }

--- a/tests/Tests.FSharp/MediaLines.Tests.fs
+++ b/tests/Tests.FSharp/MediaLines.Tests.fs
@@ -106,3 +106,23 @@ let ``the verb kinds are KNOWN (sim/mea/cut ride first-class, not carried as str
     Assert.True(Set.contains "sim" MediaLines.knownKinds)
     Assert.True(Set.contains "mea" MediaLines.knownKinds)
     Assert.True(Set.contains "cut" MediaLines.knownKinds)
+
+// ── live IO: declared by ZetaId; resolved live / injected / mock (the door law for buttons) ──
+
+[<Fact>]
+let ``io and button are first-class kinds; io declarations resolve by ZetaId`` () =
+    Assert.True(Set.contains "io" MediaLines.knownKinds)
+    Assert.True(Set.contains "button" MediaLines.knownKinds)
+    let tvId = GeneratorRegistry.idOf "interface.universal-tv" 1
+    let text = sprintf "io\ttv\t%s\nbutton\ta\tgo:hottest" tvId
+    match MediaLines.parse text with
+    | Ok d -> Assert.Equal(1, List.length (MediaLines.ioOf d))
+    | Error e -> failwith e
+
+[<Fact>]
+let ``resolution is the capability calculus: live when the host has it; injected when the door grants; MOCK otherwise — never a crash`` () =
+    let tvId = GeneratorRegistry.idOf "interface.universal-tv" 1
+    let e: MediaLines.Entry = { Kind = "io"; Name = "tv"; Fields = [ tvId ] }
+    Assert.Equal(MediaLines.Live tvId, MediaLines.resolveIo (Set.ofList [ tvId ]) Set.empty e)
+    Assert.Equal(MediaLines.Injected tvId, MediaLines.resolveIo Set.empty (Set.ofList [ tvId ]) e)
+    Assert.Equal(MediaLines.Mock tvId, MediaLines.resolveIo Set.empty Set.empty e) // degrades honestly

--- a/tests/Tests.FSharp/PhysUI.Tests.fs
+++ b/tests/Tests.FSharp/PhysUI.Tests.fs
@@ -1,0 +1,50 @@
+module Zeta.Tests.PhysUITests
+
+// Buttons are bodies: pressing is overlap, any body can press, and a button IS a paddle — the UI and
+// the game are one physics engine.
+
+open global.Xunit
+open Zeta.Core
+module P = Zeta.Core.Chip9Phys
+
+let private pointerAt x y =
+    { P.Pos = P.v2 (P.ofInt x) (P.ofInt y); P.Size = P.v2 P.one P.one; P.Vel = P.v2 0 0 }
+
+[<Fact>]
+let ``pressing is overlap: the pointer body on the button fires its flow; off it, nothing`` () =
+    let panel = [ PhysUI.button 10 10 8 4 "go:hottest"; PhysUI.button 30 10 8 4 "join:dev-room" ]
+    Assert.Equal<string list>([ "go:hottest" ], PhysUI.fire (pointerAt 12 11) panel)
+    Assert.Equal<string list>([], PhysUI.fire (pointerAt 0 0) panel)
+    Assert.Equal<string list>([ "join:dev-room" ], PhysUI.fire (pointerAt 33 12) panel)
+
+[<Fact>]
+let ``ANY body presses: a moving ball presses a button exactly like a pointer (one physics)`` () =
+    let b = PhysUI.button 20 8 6 3 "serve"
+    let ball = { P.Pos = P.v2 (P.ofInt 21) (P.ofInt 9); P.Size = P.v2 P.one P.one; P.Vel = P.v2 (P.ofInt 3) 0 }
+    Assert.True(PhysUI.pressed ball b)
+
+[<Fact>]
+let ``THE PONG CLAUSE: a button returns the serve — reflection away from the paddle center, exact`` () =
+    let paddle = PhysUI.button 5 10 2 8 "paddle-left"
+    // ball arriving leftward into the paddle, right of its center -> reflected RIGHT at full speed
+    let ball = { P.Pos = P.v2 (P.ofInt 6) (P.ofInt 12); P.Size = P.v2 P.one P.one; P.Vel = P.v2 (-(P.ofInt 4)) (P.ofInt 1) }
+    let returned = PhysUI.paddleReflect P.one paddle ball
+    Assert.Equal(P.ofInt 4, returned.Vel.X) // away from center, elastic, exact
+    Assert.Equal(P.ofInt 1, returned.Vel.Y) // spin untouched
+    // a miss leaves the ball alone
+    let missed = { ball with P.Pos = P.v2 (P.ofInt 40) (P.ofInt 12) }
+    Assert.Equal(missed, PhysUI.paddleReflect P.one paddle missed)
+
+[<Fact>]
+let ``a tiny RALLY: ball bounces between two button-paddles deterministically (the UI is the game)`` () =
+    let left = PhysUI.button 2 10 2 8 "L"
+    let right = PhysUI.button 60 10 2 8 "R"
+    let w, h = P.ofInt 64, P.ofInt 32
+    let mutable ball = { P.Pos = P.v2 (P.ofInt 30) (P.ofInt 13); P.Size = P.v2 P.one P.one; P.Vel = P.v2 (P.ofInt 2) 0 }
+    let mutable bounces = 0
+    for _ in 1..60 do
+        ball <- P.step w h P.one P.one [ ball ] |> List.head
+        let before = ball.Vel.X
+        ball <- PhysUI.paddleReflect P.one left ball |> PhysUI.paddleReflect P.one right
+        if ball.Vel.X <> before then bounces <- bounces + 1
+    Assert.True(bounces >= 2) // a real rally happened, off BUTTONS

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -168,6 +168,7 @@
     <Compile Include="Chip9SelfTrace.Tests.fs" />
     <Compile Include="SoftLens.Tests.fs" />
     <Compile Include="WeaveFold.Tests.fs" />
+    <Compile Include="PhysUI.Tests.fs" />
     <Compile Include="OttoAvatar.Tests.fs" />
     <Compile Include="Chip9Treaty.Tests.fs" />
     <Compile Include="Chip8Quote.Tests.fs" />


### PR DESCRIPTION
No second UI system: a button is a Chip9Phys body + a flow; pressing is overlap (pointer, ball, avatar — one physics); paddleReflect makes any button a paddle (exact integer serve-return); the rally test plays real pong off two buttons. 4/4 green.