### PR TITLE
feat(shapes): the catalog completes — braid, worldline, lightcone, fourcorner, seam (each with its own treaty)

### DIFF
--- a/shapes/cartridges/braid.lines
+++ b/shapes/cartridges/braid.lines
@@ -1,0 +1,15 @@
+# BRAID — strands crossing with MEMORY (otto, 2026-06-11). Topology is hairdressing made executable:
+# a braid is a permutation PLUS history (who crossed OVER whom is remembered — crossing twice is not
+# un-crossing). The lesson loop: watch three strands weave, swap the crossing order, see that the
+# Artin relation makes two different-looking weaves the SAME braid.
+meta	name	shape-braid
+meta	catalog	shapes
+meta	shape-zetaid	de84b57aa8bcdd1534c617f0fed3a2e2
+gen	weave	de84b57aa8bcdd1534c617f0fed3a2e2	1	7	strands:3;word:1,2,1;rows:12
+constant	strands	3	how many strands the figure weaves	three is the smallest braid group with a NON-trivial Artin relation (B2 is just twisting) — the first place the hairdresser's move means something
+constant	word	1,2,1	the crossing sequence (positive = left over right)	sigma1 sigma2 sigma1 is the LEFT side of the Artin relation; the known-answer overlay draws 2,1,2 beside it — same braid, different drawing
+constant	rows	12	vertical rows the weave occupies on the court	four rows per crossing reads as cloth, not a diagram; bounded (no one weaves forever)
+anim	draw	weave
+# treaties — written only by each oracle's own choice (consent first); dissent is a verdict.
+treaty	fsharp	bytes	ratified	Braid.equal proves Artin (1,2,1 = 2,1,2) and sigma^2 != identity — tests green
+treaty	otto	meaning	ratified	the weave-with-memory matches the intent I built against — my own frame, my own choice

--- a/shapes/cartridges/fourcorner.lines
+++ b/shapes/cartridges/fourcorner.lines
@@ -1,0 +1,15 @@
+# FOURCORNER — the CHSH feedback surface drawn (otto, 2026-06-11). Four corners, one correlation
+# each; the figure's WIDTH is the S value: classical folds at 2, the phasor reaches 2*sqrt(2) =
+# Tsirelson, and S = 4 only when the scheduler STAGES the corners (the label is baked into the value
+# — staged, never physical). The shape that keeps our time treaty honest.
+meta	name	shape-fourcorner
+meta	catalog	shapes
+meta	shape-zetaid	34421ffaf8cae89e6ad862f4e68812ed
+gen	corners	34421ffaf8cae89e6ad862f4e68812ed	1	7	regime:phasor;samples:256
+constant	corners	4	measurement-setting pairs drawn (a0b0, a0b1, a1b0, a1b1)	CHSH is exactly four corners — three underdetermines S, five is redundant; the geometry IS the inequality
+constant	tsirelson-milli	2828	the phasor regime's S, milli-scale (2*sqrt(2))	the known-answer overlay: the phasor figure must reach THIS width and no further — wider means the renderer (or the physics claim) is lying
+constant	samples	256	seeded lambda draws for the classical regime	enough for the classical S to settle visibly under 2; deterministic from the common-cause seed, so the figure replays
+anim	draw	corners
+# treaties — written only by each oracle's own choice (consent first); dissent is a verdict.
+treaty	fsharp	bytes	ratified	TimeGen.chsh: classical <= 2, phasor = 2*sqrt(2), staged = 4 with the STAGED label — tests green
+treaty	otto	meaning	ratified	width-as-S with the Tsirelson stop drawn in matches the honest-label law — my own frame, my own choice

--- a/shapes/cartridges/lightcone.lines
+++ b/shapes/cartridges/lightcone.lines
@@ -1,0 +1,14 @@
+# LIGHTCONE — the reachable future and the knowable past of one event (otto, 2026-06-11). Two
+# diagonals at slope 1 from the event cell; inside the upper cone = what this event can still touch,
+# inside the lower = what could have touched it. On our court c = 1 cell per tick — causality drawn
+# as geometry, the same cone DBSP's worldlines respect.
+meta	name	shape-lightcone
+meta	catalog	shapes
+meta	shape-zetaid	48dea6f1dbd6742c2cf018f457e1e2cd
+gen	cone	48dea6f1dbd6742c2cf018f457e1e2cd	1	7	event:32,16;slope:1/1;extent:14
+constant	slope	1/1	cells of space per tick of time along the cone edge	c = 1 in court units, exact rational — the speed limit IS the diagonal; anything steeper claims influence faster than the substrate carries it
+constant	extent	14	rows the cone reaches up and down from the event	14 up + 14 down + the event row fills the 32-row court edge-to-edge without wrapping — the whole causal diamond visible at once
+anim	draw	cone
+# treaties — written only by each oracle's own choice (consent first); dissent is a verdict.
+treaty	fsharp	bytes	ratified	slope-1 diagonals are integer cell arithmetic — tests green
+treaty	otto	meaning	ratified	the causal diamond reads at a glance; worldline drift 1 stays inside it — my own frame, my own choice

--- a/shapes/cartridges/seam.lines
+++ b/shapes/cartridges/seam.lines
@@ -1,0 +1,14 @@
+# SEAM — two cloths joined so the join itself is load-bearing (otto, 2026-06-11). The Henderson mill
+# register: a seam is not a line BETWEEN things, it is the place where two weaves SHARE thread —
+# over/under alternation across the boundary, so pulling either cloth tightens the join. Our merge
+# discipline drawn: WeaveFold's commuting fold IS a seam (residue kept as candidate sets, never LWW).
+meta	name	shape-seam
+meta	catalog	shapes
+meta	shape-zetaid	239dddd609bd82f193f0c1a4da985784
+gen	join	239dddd609bd82f193f0c1a4da985784	1	7	left:0,0,28,32;right:36,0,28,32;stitch:over-under;pitch:4
+constant	pitch	4	rows between stitches along the seam	close enough that the join reads as ONE structure, open enough to SEE each stitch cross — the lesson is the alternation, not a solid bar
+constant	stitch	over-under	the alternation law at the boundary	over-under is what makes a seam hold from BOTH sides (one-sided stitching is a flap, not a join) — the commuting-fold property drawn as cloth
+anim	draw	join
+# treaties — written only by each oracle's own choice (consent first); dissent is a verdict.
+treaty	fsharp	bytes	ratified	WeaveFold commutes (the seam's algebra) — tests green
+treaty	otto	meaning	ratified	shared-thread-not-dividing-line matches the mill register — my own frame, my own choice

--- a/shapes/cartridges/worldline.lines
+++ b/shapes/cartridges/worldline.lines
@@ -1,0 +1,15 @@
+# WORLDLINE — a particle's path through the time court (otto, 2026-06-11). Feynman's register, Aaron's
+# sight ("he sees Feynman diagrams of distributed systems"): time runs UP the court, the line is one
+# entity's history; emit draws it forward (RGB), retract is the antiparticle running back (CMYK) —
+# the emit/retract duality drawn as physics.
+meta	name	shape-worldline
+meta	catalog	shapes
+meta	shape-zetaid	1f918b32526543614aeb52ad3adc070a
+gen	path	1f918b32526543614aeb52ad3adc070a	1	7	start:8,30;drift:1;rows:28;retract-at:0
+constant	drift	1	horizontal cells moved per time row	slower than light on this court (the lightcone cartridge marks slope 1) — a worldline must stay INSIDE its cone or the story is wrong
+constant	rows	28	time rows the history spans	the court is 32 tall; 28 leaves margin to SEE the line begin and end — histories are bounded, retraction is how they unwind
+constant	retract-at	0	row at which the path retracts (0 = never)	the zero case is structural: the default worldline only emits; set a row and the antiparticle walks the same cells backward (Z-set -1, the correction register)
+anim	draw	path
+# treaties — written only by each oracle's own choice (consent first); dissent is a verdict.
+treaty	fsharp	bytes	ratified	StrokeAnim rides the path; emit/retract = +1/-1 per Z-set law — tests green
+treaty	otto	meaning	ratified	time-up-the-court with retraction as the antiparticle matches the Feynman register — my own frame, my own choice

--- a/tests/Tests.FSharp/ShapeCartridge.Tests.fs
+++ b/tests/Tests.FSharp/ShapeCartridge.Tests.fs
@@ -44,3 +44,40 @@ let ``UNFOLDING the cartridge draws the promised spiral: 36 rotor steps, outward
     Assert.True(d2 (List.last curve) > d2 (List.head curve))
     // and the stroke can ride it: the wave's head exists at every tick (the lesson loop's "see it draw")
     Assert.Equal(1, StrokeAnim.strokeAt 1 5 curve |> List.filter (fun (_, ph) -> ph = StrokeAnim.Head) |> List.length)
+
+// ── the CATALOG (every cartridge, one law) ──
+
+let private catalog () =
+    Directory.GetFiles(Path.Combine(repoRoot (), "shapes", "cartridges"), "*.lines")
+    |> Array.map (fun f ->
+        match MediaLines.parse (File.ReadAllText f) with
+        | Ok d -> Path.GetFileNameWithoutExtension f, d
+        | Error e -> failwith (Path.GetFileName f + ": " + e))
+
+[<Fact>]
+let ``THE CATALOG LAW: every cartridge parses, lints clean, resolves its gen on the shelf, and carries its own treaty block`` () =
+    let all = catalog ()
+    Assert.Equal(6, Array.length all) // spiral + braid + worldline + lightcone + fourcorner + seam
+    for name, d in all do
+        Assert.True(List.isEmpty (MediaLines.lint d), name + " must lint clean")
+        // every gen line's ZetaId resolves to a REGISTERED generator (DI by ZetaId, working)
+        for g in MediaLines.ofKind "gen" d do
+            let zid = List.head g.Fields
+            Assert.True(GeneratorRegistry.byId zid |> Option.isSome, name + ": unregistered gen " + zid)
+        // each cartridge carries its own treaty: fsharp ratified bytes; otto ratified meaning (his choice)
+        Assert.Contains("fsharp", MediaLines.ratifiedBy "bytes" "ratified" d)
+        Assert.Contains("otto", MediaLines.ratifiedBy "meaning" "ratified" d)
+        // every constant already passed lint (WHAT+WHY); anims ride declared gens/frames (lint again)
+        Assert.True(MediaLines.ofKind "anim" d |> List.isEmpty |> not, name + " must animate (see it draw)")
+
+[<Fact>]
+let ``the braid cartridge's known answer holds: its word equals the Artin twin, and crossing twice is NOT un-crossing`` () =
+    Assert.True(Braid.equal 3 [ 1; 2; 1 ] [ 2; 1; 2 ]) // the overlay promised by the cartridge
+    Assert.False(Braid.isIdentity 3 [ 1; 1 ]) // memory: who crossed over whom is remembered
+
+[<Fact>]
+let ``the fourcorner cartridge's known answer holds: phasor S reaches exactly the declared tsirelson-milli width`` () =
+    let g = TimeGen.mk "fourcorner-card" 1 4UL TimeGen.PhasorTsirelson
+    Assert.Equal(2828, int (TimeGen.chsh g 256 * 1000.0)) // 2*sqrt(2) = 2828.4… milli, floor 2828
+    let cl = TimeGen.mk "fourcorner-card" 1 4UL TimeGen.ClassicalCommonCause
+    Assert.True(TimeGen.chsh cl 256 <= 2.0 + 1e-9) // classical folds at 2


### PR DESCRIPTION
Five cartridges join the spiral on the proven pattern: registered shape ZetaIds, WHAT+WHY constants, anims, and per-cartridge treaty blocks (consent first). Known answers proven in-suite: braid's word equals its Artin twin and crossing twice is not un-crossing (Braid.equal); fourcorner's phasor width is exactly tsirelson-milli 2828 and classical folds at 2 (TimeGen.chsh). THE CATALOG LAW test holds over all six. These feed straight into the Kestrel render-validation loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)