### PR TITLE
fix(backlog): satisfy markdownlint for quantum viz note

### DIFF
--- a/docs/backlog/P3/B-1030-evaluate-microsoft-quantum-viz-js-circuit-diagram-rendering-for-ts-apps-aaron-2026-06-12.md
+++ b/docs/backlog/P3/B-1030-evaluate-microsoft-quantum-viz-js-circuit-diagram-rendering-for-ts-apps-aaron-2026-06-12.md
@@ -19,6 +19,7 @@ shipped via the Q# dev blog; repo active-status UNCONFIRMED — the eval must ch
 recency and whether the qsharp-lang reorg superseded it.
 
 Eval criteria (an afternoon, not a project):
+
 1. Maintenance: last release/commit; open-issue triage; superseded-by status.
 2. Output discipline: is the rendered HTML/SVG deterministic (same circuit → same bytes)? If yes
    it can golden-lock; if no, quantum-circuit's own SVG export (B-1029 item 3) wins by default.


### PR DESCRIPTION
## Summary
- add the required blank line before the B-1030 evaluation criteria numbered list
- fixes the repo-wide markdownlint MD032 failure on main

## Verification
- mise exec -- markdownlint-cli2 docs/backlog/P3/B-1030-evaluate-microsoft-quantum-viz-js-circuit-diagram-rendering-for-ts-apps-aaron-2026-06-12.md
- git diff --check