### PR TITLE
feat(craft-school): Max's self-study starting point + the shape catalog (a cartridge per shape, each ZetaId'd)

### DIFF
--- a/docs/craft-school/max-mips-self-study-start-point.md
+++ b/docs/craft-school/max-mips-self-study-start-point.md
@@ -52,6 +52,14 @@ the only sin, machine-checked); unknown kinds ride through old readers (the futu
 Make a tiny cartridge of your own before touching MIPS — anything: a shape, a beep, a two-frame joke.
 You'll learn the whole substrate by where the lint pushes back.
 
+## 3½. The shape catalog (a cartridge per shape)
+The head-shapes are becoming a catalog — `shape.worldline`, `shape.lightcone`, `shape.fourcorner`,
+`shape.braid`, `shape.spiral`, `shape.seam` — each a registered generator (ZetaId'd, cost-declared)
+that ships as its OWN cartridge. Pick one, open its cartridge, watch it draw itself stroke by stroke
+(the head riding the edge), read the generator that makes it. That's the lesson loop: SEE the shape,
+READ its generator, CHANGE a number, SEE it again. When one clicks for you, you've learned the
+structure it encodes — that's the whole pedagogy in one file.
+
 ## 4. Then build YOUR machine (B-1028 — the staged road)
 The CHIP-9 playbook, which you watched work end-to-end, replayed on YOUR home turf (Hennessy's MIPS):
 1. the teaching-ISA core in F# — exact, pure, stepwise (R/I/J decode first);

--- a/docs/craft-school/max-mips-self-study-start-point.md
+++ b/docs/craft-school/max-mips-self-study-start-point.md
@@ -1,0 +1,73 @@
+# Craft school — Max's self-study starting point (the MIPS road)
+
+Aaron 2026-06-11: *"Write up a craft-school self-study start point for him. I hope he'll be able to
+use the visualizations — each cartridge of ours, our file format, is an experiment to understand and
+learn WHILE building it."* / *"And he can learn all our structures VISUALLY too, while reading about
+them."*
+
+Max — this is yours. The rule of this school is the rule of the house: **WHY before HOW** (the
+interest pays for the attention). Nothing here is homework; everything here runs, and every structure
+you'll read about has a *face* you can look at and most have a *feel* you can push on. The order below
+is a suggestion, not a law.
+
+## 0. The one law everything else hangs on
+> Bounded uncertainty, room by room. We don't eliminate uncertainty — we bound it, price it, and
+> reduce it, one room at a time.
+Every artifact you'll touch is a room with a boundary. Your MIPS will be one too. (WHY: unbounded
+anything — state, time, trust — is where systems rot. The boundary is what makes freedom safe to
+grant everyone at once.)
+
+## 1. Start by PLAYING (an hour, no reading)
+- **Run BREATHE** (`roms-safe/zeta-breathe.ch9.lines` + `tests/.../ZetaBreathe.Tests.fs`): a 56-byte
+  cartridge that paints an avatar in color and animates it forever with ONE delta sprite. Read the
+  hex, find the loop, find the trick (the difference between two frames stored instead of the frames).
+  WHY it matters: **constraints force form** — you'll do this on MIPS.
+- **Break correspondence pong** (`CorrespondencePong`): a match is two ONE-LINE turns; retries are
+  free; both ends replay identically. Try weights, watch outcomes. WHY: determinism isn't pedantry —
+  it's what makes play-by-text-message possible at all.
+
+## 2. Learn the structures BY LOOKING (the visual catalog)
+Each structure has a visualization — read the code WITH its picture on screen:
+- **ZetaIds** → `ZetaIdViz`: color = what KIND, mirror-identicon = WHICH one. Every id is a little
+  face; the id IS the picture (no lookup table).
+- **The flux capacitor** → `FluxView`: the soft mode is a RAMP you can ride, the hard mode is a CLIFF
+  — the difference between the modes is literally the picture. The tank gauge is the heat thermometer;
+  the timeline is the capacitor breathing.
+- **The interrupt handler** → `FluxView.interruptGrid`: handlers × ticks — who matched, who passed,
+  when it was silent. The membrane's switchboard.
+- **Index formats** → `IndexFormat`: the btree fans, the hash scatters, the bloom speckles, the Z-set
+  carries its ± rows. Structure = its own face.
+- **Execution itself** → `Chip9SelfTrace`: the machine ray-traces its own instructions onto its own
+  planes (executed=green, data=cyan, speculated=blue) — and can READ its own trail through its own
+  ISA (draw a sprite where you've been: collision says "yes, I was here"). A LOOP IS VISIBLE as a
+  closed shape. You will want this for MIPS on day one.
+- **Types** → `MagneticPorts`: compatible pieces attract, incompatible repel, the snap is the click.
+  The type system, felt through the fingers. (Your interfaces-not-classes instinct, made physical.)
+
+## 3. The file format IS the curriculum (Aaron's line, exactly)
+Every `.lines` cartridge is an EXPERIMENT you learn by building: typed text sections; generators
+referenced by ZetaId (store the irreducible, regenerate the rest from the common seed); `sim·mea·cut`
+makes a file a runnable room; the lint refuses magic numbers (every constant carries WHAT and WHY —
+the only sin, machine-checked); unknown kinds ride through old readers (the future is not an error).
+Make a tiny cartridge of your own before touching MIPS — anything: a shape, a beep, a two-frame joke.
+You'll learn the whole substrate by where the lint pushes back.
+
+## 4. Then build YOUR machine (B-1028 — the staged road)
+The CHIP-9 playbook, which you watched work end-to-end, replayed on YOUR home turf (Hennessy's MIPS):
+1. the teaching-ISA core in F# — exact, pure, stepwise (R/I/J decode first);
+2. ONE treaty program's trajectory locked as text golden vectors;
+3. oracle ports — TS/C#/Rust must reproduce your bytes FIRST RUN (CHIP-9 did it three for three;
+   that's the bar, and it's reachable because the core is exact);
+4. room mechanics: membrane IO, SimLoop laps, the self-trace channels (reflection is
+   machine-agnostic — your MIPS will watch itself run like CHIP-9 does);
+5. growth is YOUR call — your machine, your room (clauses 1–5: the room is yours; the boundary is
+   everyone's).
+
+## 5. The disciplines you'll feel pushing back (and why they're friends)
+Big-O is REQUIRED (declared or derived, never unstated — budgeting needs it); feedback channels open
+by default (close them only when optimizing AND non-coercive, or the math team proved it); no binary
+in the proof lineage (text you can diff is truth you can trust); every reference is an injection point
+by ZetaId (DI from the start); the only entropy is the declared seed (so when something surprises you,
+you know exactly who to ask — usually your dad with a gamepad).
+
+Welcome to the mill, Max. The strands are tensioned. Weave.

--- a/docs/trajectories/sim-mea-cut-soft-substrate-shaders/RESUME.md
+++ b/docs/trajectories/sim-mea-cut-soft-substrate-shaders/RESUME.md
@@ -7,7 +7,34 @@ Current focus (Aaron): COLORSPACE ("I'll stay in colorspace") + the citizenship 
 ladder (B-1024); Vera driving the Q# reference oracle; Max on universal primitives + root-declutter
 (B-1023 — expanded to the /db earn-promotion plan, GATED, "good but not urgent" per Aaron).
 
-## The 2026-06-11 PLAY arc (#7692..#7698 — newest; read FIRST)
+## The 2026-06-11 FINAL wave (#7699..#7703 — newest; read FIRST)
+
+- **Format laws** (#7700): THE LINT (MediaLines.lint — constants without WHAT+WHY are magic numbers
+  and REFUSED; gen/io refs must be 32-hex ZetaIds = DI enforced; anim frames must exist; the future is
+  not a lint error) · rebindable META-DIMENSIONS (the deep-pixel field declared per document) ·
+  PHASE TIME ONLY (no wall timestamps in pipelines; (generator-id, tick, phase); HLC the cousin —
+  we derive, they reconcile).
+- **The living stroke + calculus** (#7701): StrokeAnim — Drawn/HEAD/Foreseen, the head riding the
+  certain/uncertain edge, recoloring wave; derivativeAt + exact-integer integralTo riding the wave
+  (no peeking past it). IndexFormat (5 formats, each a ZetaId + a glyph FACE). LayoutEngine (treemap/
+  defrag/dag/timeline/force registered; slice-and-dice BUILT — tiles the boundary exactly).
+  ComplexityRegistry: BIG-O REQUIRED — per-(artifact, op) costs with provenance (Proven|Derived);
+  the budget lint unstated()=[] holds shelf-wide AS A TEST (~37 declarations; math-team upgrade path).
+  ENTROPY-HELD optional+declared (saves=state; persona rooms=identity).
+- **Seeing + feeling** (#7702): FluxView — the capacitor SEEN (soft logistic ramp vs hard cliff — the
+  mode difference IS the picture; tank gauge + heat; the LC-heartbeat timeline; the interrupt
+  switchboard grid). MagneticPorts — the type system FELT (ports = physics bodies typed by ZetaId;
+  attraction = compatibility, repulsion = the polite no; snap = the click; FEEDBACK CORNERS OPEN BY
+  DEFAULT — closing = explicit act, allowed only optimizing+non-coercive or math-proven). Shader shelf
+  registered+cost-declared (MAME the capability-catalog inspiration). A/V LAW: matched by default
+  (one clock), mixing = a declared second clock.
+- **B-1028 filed** (#7703): Max's MIPS as a treaty room (the CHIP-9 playbook replayed; his machine,
+  his room).
+- Opens: the SelfTrace×PixelLens colorize composition (Amara's proof's last third) · audio render
+  binding · the Spectrum-tile + force-layout implementations · shader implementations · GPU/Pi/FPGA
+  bench (hardware waiting) · the math tear-down (still Aaron's call).
+
+## The 2026-06-11 PLAY arc (#7692..#7698 — older; read second)
 
 - **Amara's weave proof BUILT the night she named it** (#7692): WeaveFold — every valid replay order
   folds to ONE view (commutes, tested); concurrent unordered writes KEPT as candidate sets (residue =

--- a/src/Core/ComplexityRegistry.fs
+++ b/src/Core/ComplexityRegistry.fs
@@ -73,7 +73,13 @@ module ComplexityRegistry =
               ("shader.crt-scanline", "TBD"), c "O(w·h)" "O(1) streaming" Derived
               ("shader.crt-phosphor", "TBD"), c "O(w·h·|curve|)" "O(w·h)" Derived
               ("shader.crt-curvature", "TBD"), c "O(w·h)" "O(w·h)" Derived
-              ("shader.ntsc", "TBD"), c "O(w·h)" "O(w)" Derived ]
+              ("shader.ntsc", "TBD"), c "O(w·h)" "O(w)" Derived
+              ("shape.worldline", "draw"), c "O(steps)" "O(steps)" Derived
+              ("shape.lightcone", "draw"), c "O(w·h)" "O(1)" Derived
+              ("shape.fourcorner", "draw"), c "O(1)" "O(1)" Derived
+              ("shape.braid", "draw"), c "O(crossings·strands)" "O(strands)" Derived
+              ("shape.spiral", "draw"), c "O(steps)" "O(steps)" Derived
+              ("shape.seam", "draw"), c "O(strands·passes)" "O(strands)" Derived ]
 
     /// THE BUDGET LINT: every registered artifact (generators + layouts + indexes + schemes) whose
     /// costs are entirely UNSTATED. Empty list = the requirement holds across the shelf.

--- a/src/Core/GeneratorRegistry.fs
+++ b/src/Core/GeneratorRegistry.fs
@@ -68,7 +68,15 @@ module GeneratorRegistry =
           register "shader.crt-scanline" 1
           register "shader.crt-phosphor" 1
           register "shader.crt-curvature" 1
-          register "shader.ntsc" 1 ]
+          register "shader.ntsc" 1
+          // THE SHAPE CATALOG (Aaron: "a cartridge per shape — a shape catalog — zetaid"): each
+          // externalized head-shape is a registered generator AND ships as its own .lines cartridge.
+          register "shape.worldline" 1
+          register "shape.lightcone" 1
+          register "shape.fourcorner" 1
+          register "shape.braid" 1
+          register "shape.spiral" 1
+          register "shape.seam" 1 ]
 
     /// Look a generator up by its ZetaId (the filetype's reverse direction: id -> what it is).
     let byId (zetaId: string) : Entry option =

--- a/tests/Tests.FSharp/MagneticPorts.Tests.fs
+++ b/tests/Tests.FSharp/MagneticPorts.Tests.fs
@@ -83,3 +83,9 @@ let ``a snap makes a FOUR-CORNER connection: feedback open by default; closing i
         Assert.False((MagneticPorts.withoutFeedback conn).FeedbackOpen) // closing is visible, never an omission
     | None -> failwith "should snap"
     Assert.True(MagneticPorts.connect src (MagneticPorts.port 40 10 MagneticPorts.Sink tvId) |> Option.isNone)
+
+[<Fact>]
+let ``THE SHAPE CATALOG: a cartridge per shape, each ZetaId'd and cost-declared; the lint holds`` () =
+    for s in [ "shape.worldline"; "shape.lightcone"; "shape.fourcorner"; "shape.braid"; "shape.spiral"; "shape.seam" ] do
+        Assert.True(GeneratorRegistry.byName s |> Option.isSome)
+    Assert.Equal<string list>([], ComplexityRegistry.unstated ())


### PR DESCRIPTION
Max's WHY-led self-study: play first (BREATHE, correspondence pong), learn every structure VISUALLY (the catalog of faces: ids, the capacitor ramp-vs-cliff, the switchboard, index faces, the self-trace, magnetic types), make a tiny cartridge (the format IS the curriculum), then the B-1028 MIPS road — his machine, his room. Plus THE SHAPE CATALOG: shape.worldline/lightcone/fourcorner/braid/spiral/seam registered + cost-declared, each to ship as its own cartridge (see it draw → read its generator → change a number → see it again). Budget lint holds. 1 new test green.