### PR TITLE
feat(dst): THE DETERMINISM LINT — and its first three catches (OrSet unseeded tags, Consensus wall-clock votes)

### DIFF
--- a/src/Core/Consensus.fs
+++ b/src/Core/Consensus.fs
@@ -79,7 +79,12 @@ module Consensus =
         | Ok of RoundState<'T>
         | InvalidTransition of reason: string
 
-    let transition<'T when 'T: equality>
+    /// The DST-clean transition: `now` is INJECTED (determinism-lint finding 2026-06-12 — votes
+    /// were stamping ambient DateTimeOffset.UtcNow inside Core; replay could never reproduce a
+    /// round byte-for-byte). Simulation and golden paths use this; the treaty's byte-locked
+    /// decision core (quorumThreshold/decide) never read the clock at all.
+    let transitionAt<'T when 'T: equality>
+        (now: DateTimeOffset)
         (state: RoundState<'T>)
         (msg: Message<'T>)
         : TransitionResult<'T> =
@@ -101,7 +106,7 @@ module Consensus =
                 let vote =
                     { Node = voter
                       Value = value
-                      Timestamp = DateTimeOffset.UtcNow }
+                      Timestamp = now }
                 Ok { state with Votes = vote :: state.Votes }
         | Voting, Finalize ->
             let result = decide state.Votes
@@ -114,6 +119,11 @@ module Consensus =
             InvalidTransition "cannot finalize before proposal"
         | Voting, Propose _ ->
             InvalidTransition "cannot propose during voting"
+
+    /// The AMBIENT transition (wall-clock edge): convenience for interactive paths; stamps
+    /// DateTimeOffset.UtcNow. Non-replayable by construction — DST paths use `transitionAt`.
+    let transition<'T when 'T: equality> (state: RoundState<'T>) (msg: Message<'T>) : TransitionResult<'T> =
+        transitionAt DateTimeOffset.UtcNow state msg
 
     type MergeVerdict =
         | Merge
@@ -137,13 +147,22 @@ module Consensus =
         else
             Merge
 
-    let prToVote
+    /// DST-clean: timestamp injected (see transitionAt).
+    let prToVoteAt
+        (now: DateTimeOffset)
         (node: NodeId)
         (pr: PrGateState)
         : Vote<MergeVerdict> =
         { Node = node
           Value = evaluateGate pr
-          Timestamp = DateTimeOffset.UtcNow }
+          Timestamp = now }
+
+    /// Ambient wall-clock edge (interactive paths only).
+    let prToVote
+        (node: NodeId)
+        (pr: PrGateState)
+        : Vote<MergeVerdict> =
+        prToVoteAt DateTimeOffset.UtcNow node pr
 
     let prConsensus
         (nodes: NodeId list)

--- a/src/Core/Crdt.fs
+++ b/src/Core/Crdt.fs
@@ -94,9 +94,18 @@ type OrSet<'T when 'T : comparison> = { Entries: ZSet<'T * Guid> }
 with
     static member Empty : OrSet<'T> = { Entries = ZSet<'T * Guid>.Empty }
 
-    member this.Add(elem: 'T) : OrSet<'T> =
-        let tag = Guid.NewGuid()
+    /// Add with a CALLER-SUPPLIED tag — the DST-clean path: derive the tag from your seeded
+    /// source (TimeGen/SplitMix fold into a Guid) so replay reproduces the same tag and OrSet
+    /// states byte-lock. Uniqueness is the caller's contract (seeded streams give it for free).
+    member this.Add(elem: 'T, tag: Guid) : OrSet<'T> =
         { Entries = ZSet.add this.Entries (ZSet.ofSeq [ (elem, tag), 1L ]) }
+
+    /// Add with an AMBIENT tag (Guid.NewGuid) — the wall-clock edge: convenient, UNIQUE, and
+    /// NON-REPLAYABLE (determinism-lint finding 2026-06-12: an unseeded tag inside Core meant
+    /// OrSet could never byte-lock under DST). Fine at interactive edges; simulation and
+    /// golden-vector paths MUST use the seeded overload above.
+    member this.Add(elem: 'T) : OrSet<'T> =
+        this.Add(elem, Guid.NewGuid())
 
     /// Remove: retract every `(elem, tag)` the local replica currently
     /// observes for `elem`. Merges with concurrent adds are preserved.

--- a/tests/Tests.FSharp/DeterminismLint.Tests.fs
+++ b/tests/Tests.FSharp/DeterminismLint.Tests.fs
@@ -1,0 +1,72 @@
+module Zeta.Tests.DeterminismLintTests
+
+// THE DETERMINISM LINT (Aaron 2026-06-12: "are we using `pure` in F# everywhere so the compiler
+// checks deterministic simulation?"). The honest answer: F# has no `pure` — no effect system, no
+// compiler enforcement; immutability is a default, not a guarantee. This test is the enforcement
+// we CAN have at build time: every source of ambient nondeterminism in src/Core must be either
+// ABSENT or on the allowlist below with a WHY (a named edge). A new unseeded Random / wall clock /
+// NewGuid / Stopwatch in Core fails the build — the lint is the `pure` we get to write ourselves.
+// (The behavioral half of enforcement stays where it always was: DST replay + golden vectors.)
+
+open System.IO
+open global.Xunit
+
+let private repoRoot () =
+    let mutable dir = DirectoryInfo(System.AppContext.BaseDirectory)
+    while not (isNull dir) && not (File.Exists(Path.Combine(dir.FullName, "Zeta.sln"))) do
+        dir <- dir.Parent
+    dir.FullName
+
+/// The banned ambient-entropy patterns (substring match per line, comments included on purpose —
+/// a commented-out wall clock is a wall clock waiting to return).
+let private banned =
+    [ "Guid.NewGuid"; "DateTime.Now"; "DateTime.UtcNow"; "DateTimeOffset.Now"; "DateTimeOffset.UtcNow"
+      "Random.Shared"; "new Random()"; "System.Random()"; "Stopwatch.StartNew"; "Stopwatch.GetTimestamp"
+      "Environment.TickCount" ]
+
+/// The NAMED EDGES: (file, pattern) pairs allowed to exist, each with its why. Adding a new edge
+/// means adding a row HERE, with a reason a reviewer can refuse.
+let private allowlist =
+    [ // the wall-clock door itself: the ONE place ambient time/entropy is abstracted behind IEnvironment
+      "Environment.fs", "DateTime.UtcNow", "the docstring NAMES the ambient sources this interface fences off"
+      "Environment.fs", "Guid.NewGuid", "the ambient implementation of IEnvironment.NewGuid — the fenced door"
+      "Environment.fs", "Random.Shared", "docstring reference to what is being fenced"
+      "Environment.fs", "Environment.TickCount", "the ambient implementation of IEnvironment.Ticks"
+      // seeded by construction: System.Random(seed + i) — deterministic per seed, the LawRunner contract
+      "LawRunner.fs", "System.Random(", "every instance is seeded (seed + sampleIndex); reproducible by design"
+      // IO-infrastructure edges: temp-file / instance names (affect disk layout, never logical state)
+      "Checkpoint.fs", "Guid.NewGuid", "tmp-file suffix for atomic rename — IO edge, not logical state"
+      "DiskSpine.fs", "Guid.NewGuid", "per-instance disk prefix — IO edge, not logical state"
+      "DiskSpineAsync.fs", "Guid.NewGuid", "per-instance disk prefix — IO edge, not logical state"
+      // interactive-edge convenience overload, documented as non-replayable; seeded overload exists
+      "Crdt.fs", "Guid.NewGuid", "OrSet.Add ambient overload — documented wall-clock edge; the seeded Add(elem, tag) is the DST path"
+      // the ambient wall-clock EDGES of consensus (the DST paths are transitionAt/prToVoteAt)
+      "Consensus.fs", "DateTimeOffset.UtcNow", "two documented ambient wrappers (transition/prToVote); injected -At variants are the DST paths"
+      "Environment.fs", "DateTimeOffset.UtcNow", "the ambient implementation of IEnvironment.Now — the fenced door"
+      "Injection.fs", "DateTimeOffset.UtcNow", "wall-time instrumentation at the injection edge — observability only"
+      // timing instrumentation at the injection boundary (observability, not logic)
+      "Injection.fs", "Stopwatch.StartNew", "wall-time instrumentation at the injection edge — observability only" ]
+
+[<Fact>]
+let ``THE DETERMINISM LINT: no ambient entropy in src/Core outside the named, justified edges`` () =
+    let core = Path.Combine(repoRoot (), "src", "Core")
+    let violations =
+        [ for file in Directory.GetFiles(core, "*.fs") do
+              let name = Path.GetFileName file
+              let lines = File.ReadAllLines file
+              for i in 0 .. lines.Length - 1 do
+                  for pat in banned do
+                      if lines.[i].Contains pat then
+                          let allowed = allowlist |> List.exists (fun (f, p, _) -> f = name && pat.StartsWith p || (f = name && lines.[i].Contains p))
+                          if not allowed then
+                              yield sprintf "%s:%d uses '%s' — ambient entropy in Core; seed it, fence it behind IEnvironment, or add a justified allowlist row" name (i + 1) pat ]
+    Assert.True(List.isEmpty violations, String.concat "\n" violations)
+
+[<Fact>]
+let ``the allowlist rows all still exist — a stale exemption is a hole waiting for a new occupant`` () =
+    let core = Path.Combine(repoRoot (), "src", "Core")
+    for (file, pat, _why) in allowlist do
+        let path = Path.Combine(core, file)
+        Assert.True(File.Exists path, file + " vanished — remove its allowlist rows")
+        let contains = (File.ReadAllText path).Contains pat
+        Assert.True(contains, sprintf "%s no longer contains '%s' — remove the stale allowlist row" file pat)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -179,6 +179,7 @@
     <Compile Include="HtmlCssBinding.Tests.fs" />
     <Compile Include="ShapeCartridge.Tests.fs" />
     <Compile Include="ShapeAcceptance.Tests.fs" />
+    <Compile Include="DeterminismLint.Tests.fs" />
     <Compile Include="WaveSim.Tests.fs" />
     <Compile Include="AdinkraViz.Tests.fs" />
     <Compile Include="SpectralPivot.Tests.fs" />


### PR DESCRIPTION
F# has no `pure`, so the lint is the enforcement we get to write: ambient entropy in src/Core fails the build unless it's a named, justified edge (with a stale-exemption guard). First catches fixed in-PR: OrSet's unseeded Guid tags (seeded overload = the DST path), Consensus's ambient vote timestamps (transitionAt/prToVoteAt injected; goldens already scoped timestamps out — no treaty breakage). 2992 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)