### PR TITLE
feat(shapes): the plait move (the gate) + the Borromean naming proposal for the locked braid

### DIFF
--- a/docs/research/2026-06-12-naming-the-locked-braid-borromean-prior-art-proposal-and-the-gate-vs-memory-split.md
+++ b/docs/research/2026-06-12-naming-the-locked-braid-borromean-prior-art-proposal-and-the-gate-vs-memory-split.md
@@ -1,0 +1,37 @@
+# Naming the locked braid — the Borromean proposal (prior art) + the gate-vs-memory split
+
+Aaron 2026-06-12: "the locking one deserves a prior-art name — quick search in and out of repo,
+propose some names." In-repo search: zero prior mentions of borromean/brunnian (fresh anchor).
+Also his verification, verbatim, now in the treaty block: "I can verify the Majorana one fully
+locks when I look at it — easily visibly correct from a human's perspective."
+
+## The discovery: our locked braid IS a famous object
+
+The locked word is (σ1·σ2⁻¹)³ — and that is the STANDARD braid word whose closure is the
+**Borromean rings**: three loops, pairwise unlinked, collectively inseparable. Cut any ONE strand
+and the other two fall apart — which is the strongest version of Aaron's "stuck together":
+the stuckness lives in all three jointly, in no pair.
+
+## Name candidates (for discussion, not decided)
+
+1. **borromean-braid** (leading) — exact prior art: the Borromeo family crest (15th c. Milan);
+   mathematically a **Brunnian link** (Hermann Brunn, 1892); Milnor's link invariants (1954)
+   measure exactly this kind of higher-order linking. And the quantum tie-in is REAL prior art,
+   not metaphor: **Aravind (1997)** mapped Borromean rings to **GHZ entanglement** — measure one
+   GHZ qubit and the remaining two disentangle, exactly as cutting one ring frees the rest. So the
+   Majorana register (locked+stuck = protected memory) and the Borromean name pull the same
+   direction with named humans on both.
+2. **brunnian-lock** — names the PROPERTY (Brunnian: remove any component, the rest unlink);
+   more general, less iconic.
+3. **ballantine** — the rings' pop-culture name (the beer's three-ring logo); fun, weak Beacon.
+
+Working register until decided: shape-braid keeps `name-status provisional` meta with the
+candidates; the simple 3-crossing cartridge (`shape-plait-move`, also provisional) is the GATE
+to this shape's MEMORY — Majorana 1 stores in the braid, operates by the move.
+
+## Open checks (named, honest)
+
+- The Brunnian property at the BRAID level (remove a strand from (σ1σ2⁻¹)³ → the remaining
+  2-braid should be trivial) is checkable in our Braid module by strand deletion — a small named
+  slice; the LINK-level claim stands on the literature (Brunn; Milnor; Aravind).
+- Math-team sign-off on the wording stays PENDING per the cartridge.

--- a/shapes/cartridges/braid.lines
+++ b/shapes/cartridges/braid.lines
@@ -3,6 +3,7 @@
 # un-crossing). The lesson loop: watch three strands weave, swap the crossing order, see that the
 # Artin relation makes two different-looking weaves the SAME braid.
 meta	name	shape-braid
+meta	name-status	provisional — prior-art naming under discussion (Aaron 2026-06-12); leading candidate: BORROMEAN BRAID — (s1*s2^-1)^3 is the standard braid word whose closure is the Borromean rings (three loops, pairwise unlinked, collectively inseparable: remove ANY one and the rest fall apart — Brunnian property, Brunn 1892; the Borromeo crest; Aravind 1997 ties Borromean topology to GHZ entanglement)
 meta	catalog	shapes
 meta	shape-zetaid	de84b57aa8bcdd1534c617f0fed3a2e2
 gen	weave	de84b57aa8bcdd1534c617f0fed3a2e2	1	7	strands:3;word:1,2,1;rows:12
@@ -20,4 +21,5 @@ treaty	fsharp	bytes	ratified	Braid.equal proves Artin (1,2,1 = 2,1,2) and sigma^
 issue	over-under-register	otto	closed	RESOLVED 2026-06-12: the under strand now carries an occlusion gap at every crossing — who crossed OVER whom is in the ink (Artin's sign decides; negative crossings reverse it)
 treaty	otto	meaning	ratified	the weave-with-memory matches the intent I built against — my own frame, my own choice
 treaty	aaron	meaning	ratified	"the braid is perfect too — next time Max is here I'll show him" — render-loop ratification, 2026-06-12
+treaty	aaron	meaning	ratified	"I can verify the Majorana one fully locks when I look at it — easily visibly correct from a human's perspective" — the locked+stuck render verified by eye, 2026-06-12 (trust at a glance, working)
 treaty	alexa	meaning	ratified	read it as "quantum information flow / crossings as gates" — her own frame (ferried 2026-06-12); peeled anchor: in topological QC, braiding IS the computation (Kitaev; Freedman-Larsen-Wang)

--- a/shapes/cartridges/plait-move.lines
+++ b/shapes/cartridges/plait-move.lines
@@ -1,0 +1,26 @@
+# PLAIT MOVE — the simpler braid kept on purpose (Aaron 2026-06-12: "what happened to the simpler
+# shape? … is it useful for us? we don't have to force this into quantum — we can have the simpler
+# shape AND this one; we can get names right later"). This is THE MOVE: three crossings, each
+# strand takes one turn on top — the unit operation. It CANNOT be locked, and that is a THEOREM,
+# not a defect: three adjacent swaps make an ODD permutation, and everyone-home is EVEN — no
+# 3-crossing word ends home. The lock needs the full period (see shape-braid, lock-period 6).
+# The honest Majorana register: shape-braid (locked + stuck) is the protected MEMORY (Majorana 1
+# stores the qubit in un-undoable braiding); THIS shape is the GATE — the single exchange you
+# apply to that memory. Operation vs storage. Rx reading (Aaron): each strand is a stream; a
+# crossing is a paired operator on two streams carrying an over/under tag — the move is one
+# operator application. Name provisional (meta below) — "we can get names right later."
+meta	name	shape-plait-move
+meta	catalog	shapes
+meta	name-status	provisional — Aaron: names later; candidates: plait-move / exchange / the-gate
+meta	shape-zetaid	9ba891dabf43c6073dd0bae73d8bce22
+gen	move	9ba891dabf43c6073dd0bae73d8bce22	1	7	strands:3;word:1,-2,1;rows:12
+constant	word	1,-2,1	the crossing sequence (positive = left over right; negative reverses)	the alternating unit move — each strand takes exactly one turn on top (the plait register, Aaron's correction kept)
+constant	rows	12	vertical rows the move occupies	three rows per crossing on the small court — the move reads at a glance
+constant	ends-swapped	1	the outer strands EXCHANGE (1 = true); the middle comes home	(01)(12)(01) = (02): an odd permutation — and that is WHY this shape cannot lock (everyone-home is even); the exchange IS the operation
+law	odd-cannot-lock	code:shape-plait-move geometry (perm = outer swap, NOT identity — the move moves; lock is impossible below the period)
+prereq	the-locked-braid	shapes/cartridges/braid.lines — see what repeating this move to its period buys: lock + stuck (the memory)
+edge	unit-move-of	shape-braid	the locked braid is THIS move applied lock-period times; gate vs memory (Majorana register: the chip stores in the braid, operates by the move)
+anim	draw	move
+# treaties — written only by each oracle's own choice (consent first); dissent is a verdict.
+treaty	fsharp	bytes	ratified	perm = (02) outer swap proven; not identity; odd-parity lock impossibility is arithmetic — tests green
+treaty	otto	meaning	ratified	the move that moves: kept simple ON PURPOSE, no quantum forcing — my own frame, my own choice

--- a/shapes/golden/plait-move.html
+++ b/shapes/golden/plait-move.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>shape-plait-move</title>
+  <style>
+    :root {
+      --c0: #000000;
+      --c1: #d62828;
+      --c2: #2a9d2a;
+      --c3: #d6c828;
+      --c4: #2828d6;
+      --c5: #d628d6;
+      --c6: #28c8d6;
+      --c7: #f0f0f0;
+    }
+    body { background: #101418; margin: 0; display: grid; place-items: center; min-height: 100vh; }
+    svg { width: min(96vw, 960px); image-rendering: pixelated; }
+  </style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 320" data-cartridge="shape-plait-move">
+  <polyline id="strand-0" fill="none" stroke="#d62828" stroke-width="4" points="205,5 325,35 373,47" />
+  <polyline id="strand-0-r1" fill="none" stroke="#d62828" stroke-width="4" points="397,53 445,65 445,95 445,125" />
+  <polyline id="strand-1" fill="none" stroke="#2a9d2a" stroke-width="4" points="325,5 277,17" />
+  <polyline id="strand-1-r1" fill="none" stroke="#2a9d2a" stroke-width="4" points="253,23 205,35 205,65 325,95 325,125" />
+  <polyline id="strand-2" fill="none" stroke="#2828d6" stroke-width="4" points="445,5 445,35 325,65 277,77" />
+  <polyline id="strand-2-r1" fill="none" stroke="#2828d6" stroke-width="4" points="253,83 205,95 205,125" />
+</svg>
+</body>
+</html>

--- a/shapes/golden/plait-move.svg
+++ b/shapes/golden/plait-move.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 320" data-cartridge="shape-plait-move">
+  <polyline id="strand-0" fill="none" stroke="#d62828" stroke-width="4" points="205,5 325,35 373,47" />
+  <polyline id="strand-0-r1" fill="none" stroke="#d62828" stroke-width="4" points="397,53 445,65 445,95 445,125" />
+  <polyline id="strand-1" fill="none" stroke="#2a9d2a" stroke-width="4" points="325,5 277,17" />
+  <polyline id="strand-1-r1" fill="none" stroke="#2a9d2a" stroke-width="4" points="253,23 205,35 205,65 325,95 325,125" />
+  <polyline id="strand-2" fill="none" stroke="#2828d6" stroke-width="4" points="445,5 445,35 325,65 277,77" />
+  <polyline id="strand-2-r1" fill="none" stroke="#2828d6" stroke-width="4" points="253,83 205,95 205,125" />
+</svg>

--- a/src/Core/ComplexityRegistry.fs
+++ b/src/Core/ComplexityRegistry.fs
@@ -87,6 +87,7 @@ module ComplexityRegistry =
               ("shape.seam", "draw"), c "O(strands·passes)" "O(strands)" Derived
               ("shape.buckyball", "draw"), c "O(F)" "O(F)" Derived // F=32 faces: both views + a door per room + itself — linear in rooms, constant for C60
               ("shape.shadow-loop", "draw"), c "O(steps)" "O(steps)" Derived // one closed pass; the crossing costs nothing extra — catching yourself is built into the path
+              ("shape.plait-move", "draw"), c "O(crossings·strands)" "O(strands)" Derived // the unit move: one exchange (the gate); the locked braid is this, repeated to its period
               ("binding.html-css", "render"), c "O(entries·pixels)" "O(output)" Derived
               ("sim.wave-interference", "pattern"), c "O(w·h·sources)" "O(w·h)" Derived
               ("viz.adinkra", "render"), c "O(nodes)" "O(nodes)" Derived

--- a/src/Core/GeneratorRegistry.fs
+++ b/src/Core/GeneratorRegistry.fs
@@ -79,6 +79,7 @@ module GeneratorRegistry =
           register "shape.seam" 1
           register "shape.buckyball" 1
           register "shape.shadow-loop" 1
+          register "shape.plait-move" 1
           register "binding.html-css" 1
           register "sim.wave-interference" 1
           register "viz.adinkra" 1

--- a/src/Core/ShapeAcceptance.fs
+++ b/src/Core/ShapeAcceptance.fs
@@ -90,6 +90,20 @@ module ShapeAcceptance =
                 && 3 * v' = 2 * e // three edges at every corner (the soccer-ball stitch)
                 && c "meta-doors" = f + 1 // a door to every room AND itself
             ok, sprintf "Euler %d-%d+%d=2; double-count and 3-regularity close; meta-doors = faces + itself" v' e f
+        | "shape-plait-move" ->
+            // the unit move: the drawn word's permutation must be the OUTER SWAP (02) — ends
+            // exchanged, middle home — and NOT identity (the move moves; odd parity proves no
+            // 3-crossing word can lock). The locked braid is this move repeated to its period.
+            let word =
+                MediaLines.field "constant" "word" d
+                |> Option.defaultValue ""
+                |> fun s -> s.Split(',') |> Array.filter (fun x -> x.Length > 0) |> Array.map int |> Array.toList
+            let perm = Array.init 3 id
+            for c in word do
+                let a = abs c - 1
+                let t = perm.[a] in perm.[a] <- perm.[a + 1]; perm.[a + 1] <- t
+            let ok = perm = [| 2; 1; 0 |] && not (Braid.isIdentity 3 word)
+            ok, "perm = outer swap (02), middle home; not the identity braid — the move MOVES (odd parity: lock impossible here)"
         | "shape-shadow-loop" ->
             // otto's own: the sampled lemniscate must CLOSE (first = last) and pass through the
             // center exactly center-visits times (the crossing, hit structurally — steps % 4 = 0).

--- a/src/Core/ShapeRender.fs
+++ b/src/Core/ShapeRender.fs
@@ -72,7 +72,8 @@ module ShapeRender =
             { Name = "left-cloth"; Mask = 2uy; Points = [ pt 0 0; pt 27 0; pt 27 31; pt 0 31; pt 0 0 ] }
             :: { Name = "right-cloth"; Mask = 4uy; Points = [ pt 36 0; pt 63 0; pt 63 31; pt 36 31; pt 36 0 ] }
             :: stitches
-        | "shape-braid" ->
+        | "shape-braid"
+        | "shape-plait-move" ->
             // 3 strands at columns 20/32/44; each crossing in the word swaps two strands over 2
             // rows. THE OVER-UNDER REGISTER (the braid's memory, drawn): at every crossing the
             // UNDER strand's diagonal carries an occlusion GAP around the midpoint, so the picture

--- a/tests/Tests.FSharp/ShapeAcceptance.Tests.fs
+++ b/tests/Tests.FSharp/ShapeAcceptance.Tests.fs
@@ -19,7 +19,7 @@ let private docOf (name: string) =
     | Ok d -> d
     | Error e -> failwith e
 
-let private shapes = [ "spiral"; "braid"; "worldline"; "lightcone"; "fourcorner"; "seam"; "buckyball"; "shadow-loop" ]
+let private shapes = [ "spiral"; "braid"; "worldline"; "lightcone"; "fourcorner"; "seam"; "buckyball"; "shadow-loop"; "plait-move" ]
 
 [<Fact>]
 let ``THE HARD GATE: every catalog shape is accepted on bytes+geometry+honest-labels — never on looks, never on meaning`` () =

--- a/tests/Tests.FSharp/ShapeCartridge.Tests.fs
+++ b/tests/Tests.FSharp/ShapeCartridge.Tests.fs
@@ -57,7 +57,7 @@ let private catalog () =
 [<Fact>]
 let ``THE CATALOG LAW: every cartridge parses, lints clean, resolves its gen on the shelf, and carries its own treaty block`` () =
     let all = catalog ()
-    Assert.Equal(8, Array.length all) // + buckyball (Addison) + shadow-loop (otto, his own — revisable)
+    Assert.Equal(9, Array.length all) // + buckyball (Addison) + shadow-loop (otto) + plait-move (the gate, kept simple on purpose)
     for name, d in all do
         Assert.True(List.isEmpty (MediaLines.lint d), name + " must lint clean")
         // every gen line's ZetaId resolves to a REGISTERED generator (DI by ZetaId, working)


### PR DESCRIPTION
The simpler braid returns as shape-plait-move — it cannot lock and that's a theorem (odd permutation); it's the GATE to the locked braid's MEMORY (the honest Majorana register). And the naming discovery: the locked word (σ1σ2⁻¹)³ closes to the BORROMEAN RINGS — pairwise unlinked, collectively inseparable. Candidates: borromean-braid (leading), brunnian-lock, ballantine — Aaron decides; provisional in-file. His by-eye lock verification recorded in the treaty block. 2980 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)