### PR TITLE
feat(render): shapes draw themselves tick by tick (pure CSS) + SoftValue/DynamicValue ladder + primitive treaty list

### DIFF
--- a/docs/research/2026-06-12-softvalue-dynamicvalue-on-the-court-how-much-fits-chip8-vs-chip9-vs-deep-pixel-and-the-primitive-treaty-list.md
+++ b/docs/research/2026-06-12-softvalue-dynamicvalue-on-the-court-how-much-fits-chip8-vs-chip9-vs-deep-pixel-and-the-primitive-treaty-list.md
@@ -1,0 +1,65 @@
+# SoftValue / DynamicValue on the court — how much fits CHIP-8 vs CHIP-9 vs deep pixel; the primitive treaty list
+
+Aaron 2026-06-12: "is it possible to visualize DynamicValue and SoftValue, and how much of that
+can make it inside chip8? chip9 I assume more, with capability upgrades. Also the primitive list
+— ours, our wish list, and dotnet and cross-language primitives in treaty."
+
+## SoftValue on the court (the ladder, honest at every rung)
+
+SoftValue = (value, confidence). The display ladder:
+
+| rung | channel budget | what a SoftValue looks like | honest limit |
+|---|---|---|---|
+| **CHIP-8 (mono)** | 1 bit/cell | the VALUE only — lit or unlit; confidence has NO channel | the zero case: a mono consumer sees the value and nothing else (it cannot even know it is missing confidence — which is why mono consumers must never be fed soft claims as hard) |
+| **CHIP-9 (3 planes)** | 3 bits/cell | value on one plane, confidence QUANTIZED to the remaining levels (bright = sure, dim/mono = unsure — PixelLens.colorize is exactly this projection) | 8 levels total; confidence gets at most 2 bits — a sketch, honestly coarse |
+| **Deep pixel (PixelLens 32-bit)** | 3+13+16 bits | the FULL SoftValue per cell: color (3) + payload (13) + uncertainty (16, milli) — `softRead` returns (value, confidence) directly | the substrate rung: this IS a SoftValue field; CHIP-9 is its display projection |
+
+So: SoftValue does not "fit inside" CHIP-8 — its VALUE does (the zero case, structural); the
+confidence needs the first capability upgrade (CHIP-9 planes, coarse) and lives fully one rung
+deeper (the deep pixel, which the planes project). The capability ladder IS the visualization
+answer: each upgrade buys channels, and what you cannot carry you must not claim.
+
+## DynamicValue on the court
+
+DynamicValue is a typed TREE (scalars/lists/maps), not a field — so its court form is not pixels
+but STRUCTURE: the treemap (LayoutEngine slice-and-dice — tiles the boundary exactly, value =
+area), the index-format glyphs, and MediaLines itself (a DynamicValue serialization with kinds).
+Named slice: `shape-dynamicvalue` — a small tree drawn as a treemap with constants stating the
+tree, in-file law = areas sum exactly to the court (integer tiling, provable). SoftValue ENTERS
+DynamicValue as the deep-pixel payload does: any node may carry (value, confidence) — rendered as
+brightness over the tile (the same colorize law, lifted from pixels to tiles).
+
+## Animation (landed this PR)
+
+Every cartridge's HTML now DRAWS ITSELF tick by tick — pure CSS (stroke-dashoffset keyframes,
+per-stroke integer delays in document order = the generator's order), zero JavaScript (the
+HtmlCssBinding law holds; the no-script test still passes on all 13). Semantically-dashed strokes
+(the sign register) fade in instead — the two meanings never fight over one attribute. Hover
+brightens a stroke (JS-free interactivity); prefers-reduced-motion is honored (consent-first at
+the CSS layer — the traveler's motion preference is a boundary). The SVG golden stays the STATIC
+truth; animation is the HTML projection's layer.
+
+## The primitive treaty list (where it lives, what's missing)
+
+- **The ledger:** `docs/PRIMITIVE-REGISTRY.md` — the standing source of truth for which
+  primitives exist in which oracle languages and their golden-vector status. This doc does not
+  duplicate it (DV2: one hub).
+- **Already cross-language in-tree** (by the src/ layout): DynamicValue (C#/Rust/TS), TriBoolean
+  (C#/F#/Rust/TS), ZetaId, Sha256/Blake3, Merkle, RangeSet, Metric, Clock, Resume, Observe,
+  FourCorner (Rust), SoftValue (Rust), CHIP-9 (all four — the ratified treaty).
+- **The wish list (treaty-pending, from this stream):** SoftValue to all four (Rust-only today —
+  the deep-pixel ladder above needs it everywhere); MediaLines parsers (TS/C#/Rust — the named
+  slice; the cartridges are the database default atom); ShapeRender conformance (the SVG goldens
+  are the treaty surface, first-run byte-lock); CartridgeLaw evaluator (a screen of code per
+  language, by design); TimeGen (structure-level treaty; float kernels stay outside the
+  byte-lock); Braid (exact integers — byte-lockable as-is); the chip9 cartridge LOADER (.lines
+  into the machine — the homoiconic close).
+- Process: each wish-list row enters via the backlog start gate; goldens locked by F# first, the
+  other oracles conform first-run (the standing discipline).
+
+## Pointers
+
+- PixelLens (softRead/colorize — the ladder's middle rungs) · LayoutEngine (the DynamicValue
+  court form) · ShapeRender.toHtml (the animation layer) · docs/PRIMITIVE-REGISTRY.md (the ledger)
+- Named slices: shape-dynamicvalue (treemap, integer-tiling law) · shape-softvalue (the ladder
+  drawn: one value at three rungs) · MediaLines + ShapeRender oracle ports

--- a/shapes/golden/adinkra.html
+++ b/shapes/golden/adinkra.html
@@ -16,6 +16,34 @@
     }
     body { background: #101418; margin: 0; display: grid; place-items: center; min-height: 100vh; }
     svg { width: min(96vw, 960px); image-rendering: pixelated; }
+    @keyframes draw { to { stroke-dashoffset: 0; } }
+    @keyframes appear { to { opacity: 1; } }
+    polyline:hover { stroke-width: 7; filter: brightness(1.6); }
+    @media (prefers-reduced-motion: reduce) { polyline { animation: none !important; stroke-dashoffset: 0 !important; opacity: 1 !important; } }
+    #edge-0-0 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 0ms forwards; }
+    #edge-1-1 { opacity: 0; animation: appear 400ms linear 180ms forwards; }
+    #edge-2-0 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 360ms forwards; }
+    #edge-4-0 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 540ms forwards; }
+    #edge-5-1 { opacity: 0; animation: appear 400ms linear 720ms forwards; }
+    #edge-6-0 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 900ms forwards; }
+    #edge-12-0 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 1080ms forwards; }
+    #edge-13-1 { opacity: 0; animation: appear 400ms linear 1260ms forwards; }
+    #edge-14-0 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 1440ms forwards; }
+    #edge-8-0 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 1620ms forwards; }
+    #edge-9-1 { opacity: 0; animation: appear 400ms linear 1800ms forwards; }
+    #edge-10-0 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 1980ms forwards; }
+    #edge-0-2 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 2160ms forwards; }
+    #edge-1-2 { opacity: 0; animation: appear 400ms linear 2340ms forwards; }
+    #edge-3-2 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 2520ms forwards; }
+    #edge-2-2 { opacity: 0; animation: appear 400ms linear 2700ms forwards; }
+    #edge-4-3 { opacity: 0; animation: appear 400ms linear 2880ms forwards; }
+    #edge-5-3 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 3060ms forwards; }
+    #edge-7-3 { opacity: 0; animation: appear 400ms linear 3240ms forwards; }
+    #edge-6-3 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 3420ms forwards; }
+    #edge-8-2 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 3600ms forwards; }
+    #edge-9-2 { opacity: 0; animation: appear 400ms linear 3780ms forwards; }
+    #edge-11-2 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 3960ms forwards; }
+    #edge-10-2 { opacity: 0; animation: appear 400ms linear 4140ms forwards; }
   </style>
 </head>
 <body>

--- a/shapes/golden/braid.html
+++ b/shapes/golden/braid.html
@@ -16,6 +16,19 @@
     }
     body { background: #101418; margin: 0; display: grid; place-items: center; min-height: 100vh; }
     svg { width: min(96vw, 960px); image-rendering: pixelated; }
+    @keyframes draw { to { stroke-dashoffset: 0; } }
+    @keyframes appear { to { opacity: 1; } }
+    polyline:hover { stroke-width: 7; filter: brightness(1.6); }
+    @media (prefers-reduced-motion: reduce) { polyline { animation: none !important; stroke-dashoffset: 0 !important; opacity: 1 !important; } }
+    #strand-0 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 0ms forwards; }
+    #strand-0-r1 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 180ms forwards; }
+    #strand-0-r2 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 360ms forwards; }
+    #strand-1 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 540ms forwards; }
+    #strand-1-r1 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 720ms forwards; }
+    #strand-1-r2 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 900ms forwards; }
+    #strand-2 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 1080ms forwards; }
+    #strand-2-r1 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 1260ms forwards; }
+    #strand-2-r2 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 1440ms forwards; }
   </style>
 </head>
 <body>

--- a/shapes/golden/buckyball.html
+++ b/shapes/golden/buckyball.html
@@ -16,6 +16,24 @@
     }
     body { background: #101418; margin: 0; display: grid; place-items: center; min-height: 100vh; }
     svg { width: min(96vw, 960px); image-rendering: pixelated; }
+    @keyframes draw { to { stroke-dashoffset: 0; } }
+    @keyframes appear { to { opacity: 1; } }
+    polyline:hover { stroke-width: 7; filter: brightness(1.6); }
+    @media (prefers-reduced-motion: reduce) { polyline { animation: none !important; stroke-dashoffset: 0 !important; opacity: 1 !important; } }
+    #inside-room { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 0ms forwards; }
+    #inside-bound { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 180ms forwards; }
+    #door-0 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 360ms forwards; }
+    #door-1 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 540ms forwards; }
+    #door-2 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 720ms forwards; }
+    #door-3 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 900ms forwards; }
+    #door-4 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 1080ms forwards; }
+    #self-door { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 1260ms forwards; }
+    #outside-room { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 1440ms forwards; }
+    #ray-0 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 1620ms forwards; }
+    #ray-1 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 1800ms forwards; }
+    #ray-2 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 1980ms forwards; }
+    #ray-3 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 2160ms forwards; }
+    #ray-4 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 2340ms forwards; }
   </style>
 </head>
 <body>

--- a/shapes/golden/crossing.html
+++ b/shapes/golden/crossing.html
@@ -16,6 +16,13 @@
     }
     body { background: #101418; margin: 0; display: grid; place-items: center; min-height: 100vh; }
     svg { width: min(96vw, 960px); image-rendering: pixelated; }
+    @keyframes draw { to { stroke-dashoffset: 0; } }
+    @keyframes appear { to { opacity: 1; } }
+    polyline:hover { stroke-width: 7; filter: brightness(1.6); }
+    @media (prefers-reduced-motion: reduce) { polyline { animation: none !important; stroke-dashoffset: 0 !important; opacity: 1 !important; } }
+    #strand-0 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 0ms forwards; }
+    #strand-1 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 180ms forwards; }
+    #strand-1-r1 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 360ms forwards; }
   </style>
 </head>
 <body>

--- a/shapes/golden/exchange-worldlines.html
+++ b/shapes/golden/exchange-worldlines.html
@@ -16,6 +16,25 @@
     }
     body { background: #101418; margin: 0; display: grid; place-items: center; min-height: 100vh; }
     svg { width: min(96vw, 960px); image-rendering: pixelated; }
+    @keyframes draw { to { stroke-dashoffset: 0; } }
+    @keyframes appear { to { opacity: 1; } }
+    polyline:hover { stroke-width: 7; filter: brightness(1.6); }
+    @media (prefers-reduced-motion: reduce) { polyline { animation: none !important; stroke-dashoffset: 0 !important; opacity: 1 !important; } }
+    #worldline-0 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 0ms forwards; }
+    #worldline-0-r1 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 180ms forwards; }
+    #worldline-0-r2 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 360ms forwards; }
+    #worldline-1 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 540ms forwards; }
+    #worldline-1-r1 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 720ms forwards; }
+    #worldline-1-r2 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 900ms forwards; }
+    #worldline-2 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 1080ms forwards; }
+    #worldline-2-r1 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 1260ms forwards; }
+    #worldline-2-r2 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 1440ms forwards; }
+    #event-0 { opacity: 0; animation: appear 400ms linear 1620ms forwards; }
+    #event-1 { opacity: 0; animation: appear 400ms linear 1800ms forwards; }
+    #event-2 { opacity: 0; animation: appear 400ms linear 1980ms forwards; }
+    #event-3 { opacity: 0; animation: appear 400ms linear 2160ms forwards; }
+    #event-4 { opacity: 0; animation: appear 400ms linear 2340ms forwards; }
+    #event-5 { opacity: 0; animation: appear 400ms linear 2520ms forwards; }
   </style>
 </head>
 <body>

--- a/shapes/golden/fourcorner.html
+++ b/shapes/golden/fourcorner.html
@@ -16,6 +16,12 @@
     }
     body { background: #101418; margin: 0; display: grid; place-items: center; min-height: 100vh; }
     svg { width: min(96vw, 960px); image-rendering: pixelated; }
+    @keyframes draw { to { stroke-dashoffset: 0; } }
+    @keyframes appear { to { opacity: 1; } }
+    polyline:hover { stroke-width: 7; filter: brightness(1.6); }
+    @media (prefers-reduced-motion: reduce) { polyline { animation: none !important; stroke-dashoffset: 0 !important; opacity: 1 !important; } }
+    #corners { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 0ms forwards; }
+    #s-width { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 180ms forwards; }
   </style>
 </head>
 <body>

--- a/shapes/golden/kitaev-chain.html
+++ b/shapes/golden/kitaev-chain.html
@@ -16,6 +16,59 @@
     }
     body { background: #101418; margin: 0; display: grid; place-items: center; min-height: 100vh; }
     svg { width: min(96vw, 960px); image-rendering: pixelated; }
+    @keyframes draw { to { stroke-dashoffset: 0; } }
+    @keyframes appear { to { opacity: 1; } }
+    polyline:hover { stroke-width: 7; filter: brightness(1.6); }
+    @media (prefers-reduced-motion: reduce) { polyline { animation: none !important; stroke-dashoffset: 0 !important; opacity: 1 !important; } }
+    #t-mode-0-l { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 0ms forwards; }
+    #t-mode-0-r { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 180ms forwards; }
+    #t-pair-0 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 360ms forwards; }
+    #t-mode-1-l { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 540ms forwards; }
+    #t-mode-1-r { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 720ms forwards; }
+    #t-pair-1 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 900ms forwards; }
+    #t-mode-2-l { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 1080ms forwards; }
+    #t-mode-2-r { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 1260ms forwards; }
+    #t-pair-2 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 1440ms forwards; }
+    #t-mode-3-l { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 1620ms forwards; }
+    #t-mode-3-r { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 1800ms forwards; }
+    #t-pair-3 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 1980ms forwards; }
+    #t-mode-4-l { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 2160ms forwards; }
+    #t-mode-4-r { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 2340ms forwards; }
+    #t-pair-4 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 2520ms forwards; }
+    #t-mode-5-l { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 2700ms forwards; }
+    #t-mode-5-r { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 2880ms forwards; }
+    #t-pair-5 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 3060ms forwards; }
+    #t-mode-6-l { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 3240ms forwards; }
+    #t-mode-6-r { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 3420ms forwards; }
+    #t-pair-6 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 3600ms forwards; }
+    #t-mode-7-l { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 3780ms forwards; }
+    #t-mode-7-r { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 3960ms forwards; }
+    #t-pair-7 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 4140ms forwards; }
+    #k-mode-0-l { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 4320ms forwards; }
+    #k-mode-0-r { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 4500ms forwards; }
+    #k-mode-1-l { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 4680ms forwards; }
+    #k-mode-1-r { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 4860ms forwards; }
+    #k-mode-2-l { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 5040ms forwards; }
+    #k-mode-2-r { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 5220ms forwards; }
+    #k-mode-3-l { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 5400ms forwards; }
+    #k-mode-3-r { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 5580ms forwards; }
+    #k-mode-4-l { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 5760ms forwards; }
+    #k-mode-4-r { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 5940ms forwards; }
+    #k-mode-5-l { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 6120ms forwards; }
+    #k-mode-5-r { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 6300ms forwards; }
+    #k-mode-6-l { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 6480ms forwards; }
+    #k-mode-6-r { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 6660ms forwards; }
+    #k-mode-7-l { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 6840ms forwards; }
+    #k-mode-7-r { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 7020ms forwards; }
+    #k-pair-0 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 7200ms forwards; }
+    #k-pair-1 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 7380ms forwards; }
+    #k-pair-2 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 7560ms forwards; }
+    #k-pair-3 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 7740ms forwards; }
+    #k-pair-4 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 7920ms forwards; }
+    #k-pair-5 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 8100ms forwards; }
+    #k-pair-6 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 8280ms forwards; }
+    #end-mode-left { opacity: 0; animation: appear 400ms linear 8460ms forwards; }
+    #end-mode-right { opacity: 0; animation: appear 400ms linear 8640ms forwards; }
   </style>
 </head>
 <body>

--- a/shapes/golden/lightcone.html
+++ b/shapes/golden/lightcone.html
@@ -16,6 +16,14 @@
     }
     body { background: #101418; margin: 0; display: grid; place-items: center; min-height: 100vh; }
     svg { width: min(96vw, 960px); image-rendering: pixelated; }
+    @keyframes draw { to { stroke-dashoffset: 0; } }
+    @keyframes appear { to { opacity: 1; } }
+    polyline:hover { stroke-width: 7; filter: brightness(1.6); }
+    @media (prefers-reduced-motion: reduce) { polyline { animation: none !important; stroke-dashoffset: 0 !important; opacity: 1 !important; } }
+    #future-left { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 0ms forwards; }
+    #future-right { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 180ms forwards; }
+    #past-left { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 360ms forwards; }
+    #past-right { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 540ms forwards; }
   </style>
 </head>
 <body>

--- a/shapes/golden/plait-move.html
+++ b/shapes/golden/plait-move.html
@@ -16,6 +16,16 @@
     }
     body { background: #101418; margin: 0; display: grid; place-items: center; min-height: 100vh; }
     svg { width: min(96vw, 960px); image-rendering: pixelated; }
+    @keyframes draw { to { stroke-dashoffset: 0; } }
+    @keyframes appear { to { opacity: 1; } }
+    polyline:hover { stroke-width: 7; filter: brightness(1.6); }
+    @media (prefers-reduced-motion: reduce) { polyline { animation: none !important; stroke-dashoffset: 0 !important; opacity: 1 !important; } }
+    #strand-0 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 0ms forwards; }
+    #strand-0-r1 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 180ms forwards; }
+    #strand-1 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 360ms forwards; }
+    #strand-1-r1 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 540ms forwards; }
+    #strand-2 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 720ms forwards; }
+    #strand-2-r1 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 900ms forwards; }
   </style>
 </head>
 <body>

--- a/shapes/golden/seam.html
+++ b/shapes/golden/seam.html
@@ -16,6 +16,20 @@
     }
     body { background: #101418; margin: 0; display: grid; place-items: center; min-height: 100vh; }
     svg { width: min(96vw, 960px); image-rendering: pixelated; }
+    @keyframes draw { to { stroke-dashoffset: 0; } }
+    @keyframes appear { to { opacity: 1; } }
+    polyline:hover { stroke-width: 7; filter: brightness(1.6); }
+    @media (prefers-reduced-motion: reduce) { polyline { animation: none !important; stroke-dashoffset: 0 !important; opacity: 1 !important; } }
+    #left-cloth { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 0ms forwards; }
+    #right-cloth { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 180ms forwards; }
+    #stitch-0 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 360ms forwards; }
+    #stitch-1 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 540ms forwards; }
+    #stitch-2 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 720ms forwards; }
+    #stitch-3 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 900ms forwards; }
+    #stitch-4 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 1080ms forwards; }
+    #stitch-5 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 1260ms forwards; }
+    #stitch-6 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 1440ms forwards; }
+    #stitch-7 { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 1620ms forwards; }
   </style>
 </head>
 <body>

--- a/shapes/golden/shadow-loop.html
+++ b/shapes/golden/shadow-loop.html
@@ -16,6 +16,12 @@
     }
     body { background: #101418; margin: 0; display: grid; place-items: center; min-height: 100vh; }
     svg { width: min(96vw, 960px); image-rendering: pixelated; }
+    @keyframes draw { to { stroke-dashoffset: 0; } }
+    @keyframes appear { to { opacity: 1; } }
+    polyline:hover { stroke-width: 7; filter: brightness(1.6); }
+    @media (prefers-reduced-motion: reduce) { polyline { animation: none !important; stroke-dashoffset: 0 !important; opacity: 1 !important; } }
+    #loop { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 0ms forwards; }
+    #catch { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 180ms forwards; }
   </style>
 </head>
 <body>

--- a/shapes/golden/spiral.html
+++ b/shapes/golden/spiral.html
@@ -16,6 +16,11 @@
     }
     body { background: #101418; margin: 0; display: grid; place-items: center; min-height: 100vh; }
     svg { width: min(96vw, 960px); image-rendering: pixelated; }
+    @keyframes draw { to { stroke-dashoffset: 0; } }
+    @keyframes appear { to { opacity: 1; } }
+    polyline:hover { stroke-width: 7; filter: brightness(1.6); }
+    @media (prefers-reduced-motion: reduce) { polyline { animation: none !important; stroke-dashoffset: 0 !important; opacity: 1 !important; } }
+    #curve { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 0ms forwards; }
   </style>
 </head>
 <body>

--- a/shapes/golden/worldline.html
+++ b/shapes/golden/worldline.html
@@ -16,6 +16,11 @@
     }
     body { background: #101418; margin: 0; display: grid; place-items: center; min-height: 100vh; }
     svg { width: min(96vw, 960px); image-rendering: pixelated; }
+    @keyframes draw { to { stroke-dashoffset: 0; } }
+    @keyframes appear { to { opacity: 1; } }
+    polyline:hover { stroke-width: 7; filter: brightness(1.6); }
+    @media (prefers-reduced-motion: reduce) { polyline { animation: none !important; stroke-dashoffset: 0 !important; opacity: 1 !important; } }
+    #path { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear 0ms forwards; }
   </style>
 </head>
 <body>

--- a/src/Core/ShapeRender.fs
+++ b/src/Core/ShapeRender.fs
@@ -319,7 +319,32 @@ module ShapeRender =
     let toHtml (d: MediaLines.Doc) : string =
         let name = MediaLines.field "meta" "name" d |> Option.defaultValue "shape"
         let vars = [ for m in 0uy .. 7uy -> sprintf "      --c%d: %s;" m (colorHex m) ] |> String.concat "\n"
-        sprintf "<!doctype html>\n<html lang=\"en\">\n<head>\n  <meta charset=\"utf-8\" />\n  <title>%s</title>\n  <style>\n    :root {\n%s\n    }\n    body { background: #101418; margin: 0; display: grid; place-items: center; min-height: 100vh; }\n    svg { width: min(96vw, 960px); image-rendering: pixelated; }\n  </style>\n</head>\n<body>\n%s</body>\n</html>\n" name vars (toSvg d)
+        // THE DRAW-ON ANIMATION (Aaron 2026-06-12: "animation on our shapes — being drawn tick by
+        // tick — in the html and the svg"): pure CSS, zero JavaScript (the HtmlCssBinding law).
+        // Solid strokes draw themselves via stroke-dashoffset keyframes (StrokeAnim's see-it-draw,
+        // as CSS); strokes are SEQUENCED by per-stroke integer delays (tick by tick — the order is
+        // the document's stroke order, which is the generator's order). Semantically-DASHED
+        // strokes (the sign register) must keep their dasharray, so they FADE in instead — the
+        // two animations never fight over one attribute. Interactivity, also JS-free: hovering a
+        // stroke brightens it and dims nothing else (inspect by eye). The SVG golden stays the
+        // STATIC truth; animation is the HTML projection's layer.
+        let strokes = strokesOf d
+        let perStroke =
+            strokes
+            |> List.mapi (fun i s ->
+                let delay = i * 180 // ms per tick: deterministic, integer, sequential
+                if s.Dash then
+                    sprintf "    #%s { opacity: 0; animation: appear 400ms linear %dms forwards; }" s.Name delay
+                else
+                    sprintf "    #%s { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 600ms linear %dms forwards; }" s.Name delay)
+            |> String.concat "\n"
+        let anim =
+            "    @keyframes draw { to { stroke-dashoffset: 0; } }\n"
+            + "    @keyframes appear { to { opacity: 1; } }\n"
+            + "    polyline:hover { stroke-width: 7; filter: brightness(1.6); }\n"
+            + "    @media (prefers-reduced-motion: reduce) { polyline { animation: none !important; stroke-dashoffset: 0 !important; opacity: 1 !important; } }\n"
+            + perStroke
+        sprintf "<!doctype html>\n<html lang=\"en\">\n<head>\n  <meta charset=\"utf-8\" />\n  <title>%s</title>\n  <style>\n    :root {\n%s\n    }\n    body { background: #101418; margin: 0; display: grid; place-items: center; min-height: 100vh; }\n    svg { width: min(96vw, 960px); image-rendering: pixelated; }\n%s\n  </style>\n</head>\n<body>\n%s</body>\n</html>\n" name vars anim (toSvg d)
 
     /// READ BACK the strict dialect (the bidirectional half) — refuses anything outside it:
     /// script, floats in points, foreign elements. We read their format; we do not import its habits.


### PR DESCRIPTION
Every cartridge's HTML animates: strokes draw on in generator order via stroke-dashoffset keyframes (integer delays), dashed sign-register strokes fade in, hover brightens, reduced-motion honored — zero JavaScript, no-script law intact, SVG goldens stay the static truth. The SoftValue court ladder captured (mono = value only; CHIP-9 planes = coarse confidence; deep pixel = the full pair) + DynamicValue-as-treemap named slice + the primitive treaty wish list anchored to PRIMITIVE-REGISTRY. 2989 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)