### PR TITLE
fix(math): the tear-down lands — 13 findings fixed/filed (2 P0), Soraya's routing adopted, brief REVISION 2

### DIFF
--- a/docs/research/2026-06-12-the-math-team-pass-kira-13-findings-soraya-routing-every-bug-banked.md
+++ b/docs/research/2026-06-12-the-math-team-pass-kira-13-findings-soraya-routing-every-bug-banked.md
@@ -1,0 +1,40 @@
+# The math-team pass — Kira's 13 findings + Soraya's routing (every bug banked)
+
+Aaron asked "how did the math team handle it?" — the honest answer was "not yet," so the deferred
+tear-down ran today: Kira (zero-empathy) + Soraya (formal-tool routing), parallel, read-only.
+Full reports in their PR-linked outputs; the brief carries REVISION 2. Headlines:
+
+## What the eye could never have caught (the suite's side of the stack, vindicated)
+
+- **P0 — the noisy microphone:** `voiceSample` re-derived a NEW random base phase every tick
+  (TimeGen.at mixes tick into the hash) — the sawtooth was drowned in per-sample noise and the
+  coincidence lattice described phases the voices never had. The self-replay test passed because
+  noise replays too. Fixed: base phase derived once at tick 0. **The renders all looked right
+  while this was broken** — exactly why the eye is the third oracle, not the only one.
+- **P0 — the lucky gate:** the classical-CHSH acceptance check demanded ≤ 2.0 + 1e-9 on a
+  256-sample estimator with ~0.06 sampling error; seed 4UL happened to land under. Fixed to the
+  suite's honest 0.05 tolerance. A gate that passes by luck is a coin, not a gate.
+- **P1s:** the singlet/Φ⁺ sign-convention contradiction (the four-page docstring policed Tsirelson
+  and got its own correlator's sign convention mislabeled); braid.lines' gen args still saying
+  word:1,2,1 two corrections later (drawn = gated = constants, so Aaron's eye verified the real
+  thing — but the stale args were a lie in waiting); `Braid.equal 3 [5] []` returning TRUE
+  (σ₅ fixes x₀..x₂ — out-of-range words masqueraded as identity; validWord guards now);
+  harmonize claiming "exact" while flooring (187 ≠ a fifth of 125 — harmonizeExact refuses
+  instead of detuning); the vacuous STAGED gate (asserted a string constant — removed).
+- **P2s:** all six addressed (rounding cap at Tsirelson; Goertzel wording; drift by bin key with
+  missing-bin = full energy; coincidences span honesty; the Gates-gate falsifier — a gate never
+  seen rejecting proves nothing; the mod2 wording replaced by Soraya's signable statement).
+
+## The economics (every bug banked)
+
+Two P0s + five P1s + six P2s = thirteen priced reductions of collective uncertainty, found in one
+afternoon by the register the renders can't cover. The stack holds: suite (bytes) → golden lock
+(projection) → traveler's eye (meaning) — and now the fourth layer ran: adversarial math review
+(claims). Math-team treaty lines stay PENDING until Kira/Soraya choose to write theirs — the fixes
+are the application for sign-off, not the sign-off.
+
+## Pointers
+
+- The Vera brief REVISION 2 (routing + the three Q# jobs) · the fixed sources (ChipAudio, Braid,
+  BellTest, ShapeAcceptance, SpectralPivot, AdinkraViz tests) · braid.lines + adinkra.lines
+  (issues closed in-file) · Soraya's mod2 statement (adopted verbatim in the adinkra edge line)

--- a/docs/research/2026-06-12-vera-brief-qsharp-verification-candidates-for-qubit-adjacent-claims-then-math-team-then-treaty.md
+++ b/docs/research/2026-06-12-vera-brief-qsharp-verification-candidates-for-qubit-adjacent-claims-then-math-team-then-treaty.md
@@ -82,3 +82,32 @@ cartridges that earned them.
     where possible, against the same anticommutation targets). Both must land on the one Clifford
     home or the mapping is decoration. Candidate shapes ride the same discipline:
     docs/research/2026-06-12-physics-real-shape-candidates-*.md (fit or it doesn't enter).
+
+## REVISION 2 — after the math-team pass (Soraya routing + Kira tear-down, 2026-06-12)
+
+**Q# earns exactly three jobs** (Soraya's triage; nothing rides Q# sampling alone):
+- **Job 1:** singlet CHSH at the corners → converges to 2√2 (pairs with our analytic value — BP-16).
+- **Job 2:** BellTest overlap = cos²((a−b)/2) (the cleanest golden) — NOTE the sign convention fix
+  (Kira P1): our +cos(a−b) correlator is the **Φ⁺ (triplet)** convention; the singlet is −cos(a−b).
+  Headline wording corrected in-source; |S| is unchanged.
+- **Job 3:** AmplitudeEmu H·R1(φ)·H grid → P(0) = cos²(φ/2) (plus FsCheck on our side).
+- Small add-on: item-11 hardware-side anticommutation check.
+
+**Rerouted off Q#:** Tsirelson maximality → citation/NPA (sampling cannot establish a supremum);
+dashings + gauge lemma → **Z3** (32-bit bitvector, ∀-proof in milliseconds; Q# would sample noise
+on exact integers); fourcorner 2828 → unit oracle (now ROUNDED, capped at Tsirelson — Kira P0/P2);
+braid stuck law → already exact in F# + Artin 1925 citation (validity guard added — Kira P1);
+SUSY-side gammas → exact integer matrices, unit oracle or Z3.
+
+**The mod2 statement (Soraya's signable wording, adopted):** the unique homomorphism
+χ: B₃ → Z/2 with χ(σᵢ^±1) = 1 — exponent-sum (writhe) mod 2 = the permutation's sign character; a
+projection, no inverse. ("Per-pair crossing parity" is a different, finer pure-braid invariant —
+not conflated.) FsCheck homomorphism property is the follow-up once math-team signs.
+
+**Kira's tear-down: 13 findings, all addressed or filed** — P0: voiceSample per-tick phase noise
+(fixed: base phase from tick 0); classical CHSH gate passing by seed luck (fixed: 0.05 sampling
+tolerance). P1: BellTest sign wording (fixed); braid.lines stale gen args (synced); Braid.equal
+out-of-range unsoundness (validWord guard); harmonize "exact" while flooring (harmonizeExact added,
+test repaired); vacuous STAGED gate (removed — honest-labels = lint). P2: 2828 truncation (round +
+Tsirelson cap), "Goertzel-shaped" wording, drift bin-key alignment, coincidences span wording,
+Gates-gate falsifier test, adinkra quotient wording (Soraya's statement). Suite 2984 green after.

--- a/shapes/cartridges/adinkra.lines
+++ b/shapes/cartridges/adinkra.lines
@@ -19,7 +19,7 @@ law	gates-condition	code:viz.adinkra allFacesOdd standardDashing (every 2-colore
 law	gauge-lemma	code:viz.adinkra flipVertex invariance (local sign flips never change face parity — the twist is global)
 prereq	parity	popcount and the boson/fermion checkerboard — count bits, color cells, see the pattern
 prereq	the-braid-twin	shapes/cartridges/braid.lines — the ORDER register's version of the same protection (THE STUCK LAW)
-edge	same-twist	shape-braid	parity here = braid memory mod 2 (the quotient; algebra.mod2 is the adapter) — the break is honest: their generators remember, these edges are involutions
+edge	same-twist	shape-braid	parity here = the image of the unique homomorphism B3 -> Z/2 with every sigma^±1 -> 1 (exponent-sum mod 2 = the permutation's sign character; Soraya's signable statement, math tear-down 2026-06-12) — algebra.mod2 is the adapter; a projection, no inverse; the break is honest: their generators remember, these edges are involutions
 edge	clifford-home	shape-fourcorner	both registers live in Clifford algebra — where the Q# sign-convention check (Vera brief §8) meets us
 issue	wrap-edges	otto	open	the 8 omitted wrap edges need either a crossing-aware layout or a second panel — until then 24/32 stays the stated bound
 anim	draw	graph

--- a/shapes/cartridges/braid.lines
+++ b/shapes/cartridges/braid.lines
@@ -6,7 +6,7 @@ meta	name	shape-braid
 meta	name-status	provisional — Aaron 2026-06-12: ALGEBRAS named right (braid group B3 / pure braid P3, Artin; Brunnian link, Brunn; Borromean rings), MEMORY naming in Microsoft's register (majorana-memory — we test against their Q#, should be a close match); leading candidate unchanged: BORROMEAN BRAID. Prior-art naming under discussion (Aaron 2026-06-12); leading candidate: BORROMEAN BRAID — (s1*s2^-1)^3 is the standard braid word whose closure is the Borromean rings (three loops, pairwise unlinked, collectively inseparable: remove ANY one and the rest fall apart — Brunnian property, Brunn 1892; the Borromeo crest; Aravind 1997 ties Borromean topology to GHZ entanglement)
 meta	catalog	shapes
 meta	shape-zetaid	de84b57aa8bcdd1534c617f0fed3a2e2
-gen	weave	de84b57aa8bcdd1534c617f0fed3a2e2	1	7	strands:3;word:1,2,1;rows:12
+gen	weave	de84b57aa8bcdd1534c617f0fed3a2e2	1	7	strands:3;word:1,-2,1,-2,1,-2;rows:21
 constant	strands	3	how many strands the figure weaves	three is the smallest braid group with a NON-trivial Artin relation (B2 is just twisting) — the first place the hairdresser's move means something
 constant	word	1,-2,1,-2,1,-2	the crossing sequence (positive = left over right; negative reverses)	THE LOCKED PLAIT: the plait move (1,-2) repeated three times is ONE PERIOD of a real hair braid — the permutation returns to identity, so every strand starts AND ends in its own column (Aaron: "is there any way to lock them in place?" — yes: braid until they come home). Alternating signs keep each strand taking turns on top (his earlier correction); the Artin overlay (1,2,1 = 2,1,2) stays the in-code law
 constant	lock-period	6	crossings until the strands return to their own columns	((01)(12))^3 = identity — the plait's period; fewer crossings leave the ends scrambled, which is what "blue messes up" looks like
@@ -17,6 +17,7 @@ edge	same-twist	viz.adinkra	the adinkra's gauge lemma (vertex flips never make a
 anim	draw	weave
 issue	lock-in-place	aaron	closed	RESOLVED 2026-06-12: "the blue messes up… any way to lock them in place?" — the word is now one full plait period (lock-period 6): ends locked, every strand home
 issue	plait-register	aaron	closed	RESOLVED 2026-06-12: his dissent ("blue crosses on top of red for it to be a braid") changed the word to the alternating plait 1,-2,1 — joint meaning, negotiated through the render loop
+issue	stale-gen-args	otto	closed	RESOLVED 2026-06-12 (Kira P1): the gen line's args still said word:1,2,1;rows:12 after two word changes — the renderer reads the CONSTANTS (drawn = gated = what Aaron verified), but the stale args were a lie in waiting; synced, and the lesson is duplication smells (args should reference constants, not repeat them)
 # treaties — written only by each oracle's own choice (consent first); dissent is a verdict.
 treaty	fsharp	bytes	ratified	Braid.equal proves Artin (1,2,1 = 2,1,2) and sigma^2 != identity — tests green
 issue	over-under-register	otto	closed	RESOLVED 2026-06-12: the under strand now carries an occlusion gap at every crossing — who crossed OVER whom is in the ink (Artin's sign decides; negative crossings reverse it)

--- a/src/Core/BellTest.fs
+++ b/src/Core/BellTest.fs
@@ -5,7 +5,10 @@ namespace Zeta.Core
 ///
 /// Aaron: *"you created Bell inequalities in simulation through staged coincidence and seeds."* This codes it.
 /// The staged-coincidence overlap is `PhasorEndurance.overlap a b = cos²((a−b)/2)`, so the correlator
-/// `E(a,b) = 2·overlap − 1 = cos(a−b)` — **the quantum (singlet) correlator**, reproduced by the
+/// `E(a,b) = 2·overlap − 1 = cos(a−b)` — **the quantum correlator in the Φ⁺ (triplet) convention**
+/// (P1 wording fix, Kira 2026-06-12: the SINGLET gives E = −cos(a−b); +cos(a−b) is the Φ⁺ Bell
+/// state — the magnitude story and the CHSH |S| are identical, the sign convention is now stated
+/// where the headline is, not buried), reproduced by the
 /// `CoincidenceClock` staging. Feeding the canonical CHSH angles gives the CHSH value `S = 2√2` (the
 /// **Tsirelson bound**), which **violates the classical bound `2`** — in deterministic, replayable simulation.
 ///
@@ -61,7 +64,7 @@ module BellTest =
     let AlgebraicMax = 4.0
 
     /// The staged correlator between settings `a`, `b` (radians): `E = 2·overlap − 1 = cos(a−b)` — the quantum
-    /// singlet correlator, reproduced from the staged-coincidence overlap (`PhasorEndurance.overlap`).
+    /// Φ⁺-convention correlator (singlet is the −cos twin), reproduced from the staged-coincidence overlap (`PhasorEndurance.overlap`).
     let correlation (a: float) (b: float) : float =
         2.0 * PhasorEndurance.overlap a b - 1.0
 

--- a/src/Core/Braid.fs
+++ b/src/Core/Braid.fs
@@ -75,10 +75,20 @@ module Braid =
     let act (braid: int list) (w: Word) : Word =
         braid |> List.fold (fun acc c -> applyCrossing c acc) w
 
-    /// Are two braid words EQUAL as braids? (Faithful action ⇒ equal iff they act identically on
-    /// every generator of Fₙ.)
-    let equal (n: int) (b1: int list) (b2: int list) : bool =
-        [ 0 .. n - 1 ] |> List.forall (fun i -> act b1 (gen i) = act b2 (gen i))
+    /// Is every crossing in range for n strands? (σᵢ needs 1 ≤ |c| ≤ n−1; c = 0 is no crossing at
+    /// all.) P1 guard (Kira, math tear-down 2026-06-12): without this, `equal 3 [5] []` returned
+    /// true — σ₅ fixes x₀..x₂, so an out-of-range word masqueraded as the identity. Faithfulness
+    /// only holds for valid words; validity is now checked, never assumed.
+    let validWord (n: int) (b: int list) : bool =
+        b |> List.forall (fun c -> c <> 0 && abs c <= n - 1)
 
-    /// The identity test.
+    /// Are two braid words EQUAL as braids? (Faithful action ⇒ equal iff they act identically on
+    /// every generator of Fₙ.) Invalid words (out-of-range crossings) are never equal to anything —
+    /// refusal, not a false identity.
+    let equal (n: int) (b1: int list) (b2: int list) : bool =
+        validWord n b1
+        && validWord n b2
+        && ([ 0 .. n - 1 ] |> List.forall (fun i -> act b1 (gen i) = act b2 (gen i)))
+
+    /// The identity test (valid words only — an invalid word is not the identity, it is refused).
     let isIdentity (n: int) (b: int list) : bool = equal n b []

--- a/src/Core/ChipAudio.fs
+++ b/src/Core/ChipAudio.fs
@@ -37,10 +37,14 @@ module ChipAudio =
             if p < 500 then a - 128 |> max -128 |> min 127 else 128 - a |> max -128 |> min 127
 
     /// A voice: a waveform generator at a frequency, phased from the COMMON-CAUSE seed via TimeGen —
-    /// the phase at tick t is (t × freqMilli) mod 1000 offset by the generator's own phase.
+    /// the phase at tick t is (t × freqMilli) mod 1000 offset by the generator's CONSTANT base phase
+    /// (derived ONCE, at tick 0 — tick-independent). P0 fix (Kira, math tear-down 2026-06-12): the
+    /// first version re-derived the phase at EVERY tick, and TimeGen.at mixes tick into the hash —
+    /// so "the generator's own phase" was fresh noise per sample and the waveform drowned in it; the
+    /// coincidence lattice described phases the voices never had. The mic keeps its placement now.
     let voiceSample (g: TimeGen.Generator) (contributor: uint64) (w: Waveform) (freqMilli: int) (tick: int) : int =
-        let t = TimeGen.at g contributor tick
-        let basePhase = int (t.Phase * 159.154943) % 1000 // the generated phase, milli-mapped
+        let t0 = TimeGen.at g contributor 0
+        let basePhase = int (t0.Phase * 159.154943) % 1000 // the generator's base phase, milli-mapped, FIXED
         sampleAt w ((basePhase + tick * freqMilli) % 1000)
 
     /// A MIDI-style note event as a crossing payload (the membrane carries music like everything):
@@ -56,10 +60,20 @@ module ChipAudio =
     // consonance is structural — the periods coincide exactly every (num·den) of the base period,
     // forever, with zero coordination. Dancers don't message each other; they share the music. ──
 
-    /// Derive a consonant partner frequency by an exact rational ratio (3:2 the fifth, 2:1 the
-    /// octave, 1:2 half-time…) — integer milli, exact: harmony as arithmetic on the shared clock.
+    /// Derive a consonant partner frequency by a rational ratio (3:2 the fifth, 2:1 the octave,
+    /// 1:2 half-time…) — integer milli, FLOORED when den does not divide (P1 fix, Kira: the first
+    /// doc said "exact" while truncating — harmonize 3 2 125 = 187, a 0.27% flat fifth whose periods
+    /// never meet the base's). Floor is honest for display; for the COINCIDENCE arithmetic use
+    /// `harmonizeExact`, which refuses inexact ratios instead of quietly detuning them.
     let harmonize (num: int) (den: int) (freqMilli: int) : int =
         freqMilli * max 1 num / max 1 den
+
+    /// The exact form: Some partner frequency iff den divides num·freq exactly — consonance that is
+    /// claimed is consonance that is TRUE (pick base frequencies divisible by your denominators:
+    /// 150 milli at 3:2 = 225, exact; 125 at 3:2 is refused, not flattened).
+    let harmonizeExact (num: int) (den: int) (freqMilli: int) : int option =
+        let n, d = max 1 num, max 1 den
+        if (freqMilli * n) % d = 0 then Some(freqMilli * n / d) else None
 
     /// THE SOUL CLAUSE (Aaron, on the freestyle: "the imperfections where the soul lives, within the
     /// perfection"): the perfect clock is the CANVAS, never the performance — the bounded deviations
@@ -86,7 +100,8 @@ module ChipAudio =
     ///
     /// Two voices on ONE generator at a rational ratio: returns tick indices (within `span`) where
     /// their phases COINCIDE (both at phase 0 mod 1000) — the downbeats both hit without ever
-    /// speaking. Nonempty for any rational ratio: consonance is a theorem of the common cause.
+    /// speaking. Nonempty WHEN span covers the common period (lcm of the two periods — e.g. equal
+    /// frequencies coincide every 1000/gcd(freq,1000) ticks; a short span can honestly see none).
     let coincidences (freqA: int) (freqB: int) (span: int) : int list =
         [ for t in 1 .. span do
               if (t * freqA) % 1000 = 0 && (t * freqB) % 1000 = 0 then yield t ]

--- a/src/Core/ShapeAcceptance.fs
+++ b/src/Core/ShapeAcceptance.fs
@@ -51,11 +51,13 @@ module ShapeAcceptance =
                 MediaLines.field "constant" "word" d
                 |> Option.defaultValue ""
                 |> fun s -> s.Split(',') |> Array.filter (fun x -> x.Length > 0) |> Array.map int |> Array.toList
+            let valid = Braid.validWord 3 word
             let perm = Array.init 3 id
-            for c in word do
-                let a = abs c - 1
-                let t = perm.[a] in perm.[a] <- perm.[a + 1]; perm.[a + 1] <- t
-            let locked = perm = [| 0; 1; 2 |]
+            if valid then
+                for c in word do
+                    let a = abs c - 1
+                    let t = perm.[a] in perm.[a] <- perm.[a + 1]; perm.[a + 1] <- t
+            let locked = valid && perm = [| 0; 1; 2 |]
             // THE STUCK LAW (Aaron 2026-06-12, reaching for Majorana-style topology: "trying to
             // see if I can get a configuration where they are stuck together"): the drawn word
             // must be permutation-IDENTITY (every strand home — locked) yet NOT the identity
@@ -77,8 +79,18 @@ module ShapeAcceptance =
                 MediaLines.field "constant" "tsirelson-milli" d |> Option.map int |> Option.defaultValue 0
             let g = TimeGen.mk "acceptance" 1 4UL TimeGen.PhasorTsirelson
             let cl = TimeGen.mk "acceptance" 1 4UL TimeGen.ClassicalCommonCause
-            let ok = int (TimeGen.chsh g 256 * 1000.0) = declared && TimeGen.chsh cl 256 <= 2.0 + 1e-9
-            ok, sprintf "phasor S reaches exactly the declared %d milli; classical folds at 2" declared
+            // P0 fix (Kira): the classical HV model's true S at these corners is exactly 2.0, and a
+            // 256-sample estimator carries ~0.06 sampling error — the old `<= 2.0 + 1e-9` gate
+            // passed by SEED LUCK (any change to the mixer or seed flips it with no bug present).
+            // The suite's honest tolerance (0.05) is the gate's tolerance now. P2 fix: the milli
+            // comparison rounds to nearest (truncation accepted S up to 2828.99 — past Tsirelson);
+            // the phasor value is analytic, so round-equality at 2828 is exact-by-construction.
+            let sPhasor = TimeGen.chsh g 256
+            let ok =
+                int (System.Math.Round(sPhasor * 1000.0)) = declared
+                && sPhasor <= 2.0 * sqrt 2.0 + 1e-9
+                && TimeGen.chsh cl 256 <= 2.0 + 0.05
+            ok, sprintf "phasor S = declared %d milli (rounded, capped at Tsirelson); classical folds at 2 (sampling tolerance 0.05)" declared
         | "shape-buckyball" ->
             // Addison's solid checked by arithmetic, not trust: Euler characteristic, the
             // face/edge double-count, 3-regularity, and the meta room's door count (rooms + itself).
@@ -98,11 +110,13 @@ module ShapeAcceptance =
                 MediaLines.field "constant" "word" d
                 |> Option.defaultValue ""
                 |> fun s -> s.Split(',') |> Array.filter (fun x -> x.Length > 0) |> Array.map int |> Array.toList
+            let valid = Braid.validWord 3 word
             let perm = Array.init 3 id
-            for c in word do
-                let a = abs c - 1
-                let t = perm.[a] in perm.[a] <- perm.[a + 1]; perm.[a + 1] <- t
-            let ok = perm = [| 2; 1; 0 |] && not (Braid.isIdentity 3 word)
+            if valid then
+                for c in word do
+                    let a = abs c - 1
+                    let t = perm.[a] in perm.[a] <- perm.[a + 1]; perm.[a + 1] <- t
+            let ok = valid && perm = [| 2; 1; 0 |] && not (Braid.isIdentity 3 word)
             ok, "perm = outer swap (02), middle home; not the identity braid — the move MOVES (odd parity: lock impossible here)"
         | "shape-shadow-loop" ->
             // otto's own: the sampled lemniscate must CLOSE (first = last) and pass through the
@@ -150,10 +164,11 @@ module ShapeAcceptance =
             if List.isEmpty travelers then "no traveler has spoken yet (silence, not error — consent first)"
             else travelers |> List.map (fun (o, _, verdict) -> o + ":" + verdict) |> String.concat " "
         let lintOk = MediaLines.lint d |> List.isEmpty
-        let labelsOk =
-            lintOk
-            && (shape <> "shape-fourcorner"
-                || (TimeGen.label (TimeGen.mk "labels" 1 4UL TimeGen.StagedCoincidence)).Contains "STAGED")
+        // P1 fix (Kira): the old fourcorner extra check asserted a STRING CONSTANT in TimeGen.label
+        // contained "STAGED" — vacuous per-cartridge (it could never fail for the artifact under
+        // review). Honest-labels = the lint (structure: WHAT+WHY on every constant); artifact-
+        // specific honesty obligations belong in the cartridge's own law lines, where they can fail.
+        let labelsOk = lintOk
         [ v shape Bytes bytesOk (if bytesOk then "a language oracle ratified the byte register" else "no byte-register ratification in the treaty block")
           v shape Geometry geomOk geomEv
           v shape Meaning true meaningEv // reported, never gated: dissent is data

--- a/src/Core/SpectralPivot.fs
+++ b/src/Core/SpectralPivot.fs
@@ -41,10 +41,14 @@ module SpectralPivot =
                    acc <- ImaginaryStack.complex.Add(acc, ImaginaryStack.complex.Mul(spectrum.[k], tw))
                acc.Real / float n |]
 
+    // honesty note (Kira P2): idft above returns the REAL part only — the round-trip
+    // idft(dft(x)) = x holds for real input signals (our case); complex-valued signals are out of
+    // scope and would need the imaginary channel kept.
     /// A bin's energy (the fingerprint's coordinate).
     let energy (c: Complex) : float = c.Real * c.Real + c.Imag * c.Imag
 
-    /// SOFT: probe ONE bin (Goertzel-shaped, O(n)) — the spectral soft-prism: "is this pitch there?"
+    /// SOFT: probe ONE bin (a naive single-bin DFT — per-sample cos/sin, O(n); the Goertzel
+    /// recurrence is the named upgrade, not what this is) — the spectral soft-prism: "is this pitch there?"
     let probe (signal: float[]) (k: int) : float =
         let n = signal.Length
         let mutable acc = Doubled.make 0.0 0.0
@@ -64,10 +68,15 @@ module SpectralPivot =
     // (the bearing starting to sing) shows up as drift long before it shows up as failure — the
     // soft-lens discipline pointed at time: baseline = solid ground, drift = the uncertainty rising. ──
 
-    /// The drift between a baseline fingerprint and a current one (same bins): Σ |Δenergy|.
+    /// The drift between a baseline fingerprint and a current one: Σ |Δenergy|, aligned BY BIN KEY
+    /// (P2 fix, Kira: the first version zipped by position — fingerprints over different bin lists
+    /// compared as silent nonsense, mismatched lengths threw). A bin present on one side only
+    /// contributes its full energy: missing is maximal drift for that bin, never ignored.
     let drift (baseline: (int * float) list) (current: (int * float) list) : float =
-        List.zip baseline current
-        |> List.sumBy (fun ((_, a), (_, b)) -> abs (a - b))
+        let b, c = Map.ofList baseline, Map.ofList current
+        Set.union (Set.ofSeq (Map.keys b)) (Set.ofSeq (Map.keys c))
+        |> Seq.sumBy (fun k ->
+            abs ((Map.tryFind k b |> Option.defaultValue 0.0) - (Map.tryFind k c |> Option.defaultValue 0.0)))
 
     /// The maintenance question in one call: is the machine's hum still within `tolerance` of its
     /// healthy self at these probe bins?

--- a/tests/Tests.FSharp/AdinkraViz.Tests.fs
+++ b/tests/Tests.FSharp/AdinkraViz.Tests.fs
@@ -62,3 +62,6 @@ let ``THE GAUGE LEMMA: no local move removes the twist — vertex flips change t
         |> List.fold (fun d v -> AdinkraViz.flipVertex v d) AdinkraViz.standardDashing
     Assert.NotEqual<Set<int * int>>(AdinkraViz.standardDashing, walked) // the dashing genuinely changed
     Assert.True(AdinkraViz.allFacesOdd walked) // the twist did not — same sentence as THE STUCK LAW
+    // THE FALSIFIER (Kira P2: a gate never seen rejecting proves nothing): the all-solid dashing
+    // makes every face EVEN (count 0) and must FAIL the Gates condition
+    Assert.False(AdinkraViz.allFacesOdd Set.empty)

--- a/tests/Tests.FSharp/SpectralPivot.Tests.fs
+++ b/tests/Tests.FSharp/SpectralPivot.Tests.fs
@@ -57,11 +57,15 @@ let ``PREDICTIVE MAINTENANCE: a new harmonic (the bearing starting to sing) show
 
 [<Fact>]
 let ``SINGING: a fifth (3:2) on the shared clock — downbeats coincide exactly, zero messages exchanged`` () =
+    // Kira P1 fix: the old test asserted the FLOORED 187 and called it a fifth — a known-answer
+    // test documenting its own answer being wrong. Now: floor is tested AS floor; the exact form
+    // refuses 125 (3·125 not divisible by 2) and DELIVERS on 150; coincidences use exact pairs.
     let baseF = 125 // base voice: period 8 ticks (125*8 = 1000)
-    let fifth = ChipAudio.harmonize 3 2 baseF
-    Assert.Equal(187, fifth) // 3:2 in integer milli (187.5 floors — the exact-slice note: rational milli)
-    // use the exact pair 125 & 250 (the octave) for the coincidence theorem at integer milli:
-    let octave = ChipAudio.harmonize 2 1 baseF
+    Assert.Equal(187, ChipAudio.harmonize 3 2 baseF) // floored — display form, honest about it
+    Assert.Equal(None, ChipAudio.harmonizeExact 3 2 baseF) // the inexact fifth is REFUSED, not flattened
+    Assert.Equal(Some 225, ChipAudio.harmonizeExact 3 2 150) // a divisible base gets the TRUE fifth
+    // the exact pair 125 & 250 (the octave) for the coincidence theorem at integer milli:
+    let octave = ChipAudio.harmonizeExact 2 1 baseF |> Option.get
     let meets = ChipAudio.coincidences baseF octave 32
     Assert.Equal<int list>([ 8; 16; 24; 32 ], meets) // every base period, both hit the downbeat — forever
 


### PR DESCRIPTION
Kira found what no render could: voiceSample drowning in per-tick phase noise (P0 — every render looked right while it was broken), a CHSH gate passing by seed luck (P0), the Φ⁺/singlet sign mislabel, out-of-range braid words masquerading as identity, harmonize claiming exact while flooring, a vacuous gate, and six P2s — all fixed or filed in-cartridge. Soraya's routing: Q# earns exactly three jobs; dashings go to Z3; Tsirelson maximality to citation; her signable mod2 statement adopted verbatim. Math-team treaty lines stay PENDING — the fixes are the application, not the sign-off. 2984 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)