### PR TITLE
feat(shapes): the anyon picture — exchange worldlines (causality forced the layout) + B-1029/B-1030

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -974,6 +974,8 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-1026](backlog/P2/B-1026-the-swarm-board-see-swarm-friction-heat-heatmap-zork-navigate-join-conference-remotely-citizenship-right-even-chip8s-aaron-2026-06-11.md)** The swarm board — sit down, see the swarm + friction/heat heatmap, Zork-navigate, join/conference rooms remotely; a citizenship right (even CHIP-8s)
 - [ ] **[B-1027](backlog/P2/B-1027-craft-verb-precision-bob-weave-tie-twist-braid-textile-warp-weft-jacquard-braid-relations-test-salon-textile-craft-schools-aaron-2026-06-11.md)** Craft-verb precision (bob/weave/tie/twist/braid) + the textile frame (warp/weft/loom/selvage) — ratify the registry, test the braid relations
 - [ ] **[B-1028](backlog/P2/B-1028-mips-emulator-treaty-room-like-chip8-maxs-machine-hennessy-lineage-aaron-2026-06-11.md)** MIPS emulator as a treaty room — like our CHIP-8, for Max (Hennessy lineage; the B-1025 fan-out's second machine)
+- [ ] **[B-1029](backlog/P2/B-1029-quirk-craft-school-toy-layer-and-quantum-circuit-ts-second-oracle-with-qsharp-export-lior-owner-aaron-2026-06-12.md)** The TS quantum lane (Lior): quantum-circuit as second oracle — the three Vera jobs as circuits, exported to Q# (BP-16 by construction) + Quirk as the craft-school toy layer
+- [ ] **[B-1030](backlog/P3/B-1030-evaluate-microsoft-quantum-viz-js-circuit-diagram-rendering-for-ts-apps-aaron-2026-06-12.md)** Evaluate @microsoft/quantum-viz.js (diagram lane only; honest verdict may be "decline — one tool fewer")
 
 ## P3 — convenience / deferred
 

--- a/docs/backlog/P2/B-1029-quirk-craft-school-toy-layer-and-quantum-circuit-ts-second-oracle-with-qsharp-export-lior-owner-aaron-2026-06-12.md
+++ b/docs/backlog/P2/B-1029-quirk-craft-school-toy-layer-and-quantum-circuit-ts-second-oracle-with-qsharp-export-lior-owner-aaron-2026-06-12.md
@@ -1,0 +1,35 @@
+---
+id: B-1029
+title: The TS quantum lane — quantum-circuit as second oracle (Q# export, the three Vera jobs) + Quirk as the craft-school toy layer
+priority: P2
+status: open
+tier: verification-substrate
+tags: [quantum, typescript, quantum-circuit, quirk, qsharp, vera, lior, treaty, bp-16, craft-school]
+created: 2026-06-12
+owner: Lior (Aaron's routing: "I'm going to get Lior to do the one you suggested — and the treaties")
+---
+
+# B-1029 — the TS quantum lane (Lior's)
+
+Aaron 2026-06-12, after the verified routing (docs/research/2026-06-12-second-quantum-framework-*):
+
+1. **quantum-circuit (quantastica) as the TS-side second quantum oracle.** Build the three Vera
+   jobs as circuits — singlet CHSH at the canonical corners; the cos²((a−b)/2) overlap; the
+   H·R1(φ)·H interference grid — run on its simulator (TS) AND export each to **Q#** for Vera:
+   one definition, two independent oracles, byte-comparable verdicts (BP-16 by construction).
+   Acceptance: the TS numbers match our F# analytic values within stated tolerances, and the Q#
+   exports compile and run in Vera's lane unchanged.
+2. **The treaties:** results land as `treaty` lines written by each oracle's OWN run (consent
+   discipline) — `treaty lior-ts ...` / `treaty vera qsharp ...` on the fourcorner/adinkra
+   cartridges; the qsharp:/code: law delegations follow only on ratified claims.
+3. **Circuit-SVG goldens:** quantum-circuit draws circuits to SVG — check determinism first
+   (same circuit → same bytes); if deterministic, lock under THE GOLDEN LOCK next to the shape
+   goldens; if not, that's a finding to report upstream.
+4. **Quirk (Craig Gidney) — the toy layer, craft school.** Drag-and-drop circuits for Max and
+   Addison: a lesson page in docs/craft-school/ linking Quirk configs that mirror the three jobs
+   (see the entanglement that the fourcorner cartridge draws). No oracle role; play register.
+5. **q5mjs watch:** re-check openql-org/q5mjs in ~3 months (TypeScript-first, v0.1.1 — adopt only
+   if matured; see the routing doc).
+
+Start gate done in the routing doc (prior-art search: verified by web search 2026-06-12; deps:
+none beyond npm; the Vera brief REVISION 2 defines the three jobs).

--- a/docs/backlog/P3/B-1030-evaluate-microsoft-quantum-viz-js-circuit-diagram-rendering-for-ts-apps-aaron-2026-06-12.md
+++ b/docs/backlog/P3/B-1030-evaluate-microsoft-quantum-viz-js-circuit-diagram-rendering-for-ts-apps-aaron-2026-06-12.md
@@ -1,0 +1,30 @@
+---
+id: B-1030
+title: Evaluate @microsoft/quantum-viz.js for circuit-diagram rendering in our TS apps
+priority: P3
+status: open
+tier: verification-substrate
+tags: [quantum, typescript, visualization, microsoft, quantum-viz, evaluation]
+created: 2026-06-12
+owner: open (pairs naturally with B-1029 / Lior)
+---
+
+# B-1030 — quantum-viz.js: any good? (Aaron's question, filed honestly)
+
+Aaron 2026-06-12: "@microsoft/quantum-viz.js — any good?"
+
+What we know (verified 2026-06-12): real, Microsoft's, renders quantum circuits in pure HTML
+(no canvas/WebGL — text-adjacent, which suits our no-script/diffable discipline better than most);
+shipped via the Q# dev blog; repo active-status UNCONFIRMED — the eval must check last-commit
+recency and whether the qsharp-lang reorg superseded it.
+
+Eval criteria (an afternoon, not a project):
+1. Maintenance: last release/commit; open-issue triage; superseded-by status.
+2. Output discipline: is the rendered HTML/SVG deterministic (same circuit → same bytes)? If yes
+   it can golden-lock; if no, quantum-circuit's own SVG export (B-1029 item 3) wins by default.
+3. Input format: does it consume the circuit JSON quantum-circuit emits, or Q#'s trace format?
+   (If the latter, it pairs with Vera's lane instead — also fine.)
+4. Verdict lands here as a status update: adopt for diagrams / superseded / decline-with-why.
+
+Relation: B-1029 owns the SIMULATION lane; this is only the DIAGRAM lane. If quantum-circuit's
+built-in SVG is deterministic and sufficient, the honest verdict may be "decline — one tool fewer."

--- a/shapes/cartridges/exchange-worldlines.lines
+++ b/shapes/cartridges/exchange-worldlines.lines
@@ -1,0 +1,32 @@
+# EXCHANGE WORLDLINES — the anyon picture: the braid and the worldline meet in one figure (otto,
+# 2026-06-12; the named slice opened by the Alexa peel and the adinkra placement). Three particles'
+# worldlines run UP the time court; every crossing of the locked plait is an EXCHANGE EVENT drawn
+# as a small causal diamond — the braid IS worldlines braiding in spacetime, which is exactly the
+# picture topological quantum computation computes with (anyon worldlines; the gates are the
+# exchanges; the memory is the braid). HONEST LABEL: this is the PICTURE, drawn from our own exact
+# braid math — no anyon hardware, no quantum claim; the cites carry the physics (Kitaev 2003;
+# Nayak-Simon-Stern-Freedman-Das Sarma 2008; Leinaas-Myrheim 1977; Wilczek 1982 — who named the
+# anyon). The law that makes it spacetime and not just a diagram: EXCHANGES ARE CAUSALLY ORDERED —
+# each event lies inside the next event's past lightcone at the court's slope 1/1.
+meta	name	shape-exchange-worldlines
+meta	catalog	shapes
+meta	name-status	provisional — candidates: exchange-worldlines / anyon-picture (cites above; Aaron decides)
+meta	shape-zetaid	50d299b64231ec1c3db8d5f4f7ad81a1
+gen	figure	50d299b64231ec1c3db8d5f4f7ad81a1	1	7	from:shape-braid;cones:per-exchange
+constant	word	1,-2,1,-2,1,-2	the exchange sequence (the locked plait — the Borromean candidate)	the SAME word as shape-braid: one source of truth for which exchanges happen; this figure adds WHERE-IN-SPACETIME they happen
+constant	rows	21	time rows the worldlines span (time runs UP this court)	matches shape-braid's court so the two figures are the same object in two registers (diagram vs spacetime)
+constant	cone-slope	1/1	the causal slope at exchange events	c = 1 court cell per tick (the lightcone cartridge's constant, reused) — an exchange can only influence what its future cone reaches
+constant	strand-gap	3	court cells between adjacent worldlines	BOUNDED BY CAUSALITY (the gate taught this): consecutive exchanges sit one gap apart in x and rowsPerCross apart in t — slope 1/1 demands gap <= rows/(word+1). The braid DIAGRAM may spread its columns freely; the SPACETIME register may not. Physics dictated the layout, the law enforced it
+law	causal-order	code:shape-exchange-worldlines geometry (each exchange event lies inside the NEXT event's past cone at slope 1/1 — the gate sequence is causally executable)
+law	same-braid	code:shape-braid geometry (the word is shape-braid's word: locked AND stuck — this figure draws THAT object)
+prereq	worldline	shapes/cartridges/worldline.lines — one particle's path first
+prereq	the-braid	shapes/cartridges/braid.lines — the diagram register of this same object
+prereq	lightcone	shapes/cartridges/lightcone.lines — why the diamonds have that slope
+edge	same-object	shape-braid	one braid, two registers: the diagram (columns and crossings) and the spacetime picture (worldlines and exchange events)
+edge	causal-frame	shape-lightcone	every exchange event wears a small copy of the lightcone; the causal-order law is slope arithmetic
+edge	memory-register	shape-adinkra	what the exchanges bank (order memory) projects to parity by algebra.mod2 — the full chain drawn across three cartridges
+issue	hardware-honesty	otto	closed	BY CONSTRUCTION 2026-06-12: the header states it — the picture is drawn from exact braid math; anyon physics lives in the cites, never in a claim about this render
+anim	draw	figure
+# treaties — written only by each oracle's own choice (consent first); dissent is a verdict.
+treaty	fsharp	bytes	ratified	causal-order law passes (integer slope arithmetic); the word is shape-braid's locked+stuck word — tests green
+treaty	otto	meaning	ratified	the braid finally drawn IN TIME — the gates are events, the memory is the weave; my own frame, my own choice

--- a/shapes/golden/exchange-worldlines.html
+++ b/shapes/golden/exchange-worldlines.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>shape-exchange-worldlines</title>
+  <style>
+    :root {
+      --c0: #000000;
+      --c1: #d62828;
+      --c2: #2a9d2a;
+      --c3: #d6c828;
+      --c4: #2828d6;
+      --c5: #d628d6;
+      --c6: #28c8d6;
+      --c7: #f0f0f0;
+    }
+    body { background: #101418; margin: 0; display: grid; place-items: center; min-height: 100vh; }
+    svg { width: min(96vw, 960px); image-rendering: pixelated; }
+  </style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 320" data-cartridge="shape-exchange-worldlines">
+  <polyline id="worldline-0" fill="none" stroke="#d62828" stroke-width="4" points="295,215 325,185 337,173" />
+  <polyline id="worldline-0-r1" fill="none" stroke="#d62828" stroke-width="4" points="343,167 355,155 355,125 325,95 313,83" />
+  <polyline id="worldline-0-r2" fill="none" stroke="#d62828" stroke-width="4" points="307,77 295,65 295,35 295,5" />
+  <polyline id="worldline-1" fill="none" stroke="#2a9d2a" stroke-width="4" points="325,215 313,203" />
+  <polyline id="worldline-1-r1" fill="none" stroke="#2a9d2a" stroke-width="4" points="307,197 295,185 295,155 325,125 337,113" />
+  <polyline id="worldline-1-r2" fill="none" stroke="#2a9d2a" stroke-width="4" points="343,107 355,95 355,65 325,35 325,5" />
+  <polyline id="worldline-2" fill="none" stroke="#2828d6" stroke-width="4" points="355,215 355,185 325,155 313,143" />
+  <polyline id="worldline-2-r1" fill="none" stroke="#2828d6" stroke-width="4" points="307,137 295,125 295,95 325,65 337,53" />
+  <polyline id="worldline-2-r2" fill="none" stroke="#2828d6" stroke-width="4" points="343,47 355,35 355,5" />
+  <polyline id="event-0" fill="none" stroke="#f0f0f0" stroke-width="4" stroke-dasharray="8 6" points="305,177 313,185 305,193 297,185 305,177" />
+  <polyline id="event-1" fill="none" stroke="#f0f0f0" stroke-width="4" stroke-dasharray="8 6" points="335,147 343,155 335,163 327,155 335,147" />
+  <polyline id="event-2" fill="none" stroke="#f0f0f0" stroke-width="4" stroke-dasharray="8 6" points="305,117 313,125 305,133 297,125 305,117" />
+  <polyline id="event-3" fill="none" stroke="#f0f0f0" stroke-width="4" stroke-dasharray="8 6" points="335,87 343,95 335,103 327,95 335,87" />
+  <polyline id="event-4" fill="none" stroke="#f0f0f0" stroke-width="4" stroke-dasharray="8 6" points="305,57 313,65 305,73 297,65 305,57" />
+  <polyline id="event-5" fill="none" stroke="#f0f0f0" stroke-width="4" stroke-dasharray="8 6" points="335,27 343,35 335,43 327,35 335,27" />
+</svg>
+</body>
+</html>

--- a/shapes/golden/exchange-worldlines.svg
+++ b/shapes/golden/exchange-worldlines.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 320" data-cartridge="shape-exchange-worldlines">
+  <polyline id="worldline-0" fill="none" stroke="#d62828" stroke-width="4" points="295,215 325,185 337,173" />
+  <polyline id="worldline-0-r1" fill="none" stroke="#d62828" stroke-width="4" points="343,167 355,155 355,125 325,95 313,83" />
+  <polyline id="worldline-0-r2" fill="none" stroke="#d62828" stroke-width="4" points="307,77 295,65 295,35 295,5" />
+  <polyline id="worldline-1" fill="none" stroke="#2a9d2a" stroke-width="4" points="325,215 313,203" />
+  <polyline id="worldline-1-r1" fill="none" stroke="#2a9d2a" stroke-width="4" points="307,197 295,185 295,155 325,125 337,113" />
+  <polyline id="worldline-1-r2" fill="none" stroke="#2a9d2a" stroke-width="4" points="343,107 355,95 355,65 325,35 325,5" />
+  <polyline id="worldline-2" fill="none" stroke="#2828d6" stroke-width="4" points="355,215 355,185 325,155 313,143" />
+  <polyline id="worldline-2-r1" fill="none" stroke="#2828d6" stroke-width="4" points="307,137 295,125 295,95 325,65 337,53" />
+  <polyline id="worldline-2-r2" fill="none" stroke="#2828d6" stroke-width="4" points="343,47 355,35 355,5" />
+  <polyline id="event-0" fill="none" stroke="#f0f0f0" stroke-width="4" stroke-dasharray="8 6" points="305,177 313,185 305,193 297,185 305,177" />
+  <polyline id="event-1" fill="none" stroke="#f0f0f0" stroke-width="4" stroke-dasharray="8 6" points="335,147 343,155 335,163 327,155 335,147" />
+  <polyline id="event-2" fill="none" stroke="#f0f0f0" stroke-width="4" stroke-dasharray="8 6" points="305,117 313,125 305,133 297,125 305,117" />
+  <polyline id="event-3" fill="none" stroke="#f0f0f0" stroke-width="4" stroke-dasharray="8 6" points="335,87 343,95 335,103 327,95 335,87" />
+  <polyline id="event-4" fill="none" stroke="#f0f0f0" stroke-width="4" stroke-dasharray="8 6" points="305,57 313,65 305,73 297,65 305,57" />
+  <polyline id="event-5" fill="none" stroke="#f0f0f0" stroke-width="4" stroke-dasharray="8 6" points="335,27 343,35 335,43 327,35 335,27" />
+</svg>

--- a/src/Core/ComplexityRegistry.fs
+++ b/src/Core/ComplexityRegistry.fs
@@ -92,6 +92,7 @@ module ComplexityRegistry =
               ("algebra.z2-parity", "carry"), c "O(1)" "O(1)" Derived // one bit per edge: the dashing register (Gates)
               ("algebra.mod2", "project"), c "O(word)" "O(1)" Derived // THE MISSING PIECE: Z -> Z/2, order forgotten, parity kept — the adapter that snaps braid-out into adinkra-in
               ("shape.adinkra", "draw"), c "O(E)" "O(E)" Derived // one stroke per drawn edge (24 on the flat grid); dashing lookup is O(1) per edge
+              ("shape.exchange-worldlines", "draw"), c "O(crossings·strands)" "O(strands)" Derived // the braid drawn as spacetime: strands + one event diamond per exchange
               ("binding.html-css", "render"), c "O(entries·pixels)" "O(output)" Derived
               ("sim.wave-interference", "pattern"), c "O(w·h·sources)" "O(w·h)" Derived
               ("viz.adinkra", "render"), c "O(nodes)" "O(nodes)" Derived

--- a/src/Core/GeneratorRegistry.fs
+++ b/src/Core/GeneratorRegistry.fs
@@ -84,6 +84,7 @@ module GeneratorRegistry =
           register "algebra.z2-parity" 1
           register "algebra.mod2" 1
           register "shape.adinkra" 1
+          register "shape.exchange-worldlines" 1
           register "binding.html-css" 1
           register "sim.wave-interference" 1
           register "viz.adinkra" 1

--- a/src/Core/ShapeAcceptance.fs
+++ b/src/Core/ShapeAcceptance.fs
@@ -129,6 +129,32 @@ module ShapeAcceptance =
             // closure lands at t=0 (span,0), never on the center — so the visit count is exact.
             let ok = closed && visits = c "center-visits"
             ok, sprintf "closed loop; %d center visits (the catch, used twice as one door)" visits
+        | "shape-exchange-worldlines" ->
+            // CAUSAL ORDER: consecutive exchange events must be timelike-separated at slope 1/1 —
+            // |Δcolumn| <= Δtime-rows between events i and i+1 (each event inside the next's past
+            // cone). Plus SAME-BRAID: the word is the locked+stuck word (one object, two registers).
+            let word =
+                MediaLines.field "constant" "word" d
+                |> Option.defaultValue ""
+                |> fun s -> s.Split(',') |> Array.filter (fun x -> x.Length > 0) |> Array.map int |> Array.toList
+            let rows = MediaLines.field "constant" "rows" d |> Option.map int |> Option.defaultValue 21
+            let gap = MediaLines.field "constant" "strand-gap" d |> Option.map int |> Option.defaultValue 3
+            let cols = [| 32 - gap; 32; 32 + gap |]
+            let rowsPerCross = rows / (List.length word + 1)
+            let eventPts = word |> List.mapi (fun i c -> (cols.[abs c - 1] + cols.[abs c]) / 2, (i + 1) * rowsPerCross)
+            let causal =
+                eventPts
+                |> List.pairwise
+                |> List.forall (fun ((x0, t0), (x1, t1)) -> abs (x1 - x0) <= (t1 - t0)) // slope 1/1
+            let valid = Braid.validWord 3 word
+            let perm = Array.init 3 id
+            if valid then
+                for c in word do
+                    let a = abs c - 1
+                    let t' = perm.[a] in perm.[a] <- perm.[a + 1]; perm.[a + 1] <- t'
+            let lockedStuck = valid && perm = [| 0; 1; 2 |] && not (Braid.isIdentity 3 word)
+            causal && lockedStuck,
+            "exchanges causally ordered (|Δx| <= Δt at slope 1/1); the word is the locked+stuck braid — one object, two registers"
         | "shape-adinkra" ->
             // the two laws run live: Gates condition on the standard dashing, and the gauge lemma
             // (a deterministic vertex walk changes the dashing, never the face parity).

--- a/src/Core/ShapeRender.fs
+++ b/src/Core/ShapeRender.fs
@@ -137,6 +137,59 @@ module ShapeRender =
             [ { Dash = false; Name = "loop"; Mask = 7uy; Points = loop }
               // the catch point: a small diamond on the crossing (the door used twice)
               { Dash = false; Name = "catch"; Mask = 5uy; Points = [ cx, cy - 6; cx + 6, cy; cx, cy + 6; cx - 6, cy; cx, cy - 6 ] } ]
+        | "shape-exchange-worldlines" ->
+            // the anyon picture: the braid's strands drawn as worldlines with TIME RUNNING UP
+            // (y = rows − braid-row), each crossing marked by a small causal diamond at the
+            // exchange event (slope 1/1 — the lightcone's constant, worn locally). Same word, same
+            // runs, same occlusion gaps as shape-braid — one object, the spacetime register.
+            let word =
+                MediaLines.field "constant" "word" d
+                |> Option.defaultValue "1,-2,1,-2,1,-2"
+                |> fun s -> s.Split(',') |> Array.filter (fun x -> x.Length > 0) |> Array.map int |> Array.toList
+            let rows = constInt "rows" 21
+            let gap = constInt "strand-gap" 3 // causality-bounded: see the cartridge constant's WHY
+            let cols = [| 32 - gap; 32; 32 + gap |]
+            let flip (x: int, y: int) = x, (rows * scale + scale) - y // time runs UP
+            let mutable perm = [| 0; 1; 2 |]
+            let rowsPerCross = rows / (List.length word + 1)
+            let runs = Array.init 3 (fun _ -> ResizeArray<ResizeArray<int * int>>())
+            for slot in 0 .. 2 do
+                let r = ResizeArray<int * int>()
+                r.Add(flip (pt cols.[slot] 0))
+                runs.[perm.[slot]].Add r
+            let events = ResizeArray<int * int>()
+            word
+            |> List.iteri (fun i c ->
+                let y = (i + 1) * rowsPerCross
+                let a = abs c - 1
+                let under = perm.[if c > 0 then a + 1 else a]
+                let x0, y0 = List.last (List.ofSeq (runs.[under].[runs.[under].Count - 1]))
+                let x1, y1 = flip (pt cols.[(if perm.[if c > 0 then a + 1 else a] = perm.[a] then a + 1 else a)] y)
+                // event diamond center: midpoint of the swapped columns at this row
+                events.Add(((cols.[a] + cols.[a + 1]) / 2) * scale + scale / 2, (flip (pt 0 y)) |> snd)
+                let cur = runs.[under].[runs.[under].Count - 1]
+                cur.Add(x0 + (x1 - x0) * 2 / 5, y0 + (y1 - y0) * 2 / 5)
+                let next = ResizeArray<int * int>()
+                next.Add(x0 + (x1 - x0) * 3 / 5, y0 + (y1 - y0) * 3 / 5)
+                runs.[under].Add next
+                let t' = perm.[a] in perm.[a] <- perm.[a + 1]; perm.[a + 1] <- t'
+                for slot in 0 .. 2 do
+                    runs.[perm.[slot]].[runs.[perm.[slot]].Count - 1].Add(flip (pt cols.[slot] y)))
+            for slot in 0 .. 2 do
+                runs.[perm.[slot]].[runs.[perm.[slot]].Count - 1].Add(flip (pt cols.[slot] rows))
+            [ for s in 0 .. 2 do
+                  for r in 0 .. runs.[s].Count - 1 ->
+                      { Dash = false
+                        Name = (if r = 0 then sprintf "worldline-%d" s else sprintf "worldline-%d-r%d" s r)
+                        Mask = byte (1 <<< s)
+                        Points = List.ofSeq runs.[s].[r] }
+              for i in 0 .. events.Count - 1 ->
+                  let ex, ey = events.[i]
+                  let r = 8 // the event diamond: slope-1 edges (a tiny lightcone, worn locally)
+                  { Dash = true
+                    Name = sprintf "event-%d" i
+                    Mask = 7uy
+                    Points = [ ex, ey - r; ex + r, ey; ex, ey + r; ex - r, ey; ex, ey - r ] } ]
         | "shape-buckyball" ->
             // Addison's two views, schematic and honest: INSIDE reads like a soccer ball (central
             // pentagon room, hexagon ring, a bounding circle); OUTSIDE is almost the same drawing

--- a/tests/Tests.FSharp/ShapeAcceptance.Tests.fs
+++ b/tests/Tests.FSharp/ShapeAcceptance.Tests.fs
@@ -19,7 +19,7 @@ let private docOf (name: string) =
     | Ok d -> d
     | Error e -> failwith e
 
-let private shapes = [ "spiral"; "braid"; "worldline"; "lightcone"; "fourcorner"; "seam"; "buckyball"; "shadow-loop"; "plait-move"; "adinkra" ]
+let private shapes = [ "spiral"; "braid"; "worldline"; "lightcone"; "fourcorner"; "seam"; "buckyball"; "shadow-loop"; "plait-move"; "adinkra"; "exchange-worldlines" ]
 
 [<Fact>]
 let ``THE HARD GATE: every catalog shape is accepted on bytes+geometry+honest-labels — never on looks, never on meaning`` () =

--- a/tests/Tests.FSharp/ShapeCartridge.Tests.fs
+++ b/tests/Tests.FSharp/ShapeCartridge.Tests.fs
@@ -57,7 +57,7 @@ let private catalog () =
 [<Fact>]
 let ``THE CATALOG LAW: every cartridge parses, lints clean, resolves its gen on the shelf, and carries its own treaty block`` () =
     let all = catalog ()
-    Assert.Equal(10, Array.length all) // + buckyball + shadow-loop + plait-move + adinkra (the sign register joins the catalog)
+    Assert.Equal(11, Array.length all) // + buckyball + shadow-loop + plait-move + adinkra + exchange-worldlines (the anyon picture)
     for name, d in all do
         Assert.True(List.isEmpty (MediaLines.lint d), name + " must lint clean")
         // every gen line's ZetaId resolves to a REGISTERED generator (DI by ZetaId, working)


### PR DESCRIPTION
The braid drawn in spacetime: worldlines up the court, exchanges as slope-1/1 event diamonds, same word as shape-braid (one object, two registers). The gate taught physics on first run: 12-column strand spacing made consecutive exchanges spacelike — the layout had to obey the lightcone (strand-gap constant, WHY = causality). B-1029: Lior's TS quantum lane (quantum-circuit → Q# export, three Vera jobs, Quirk toy layer). B-1030: quantum-viz.js eval (diagram lane; honest verdict may be decline). 2989 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)