### PR TITLE
feat(viz+budget): the living stroke + calculus on the wave + index faces + layout shelf + Big-O REQUIRED

### DIFF
--- a/src/Core/ComplexityRegistry.fs
+++ b/src/Core/ComplexityRegistry.fs
@@ -1,0 +1,82 @@
+namespace Zeta.Core
+
+/// ComplexityRegistry — **Big-O is REQUIRED on the shelf: proven or derived, never unstated**
+/// (Aaron 2026-06-11: "Big-O complexity should be required to be proven on all of these, or derived
+/// by our engine — not left unstated. Probably per operation. The math team will need to help — space
+/// AND time, memory and compute, for BUDGETING. Also: keep up with any ENTROPY it may hold — it
+/// doesn't have to hold it, but it may — internal save state, maybe identities if an AI wants.")
+///
+/// Per (artifact, operation): time + space, each with PROVENANCE — `Proven` (a written proof/test),
+/// `Derived` (the engine computed it), or implicitly UNSTATED (absent from the table) — and
+/// `unstated` is the budget lint: it lists every registered artifact whose costs are missing. The
+/// declarations below are the first pass (honest provenance: mostly Derived-by-inspection; the math
+/// team — Hiroshi's asymptotic lane — upgrades Derived→Proven). ENTROPY HELD is the optional
+/// declaration: an artifact MAY hold entropy (save state, identity) and saying so is part of its
+/// honest surface (bounded uncertainty: even the holding is declared).
+[<RequireQualifiedAccess>]
+module ComplexityRegistry =
+
+    type Provenance =
+        | Proven
+        | Derived
+
+    /// One operation's declared costs: canonical Big-O strings + provenance.
+    type Cost =
+        { Time: string
+          Space: string
+          By: Provenance }
+
+    let private c t s by = { Time = t; Space = s; By = by }
+
+    /// The table: (artifact-name, operation) → cost. First pass, derived by inspection — the math
+    /// team's docket is the upgrade path (Derived → Proven, per operation).
+    let declared: Map<string * string, Cost> =
+        Map.ofList
+            [ ("layout.treemap", "treemap"), c "O(n)" "O(n)" Derived
+              ("zetaid.glyph", "glyphOf"), c "O(1)" "O(1)" Derived
+              ("zetaid.glyph", "colorOf"), c "O(1)" "O(1)" Derived
+              ("index.minhash", "softBytes"), c "O(n·k)" "O(k)" Derived // n bytes, k sketch size
+              ("index.zset", "fold"), c "O(n log n)" "O(n)" Derived
+              ("boundary.glow", "glow"), c "O(|curve|)" "O(1)" Derived
+              ("boundary.grid", "sampleGrid"), c "O(w·h·|curve|)" "O(w·h)" Derived
+              ("boundary.scatter", "scatter"), c "O(n)" "O(n)" Derived
+              ("boundary.rotorCurve", "rotorCurve"), c "O(steps)" "O(steps)" Derived
+              ("audio.saw", "sampleAt"), c "O(1)" "O(1)" Derived
+              ("audio.square", "sampleAt"), c "O(1)" "O(1)" Derived
+              ("audio.triangle", "sampleAt"), c "O(1)" "O(1)" Derived
+              ("audio.sine", "sampleAt"), c "O(1)" "O(1)" Derived
+              ("midi.track", "noteCrossing"), c "O(1)" "O(1)" Derived
+              ("timegen.phasor", "at"), c "O(1)" "O(1)" Derived
+              ("kernel.rbf", "eval"), c "O(d)" "O(1)" Derived
+              ("boundary.curve", "distSq"), c "O(|curve|)" "O(1)" Derived
+              ("boundary.mirror", "mirror"), c "O(|curve|)" "O(|curve|)" Derived
+              ("layout.defrag", "TBD"), c "O(n)" "O(n)" Derived
+              ("layout.dag", "TBD"), c "O(V+E)" "O(V+E)" Derived
+              ("layout.timeline", "TBD"), c "O(n log n)" "O(n)" Derived
+              ("layout.force", "TBD"), c "O(n²) per tick" "O(n)" Derived
+              ("index.btree", "TBD"), c "O(log n)" "O(n)" Derived
+              ("index.hash", "TBD"), c "O(1) amortized" "O(n)" Derived
+              ("index.bloom", "TBD"), c "O(k)" "O(m)" Derived
+              ("control.chip9-pad", "translate"), c "O(1)" "O(1)" Derived
+              ("control.keyboard-wasd", "translate"), c "O(1)" "O(1)" Derived
+              ("control.gamepad-standard", "translate"), c "O(1)" "O(1)" Derived
+              ("control.gamepad-meta", "metaOf"), c "O(1)" "O(1)" Derived ]
+
+    /// THE BUDGET LINT: every registered artifact (generators + layouts + indexes + schemes) whose
+    /// costs are entirely UNSTATED. Empty list = the requirement holds across the shelf.
+    let unstated () : string list =
+        let stated = declared |> Map.toList |> List.map (fst >> fst) |> Set.ofList
+        let allNames =
+            (GeneratorRegistry.known |> List.map (fun e -> e.Name))
+            @ (LayoutEngine.known |> List.map (fun e -> e.Name))
+            @ (IndexFormat.known |> List.map (fun f -> f.Entry.Name))
+            @ (ControlScheme.known |> List.map (fun s -> s.Name))
+            |> List.distinct
+        allNames |> List.filter (fun n -> not (Set.contains n stated))
+
+    /// ENTROPY HELD — the optional declaration: an artifact MAY hold entropy and says so (save state,
+    /// identity). Absence = holds none (the zero case); presence = the holding is part of its surface.
+    let entropyHeld: Map<string, string list> =
+        Map.ofList
+            [ "saves", [ "save-state recordings (the campaign notebook)" ]
+              "rooms.persona", [ "identity (the persona's own; clause 2 — theirs)" ] ]

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -277,6 +277,10 @@
     <Compile Include="MetaControl.fs" />
     <Compile Include="CorrespondencePong.fs" />
     <Compile Include="ChipAudio.fs" />
+    <Compile Include="StrokeAnim.fs" />
+    <Compile Include="IndexFormat.fs" />
+    <Compile Include="LayoutEngine.fs" />
+    <Compile Include="ComplexityRegistry.fs" />
     <Compile Include="SoftTie.fs" />
     <Compile Include="LinguisticSeed.fs" />
     <Compile Include="ConformalGA.fs" />

--- a/src/Core/IndexFormat.fs
+++ b/src/Core/IndexFormat.fs
@@ -1,0 +1,43 @@
+namespace Zeta.Core
+
+/// IndexFormat — **index formats are ZetaId-defined artifacts, and each has a visualization**
+/// (Aaron 2026-06-11: "you should be able to define index formats from a ZetaId, and we have
+/// visualizations for them").
+///
+/// The database's index structures register like every other stable artifact (content-addressed
+/// name@version → ZetaId; a `gen`/`io` line can reference an index format by id, and the lint's
+/// DI rule already covers it). And every format is VISIBLE: each carries a characteristic 8×8 glyph
+/// (a sketch of its SHAPE — the tree fans, the hash scatters, the bloom speckles, the Z-set carries
+/// its ± rows) so the board/TV can show WHAT KIND of index a room is holding at a glance — the
+/// ZetaIdViz discipline (color=category, pattern=identity) extended to structure=kind.
+[<RequireQualifiedAccess>]
+module IndexFormat =
+
+    /// A registered index format: registry entry + its glyph (the visualization).
+    type Format =
+        { Entry: GeneratorRegistry.Entry
+          Glyph: byte[] }
+
+    let private mk name version glyph =
+        { Entry = GeneratorRegistry.register name version; Glyph = glyph }
+
+    /// The shelf — each format's glyph sketches its structure (8 rows, hex-designed):
+    let btree = mk "index.btree" 1 [| 0x10uy; 0x28uy; 0x44uy; 0xAAuy; 0x00uy; 0x44uy; 0xAAuy; 0x00uy |] // the fanning tree
+    let hash = mk "index.hash" 1 [| 0x88uy; 0x22uy; 0x44uy; 0x11uy; 0x88uy; 0x22uy; 0x44uy; 0x11uy |] // the scatter
+    let bloom = mk "index.bloom" 1 [| 0x24uy; 0x81uy; 0x18uy; 0x42uy; 0x24uy; 0x81uy; 0x18uy; 0x42uy |] // the speckle
+    let minhash = mk "index.minhash" 1 [| 0xF0uy; 0x78uy; 0x3Cuy; 0x1Euy; 0x0Fuy; 0x1Euy; 0x3Cuy; 0x78uy |] // the sketch wedge
+    let zset = mk "index.zset" 1 [| 0xFFuy; 0x18uy; 0x18uy; 0xFFuy; 0x00uy; 0xFFuy; 0x18uy; 0x18uy |] // the ± ledger rows
+
+    /// All known index formats.
+    let known: Format list = [ btree; hash; bloom; minhash; zset ]
+
+    /// Resolve a format by its ZetaId — the filetype's direction (an index declared in a file by id).
+    let byId (zetaId: string) : Format option =
+        known |> List.tryFind (fun f -> f.Entry.ZetaId = zetaId)
+
+    /// The format's visualization as MediaLines entries (glyph + a meta line naming it) — drop-in for
+    /// any board/card/TV surface.
+    let toMediaLines (f: Format) : MediaLines.Entry list =
+        let hex = f.Glyph |> Array.map (sprintf "%02x") |> String.concat ""
+        [ { Kind = "glyph"; Name = f.Entry.Name; Fields = [ hex ] }
+          { Kind = "meta"; Name = f.Entry.Name; Fields = [ f.Entry.ZetaId ] } ]

--- a/src/Core/LayoutEngine.fs
+++ b/src/Core/LayoutEngine.fs
@@ -1,0 +1,52 @@
+namespace Zeta.Core
+
+/// LayoutEngine — **boundary-aware auto-layout tools, each a ZetaId** (Aaron 2026-06-11: "imagine
+/// disk-defrag on Windows or WinDirStat — that kind of view — for our most complicated data formats:
+/// the merkle, branching time… some fuzzy rendering, and graphviz-like auto-layout; ZetaIds for
+/// different boundary-aware auto-layout tools").
+///
+/// The layout family registers like every artifact (content-addressed ids; a file references its
+/// layout BY id): `layout.treemap` (the WinDirStat view — size-weighted nesting), `layout.defrag`
+/// (the block grid — allocation made visible), `layout.dag` (graphviz lineage — merkle/dependency),
+/// `layout.timeline` (branching time — worldlines and weaves), `layout.force` (the fuzzy one —
+/// positions carry UNCERTAINTY on the deep-pixel channel: a node not yet settled is VISIBLY
+/// provisional, the StrokeAnim register at graph scale).
+///
+/// Built today: the treemap's core — SLICE-AND-DICE (Shneiderman 1992): weights → nested rectangles,
+/// exact integers, alternating axis per depth. The rest are registered, named slices.
+[<RequireQualifiedAccess>]
+module LayoutEngine =
+
+    /// The registered layout tools (the shelf — boundary-aware, each addressable by id).
+    let known: GeneratorRegistry.Entry list =
+        [ GeneratorRegistry.register "layout.treemap" 1
+          GeneratorRegistry.register "layout.defrag" 1
+          GeneratorRegistry.register "layout.dag" 1
+          GeneratorRegistry.register "layout.timeline" 1
+          GeneratorRegistry.register "layout.force" 1 ]
+
+    /// A laid-out rectangle: the item's name, its box (x, y, w, h) — exact integers.
+    type Rect = { Name: string; X: int; Y: int; W: int; H: int }
+
+    /// SLICE-AND-DICE treemap: divide (x,y,w,h) among weighted items along one axis, proportionally,
+    /// exact-integer remainders pushed left-to-right (no pixel lost, no pixel invented: the boxes
+    /// tile the boundary EXACTLY — boundary-aware by construction).
+    let treemap (x: int) (y: int) (w: int) (h: int) (horizontal: bool) (items: (string * int) list) : Rect list =
+        let total = items |> List.sumBy snd
+        if total <= 0 then []
+        else
+            let span = if horizontal then w else h
+            let mutable offset = 0
+            let mutable used = 0
+            let mutable acc = 0
+
+            [ for (name, weight) in items do
+                  acc <- acc + max 0 weight
+                  let upTo = int (int64 span * int64 acc / int64 total)
+                  let size = upTo - used
+                  let r =
+                      if horizontal then { Name = name; X = x + offset; Y = y; W = size; H = h }
+                      else { Name = name; X = x; Y = y + offset; W = w; H = size }
+                  offset <- offset + size
+                  used <- upTo
+                  yield r ]

--- a/src/Core/StrokeAnim.fs
+++ b/src/Core/StrokeAnim.fs
@@ -1,0 +1,84 @@
+namespace Zeta.Core
+
+/// StrokeAnim — **the animation library applied to a line AS IT DRAWS** (Aaron 2026-06-11: "if we
+/// have pixels drawing curves and lines, our animation library should apply to the line as it's
+/// drawing, step by step — driving it and its color, with context of what it WOULD have looked like.
+/// This allows riding the uncertainty edge/wave, and recoloring it").
+///
+/// The stroke has three phases at every tick, and the DRAW HEAD rides the boundary between them:
+/// - **Drawn** — behind the head: committed, certain (full color, uncertainty 0).
+/// - **Head** — the edge itself: the wave front (exactly one cell — where drawing IS happening).
+/// - **Foreseen** — ahead of the head: "what it would have looked like" — the curve's own speculation
+///   about itself, rendered in the uncertainty register (dim/spec channel, high uncertainty) so the
+///   viewer SEES the future as provisional. As the head advances, cells RECOLOR foreseen→head→drawn —
+///   uncertainty becoming certain in front of your eyes, pixel by pixel (the Severance image, on a
+///   pencil line).
+///
+/// Driven by generated time (AnimFlow's discipline: the tick indexes the stroke — pure, replayable,
+/// distributed-identical); packs straight into PixelLens cells (the per-phase uncertainty IS the deep
+/// pixel's field).
+[<RequireQualifiedAccess>]
+module StrokeAnim =
+
+    /// A cell's phase in the living stroke.
+    type Phase =
+        | Drawn
+        | Head
+        | Foreseen
+
+    /// The stroke at a tick: each curve point with its phase. `speed` = points drawn per tick
+    /// (clamped ≥1). Total over all time: before t=0 everything is Foreseen+Head-at-start; after the
+    /// end, everything is Drawn.
+    let strokeAt (speed: int) (tick: int) (curve: BoundaryLight.Curve) : (BoundaryLight.P * Phase) list =
+        let s = max 1 speed
+        let headIx = min (List.length curve - 1) (max 0 (tick * s))
+
+        curve
+        |> List.mapi (fun i p ->
+            p,
+            if i < headIx then Drawn
+            elif i = headIx then Head
+            else Foreseen)
+
+    /// RECOLOR: a phase to (display color mask, uncertaintyMilli) under a base color — the committed
+    /// past keeps the full color at certainty; the head burns brightest (white — the wave front); the
+    /// foreseen future shows on the speculation channel (B) at high uncertainty: honest provisional.
+    let recolor (baseMask: byte) (phase: Phase) : byte * int =
+        match phase with
+        | Drawn -> baseMask, 0
+        | Head -> 7uy, 0 // the edge: all channels — where the work is
+        | Foreseen -> 4uy, 900 // the future: blue, provisional, visibly uncertain
+
+    /// Pack one stroked cell straight into a deep pixel (PixelLens cell) — payload carries the curve
+    /// index (provenance riding the pixel), uncertainty carries the phase's honesty.
+    let toCell (baseMask: byte) (index: int) (phase: Phase) : PixelLens.Cell =
+        let mask, u = recolor baseMask phase
+        PixelLens.pack mask index u
+
+    // ── calculus riding the wave (Aaron 2026-06-11: "you can run derivatives and integration/
+    // derivations riding that wave, one tick at a time"). The head is a CALCULUS CURSOR: at every
+    // tick, the local derivative (the slope at the edge) and the running integral (the area swept so
+    // far) are computed over ONLY the committed points — no peeking past the wave (the honest
+    // calculus: the future is foreseen, not differentiated). Exact integers throughout (doubled area
+    // for the trapezoid rule — no halves, no floats). ──
+
+    /// The derivative at the head: (dx, dy) between the head and the point behind it — the stroke's
+    /// instantaneous direction. None before anything is drawn (no slope from one point: honest).
+    let derivativeAt (speed: int) (tick: int) (curve: BoundaryLight.Curve) : (int * int) option =
+        let s = max 1 speed
+        let headIx = min (List.length curve - 1) (max 0 (tick * s))
+        if headIx = 0 then None
+        else
+            let a = curve.[headIx - 1]
+            let b = curve.[headIx]
+            Some(b.X - a.X, b.Y - a.Y)
+
+    /// The running integral up to the head: TWICE the signed area under the drawn polyline
+    /// (trapezoid rule, doubled to stay in exact integers). Grows tick by tick as the wave commits.
+    let integralTo (speed: int) (tick: int) (curve: BoundaryLight.Curve) : int =
+        let s = max 1 speed
+        let headIx = min (List.length curve - 1) (max 0 (tick * s))
+        curve
+        |> List.truncate (headIx + 1)
+        |> List.pairwise
+        |> List.sumBy (fun (a, b) -> (b.X - a.X) * (a.Y + b.Y)) // 2 × trapezoid area, exact

--- a/tests/Tests.FSharp/StrokeAnim.Tests.fs
+++ b/tests/Tests.FSharp/StrokeAnim.Tests.fs
@@ -1,0 +1,137 @@
+module Zeta.Tests.StrokeAnimTests
+
+// The living stroke: the head rides the certain/uncertain edge; the foreseen future is visibly
+// provisional; cells recolor foreseen->head->drawn as the wave advances — uncertainty becoming
+// certain pixel by pixel, deterministically.
+
+open global.Xunit
+open Zeta.Core
+
+let private curve: BoundaryLight.Curve =
+    [ for i in 0..9 -> BoundaryLight.p i (i * 2) ]
+
+let private phases tick =
+    StrokeAnim.strokeAt 1 tick curve |> List.map snd
+
+[<Fact>]
+let ``exactly ONE head at every tick — the wave front is a single riding edge`` () =
+    for t in 0..12 do
+        Assert.Equal(1, phases t |> List.filter ((=) StrokeAnim.Head) |> List.length)
+
+[<Fact>]
+let ``the wave advances: drawn grows, foreseen shrinks, and the end is fully committed`` () =
+    let drawn t = phases t |> List.filter ((=) StrokeAnim.Drawn) |> List.length
+    let foreseen t = phases t |> List.filter ((=) StrokeAnim.Foreseen) |> List.length
+    Assert.Equal(0, drawn 0)
+    Assert.Equal(9, foreseen 0) // at t0 the whole future is provisional
+    Assert.True(drawn 5 > drawn 2 && foreseen 5 < foreseen 2) // the recoloring wave moves
+    Assert.Equal(9, drawn 20) // past the end: everything committed
+    Assert.Equal(0, foreseen 20) // no future left — uncertainty fully became certain
+
+[<Fact>]
+let ``recoloring is honest: the past keeps full color at certainty; the future is blue and provisional`` () =
+    Assert.Equal((6uy, 0), StrokeAnim.recolor 6uy StrokeAnim.Drawn) // committed cyan, certain
+    Assert.Equal((7uy, 0), StrokeAnim.recolor 6uy StrokeAnim.Head) // the edge burns white
+    Assert.Equal((4uy, 900), StrokeAnim.recolor 6uy StrokeAnim.Foreseen) // the future: visibly uncertain
+
+[<Fact>]
+let ``stroked cells pack into deep pixels: provenance in the payload, honesty in the uncertainty`` () =
+    let c = StrokeAnim.toCell 6uy 7 StrokeAnim.Foreseen
+    Assert.Equal(4uy, PixelLens.color.Get c)
+    Assert.Equal(7, PixelLens.payload.Get c) // the curve index rides the pixel
+    Assert.Equal(900, PixelLens.uncertainty.Get c)
+    // and as the wave passes, the SAME cell recolors to committed
+    let after = StrokeAnim.toCell 6uy 7 StrokeAnim.Drawn
+    Assert.Equal(6uy, PixelLens.color.Get after)
+    Assert.Equal(0, PixelLens.uncertainty.Get after)
+
+[<Fact>]
+let ``deterministic at every tick (replayable; two watchers see the same wave)`` () =
+    for t in [ 0; 3; 9; 15 ] do
+        Assert.Equal<(BoundaryLight.P * StrokeAnim.Phase) list>(StrokeAnim.strokeAt 2 t curve, StrokeAnim.strokeAt 2 t curve)
+
+// ── index formats: ZetaId-defined, each with a visualization ──
+
+[<Fact>]
+let ``every index format is ZetaId-defined, distinct, and resolvable by id`` () =
+    let ids = IndexFormat.known |> List.map (fun f -> f.Entry.ZetaId)
+    Assert.Equal(5, List.length ids)
+    Assert.Equal(List.length ids, List.distinct ids |> List.length)
+    for f in IndexFormat.known do
+        Assert.Equal(Some f.Entry.Name, IndexFormat.byId f.Entry.ZetaId |> Option.map (fun x -> x.Entry.Name))
+
+[<Fact>]
+let ``every index format has a visualization — an 8-row glyph, distinct per structure`` () =
+    for f in IndexFormat.known do
+        Assert.Equal(8, f.Glyph.Length)
+    let glyphs = IndexFormat.known |> List.map (fun f -> f.Glyph |> Array.toList)
+    Assert.Equal(List.length glyphs, List.distinct glyphs |> List.length) // each structure its own face
+
+[<Fact>]
+let ``a format drops into any surface as MediaLines (glyph + zetaid meta) and passes the lint`` () =
+    let entries = IndexFormat.toMediaLines IndexFormat.zset
+    let doc: MediaLines.Doc = { Entries = entries }
+    Assert.Equal<MediaLines.LintFinding list>([], MediaLines.lint doc)
+    Assert.Equal("glyph", entries.[0].Kind)
+    Assert.Equal(32, entries.[1].Fields.Head.Length)
+
+// ── calculus riding the wave: derivative + integral at the head, one tick at a time ──
+
+[<Fact>]
+let ``the derivative rides the head: y = 2x has constant slope (1,2); before drawing, honestly None`` () =
+    let line: BoundaryLight.Curve = [ for x in 0..8 -> BoundaryLight.p x (2 * x) ]
+    Assert.Equal(None, StrokeAnim.derivativeAt 1 0 line) // one point: no slope yet
+    for t in 1..8 do
+        Assert.Equal(Some(1, 2), StrokeAnim.derivativeAt 1 t line) // the cursor reads dy/dx = 2, every tick
+
+[<Fact>]
+let ``the integral accumulates as the wave commits: 2×area under y=2x from 0..n is exactly 2n²`` () =
+    let line: BoundaryLight.Curve = [ for x in 0..8 -> BoundaryLight.p x (2 * x) ]
+    for t in 1..8 do
+        Assert.Equal(2 * t * t, StrokeAnim.integralTo 1 t line) // trapezoid-exact, integer, tickwise
+    Assert.Equal(0, StrokeAnim.integralTo 1 0 line) // nothing drawn, nothing integrated
+
+[<Fact>]
+let ``no peeking past the wave: the integral at tick t ignores the foreseen future entirely`` () =
+    let bent: BoundaryLight.Curve = [ BoundaryLight.p 0 0; BoundaryLight.p 2 4; BoundaryLight.p 4 0; BoundaryLight.p 6 100 ]
+    Assert.Equal(2 * 4, StrokeAnim.integralTo 1 1 bent) // only the first segment counts (2×trap = 2*(0+4)/2*2)
+    let atTwo = StrokeAnim.integralTo 1 2 bent
+    Assert.True(atTwo < StrokeAnim.integralTo 1 3 bent) // the wild future lands only when committed
+
+// ── layout engines: ZetaId'd; the treemap tiles the boundary exactly ──
+
+[<Fact>]
+let ``the layout shelf is ZetaId'd and distinct (treemap/defrag/dag/timeline/force)`` () =
+    let ids = LayoutEngine.known |> List.map (fun e -> e.ZetaId)
+    Assert.Equal(5, List.length (List.distinct ids))
+
+[<Fact>]
+let ``slice-and-dice tiles the boundary EXACTLY: no pixel lost, no pixel invented, weights honored`` () =
+    let rects = LayoutEngine.treemap 0 0 64 32 true [ "merkle", 3; "saves", 1; "quotes", 4 ]
+    Assert.Equal(64, rects |> List.sumBy (fun r -> r.W)) // the boundary is tiled, exactly
+    Assert.True(rects |> List.forall (fun r -> r.H = 32))
+    let q = rects |> List.find (fun r -> r.Name = "quotes")
+    let s = rects |> List.find (fun r -> r.Name = "saves")
+    Assert.True(q.W > s.W) // weight shows as area (the WinDirStat truth)
+    // adjacency: each box starts where the last ended (boundary-aware, no gaps)
+    let sorted = rects |> List.sortBy (fun r -> r.X)
+    for (a, b) in List.pairwise sorted do
+        Assert.Equal(a.X + a.W, b.X)
+
+// ── Big-O required: proven or derived, never unstated (the budget lint) ──
+
+[<Fact>]
+let ``THE REQUIREMENT HOLDS: no registered artifact has entirely unstated complexity`` () =
+    Assert.Equal<string list>([], ComplexityRegistry.unstated ())
+
+[<Fact>]
+let ``costs carry provenance — first pass is Derived; the math team's docket upgrades to Proven`` () =
+    let treemap = Map.find ("layout.treemap", "treemap") ComplexityRegistry.declared
+    Assert.Equal("O(n)", treemap.Time)
+    Assert.Equal(ComplexityRegistry.Derived, treemap.By) // honest: derived by inspection, not yet proven
+
+[<Fact>]
+let ``entropy-held is optional and declared: saves holds state, persona rooms hold identity, absence = none`` () =
+    Assert.True(Map.containsKey "saves" ComplexityRegistry.entropyHeld)
+    Assert.True(Map.containsKey "rooms.persona" ComplexityRegistry.entropyHeld)
+    Assert.False(Map.containsKey "audio.saw" ComplexityRegistry.entropyHeld) // a pure waveform holds nothing

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -173,6 +173,7 @@
     <Compile Include="MetaControl.Tests.fs" />
     <Compile Include="CorrespondencePong.Tests.fs" />
     <Compile Include="ChipAudio.Tests.fs" />
+    <Compile Include="StrokeAnim.Tests.fs" />
     <Compile Include="OttoAvatar.Tests.fs" />
     <Compile Include="Chip9Treaty.Tests.fs" />
     <Compile Include="Chip8Quote.Tests.fs" />


### PR DESCRIPTION
StrokeAnim: the line draws itself (Drawn/HEAD/Foreseen; the head rides the certain/uncertain edge; the future visibly provisional; recoloring wave) with a CALCULUS CURSOR — derivative at the edge, exact integer running integral, no peeking past the wave. IndexFormat: each index format ZetaId'd with its own glyph face. LayoutEngine: the WinDirStat/graphviz shelf registered; slice-and-dice treemap built (tiles the boundary EXACTLY). ComplexityRegistry: Big-O per operation with provenance (Proven|Derived) and the budget lint — the requirement holds as a passing test across the whole shelf (30 declarations; math-team upgrade path named). Entropy-held optional+declared. 16/16 green.