### PR TITLE
fix(codeql): authenticate mise release lookups

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -130,6 +130,15 @@ on:
 permissions:
   contents: read
 
+# Workflow-level env: exposes the read-scoped Actions token to
+# tools/setup/common/mise.sh. That script promotes it to
+# MISE_GITHUB_TOKEN and masks the bare GITHUB_TOKEN before running
+# `mise install`, so parallel CodeQL jobs use authenticated release
+# metadata calls instead of exhausting GitHub's anonymous 60/hr
+# quota.
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 concurrency:
   # PR force-push supersedes the previous run. Schedule runs
   # carry a distinct ref (`refs/heads/main` on cron) so they


### PR DESCRIPTION
## Summary
- expose the workflow-scoped Actions token to the CodeQL workflow environment
- let tools/setup/common/mise.sh promote that token to MISE_GITHUB_TOKEN during mise install
- prevent the C# CodeQL leg from exhausting anonymous GitHub API quota while fetching release metadata

## Root cause
The latest main CodeQL run failed in the C# leg before analysis. `./tools/setup/install.sh` invoked `mise install` without any GitHub token in the environment, so mise/aqua used anonymous release metadata calls and hit the 60/hr GitHub API limit.

## Validation
- mise exec -- actionlint .github/workflows/codeql.yml
- git diff --check origin/main..HEAD