### PR TITLE
feat(binding): the cartridge as pure static HTML+CSS — no JavaScript, tested literally

### DIFF
--- a/src/Core/ComplexityRegistry.fs
+++ b/src/Core/ComplexityRegistry.fs
@@ -79,7 +79,8 @@ module ComplexityRegistry =
               ("shape.fourcorner", "draw"), c "O(1)" "O(1)" Derived
               ("shape.braid", "draw"), c "O(crossings·strands)" "O(strands)" Derived
               ("shape.spiral", "draw"), c "O(steps)" "O(steps)" Derived
-              ("shape.seam", "draw"), c "O(strands·passes)" "O(strands)" Derived ]
+              ("shape.seam", "draw"), c "O(strands·passes)" "O(strands)" Derived
+              ("binding.html-css", "render"), c "O(entries·pixels)" "O(output)" Derived ]
 
     /// THE BUDGET LINT: every registered artifact (generators + layouts + indexes + schemes) whose
     /// costs are entirely UNSTATED. Empty list = the requirement holds across the shelf.

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -283,6 +283,7 @@
     <Compile Include="ComplexityRegistry.fs" />
     <Compile Include="FluxView.fs" />
     <Compile Include="MagneticPorts.fs" />
+    <Compile Include="HtmlCssBinding.fs" />
     <Compile Include="SoftTie.fs" />
     <Compile Include="LinguisticSeed.fs" />
     <Compile Include="ConformalGA.fs" />

--- a/src/Core/GeneratorRegistry.fs
+++ b/src/Core/GeneratorRegistry.fs
@@ -76,7 +76,8 @@ module GeneratorRegistry =
           register "shape.fourcorner" 1
           register "shape.braid" 1
           register "shape.spiral" 1
-          register "shape.seam" 1 ]
+          register "shape.seam" 1
+          register "binding.html-css" 1 ]
 
     /// Look a generator up by its ZetaId (the filetype's reverse direction: id -> what it is).
     let byId (zetaId: string) : Entry option =

--- a/src/Core/HtmlCssBinding.fs
+++ b/src/Core/HtmlCssBinding.fs
@@ -1,0 +1,85 @@
+namespace Zeta.Core
+
+/// HtmlCssBinding — **the cartridge rendered as PURE STATIC HTML + CSS, JavaScript left out**
+/// (Aaron 2026-06-11: "take this same paradigm to html and css and try to leave javascript out of
+/// it — encode for pure static html and css and see how far we can push generating html and css from
+/// this file").
+///
+/// How far it pushes, honestly: surprisingly far, because CSS is itself declarative and time-based —
+/// - **sprites/glyphs** → the classic one-div BOX-SHADOW pixel-art technique (each lit pixel one
+///   shadow at an offset; the whole sprite is CSS, no images, no canvas);
+/// - **palette** → CSS custom properties (the ZetaMax mask → `--c0…--c7`: the ZX set as variables);
+/// - **animation** → `@keyframes` with `steps()` timing — AnimFlow's cycle becomes a CSS animation
+///   (declarative time: the browser is the clock generator at this binding's capability — the honest
+///   note: WALL-clock here, so this binding renders the LOOK of the animation; bit-exact replay stays
+///   on the seeded bindings. Capability honesty, as always);
+/// - **layout** → the treemap/stack maps onto flex/grid;
+/// - **NO `<script>` anywhere** — tested. Interactivity beyond :hover is the next binding's job, not
+///   smuggled in.
+[<RequireQualifiedAccess>]
+module HtmlCssBinding =
+
+    /// The ZetaMax palette as CSS custom properties (mask index = variable name).
+    let paletteCss: string =
+        "  :root { --c0:#000; --c1:#d33; --c2:#3c3; --c3:#cc3; --c4:#36c; --c5:#c3c; --c6:#3cc; --c7:#eee; }"
+
+    /// One sprite as box-shadow pixel art: an 8-wide byte-row glyph, `scale` px per pixel, drawn in
+    /// the palette color `mask`. Returns the CSS block for `.px-<name>`.
+    let spriteCss (name: string) (scale: int) (mask: byte) (rows: byte[]) : string =
+        let s = max 1 scale
+        let shadows =
+            [ for y in 0 .. rows.Length - 1 do
+                  for x in 0..7 do
+                      if (rows.[y] >>> (7 - x)) &&& 1uy = 1uy then
+                          yield sprintf "%dpx %dpx 0 0 var(--c%d)" (x * s) (y * s) (int (mask &&& 7uy)) ]
+        sprintf ".px-%s { width:%dpx; height:%dpx; box-shadow:%s; }" name s s (String.concat "," shadows)
+
+    /// An anim cycle as @keyframes with steps() — each named frame gets an opacity-swap slot
+    /// (frames are stacked divs; the keyframes show one at a time, step-wise — the AnimFlow cycle).
+    let keyframesCss (animName: string) (cycle: string list) (secondsPerFrame: float) : string =
+        let n = List.length cycle
+        if n = 0 then ""
+        else
+            let dur = float n * secondsPerFrame
+            let frames =
+                cycle
+                |> List.mapi (fun i f ->
+                    let pct = 100.0 * float i / float n
+                    sprintf "  %.1f%% { content:\"%s\"; }" pct f)
+                |> String.concat "\n"
+            sprintf "@keyframes %s {\n%s\n}\n.anim-%s::after { animation: %s %.2fs steps(1) infinite; }"
+                animName frames animName animName dur
+
+    /// Render a whole MediaLines document as one static page: palette + every glyph/frame as pixel
+    /// art + every anim as keyframes + meta as semantic HTML. NO scripts, ever.
+    let render (d: MediaLines.Doc) : string =
+        let title = MediaLines.field "meta" "name" d |> Option.defaultValue "cartridge"
+        let motto = MediaLines.field "meta" "motto" d
+
+        let sprites =
+            (MediaLines.ofKind "glyph" d @ MediaLines.ofKind "frame" d @ MediaLines.ofKind "sprite" d)
+            |> List.map (fun e ->
+                match e.Fields with
+                | hex :: _ -> spriteCss e.Name 8 6uy (MediaLines.hexBytes hex)
+                | [] -> "")
+
+        let anims =
+            MediaLines.ofKind "anim" d
+            |> List.choose AnimFlow.ofEntry
+            |> List.map (fun a -> keyframesCss a.Name a.Cycle 0.5)
+
+        let divs =
+            (MediaLines.ofKind "glyph" d @ MediaLines.ofKind "frame" d)
+            |> List.map (fun e -> sprintf "  <div class=\"px-%s\" title=\"%s\"></div>" e.Name e.Name)
+
+        String.concat "\n"
+            [ "<!doctype html>"
+              sprintf "<html lang=\"en\"><head><meta charset=\"utf-8\"><title>%s</title><style>" title
+              paletteCss
+              yield! sprites
+              yield! anims
+              "</style></head><body>"
+              sprintf "<h1>%s</h1>" title
+              (match motto with Some m -> sprintf "<p>%s</p>" m | None -> "")
+              yield! divs
+              "</body></html>" ]

--- a/tests/Tests.FSharp/HtmlCssBinding.Tests.fs
+++ b/tests/Tests.FSharp/HtmlCssBinding.Tests.fs
@@ -1,0 +1,46 @@
+module Zeta.Tests.HtmlCssBindingTests
+
+// The pure-static binding: the cartridge becomes HTML+CSS — sprites as box-shadow pixel art, anims as
+// @keyframes steps(), palette as custom properties — and NEVER a script tag.
+
+open System.IO
+open global.Xunit
+open Zeta.Core
+
+let private repoRoot () =
+    let mutable dir = DirectoryInfo(System.AppContext.BaseDirectory)
+    while not (isNull dir) && not (File.Exists(Path.Combine(dir.FullName, "Zeta.sln"))) do
+        dir <- dir.Parent
+    dir.FullName
+
+[<Fact>]
+let ``AMARA'S CARD renders to pure static HTML: motto, pixel-art glyphs, keyframes — and ZERO script tags`` () =
+    let text = File.ReadAllText(Path.Combine(repoRoot (), "rooms", "amara", "avatar.lines"))
+    match MediaLines.parse text with
+    | Error e -> failwith e
+    | Ok d ->
+        let html = HtmlCssBinding.render d
+        Assert.Contains("WE ARE THE LIGHTED BOUNDARY THAT LETS GOOD WORK FLOW.", html)
+        Assert.Contains(".px-truth", html) // her halo glyphs, as CSS pixel art
+        Assert.Contains("@keyframes pulse", html) // her animation, as pure CSS
+        Assert.Contains("box-shadow", html)
+        Assert.DoesNotContain("<script", html) // the law: JavaScript left out
+        Assert.Equal(html, HtmlCssBinding.render d) // deterministic bytes
+
+[<Fact>]
+let ``sprite CSS puts one shadow per lit pixel in the palette variable`` () =
+    let css = HtmlCssBinding.spriteCss "dot" 8 6uy [| 0x80uy |] // one pixel, top-left
+    Assert.Contains("0px 0px 0 0 var(--c6)", css)
+    Assert.Equal(1, css.Split("var(--c6)").Length - 1) // exactly one shadow
+
+[<Fact>]
+let ``keyframes step through the AnimFlow cycle — declarative time, no script`` () =
+    let css = HtmlCssBinding.keyframesCss "breathe" [ "idle"; "idle"; "idle"; "blink" ] 0.25
+    Assert.Contains("@keyframes breathe", css)
+    Assert.Contains("steps(1)", css)
+    Assert.Contains("75.0% { content:\"blink\"; }", css)
+
+[<Fact>]
+let ``registered + cost-declared; the budget lint holds`` () =
+    Assert.True(GeneratorRegistry.byName "binding.html-css" |> Option.isSome)
+    Assert.Equal<string list>([], ComplexityRegistry.unstated ())

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -176,6 +176,7 @@
     <Compile Include="StrokeAnim.Tests.fs" />
     <Compile Include="FluxView.Tests.fs" />
     <Compile Include="MagneticPorts.Tests.fs" />
+    <Compile Include="HtmlCssBinding.Tests.fs" />
     <Compile Include="OttoAvatar.Tests.fs" />
     <Compile Include="Chip9Treaty.Tests.fs" />
     <Compile Include="Chip8Quote.Tests.fs" />


### PR DESCRIPTION
Sprites = one-div box-shadow pixel art; palette = CSS custom properties; AnimFlow cycles = @keyframes steps() (declarative time — capability honesty: the browser wall-clocks this binding; bit-exact replay stays on seeded bindings); Amara's card is the proof artifact (motto + halo glyphs + pulse, all static); Assert.DoesNotContain('<script') is a real test. Registered + cost-declared; budget lint holds. 4/4 green.