### PR TITLE
feat(sim): WaveSim — honest interference (superposition IS the Cayley Add; the fringe test is physics) + UV/IR in the deep cell

### DIFF
--- a/src/Core/ComplexityRegistry.fs
+++ b/src/Core/ComplexityRegistry.fs
@@ -80,7 +80,8 @@ module ComplexityRegistry =
               ("shape.braid", "draw"), c "O(crossings·strands)" "O(strands)" Derived
               ("shape.spiral", "draw"), c "O(steps)" "O(steps)" Derived
               ("shape.seam", "draw"), c "O(strands·passes)" "O(strands)" Derived
-              ("binding.html-css", "render"), c "O(entries·pixels)" "O(output)" Derived ]
+              ("binding.html-css", "render"), c "O(entries·pixels)" "O(output)" Derived
+              ("sim.wave-interference", "pattern"), c "O(w·h·sources)" "O(w·h)" Derived ]
 
     /// THE BUDGET LINT: every registered artifact (generators + layouts + indexes + schemes) whose
     /// costs are entirely UNSTATED. Empty list = the requirement holds across the shelf.

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -284,6 +284,7 @@
     <Compile Include="FluxView.fs" />
     <Compile Include="MagneticPorts.fs" />
     <Compile Include="HtmlCssBinding.fs" />
+    <Compile Include="WaveSim.fs" />
     <Compile Include="SoftTie.fs" />
     <Compile Include="LinguisticSeed.fs" />
     <Compile Include="ConformalGA.fs" />

--- a/src/Core/GeneratorRegistry.fs
+++ b/src/Core/GeneratorRegistry.fs
@@ -77,7 +77,8 @@ module GeneratorRegistry =
           register "shape.braid" 1
           register "shape.spiral" 1
           register "shape.seam" 1
-          register "binding.html-css" 1 ]
+          register "binding.html-css" 1
+          register "sim.wave-interference" 1 ]
 
     /// Look a generator up by its ZetaId (the filetype's reverse direction: id -> what it is).
     let byId (zetaId: string) : Entry option =

--- a/src/Core/WaveSim.fs
+++ b/src/Core/WaveSim.fs
@@ -1,0 +1,54 @@
+namespace Zeta.Core
+
+/// WaveSim — **honest interference patterns from generators** (Aaron 2026-06-11: "we should be able
+/// to generate honest interference patterns — simulated bit-perfect quantum and regular waves, all
+/// sorts of physical simulators from generators — with the Cayley-Dickson and Clifford algebra we
+/// already have").
+///
+/// The machinery is exactly the algebra on the shelf: each source contributes a PHASOR (a Cayley
+/// complex — `ImaginaryStack.complex`), superposition is literally `complex.Add`, and the visible
+/// pattern is the squared magnitude of the sum. Two sources make the classic double-slit fringes:
+/// bright where path difference = nλ (constructive), dark at half-wavelength offsets (destructive) —
+/// and the TEST is that physics, not a screenshot.
+///
+/// **The honest labels (the register matters here):** this is a deterministic SIMULATION of wave
+/// interference — the amplitude mathematics that classical waves and quantum amplitudes share. We do
+/// NOT claim quantum hardware or physical nonlocality (the same discipline as TimeGen's staged
+/// regime: the math is exact, the interpretation is labeled). "Bit-perfect" = same inputs, same
+/// pattern, every run — deterministic in-process; the cross-oracle exact-phase slice (integer-only
+/// distances) is named, not claimed.
+[<RequireQualifiedAccess>]
+module WaveSim =
+
+    /// A wave source: position + wavelength (in cell units) + amplitude.
+    type Source =
+        { X: float
+          Y: float
+          Wavelength: float
+          Amplitude: float }
+
+    let source x y wl amp =
+        { X = x; Y = y; Wavelength = max 1e-9 wl; Amplitude = amp }
+
+    /// The phasor one source contributes at a cell at tick t (ω advances phase per tick):
+    /// amplitude × e^{i(2π·d/λ − ωt)} — built as a Cayley complex.
+    let phasorAt (omega: float) (t: int) (s: Source) (cx: float) (cy: float) : Complex =
+        let dx, dy = cx - s.X, cy - s.Y
+        let d = sqrt (dx * dx + dy * dy)
+        let phase = 2.0 * System.Math.PI * d / s.Wavelength - omega * float t
+        Doubled.make (s.Amplitude * cos phase) (s.Amplitude * sin phase)
+
+    /// SUPERPOSITION — literally the Cayley complex Add over all sources (the algebra we have).
+    let fieldAt (omega: float) (t: int) (sources: Source list) (cx: float) (cy: float) : Complex =
+        sources
+        |> List.fold (fun acc s -> ImaginaryStack.complex.Add(acc, phasorAt omega t s cx cy)) (Doubled.make 0.0 0.0)
+
+    /// The visible intensity: |Σ phasors|² (what a screen/plane shows).
+    let intensityAt (omega: float) (t: int) (sources: Source list) (cx: float) (cy: float) : float =
+        let f = fieldAt omega t sources cx cy
+        f.Real * f.Real + f.Imag * f.Imag
+
+    /// Render the pattern onto a w×h grid as intensities (the generator form — samples, like every
+    /// other generator; quantization to planes/cells happens at the binding, as always).
+    let pattern (omega: float) (t: int) (sources: Source list) (w: int) (h: int) : float[,] =
+        Array2D.init h w (fun y x -> intensityAt omega t sources (float x) (float y))

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -178,6 +178,7 @@
     <Compile Include="MagneticPorts.Tests.fs" />
     <Compile Include="HtmlCssBinding.Tests.fs" />
     <Compile Include="ShapeCartridge.Tests.fs" />
+    <Compile Include="WaveSim.Tests.fs" />
     <Compile Include="OttoAvatar.Tests.fs" />
     <Compile Include="Chip9Treaty.Tests.fs" />
     <Compile Include="Chip8Quote.Tests.fs" />

--- a/tests/Tests.FSharp/WaveSim.Tests.fs
+++ b/tests/Tests.FSharp/WaveSim.Tests.fs
@@ -1,0 +1,61 @@
+module Zeta.Tests.WaveSimTests
+
+// Honest interference: superposition IS the Cayley complex Add; the TEST is the physics — bright
+// where path difference = nλ, dark at λ/2 — not a screenshot. Deterministic; labels honest.
+
+open global.Xunit
+open Zeta.Core
+
+// two sources on a horizontal line, the classic double-slit geometry
+let private slits = [ WaveSim.source 20.0 16.0 4.0 1.0; WaveSim.source 28.0 16.0 4.0 1.0 ]
+
+[<Fact>]
+let ``CONSTRUCTIVE on the center line: equidistant cells see double amplitude (intensity 4x a single source)`` () =
+    // the midline x=24: path difference 0 => phasors aligned => |2A|^2 = 4A^2
+    let two = WaveSim.intensityAt 0.0 0 slits 24.0 30.0
+    let one = WaveSim.intensityAt 0.0 0 [ List.head slits ] 24.0 30.0
+    Assert.True(two > 3.5 * one) // constructive: ~4x (slack for distance falloff-free model)
+
+[<Fact>]
+let ``DESTRUCTIVE at half-wavelength path difference: a dark fringe (intensity near zero)`` () =
+    // find a cell where |d1 - d2| ≈ λ/2 = 2.0: source A at (20,16), B at (28,16); cell on the line
+    // between them at x=23: d1=3, d2=5 -> difference 2.0 exactly
+    let dark = WaveSim.intensityAt 0.0 0 slits 23.0 16.0
+    Assert.True(dark < 0.01) // the phasors cancel — the fringe is REAL math, not painted
+
+[<Fact>]
+let ``the pattern FRINGES: along a screen line, intensity alternates (maxima and minima both present)`` () =
+    let screen = [ for x in 0..47 -> WaveSim.intensityAt 0.0 0 slits (float x) 31.0 ]
+    let mx, mn = List.max screen, List.min screen
+    Assert.True(mx > 3.0 && mn < 0.5) // bright and dark bands coexist: interference, visibly
+
+[<Fact>]
+let ``superposition is LITERALLY the Cayley Add — and the simulation is bit-stable (same inputs, same pattern)`` () =
+    let a = WaveSim.pattern 0.5 7 slits 32 16
+    let b = WaveSim.pattern 0.5 7 slits 32 16
+    Assert.Equal<float[,]>(a, b) // deterministic every run
+    // the algebra check: field of two = Add of the two phasors
+    let p1 = WaveSim.phasorAt 0.0 0 slits.[0] 24.0 30.0
+    let p2 = WaveSim.phasorAt 0.0 0 slits.[1] 24.0 30.0
+    let sum = ImaginaryStack.complex.Add(p1, p2)
+    let f = WaveSim.fieldAt 0.0 0 slits 24.0 30.0
+    Assert.Equal(sum.Real, f.Real, 12)
+    Assert.Equal(sum.Imag, f.Imag, 12)
+
+[<Fact>]
+let ``registered + cost-declared; the budget lint holds`` () =
+    Assert.True(GeneratorRegistry.byName "sim.wave-interference" |> Option.isSome)
+    Assert.Equal<string list>([], ComplexityRegistry.unstated ())
+
+[<Fact>]
+let ``UV and IR: out-of-gamut intensity rides the deep cell — invisible to the display, real to the physics`` () =
+    // the visible 3-bit gamut shows mask only; the INVISIBLE bands (IR below, UV above) ride the
+    // payload, declared as a dimension rebind — the lens overlay is the IR camera
+    let irDecl = "dimension\tir\tpayload-field\tinfrared-band-intensity-milli\ndimension\tuv\tpayload-field\tultraviolet-band-intensity-milli"
+    match MediaLines.parse irDecl with
+    | Ok d -> Assert.Equal<MediaLines.LintFinding list>([], MediaLines.lint d) // declared, lint-clean
+    | Error e -> failwith e
+    // a hot-but-dark pixel: visibly black, IR-bright — the heat ledger radiating into the cell
+    let hotDark = PixelLens.pack 0uy 850 0 // visible: nothing; payload: 850 milli of IR
+    Assert.Equal(0uy, PixelLens.color.Get hotDark) // the display sees darkness
+    Assert.Equal(850, PixelLens.payload.Get hotDark) // the IR camera (the rebound lens) sees the heat


### PR DESCRIPTION
Superposition = ImaginaryStack.complex.Add literally (algebra check to 1e-12). The tests ARE the physics: constructive ~4× on the midline, destructive <0.01 at exactly λ/2, coexisting fringes on a screen line. Labels honest (the TimeGen discipline): deterministic simulation of shared amplitude math — no quantum-hardware/nonlocality claims; exact-phase cross-oracle slice named. Plus the invisible bands: UV/IR ride the deep-cell payload via declared dimension rebinds — a visibly-black, IR-bright pixel works (the display sees darkness; the rebound lens sees the heat). 6/6 green; budget lint holds.