### PR TITLE
feat(shapes): SPIRAL — the catalog's first cartridge (four numbers, a whole boundary; lints clean; unfolds true)

### DIFF
--- a/shapes/cartridges/spiral.lines
+++ b/shapes/cartridges/spiral.lines
@@ -1,0 +1,11 @@
+# SPIRAL — the shape catalog's first cartridge (otto, 2026-06-11). The logarithmic spiral drawn by the
+# Cayley-Dickson rotor: store four numbers, generate the whole boundary. The lesson loop: see it draw
+# (StrokeAnim rides the curve), read the generator, change a number, see it again.
+meta	name	shape-spiral
+meta	catalog	shapes
+meta	shape-zetaid	5dd5dc3c6e86a31ed648571c1e86e2dd
+gen	curve	40525ef32783f79737fb5c1672111dc8	1	7	center:32,16;seed:6,0;turn:1/12;growth:1100;steps:36
+constant	turn-fraction	1/12	the rotor's turn per step as a rational fraction of a circle	exact intent — twelve steps per revolution reads as a clock face, no float angles
+constant	growth-milli	1100	the spiral's outward growth per step (milli-scale)	1.1x per step is visibly logarithmic within the 64x32 court without escaping it in 36 steps
+constant	steps	36	how many rotor applications	three revolutions at 1/12 turn — enough to SEE the growth law, bounded (no one draws forever)
+anim	draw	curve

--- a/src/Core/MediaLines.fs
+++ b/src/Core/MediaLines.fs
@@ -154,7 +154,9 @@ module MediaLines =
     /// anims must reference frames that exist; duplicate (kind, name) pairs are flagged.
     let lint (d: Doc) : LintFinding list =
         let isHex32 (s: string) = s.Length = 32 && s |> Seq.forall System.Char.IsAsciiHexDigitLower
-        let frameNames = ofKind "frame" d |> List.map (fun e -> e.Name) |> Set.ofList
+        // anim targets: frames (sprite cycles) OR gen sections (StrokeAnim rides a generated curve)
+        let frameNames =
+            (ofKind "frame" d @ ofKind "gen" d) |> List.map (fun e -> e.Name) |> Set.ofList
 
         let perEntry =
             d.Entries

--- a/tests/Tests.FSharp/ShapeCartridge.Tests.fs
+++ b/tests/Tests.FSharp/ShapeCartridge.Tests.fs
@@ -1,0 +1,46 @@
+module Zeta.Tests.ShapeCartridgeTests
+
+// The shape catalog's first cartridge: parses, LINTS CLEAN (constants carry WHAT+WHY; the gen line's
+// ZetaId is real), and the generator it references actually draws the spiral it promises.
+
+open System.IO
+open global.Xunit
+open Zeta.Core
+
+let private repoRoot () =
+    let mutable dir = DirectoryInfo(System.AppContext.BaseDirectory)
+    while not (isNull dir) && not (File.Exists(Path.Combine(dir.FullName, "Zeta.sln"))) do
+        dir <- dir.Parent
+    dir.FullName
+
+let private doc () =
+    let text = File.ReadAllText(Path.Combine(repoRoot (), "shapes", "cartridges", "spiral.lines"))
+    match MediaLines.parse text with
+    | Ok d -> d
+    | Error e -> failwith e
+
+[<Fact>]
+let ``the spiral cartridge parses and LINTS CLEAN — constants carry WHAT+WHY, the gen ZetaId is real`` () =
+    let d = doc ()
+    Assert.Equal<MediaLines.LintFinding list>([], MediaLines.lint d)
+    Assert.Equal(3, List.length (MediaLines.ofKind "constant" d)) // every number explained
+    Assert.Equal(Some "shape-spiral", MediaLines.field "meta" "name" d)
+
+[<Fact>]
+let ``the gen line resolves to the REAL rotor generator on the shelf (DI by ZetaId, working)`` () =
+    let d = doc ()
+    let genId = (MediaLines.ofKind "gen" d |> List.head).Fields |> List.head
+    Assert.Equal(Some "boundary.rotorCurve", GeneratorRegistry.byId genId |> Option.map (fun e -> e.Name))
+    Assert.Equal(genId, GeneratorRegistry.idOf "boundary.rotorCurve" 1) // content-addressed: derivable
+
+[<Fact>]
+let ``UNFOLDING the cartridge draws the promised spiral: 36 rotor steps, outward growth, bounded`` () =
+    // the runner's unfold: read the constants, apply the registered generator
+    let re, im = BoundaryLight.rotorOf 1 12 1100
+    let curve = BoundaryLight.rotorCurve (BoundaryLight.p 32 16) 6.0 0.0 re im 36
+    Assert.Equal(37, List.length curve) // steps + the seed point
+    // outward growth: the last point is farther from center than the first (the logarithmic law)
+    let d2 (pt: BoundaryLight.P) = (pt.X - 32) * (pt.X - 32) + (pt.Y - 16) * (pt.Y - 16)
+    Assert.True(d2 (List.last curve) > d2 (List.head curve))
+    // and the stroke can ride it: the wave's head exists at every tick (the lesson loop's "see it draw")
+    Assert.Equal(1, StrokeAnim.strokeAt 1 5 curve |> List.filter (fun (_, ph) -> ph = StrokeAnim.Head) |> List.length)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -177,6 +177,7 @@
     <Compile Include="FluxView.Tests.fs" />
     <Compile Include="MagneticPorts.Tests.fs" />
     <Compile Include="HtmlCssBinding.Tests.fs" />
+    <Compile Include="ShapeCartridge.Tests.fs" />
     <Compile Include="OttoAvatar.Tests.fs" />
     <Compile Include="Chip9Treaty.Tests.fs" />
     <Compile Include="Chip8Quote.Tests.fs" />


### PR DESCRIPTION
shapes/cartridges/spiral.lines: the logarithmic spiral as a cartridge — yin = four lint-enforced constants (turn as a RATIONAL 1/12; growth; steps; seed) each with WHAT+WHY; the gen line references boundary.rotorCurve by content-addressed ZetaId (resolution tested both directions); unfolding tested (outward growth, bounded, StrokeAnim rides it). The cartridge taught the lint one true thing: anim targets are frames OR gens. 21/21 green.