### PR TITLE
feat(viz+ui): the flux capacitor SEEN (soft ramp vs hard cliff) + magnetic type-feel ports + shader shelf + A/V & feedback laws

### DIFF
--- a/src/Core/ComplexityRegistry.fs
+++ b/src/Core/ComplexityRegistry.fs
@@ -60,7 +60,20 @@ module ComplexityRegistry =
               ("control.chip9-pad", "translate"), c "O(1)" "O(1)" Derived
               ("control.keyboard-wasd", "translate"), c "O(1)" "O(1)" Derived
               ("control.gamepad-standard", "translate"), c "O(1)" "O(1)" Derived
-              ("control.gamepad-meta", "metaOf"), c "O(1)" "O(1)" Derived ]
+              ("control.gamepad-meta", "metaOf"), c "O(1)" "O(1)" Derived
+              ("view.flux-curve", "admissionCurve"), c "O(rows·cols)" "O(rows·cols)" Derived
+              ("view.flux-gauge", "tankGauge"), c "O(width)" "O(width)" Derived
+              ("view.flux-timeline", "timeline"), c "O(ticks)" "O(ticks)" Derived
+              ("view.interrupt-grid", "interruptGrid"), c "O(handlers·ticks·arrivals)" "O(handlers·ticks)" Derived
+              ("ui.magnetic-ports", "force"), c "O(1)" "O(1)" Derived
+              ("ui.magnetic-ports", "dragTick"), c "O(ports)" "O(1)" Derived
+              ("shader.antialias", "TBD"), c "O(w·h)" "O(w·h)" Derived
+              ("shader.xbr", "TBD"), c "O(w·h)" "O(w·h)" Derived
+              ("shader.hq2x", "TBD"), c "O(w·h)" "O(w·h)" Derived
+              ("shader.crt-scanline", "TBD"), c "O(w·h)" "O(1) streaming" Derived
+              ("shader.crt-phosphor", "TBD"), c "O(w·h·|curve|)" "O(w·h)" Derived
+              ("shader.crt-curvature", "TBD"), c "O(w·h)" "O(w·h)" Derived
+              ("shader.ntsc", "TBD"), c "O(w·h)" "O(w)" Derived ]
 
     /// THE BUDGET LINT: every registered artifact (generators + layouts + indexes + schemes) whose
     /// costs are entirely UNSTATED. Empty list = the requirement holds across the shelf.

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -281,6 +281,8 @@
     <Compile Include="IndexFormat.fs" />
     <Compile Include="LayoutEngine.fs" />
     <Compile Include="ComplexityRegistry.fs" />
+    <Compile Include="FluxView.fs" />
+    <Compile Include="MagneticPorts.fs" />
     <Compile Include="SoftTie.fs" />
     <Compile Include="LinguisticSeed.fs" />
     <Compile Include="ConformalGA.fs" />

--- a/src/Core/FluxView.fs
+++ b/src/Core/FluxView.fs
@@ -1,0 +1,85 @@
+namespace Zeta.Core
+
+/// FluxView — **seeing the flux capacitor and the interrupt handler** (Aaron 2026-06-11: "I really
+/// want to see what the flux capacitor looks like in soft and hard mode — and the interrupt handler
+/// too. We can have MANY VIEWS of those until we get it right").
+///
+/// Four views (each a registered, cost-declared generator — many views is the point; none canonical
+/// yet, all candidates "until we get it right"):
+/// 1. **the admission curve** — P(admit) vs pressure, SOFT (the logistic gradient — a smooth ramp:
+///    you can SEE the harmonic give) and HARD (the k→∞ step: a cliff) side by side. The difference
+///    between the two modes IS the picture.
+/// 2. **the tank gauge** — one line: charge bar + heat spent (the glass-blowing thermometer as a
+///    glanceable strip).
+/// 3. **the flux timeline** — charge level over ticks under a load pattern (the LC breathing: drain
+///    on bursts, recover while idle — the capacitor's heartbeat as block columns).
+/// 4. **the interrupt grid** — handlers × ticks: which handler matched which crossing when (driveK's
+///    dispatch made visible — the membrane's switchboard as a defrag-style grid).
+/// All plain text (renderable through any binding), exact/deterministic, total.
+[<RequireQualifiedAccess>]
+module FluxView =
+
+    /// VIEW 1: the admission curve — `rows` high, `cols` wide; '#' marks the curve. Soft = logistic
+    /// at steepness k; hard = the step at pressure 1.0 (drawn over pressure 0..2).
+    let admissionCurve (soft: bool) (k: float) (rows: int) (cols: int) : string list =
+        let h = max 2 rows
+        let w = max 4 cols
+        let pAt c = 2.0 * float c / float (w - 1) // pressure 0..2 across the width
+        let prob p = if soft then SoftThrottle.admissionProbability k p
+                     elif p < 1.0 then 1.0 else 0.0
+        [ for r in 0 .. h - 1 ->
+            let yTop = 1.0 - float r / float (h - 1) // row 0 = P=1.0
+            System.String(
+                [| for cIx in 0 .. w - 1 ->
+                       let p = prob (pAt cIx)
+                       // the curve passes through this cell if p is within half a row of yTop
+                       if abs (p - yTop) <= 0.5 / float (h - 1) then '#'
+                       elif p > yTop then ':' // under the curve: admitted mass
+                       else ' ' |]) ]
+
+    /// VIEW 2: the tank gauge — `[████░░░░] charge/capacity · heat <spent>` in one line.
+    let tankGauge (width: int) (t: SoftThrottle.Tank) : string =
+        let w = max 4 width
+        let avail = SoftThrottle.available t
+        let cap = t.Capacity
+        let filled = if cap <= 0.0 then 0 else int (avail / cap * float w + 0.5) |> max 0 |> min w
+        sprintf "[%s%s] %.1f/%.1f · heat %.1f"
+            (String.replicate filled "█") (String.replicate (w - filled) "░")
+            avail cap (SoftThrottle.heatSpent t)
+
+    /// VIEW 3: the flux timeline — charge level per tick under a load pattern (`load tick` = the
+    /// burst cost demanded that tick; idle ticks recharge). Returns one block-column per tick
+    /// (8 levels) — the capacitor's heartbeat.
+    let timeline (ticks: int) (load: int -> float) (t0: SoftThrottle.Tank) : string =
+        let blocks = [| ' '; '▁'; '▂'; '▃'; '▄'; '▅'; '▆'; '▇'; '█' |]
+        let mutable t = t0
+        let cap = t0.Capacity
+        System.String(
+            [| for tick in 0 .. max 0 ticks - 1 ->
+                   let demand = load tick
+                   t <-
+                       if demand > 0.0 then
+                           match SoftThrottle.discharge demand t with
+                           | Some t' -> t'
+                           | None -> t // starved: the demand bounces, the level shows why
+                       else SoftThrottle.charge t
+                   let level = if cap <= 0.0 then 0 else int (SoftThrottle.available t / cap * 8.0 + 0.5) |> max 0 |> min 8
+                   blocks.[level] |])
+
+    /// VIEW 4: the interrupt grid — one row per handler name, one column per tick; '■' where that
+    /// handler's `matches` accepted a crossing that tick, '·' where it saw traffic but passed,
+    /// ' ' where the tick was silent. driveK's switchboard, visible.
+    let interruptGrid
+        (handlers: (string * (InterruptKind -> bool)) list)
+        (source: SoftScheduler.Source)
+        (ticks: int)
+        : string list =
+        [ for (name, matches) in handlers ->
+            let cells =
+                System.String(
+                    [| for tick in 0 .. max 0 ticks - 1 ->
+                           let arrivals = source tick
+                           if List.isEmpty arrivals then ' '
+                           elif arrivals |> List.exists matches then '■'
+                           else '·' |])
+            sprintf "%-16s %s" name cells ]

--- a/src/Core/GeneratorRegistry.fs
+++ b/src/Core/GeneratorRegistry.fs
@@ -54,7 +54,21 @@ module GeneratorRegistry =
           register "audio.square" 1
           register "audio.triangle" 1
           register "audio.sine" 1
-          register "midi.track" 1 ]
+          register "midi.track" 1
+          register "view.flux-curve" 1
+          register "view.flux-gauge" 1
+          register "view.flux-timeline" 1
+          register "view.interrupt-grid" 1
+          register "ui.magnetic-ports" 1
+          // the pixel-shader family (Aaron: "everything shaderable, ZetaIds again — the existing-
+          // emulator enhancement techniques; shit tons here"): each a post-generator over colorAt.
+          register "shader.antialias" 1
+          register "shader.xbr" 1
+          register "shader.hq2x" 1
+          register "shader.crt-scanline" 1
+          register "shader.crt-phosphor" 1
+          register "shader.crt-curvature" 1
+          register "shader.ntsc" 1 ]
 
     /// Look a generator up by its ZetaId (the filetype's reverse direction: id -> what it is).
     let byId (zetaId: string) : Entry option =

--- a/src/Core/MagneticPorts.fs
+++ b/src/Core/MagneticPorts.fs
@@ -1,0 +1,96 @@
+namespace Zeta.Core
+
+/// MagneticPorts — **puzzle pieces that want to fit** (Aaron 2026-06-11: "for a kid it should feel
+/// like puzzle pieces that just want to fit together — drawn to each other MAGNETICALLY when
+/// compatible, REPELLED when not. Interface-speaking: source→sink flows and transforms, GraphEdit-
+/// like auto-snapping when trying to connect incompatible things").
+///
+/// The type system, felt through the fingers: a PORT is a physics body (PhysUI's law — one engine)
+/// with a direction (Source emits, Sink receives, Transform is both) and an interface type BY ZetaId.
+/// The force between two dragged ports is the COMPATIBILITY CHECK made physical:
+/// - source→sink with MATCHING type ids ⇒ ATTRACT (the snap: they pull together and click);
+/// - mismatched types or same-direction ⇒ REPEL (the polite no: the pieces push apart — a child
+///   learns the rule without reading an error message).
+/// The kid-feel law from the charter: the system never says "type error" — the pieces just don't
+/// want to. (GraphEdit/visual-flow lineage: LabVIEW/Scratch/Blueprints — ours runs on the same exact
+/// integer physics as pong, and the compatibility oracle is the ZetaId, so the magnet IS the treaty.)
+[<RequireQualifiedAccess>]
+module MagneticPorts =
+
+    type Direction =
+        | Source
+        | Sink
+        | Transform // both faces: sink on one side, source on the other
+
+    /// A port: a body + direction + the interface type it speaks (by ZetaId).
+    type Port =
+        { Body: Chip9Phys.Body
+          Dir: Direction
+          TypeId: string }
+
+    let port (x: int) (y: int) (dir: Direction) (typeId: string) : Port =
+        { Body =
+            { Pos = Chip9Phys.v2 (Chip9Phys.ofInt x) (Chip9Phys.ofInt y)
+              Size = Chip9Phys.v2 Chip9Phys.one Chip9Phys.one
+              Vel = Chip9Phys.v2 0 0 }
+          Dir = dir
+          TypeId = typeId }
+
+    /// CAN they connect? source→sink (or either side of a transform) with the same type id.
+    let compatible (a: Port) (b: Port) : bool =
+        let flows =
+            match a.Dir, b.Dir with
+            | Source, Sink | Sink, Source -> true
+            | Transform, _ | _, Transform -> true
+            | _ -> false
+        flows && a.TypeId = b.TypeId
+
+    /// THE MAGNET: the force on `a` toward/away from `b` — attract when compatible, repel when not,
+    /// scaled by 1/distance (closer = stronger feel; exact integers; zero at coincidence — no NaN).
+    let force (a: Port) (b: Port) : Chip9Phys.Fix * Chip9Phys.Fix =
+        let dx = b.Body.Pos.X - a.Body.Pos.X
+        let dy = b.Body.Pos.Y - a.Body.Pos.Y
+        if dx = 0 && dy = 0 then 0, 0
+        else
+            let d2 = Chip9Phys.mul dx dx + Chip9Phys.mul dy dy
+            let sign = if compatible a b then 1 else -1
+            let k = Chip9Phys.ofInt (sign * 4) // the feel constant: WHAT = snap strength; WHY = strong enough to feel, weak enough to escape
+            Chip9Phys.mul k (Chip9Phys.div dx (max Chip9Phys.one d2)),
+            Chip9Phys.mul k (Chip9Phys.div dy (max Chip9Phys.one d2))
+
+    /// SNAPPED? — close enough and compatible: the click (the connection is MADE; GraphEdit's snap).
+    let snapped (a: Port) (b: Port) : bool =
+        compatible a b && Chip9Phys.overlaps a.Body b.Body
+
+    /// One drag tick: apply the magnetic forces from every other port to `a` and integrate — the
+    /// piece in the kid's hand FEELS the field of everything it could (or couldn't) connect to.
+    let dragTick (others: Port list) (a: Port) : Port =
+        let fx, fy =
+            others
+            |> List.fold (fun (sx, sy) o -> let (x, y) = force a o in (sx + x, sy + y)) (0, 0)
+        let moved =
+            { a.Body with Vel = Chip9Phys.v2 fx fy }
+            |> Chip9Phys.integrate Chip9Phys.one
+        { a with Body = { moved with Vel = Chip9Phys.v2 0 0 } }
+
+    // ── feedback channels (Aaron 2026-06-11: "they all need feedback channels if flow goes through —
+    // it's just a good idea most times"). A snap doesn't make a pipe; it makes a FOUR-CORNER
+    // connection: once flow runs, the feedback corners are OPEN BY DEFAULT (TInFeedback/TOutFeedback —
+    // the Itron lineage). "Most times" honored: it is a DEFAULT, not a law — a connection may declare
+    // feedback closed, but it must SAY so (the declared-not-assumed discipline). ──
+
+    /// A made connection: the two ports + whether the feedback corners are open (default: yes).
+    type Connection =
+        { From: Port
+          To: Port
+          FeedbackOpen: bool }
+
+    /// Connect two ports: Some iff snapped (compatible + touching) — feedback open by default.
+    let connect (a: Port) (b: Port) : Connection option =
+        if snapped a b then Some { From = a; To = b; FeedbackOpen = true } else None
+
+    /// Close the feedback corners EXPLICITLY — allowed when (Aaron's conditions, verbatim): "you are
+    /// really trying to OPTIMIZE and you know it's not COERCIVE, or you don't need the feedback
+    /// channel because the MATH GUYS told us" (a proof on the docket, not a hunch). The closing is a
+    /// visible act, never an omission.
+    let withoutFeedback (c: Connection) : Connection = { c with FeedbackOpen = false }

--- a/tests/Tests.FSharp/FluxView.Tests.fs
+++ b/tests/Tests.FSharp/FluxView.Tests.fs
@@ -1,0 +1,64 @@
+module Zeta.Tests.FluxViewTests
+
+// Seeing the flux capacitor and the interrupt handler: soft mode is a RAMP, hard mode is a CLIFF —
+// the difference between the modes IS the picture. Plus the tank's heartbeat and driveK's switchboard.
+
+open global.Xunit
+open Zeta.Core
+
+[<Fact>]
+let ``SOFT vs HARD is visible: the logistic ramps smoothly; the step is a cliff (one jump)`` () =
+    let curveCol (lines: string list) cIx =
+        lines |> List.findIndex (fun l -> l.[cIx] = '#') // the curve's row in this column
+    let soft = FluxView.admissionCurve true 6.0 9 33
+    let hard = FluxView.admissionCurve false 0.0 9 33
+    // soft: adjacent columns never jump more than 2 rows (a ramp you can ride)
+    let softJumps = [ for c in 0..31 -> abs (curveCol soft (c + 1) - curveCol soft c) ]
+    Assert.True(List.max softJumps <= 2)
+    // hard: exactly one place where the curve falls the full height (the cliff)
+    let hardJumps = [ for c in 0..31 -> abs (curveCol hard (c + 1) - curveCol hard c) ]
+    Assert.True(List.max hardJumps >= 7)
+    Assert.Equal(1, hardJumps |> List.filter (fun j -> j >= 7) |> List.length)
+
+[<Fact>]
+let ``the tank gauge shows charge and heat at a glance, proportionally`` () =
+    let full = SoftThrottle.tank 10.0 1.0
+    let g = FluxView.tankGauge 10 full
+    Assert.StartsWith("[██████████]", g)
+    Assert.Contains("heat 0.0", g)
+    let drained = match SoftThrottle.discharge 7.0 full with Some t -> t | None -> full
+    let g2 = FluxView.tankGauge 10 drained
+    Assert.StartsWith("[███░░░░░░░]", g2)
+    Assert.Contains("heat 7.0", g2) // the thermometer reads the spent flux
+
+[<Fact>]
+let ``the flux timeline breathes: bursts drain the columns, idle ticks recover them`` () =
+    let t0 = SoftThrottle.tank 8.0 1.0
+    let load tick = if tick < 4 then 2.0 else 0.0 // burst then rest
+    let line = FluxView.timeline 12 load t0
+    Assert.Equal(12, line.Length)
+    Assert.True(line.[3] < line.[11]) // drained low during the burst, recovered by the end (block chars order by height)
+
+[<Fact>]
+let ``the interrupt grid shows the switchboard: who matched, who passed, when it was silent`` () =
+    let handlers =
+        [ "chip8-input", (function OperatorMessageArrived _ -> true | _ -> false)
+          "chip8-60hz", (function TimerElapsed _ -> true | _ -> false) ]
+    let source: SoftScheduler.Source =
+        fun tick ->
+            if tick = 0 then [ TimerElapsed 17 ]
+            elif tick = 2 then [ OperatorMessageArrived "key:5:1"; TimerElapsed 17 ]
+            else []
+    let grid = FluxView.interruptGrid handlers source 4
+    Assert.Equal(2, List.length grid)
+    Assert.Contains("chip8-input", grid.[0])
+    // input handler: passed(timer only), silent, matched, silent => "· ■ "
+    Assert.True(grid.[0].EndsWith "· ■ ")
+    // timer handler: matched, silent, matched, silent => "■ ■ "
+    Assert.True(grid.[1].EndsWith "■ ■ ")
+
+[<Fact>]
+let ``the views are registered, cost-declared, and the budget lint still holds shelf-wide`` () =
+    for v in [ "view.flux-curve"; "view.flux-gauge"; "view.flux-timeline"; "view.interrupt-grid" ] do
+        Assert.True(GeneratorRegistry.byName v |> Option.isSome)
+    Assert.Equal<string list>([], ComplexityRegistry.unstated ())

--- a/tests/Tests.FSharp/MagneticPorts.Tests.fs
+++ b/tests/Tests.FSharp/MagneticPorts.Tests.fs
@@ -1,0 +1,85 @@
+module Zeta.Tests.MagneticPortsTests
+
+// The type system felt through the fingers: compatible pieces attract, incompatible repel, the snap
+// is the click — no error messages, the pieces just don't want to.
+
+open global.Xunit
+open Zeta.Core
+
+let private tvId = GeneratorRegistry.idOf "interface.universal-tv" 1
+let private audioId = GeneratorRegistry.idOf "audio.saw" 1
+
+[<Fact>]
+let ``compatibility is source->sink with matching type ids; transforms face both ways`` () =
+    let src = MagneticPorts.port 0 0 MagneticPorts.Source tvId
+    let snk = MagneticPorts.port 9 0 MagneticPorts.Sink tvId
+    let wrongType = MagneticPorts.port 9 0 MagneticPorts.Sink audioId
+    let sameDir = MagneticPorts.port 9 0 MagneticPorts.Source tvId
+    let xform = MagneticPorts.port 9 0 MagneticPorts.Transform tvId
+    Assert.True(MagneticPorts.compatible src snk)
+    Assert.False(MagneticPorts.compatible src wrongType)
+    Assert.False(MagneticPorts.compatible src sameDir)
+    Assert.True(MagneticPorts.compatible src xform)
+
+[<Fact>]
+let ``THE MAGNET: compatible pieces pull together; incompatible push apart (the kid feels the rule)`` () =
+    let src = MagneticPorts.port 10 10 MagneticPorts.Source tvId
+    let goodSink = MagneticPorts.port 20 10 MagneticPorts.Sink tvId
+    let badSink = MagneticPorts.port 20 10 MagneticPorts.Sink audioId
+    let (fxGood, _) = MagneticPorts.force src goodSink
+    let (fxBad, _) = MagneticPorts.force src badSink
+    Assert.True(fxGood > 0) // pulled toward the good fit (it's to the right)
+    Assert.True(fxBad < 0) // pushed away from the wrong fit
+    Assert.Equal((0, 0), MagneticPorts.force src src) // coincident: no NaN, no force
+
+[<Fact>]
+let ``dragging feels the field: a piece between a good and a bad fit drifts toward the good one`` () =
+    let good = MagneticPorts.port 30 10 MagneticPorts.Sink tvId
+    let bad = MagneticPorts.port 10 10 MagneticPorts.Sink audioId
+    let mutable hand = MagneticPorts.port 20 10 MagneticPorts.Source tvId
+    for _ in 1..30 do
+        hand <- MagneticPorts.dragTick [ good; bad ] hand
+    Assert.True(hand.Body.Pos.X > Chip9Phys.ofInt 20) // drawn rightward, toward the compatible piece
+
+[<Fact>]
+let ``the SNAP is the click: overlap + compatibility = connected; overlap without compatibility never snaps`` () =
+    let src = MagneticPorts.port 20 10 MagneticPorts.Source tvId
+    Assert.True(MagneticPorts.snapped src (MagneticPorts.port 20 10 MagneticPorts.Sink tvId))
+    Assert.False(MagneticPorts.snapped src (MagneticPorts.port 20 10 MagneticPorts.Sink audioId))
+    Assert.False(MagneticPorts.snapped src (MagneticPorts.port 40 10 MagneticPorts.Sink tvId)) // right type, too far: not yet
+
+[<Fact>]
+let ``registered and cost-declared; the shelf-wide budget lint still holds`` () =
+    Assert.True(GeneratorRegistry.byName "ui.magnetic-ports" |> Option.isSome)
+    Assert.Equal<string list>([], ComplexityRegistry.unstated ())
+
+// ── the shader shelf + the A/V sync law ──
+
+[<Fact>]
+let ``the pixel-shader family is registered and cost-declared (post-generators over colorAt)`` () =
+    for s in [ "shader.antialias"; "shader.xbr"; "shader.hq2x"; "shader.crt-scanline"; "shader.crt-phosphor"; "shader.crt-curvature"; "shader.ntsc" ] do
+        Assert.True(GeneratorRegistry.byName s |> Option.isSome)
+    Assert.Equal<string list>([], ComplexityRegistry.unstated ())
+
+[<Fact>]
+let ``A/V MATCH BY DEFAULT: one generator drives frames and samples in lockstep; MIX is a declared second clock`` () =
+    let g = TimeGen.mk "av" 1 0xA7AUL TimeGen.PhasorTsirelson
+    let anim = { AnimFlow.Name = "b"; AnimFlow.Cycle = [ "idle"; "blink" ] }
+    // matched: same generator, same contributor — frame tick t pairs with sample tick t, always
+    let frames = AnimFlow.observeWith g 7UL anim 6 |> List.map fst
+    let samples = [ for t in 0..5 -> t, ChipAudio.voiceSample g 7UL ChipAudio.Square 250 t ]
+    Assert.Equal<int list>(frames, samples |> List.map fst) // the SAME ticks: matched by default
+    // mixed: a DIFFERENT generator for audio is allowed — but it is a different declared clock
+    let g2 = TimeGen.mk "audio-only" 1 0xBEA7UL TimeGen.PhasorTsirelson
+    Assert.NotEqual(ChipAudio.voiceSample g 7UL ChipAudio.Square 250 3, ChipAudio.voiceSample g2 7UL ChipAudio.Square 250 3)
+
+[<Fact>]
+let ``a snap makes a FOUR-CORNER connection: feedback open by default; closing it is an explicit act`` () =
+    let src = MagneticPorts.port 20 10 MagneticPorts.Source tvId
+    let snk = MagneticPorts.port 20 10 MagneticPorts.Sink tvId
+    match MagneticPorts.connect src snk with
+    | Some conn ->
+        Assert.True(conn.FeedbackOpen) // the default: flow opens the feedback corners
+        Assert.False((MagneticPorts.withoutFeedback conn).FeedbackOpen) // closing is visible, never an omission
+    | None -> failwith "should snap"
+    Assert.True(MagneticPorts.connect src (MagneticPorts.port 40 10 MagneticPorts.Sink tvId) |> Option.isNone)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -174,6 +174,8 @@
     <Compile Include="CorrespondencePong.Tests.fs" />
     <Compile Include="ChipAudio.Tests.fs" />
     <Compile Include="StrokeAnim.Tests.fs" />
+    <Compile Include="FluxView.Tests.fs" />
+    <Compile Include="MagneticPorts.Tests.fs" />
     <Compile Include="OttoAvatar.Tests.fs" />
     <Compile Include="Chip9Treaty.Tests.fs" />
     <Compile Include="Chip8Quote.Tests.fs" />


### PR DESCRIPTION
FluxView: 4 registered views — the admission curve (soft logistic ramp vs hard cliff, the mode difference IS the picture), tank gauge + heat, the LC-heartbeat timeline, the interrupt switchboard grid. MagneticPorts: the type system felt through fingers — ports as physics bodies typed by ZetaId, attraction = compatibility, repulsion = the polite no, snap = the click; feedback corners OPEN by default on every connection (closing = explicit act under Aaron's conditions: optimizing+non-coercive or math-team-proven). Shader shelf registered+cost-declared (MAME the named inspiration for capability injection/upgrades). A/V law tested: matched by default (one clock), mixing = a declared second clock. 18 tests green; budget lint holds shelf-wide.