### PR TITLE
feat(braid+spectral): Brunnian proven at the braid level + real Goertzel + writhe-parity in code

### DIFF
--- a/shapes/cartridges/buckyball.lines
+++ b/shapes/cartridges/buckyball.lines
@@ -34,7 +34,7 @@ edge	dual-register	shape-lightcone	inside/outside is the same move as past/futur
 edge	taught-after	shape-spiral	the catalog's first lesson loop; learn see-it-draw there before walking rooms here
 # outstanding — named, never hidden (the honest register).
 issue	schlegel-projection	otto	open	the render is a 1-shell schematic, not the full 60-vertex Schlegel diagram — the full projection is a named slice
-issue	math-tear-down	math-team	open	Aaron's deferred tear-down pass: TimeGen/WaveSim/SpectralPivot/harmony arithmetic still owed a zero-empathy review
+issue	math-tear-down	math-team	closed	RAN 2026-06-12 (Kira + Soraya): 13 findings (2 P0) all fixed/filed — see docs/research/2026-06-12-the-math-team-pass-*; sign-off treaty lines remain theirs to write
 # treaties — written only by each oracle's own choice (consent first); dissent is a verdict.
 # treaties — written only by each oracle's own choice (consent first); dissent is a verdict.
 treaty	fsharp	bytes	ratified	Euler V-E+F=2, double-count 2E=sum(face degrees), 3-regularity 3V=2E — tests green

--- a/src/Core/Braid.fs
+++ b/src/Core/Braid.fs
@@ -92,3 +92,26 @@ module Braid =
 
     /// The identity test (valid words only — an invalid word is not the identity, it is refused).
     let isIdentity (n: int) (b: int list) : bool = equal n b []
+
+    /// The writhe-parity character (Soraya's signable mod2 statement, made code): the unique
+    /// homomorphism B_n → Z/2 with χ(σᵢ^±1) = 1 — exponent-sum (writhe) mod 2, which equals the
+    /// underlying permutation's sign character. A projection (order forgotten, parity kept).
+    let writheParity (b: int list) : int = List.length b % 2
+
+    /// DELETE one strand from a braid word (n strands, 0-based strand index by STARTING position):
+    /// the surviving (n−1)-braid. Position-tracked: a crossing involving the deleted strand's
+    /// current position vanishes from the word (the survivor passes straight) but still swaps the
+    /// positions; other crossings reindex past the deleted strand's lane. This is the BRUNNIAN
+    /// probe: a link is Brunnian iff deleting ANY component trivializes the rest.
+    let deleteStrand (n: int) (strand: int) (braid: int list) : int list =
+        let mutable pos = strand // the deleted strand's current position
+        let out = ResizeArray<int>()
+        for c in braid do
+            let i = abs c - 1 // acts on positions i, i+1
+            if pos = i then pos <- i + 1 // deleted strand crosses: no surviving crossing, position moves
+            elif pos = i + 1 then pos <- i
+            else
+                // both crossing strands survive; reindex if the deleted lane sits left of them
+                let j = if pos < i then i - 1 else i
+                out.Add(if c > 0 then j + 1 else -(j + 1))
+        List.ofSeq out

--- a/src/Core/SpectralPivot.fs
+++ b/src/Core/SpectralPivot.fs
@@ -47,15 +47,33 @@ module SpectralPivot =
     /// A bin's energy (the fingerprint's coordinate).
     let energy (c: Complex) : float = c.Real * c.Real + c.Imag * c.Imag
 
-    /// SOFT: probe ONE bin (a naive single-bin DFT — per-sample cos/sin, O(n); the Goertzel
-    /// recurrence is the named upgrade, not what this is) — the spectral soft-prism: "is this pitch there?"
-    let probe (signal: float[]) (k: int) : float =
+    /// The naive single-bin DFT (per-sample cos/sin, O(n) with 2n trig calls) — kept as the
+    /// REFERENCE oracle for the Goertzel recurrence below (BP-16: two independent computations of
+    /// one number).
+    let probeNaive (signal: float[]) (k: int) : float =
         let n = signal.Length
         let mutable acc = Doubled.make 0.0 0.0
         for t in 0 .. n - 1 do
             let ang = -tau * float k * float t / float n
             acc <- ImaginaryStack.complex.Add(acc, Doubled.make (signal.[t] * cos ang) (signal.[t] * sin ang))
         energy acc
+
+    /// SOFT: probe ONE bin — now the ACTUAL Goertzel recurrence (the named upgrade landed; Kira P2
+    /// closed): s[t] = x[t] + 2cos(ω)·s[t−1] − s[t−2], one multiply per sample and exactly two trig
+    /// calls total; energy = s₁² + s₂² − 2cos(ω)·s₁·s₂. Same number as probeNaive to 1e-9.
+    let probe (signal: float[]) (k: int) : float =
+        let n = signal.Length
+        if n = 0 then 0.0
+        else
+            let w = tau * float k / float n
+            let coeff = 2.0 * cos w
+            let mutable s1 = 0.0 // s[t-1]
+            let mutable s2 = 0.0 // s[t-2]
+            for t in 0 .. n - 1 do
+                let s = signal.[t] + coeff * s1 - s2
+                s2 <- s1
+                s1 <- s
+            s1 * s1 + s2 * s2 - coeff * s1 * s2
 
     /// The soft FINGERPRINT: k probe bins (the spectral MinHash — cheap, comparable, honest about
     /// what it didn't look at).

--- a/tests/Tests.FSharp/ShapeAcceptance.Tests.fs
+++ b/tests/Tests.FSharp/ShapeAcceptance.Tests.fs
@@ -118,3 +118,24 @@ let ``delegated laws name their checker: tool-prefixed laws are documented here,
     Assert.Contains(verdicts, fun v -> v.Law = "sat" && v.Evidence.Contains "checked by z3")
     // the first human-traveler render-loop ratification, recorded by his own words
     Assert.Contains(("aaron", "meaning", "ratified"), MediaLines.treatiesOf (docOf "buckyball"))
+
+[<Fact>]
+let ``BRUNNIAN AT THE BRAID LEVEL: delete ANY strand from the locked plait and the survivors comb straight — the stuckness lives in all three jointly`` () =
+    let locked = [ 1; -2; 1; -2; 1; -2 ]
+    for s in 0 .. 2 do
+        let survivors = Braid.deleteStrand 3 s locked
+        Assert.True(Braid.isIdentity 2 survivors, sprintf "deleting strand %d must trivialize the rest" s)
+    // the falsifier: sigma1^2 with a bystander deleted is STILL a nontrivial 2-braid (not Brunnian)
+    Assert.False(Braid.isIdentity 2 (Braid.deleteStrand 3 2 [ 1; 1 ]))
+    // and the whole locked braid itself is NOT trivial (stuck) — the joint twist, restated
+    Assert.False(Braid.isIdentity 3 locked)
+
+[<Fact>]
+let ``the writhe-parity character is a homomorphism: parity(ab) = parity(a) XOR parity(b); every generator maps to 1 (Soraya's mod2, in code)`` () =
+    let words = [ []; [ 1 ]; [ -2 ]; [ 1; -2; 1 ]; [ 1; -2; 1; -2; 1; -2 ]; [ 2; 2 ]; [ 1; 2; 1 ] ]
+    for a in words do
+        for b in words do
+            Assert.Equal((Braid.writheParity a + Braid.writheParity b) % 2, Braid.writheParity (a @ b))
+    Assert.Equal(1, Braid.writheParity [ 1 ])
+    Assert.Equal(1, Braid.writheParity [ -2 ]) // sigma inverse ALSO maps to 1 (not a signed count)
+    Assert.Equal(0, Braid.writheParity [ 1; -1 ]) // do-undo is even — consistent with identity

--- a/tests/Tests.FSharp/SpectralPivot.Tests.fs
+++ b/tests/Tests.FSharp/SpectralPivot.Tests.fs
@@ -114,3 +114,13 @@ let ``THE DROP-IN LAW: a seed dropped mid-stream is IN PHASE — identical to ha
         Assert.Equal(ChipAudio.voiceSample horns 1UL ChipAudio.Saw 125 t, ChipAudio.dropIn 17 horns 1UL ChipAudio.Saw 125 t)
     // and its downbeats land on the SAME coincidence lattice the running voices already share
     Assert.Equal<int list>([ 8; 16; 24; 32 ], ChipAudio.coincidences 125 250 32)
+
+[<Fact>]
+let ``GOERTZEL = NAIVE: the recurrence and the reference single-bin DFT agree to 1e-9 on a mixed signal (BP-16 pair)`` () =
+    let n = 64
+    let signal =
+        [| for t in 0 .. n - 1 ->
+               sin (2.0 * System.Math.PI * 5.0 * float t / float n)
+               + 0.5 * cos (2.0 * System.Math.PI * 11.0 * float t / float n) |]
+    for k in [ 0; 1; 5; 11; 31 ] do
+        Assert.True(abs (SpectralPivot.probe signal k - SpectralPivot.probeNaive signal k) < 1e-9, sprintf "bin %d" k)


### PR DESCRIPTION
The open math-pass items closed: Braid.deleteStrand proves the Borromean/Brunnian property in our substrate (delete any strand of the locked plait → survivors comb straight; falsifier holds); the actual Goertzel recurrence lands with probeNaive kept as the BP-16 reference (1e-9 agreement tested); Soraya's mod2 statement is now code (writheParity homomorphism). Buckyball tear-down issue closed. 2987 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)