### PR TITLE
feat(adinkra+ports): dashings (Gates condition + gauge lemma) + the missing-piece lens (mod2) + naming direction

### DIFF
--- a/docs/research/2026-06-12-dashings-landed-the-rhyme-is-two-tests-mod2-is-the-missing-piece-and-the-naming-direction.md
+++ b/docs/research/2026-06-12-dashings-landed-the-rhyme-is-two-tests-mod2-is-the-missing-piece-and-the-naming-direction.md
@@ -1,0 +1,41 @@
+# Dashings landed (the rhyme is two tests) · mod2 is the missing piece · the naming direction
+
+Three of Aaron's beats, 2026-06-12, built same-stream.
+
+## The dashings (Gates' condition + the gauge lemma, in code)
+
+`AdinkraViz` now carries the retraction register: a `Dashing` is the set of dashed (−1) edges on
+the N=4 hypercube; `standardDashing` is the Clifford sign rule (dash (v,i) iff odd bits below i);
+**THE GATES CONDITION** (`allFacesOdd`) — every 2-colored 4-cycle carries an odd number of dashes
+(γiγj = −γjγi, drawn) — and **THE GAUGE LEMMA** (`flipVertex` invariance): local sign flips change
+the dashing, never the parity. The braid cartridge and this module now point at each other
+(`edge same-twist viz.adinkra`): no local move removes the twist — the same sentence as THE STUCK
+LAW, with the break stated in both places (their edges are involutions; our generators remember).
+
+## "Are they inverse in some way?" — no: a QUOTIENT
+
+The precise relation: adinkra parity is braid memory **mod 2**. Z (crossing order, Artin) → Z/2
+(the dashing bit, Gates): order forgotten, parity kept. A projection, not an inverse — the lens
+that completes the flow is the map that forgets exactly the register the sink cannot hear.
+
+## The GraphEdit lens — THE MISSING PIECE, working
+
+`MagneticPorts.Piece` + `findAdapter`: when two ports don't speak the same type, search the
+toolbox for the adapter whose in-face matches the source and out-face matches the sink. First
+real adapter: **algebra.mod2** (registered, cost-declared) — braid-memory out → mod2 → adinkra
+parity in. The test proves the GraphEdit feel: direct connection repels honestly; with the piece
+the chain snaps; an empty toolbox reports the gap (named, never force-fit).
+
+## The naming direction (Aaron's call, recorded)
+
+Algebras named RIGHT (Beacon): braid group B₃ / pure braid P₃ (Artin), Brunnian link (Brunn),
+Borromean rings, Clifford algebra (the dashing's home). Memory naming in MICROSOFT's register:
+majorana-memory — "we are also testing with their Q#, should be a close match" (the Vera brief is
+the verification road). Leading shape name unchanged: BORROMEAN BRAID; still provisional in-file.
+
+## Pointers
+
+- `src/Core/AdinkraViz.fs` (Dashing/standardDashing/allFacesOdd/flipVertex) ·
+  `src/Core/MagneticPorts.fs` (Piece/findAdapter) · `shapes/cartridges/braid.lines` (same-twist
+  edge; naming meta) · `GeneratorRegistry` (algebra.braid-memory / z2-parity / mod2)
+- Treaty-lint refinement: `treaty` lines may repeat per oracle (re-ratification is a log, not a dupe)

--- a/shapes/cartridges/braid.lines
+++ b/shapes/cartridges/braid.lines
@@ -3,7 +3,7 @@
 # un-crossing). The lesson loop: watch three strands weave, swap the crossing order, see that the
 # Artin relation makes two different-looking weaves the SAME braid.
 meta	name	shape-braid
-meta	name-status	provisional — prior-art naming under discussion (Aaron 2026-06-12); leading candidate: BORROMEAN BRAID — (s1*s2^-1)^3 is the standard braid word whose closure is the Borromean rings (three loops, pairwise unlinked, collectively inseparable: remove ANY one and the rest fall apart — Brunnian property, Brunn 1892; the Borromeo crest; Aravind 1997 ties Borromean topology to GHZ entanglement)
+meta	name-status	provisional — Aaron 2026-06-12: ALGEBRAS named right (braid group B3 / pure braid P3, Artin; Brunnian link, Brunn; Borromean rings), MEMORY naming in Microsoft's register (majorana-memory — we test against their Q#, should be a close match); leading candidate unchanged: BORROMEAN BRAID. Prior-art naming under discussion (Aaron 2026-06-12); leading candidate: BORROMEAN BRAID — (s1*s2^-1)^3 is the standard braid word whose closure is the Borromean rings (three loops, pairwise unlinked, collectively inseparable: remove ANY one and the rest fall apart — Brunnian property, Brunn 1892; the Borromeo crest; Aravind 1997 ties Borromean topology to GHZ entanglement)
 meta	catalog	shapes
 meta	shape-zetaid	de84b57aa8bcdd1534c617f0fed3a2e2
 gen	weave	de84b57aa8bcdd1534c617f0fed3a2e2	1	7	strands:3;word:1,2,1;rows:12
@@ -13,6 +13,7 @@ constant	lock-period	6	crossings until the strands return to their own columns	(
 constant	stuck	1	the locked word is NOT the identity braid (1 = true, proven by Artin's faithful action)	Aaron's Majorana reach: strands HOME yet the braid CANNOT be pulled apart — pure-braid-group memory, the configuration topological qubits bank on (Kitaev chain; Microsoft Majorana 1; sigma1*sigma2^-1 is the figure-eight braid word)
 law	stuck-together	code:shape-braid geometry (perm = identity AND Braid.isIdentity = false — locked AND stuck)
 constant	rows	21	vertical rows the weave occupies on the court	three rows per crossing across the 6-crossing period fits the 32-row court with margin; bounded (no one weaves forever)
+edge	same-twist	viz.adinkra	the adinkra's gauge lemma (vertex flips never make a face even) and THE STUCK LAW here are the same sentence — information held as a globally-nontrivial, locally-invisible twist; the break is honest (their edges are involutions, our generators remember)
 anim	draw	weave
 issue	lock-in-place	aaron	closed	RESOLVED 2026-06-12: "the blue messes up… any way to lock them in place?" — the word is now one full plait period (lock-period 6): ends locked, every strand home
 issue	plait-register	aaron	closed	RESOLVED 2026-06-12: his dissent ("blue crosses on top of red for it to be a braid") changed the word to the alternating plait 1,-2,1 — joint meaning, negotiated through the render loop

--- a/src/Core/AdinkraViz.fs
+++ b/src/Core/AdinkraViz.fs
@@ -75,3 +75,69 @@ module AdinkraViz =
                             let bit = flippedBit (nodeAt col row) (nodeAt col (row + 1))
                             edgeStr bit "│" + "  " ]
                       |> String.concat "" ]
+
+    // ── DASHINGS (the retraction register — the named slice, landed via Aaron's adinkra↔Majorana
+    // question 2026-06-12). An adinkra is not just colored edges: each edge carries a SIGN
+    // (solid = +1, dashed = −1), and the Gates condition is that every 2-colored 4-cycle carries
+    // an ODD number of dashed edges (this is gamma-matrix anticommutation drawn: γiγj = −γjγi).
+    // The twist is GLOBAL: flipping all edges at a vertex (the gauge move) changes which edges
+    // are dashed but can NEVER make a 4-cycle's dash count even — the same sentence THE STUCK LAW
+    // says about the locked braid (no local move removes the twist). Rhyme, made testable;
+    // the break stays honest (adinkra edges are involutions; braid generators remember). ──
+
+    /// An edge of the N=4 hypercube, canonical form: (lower vertex, bit). 32 edges total.
+    type Edge = int * int
+
+    /// All 32 edges (vertex v < v ^^^ (1 <<< bit) — each edge once).
+    let allEdges: Edge list =
+        [ for v in 0..15 do
+              for bit in 0..3 do
+                  if v &&& (1 <<< bit) = 0 then yield v, bit ]
+
+    /// A dashing: the set of DASHED edges (−1 signs); everything else solid (+1).
+    type Dashing = Set<Edge>
+
+    /// The standard (valise/Clifford) dashing: edge (v, i) is dashed iff v has an odd number of
+    /// set bits BELOW bit i — exactly the sign rule of the standard gamma-matrix representation.
+    let standardDashing: Dashing =
+        Set.ofList
+            [ for (v, bit) in allEdges do
+                  if System.Numerics.BitOperations.PopCount(uint (v &&& ((1 <<< bit) - 1))) % 2 = 1 then
+                      yield v, bit ]
+
+    /// Canonicalize an arbitrary (vertex, bit) reference to the edge's stored form.
+    let private canon (v: int) (bit: int) : Edge =
+        (if v &&& (1 <<< bit) = 0 then v else v ^^^ (1 <<< bit)), bit
+
+    /// Is the edge at (v, bit) dashed under d?
+    let isDashed (d: Dashing) (v: int) (bit: int) : bool = Set.contains (canon v bit) d
+
+    /// THE GATES CONDITION on one 2-colored face: the 4-cycle at v in colors (i, j) — edges
+    /// v→v^i, v^i→v^i^j, v^i^j→v^j, v^j→v — must carry an ODD number of dashes.
+    let faceOdd (d: Dashing) (v: int) (i: int) (j: int) : bool =
+        let vi = v ^^^ (1 <<< i)
+        let vj = v ^^^ (1 <<< j)
+        let count =
+            [ isDashed d v i; isDashed d vi j; isDashed d vj i; isDashed d v j ]
+            |> List.filter id
+            |> List.length
+        count % 2 = 1
+
+    /// Does the Gates condition hold on EVERY 2-colored 4-cycle? (16 vertices × 6 color pairs,
+    /// each face counted from each corner — redundancy is fine, the law is per-face.)
+    let allFacesOdd (d: Dashing) : bool =
+        [ for v in 0..15 do
+              for i in 0..3 do
+                  for j in i + 1 .. 3 -> faceOdd d v i j ]
+        |> List.forall id
+
+    /// THE GAUGE MOVE: flip every edge at vertex v (the local sign change — relabeling one node's
+    /// fermion phase). Toggles 4 edges; each adjacent 2-colored face sees exactly TWO of its
+    /// edges toggle, so its dash parity is INVARIANT — the twist cannot be removed locally.
+    let flipVertex (v: int) (d: Dashing) : Dashing =
+        [ 0..3 ]
+        |> List.fold
+            (fun (acc: Dashing) bit ->
+                let e = canon v bit
+                if Set.contains e acc then Set.remove e acc else Set.add e acc)
+            d

--- a/src/Core/ComplexityRegistry.fs
+++ b/src/Core/ComplexityRegistry.fs
@@ -88,9 +88,13 @@ module ComplexityRegistry =
               ("shape.buckyball", "draw"), c "O(F)" "O(F)" Derived // F=32 faces: both views + a door per room + itself — linear in rooms, constant for C60
               ("shape.shadow-loop", "draw"), c "O(steps)" "O(steps)" Derived // one closed pass; the crossing costs nothing extra — catching yourself is built into the path
               ("shape.plait-move", "draw"), c "O(crossings·strands)" "O(strands)" Derived // the unit move: one exchange (the gate); the locked braid is this, repeated to its period
+              ("algebra.braid-memory", "carry"), c "O(word)" "O(word)" Derived // crossing order is the payload: Z-valued memory (Artin)
+              ("algebra.z2-parity", "carry"), c "O(1)" "O(1)" Derived // one bit per edge: the dashing register (Gates)
+              ("algebra.mod2", "project"), c "O(word)" "O(1)" Derived // THE MISSING PIECE: Z -> Z/2, order forgotten, parity kept — the adapter that snaps braid-out into adinkra-in
               ("binding.html-css", "render"), c "O(entries·pixels)" "O(output)" Derived
               ("sim.wave-interference", "pattern"), c "O(w·h·sources)" "O(w·h)" Derived
               ("viz.adinkra", "render"), c "O(nodes)" "O(nodes)" Derived
+              ("viz.adinkra", "dashing"), c "O(V·N²)" "O(E)" Derived // all faces checked: 16 vertices x 6 color pairs; the dashing set is at most the 32 edges
               ("spectral.hard-dft", "dft"), c "O(n²)" "O(n)" Derived
               ("spectral.hard-dft", "idft"), c "O(n²)" "O(n)" Derived
               ("spectral.soft-probe", "probe"), c "O(n)" "O(1)" Derived

--- a/src/Core/GeneratorRegistry.fs
+++ b/src/Core/GeneratorRegistry.fs
@@ -80,6 +80,9 @@ module GeneratorRegistry =
           register "shape.buckyball" 1
           register "shape.shadow-loop" 1
           register "shape.plait-move" 1
+          register "algebra.braid-memory" 1
+          register "algebra.z2-parity" 1
+          register "algebra.mod2" 1
           register "binding.html-css" 1
           register "sim.wave-interference" 1
           register "viz.adinkra" 1

--- a/src/Core/MagneticPorts.fs
+++ b/src/Core/MagneticPorts.fs
@@ -94,3 +94,35 @@ module MagneticPorts =
     /// channel because the MATH GUYS told us" (a proof on the docket, not a hunch). The closing is a
     /// visible act, never an omission.
     let withoutFeedback (c: Connection) : Connection = { c with FeedbackOpen = false }
+
+    // ── THE MISSING PIECE (Aaron 2026-06-12: "is there a lens we could slap on, like the old
+    // GraphEdit, that would make these snap together using a missing piece from the toolbox — the
+    // shape that completes the graph flow?"). GraphEdit's move, made ours: when two ports do NOT
+    // speak the same type, search the toolbox for the ADAPTER whose in-face matches the source and
+    // whose out-face matches the sink. The first real adapter is algebra.mod2 — the quotient
+    // Z → Z/2 that snaps braid memory (crossing ORDER, Artin) into adinkra parity (the dashing
+    // bit, Gates): order forgotten, parity kept. Not an inverse — a projection; the lens that
+    // completes the flow is the map that forgets exactly the register the sink cannot hear. ──
+
+    /// A toolbox piece: one body, two faces — a sink it listens on and a source it speaks from.
+    type Piece =
+        { Name: string
+          ZetaId: string
+          In: Port
+          Out: Port }
+
+    let piece (name: string) (zetaId: string) (x: int) (y: int) (inType: string) (outType: string) : Piece =
+        { Name = name
+          ZetaId = zetaId
+          In = port x y Sink inType
+          Out = port (x + 1) y Source outType }
+
+    /// Does this piece complete the flow a → piece → b?
+    let adapts (p: Piece) (a: Port) (b: Port) : bool =
+        compatible a p.In && compatible p.Out b
+
+    /// THE LENS: when a and b cannot connect directly, the first toolbox piece that completes the
+    /// flow — None means the toolbox is honestly missing the shape (a named gap, not a forced fit).
+    let findAdapter (toolbox: Piece list) (a: Port) (b: Port) : Piece option =
+        if compatible a b then None // nothing missing: they already snap
+        else toolbox |> List.tryFind (fun p -> adapts p a b)

--- a/src/Core/MediaLines.fs
+++ b/src/Core/MediaLines.fs
@@ -193,7 +193,7 @@ module MediaLines =
 
         let dupes =
             d.Entries
-            |> List.filter (fun e -> Set.contains e.Kind knownKinds && e.Kind <> "rom") // rom legitimately repeats per address
+            |> List.filter (fun e -> Set.contains e.Kind knownKinds && e.Kind <> "rom" && e.Kind <> "treaty") // rom repeats per address; treaty repeats per verdict (an oracle may re-ratify over time — the block is a log)
             |> List.groupBy (fun e -> e.Kind, e.Name)
             |> List.filter (fun (_, es) -> List.length es > 1)
             |> List.map (fun ((k, n), _) -> { Kind = k; Name = n; Problem = "duplicate (kind, name)" })

--- a/tests/Tests.FSharp/AdinkraViz.Tests.fs
+++ b/tests/Tests.FSharp/AdinkraViz.Tests.fs
@@ -46,3 +46,19 @@ let ``deterministic + registered + cost-declared (the budget lint holds)`` () =
     Assert.Equal<string list>(AdinkraViz.render (Some 1), AdinkraViz.render (Some 1))
     Assert.True(GeneratorRegistry.byName "viz.adinkra" |> Option.isSome)
     Assert.Equal<string list>([], ComplexityRegistry.unstated ())
+
+[<Fact>]
+let ``THE GATES CONDITION: the standard dashing puts an ODD number of dashes on every 2-colored 4-cycle (anticommutation, drawn)`` () =
+    Assert.True(AdinkraViz.allFacesOdd AdinkraViz.standardDashing)
+    Assert.Equal(32, List.length AdinkraViz.allEdges)
+    // and it is a real dashing, not all-solid (all-solid would make every face EVEN — count 0)
+    Assert.False(Set.isEmpty AdinkraViz.standardDashing)
+
+[<Fact>]
+let ``THE GAUGE LEMMA: no local move removes the twist — vertex flips change the dashing but every face stays ODD (the adinkra's stuck law)`` () =
+    // flip a handful of vertices in sequence (deterministic walk); the parity law must survive all of them
+    let walked =
+        [ 0; 5; 10; 15; 3; 12 ]
+        |> List.fold (fun d v -> AdinkraViz.flipVertex v d) AdinkraViz.standardDashing
+    Assert.NotEqual<Set<int * int>>(AdinkraViz.standardDashing, walked) // the dashing genuinely changed
+    Assert.True(AdinkraViz.allFacesOdd walked) // the twist did not — same sentence as THE STUCK LAW

--- a/tests/Tests.FSharp/MagneticPorts.Tests.fs
+++ b/tests/Tests.FSharp/MagneticPorts.Tests.fs
@@ -89,3 +89,22 @@ let ``THE SHAPE CATALOG: a cartridge per shape, each ZetaId'd and cost-declared;
     for s in [ "shape.worldline"; "shape.lightcone"; "shape.fourcorner"; "shape.braid"; "shape.spiral"; "shape.seam" ] do
         Assert.True(GeneratorRegistry.byName s |> Option.isSome)
     Assert.Equal<string list>([], ComplexityRegistry.unstated ())
+
+[<Fact>]
+let ``THE MISSING PIECE: braid memory cannot snap into adinkra parity directly — the mod2 adapter from the toolbox completes the flow`` () =
+    let braidOut = MagneticPorts.port 0 0 MagneticPorts.Source (GeneratorRegistry.idOf "algebra.braid-memory" 1)
+    let adinkraIn = MagneticPorts.port 8 0 MagneticPorts.Sink (GeneratorRegistry.idOf "algebra.z2-parity" 1)
+    // direct: incompatible (different registers — order vs parity); the magnet repels, honestly
+    Assert.False(MagneticPorts.compatible braidOut adinkraIn)
+    // the toolbox holds the quotient: Z -> Z/2 (order forgotten, parity kept — a projection, not an inverse)
+    let mod2 =
+        MagneticPorts.piece "mod2" (GeneratorRegistry.idOf "algebra.mod2" 1) 4 0
+            (GeneratorRegistry.idOf "algebra.braid-memory" 1)
+            (GeneratorRegistry.idOf "algebra.z2-parity" 1)
+    match MagneticPorts.findAdapter [ mod2 ] braidOut adinkraIn with
+    | Some p ->
+        Assert.Equal("mod2", p.Name)
+        Assert.True(MagneticPorts.adapts p braidOut adinkraIn) // the chain snaps: braid -> mod2 -> adinkra
+    | None -> Assert.True(false, "the toolbox piece that completes the flow was not found")
+    // and an empty toolbox reports the gap honestly — no forced fit
+    Assert.True(MagneticPorts.findAdapter [] braidOut adinkraIn |> Option.isNone)


### PR DESCRIPTION
The rhyme is two tests now: dashings land with THE GATES CONDITION (every 2-colored 4-cycle odd) and THE GAUGE LEMMA (local flips never change face parity) — pointing at THE STUCK LAW via a same-twist edge, break stated honestly. 'Inverse?' answered: a quotient — adinkra parity = braid memory mod 2. The GraphEdit lens: MagneticPorts.findAdapter finds the toolbox piece completing a flow; algebra.mod2 is the first adapter (braid→mod2→adinkra snaps; empty toolbox = honest gap). Algebras named right; memory naming in Microsoft's register. 2983 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)