### PR TITLE
docs(research): where adinkras sit — the sign register's organ; Microsoft uses the algebra, not the diagrams

### DIFF
--- a/docs/research/2026-06-12-where-adinkras-sit-now-the-sign-registers-display-organ-and-the-microsoft-answer.md
+++ b/docs/research/2026-06-12-where-adinkras-sit-now-the-sign-registers-display-organ-and-the-microsoft-answer.md
@@ -1,0 +1,47 @@
+# Where adinkras sit now — the sign register's display organ; and the Microsoft answer
+
+Aaron 2026-06-12: "what about adinkras — how do they fit in now, is it clearer, and does
+Microsoft use them?"
+
+## The fit (clear now)
+
+Two registers of protected memory, one bridge, one shared home:
+
+| register | carrier | algebra | law in code | organ |
+|---|---|---|---|---|
+| ORDER | braid crossings | Z (Artin, B3) | THE STUCK LAW | shape-braid (borromean candidate) |
+| PARITY | dashing bits | Z/2 (Gates) | GATES CONDITION + GAUGE LEMMA | AdinkraViz |
+
+Bridge: `algebra.mod2` (order forgotten, parity kept — the missing-piece adapter, now also the
+ADAPTED rung in the io ladder). Shared home: **Clifford algebra**.
+
+The adinkra's JOB in Zeta: the display-and-checker organ for any parity-protected invariant —
+where sign/parity claims get DRAWN (the fourth organ of the one phase math: WaveSim interference,
+SpectralPivot frequency, ChipAudio sound, AdinkraViz signs) and CHECKED (the two laws). Gates'
+codes-in-the-equations (doubly-even self-dual codes inside adinkras) makes this more than
+display: adinkra structure IS error-correcting structure, which is the same reason topological
+memory resists noise.
+
+## Does Microsoft use adinkras? — No, but the algebra is shared
+
+Microsoft (Majorana 1, Q#, Station Q) does NOT use adinkra diagrams. They live on the Clifford
+side of the same house: Majorana zero modes generate Clifford algebras (Kitaev 2001); Q# is
+saturated with Clifford-group machinery (stabilizer circuits, Pauli frames). Adinkras are
+Gates–Faux (2004) SUSY representation theory — academic physics; the name honors the Akan adinkra
+symbols of Ghana (Gates' deliberate choice — a human anchor inside the human anchor). Same
+algebraic home, different doors: Gates draws Clifford representations as dashed colored graphs;
+Microsoft engineers them as hardware and stabilizer software. That shared Clifford/Pauli layer is
+exactly WHY the Vera brief's §8 (our dashings vs Q# sign conventions) is testable — the registers
+meet there, in exact signs.
+
+## Named slice
+
+An **adinkra cartridge** in the shape catalog: the two laws in-file (`code:` delegations to
+allFacesOdd / flipVertex invariance), the same-twist edge back to shape-braid, dashed-edge render
+in the strict SVG dialect (dashes are TEXT: stroke-dasharray, integer-only). Then the parity
+register is a full citizen of the shape system.
+
+## Pointers
+
+- `src/Core/AdinkraViz.fs` (the laws) · `shapes/cartridges/braid.lines` (same-twist edge) ·
+  the adapter-economy map (2026-06-12) · the Vera brief §8 · Gates & Faux 2004; Kitaev 2001


### PR DESCRIPTION
The two-register table (ORDER: braid/Z/Artin · PARITY: dashing/Z2/Gates), bridged by mod2, sharing Clifford as home. The adinkra = display-and-checker organ for parity-protected invariants; Gates' codes make it error-correcting structure. Microsoft: no adinkra diagrams — Clifford side only (Majorana, Q# stabilizers); same house, different doors — why Vera §8 is testable in exact signs. Named slice: the adinkra cartridge. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)