### PR TITLE
feat(selftrace): THE DEEP VIEW — SelfTrace × PixelLens composition (Amara's proof, last third)

### DIFF
--- a/src/Core/Chip9SelfTrace.fs
+++ b/src/Core/Chip9SelfTrace.fs
@@ -75,3 +75,21 @@ module Chip9SelfTrace =
     /// Run n self-tracing steps — the program ray-traces itself while running itself.
     let run (specDepth: int) (steps: int) (f: Chip8Cow.Frame) : Chip8Cow.Frame =
         List.fold (fun acc _ -> traceStep specDepth acc) f [ 1 .. max 0 steps ]
+
+    /// THE DEEP VIEW — the SelfTrace × PixelLens composition (the last third of Amara's named proof):
+    /// project the traced machine into 32-bit deep pixels so the trace's EPISTEMIC STATUS travels
+    /// WITH each pixel. Color = the full plane mask; payload = the instruction slot this cell
+    /// projects (the data riding with the pixel); uncertainty = 900 milli where the cell's ONLY
+    /// claim is speculation (B set, G clear — the foreseen future), 0 where the claim is executed
+    /// past or the program's own drawing. Then `PixelLens.colorize` is the honest projection:
+    /// the DRAWN past survives, the FORESEEN future collapses — the display literally cannot
+    /// present speculation as fact. (StrokeAnim's Foreseen=(4,900) convention, kept.)
+    let deepView (f: Chip8Cow.Frame) : Map<int * int, PixelLens.Cell> =
+        Map.ofList
+            [ for y in 0 .. Chip8.DisplayH - 1 do
+                  for x in 0 .. Chip8.DisplayW - 1 do
+                      let mask = Chip8Cow.colorAt x y f
+                      if mask <> 0uy then
+                          let speculativeOnly = mask &&& 4uy <> 0uy && mask &&& 2uy = 0uy
+                          let u = if speculativeOnly then 900 else 0
+                          yield (x, y), PixelLens.pack mask (y * Chip8.DisplayW + x) u ]

--- a/tests/Tests.FSharp/Chip9SelfTrace.Tests.fs
+++ b/tests/Tests.FSharp/Chip9SelfTrace.Tests.fs
@@ -63,3 +63,25 @@ let ``THE JEWEL: the machine reads its own worldline THROUGH its own ISA — DRW
 [<Fact>]
 let ``deterministic: the self-trace replays bit-identically (soft mode, DST to the bone)`` () =
     Assert.Equal<Chip8Cow.Frame>(Chip9SelfTrace.run 2 12 (frame ()), Chip9SelfTrace.run 2 12 (frame ()))
+
+[<Fact>]
+let ``THE DEEP VIEW (SelfTrace x PixelLens): the drawn past survives honest colorize; the foreseen future collapses`` () =
+    // ONE trace step: the PC's cell is painted executed (G), the lookahead cells are painted
+    // foreseen (B) and have NOT yet executed — pure future. (A longer run closes the loop and the
+    // future becomes past everywhere — itself the honest behavior.)
+    let f = Chip9SelfTrace.traceStep 2 (frame ())
+    let deep = Chip9SelfTrace.deepView f
+    // an executed cell: certain — colorize keeps its full color
+    let gx, gy = Chip9SelfTrace.cellOf 0x200
+    let gCell = Map.find (gx, gy) deep
+    Assert.Equal(0, PixelLens.uncertainty.Get gCell)
+    Assert.Equal(PixelLens.color.Get gCell, PixelLens.colorize 500 gCell)
+    // a speculative-only cell: 900 milli uncertain — colorize collapses it below the mono bit
+    let specCells =
+        deep |> Map.filter (fun _ c -> PixelLens.uncertainty.Get c = 900)
+    Assert.False(Map.isEmpty specCells) // the future was foreseen somewhere
+    for KeyValue(_, c) in specCells do
+        Assert.Equal(0uy, PixelLens.colorize 500 c &&& 6uy) // no trace channel survives
+        Assert.Equal(PixelLens.color.Get c &&& 1uy, PixelLens.colorize 500 c) // mono stays the program's
+    // and the payload rides with the pixel: the slot index is readable through the lens
+    Assert.Equal(gy * 64 + gx, PixelLens.payload.Get gCell)


### PR DESCRIPTION
Chip9SelfTrace.deepView: the trace's epistemic status travels WITH each pixel — executed past certain, foreseen future at 900 milli uncertainty — so PixelLens.colorize is the honest projection: the drawn past survives, speculation collapses; the display cannot present the foreseen as fact. Bonus discovery in the test: a 3-step run of the closed loop leaves no speculative-only cells — the loop closes over its own future. 7/7 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)