### PR TITLE
feat(input): ControlScheme — ZetaId'd schemes; every device second to the action grammar

### DIFF
--- a/src/Core/ControlScheme.fs
+++ b/src/Core/ControlScheme.fs
@@ -1,0 +1,79 @@
+namespace Zeta.Core
+
+/// ControlScheme — **control schemes are ZetaId-addressed artifacts, and every device is SECOND to
+/// the universal action grammar** (Aaron 2026-06-11: "make sure our zetaids are capable of expressing
+/// control schemes — gamepad, keyboard — all are 2nd to our universal action grammar; that's where
+/// the mappings come from").
+///
+/// The law: the GRAMMAR owns the action set (the canonical things a citizen can MEAN — the compass
+/// from the four corners, select/back, conference, the raw CHIP-9 pad); a SCHEME is a total mapping
+/// from one device's physical inputs INTO that set — never past it. Schemes are registered with
+/// content-addressed ZetaIds (GeneratorRegistry — same id everywhere; version bump = new id), so a
+/// cartridge's `io`/`button` lines can reference a control scheme BY ID and any host resolves the
+/// same mapping. Portability is the theorem: dpad-up ≡ 'w' ≡ pad-5 — different fingers, one meaning.
+[<RequireQualifiedAccess>]
+module ControlScheme =
+
+    /// THE GRAMMAR'S ACTION SET — the canonical meanings (devices map into these, the wire form is
+    /// the crossing payload the rooms already speak).
+    type Action =
+        | Go of string // the compass: "n" | "s" | "e" | "w" (the four corners) | "hottest" | "self"
+        | Select
+        | Back
+        | Conference
+        | Pad of int // the raw CHIP-9 16-key pass-through (0x0..0xF)
+
+    /// The crossing payload an action means (the wire the rooms speak — go:/key: precedents).
+    let payload (a: Action) : string =
+        match a with
+        | Go d -> "go:" + d
+        | Select -> "ui:select"
+        | Back -> "ui:back"
+        | Conference -> "ui:conference"
+        | Pad k -> SoftChip8Flux.encodeKey (k &&& 0xF) true
+
+    /// A scheme: a named, versioned, ZetaId-addressed device mapping into the grammar.
+    type Scheme =
+        { Name: string
+          Version: int
+          ZetaId: string
+          Map: Map<string, Action> }
+
+    let private mk (name: string) (version: int) (map: (string * Action) list) : Scheme =
+        { Name = name
+          Version = version
+          ZetaId = GeneratorRegistry.idOf name version
+          Map = Map.ofList map }
+
+    /// The CHIP-9 16-key pad (the atom's native scheme — keys pass through; 5/8/7/9 double as compass).
+    let chip9Pad: Scheme =
+        mk "control.chip9-pad" 1
+            ([ for k in 0..15 -> sprintf "%x" k, Pad k ]
+             @ [ "5", Go "n"; "8", Go "s"; "7", Go "w"; "9", Go "e" ])
+
+    /// Keyboard WASD (+ enter/esc/c/h/.) — the desk scheme.
+    let keyboardWasd: Scheme =
+        mk "control.keyboard-wasd" 1
+            [ "w", Go "n"; "s", Go "s"; "a", Go "w"; "d", Go "e"
+              "h", Go "hottest"; ".", Go "self"
+              "enter", Select; "esc", Back; "c", Conference ]
+
+    /// The standard gamepad — dpad to the compass, face buttons to the verbs.
+    let gamepadStandard: Scheme =
+        mk "control.gamepad-standard" 1
+            [ "dpad-up", Go "n"; "dpad-down", Go "s"; "dpad-left", Go "w"; "dpad-right", Go "e"
+              "a", Select; "b", Back; "y", Conference; "x", Go "hottest" ]
+
+    /// The registered schemes (the shelf — each referenceable by its ZetaId from io/button lines).
+    let known: Scheme list = [ chip9Pad; keyboardWasd; gamepadStandard ]
+
+    /// Resolve a scheme by ZetaId (the cartridge's direction).
+    let byId (zetaId: string) : Scheme option =
+        known |> List.tryFind (fun s -> s.ZetaId = zetaId)
+
+    /// Translate one physical input under a scheme — None = unmapped (honest; never invented).
+    let translate (s: Scheme) (input: string) : Action option = Map.tryFind input s.Map
+
+    /// The wire crossing for a physical input under a scheme (the whole pipeline in one call).
+    let crossing (s: Scheme) (input: string) : string option =
+        translate s input |> Option.map payload

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -273,6 +273,7 @@
     <Compile Include="SoftLens.fs" />
     <Compile Include="WeaveFold.fs" />
     <Compile Include="PhysUI.fs" />
+    <Compile Include="ControlScheme.fs" />
     <Compile Include="SoftTie.fs" />
     <Compile Include="LinguisticSeed.fs" />
     <Compile Include="ConformalGA.fs" />

--- a/tests/Tests.FSharp/ControlScheme.Tests.fs
+++ b/tests/Tests.FSharp/ControlScheme.Tests.fs
@@ -1,0 +1,36 @@
+module Zeta.Tests.ControlSchemeTests
+
+// Devices are SECOND to the grammar: schemes are ZetaId'd total maps INTO the canonical action set;
+// portability is the theorem (dpad-up ≡ 'w' ≡ pad-5 — different fingers, one meaning, one wire form).
+
+open global.Xunit
+open Zeta.Core
+
+[<Fact>]
+let ``every scheme is ZetaId-addressed and resolvable by id (the cartridge's direction)`` () =
+    for s in ControlScheme.known do
+        Assert.Equal(32, s.ZetaId.Length)
+        Assert.Equal(Some s.Name, ControlScheme.byId s.ZetaId |> Option.map (fun x -> x.Name))
+    // distinct schemes, distinct ids
+    let ids = ControlScheme.known |> List.map (fun s -> s.ZetaId)
+    Assert.Equal(List.length ids, List.distinct ids |> List.length)
+
+[<Fact>]
+let ``PORTABILITY: dpad-up, 'w', and pad-5 all mean the SAME grammar action and the SAME wire crossing`` () =
+    let viaPad = ControlScheme.crossing ControlScheme.chip9Pad "5"
+    let viaKbd = ControlScheme.crossing ControlScheme.keyboardWasd "w"
+    let viaPadlt = ControlScheme.crossing ControlScheme.gamepadStandard "dpad-up"
+    Assert.Equal(Some "go:n", viaPad)
+    Assert.Equal(viaPad, viaKbd)
+    Assert.Equal(viaKbd, viaPadlt) // one meaning, three fingers
+
+[<Fact>]
+let ``the grammar owns the wire: actions encode to the crossing payloads the rooms already speak`` () =
+    Assert.Equal("go:hottest", ControlScheme.payload (ControlScheme.Go "hottest"))
+    Assert.Equal("ui:conference", ControlScheme.payload ControlScheme.Conference)
+    Assert.Equal("key:10:1", ControlScheme.payload (ControlScheme.Pad 0xA)) // the chip9 pad pass-through
+
+[<Fact>]
+let ``unmapped inputs are honest Nones — a scheme never invents meaning`` () =
+    Assert.True(ControlScheme.translate ControlScheme.keyboardWasd "f13" |> Option.isNone)
+    Assert.True(ControlScheme.crossing ControlScheme.gamepadStandard "select-plus-start" |> Option.isNone)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -169,6 +169,7 @@
     <Compile Include="SoftLens.Tests.fs" />
     <Compile Include="WeaveFold.Tests.fs" />
     <Compile Include="PhysUI.Tests.fs" />
+    <Compile Include="ControlScheme.Tests.fs" />
     <Compile Include="OttoAvatar.Tests.fs" />
     <Compile Include="Chip9Treaty.Tests.fs" />
     <Compile Include="Chip8Quote.Tests.fs" />


### PR DESCRIPTION
The grammar owns the action set (compass/select/back/conference/pad) and its wire form (the crossing payloads rooms speak); schemes are ZetaId-addressed total maps INTO it — never past it (unmapped = honest None). Three on the shelf: chip9-pad, keyboard-wasd, gamepad-standard — cartridges reference schemes by id. Portability tested: dpad-up ≡ 'w' ≡ pad-5 → one action, one crossing. 4/4 green.