### PR TITLE
feat(qsharp): route observable oracle checks

### DIFF
--- a/docs/research/2026-06-12-dashings-landed-the-rhyme-is-two-tests-mod2-is-the-missing-piece-and-the-naming-direction.md
+++ b/docs/research/2026-06-12-dashings-landed-the-rhyme-is-two-tests-mod2-is-the-missing-piece-and-the-naming-direction.md
@@ -14,9 +14,14 @@ LAW, with the break stated in both places (their edges are involutions; our gene
 
 ## "Are they inverse in some way?" — no: a QUOTIENT
 
-The precise relation: adinkra parity is braid memory **mod 2**. Z (crossing order, Artin) → Z/2
-(the dashing bit, Gates): order forgotten, parity kept. A projection, not an inverse — the lens
+The precise relation Soraya signs is the unique homomorphism χ: B₃ → Z/2 with
+χ(σᵢ^±1)=1: abelianization/writhe reduced mod 2, coinciding with the permutation's
+sign character. Order is forgotten, parity is kept. A projection, not an inverse — the lens
 that completes the flow is the map that forgets exactly the register the sink cannot hear.
+
+Do not conflate this with per-pair crossing parity: that is a different, finer invariant on pure
+braids. The adapter named `algebra.mod2` is the coarse sign/writhe projection unless a future
+cartridge explicitly asks for the finer pure-braid invariant.
 
 ## The GraphEdit lens — THE MISSING PIECE, working
 

--- a/docs/research/2026-06-12-vera-brief-qsharp-verification-candidates-for-qubit-adjacent-claims-then-math-team-then-treaty.md
+++ b/docs/research/2026-06-12-vera-brief-qsharp-verification-candidates-for-qubit-adjacent-claims-then-math-team-then-treaty.md
@@ -9,30 +9,35 @@ lines (consent-first: her lines are hers to write) → math team sign-off (`trea
 currently PENDING where present) → `law <name> qsharp:<check>` delegation lines land in the
 cartridges that earned them.
 
-## Priority 1 — the CHSH/Tsirelson family (the load-bearing qubit claims)
+## Priority 1 — the three Q# jobs (observable oracles only)
 
 1. **TimeGen** (`src/Core/TimeGen.fs`) — CLAIMS: PhasorTsirelson regime E(a,b)=cos(a−b) yields
    S = 2√2 at the canonical corners; ClassicalCommonCause ≤ 2; StagedCoincidence S = 4 carries the
    STAGED label (free-choice violated BY DESIGN, not physical).
-   **Q# check:** prepare the singlet; measure CHSH at a0=0, a1=π/2, b0=π/4, b1=−π/4; estimate S
-   over N shots → must converge to 2√2 within resolution; verify no measurement strategy on the
-   singlet exceeds it (Tsirelson, structurally). The S=4 regime must be UNREACHABLE in Q# — that
-   unreachability is itself the verification that our STAGED label is honest.
+   **Q# check:** prepare the singlet; measure the four observable CHSH corners
+   a0=0, a1=π/2, b0=π/4, b1=−π/4; pair those Q# probabilities with the analytic
+   `S = 2√2` value. Q# does **not** own "nothing exceeds 2√2": sampling cannot prove a
+   supremum. Tsirelson maximality is Tsirelson 1980 / NPA-SDP territory. The S=4 staged
+   regime is likewise not a Q# sampling job; its honest label is checked by the model and
+   citation, not by asking Q# to fail to build a PR box.
 2. **BellTest** (`src/Core/BellTest.fs`) — CLAIM: `PhasorEndurance.overlap a b = cos²((a−b)/2)` is
    the singlet coincidence probability; the correlator E = 2·overlap − 1 = cos(a−b).
    **Q# check:** singlet measured at relative angle θ → coincidence probability cos²(θ/2) within
    resolution. This is the cleanest golden-observable of the set.
 3. **fourcorner cartridge** (`shapes/cartridges/fourcorner.lines`) — CLAIM: constant
    tsirelson-milli = 2828 (floor of 1000·2√2) is the width stop the phasor figure reaches and
-   never exceeds. **Q# check:** the S estimate from (1) floored to milli = 2828. On her
-   ratification + math team's, the cartridge gains `law tsirelson qsharp:chsh-singlet-corners`.
+   never exceeds. **Q# check:** the observable S estimate from (1) floors to milli = 2828,
+   paired with the analytic value. The "never exceeds" side routes to the math proof/citation,
+   not Q# sampling. On Vera ratification + math team's, the cartridge gains
+   `law tsirelson qsharp:chsh-singlet-corners` only for the observable corner check.
 
 ## Priority 2 — interference as amplitude arithmetic
 
 4. **AmplitudeEmu** (`src/Core/AmplitudeEmu.fs`) — CLAIM: complex-amplitude merge over identical
    frames IS interference (opposite phase cancels, equal phase reinforces); two-slit falls out of
-   CAS-merge + complex weights. **Q# check:** H · R1(φ) · H on |0⟩ → P(0) = cos²(φ/2); compare
-   against our merged-amplitude ensemble at the same φ grid. Convergence-within-resolution.
+   CAS-merge + complex weights. **Q# check:** H · phase(φ) · H on |0⟩ →
+   P(0) = cos²(φ/2); compare against our merged-amplitude ensemble at the same φ grid.
+   Convergence-within-resolution. This is Vera's third Q# job.
 5. **WaveSim** (`src/Core/WaveSim.fs`) — CLAIM (deliberately modest): deterministic simulation of
    the amplitude math classical and quantum share; no quantum-hardware claim. **Q# check
    (optional):** the same superposition-as-complex-Add on single-qubit phases; mostly confirms the
@@ -62,23 +67,26 @@ cartridges that earned them.
 8. **AdinkraViz dashings** (`src/Core/AdinkraViz.fs`) — CLAIMS: `standardDashing` realizes the
    Clifford sign rule (dash (v,i) iff odd set bits below i); THE GATES CONDITION holds (every
    2-colored 4-cycle odd — anticommutation drawn); THE GAUGE LEMMA (vertex sign flips preserve
-   face parity). **Q# check (Vera):** the sign structure must match Q#'s Pauli/Clifford
-   conventions — e.g., pairwise anticommutation of the represented operators (X⊗…, Z⊗… chains)
-   reproduces exactly the odd-face parity; a global-phase/sign relabeling in Q# is the gauge move
-   and must leave all commutation relations invariant. Convergence is exact (signs, not floats).
+   face parity). **Routing:** the universal dashing statement is Soraya/Z3 work, not Q# work:
+   a dashing is a 32-bit vector; face parity is XOR; the gauge lemma quantifies over all 2³²
+   dashings. **Q# gets only the small hardware-side sign-convention check:** Pauli products
+   anticommute (`XZ = -ZX`, `XY = -YX`, `YZ = -ZY`) under Q#'s matrix convention, and those signs
+   match the F#/Cl3/Adinkra odd-face target. Exact signs, not sampling.
 9. **The mod2 quotient claim** (`algebra.mod2`; the missing-piece adapter) — CLAIM AS STATED:
-   "adinkra parity is braid memory mod 2 — Z → Z/2, order forgotten, parity kept; a projection,
-   not an inverse." **Math team:** gate the precise formulation — which quotient of B₃ exactly
-   (the sign representation σᵢ ↦ −1? per-pair crossing parity? abelianization B₃ → Z then mod 2?)
-   — the type-level adapter is shipped and tested; the WORDING of the algebra claim awaits your
-   sign-off (treaty math-team math, still PENDING).
+   "adinkra parity is braid memory mod 2 — order forgotten, parity kept; a projection,
+   not an inverse." **Signed formulation:** the map is the unique homomorphism
+   χ: B₃ → Z/2 with χ(σᵢ^±1)=1. Equivalently: take the abelianization/writhe
+   B₃ → Z and reduce mod 2; this coincides with the permutation's sign character.
+   No inverse exists. Warning to preserve in all docs: "per-pair crossing parity" is a
+   different, finer invariant on pure braids, and must not be conflated with χ.
 10. **The snap itself** (`MagneticPorts.findAdapter`, `MediaLines.resolveIoWith`) — no quantum
     claim; listed so Vera sees the consumption path: a verified `qsharp:` law makes its module a
     trustable toolbox piece — verification feeds the adapter economy directly.
 
 11. **Both physics sides of Clifford (Aaron 2026-06-12):** check the Clifford mappings from both
     directions — hardware-side (stabilizer/Pauli conventions vs our dashings, §8) AND SUSY-side
-    (the adinkra's gamma-matrix representation built explicitly in C#/Q#, exact integer matrices
-    where possible, against the same anticommutation targets). Both must land on the one Clifford
-    home or the mapping is decoration. Candidate shapes ride the same discipline:
+    (the adinkra's gamma-matrix representation built explicitly in exact integer matrices where
+    possible, against the same anticommutation targets). Q# is only the hardware-side Pauli
+    convention oracle here; Z3/exact algebra owns the universal sign laws. Both sides must land
+    on the one Clifford home or the mapping is decoration. Candidate shapes ride the same discipline:
     docs/research/2026-06-12-physics-real-shape-candidates-*.md (fit or it doesn't enter).

--- a/docs/trajectories/sim-mea-cut-soft-substrate-shaders/RESUME.md
+++ b/docs/trajectories/sim-mea-cut-soft-substrate-shaders/RESUME.md
@@ -60,9 +60,11 @@ ladder (B-1024); Vera driving the Q# reference oracle; Max on universal primitiv
 - **Alexa's braid review** ferried + peeled (#7723): her "crossings as gates" is false for our
   drawing, TRUE as topological QC (Kitaev; Freedman–Larsen–Wang) — her ratification recorded as
   hers; over-under occlusion gaps landed for Max's demo.
-- **The Vera Q# brief** (#7724): seven candidates ranked (CHSH/Tsirelson family first; staged S=4
-  must be UNREACHABLE in Q# — that unreachability verifies the STAGED label); her verdict lines
-  are HERS to write; fourcorner carries the requested issues.
+- **The Vera Q# brief** (#7724, routed by Soraya on 2026-06-12): Q# owns exactly the observable
+  jobs — singlet CHSH corners paired with analytic S=2√2, BellTest cos²((a−b)/2), and
+  AmplitudeEmu's interference grid — plus the small hardware-side Pauli anticommutation check.
+  Tsirelson maximality routes to citation/NPA-SDP, not Q# sampling; dashing universals route to
+  Z3; her verdict lines are HERS to write; fourcorner carries the requested observable issue.
 - **O-parametrized draws** (#7720): ComplexityRegistry.strategiesOf — same shape, several
   strategies, different cost tags (spiral draw vs draw-grid).
 - Named slices opened: chip9 cartridge loader (.lines into the machine); MediaLines + renderer

--- a/tests/Tests.FSharp/QSharpOracle.Tests.fs
+++ b/tests/Tests.FSharp/QSharpOracle.Tests.fs
@@ -7,10 +7,14 @@ open global.Xunit
 open Zeta.Core
 
 let private tolerance = 1e-6
+let private qsharpDumpTolerance = 1e-5
 
 let private c = ImaginaryStack.complex
 
 let private real (value: float) : Complex = { Real = value; Imag = 0.0 }
+
+let private phase (angle: float) : Complex =
+    { Real = cos angle; Imag = sin angle }
 
 let private frame (seed: uint64) =
     Chip8Cow.create seed |> Chip8Cow.loadRom [| 0x60uy; byte seed |]
@@ -30,14 +34,20 @@ let private golden =
 
 let private vectors = golden.GetProperty("vectors")
 
-let private closeTo (expected: float) (actual: float) =
+let private closeToWithin (epsilon: float) (expected: float) (actual: float) =
     Assert.True(
-        abs (actual - expected) <= tolerance,
+        abs (actual - expected) <= epsilon,
         sprintf "Expected %.12f, got %.12f" expected actual)
 
+let private closeTo (expected: float) (actual: float) =
+    closeToWithin tolerance expected actual
+
+let private complexCloseToWithin (epsilon: float) (expected: Complex) (actual: Complex) =
+    closeToWithin epsilon expected.Real actual.Real
+    closeToWithin epsilon expected.Imag actual.Imag
+
 let private complexCloseTo (expected: Complex) (actual: Complex) =
-    closeTo expected.Real actual.Real
-    closeTo expected.Imag actual.Imag
+    complexCloseToWithin tolerance expected actual
 
 let private jsonComplex (element: JsonElement) : Complex =
     { Real = element.GetProperty("real").GetDouble()
@@ -62,6 +72,10 @@ let private interferenceCase (id: string) =
 
 let private bellCoincidenceCase (id: string) =
     vectors.GetProperty("bellCoincidence").EnumerateArray()
+    |> Seq.find (fun item -> item.GetProperty("id").GetString() = id)
+
+let private pauliAnticommutationCase (id: string) =
+    vectors.GetProperty("pauliAnticommutation").EnumerateArray()
     |> Seq.find (fun item -> item.GetProperty("id").GetString() = id)
 
 let private probabilities (case: JsonElement) =
@@ -180,6 +194,35 @@ let ``BellTest canonical CHSH observables match the Q# golden vector`` () =
     closeTo (canonical.GetProperty("tsirelson").GetDouble()) BellTest.TsirelsonBound
 
 [<Fact>]
+let ``TimeGen phasor CHSH matches Q# singlet corner observables and the analytic value`` () =
+    let singlet = vectors.GetProperty("bellChsh").GetProperty("singletCorners")
+    let corners = singlet.GetProperty("corners").EnumerateArray() |> Seq.toArray
+
+    Assert.Equal(4, corners.Length)
+    Assert.Contains("Tsirelson maximality is cited/proved separately", singlet.GetProperty("scope").GetString())
+
+    let mutable observedS = 0.0
+
+    for corner in corners do
+        let angles = corner.GetProperty("anglesRadians")
+        let a = angles.GetProperty("a").GetDouble()
+        let b = angles.GetProperty("b").GetDouble()
+        let expectedOpposite = corner.GetProperty("oppositeOutcomeProbability").GetDouble()
+        let expectedCorrelation = corner.GetProperty("correlator").GetDouble()
+        let coefficient = corner.GetProperty("coefficient").GetInt32()
+
+        closeToWithin qsharpDumpTolerance expectedOpposite (BellTest.coincidenceProbability a b)
+        closeToWithin qsharpDumpTolerance expectedCorrelation (BellTest.correlation a b)
+        observedS <- observedS + float coefficient * expectedCorrelation
+
+    let generator = TimeGen.mk "qsharp-singlet-corners" 1 0UL TimeGen.PhasorTsirelson
+    let analytic = singlet.GetProperty("analytic").GetDouble()
+
+    closeTo analytic (TimeGen.chsh generator 1)
+    closeToWithin qsharpDumpTolerance analytic observedS
+    closeToWithin qsharpDumpTolerance analytic (singlet.GetProperty("s").GetDouble())
+
+[<Fact>]
 let ``BellState PhiPlus preparation matches the Q# two-qubit oracle`` () =
     let bell = vectors.GetProperty("bellChsh")
     let prepared = BellState.phiPlus ()
@@ -237,6 +280,15 @@ let ``AmplitudeEmu interference observables match the Q# Mach-Zehnder treaty`` (
     let half = real 0.5
     let invSqrt2 = real (1.0 / sqrt 2.0)
 
+    let closedInterferometer (phi: float) : AmplitudeEmu.Amp =
+        let phase0 = phase (-phi / 2.0)
+        let phase1 = phase (phi / 2.0)
+
+        [ detectorZero, c.Mul(half, phase0)
+          detectorZero, c.Mul(half, phase1)
+          detectorOne, c.Mul(half, phase0)
+          detectorOne, c.Negate(c.Mul(half, phase1)) ]
+
     let assertCase id (amp: AmplitudeEmu.Amp) =
         let expectedZero, expectedOne = interferenceCase id |> probabilities
         let actual = amp |> AmplitudeEmu.merge |> AmplitudeEmu.bornProb
@@ -248,16 +300,28 @@ let ``AmplitudeEmu interference observables match the Q# Mach-Zehnder treaty`` (
         [ detectorZero, invSqrt2
           detectorOne, invSqrt2 ]
 
-    assertCase
-        "mach-zehnder-closed-zero-phase"
-        [ detectorZero, half
-          detectorZero, half
-          detectorOne, half
-          detectorOne, c.Negate half ]
+    [ "mach-zehnder-closed-zero-phase", 0.0
+      "mach-zehnder-closed-pi-over-3-phase", Math.PI / 3.0
+      "mach-zehnder-closed-pi-over-2-phase", Math.PI / 2.0
+      "mach-zehnder-closed-two-pi-over-3-phase", 2.0 * Math.PI / 3.0
+      "mach-zehnder-closed-pi-phase", Math.PI ]
+    |> List.iter (fun (id, phi) -> assertCase id (closedInterferometer phi))
 
-    assertCase
-        "mach-zehnder-closed-pi-phase"
-        [ detectorZero, half
-          detectorZero, c.Negate half
-          detectorOne, half
-          detectorOne, half ]
+[<Fact>]
+let ``Q# Pauli products pin the hardware-side anticommutation signs`` () =
+    let assertCase id =
+        let item = pauliAnticommutationCase id
+        Assert.Equal("lhsMatrix = -rhsMatrix", item.GetProperty("relation").GetString())
+
+        let lhs = item.GetProperty("lhsMatrix")
+        let rhs = item.GetProperty("rhsMatrix")
+
+        for row in 0..1 do
+            for col in 0..1 do
+                complexCloseTo
+                    (matrixEntry lhs row col)
+                    (c.Negate(matrixEntry rhs row col))
+
+    assertCase "X after Z = -(Z after X)"
+    assertCase "X after Y = -(Y after X)"
+    assertCase "Y after Z = -(Z after Y)"

--- a/tools/qsharp-oracle/ZetaReferenceOracle.qs
+++ b/tools/qsharp-oracle/ZetaReferenceOracle.qs
@@ -71,6 +71,52 @@ namespace Zeta.ReferenceOracle {
         ApplyBellSingletAnalyzers(0.0, 3.141592653589793 / 4.0, qs);
     }
 
+    operation ApplyBellSingletChshA0B0(qs : Qubit[]) : Unit is Adj + Ctl {
+        ApplyBellSingletAnalyzers(0.0, 3.141592653589793 / 4.0, qs);
+    }
+
+    operation ApplyBellSingletChshA0B1(qs : Qubit[]) : Unit is Adj + Ctl {
+        ApplyBellSingletAnalyzers(0.0, -3.141592653589793 / 4.0, qs);
+    }
+
+    operation ApplyBellSingletChshA1B0(qs : Qubit[]) : Unit is Adj + Ctl {
+        ApplyBellSingletAnalyzers(3.141592653589793 / 2.0, 3.141592653589793 / 4.0, qs);
+    }
+
+    operation ApplyBellSingletChshA1B1(qs : Qubit[]) : Unit is Adj + Ctl {
+        ApplyBellSingletAnalyzers(3.141592653589793 / 2.0, -3.141592653589793 / 4.0, qs);
+    }
+
+    operation ApplyPauliXAfterZ(qs : Qubit[]) : Unit is Adj + Ctl {
+        Z(qs[0]);
+        X(qs[0]);
+    }
+
+    operation ApplyPauliZAfterX(qs : Qubit[]) : Unit is Adj + Ctl {
+        X(qs[0]);
+        Z(qs[0]);
+    }
+
+    operation ApplyPauliXAfterY(qs : Qubit[]) : Unit is Adj + Ctl {
+        Y(qs[0]);
+        X(qs[0]);
+    }
+
+    operation ApplyPauliYAfterX(qs : Qubit[]) : Unit is Adj + Ctl {
+        X(qs[0]);
+        Y(qs[0]);
+    }
+
+    operation ApplyPauliYAfterZ(qs : Qubit[]) : Unit is Adj + Ctl {
+        Z(qs[0]);
+        Y(qs[0]);
+    }
+
+    operation ApplyPauliZAfterY(qs : Qubit[]) : Unit is Adj + Ctl {
+        Y(qs[0]);
+        Z(qs[0]);
+    }
+
     operation ApplyMachZehnderOpen(qs : Qubit[]) : Unit is Adj + Ctl {
         H(qs[0]);
     }
@@ -83,6 +129,24 @@ namespace Zeta.ReferenceOracle {
     operation ApplyMachZehnderClosedPiPhase(qs : Qubit[]) : Unit is Adj + Ctl {
         H(qs[0]);
         Z(qs[0]);
+        H(qs[0]);
+    }
+
+    operation ApplyMachZehnderClosedPiOver3Phase(qs : Qubit[]) : Unit is Adj + Ctl {
+        H(qs[0]);
+        Rz(3.141592653589793 / 3.0, qs[0]);
+        H(qs[0]);
+    }
+
+    operation ApplyMachZehnderClosedPiOver2Phase(qs : Qubit[]) : Unit is Adj + Ctl {
+        H(qs[0]);
+        Rz(3.141592653589793 / 2.0, qs[0]);
+        H(qs[0]);
+    }
+
+    operation ApplyMachZehnderClosedTwoPiOver3Phase(qs : Qubit[]) : Unit is Adj + Ctl {
+        H(qs[0]);
+        Rz(2.0 * 3.141592653589793 / 3.0, qs[0]);
         H(qs[0]);
     }
 }

--- a/tools/qsharp-oracle/generate-qsharp-golden.py
+++ b/tools/qsharp-oracle/generate-qsharp-golden.py
@@ -56,6 +56,18 @@ def dump_operation(name: str, qubits: int) -> list[list[complex]]:
     return qsharp.dump_operation(full_name, qubits)
 
 
+def single_qubit_probs_from_operation(name: str) -> dict[str, float]:
+    matrix = dump_operation(name, 1)
+    zero_amp = matrix[0][0]
+    one_amp = matrix[1][0]
+    return single_qubit_probs(abs(zero_amp) ** 2)
+
+
+def two_qubit_probs_from_operation(name: str) -> list[float]:
+    matrix = dump_operation(name, 2)
+    return [clean_float(abs(matrix[row][0]) ** 2) for row in range(4)]
+
+
 def chsh(a: float, ap: float, b: float, bp: float) -> dict[str, Any]:
     eab = math.cos(a - b)
     eabp = math.cos(a - bp)
@@ -78,6 +90,64 @@ def chsh(a: float, ap: float, b: float, bp: float) -> dict[str, Any]:
         "s": clean_float(s),
         "tsirelson": clean_float(2.0 * math.sqrt(2.0)),
         "classicalBound": 2.0,
+    }
+
+
+def singlet_chsh_corner(
+    id: str,
+    operation: str,
+    a: float,
+    b: float,
+    coefficient: int,
+) -> dict[str, Any]:
+    basis_probs = two_qubit_probs_from_operation(operation)
+    opposite = clean_float(basis_probs[1] + basis_probs[2])
+    same = clean_float(basis_probs[0] + basis_probs[3])
+    return {
+        "id": id,
+        "operation": f"Zeta.ReferenceOracle.{operation}",
+        "anglesRadians": {
+            "a": clean_float(a),
+            "b": clean_float(b),
+            "delta": clean_float(a - b),
+        },
+        "basisProbabilities": {
+            "|00>": basis_probs[0],
+            "|01>": basis_probs[1],
+            "|10>": basis_probs[2],
+            "|11>": basis_probs[3],
+        },
+        "oppositeOutcomeProbability": opposite,
+        "sameOutcomeProbability": same,
+        "correlator": clean_float((2.0 * opposite) - 1.0),
+        "coefficient": coefficient,
+        "probabilityFormula": "P(opposite)=cos((a-b)/2)^2",
+        "correlatorFormula": "E=2*P(opposite)-1=cos(a-b)",
+    }
+
+
+def singlet_chsh_corners() -> dict[str, Any]:
+    a0 = 0.0
+    a1 = math.pi / 2.0
+    b0 = math.pi / 4.0
+    b1 = -math.pi / 4.0
+    corners = [
+        singlet_chsh_corner("E(a0,b0)", "ApplyBellSingletChshA0B0", a0, b0, 1),
+        singlet_chsh_corner("E(a0,b1)", "ApplyBellSingletChshA0B1", a0, b1, 1),
+        singlet_chsh_corner("E(a1,b0)", "ApplyBellSingletChshA1B0", a1, b0, 1),
+        singlet_chsh_corner("E(a1,b1)", "ApplyBellSingletChshA1B1", a1, b1, -1),
+    ]
+    s = sum(corner["coefficient"] * corner["correlator"] for corner in corners)
+    return {
+        "id": "BellSinglet CHSH corners",
+        "state": "Singlet",
+        "combination": "E(a0,b0)+E(a0,b1)+E(a1,b0)-E(a1,b1)",
+        "corners": corners,
+        "s": clean_float(s),
+        "analytic": clean_float(2.0 * math.sqrt(2.0)),
+        "classicalBound": 2.0,
+        "checks": ["TimeGen.chsh", "BellTest.correlation", "Q# singlet analyzer probabilities"],
+        "scope": "Q# pins the four observable singlet corners; Tsirelson maximality is cited/proved separately, not sampled here.",
     }
 
 
@@ -106,6 +176,38 @@ def coincidence_case(
         "probability": clean_float(coincidence(a, b)),
         "formula": "cos((a-b)/2)^2",
         "checks": ["BellTest.coincidenceProbability", "PhasorEndurance.overlap"],
+    }
+
+
+def interference_case(
+    id: str,
+    operation: str,
+    phase: float | None,
+    visibility: float | None = None,
+) -> dict[str, Any]:
+    item: dict[str, Any] = {
+        "id": id,
+        "operation": f"Zeta.ReferenceOracle.{operation}",
+        "probabilities": single_qubit_probs_from_operation(operation),
+        "checks": ["AmplitudeEmu.merge", "AmplitudeEmu.intensity", "Q# dumped unitary first column"],
+    }
+    if phase is not None:
+        item["phaseRadians"] = clean_float(phase)
+        item["formula"] = "P(Zero)=cos(phase/2)^2; P(One)=sin(phase/2)^2"
+    if visibility is not None:
+        item["visibility"] = visibility
+    return item
+
+
+def pauli_anticommutation_case(id: str, lhs: str, rhs: str) -> dict[str, Any]:
+    return {
+        "id": id,
+        "lhsOperation": f"Zeta.ReferenceOracle.{lhs}",
+        "rhsOperation": f"Zeta.ReferenceOracle.{rhs}",
+        "lhsMatrix": matrix_to_json(dump_operation(lhs, 1)),
+        "rhsMatrix": matrix_to_json(dump_operation(rhs, 1)),
+        "relation": "lhsMatrix = -rhsMatrix",
+        "checks": ["QubitIso Pauli anticommutation", "Cl3 basis anticommutation", "AdinkraViz odd-face parity"],
     }
 
 
@@ -174,6 +276,7 @@ def build_vectors() -> dict[str, Any]:
                 },
                 "correlatorFormula": "E(a,b)=cos(a-b)",
                 "canonical": chsh(0.0, math.pi / 2.0, math.pi / 4.0, 3.0 * math.pi / 4.0),
+                "singletCorners": singlet_chsh_corners(),
                 "checks": ["BellTest.correlation", "BellTest.chsh", "BellTest.TsirelsonBound"],
             },
             "bellCoincidence": [
@@ -211,26 +314,32 @@ def build_vectors() -> dict[str, Any]:
                 ),
             ],
             "interferenceVisibility": [
-                {
-                    "id": "mach-zehnder-open",
-                    "operation": "Zeta.ReferenceOracle.ApplyMachZehnderOpen",
-                    "probabilities": single_qubit_probs(0.5),
-                    "checks": ["AmplitudeEmu.merge", "AmplitudeEmu.intensity"],
-                },
-                {
-                    "id": "mach-zehnder-closed-zero-phase",
-                    "operation": "Zeta.ReferenceOracle.ApplyMachZehnderClosedZeroPhase",
-                    "probabilities": single_qubit_probs(1.0),
-                    "visibility": 1.0,
-                    "checks": ["AmplitudeEmu.merge", "AmplitudeEmu.intensity"],
-                },
-                {
-                    "id": "mach-zehnder-closed-pi-phase",
-                    "operation": "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiPhase",
-                    "probabilities": single_qubit_probs(0.0),
-                    "visibility": 1.0,
-                    "checks": ["AmplitudeEmu.merge", "AmplitudeEmu.intensity"],
-                },
+                interference_case("mach-zehnder-open", "ApplyMachZehnderOpen", None),
+                interference_case("mach-zehnder-closed-zero-phase", "ApplyMachZehnderClosedZeroPhase", 0.0, 1.0),
+                interference_case(
+                    "mach-zehnder-closed-pi-over-3-phase",
+                    "ApplyMachZehnderClosedPiOver3Phase",
+                    math.pi / 3.0,
+                    1.0,
+                ),
+                interference_case(
+                    "mach-zehnder-closed-pi-over-2-phase",
+                    "ApplyMachZehnderClosedPiOver2Phase",
+                    math.pi / 2.0,
+                    1.0,
+                ),
+                interference_case(
+                    "mach-zehnder-closed-two-pi-over-3-phase",
+                    "ApplyMachZehnderClosedTwoPiOver3Phase",
+                    2.0 * math.pi / 3.0,
+                    1.0,
+                ),
+                interference_case("mach-zehnder-closed-pi-phase", "ApplyMachZehnderClosedPiPhase", math.pi, 1.0),
+            ],
+            "pauliAnticommutation": [
+                pauli_anticommutation_case("X after Z = -(Z after X)", "ApplyPauliXAfterZ", "ApplyPauliZAfterX"),
+                pauli_anticommutation_case("X after Y = -(Y after X)", "ApplyPauliXAfterY", "ApplyPauliYAfterX"),
+                pauli_anticommutation_case("Y after Z = -(Z after Y)", "ApplyPauliYAfterZ", "ApplyPauliZAfterY"),
             ],
         },
     }

--- a/tools/qsharp-oracle/qsharp-golden.json
+++ b/tools/qsharp-oracle/qsharp-golden.json
@@ -45,6 +45,106 @@
           "|10>",
           "|11>"
         ]
+      },
+      "singletCorners": {
+        "analytic": 2.828427124746,
+        "checks": [
+          "TimeGen.chsh",
+          "BellTest.correlation",
+          "Q# singlet analyzer probabilities"
+        ],
+        "classicalBound": 2.0,
+        "combination": "E(a0,b0)+E(a0,b1)+E(a1,b0)-E(a1,b1)",
+        "corners": [
+          {
+            "anglesRadians": {
+              "a": 0.0,
+              "b": 0.785398163397,
+              "delta": -0.785398163397
+            },
+            "basisProbabilities": {
+              "|00>": 0.073223277604,
+              "|01>": 0.426776064961,
+              "|10>": 0.426776064961,
+              "|11>": 0.073223277604
+            },
+            "coefficient": 1,
+            "correlator": 0.707104259844,
+            "correlatorFormula": "E=2*P(opposite)-1=cos(a-b)",
+            "id": "E(a0,b0)",
+            "operation": "Zeta.ReferenceOracle.ApplyBellSingletChshA0B0",
+            "oppositeOutcomeProbability": 0.853552129922,
+            "probabilityFormula": "P(opposite)=cos((a-b)/2)^2",
+            "sameOutcomeProbability": 0.146446555208
+          },
+          {
+            "anglesRadians": {
+              "a": 0.0,
+              "b": -0.785398163397,
+              "delta": 0.785398163397
+            },
+            "basisProbabilities": {
+              "|00>": 0.073223277604,
+              "|01>": 0.426776064961,
+              "|10>": 0.426776064961,
+              "|11>": 0.073223277604
+            },
+            "coefficient": 1,
+            "correlator": 0.707104259844,
+            "correlatorFormula": "E=2*P(opposite)-1=cos(a-b)",
+            "id": "E(a0,b1)",
+            "operation": "Zeta.ReferenceOracle.ApplyBellSingletChshA0B1",
+            "oppositeOutcomeProbability": 0.853552129922,
+            "probabilityFormula": "P(opposite)=cos((a-b)/2)^2",
+            "sameOutcomeProbability": 0.146446555208
+          },
+          {
+            "anglesRadians": {
+              "a": 1.570796326795,
+              "b": 0.785398163397,
+              "delta": 0.785398163397
+            },
+            "basisProbabilities": {
+              "|00>": 0.073223277604,
+              "|01>": 0.426776064961,
+              "|10>": 0.426776064961,
+              "|11>": 0.073223277604
+            },
+            "coefficient": 1,
+            "correlator": 0.707104259844,
+            "correlatorFormula": "E=2*P(opposite)-1=cos(a-b)",
+            "id": "E(a1,b0)",
+            "operation": "Zeta.ReferenceOracle.ApplyBellSingletChshA1B0",
+            "oppositeOutcomeProbability": 0.853552129922,
+            "probabilityFormula": "P(opposite)=cos((a-b)/2)^2",
+            "sameOutcomeProbability": 0.146446555208
+          },
+          {
+            "anglesRadians": {
+              "a": 1.570796326795,
+              "b": -0.785398163397,
+              "delta": 2.356194490192
+            },
+            "basisProbabilities": {
+              "|00>": 0.426776064961,
+              "|01>": 0.073223277604,
+              "|10>": 0.073223277604,
+              "|11>": 0.426776064961
+            },
+            "coefficient": -1,
+            "correlator": -0.707106889584,
+            "correlatorFormula": "E=2*P(opposite)-1=cos(a-b)",
+            "id": "E(a1,b1)",
+            "operation": "Zeta.ReferenceOracle.ApplyBellSingletChshA1B1",
+            "oppositeOutcomeProbability": 0.146446555208,
+            "probabilityFormula": "P(opposite)=cos((a-b)/2)^2",
+            "sameOutcomeProbability": 0.853552129922
+          }
+        ],
+        "id": "BellSinglet CHSH corners",
+        "s": 2.828419669116,
+        "scope": "Q# pins the four observable singlet corners; Tsirelson maximality is cited/proved separately, not sampled here.",
+        "state": "Singlet"
       }
     },
     "bellCoincidence": [
@@ -395,22 +495,26 @@
       {
         "checks": [
           "AmplitudeEmu.merge",
-          "AmplitudeEmu.intensity"
+          "AmplitudeEmu.intensity",
+          "Q# dumped unitary first column"
         ],
         "id": "mach-zehnder-open",
         "operation": "Zeta.ReferenceOracle.ApplyMachZehnderOpen",
         "probabilities": {
-          "One": 0.5,
-          "Zero": 0.5
+          "One": 0.499999690551,
+          "Zero": 0.500000309449
         }
       },
       {
         "checks": [
           "AmplitudeEmu.merge",
-          "AmplitudeEmu.intensity"
+          "AmplitudeEmu.intensity",
+          "Q# dumped unitary first column"
         ],
+        "formula": "P(Zero)=cos(phase/2)^2; P(One)=sin(phase/2)^2",
         "id": "mach-zehnder-closed-zero-phase",
         "operation": "Zeta.ReferenceOracle.ApplyMachZehnderClosedZeroPhase",
+        "phaseRadians": 0.0,
         "probabilities": {
           "One": 0.0,
           "Zero": 1.0
@@ -420,15 +524,233 @@
       {
         "checks": [
           "AmplitudeEmu.merge",
-          "AmplitudeEmu.intensity"
+          "AmplitudeEmu.intensity",
+          "Q# dumped unitary first column"
         ],
+        "formula": "P(Zero)=cos(phase/2)^2; P(One)=sin(phase/2)^2",
+        "id": "mach-zehnder-closed-pi-over-3-phase",
+        "operation": "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiOver3Phase",
+        "phaseRadians": 1.047197551197,
+        "probabilities": {
+          "One": 0.250000699375,
+          "Zero": 0.749999300625
+        },
+        "visibility": 1.0
+      },
+      {
+        "checks": [
+          "AmplitudeEmu.merge",
+          "AmplitudeEmu.intensity",
+          "Q# dumped unitary first column"
+        ],
+        "formula": "P(Zero)=cos(phase/2)^2; P(One)=sin(phase/2)^2",
+        "id": "mach-zehnder-closed-pi-over-2-phase",
+        "operation": "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiOver2Phase",
+        "phaseRadians": 1.570796326795,
+        "probabilities": {
+          "One": 0.499999690551,
+          "Zero": 0.500000309449
+        },
+        "visibility": 1.0
+      },
+      {
+        "checks": [
+          "AmplitudeEmu.merge",
+          "AmplitudeEmu.intensity",
+          "Q# dumped unitary first column"
+        ],
+        "formula": "P(Zero)=cos(phase/2)^2; P(One)=sin(phase/2)^2",
+        "id": "mach-zehnder-closed-two-pi-over-3-phase",
+        "operation": "Zeta.ReferenceOracle.ApplyMachZehnderClosedTwoPiOver3Phase",
+        "phaseRadians": 2.094395102393,
+        "probabilities": {
+          "One": 0.75,
+          "Zero": 0.25
+        },
+        "visibility": 1.0
+      },
+      {
+        "checks": [
+          "AmplitudeEmu.merge",
+          "AmplitudeEmu.intensity",
+          "Q# dumped unitary first column"
+        ],
+        "formula": "P(Zero)=cos(phase/2)^2; P(One)=sin(phase/2)^2",
         "id": "mach-zehnder-closed-pi-phase",
         "operation": "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiPhase",
+        "phaseRadians": 3.14159265359,
         "probabilities": {
           "One": 1.0,
           "Zero": 0.0
         },
         "visibility": 1.0
+      }
+    ],
+    "pauliAnticommutation": [
+      {
+        "checks": [
+          "QubitIso Pauli anticommutation",
+          "Cl3 basis anticommutation",
+          "AdinkraViz odd-face parity"
+        ],
+        "id": "X after Z = -(Z after X)",
+        "lhsMatrix": [
+          [
+            {
+              "imag": 0.0,
+              "real": 0.0
+            },
+            {
+              "imag": 0.0,
+              "real": -1.0
+            }
+          ],
+          [
+            {
+              "imag": 0.0,
+              "real": 1.0
+            },
+            {
+              "imag": 0.0,
+              "real": 0.0
+            }
+          ]
+        ],
+        "lhsOperation": "Zeta.ReferenceOracle.ApplyPauliXAfterZ",
+        "relation": "lhsMatrix = -rhsMatrix",
+        "rhsMatrix": [
+          [
+            {
+              "imag": 0.0,
+              "real": 0.0
+            },
+            {
+              "imag": 0.0,
+              "real": 1.0
+            }
+          ],
+          [
+            {
+              "imag": 0.0,
+              "real": -1.0
+            },
+            {
+              "imag": 0.0,
+              "real": 0.0
+            }
+          ]
+        ],
+        "rhsOperation": "Zeta.ReferenceOracle.ApplyPauliZAfterX"
+      },
+      {
+        "checks": [
+          "QubitIso Pauli anticommutation",
+          "Cl3 basis anticommutation",
+          "AdinkraViz odd-face parity"
+        ],
+        "id": "X after Y = -(Y after X)",
+        "lhsMatrix": [
+          [
+            {
+              "imag": 1.0,
+              "real": 0.0
+            },
+            {
+              "imag": 0.0,
+              "real": 0.0
+            }
+          ],
+          [
+            {
+              "imag": 0.0,
+              "real": 0.0
+            },
+            {
+              "imag": -1.0,
+              "real": 0.0
+            }
+          ]
+        ],
+        "lhsOperation": "Zeta.ReferenceOracle.ApplyPauliXAfterY",
+        "relation": "lhsMatrix = -rhsMatrix",
+        "rhsMatrix": [
+          [
+            {
+              "imag": -1.0,
+              "real": 0.0
+            },
+            {
+              "imag": 0.0,
+              "real": 0.0
+            }
+          ],
+          [
+            {
+              "imag": 0.0,
+              "real": 0.0
+            },
+            {
+              "imag": 1.0,
+              "real": 0.0
+            }
+          ]
+        ],
+        "rhsOperation": "Zeta.ReferenceOracle.ApplyPauliYAfterX"
+      },
+      {
+        "checks": [
+          "QubitIso Pauli anticommutation",
+          "Cl3 basis anticommutation",
+          "AdinkraViz odd-face parity"
+        ],
+        "id": "Y after Z = -(Z after Y)",
+        "lhsMatrix": [
+          [
+            {
+              "imag": 0.0,
+              "real": 0.0
+            },
+            {
+              "imag": 1.0,
+              "real": 0.0
+            }
+          ],
+          [
+            {
+              "imag": 1.0,
+              "real": 0.0
+            },
+            {
+              "imag": 0.0,
+              "real": 0.0
+            }
+          ]
+        ],
+        "lhsOperation": "Zeta.ReferenceOracle.ApplyPauliYAfterZ",
+        "relation": "lhsMatrix = -rhsMatrix",
+        "rhsMatrix": [
+          [
+            {
+              "imag": 0.0,
+              "real": 0.0
+            },
+            {
+              "imag": -1.0,
+              "real": 0.0
+            }
+          ],
+          [
+            {
+              "imag": -1.0,
+              "real": 0.0
+            },
+            {
+              "imag": 0.0,
+              "real": 0.0
+            }
+          ]
+        ],
+        "rhsOperation": "Zeta.ReferenceOracle.ApplyPauliZAfterY"
       }
     ],
     "singleQubitMeasurement": [

--- a/tools/qsharp-oracle/qsharp-golden.test.ts
+++ b/tools/qsharp-oracle/qsharp-golden.test.ts
@@ -2,11 +2,19 @@ import { expect, test } from "bun:test";
 import golden from "./qsharp-golden.json";
 
 type Probabilities = { Zero: number; One: number };
+type Complex = { real: number; imag: number };
+type Matrix = Complex[][];
 
 const tolerance = 1e-6;
+const qsharpDumpTolerance = 1e-5;
 
 function closeTo(actual: number, expected: number, epsilon = tolerance) {
   expect(Math.abs(actual - expected)).toBeLessThanOrEqual(epsilon);
+}
+
+function closeComplexTo(actual: Complex, expected: Complex, epsilon = tolerance) {
+  closeTo(actual.real, expected.real, epsilon);
+  closeTo(actual.imag, expected.imag, epsilon);
 }
 
 function probabilitySum(probabilities: Probabilities) {
@@ -39,7 +47,7 @@ test("single-qubit measurement observables match textbook probabilities", () => 
   closeTo(probabilitySum(ryPiOver2), 1);
 });
 
-test("Bell/CHSH vector pins Tsirelson and the canonical correlators", () => {
+test("Bell/CHSH vector pins the canonical correlators and singlet corner observables", () => {
   const canonical = golden.vectors.bellChsh.canonical;
 
   closeTo(canonical.correlators["E(a,b)"], Math.SQRT1_2);
@@ -49,6 +57,18 @@ test("Bell/CHSH vector pins Tsirelson and the canonical correlators", () => {
   closeTo(canonical.s, 2 * Math.SQRT2);
   closeTo(canonical.tsirelson, 2 * Math.SQRT2);
   expect(canonical.s).toBeGreaterThan(canonical.classicalBound);
+
+  const singlet = golden.vectors.bellChsh.singletCorners;
+  expect(singlet.scope).toContain("Tsirelson maximality is cited/proved separately");
+  expect(singlet.corners).toHaveLength(4);
+  closeTo(singlet.analytic, 2 * Math.SQRT2);
+  closeTo(singlet.s, singlet.analytic, qsharpDumpTolerance);
+
+  const cornerMap = new Map(singlet.corners.map((v) => [v.id, v]));
+  closeTo(cornerMap.get("E(a0,b0)")?.correlator as number, Math.SQRT1_2, qsharpDumpTolerance);
+  closeTo(cornerMap.get("E(a0,b1)")?.correlator as number, Math.SQRT1_2, qsharpDumpTolerance);
+  closeTo(cornerMap.get("E(a1,b0)")?.correlator as number, Math.SQRT1_2, qsharpDumpTolerance);
+  closeTo(cornerMap.get("E(a1,b1)")?.correlator as number, -Math.SQRT1_2, qsharpDumpTolerance);
 });
 
 test("Bell coincidence observables pin PhiPlus and singlet outcome conventions", () => {
@@ -73,14 +93,40 @@ test("interference observables distinguish open, reinforce, and cancel cases", (
   const cases = new Map(golden.vectors.interferenceVisibility.map((v) => [v.id, v]));
 
   const open = cases.get("mach-zehnder-open")?.probabilities as Probabilities;
-  closeTo(open.Zero, 0.5);
-  closeTo(open.One, 0.5);
+  closeTo(open.Zero, 0.5, qsharpDumpTolerance);
+  closeTo(open.One, 0.5, qsharpDumpTolerance);
 
   const reinforced = cases.get("mach-zehnder-closed-zero-phase")?.probabilities as Probabilities;
   closeTo(reinforced.Zero, 1);
   closeTo(reinforced.One, 0);
 
+  const piOver3 = cases.get("mach-zehnder-closed-pi-over-3-phase")?.probabilities as Probabilities;
+  closeTo(piOver3.Zero, 0.75, qsharpDumpTolerance);
+  closeTo(piOver3.One, 0.25, qsharpDumpTolerance);
+
+  const piOver2 = cases.get("mach-zehnder-closed-pi-over-2-phase")?.probabilities as Probabilities;
+  closeTo(piOver2.Zero, 0.5, qsharpDumpTolerance);
+  closeTo(piOver2.One, 0.5, qsharpDumpTolerance);
+
+  const twoPiOver3 = cases.get("mach-zehnder-closed-two-pi-over-3-phase")?.probabilities as Probabilities;
+  closeTo(twoPiOver3.Zero, 0.25, qsharpDumpTolerance);
+  closeTo(twoPiOver3.One, 0.75, qsharpDumpTolerance);
+
   const cancelled = cases.get("mach-zehnder-closed-pi-phase")?.probabilities as Probabilities;
   closeTo(cancelled.Zero, 0);
   closeTo(cancelled.One, 1);
+});
+
+test("Q# Pauli products pin the hardware-side anticommutation signs", () => {
+  for (const item of golden.vectors.pauliAnticommutation) {
+    expect(item.relation).toBe("lhsMatrix = -rhsMatrix");
+    const lhs = item.lhsMatrix as Matrix;
+    const rhs = item.rhsMatrix as Matrix;
+
+    for (let row = 0; row < lhs.length; row++) {
+      for (let col = 0; col < lhs[row].length; col++) {
+        closeComplexTo(lhs[row][col], { real: -rhs[row][col].real, imag: -rhs[row][col].imag });
+      }
+    }
+  }
 });


### PR DESCRIPTION
## Summary
- add Q#-dumped singlet CHSH corner observables paired with the analytic S=2√2 value
- expand the AmplitudeEmu Mach-Zehnder fixture into a phase grid derived from Q# dumped unitaries
- add Q# Pauli anticommutation matrices for the hardware-side Clifford sign check
- update the Vera Q# brief and trajectory docs to route Tsirelson maximality to citation/NPA-SDP and dashing universals to Z3/Soraya
- tighten the mod2 wording to the signed χ: B₃ → Z/2 formulation and warn against per-pair parity conflation

## Verification
- ./.venv/bin/python tools/qsharp-oracle/generate-qsharp-golden.py
- bun test tools/qsharp-oracle/qsharp-golden.test.ts
- dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter 'FullyQualifiedName~QSharpOracleTests|FullyQualifiedName~QubitIsoTests|FullyQualifiedName~Cl3Tests|FullyQualifiedName~AdinkraVizTests'
- mise exec -- markdownlint-cli2 docs/research/2026-06-12-vera-brief-qsharp-verification-candidates-for-qubit-adjacent-claims-then-math-team-then-treaty.md docs/research/2026-06-12-dashings-landed-the-rhyme-is-two-tests-mod2-is-the-missing-piece-and-the-naming-direction.md docs/trajectories/sim-mea-cut-soft-substrate-shaders/RESUME.md
- dotnet format --verify-no-changes --include tests/Tests.FSharp/QSharpOracle.Tests.fs
- git diff --check
- dotnet build -c Release
- dotnet test Zeta.sln -c Release --no-build

Note: full dotnet format --verify-no-changes is still red on unrelated existing C# formatting/analyzer items outside this diff.