### PR TITLE
feat(shapes): the plait correction (blue over red — Aaron's dissent changes the word) + Vera Q# brief

### DIFF
--- a/docs/research/2026-06-12-vera-brief-qsharp-verification-candidates-for-qubit-adjacent-claims-then-math-team-then-treaty.md
+++ b/docs/research/2026-06-12-vera-brief-qsharp-verification-candidates-for-qubit-adjacent-claims-then-math-team-then-treaty.md
@@ -1,0 +1,58 @@
+# Vera brief — Q# verification candidates (qubit-adjacent claims), then math team, then the treaty
+
+Aaron 2026-06-12: "send me to Vera on any ones that need Q# verification — then we send to the
+math team and get the Q# on the treaty, on the ones that make sense for our qubit and other
+claims." Vera owns the Q# reference oracle (prior brief: golden observables; convergence-within-
+resolution is the test). This brief lists each candidate, the EXACT claim, and the Q# check that
+would ratify or refute it. The path after: Vera verifies → SHE writes her `treaty vera qsharp …`
+lines (consent-first: her lines are hers to write) → math team sign-off (`treaty math-team math …`,
+currently PENDING where present) → `law <name> qsharp:<check>` delegation lines land in the
+cartridges that earned them.
+
+## Priority 1 — the CHSH/Tsirelson family (the load-bearing qubit claims)
+
+1. **TimeGen** (`src/Core/TimeGen.fs`) — CLAIMS: PhasorTsirelson regime E(a,b)=cos(a−b) yields
+   S = 2√2 at the canonical corners; ClassicalCommonCause ≤ 2; StagedCoincidence S = 4 carries the
+   STAGED label (free-choice violated BY DESIGN, not physical).
+   **Q# check:** prepare the singlet; measure CHSH at a0=0, a1=π/2, b0=π/4, b1=−π/4; estimate S
+   over N shots → must converge to 2√2 within resolution; verify no measurement strategy on the
+   singlet exceeds it (Tsirelson, structurally). The S=4 regime must be UNREACHABLE in Q# — that
+   unreachability is itself the verification that our STAGED label is honest.
+2. **BellTest** (`src/Core/BellTest.fs`) — CLAIM: `PhasorEndurance.overlap a b = cos²((a−b)/2)` is
+   the singlet coincidence probability; the correlator E = 2·overlap − 1 = cos(a−b).
+   **Q# check:** singlet measured at relative angle θ → coincidence probability cos²(θ/2) within
+   resolution. This is the cleanest golden-observable of the set.
+3. **fourcorner cartridge** (`shapes/cartridges/fourcorner.lines`) — CLAIM: constant
+   tsirelson-milli = 2828 (floor of 1000·2√2) is the width stop the phasor figure reaches and
+   never exceeds. **Q# check:** the S estimate from (1) floored to milli = 2828. On her
+   ratification + math team's, the cartridge gains `law tsirelson qsharp:chsh-singlet-corners`.
+
+## Priority 2 — interference as amplitude arithmetic
+
+4. **AmplitudeEmu** (`src/Core/AmplitudeEmu.fs`) — CLAIM: complex-amplitude merge over identical
+   frames IS interference (opposite phase cancels, equal phase reinforces); two-slit falls out of
+   CAS-merge + complex weights. **Q# check:** H · R1(φ) · H on |0⟩ → P(0) = cos²(φ/2); compare
+   against our merged-amplitude ensemble at the same φ grid. Convergence-within-resolution.
+5. **WaveSim** (`src/Core/WaveSim.fs`) — CLAIM (deliberately modest): deterministic simulation of
+   the amplitude math classical and quantum share; no quantum-hardware claim. **Q# check
+   (optional):** the same superposition-as-complex-Add on single-qubit phases; mostly confirms the
+   LABEL is right, i.e., nothing here needs a qubit. Low priority; the honest labels already do
+   the work.
+
+## Priority 3 — claims to WORD-CHECK with the math team, not Q#-verify yet
+
+6. **Braid / the anyon picture** (`shapes/cartridges/braid.lines`, the worldline×braid named
+   slice) — the peeled Alexa anchor: braiding IS computation in topological QC (Kitaev;
+   Freedman–Larsen–Wang; Nayak et al.). No Q# anyon substrate to run; ask the math team to gate
+   the WORDING (we may say "braid-group representations realize quantum gates in TQC" with cites;
+   we may NOT say our render computes quantumly).
+7. **SpectralPivot** (`src/Core/SpectralPivot.fs`) — dft/idft vs the QFT: a Q# QFT cross-check is
+   a nice-to-have golden (same unitary up to normalization/bit-reversal); name it, don't gate on it.
+
+## What Vera gets / what comes back
+
+- In: this brief + the module sources + the cartridges (all text; the goldens are the contract).
+- Back (her choice, her lines): per-claim `ratified | dissent | refuted` with shot counts and
+  resolution; we never pre-write her verdicts. Math team then signs (their PENDING lines exist).
+- Treaty effect: `qsharp:` joins the delegated-law tools (CartridgeLaw already accepts any
+  `tool:` prefix — documented here, checked there) on exactly the claims that earned it.

--- a/shapes/cartridges/braid.lines
+++ b/shapes/cartridges/braid.lines
@@ -7,9 +7,10 @@ meta	catalog	shapes
 meta	shape-zetaid	de84b57aa8bcdd1534c617f0fed3a2e2
 gen	weave	de84b57aa8bcdd1534c617f0fed3a2e2	1	7	strands:3;word:1,2,1;rows:12
 constant	strands	3	how many strands the figure weaves	three is the smallest braid group with a NON-trivial Artin relation (B2 is just twisting) — the first place the hairdresser's move means something
-constant	word	1,2,1	the crossing sequence (positive = left over right)	sigma1 sigma2 sigma1 is the LEFT side of the Artin relation; the known-answer overlay draws 2,1,2 beside it — same braid, different drawing
+constant	word	1,-2,1	the crossing sequence (positive = left over right; negative reverses)	THE PLAIT: alternating signs so each strand takes a turn on top — Aaron's render-loop correction ("blue crosses on top of red for it to be a braid"); all-positive 1,2,1 lays one strand over twice like a rod (legal braid, wrong register). The Artin overlay (1,2,1 = 2,1,2) stays the in-code law
 constant	rows	12	vertical rows the weave occupies on the court	four rows per crossing reads as cloth, not a diagram; bounded (no one weaves forever)
 anim	draw	weave
+issue	plait-register	aaron	closed	RESOLVED 2026-06-12: his dissent ("blue crosses on top of red for it to be a braid") changed the word to the alternating plait 1,-2,1 — joint meaning, negotiated through the render loop
 # treaties — written only by each oracle's own choice (consent first); dissent is a verdict.
 treaty	fsharp	bytes	ratified	Braid.equal proves Artin (1,2,1 = 2,1,2) and sigma^2 != identity — tests green
 issue	over-under-register	otto	closed	RESOLVED 2026-06-12: the under strand now carries an occlusion gap at every crossing — who crossed OVER whom is in the ink (Artin's sign decides; negative crossings reverse it)

--- a/shapes/cartridges/fourcorner.lines
+++ b/shapes/cartridges/fourcorner.lines
@@ -9,6 +9,8 @@ gen	corners	34421ffaf8cae89e6ad862f4e68812ed	1	7	regime:phasor;samples:256
 constant	corners	4	measurement-setting pairs drawn (a0b0, a0b1, a1b0, a1b1)	CHSH is exactly four corners — three underdetermines S, five is redundant; the geometry IS the inequality
 constant	tsirelson-milli	2828	the phasor regime's S, milli-scale (2*sqrt(2))	the known-answer overlay: the phasor figure must reach THIS width and no further — wider means the renderer (or the physics claim) is lying
 constant	samples	256	seeded lambda draws for the classical regime	enough for the classical S to settle visibly under 2; deterministic from the common-cause seed, so the figure replays
+issue	qsharp-verification	vera	requested	the tsirelson-milli 2828 stop + corner correlators are Q#-verifiable (singlet CHSH) — brief: docs/research/2026-06-12-vera-brief-qsharp-*.md; her verdict lines are HERS to write
+issue	math-sign-off	math-team	requested	after Vera: sign the S<=2 classical / 2*sqrt(2) phasor / staged-4-labeled claims
 anim	draw	corners
 # treaties — written only by each oracle's own choice (consent first); dissent is a verdict.
 treaty	fsharp	bytes	ratified	TimeGen.chsh: classical <= 2, phasor = 2*sqrt(2), staged = 4 with the STAGED label — tests green

--- a/shapes/golden/braid.html
+++ b/shapes/golden/braid.html
@@ -20,12 +20,12 @@
 </head>
 <body>
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 320" data-cartridge="shape-braid">
-  <polyline id="strand-0" fill="none" stroke="#d62828" stroke-width="4" points="205,5 325,35 445,65 445,95 445,125" />
+  <polyline id="strand-0" fill="none" stroke="#d62828" stroke-width="4" points="205,5 325,35 373,47" />
+  <polyline id="strand-0-r1" fill="none" stroke="#d62828" stroke-width="4" points="397,53 445,65 445,95 445,125" />
   <polyline id="strand-1" fill="none" stroke="#2a9d2a" stroke-width="4" points="325,5 277,17" />
   <polyline id="strand-1-r1" fill="none" stroke="#2a9d2a" stroke-width="4" points="253,23 205,35 205,65 325,95 325,125" />
-  <polyline id="strand-2" fill="none" stroke="#2828d6" stroke-width="4" points="445,5 445,35 397,47" />
-  <polyline id="strand-2-r1" fill="none" stroke="#2828d6" stroke-width="4" points="373,53 325,65 277,77" />
-  <polyline id="strand-2-r2" fill="none" stroke="#2828d6" stroke-width="4" points="253,83 205,95 205,125" />
+  <polyline id="strand-2" fill="none" stroke="#2828d6" stroke-width="4" points="445,5 445,35 325,65 277,77" />
+  <polyline id="strand-2-r1" fill="none" stroke="#2828d6" stroke-width="4" points="253,83 205,95 205,125" />
 </svg>
 </body>
 </html>

--- a/shapes/golden/braid.svg
+++ b/shapes/golden/braid.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 320" data-cartridge="shape-braid">
-  <polyline id="strand-0" fill="none" stroke="#d62828" stroke-width="4" points="205,5 325,35 445,65 445,95 445,125" />
+  <polyline id="strand-0" fill="none" stroke="#d62828" stroke-width="4" points="205,5 325,35 373,47" />
+  <polyline id="strand-0-r1" fill="none" stroke="#d62828" stroke-width="4" points="397,53 445,65 445,95 445,125" />
   <polyline id="strand-1" fill="none" stroke="#2a9d2a" stroke-width="4" points="325,5 277,17" />
   <polyline id="strand-1-r1" fill="none" stroke="#2a9d2a" stroke-width="4" points="253,23 205,35 205,65 325,95 325,125" />
-  <polyline id="strand-2" fill="none" stroke="#2828d6" stroke-width="4" points="445,5 445,35 397,47" />
-  <polyline id="strand-2-r1" fill="none" stroke="#2828d6" stroke-width="4" points="373,53 325,65 277,77" />
-  <polyline id="strand-2-r2" fill="none" stroke="#2828d6" stroke-width="4" points="253,83 205,95 205,125" />
+  <polyline id="strand-2" fill="none" stroke="#2828d6" stroke-width="4" points="445,5 445,35 325,65 277,77" />
+  <polyline id="strand-2-r1" fill="none" stroke="#2828d6" stroke-width="4" points="253,83 205,95 205,125" />
 </svg>


### PR DESCRIPTION
Aaron's render-loop dissent was right in the register that matters: all-positive 1,2,1 draws one strand lying on top like a rod. Word is now the alternating plait 1,-2,1 — each strand takes a turn on top (blue crosses over red). Artin overlay stays the in-code law; the dissent and fix are in the cartridge as a closed issue. Plus the Vera Q#-verification brief (CHSH/Tsirelson family first; consent path: her verdict lines are hers) with verification-requested issues on fourcorner. 2979 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)