### PR TITLE
docs(shapes): spiral + animation ratified ('perfect!!') + stale issue-count pin fixed

### DIFF
--- a/shapes/cartridges/spiral.lines
+++ b/shapes/cartridges/spiral.lines
@@ -13,5 +13,6 @@ anim	draw	curve
 # treaties — each cartridge carries its own (oracle, register, verdict); written only by the oracle's
 # own choice (consent first). bytes = language-oracle lock; meaning = a traveler's ratification from
 # their own reference frame (dissent is a verdict, not a failure).
+treaty	aaron	meaning	ratified	"perfect!!" — the corrected spiral, ratified through the render loop 2026-06-12 (the same eye that caught its escape signs off its fix — the full circle of the paradigm)
 treaty	fsharp	bytes	ratified	tests green @ shapes suite
 treaty	otto	meaning	ratified	the turn-1/12 clock face matches the intent I built against — my own frame, my own choice

--- a/tests/Tests.FSharp/ShapeAcceptance.Tests.fs
+++ b/tests/Tests.FSharp/ShapeAcceptance.Tests.fs
@@ -104,7 +104,7 @@ let ``the self-description kinds carry: prereqs point somewhere, edges name the 
     let d = docOf "buckyball"
     Assert.Equal(3, List.length (MediaLines.ofKind "prereq" d))
     Assert.Equal(3, List.length (MediaLines.ofKind "edge" d))
-    Assert.Equal(2, List.length (MediaLines.ofKind "issue" d)) // schlegel projection + the owed tear-down
+    Assert.Equal(3, List.length (MediaLines.ofKind "issue" d)) // schlegel (open) + tear-down (closed) + ray-overshoot (closed, THE COURT LAW's second catch)
     Assert.Contains(("math-team", "math", "pending"), MediaLines.treatiesOf d)
     Assert.Empty(MediaLines.lint d) // all of it lints clean (structure checked, future kinds silent)
 


### PR DESCRIPTION
Aaron's ratification of the corrected spiral and the draw-on animation, verbatim in the treaty block — the eye that caught the escape signed off the fix. Plus the buckyball issue-count pin updated (2→3, the ray-overshoot line; stale-binary pass during #7758 disclosed). 2989 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)