### PR TITLE
feat(media): the lint + constants need WHY/WHAT + rebindable meta-dimensions + phase-time-only

### DIFF
--- a/docs/research/2026-06-11-quantum-phase-time-only-mp3-style-metadata-rx-meta-dimensions-constants-with-why-what-and-the-lint.md
+++ b/docs/research/2026-06-11-quantum-phase-time-only-mp3-style-metadata-rx-meta-dimensions-constants-with-why-what-and-the-lint.md
@@ -1,0 +1,49 @@
+# Phase time only · mp3-style metadata, standardized better · Rx meta-dimensions · constants with WHY and WHAT · the lint
+
+Aaron 2026-06-11, the format's closing laws:
+
+## 1. Quantum phase time from the common seed — the ONLY timestamp
+
+> "All our timing should be in quantum phase time based on the common seed — I think this is similar
+> to CockroachDB maybe — but we don't need any other kind of timestamps for the graphics pipeline and
+> audio pipeline. Just the metadata — think mp3 metadata tagging, but we standardize better."
+
+The law: pipelines carry NO wall timestamps — a moment is (generator-ZetaId, tick, phase), all derived
+from the seeded TimeGen (already how AnimFlow and ChipAudio run: the same phase drives frame and
+sample). CockroachDB's HLC is the honest cousin (hybrid logical clocks: causality without trusting
+walls) — ours goes further because the clock is GENERATED, so two nodes don't reconcile time, they
+DERIVE the same time. Provenance/wall-time, when needed at all, is METADATA — `meta` lines in the
+file (the mp3/ID3 instinct, standardized better: our tags are typed kinds with a lint, not freeform).
+
+## 2. Rx defines the pixel's META-DIMENSION
+
+> "Rx can define meta-dimensions that travel on the pixels instead of uncertainty, if it makes sense —
+> or 4-color CMYK kind of sharp stuff."
+
+The deep-pixel field (PixelLens's 16 bits) is REBINDABLE: uncertainty is the default semantics, but a
+`dimension` line declares what the field carries for this document — depth (the psych-3D z),
+CMYK-K (the subtractive/retraction channel), phosphor persistence, perceptual trick-load, anything Rx
+derives. DECLARED, never assumed (built: the `dimension` kind + lint check). One cell layout, many
+meanings, each file saying which.
+
+## 3. Constants must have WHY and WHAT (built, lint-enforced)
+
+> "We should have constants — constants must have WHY and WHAT."
+
+`constant <name> <value> <WHAT> <WHY>` — a value without its WHAT and WHY **is a magic number and the
+lint refuses it**. The Stump-Dad rule applied to numbers: every value answers why, or it doesn't ship.
+(The only sin, machine-checked.)
+
+## 4. The lint (built: `MediaLines.lint`, 4 rule families, tested)
+
+Structure, never style: constants carry WHAT+WHY · dimensions declare field+semantics · gen/io first
+fields are 32-hex ZetaIds (DI-from-the-start enforced) · anims reference existing frames · duplicate
+(kind,name) flagged — and per the expansion law the lint is SILENT about carried future kinds: **the
+future is not a lint error.**
+
+## Pointers
+
+- `MediaLines.lint` + the constant/dimension kinds (built, 17/17 module tests) · TimeGen/AnimFlow/
+  ChipAudio (phase time already the only clock) · PixelLens (the rebindable field) · anchors:
+  CockroachDB HLC (Kimball et al.) · ID3/mp3 tagging (the instinct; ours typed+linted) · the only-sin
+  rule (constants answer why).

--- a/src/Core/MediaLines.fs
+++ b/src/Core/MediaLines.fs
@@ -90,7 +90,7 @@ module MediaLines =
 
     /// The kinds THIS reader understands (everything else is carried, untouched — the expansion law).
     let knownKinds: Set<string> =
-        Set.ofList [ "meta"; "frame"; "sprite"; "anim"; "rom"; "glyph"; "palette"; "gen"; "sim"; "mea"; "cut"; "io"; "button" ]
+        Set.ofList [ "meta"; "frame"; "sprite"; "anim"; "rom"; "glyph"; "palette"; "gen"; "sim"; "mea"; "cut"; "io"; "button"; "constant"; "dimension" ]
 
     /// The entries a reader carries without understanding — future media types in transit.
     let carried (d: Doc) : Entry list =
@@ -135,6 +135,56 @@ module MediaLines =
         | zid :: _ when Set.contains zid granted -> Injected zid
         | zid :: _ -> Mock zid
         | [] -> Mock ""
+
+    // ── constants, meta-dimensions, and THE LINT (Aaron 2026-06-11: "we should have constants —
+    // constants MUST have WHY and WHAT" / "rx can define meta-dimensions that travel on the pixels
+    // instead of uncertainty, if it makes sense — CMYK-kind of sharp stuff" / "we need lint for our
+    // file"). A `constant` line is `constant <name> <value> <WHAT> <WHY>` — a value with no stated
+    // WHAT and WHY is not a constant, it is a magic number, and the lint refuses it (the Stump-Dad
+    // rule applied to numbers: every value answers why). A `dimension` line REBINDS what the deep
+    // pixel field carries — `dimension <name> <field> <semantics>` (uncertainty is the default; Rx
+    // may rebind to depth, CMYK-K, persistence, trick-load… the pixel's meta-dimension is DECLARED,
+    // never assumed). The lint checks structure, never style — and per the expansion law it stays
+    // SILENT about carried (unknown) kinds: the future is not a lint error. ──
+
+    /// One lint finding: the line's kind/name and what is wrong.
+    type LintFinding = { Kind: string; Name: string; Problem: string }
+
+    /// Lint a document: constants must carry value+WHAT+WHY; gen/io must reference 32-hex ZetaIds;
+    /// anims must reference frames that exist; duplicate (kind, name) pairs are flagged.
+    let lint (d: Doc) : LintFinding list =
+        let isHex32 (s: string) = s.Length = 32 && s |> Seq.forall System.Char.IsAsciiHexDigitLower
+        let frameNames = ofKind "frame" d |> List.map (fun e -> e.Name) |> Set.ofList
+
+        let perEntry =
+            d.Entries
+            |> List.collect (fun e ->
+                match e.Kind with
+                | "constant" when List.length e.Fields < 3 ->
+                    [ { Kind = e.Kind; Name = e.Name; Problem = "a constant MUST carry value, WHAT, and WHY — else it is a magic number" } ]
+                | "dimension" when List.length e.Fields < 2 ->
+                    [ { Kind = e.Kind; Name = e.Name; Problem = "a dimension must declare field and semantics" } ]
+                | "gen"
+                | "io" when (match e.Fields with z :: _ -> not (isHex32 z) | [] -> true) ->
+                    [ { Kind = e.Kind; Name = e.Name; Problem = "first field must be a 32-hex ZetaId (DI-from-the-start: references are injection points)" } ]
+                | "anim" ->
+                    match e.Fields with
+                    | head :: _ ->
+                        head.Split(',')
+                        |> Array.filter (fun f -> f.Length > 0 && not (Set.contains f frameNames))
+                        |> Array.toList
+                        |> List.map (fun f -> { Kind = e.Kind; Name = e.Name; Problem = sprintf "anim references missing frame '%s'" f })
+                    | [] -> [ { Kind = e.Kind; Name = e.Name; Problem = "anim has no cycle" } ]
+                | _ -> [])
+
+        let dupes =
+            d.Entries
+            |> List.filter (fun e -> Set.contains e.Kind knownKinds && e.Kind <> "rom") // rom legitimately repeats per address
+            |> List.groupBy (fun e -> e.Kind, e.Name)
+            |> List.filter (fun (_, es) -> List.length es > 1)
+            |> List.map (fun ((k, n), _) -> { Kind = k; Name = n; Problem = "duplicate (kind, name)" })
+
+        perEntry @ dupes
 
     /// The document AS a room declaration: Some (sim, mea, cut) when all three verbs are present —
     /// the file defines its own loop in the verb engine; None = a media-only document (honest).

--- a/tests/Tests.FSharp/MediaLines.Tests.fs
+++ b/tests/Tests.FSharp/MediaLines.Tests.fs
@@ -126,3 +126,48 @@ let ``resolution is the capability calculus: live when the host has it; injected
     Assert.Equal(MediaLines.Live tvId, MediaLines.resolveIo (Set.ofList [ tvId ]) Set.empty e)
     Assert.Equal(MediaLines.Injected tvId, MediaLines.resolveIo Set.empty (Set.ofList [ tvId ]) e)
     Assert.Equal(MediaLines.Mock tvId, MediaLines.resolveIo Set.empty Set.empty e) // degrades honestly
+
+// ── constants (WHY and WHAT required), meta-dimensions, and the lint ──
+
+[<Fact>]
+let ``a constant without WHAT and WHY is a magic number — the lint refuses it`` () =
+    let bad = "constant\tmax-laps\t1000"
+    let good = "constant\tmax-laps\t1000\tthe SimLoop lap rail\tno one gets to run for infinity"
+    match MediaLines.parse bad, MediaLines.parse good with
+    | Ok b, Ok g ->
+        Assert.Equal(1, List.length (MediaLines.lint b))
+        Assert.Contains("magic number", (MediaLines.lint b |> List.head).Problem)
+        Assert.Equal<MediaLines.LintFinding list>([], MediaLines.lint g)
+    | _ -> failwith "parse failed"
+
+[<Fact>]
+let ``a dimension REBINDS the deep-pixel field — declared, never assumed; lint checks the declaration`` () =
+    let ok = "dimension\tdepth\tuncertainty-field\tpsych-z-from-contrast-pairs"
+    let bad = "dimension\tdepth"
+    match MediaLines.parse ok, MediaLines.parse bad with
+    | Ok o, Error _ -> Assert.Equal<MediaLines.LintFinding list>([], MediaLines.lint o)
+    | Ok o, Ok b ->
+        Assert.Equal<MediaLines.LintFinding list>([], MediaLines.lint o)
+        Assert.Equal(1, List.length (MediaLines.lint b))
+    | _ -> failwith "parse failed"
+
+[<Fact>]
+let ``the lint enforces DI-from-the-start: gen/io first fields must be 32-hex ZetaIds`` () =
+    let bad = "gen\tstars\tnot-a-zetaid\t1\t99"
+    let good = sprintf "gen\tstars\t%s\t1\t99" (GeneratorRegistry.idOf "boundary.scatter" 1)
+    match MediaLines.parse bad, MediaLines.parse good with
+    | Ok b, Ok g ->
+        Assert.Equal(1, List.length (MediaLines.lint b))
+        Assert.Equal<MediaLines.LintFinding list>([], MediaLines.lint g)
+    | _ -> failwith "parse failed"
+
+[<Fact>]
+let ``the lint catches missing anim frames and duplicates — but stays SILENT on carried future kinds`` () =
+    let doc = "frame\tidle\taa\nanim\tgo\tidle,missing\nmeta\tname\tx\nmeta\tname\ty\nholo3d\tbust\twhatever"
+    match MediaLines.parse doc with
+    | Ok d ->
+        let findings = MediaLines.lint d
+        Assert.True(findings |> List.exists (fun f -> f.Problem.Contains "missing frame 'missing'"))
+        Assert.True(findings |> List.exists (fun f -> f.Problem = "duplicate (kind, name)"))
+        Assert.False(findings |> List.exists (fun f -> f.Kind = "holo3d")) // the future is not a lint error
+    | Error e -> failwith e


### PR DESCRIPTION
Four format laws built/captured: constants without WHAT+WHY are magic numbers and the lint refuses them (the only sin, machine-checked); the deep-pixel field is rebindable by declared dimension lines (uncertainty default — depth/CMYK-K/persistence per Rx); MediaLines.lint enforces structure (ZetaId refs = DI-from-the-start; anim frame existence; dupes) while staying silent on future kinds (the future is not a lint error); and phase time is the ONLY timestamp — pipelines derive time from the seeded clock (CockroachDB HLC the cousin), provenance is typed metadata (mp3 instinct, standardized better). 17/17 green.