### PR TITLE
feat(core): add Q# Bell coincidence oracle

### DIFF
--- a/src/Core/BellTest.fs
+++ b/src/Core/BellTest.fs
@@ -65,6 +65,11 @@ module BellTest =
     let correlation (a: float) (b: float) : float =
         2.0 * PhasorEndurance.overlap a b - 1.0
 
+    /// Coincidence probability for the cosine-correlator convention: `P(same outcome on Phi+) = cos²((a-b)/2)`.
+    /// For the singlet this same scalar is the opposite-outcome probability, because one outcome axis is flipped.
+    let coincidenceProbability (a: float) (b: float) : float =
+        PhasorEndurance.overlap a b
+
     /// CHSH from four correlators: `S = E(a,b) − E(a,b') + E(a',b) + E(a',b')`.
     let chshOf (eab: float) (eab': float) (ea'b: float) (ea'b': float) : float =
         eab - eab' + ea'b + ea'b'

--- a/tests/Tests.FSharp/QSharpOracle.Tests.fs
+++ b/tests/Tests.FSharp/QSharpOracle.Tests.fs
@@ -20,7 +20,7 @@ let rec private findRepoRoot (dir: DirectoryInfo) =
     elif isNull dir.Parent then failwith "Could not find repository root from test output directory."
     else findRepoRoot dir.Parent
 
-let private root = findRepoRoot (DirectoryInfo(Environment.CurrentDirectory))
+let private root = findRepoRoot (DirectoryInfo(__SOURCE_DIRECTORY__))
 
 let private goldenPath =
     Path.Combine(root, "tools", "qsharp-oracle", "qsharp-golden.json")
@@ -58,6 +58,10 @@ let private singleQubitCase (id: string) =
 
 let private interferenceCase (id: string) =
     vectors.GetProperty("interferenceVisibility").EnumerateArray()
+    |> Seq.find (fun item -> item.GetProperty("id").GetString() = id)
+
+let private bellCoincidenceCase (id: string) =
+    vectors.GetProperty("bellCoincidence").EnumerateArray()
     |> Seq.find (fun item -> item.GetProperty("id").GetString() = id)
 
 let private probabilities (case: JsonElement) =
@@ -190,6 +194,24 @@ let ``BellState PhiPlus preparation matches the Q# two-qubit oracle`` () =
     |> Array.iter (fun (expected, actual) -> closeTo expected actual)
 
     closeTo 1.0 (BellState.normSq prepared)
+
+[<Fact>]
+let ``BellTest coincidence probability matches Q# Bell analyzer observables`` () =
+    let assertCase id =
+        let item = bellCoincidenceCase id
+        let angles = item.GetProperty("anglesRadians")
+        let a = angles.GetProperty("a").GetDouble()
+        let b = angles.GetProperty("b").GetDouble()
+        let expected = item.GetProperty("probability").GetDouble()
+
+        closeTo expected (BellTest.coincidenceProbability a b)
+        closeTo expected (PhasorEndurance.overlap a b)
+        closeTo (2.0 * expected - 1.0) (BellTest.correlation a b)
+
+    assertCase "PhiPlus same-outcome a=0 b=pi/4"
+    assertCase "Singlet opposite-outcome a=0 b=pi/4"
+    assertCase "PhiPlus same-outcome a=0 b=pi/2"
+    assertCase "PhiPlus same-outcome a=0 b=pi"
 
 [<Fact>]
 let ``single-qubit probability formulas match the Q# observable treaty`` () =

--- a/tools/qsharp-oracle/ZetaReferenceOracle.qs
+++ b/tools/qsharp-oracle/ZetaReferenceOracle.qs
@@ -40,6 +40,37 @@ namespace Zeta.ReferenceOracle {
         CNOT(qs[0], qs[1]);
     }
 
+    operation ApplyBellSinglet(qs : Qubit[]) : Unit is Adj + Ctl {
+        H(qs[0]);
+        CNOT(qs[0], qs[1]);
+        X(qs[1]);
+        Z(qs[1]);
+    }
+
+    operation ApplyBellPhiPlusAnalyzers(a : Double, b : Double, qs : Qubit[]) : Unit is Adj + Ctl {
+        H(qs[0]);
+        CNOT(qs[0], qs[1]);
+        Ry(-a, qs[0]);
+        Ry(-b, qs[1]);
+    }
+
+    operation ApplyBellSingletAnalyzers(a : Double, b : Double, qs : Qubit[]) : Unit is Adj + Ctl {
+        H(qs[0]);
+        CNOT(qs[0], qs[1]);
+        X(qs[1]);
+        Z(qs[1]);
+        Ry(-a, qs[0]);
+        Ry(-b, qs[1]);
+    }
+
+    operation ApplyBellPhiPlusAnalyzersCanonical(qs : Qubit[]) : Unit is Adj + Ctl {
+        ApplyBellPhiPlusAnalyzers(0.0, 3.141592653589793 / 4.0, qs);
+    }
+
+    operation ApplyBellSingletAnalyzersCanonical(qs : Qubit[]) : Unit is Adj + Ctl {
+        ApplyBellSingletAnalyzers(0.0, 3.141592653589793 / 4.0, qs);
+    }
+
     operation ApplyMachZehnderOpen(qs : Qubit[]) : Unit is Adj + Ctl {
         H(qs[0]);
     }

--- a/tools/qsharp-oracle/generate-qsharp-golden.py
+++ b/tools/qsharp-oracle/generate-qsharp-golden.py
@@ -81,6 +81,34 @@ def chsh(a: float, ap: float, b: float, bp: float) -> dict[str, Any]:
     }
 
 
+def coincidence(a: float, b: float) -> float:
+    return math.cos((a - b) / 2.0) ** 2
+
+
+def coincidence_case(
+    id: str,
+    state: str,
+    operation: str,
+    a: float,
+    b: float,
+    event: str,
+) -> dict[str, Any]:
+    return {
+        "id": id,
+        "state": state,
+        "operation": operation,
+        "anglesRadians": {
+            "a": clean_float(a),
+            "b": clean_float(b),
+            "delta": clean_float(a - b),
+        },
+        "event": event,
+        "probability": clean_float(coincidence(a, b)),
+        "formula": "cos((a-b)/2)^2",
+        "checks": ["BellTest.coincidenceProbability", "PhasorEndurance.overlap"],
+    }
+
+
 def build_vectors() -> dict[str, Any]:
     qsharp.init()
     qsharp.eval(QSHARP_SOURCE.read_text(encoding="utf-8"))
@@ -148,6 +176,40 @@ def build_vectors() -> dict[str, Any]:
                 "canonical": chsh(0.0, math.pi / 2.0, math.pi / 4.0, 3.0 * math.pi / 4.0),
                 "checks": ["BellTest.correlation", "BellTest.chsh", "BellTest.TsirelsonBound"],
             },
+            "bellCoincidence": [
+                coincidence_case(
+                    "PhiPlus same-outcome a=0 b=pi/4",
+                    "PhiPlus",
+                    "Zeta.ReferenceOracle.ApplyBellPhiPlusAnalyzers",
+                    0.0,
+                    math.pi / 4.0,
+                    "sameOutcome",
+                ),
+                coincidence_case(
+                    "Singlet opposite-outcome a=0 b=pi/4",
+                    "Singlet",
+                    "Zeta.ReferenceOracle.ApplyBellSingletAnalyzers",
+                    0.0,
+                    math.pi / 4.0,
+                    "oppositeOutcome",
+                ),
+                coincidence_case(
+                    "PhiPlus same-outcome a=0 b=pi/2",
+                    "PhiPlus",
+                    "Zeta.ReferenceOracle.ApplyBellPhiPlusAnalyzers",
+                    0.0,
+                    math.pi / 2.0,
+                    "sameOutcome",
+                ),
+                coincidence_case(
+                    "PhiPlus same-outcome a=0 b=pi",
+                    "PhiPlus",
+                    "Zeta.ReferenceOracle.ApplyBellPhiPlusAnalyzers",
+                    0.0,
+                    math.pi,
+                    "sameOutcome",
+                ),
+            ],
             "interferenceVisibility": [
                 {
                     "id": "mach-zehnder-open",

--- a/tools/qsharp-oracle/qsharp-golden.json
+++ b/tools/qsharp-oracle/qsharp-golden.json
@@ -24,15 +24,99 @@
         "s": 2.828427124746,
         "tsirelson": 2.828427124746
       },
-      "checks": ["BellTest.correlation", "BellTest.chsh", "BellTest.TsirelsonBound"],
+      "checks": [
+        "BellTest.correlation",
+        "BellTest.chsh",
+        "BellTest.TsirelsonBound"
+      ],
       "correlatorFormula": "E(a,b)=cos(a-b)",
       "id": "BellPhiPlus canonical CHSH",
       "preparation": {
         "operation": "Zeta.ReferenceOracle.ApplyBellPhiPlus",
-        "probabilities": [0.5, 0.0, 0.0, 0.5],
-        "stateBasis": ["|00>", "|01>", "|10>", "|11>"]
+        "probabilities": [
+          0.5,
+          0.0,
+          0.0,
+          0.5
+        ],
+        "stateBasis": [
+          "|00>",
+          "|01>",
+          "|10>",
+          "|11>"
+        ]
       }
     },
+    "bellCoincidence": [
+      {
+        "anglesRadians": {
+          "a": 0.0,
+          "b": 0.785398163397,
+          "delta": -0.785398163397
+        },
+        "checks": [
+          "BellTest.coincidenceProbability",
+          "PhasorEndurance.overlap"
+        ],
+        "event": "sameOutcome",
+        "formula": "cos((a-b)/2)^2",
+        "id": "PhiPlus same-outcome a=0 b=pi/4",
+        "operation": "Zeta.ReferenceOracle.ApplyBellPhiPlusAnalyzers",
+        "probability": 0.853553390593,
+        "state": "PhiPlus"
+      },
+      {
+        "anglesRadians": {
+          "a": 0.0,
+          "b": 0.785398163397,
+          "delta": -0.785398163397
+        },
+        "checks": [
+          "BellTest.coincidenceProbability",
+          "PhasorEndurance.overlap"
+        ],
+        "event": "oppositeOutcome",
+        "formula": "cos((a-b)/2)^2",
+        "id": "Singlet opposite-outcome a=0 b=pi/4",
+        "operation": "Zeta.ReferenceOracle.ApplyBellSingletAnalyzers",
+        "probability": 0.853553390593,
+        "state": "Singlet"
+      },
+      {
+        "anglesRadians": {
+          "a": 0.0,
+          "b": 1.570796326795,
+          "delta": -1.570796326795
+        },
+        "checks": [
+          "BellTest.coincidenceProbability",
+          "PhasorEndurance.overlap"
+        ],
+        "event": "sameOutcome",
+        "formula": "cos((a-b)/2)^2",
+        "id": "PhiPlus same-outcome a=0 b=pi/2",
+        "operation": "Zeta.ReferenceOracle.ApplyBellPhiPlusAnalyzers",
+        "probability": 0.5,
+        "state": "PhiPlus"
+      },
+      {
+        "anglesRadians": {
+          "a": 0.0,
+          "b": 3.14159265359,
+          "delta": -3.14159265359
+        },
+        "checks": [
+          "BellTest.coincidenceProbability",
+          "PhasorEndurance.overlap"
+        ],
+        "event": "sameOutcome",
+        "formula": "cos((a-b)/2)^2",
+        "id": "PhiPlus same-outcome a=0 b=pi",
+        "operation": "Zeta.ReferenceOracle.ApplyBellPhiPlusAnalyzers",
+        "probability": 0.0,
+        "state": "PhiPlus"
+      }
+    ],
     "gateUnitaries": {
       "BellPhiPlusPrep": [
         [
@@ -309,7 +393,10 @@
     },
     "interferenceVisibility": [
       {
-        "checks": ["AmplitudeEmu.merge", "AmplitudeEmu.intensity"],
+        "checks": [
+          "AmplitudeEmu.merge",
+          "AmplitudeEmu.intensity"
+        ],
         "id": "mach-zehnder-open",
         "operation": "Zeta.ReferenceOracle.ApplyMachZehnderOpen",
         "probabilities": {
@@ -318,7 +405,10 @@
         }
       },
       {
-        "checks": ["AmplitudeEmu.merge", "AmplitudeEmu.intensity"],
+        "checks": [
+          "AmplitudeEmu.merge",
+          "AmplitudeEmu.intensity"
+        ],
         "id": "mach-zehnder-closed-zero-phase",
         "operation": "Zeta.ReferenceOracle.ApplyMachZehnderClosedZeroPhase",
         "probabilities": {
@@ -328,7 +418,10 @@
         "visibility": 1.0
       },
       {
-        "checks": ["AmplitudeEmu.merge", "AmplitudeEmu.intensity"],
+        "checks": [
+          "AmplitudeEmu.merge",
+          "AmplitudeEmu.intensity"
+        ],
         "id": "mach-zehnder-closed-pi-phase",
         "operation": "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiPhase",
         "probabilities": {
@@ -341,7 +434,10 @@
     "singleQubitMeasurement": [
       {
         "basis": "Z",
-        "checks": ["AmplitudeEmu.bornProb", "QubitIso.H"],
+        "checks": [
+          "AmplitudeEmu.bornProb",
+          "QubitIso.H"
+        ],
         "id": "H|0>",
         "operation": "Zeta.ReferenceOracle.ApplyH",
         "probabilities": {
@@ -351,7 +447,10 @@
       },
       {
         "basis": "Z",
-        "checks": ["AmplitudeEmu.bornProb", "QubitIso.Ry"],
+        "checks": [
+          "AmplitudeEmu.bornProb",
+          "QubitIso.Ry"
+        ],
         "formula": "P(Zero)=cos(theta/2)^2; P(One)=sin(theta/2)^2",
         "id": "Ry(pi/3)|0>",
         "operation": "Zeta.ReferenceOracle.ApplyRyPiOver3",
@@ -363,7 +462,10 @@
       },
       {
         "basis": "Z",
-        "checks": ["AmplitudeEmu.bornProb", "QubitIso.Ry"],
+        "checks": [
+          "AmplitudeEmu.bornProb",
+          "QubitIso.Ry"
+        ],
         "formula": "P(Zero)=cos(theta/2)^2; P(One)=sin(theta/2)^2",
         "id": "Ry(pi/2)|0>",
         "operation": "Zeta.ReferenceOracle.ApplyRyPiOver2",

--- a/tools/qsharp-oracle/qsharp-golden.test.ts
+++ b/tools/qsharp-oracle/qsharp-golden.test.ts
@@ -51,6 +51,24 @@ test("Bell/CHSH vector pins Tsirelson and the canonical correlators", () => {
   expect(canonical.s).toBeGreaterThan(canonical.classicalBound);
 });
 
+test("Bell coincidence observables pin PhiPlus and singlet outcome conventions", () => {
+  const cases = new Map(golden.vectors.bellCoincidence.map((v) => [v.id, v]));
+
+  const phiPiOver4 = cases.get("PhiPlus same-outcome a=0 b=pi/4");
+  closeTo(phiPiOver4?.probability as number, Math.cos(Math.PI / 8) ** 2);
+  expect(phiPiOver4?.event).toBe("sameOutcome");
+
+  const singletPiOver4 = cases.get("Singlet opposite-outcome a=0 b=pi/4");
+  closeTo(singletPiOver4?.probability as number, Math.cos(Math.PI / 8) ** 2);
+  expect(singletPiOver4?.event).toBe("oppositeOutcome");
+
+  const phiPiOver2 = cases.get("PhiPlus same-outcome a=0 b=pi/2");
+  closeTo(phiPiOver2?.probability as number, 0.5);
+
+  const phiPi = cases.get("PhiPlus same-outcome a=0 b=pi");
+  closeTo(phiPi?.probability as number, 0);
+});
+
 test("interference observables distinguish open, reinforce, and cancel cases", () => {
   const cases = new Map(golden.vectors.interferenceVisibility.map((v) => [v.id, v]));
 


### PR DESCRIPTION
## Summary
- Add Q# Bell analyzer oracle operations for PhiPlus and singlet conventions.
- Extend qsharp-golden.json with bellCoincidence observable vectors for PhiPlus same-outcome and singlet opposite-outcome probabilities.
- Add BellTest.coincidenceProbability and F#/TS tests that lock the phasor overlap to the Q# observable treaty.
- Anchor QSharpOracle.Tests golden lookup to __SOURCE_DIRECTORY__ so test runner cwd no longer matters.

## Verification
- ./.venv/bin/python tools/qsharp-oracle/generate-qsharp-golden.py
- bun test tools/qsharp-oracle/qsharp-golden.test.ts
- dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter 'FullyQualifiedName~QSharpOracleTests|FullyQualifiedName~BellTestTests'
- dotnet build -c Release
- dotnet test Zeta.sln -c Release --no-build
- dotnet format --verify-no-changes --include src/Core/BellTest.fs tests/Tests.FSharp/QSharpOracle.Tests.fs
- git diff --check