### PR TITLE
feat(viz+spectral): adinkras SEEN (with the generator shine) + the soft/hard FFT pivot

### DIFF
--- a/src/Core/AdinkraViz.fs
+++ b/src/Core/AdinkraViz.fs
@@ -1,0 +1,77 @@
+namespace Zeta.Core
+
+/// AdinkraViz — **seeing the adinkras** (Aaron 2026-06-11: "does this make adinkras easy now? Can we
+/// see what they look like? — with a generator SHINING, or prisming, or whatever they do when you use
+/// it in that direction").
+///
+/// Yes — easy now, because the mapping is exact: an adinkra (Gates/Iga — the supersymmetry
+/// chromotopology) is nodes + COLORED edges, one color per SUSY generator — and an N=4 adinkra's four
+/// edge colors land on our four channels (R, G, B, cyan) one-to-one. Bosons (even weight) are filled
+/// nodes, fermions (odd) open; flipping any one bit flips parity, so the 4×4 gray-code layout is a
+/// perfect boson/fermion CHECKERBOARD — visible at a glance, which is the point.
+///
+/// **The SHINE**: using generator i in a direction lights its color — `render shine=Some i` draws
+/// that generator's edges BRIGHT (its channel) and dims the rest. The prism reading is exact: the
+/// adinkra holds all four colors superposed; shining selects one out — the soft prism applied to a
+/// supersymmetry diagram.
+///
+/// Honest scope: the 4×4 gray-code grid shows the 24 grid-adjacent edges of the 4-cube (the 8 wrap
+/// edges are stated, not drawn — a flat grid cannot show a tesseract whole); DASHINGS (the sign
+/// assignment — the actual Hamming-code content of AdinkraCode) are the named next slice, and they
+/// belong on the retraction register (a dashed edge = a −1: the CMYK reading was born for this).
+[<RequireQualifiedAccess>]
+module AdinkraViz =
+
+    let private esc (c: int) = sprintf "[3%dm" c
+    let private dim = "[2m"
+    let private reset = "[0m"
+
+    /// Gray code order for the 4×4 layout (adjacent cells differ in exactly one bit).
+    let private gray = [| 0; 1; 3; 2 |]
+
+    /// The 4-bit node at grid (col, row): low two bits from the column gray code, high two from row.
+    let nodeAt (col: int) (row: int) : int = gray.[col &&& 3] ||| (gray.[row &&& 3] <<< 2)
+
+    /// Which bit differs between two grid-adjacent nodes (the edge's GENERATOR = its color).
+    let private flippedBit (a: int) (b: int) : int =
+        let d = a ^^^ b
+        [ 0..3 ] |> List.find (fun i -> d = (1 <<< i))
+
+    /// The four generator colors on our channels: bit0=R(1), bit1=G(2), bit2=B(4), bit3=cyan(6).
+    let colorOfBit (bit: int) : int =
+        match bit with
+        | 0 -> 1
+        | 1 -> 2
+        | 2 -> 4
+        | _ -> 6
+
+    /// Render the N=4 adinkra as ANSI lines. `shine = Some bit` lights that generator's edges bright
+    /// and dims the others (the prism: one color selected out of the superposition). Bosons ●,
+    /// fermions ○ — the checkerboard is the parity proof, visible.
+    let render (shine: int option) : string list =
+        let edgeStr (bit: int) (glyph: string) =
+            let c = esc (colorOfBit bit)
+            match shine with
+            | Some s when s = bit -> c + glyph + reset // shining: bright in its channel
+            | Some _ -> dim + glyph + reset // another generator selected: dimmed
+            | None -> c + glyph + reset // no shine: all four colors live together
+
+        [ for row in 0..3 do
+              // the node row: nodes + horizontal edges (bit from the column gray flip)
+              let nodes =
+                  [ for col in 0..3 ->
+                        let n = nodeAt col row
+                        let glyph = if (System.Numerics.BitOperations.PopCount(uint n)) % 2 = 0 then "●" else "○"
+                        let h =
+                            if col < 3 then edgeStr (flippedBit n (nodeAt (col + 1) row)) "──"
+                            else ""
+                        glyph + h ]
+                  |> String.concat ""
+              yield nodes
+              // the vertical-edge row (bit from the row gray flip)
+              if row < 3 then
+                  yield
+                      [ for col in 0..3 ->
+                            let bit = flippedBit (nodeAt col row) (nodeAt col (row + 1))
+                            edgeStr bit "│" + "  " ]
+                      |> String.concat "" ]

--- a/src/Core/ComplexityRegistry.fs
+++ b/src/Core/ComplexityRegistry.fs
@@ -81,7 +81,12 @@ module ComplexityRegistry =
               ("shape.spiral", "draw"), c "O(steps)" "O(steps)" Derived
               ("shape.seam", "draw"), c "O(strands·passes)" "O(strands)" Derived
               ("binding.html-css", "render"), c "O(entries·pixels)" "O(output)" Derived
-              ("sim.wave-interference", "pattern"), c "O(w·h·sources)" "O(w·h)" Derived ]
+              ("sim.wave-interference", "pattern"), c "O(w·h·sources)" "O(w·h)" Derived
+              ("viz.adinkra", "render"), c "O(nodes)" "O(nodes)" Derived
+              ("spectral.hard-dft", "dft"), c "O(n²)" "O(n)" Derived
+              ("spectral.hard-dft", "idft"), c "O(n²)" "O(n)" Derived
+              ("spectral.soft-probe", "probe"), c "O(n)" "O(1)" Derived
+              ("spectral.soft-probe", "fingerprint"), c "O(n·k)" "O(k)" Derived ]
 
     /// THE BUDGET LINT: every registered artifact (generators + layouts + indexes + schemes) whose
     /// costs are entirely UNSTATED. Empty list = the requirement holds across the shelf.

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -285,6 +285,8 @@
     <Compile Include="MagneticPorts.fs" />
     <Compile Include="HtmlCssBinding.fs" />
     <Compile Include="WaveSim.fs" />
+    <Compile Include="AdinkraViz.fs" />
+    <Compile Include="SpectralPivot.fs" />
     <Compile Include="SoftTie.fs" />
     <Compile Include="LinguisticSeed.fs" />
     <Compile Include="ConformalGA.fs" />

--- a/src/Core/GeneratorRegistry.fs
+++ b/src/Core/GeneratorRegistry.fs
@@ -78,7 +78,10 @@ module GeneratorRegistry =
           register "shape.spiral" 1
           register "shape.seam" 1
           register "binding.html-css" 1
-          register "sim.wave-interference" 1 ]
+          register "sim.wave-interference" 1
+          register "viz.adinkra" 1
+          register "spectral.hard-dft" 1
+          register "spectral.soft-probe" 1 ]
 
     /// Look a generator up by its ZetaId (the filetype's reverse direction: id -> what it is).
     let byId (zetaId: string) : Entry option =

--- a/src/Core/SpectralPivot.fs
+++ b/src/Core/SpectralPivot.fs
@@ -1,0 +1,59 @@
+namespace Zeta.Core
+
+/// SpectralPivot — **the soft and hard FFT: fingerprinting into spectral, a pivot in phase spaces**
+/// (Aaron 2026-06-11: "since we have audio we probably need some sort of soft and hard FFT — it's
+/// kind of like fingerprinting into spectral; it's like a pivot in phase spaces").
+///
+/// Exactly the rainbow-table shape, in frequency:
+/// - **HARD** — the exact DFT (O(n²), honest — the n·log n fast factorization is the named upgrade):
+///   the full spectral fingerprint, the lossless PIVOT between phase spaces — time↔frequency are two
+///   bases for one signal, and the pivot is invertible (the inverse round-trip is a TEST).
+/// - **SOFT** — the probe (Goertzel-shaped): evaluate just k chosen bins — the spectral MinHash: a
+///   cheap fingerprint that answers "is THIS pitch in there?" without paying for the whole spectrum
+///   (the soft prism pointed at frequency space).
+/// Both run on the Cayley complex we already have (the twiddle factors are rotor applications —
+/// the same algebra that draws spirals and interferes waves now hears pitch).
+[<RequireQualifiedAccess>]
+module SpectralPivot =
+
+    let private tau = 2.0 * System.Math.PI
+
+    /// HARD: the exact DFT of a real signal — bin k's phasor (Cayley complex), for all n bins.
+    let dft (signal: float[]) : Complex[] =
+        let n = signal.Length
+        [| for k in 0 .. n - 1 ->
+               let mutable acc = Doubled.make 0.0 0.0
+               for t in 0 .. n - 1 do
+                   let ang = -tau * float k * float t / float n
+                   let tw = Doubled.make (cos ang) (sin ang)
+                   let s = Doubled.make signal.[t] 0.0
+                   acc <- ImaginaryStack.complex.Add(acc, ImaginaryStack.complex.Mul(s, tw))
+               acc |]
+
+    /// The inverse pivot: back from frequency to time (the round-trip proves the pivot loses nothing).
+    let idft (spectrum: Complex[]) : float[] =
+        let n = spectrum.Length
+        [| for t in 0 .. n - 1 ->
+               let mutable acc = Doubled.make 0.0 0.0
+               for k in 0 .. n - 1 do
+                   let ang = tau * float k * float t / float n
+                   let tw = Doubled.make (cos ang) (sin ang)
+                   acc <- ImaginaryStack.complex.Add(acc, ImaginaryStack.complex.Mul(spectrum.[k], tw))
+               acc.Real / float n |]
+
+    /// A bin's energy (the fingerprint's coordinate).
+    let energy (c: Complex) : float = c.Real * c.Real + c.Imag * c.Imag
+
+    /// SOFT: probe ONE bin (Goertzel-shaped, O(n)) — the spectral soft-prism: "is this pitch there?"
+    let probe (signal: float[]) (k: int) : float =
+        let n = signal.Length
+        let mutable acc = Doubled.make 0.0 0.0
+        for t in 0 .. n - 1 do
+            let ang = -tau * float k * float t / float n
+            acc <- ImaginaryStack.complex.Add(acc, Doubled.make (signal.[t] * cos ang) (signal.[t] * sin ang))
+        energy acc
+
+    /// The soft FINGERPRINT: k probe bins (the spectral MinHash — cheap, comparable, honest about
+    /// what it didn't look at).
+    let fingerprint (bins: int list) (signal: float[]) : (int * float) list =
+        bins |> List.map (fun k -> k, probe signal k)

--- a/tests/Tests.FSharp/AdinkraViz.Tests.fs
+++ b/tests/Tests.FSharp/AdinkraViz.Tests.fs
@@ -1,0 +1,48 @@
+module Zeta.Tests.AdinkraVizTests
+
+// Seeing the adinkra: the gray-code 4x4 is a perfect boson/fermion checkerboard; every edge carries
+// exactly one generator's color (four colors = our four channels); the SHINE selects one generator
+// out of the superposition (bright in its channel, the rest dimmed) — the prism, working.
+
+open global.Xunit
+open Zeta.Core
+
+[<Fact>]
+let ``the gray layout is lawful: grid-adjacent nodes differ in exactly one bit (every edge has ONE color)`` () =
+    for row in 0..3 do
+        for col in 0..2 do
+            let d = AdinkraViz.nodeAt col row ^^^ AdinkraViz.nodeAt (col + 1) row
+            Assert.Equal(1, System.Numerics.BitOperations.PopCount(uint d))
+    for row in 0..2 do
+        for col in 0..3 do
+            let d = AdinkraViz.nodeAt col row ^^^ AdinkraViz.nodeAt col (row + 1)
+            Assert.Equal(1, System.Numerics.BitOperations.PopCount(uint d))
+
+[<Fact>]
+let ``the boson/fermion CHECKERBOARD is visible: parity alternates at every step (filled/open)`` () =
+    let lines = AdinkraViz.render None
+    Assert.Equal(7, List.length lines) // 4 node rows + 3 edge rows
+    let parity c r = System.Numerics.BitOperations.PopCount(uint (AdinkraViz.nodeAt c r)) % 2
+    for r in 0..3 do
+        for c in 0..2 do
+            Assert.NotEqual(parity c r, parity (c + 1) r) // one bit flip = parity flip: checkerboard
+
+[<Fact>]
+let ``all FOUR generator colors appear (R, G, B, cyan — the N=4 chromotopology on our channels)`` () =
+    let all = AdinkraViz.render None |> String.concat "\n"
+    for c in [ 1; 2; 4; 6 ] do
+        Assert.Contains(sprintf "[3%dm" c, all)
+
+[<Fact>]
+let ``THE SHINE: selecting a generator brightens its edges and DIMS the other three (the prism)`` () =
+    let shone = AdinkraViz.render (Some 2) |> String.concat "\n"
+    Assert.Contains("[34m", shone) // bit 2's color (blue, 4) still bright
+    Assert.Contains("[2m", shone) // and dimming exists — the unselected generators recede
+    let unshone = AdinkraViz.render None |> String.concat "\n"
+    Assert.DoesNotContain("[2m", unshone) // no shine: nothing dimmed, all four live together
+
+[<Fact>]
+let ``deterministic + registered + cost-declared (the budget lint holds)`` () =
+    Assert.Equal<string list>(AdinkraViz.render (Some 1), AdinkraViz.render (Some 1))
+    Assert.True(GeneratorRegistry.byName "viz.adinkra" |> Option.isSome)
+    Assert.Equal<string list>([], ComplexityRegistry.unstated ())

--- a/tests/Tests.FSharp/SpectralPivot.Tests.fs
+++ b/tests/Tests.FSharp/SpectralPivot.Tests.fs
@@ -1,0 +1,45 @@
+module Zeta.Tests.SpectralPivotTests
+
+// The spectral pivot: hard = the exact, INVERTIBLE basis change (round-trip is the test); soft = the
+// probe fingerprint (right pitch >> wrong pitch). The same Cayley complex hears pitch now.
+
+open global.Xunit
+open Zeta.Core
+
+// a pure tone at bin 4 of 32 samples (from our own chip waveform family — the saw's fundamental sibling)
+let private tone =
+    [| for t in 0..31 -> cos (2.0 * System.Math.PI * 4.0 * float t / 32.0) |]
+
+[<Fact>]
+let ``HARD fingerprint: the DFT finds the pitch — bin 4 dominates everything else`` () =
+    let spec = SpectralPivot.dft tone
+    let e4 = SpectralPivot.energy spec.[4]
+    for k in [ 1; 2; 3; 5; 7; 11 ] do
+        Assert.True(e4 > 100.0 * SpectralPivot.energy spec.[k])
+
+[<Fact>]
+let ``THE PIVOT IS LOSSLESS: idft (dft signal) recovers the signal (two bases, one signal)`` () =
+    let back = SpectralPivot.idft (SpectralPivot.dft tone)
+    for t in 0..31 do
+        Assert.Equal(tone.[t], back.[t], 9)
+
+[<Fact>]
+let ``SOFT probe: the right pitch answers loud, the wrong pitch answers quiet — the spectral soft-prism`` () =
+    Assert.True(SpectralPivot.probe tone 4 > 100.0 * SpectralPivot.probe tone 7)
+    let fp = SpectralPivot.fingerprint [ 2; 4; 8 ] tone
+    Assert.Equal(3, List.length fp) // it looked at exactly what it said it would
+    Assert.True(snd fp.[1] > snd fp.[0] && snd fp.[1] > snd fp.[2])
+
+[<Fact>]
+let ``our own square wave fingerprints as physics says: odd harmonics only (bin 4 and 12 live, bin 8 dark)`` () =
+    let square = [| for t in 0..31 -> if (t / 4) % 2 = 0 then 1.0 else -1.0 |] // period 8 = 4 cycles in 32
+    let f = SpectralPivot.probe square
+    Assert.True(f 4 > 50.0 * f 8) // the even harmonic is silent — the square's signature
+    Assert.True(f 12 > f 8) // the third harmonic rings
+
+[<Fact>]
+let ``deterministic + registered + cost-declared (hard O(n²) honest; the n·log n upgrade is named)`` () =
+    Assert.Equal<(int * float) list>(SpectralPivot.fingerprint [ 4 ] tone, SpectralPivot.fingerprint [ 4 ] tone)
+    Assert.True(GeneratorRegistry.byName "spectral.hard-dft" |> Option.isSome)
+    Assert.True(GeneratorRegistry.byName "spectral.soft-probe" |> Option.isSome)
+    Assert.Equal<string list>([], ComplexityRegistry.unstated ())

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -179,6 +179,8 @@
     <Compile Include="HtmlCssBinding.Tests.fs" />
     <Compile Include="ShapeCartridge.Tests.fs" />
     <Compile Include="WaveSim.Tests.fs" />
+    <Compile Include="AdinkraViz.Tests.fs" />
+    <Compile Include="SpectralPivot.Tests.fs" />
     <Compile Include="OttoAvatar.Tests.fs" />
     <Compile Include="Chip9Treaty.Tests.fs" />
     <Compile Include="Chip8Quote.Tests.fs" />


### PR DESCRIPTION
AdinkraViz: N=4's four edge colors land 1:1 on our four channels; gray-code 4×4 = the boson/fermion checkerboard, visible; THE SHINE selects one generator bright, dims the rest (the soft prism on a SUSY diagram). Honest: 24/32 edges flat (wraps stated); dashings = next slice, on the retraction register. SpectralPivot: hard DFT = the lossless pivot (idft∘dft=id tested to 1e-9), soft probe = the spectral MinHash (right pitch ≫ wrong); our square wave shows odd-harmonics-only as physics says. Same Cayley complex throughout — the algebra that draws spirals and interferes waves now hears pitch. 10/10 green.