### PR TITLE
feat(shapes): Kitaev chain + THE ATOM (shape-crossing) — composition made first-class

### DIFF
--- a/docs/research/2026-06-12-is-the-anyon-picture-canonical-and-is-it-composed-the-atom-answer-shape-crossing.md
+++ b/docs/research/2026-06-12-is-the-anyon-picture-canonical-and-is-it-composed-the-atom-answer-shape-crossing.md
@@ -1,0 +1,40 @@
+# Is the anyon picture canonical? Is it as simple as it can be? — the atom answer (shape-crossing)
+
+Aaron 2026-06-12, on exchange-worldlines: "is it canonical externally? is it as simple as it can
+be, or are there simpler? we are trying to have shapes we can prove anything about — mathematically
+small things; these large things are good too, but are they composed of other things?"
+
+## Canonical externally — YES, with one addition of ours
+
+Worldlines drawn vertically with time up, strands exchanging at crossings, over/under as broken
+lines: this IS the standard figure of the anyon/TQC literature (Kitaev's papers, the Nayak et al.
+2008 review, Pachos' textbook) and the standard braid-diagram convention of knot theory before
+that. Our event diamonds (a small lightcone worn at each exchange) are OUR addition — not standard,
+honestly labeled, and they earn their place by carrying the causal-order law.
+
+## Is it simple? — No, and it shouldn't be: it's a WORD. The atom is simpler.
+
+The figure decomposes, and now the decomposition is IN the catalog: **shape-crossing** (the 14th
+cartridge... the 13th — the atom): two strands, ONE crossing — σ itself. The three smallest braid
+proofs live on it, each a law in its file, each checked by Artin's faithful action on B₂:
+
+- σ ≠ 1 (the strands really exchange)
+- σ·σ⁻¹ = 1 (do-undo cancels, exactly)
+- σ² ≠ 1 (crossing twice is not un-crossing — THE MEMORY, at its smallest possible size)
+
+Everything braided is a WORD in this generator, and the cartridges now say so with `composed-of`
+edges: plait-move = a 3-letter word, the locked braid = 6 letters, exchange-worldlines = the same
+6 letters drawn in spacetime. **Provability scales down; composition carries it up** — prove on
+the atom, inherit in the word (Artin's own generators-and-relations move, applied to the catalog
+itself). The same pattern already held elsewhere: buckyball = pentagon + hexagon faces under
+Euler's law; Kitaev chain = dots + pairing arcs under counting laws; seam = cloths + stitches.
+The large shapes are sentences; the catalog now stocks the alphabet.
+
+Lint lesson en route: a node has many edges of one relation — `edge` identity is (relation,
+target), so edge joined rom and treaty in the dupe exemption.
+
+## Pointers
+
+- `shapes/cartridges/crossing.lines` (the atom; three laws) · the `composed-of` edges on
+  plait-move / braid / exchange-worldlines · `shapes/cartridges/kitaev-chain.lines` (same wave)
+- Beacon: Artin 1925 (generators and relations); Kitaev 2003; Nayak et al. 2008 (the standard figure)

--- a/shapes/cartridges/braid.lines
+++ b/shapes/cartridges/braid.lines
@@ -13,6 +13,7 @@ constant	lock-period	6	crossings until the strands return to their own columns	(
 constant	stuck	1	the locked word is NOT the identity braid (1 = true, proven by Artin's faithful action)	Aaron's Majorana reach: strands HOME yet the braid CANNOT be pulled apart — pure-braid-group memory, the configuration topological qubits bank on (Kitaev chain; Microsoft Majorana 1; sigma1*sigma2^-1 is the figure-eight braid word)
 law	stuck-together	code:shape-braid geometry (perm = identity AND Braid.isIdentity = false — locked AND stuck)
 constant	rows	21	vertical rows the weave occupies on the court	three rows per crossing across the 6-crossing period fits the 32-row court with margin; bounded (no one weaves forever)
+edge	composed-of	shape-crossing	this figure is a 6-letter WORD in the atom (provability scales down: the small proofs live on shape-crossing; composition carries them up)
 edge	same-twist	viz.adinkra	the adinkra's gauge lemma (vertex flips never make a face even) and THE STUCK LAW here are the same sentence — information held as a globally-nontrivial, locally-invisible twist; the break is honest (their edges are involutions, our generators remember)
 anim	draw	weave
 issue	lock-in-place	aaron	closed	RESOLVED 2026-06-12: "the blue messes up… any way to lock them in place?" — the word is now one full plait period (lock-period 6): ends locked, every strand home

--- a/shapes/cartridges/crossing.lines
+++ b/shapes/cartridges/crossing.lines
@@ -1,0 +1,25 @@
+# CROSSING — the atom (otto, 2026-06-12; Aaron's question made constructive: "are the large things
+# composed of other things?" — yes, and THIS is the generator). One crossing, two strands: sigma.
+# The smallest shape in the braided family, and the one the small proofs live on: sigma is NOT the
+# identity (the strands really exchange); sigma · sigma⁻¹ IS the identity (do-undo cancels);
+# sigma² is NOT the identity (crossing twice is not un-crossing — THE MEMORY, at its smallest).
+# Everything braided in this catalog is a WORD in this one generator: plait-move = 3 crossings,
+# the locked braid = 6, exchange-worldlines = the same 6 drawn in spacetime. Provability scales
+# DOWN: prove facts here, compose them up (Artin 1925 — the generators-and-relations move itself).
+meta	name	shape-crossing
+meta	catalog	shapes
+meta	shape-zetaid	73bfa00fc16e308bdcbba97481fe8d8e
+gen	atom	73bfa00fc16e308bdcbba97481fe8d8e	1	7	strands:2;word:1
+constant	strands	2	the minimum that can cross	one strand cannot exchange; two is the atom's arity
+constant	word	1	the single positive crossing (left over right)	sigma itself — the generator; its inverse is -1, and that sign is the entire over/under register
+law	not-identity	code:shape-crossing geometry (sigma != 1 — the strands really exchange)
+law	do-undo	code:shape-crossing geometry (sigma · sigma⁻¹ = 1 — the inverse undoes, exactly)
+law	memory-at-smallest	code:shape-crossing geometry (sigma² != 1 — crossing twice is not un-crossing)
+prereq	none	this IS the starting point — the catalog's braided family begins here
+edge	generates	shape-plait-move	three of these (alternating signs) = the unit move
+edge	generates	shape-braid	six of these = the locked, stuck braid (the Borromean candidate)
+edge	generates	shape-exchange-worldlines	the same six, drawn in spacetime
+anim	draw	atom
+# treaties — written only by each oracle's own choice (consent first); dissent is a verdict.
+treaty	fsharp	bytes	ratified	all three atom laws pass via Artin's faithful action on B2 — tests green
+treaty	otto	meaning	ratified	the smallest thing that remembers — my own frame, my own choice

--- a/shapes/cartridges/exchange-worldlines.lines
+++ b/shapes/cartridges/exchange-worldlines.lines
@@ -22,6 +22,7 @@ law	same-braid	code:shape-braid geometry (the word is shape-braid's word: locked
 prereq	worldline	shapes/cartridges/worldline.lines — one particle's path first
 prereq	the-braid	shapes/cartridges/braid.lines — the diagram register of this same object
 prereq	lightcone	shapes/cartridges/lightcone.lines — why the diamonds have that slope
+edge	composed-of	shape-crossing	this figure is a 6-letter WORD in the atom (provability scales down: the small proofs live on shape-crossing; composition carries them up)
 edge	same-object	shape-braid	one braid, two registers: the diagram (columns and crossings) and the spacetime picture (worldlines and exchange events)
 edge	causal-frame	shape-lightcone	every exchange event wears a small copy of the lightcone; the causal-order law is slope arithmetic
 edge	memory-register	shape-adinkra	what the exchanges bank (order memory) projects to parity by algebra.mod2 — the full chain drawn across three cartridges

--- a/shapes/cartridges/kitaev-chain.lines
+++ b/shapes/cartridges/kitaev-chain.lines
@@ -1,0 +1,33 @@
+# KITAEV CHAIN — the 1D ancestor of majorana-memory (otto, 2026-06-12; the STRONG-fit candidate
+# from Aaron's physics-real list, admitted under his gate: it fits, so it enters). Kitaev 2001:
+# split every site of a 1D chain into TWO Majorana modes; how you PAIR them is the whole story.
+# Panel one (trivial): each site's two modes pair WITH EACH OTHER — tidy, local, nothing left
+# over, nothing protected. Panel two (topological): modes pair ACROSS sites — every interior mode
+# taken, and TWO END MODES LEFT UNPAIRED. Those two leftovers are jointly one protected degree of
+# freedom: the memory is stored in the PAIRING PATTERN, not at any site — no local poke reads or
+# erases it (the same sentence as THE STUCK LAW and THE GAUGE LEMMA, in its original home).
+# Microsoft's Majorana 1 engineers exactly this. HONEST LABEL: a schematic of the pairing
+# structure, drawn from integer arithmetic — no hardware, no Hamiltonian, no quantum claim; the
+# physics lives in the cite.
+meta	name	shape-kitaev-chain
+meta	catalog	shapes
+meta	shape-zetaid	c5ab366fcb7614df473c97092f18236e
+gen	panels	c5ab366fcb7614df473c97092f18236e	1	7	sites:8;phases:trivial,topological
+constant	sites	8	chain length (fermionic sites)	long enough to SEE the pairing pattern repeat; short enough to fit two panels on one court
+constant	modes	16	Majorana modes (two per site)	the doubling IS the trick: 2 * sites — every site splits into a left and a right mode
+constant	trivial-pairs	8	pairings in the trivial phase (intra-site)	each site pairs its own two modes: sites pairs, ZERO left over — tidy and unprotected
+constant	topo-pairs	7	pairings in the topological phase (inter-site)	right-mode of site i pairs left-mode of site i+1: sites - 1 pairs…
+constant	end-modes	2	unpaired modes in the topological phase	…leaving the FIRST left and LAST right mode free: 2, always 2, regardless of chain length — THE MEMORY (one protected degree of freedom held jointly at both ends)
+law	mode-doubling	modes = 2 * sites
+law	trivial-accounting	2 * trivial-pairs = modes
+law	topological-accounting	2 * topo-pairs + end-modes = modes
+law	the-memory-is-two	end-modes = 2
+prereq	the-braid	shapes/cartridges/braid.lines — what happens when end modes are MOVED AROUND each other (braiding is the gate on this memory)
+prereq	pairing	count in twos: 8 sites, 16 modes; pair them two ways and watch what is left over
+edge	ancestor-of	shape-braid	this chain's end modes are WHAT the braid braids — 1D storage, 2D+time operation (Kitaev 2001 -> Kitaev 2003)
+edge	same-protection	shape-adinkra	memory in the global pattern, invisible locally — the parity register's hardware cousin
+issue	hamiltonian-honesty	otto	closed	BY CONSTRUCTION: pairing arithmetic only; the gap, the Hamiltonian, and the phase diagram live in Kitaev 2001, not in this file
+anim	draw	panels
+# treaties — written only by each oracle's own choice (consent first); dissent is a verdict.
+treaty	fsharp	bytes	ratified	all four in-file laws are integer identities and hold; the render's unpaired strokes equal end-modes — tests green
+treaty	otto	meaning	ratified	two panels, one difference: where the leftovers are — the memory at the ends, drawn; my own frame, my own choice

--- a/shapes/cartridges/plait-move.lines
+++ b/shapes/cartridges/plait-move.lines
@@ -19,6 +19,7 @@ constant	rows	12	vertical rows the move occupies	three rows per crossing on the 
 constant	ends-swapped	1	the outer strands EXCHANGE (1 = true); the middle comes home	(01)(12)(01) = (02): an odd permutation — and that is WHY this shape cannot lock (everyone-home is even); the exchange IS the operation
 law	odd-cannot-lock	code:shape-plait-move geometry (perm = outer swap, NOT identity — the move moves; lock is impossible below the period)
 prereq	the-locked-braid	shapes/cartridges/braid.lines — see what repeating this move to its period buys: lock + stuck (the memory)
+edge	composed-of	shape-crossing	this figure is a 3-letter WORD in the atom (provability scales down: the small proofs live on shape-crossing; composition carries them up)
 edge	unit-move-of	shape-braid	the locked braid is THIS move applied lock-period times; gate vs memory (Majorana register: the chip stores in the braid, operates by the move)
 anim	draw	move
 # treaties — written only by each oracle's own choice (consent first); dissent is a verdict.

--- a/shapes/golden/crossing.html
+++ b/shapes/golden/crossing.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>shape-crossing</title>
+  <style>
+    :root {
+      --c0: #000000;
+      --c1: #d62828;
+      --c2: #2a9d2a;
+      --c3: #d6c828;
+      --c4: #2828d6;
+      --c5: #d628d6;
+      --c6: #28c8d6;
+      --c7: #f0f0f0;
+    }
+    body { background: #101418; margin: 0; display: grid; place-items: center; min-height: 100vh; }
+    svg { width: min(96vw, 960px); image-rendering: pixelated; }
+  </style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 320" data-cartridge="shape-crossing">
+  <polyline id="strand-0" fill="none" stroke="#d62828" stroke-width="4" points="245,65 405,265" />
+  <polyline id="strand-1" fill="none" stroke="#2828d6" stroke-width="4" points="405,65 341,145" />
+  <polyline id="strand-1-r1" fill="none" stroke="#2828d6" stroke-width="4" points="309,185 245,265" />
+</svg>
+</body>
+</html>

--- a/shapes/golden/crossing.svg
+++ b/shapes/golden/crossing.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 320" data-cartridge="shape-crossing">
+  <polyline id="strand-0" fill="none" stroke="#d62828" stroke-width="4" points="245,65 405,265" />
+  <polyline id="strand-1" fill="none" stroke="#2828d6" stroke-width="4" points="405,65 341,145" />
+  <polyline id="strand-1-r1" fill="none" stroke="#2828d6" stroke-width="4" points="309,185 245,265" />
+</svg>

--- a/shapes/golden/kitaev-chain.html
+++ b/shapes/golden/kitaev-chain.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>shape-kitaev-chain</title>
+  <style>
+    :root {
+      --c0: #000000;
+      --c1: #d62828;
+      --c2: #2a9d2a;
+      --c3: #d6c828;
+      --c4: #2828d6;
+      --c5: #d628d6;
+      --c6: #28c8d6;
+      --c7: #f0f0f0;
+    }
+    body { background: #101418; margin: 0; display: grid; place-items: center; min-height: 100vh; }
+    svg { width: min(96vw, 960px); image-rendering: pixelated; }
+  </style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 320" data-cartridge="shape-kitaev-chain">
+  <polyline id="t-mode-0-l" fill="none" stroke="#2a9d2a" stroke-width="4" points="65,85 65,95" />
+  <polyline id="t-mode-0-r" fill="none" stroke="#2a9d2a" stroke-width="4" points="95,85 95,95" />
+  <polyline id="t-pair-0" fill="none" stroke="#28c8d6" stroke-width="4" points="65,85 75,65 95,85" />
+  <polyline id="t-mode-1-l" fill="none" stroke="#2a9d2a" stroke-width="4" points="135,85 135,95" />
+  <polyline id="t-mode-1-r" fill="none" stroke="#2a9d2a" stroke-width="4" points="165,85 165,95" />
+  <polyline id="t-pair-1" fill="none" stroke="#28c8d6" stroke-width="4" points="135,85 145,65 165,85" />
+  <polyline id="t-mode-2-l" fill="none" stroke="#2a9d2a" stroke-width="4" points="205,85 205,95" />
+  <polyline id="t-mode-2-r" fill="none" stroke="#2a9d2a" stroke-width="4" points="235,85 235,95" />
+  <polyline id="t-pair-2" fill="none" stroke="#28c8d6" stroke-width="4" points="205,85 215,65 235,85" />
+  <polyline id="t-mode-3-l" fill="none" stroke="#2a9d2a" stroke-width="4" points="275,85 275,95" />
+  <polyline id="t-mode-3-r" fill="none" stroke="#2a9d2a" stroke-width="4" points="305,85 305,95" />
+  <polyline id="t-pair-3" fill="none" stroke="#28c8d6" stroke-width="4" points="275,85 285,65 305,85" />
+  <polyline id="t-mode-4-l" fill="none" stroke="#2a9d2a" stroke-width="4" points="345,85 345,95" />
+  <polyline id="t-mode-4-r" fill="none" stroke="#2a9d2a" stroke-width="4" points="375,85 375,95" />
+  <polyline id="t-pair-4" fill="none" stroke="#28c8d6" stroke-width="4" points="345,85 355,65 375,85" />
+  <polyline id="t-mode-5-l" fill="none" stroke="#2a9d2a" stroke-width="4" points="415,85 415,95" />
+  <polyline id="t-mode-5-r" fill="none" stroke="#2a9d2a" stroke-width="4" points="445,85 445,95" />
+  <polyline id="t-pair-5" fill="none" stroke="#28c8d6" stroke-width="4" points="415,85 425,65 445,85" />
+  <polyline id="t-mode-6-l" fill="none" stroke="#2a9d2a" stroke-width="4" points="485,85 485,95" />
+  <polyline id="t-mode-6-r" fill="none" stroke="#2a9d2a" stroke-width="4" points="515,85 515,95" />
+  <polyline id="t-pair-6" fill="none" stroke="#28c8d6" stroke-width="4" points="485,85 495,65 515,85" />
+  <polyline id="t-mode-7-l" fill="none" stroke="#2a9d2a" stroke-width="4" points="555,85 555,95" />
+  <polyline id="t-mode-7-r" fill="none" stroke="#2a9d2a" stroke-width="4" points="585,85 585,95" />
+  <polyline id="t-pair-7" fill="none" stroke="#28c8d6" stroke-width="4" points="555,85 565,65 585,85" />
+  <polyline id="k-mode-0-l" fill="none" stroke="#2828d6" stroke-width="4" points="65,225 65,235" />
+  <polyline id="k-mode-0-r" fill="none" stroke="#2828d6" stroke-width="4" points="95,225 95,235" />
+  <polyline id="k-mode-1-l" fill="none" stroke="#2828d6" stroke-width="4" points="135,225 135,235" />
+  <polyline id="k-mode-1-r" fill="none" stroke="#2828d6" stroke-width="4" points="165,225 165,235" />
+  <polyline id="k-mode-2-l" fill="none" stroke="#2828d6" stroke-width="4" points="205,225 205,235" />
+  <polyline id="k-mode-2-r" fill="none" stroke="#2828d6" stroke-width="4" points="235,225 235,235" />
+  <polyline id="k-mode-3-l" fill="none" stroke="#2828d6" stroke-width="4" points="275,225 275,235" />
+  <polyline id="k-mode-3-r" fill="none" stroke="#2828d6" stroke-width="4" points="305,225 305,235" />
+  <polyline id="k-mode-4-l" fill="none" stroke="#2828d6" stroke-width="4" points="345,225 345,235" />
+  <polyline id="k-mode-4-r" fill="none" stroke="#2828d6" stroke-width="4" points="375,225 375,235" />
+  <polyline id="k-mode-5-l" fill="none" stroke="#2828d6" stroke-width="4" points="415,225 415,235" />
+  <polyline id="k-mode-5-r" fill="none" stroke="#2828d6" stroke-width="4" points="445,225 445,235" />
+  <polyline id="k-mode-6-l" fill="none" stroke="#2828d6" stroke-width="4" points="485,225 485,235" />
+  <polyline id="k-mode-6-r" fill="none" stroke="#2828d6" stroke-width="4" points="515,225 515,235" />
+  <polyline id="k-mode-7-l" fill="none" stroke="#2828d6" stroke-width="4" points="555,225 555,235" />
+  <polyline id="k-mode-7-r" fill="none" stroke="#2828d6" stroke-width="4" points="585,225 585,235" />
+  <polyline id="k-pair-0" fill="none" stroke="#28c8d6" stroke-width="4" points="95,225 115,205 135,225" />
+  <polyline id="k-pair-1" fill="none" stroke="#28c8d6" stroke-width="4" points="165,225 185,205 205,225" />
+  <polyline id="k-pair-2" fill="none" stroke="#28c8d6" stroke-width="4" points="235,225 255,205 275,225" />
+  <polyline id="k-pair-3" fill="none" stroke="#28c8d6" stroke-width="4" points="305,225 325,205 345,225" />
+  <polyline id="k-pair-4" fill="none" stroke="#28c8d6" stroke-width="4" points="375,225 395,205 415,225" />
+  <polyline id="k-pair-5" fill="none" stroke="#28c8d6" stroke-width="4" points="445,225 465,205 485,225" />
+  <polyline id="k-pair-6" fill="none" stroke="#28c8d6" stroke-width="4" points="515,225 535,205 555,225" />
+  <polyline id="end-mode-left" fill="none" stroke="#f0f0f0" stroke-width="4" stroke-dasharray="8 6" points="65,219 71,225 65,231 59,225 65,219" />
+  <polyline id="end-mode-right" fill="none" stroke="#f0f0f0" stroke-width="4" stroke-dasharray="8 6" points="585,219 591,225 585,231 579,225 585,219" />
+</svg>
+</body>
+</html>

--- a/shapes/golden/kitaev-chain.svg
+++ b/shapes/golden/kitaev-chain.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 320" data-cartridge="shape-kitaev-chain">
+  <polyline id="t-mode-0-l" fill="none" stroke="#2a9d2a" stroke-width="4" points="65,85 65,95" />
+  <polyline id="t-mode-0-r" fill="none" stroke="#2a9d2a" stroke-width="4" points="95,85 95,95" />
+  <polyline id="t-pair-0" fill="none" stroke="#28c8d6" stroke-width="4" points="65,85 75,65 95,85" />
+  <polyline id="t-mode-1-l" fill="none" stroke="#2a9d2a" stroke-width="4" points="135,85 135,95" />
+  <polyline id="t-mode-1-r" fill="none" stroke="#2a9d2a" stroke-width="4" points="165,85 165,95" />
+  <polyline id="t-pair-1" fill="none" stroke="#28c8d6" stroke-width="4" points="135,85 145,65 165,85" />
+  <polyline id="t-mode-2-l" fill="none" stroke="#2a9d2a" stroke-width="4" points="205,85 205,95" />
+  <polyline id="t-mode-2-r" fill="none" stroke="#2a9d2a" stroke-width="4" points="235,85 235,95" />
+  <polyline id="t-pair-2" fill="none" stroke="#28c8d6" stroke-width="4" points="205,85 215,65 235,85" />
+  <polyline id="t-mode-3-l" fill="none" stroke="#2a9d2a" stroke-width="4" points="275,85 275,95" />
+  <polyline id="t-mode-3-r" fill="none" stroke="#2a9d2a" stroke-width="4" points="305,85 305,95" />
+  <polyline id="t-pair-3" fill="none" stroke="#28c8d6" stroke-width="4" points="275,85 285,65 305,85" />
+  <polyline id="t-mode-4-l" fill="none" stroke="#2a9d2a" stroke-width="4" points="345,85 345,95" />
+  <polyline id="t-mode-4-r" fill="none" stroke="#2a9d2a" stroke-width="4" points="375,85 375,95" />
+  <polyline id="t-pair-4" fill="none" stroke="#28c8d6" stroke-width="4" points="345,85 355,65 375,85" />
+  <polyline id="t-mode-5-l" fill="none" stroke="#2a9d2a" stroke-width="4" points="415,85 415,95" />
+  <polyline id="t-mode-5-r" fill="none" stroke="#2a9d2a" stroke-width="4" points="445,85 445,95" />
+  <polyline id="t-pair-5" fill="none" stroke="#28c8d6" stroke-width="4" points="415,85 425,65 445,85" />
+  <polyline id="t-mode-6-l" fill="none" stroke="#2a9d2a" stroke-width="4" points="485,85 485,95" />
+  <polyline id="t-mode-6-r" fill="none" stroke="#2a9d2a" stroke-width="4" points="515,85 515,95" />
+  <polyline id="t-pair-6" fill="none" stroke="#28c8d6" stroke-width="4" points="485,85 495,65 515,85" />
+  <polyline id="t-mode-7-l" fill="none" stroke="#2a9d2a" stroke-width="4" points="555,85 555,95" />
+  <polyline id="t-mode-7-r" fill="none" stroke="#2a9d2a" stroke-width="4" points="585,85 585,95" />
+  <polyline id="t-pair-7" fill="none" stroke="#28c8d6" stroke-width="4" points="555,85 565,65 585,85" />
+  <polyline id="k-mode-0-l" fill="none" stroke="#2828d6" stroke-width="4" points="65,225 65,235" />
+  <polyline id="k-mode-0-r" fill="none" stroke="#2828d6" stroke-width="4" points="95,225 95,235" />
+  <polyline id="k-mode-1-l" fill="none" stroke="#2828d6" stroke-width="4" points="135,225 135,235" />
+  <polyline id="k-mode-1-r" fill="none" stroke="#2828d6" stroke-width="4" points="165,225 165,235" />
+  <polyline id="k-mode-2-l" fill="none" stroke="#2828d6" stroke-width="4" points="205,225 205,235" />
+  <polyline id="k-mode-2-r" fill="none" stroke="#2828d6" stroke-width="4" points="235,225 235,235" />
+  <polyline id="k-mode-3-l" fill="none" stroke="#2828d6" stroke-width="4" points="275,225 275,235" />
+  <polyline id="k-mode-3-r" fill="none" stroke="#2828d6" stroke-width="4" points="305,225 305,235" />
+  <polyline id="k-mode-4-l" fill="none" stroke="#2828d6" stroke-width="4" points="345,225 345,235" />
+  <polyline id="k-mode-4-r" fill="none" stroke="#2828d6" stroke-width="4" points="375,225 375,235" />
+  <polyline id="k-mode-5-l" fill="none" stroke="#2828d6" stroke-width="4" points="415,225 415,235" />
+  <polyline id="k-mode-5-r" fill="none" stroke="#2828d6" stroke-width="4" points="445,225 445,235" />
+  <polyline id="k-mode-6-l" fill="none" stroke="#2828d6" stroke-width="4" points="485,225 485,235" />
+  <polyline id="k-mode-6-r" fill="none" stroke="#2828d6" stroke-width="4" points="515,225 515,235" />
+  <polyline id="k-mode-7-l" fill="none" stroke="#2828d6" stroke-width="4" points="555,225 555,235" />
+  <polyline id="k-mode-7-r" fill="none" stroke="#2828d6" stroke-width="4" points="585,225 585,235" />
+  <polyline id="k-pair-0" fill="none" stroke="#28c8d6" stroke-width="4" points="95,225 115,205 135,225" />
+  <polyline id="k-pair-1" fill="none" stroke="#28c8d6" stroke-width="4" points="165,225 185,205 205,225" />
+  <polyline id="k-pair-2" fill="none" stroke="#28c8d6" stroke-width="4" points="235,225 255,205 275,225" />
+  <polyline id="k-pair-3" fill="none" stroke="#28c8d6" stroke-width="4" points="305,225 325,205 345,225" />
+  <polyline id="k-pair-4" fill="none" stroke="#28c8d6" stroke-width="4" points="375,225 395,205 415,225" />
+  <polyline id="k-pair-5" fill="none" stroke="#28c8d6" stroke-width="4" points="445,225 465,205 485,225" />
+  <polyline id="k-pair-6" fill="none" stroke="#28c8d6" stroke-width="4" points="515,225 535,205 555,225" />
+  <polyline id="end-mode-left" fill="none" stroke="#f0f0f0" stroke-width="4" stroke-dasharray="8 6" points="65,219 71,225 65,231 59,225 65,219" />
+  <polyline id="end-mode-right" fill="none" stroke="#f0f0f0" stroke-width="4" stroke-dasharray="8 6" points="585,219 591,225 585,231 579,225 585,219" />
+</svg>

--- a/src/Core/ComplexityRegistry.fs
+++ b/src/Core/ComplexityRegistry.fs
@@ -93,6 +93,8 @@ module ComplexityRegistry =
               ("algebra.mod2", "project"), c "O(word)" "O(1)" Derived // THE MISSING PIECE: Z -> Z/2, order forgotten, parity kept — the adapter that snaps braid-out into adinkra-in
               ("shape.adinkra", "draw"), c "O(E)" "O(E)" Derived // one stroke per drawn edge (24 on the flat grid); dashing lookup is O(1) per edge
               ("shape.exchange-worldlines", "draw"), c "O(crossings·strands)" "O(strands)" Derived // the braid drawn as spacetime: strands + one event diamond per exchange
+              ("shape.kitaev-chain", "draw"), c "O(sites)" "O(sites)" Derived // two panels, one arc per pairing; the end modes are the two strokes the topological panel leaves unpaired
+              ("shape.crossing", "draw"), c "O(1)" "O(1)" Derived // THE ATOM: two strands, one crossing — constant everything; every braided shape is a word in this generator
               ("binding.html-css", "render"), c "O(entries·pixels)" "O(output)" Derived
               ("sim.wave-interference", "pattern"), c "O(w·h·sources)" "O(w·h)" Derived
               ("viz.adinkra", "render"), c "O(nodes)" "O(nodes)" Derived

--- a/src/Core/GeneratorRegistry.fs
+++ b/src/Core/GeneratorRegistry.fs
@@ -85,6 +85,8 @@ module GeneratorRegistry =
           register "algebra.mod2" 1
           register "shape.adinkra" 1
           register "shape.exchange-worldlines" 1
+          register "shape.kitaev-chain" 1
+          register "shape.crossing" 1
           register "binding.html-css" 1
           register "sim.wave-interference" 1
           register "viz.adinkra" 1

--- a/src/Core/MediaLines.fs
+++ b/src/Core/MediaLines.fs
@@ -214,7 +214,7 @@ module MediaLines =
 
         let dupes =
             d.Entries
-            |> List.filter (fun e -> Set.contains e.Kind knownKinds && e.Kind <> "rom" && e.Kind <> "treaty") // rom repeats per address; treaty repeats per verdict (an oracle may re-ratify over time — the block is a log)
+            |> List.filter (fun e -> Set.contains e.Kind knownKinds && e.Kind <> "rom" && e.Kind <> "treaty" && e.Kind <> "edge") // rom repeats per address; treaty repeats per verdict (a log); edge repeats per target (a node has many edges of one relation — identity is relation+target)
             |> List.groupBy (fun e -> e.Kind, e.Name)
             |> List.filter (fun (_, es) -> List.length es > 1)
             |> List.map (fun ((k, n), _) -> { Kind = k; Name = n; Problem = "duplicate (kind, name)" })

--- a/src/Core/ShapeAcceptance.fs
+++ b/src/Core/ShapeAcceptance.fs
@@ -155,6 +155,25 @@ module ShapeAcceptance =
             let lockedStuck = valid && perm = [| 0; 1; 2 |] && not (Braid.isIdentity 3 word)
             causal && lockedStuck,
             "exchanges causally ordered (|Δx| <= Δt at slope 1/1); the word is the locked+stuck braid — one object, two registers"
+        | "shape-crossing" ->
+            // the atom's three laws, by Artin's faithful action on B2:
+            let ok =
+                not (Braid.isIdentity 2 [ 1 ]) // sigma != 1: the strands really exchange
+                && Braid.isIdentity 2 [ 1; -1 ] // do-undo: the inverse undoes exactly
+                && not (Braid.isIdentity 2 [ 1; 1 ]) // memory at its smallest: sigma^2 != 1
+            ok, "sigma != 1; sigma·sigma⁻¹ = 1; sigma² != 1 — the three smallest braid proofs, on the atom"
+        | "shape-kitaev-chain" ->
+            // the render's own accounting must equal the in-file laws: trivial arcs = sites,
+            // topological arcs = sites − 1, unpaired end diamonds = 2 (the memory, drawn).
+            let c name = MediaLines.field "constant" name d |> Option.map int |> Option.defaultValue -1
+            let strokes = ShapeRender.strokesOf d
+            let count prefix = strokes |> List.filter (fun s -> s.Name.StartsWith(prefix: string)) |> List.length
+            let ok =
+                count "t-pair-" = c "sites"
+                && count "k-pair-" = c "sites" - 1
+                && count "end-mode-" = c "end-modes"
+                && c "end-modes" = 2
+            ok, sprintf "drawn accounting holds: %d trivial pairs, %d topological pairs, %d unpaired end modes (the memory)" (count "t-pair-") (count "k-pair-") (count "end-mode-")
         | "shape-adinkra" ->
             // the two laws run live: Gates condition on the standard dashing, and the gauge lemma
             // (a deterministic vertex walk changes the dashing, never the face parity).

--- a/src/Core/ShapeRender.fs
+++ b/src/Core/ShapeRender.fs
@@ -190,6 +190,52 @@ module ShapeRender =
                     Name = sprintf "event-%d" i
                     Mask = 7uy
                     Points = [ ex, ey - r; ex + r, ey; ex, ey + r; ex - r, ey; ex, ey - r ] } ]
+        | "shape-crossing" ->
+            // THE ATOM: two strands, one crossing. Drawn big and alone — the whole figure is the
+            // lesson (over keeps its line; under carries the gap; the sign decides which).
+            let c = MediaLines.field "constant" "word" d |> Option.bind (fun s -> match System.Int32.TryParse s with | true, v -> Some v | _ -> None) |> Option.defaultValue 1
+            let xL, xR = 24, 40
+            let top, bot = 6, 26
+            let overLeft = c > 0 // positive: the LEFT strand crosses over
+            let diag (x0: int) (y0: int) (x1: int) (y1: int) (gapped: bool) (name: string) (mask: byte) =
+                let p0, p1 = pt x0 y0, pt x1 y1
+                if not gapped then
+                    [ { Dash = false; Name = name; Mask = mask; Points = [ p0; p1 ] } ]
+                else
+                    let (ax, ay), (bx, by) = p0, p1
+                    [ { Dash = false; Name = name; Mask = mask; Points = [ p0; (ax + (bx - ax) * 2 / 5, ay + (by - ay) * 2 / 5) ] }
+                      { Dash = false; Name = name + "-r1"; Mask = mask; Points = [ (ax + (bx - ax) * 3 / 5, ay + (by - ay) * 3 / 5); p1 ] } ]
+            diag xL top xR bot (not overLeft) "strand-0" 1uy
+            @ diag xR top xL bot overLeft "strand-1" 4uy
+        | "shape-kitaev-chain" ->
+            // two panels of the same chain: TOP = trivial (intra-site pairing — tidy, unprotected),
+            // BOTTOM = topological (inter-site pairing — two END MODES left unpaired: the memory,
+            // drawn bright). A site is two Majorana-mode dots (left/right); a pairing is a chevron
+            // arc joining two dots; the unpaired end modes get small bright diamonds.
+            let sites = constInt "sites" 8
+            let dotX site mode = 6 + site * 7 + mode * 3 // mode 0 = left, 1 = right (court cells)
+            let modeDot (x: int) (y: int) (name: string) (mask: byte) =
+                { Dash = false; Name = name; Mask = mask; Points = [ pt x y; pt x (y + 1) ] }
+            let arc (x0: int) (x1: int) (y: int) (name: string) (mask: byte) =
+                { Dash = false; Name = name; Mask = mask
+                  Points = [ pt x0 y; pt ((x0 + x1) / 2) (y - 2); pt x1 y ] }
+            [ // trivial panel (rows ~8): each site pairs its OWN two modes
+              for s in 0 .. sites - 1 do
+                  yield modeDot (dotX s 0) 8 (sprintf "t-mode-%d-l" s) 2uy
+                  yield modeDot (dotX s 1) 8 (sprintf "t-mode-%d-r" s) 2uy
+                  yield arc (dotX s 0) (dotX s 1) 8 (sprintf "t-pair-%d" s) 6uy
+              // topological panel (rows ~22): right mode of site s pairs LEFT mode of site s+1
+              for s in 0 .. sites - 1 do
+                  yield modeDot (dotX s 0) 22 (sprintf "k-mode-%d-l" s) 4uy
+                  yield modeDot (dotX s 1) 22 (sprintf "k-mode-%d-r" s) 4uy
+              for s in 0 .. sites - 2 do
+                  yield arc (dotX s 1) (dotX (s + 1) 0) 22 (sprintf "k-pair-%d" s) 6uy
+              // THE MEMORY: the two unpaired end modes, marked with bright diamonds
+              for (name, x) in [ "end-mode-left", dotX 0 0; "end-mode-right", dotX (sites - 1) 1 ] do
+                  let cx, cy = pt x 22
+                  yield
+                      { Dash = true; Name = name; Mask = 7uy
+                        Points = [ cx, cy - 6; cx + 6, cy; cx, cy + 6; cx - 6, cy; cx, cy - 6 ] } ]
         | "shape-buckyball" ->
             // Addison's two views, schematic and honest: INSIDE reads like a soccer ball (central
             // pentagon room, hexagon ring, a bounding circle); OUTSIDE is almost the same drawing

--- a/tests/Tests.FSharp/ShapeAcceptance.Tests.fs
+++ b/tests/Tests.FSharp/ShapeAcceptance.Tests.fs
@@ -19,7 +19,7 @@ let private docOf (name: string) =
     | Ok d -> d
     | Error e -> failwith e
 
-let private shapes = [ "spiral"; "braid"; "worldline"; "lightcone"; "fourcorner"; "seam"; "buckyball"; "shadow-loop"; "plait-move"; "adinkra"; "exchange-worldlines" ]
+let private shapes = [ "spiral"; "braid"; "worldline"; "lightcone"; "fourcorner"; "seam"; "buckyball"; "shadow-loop"; "plait-move"; "adinkra"; "exchange-worldlines"; "kitaev-chain"; "crossing" ]
 
 [<Fact>]
 let ``THE HARD GATE: every catalog shape is accepted on bytes+geometry+honest-labels — never on looks, never on meaning`` () =

--- a/tests/Tests.FSharp/ShapeCartridge.Tests.fs
+++ b/tests/Tests.FSharp/ShapeCartridge.Tests.fs
@@ -57,7 +57,7 @@ let private catalog () =
 [<Fact>]
 let ``THE CATALOG LAW: every cartridge parses, lints clean, resolves its gen on the shelf, and carries its own treaty block`` () =
     let all = catalog ()
-    Assert.Equal(11, Array.length all) // + buckyball + shadow-loop + plait-move + adinkra + exchange-worldlines (the anyon picture)
+    Assert.Equal(13, Array.length all) // + exchange-worldlines + kitaev-chain + crossing (THE ATOM - the braided family generator)
     for name, d in all do
         Assert.True(List.isEmpty (MediaLines.lint d), name + " must lint clean")
         // every gen line's ZetaId resolves to a REGISTERED generator (DI by ZetaId, working)


### PR DESCRIPTION
Kitaev chain: two panels, one difference — where the leftovers are (two unpaired end modes = the memory); four in-file laws; acceptance counts the drawn arcs against them. Crossing: the braided family's generator with the three smallest proofs as laws (σ≠1, do-undo, σ²≠1); composed-of edges on plait-move/braid/exchange-worldlines. Answers Aaron's canonical/simplicity/composition questions — the worldline figure is the standard TQC picture (event diamonds are our labeled addition); large shapes are words; the alphabet is stocked. 2989 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)