### PR TITLE
feat(qsharp): add TypeScript quantum-circuit oracle

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,7 @@
         "markdownlint-cli2": "0.22.1",
         "prettier": "3.8.3",
         "prettier-plugin-toml": "2.0.6",
+        "quantum-circuit": "0.9.247",
         "semver": "7.8.1",
         "stylelint": "17.12.0",
         "stylelint-config-standard": "40.0.0",
@@ -180,6 +181,8 @@
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
+    "antlr4": ["antlr4@4.7.2", "", {}, "sha512-vZA1xYufXLe3LX+ja9rIVxjRmILb1x3k7KYZHltRbfJtXjJ1DlFIqt+CbPYmghx0EuzY9DajiDw+MdyEt1qAsQ=="],
+
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "astral-regex": ["astral-regex@2.0.0", "", {}, "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="],
@@ -218,6 +221,8 @@
 
     "commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
+    "complex.js": ["complex.js@2.4.3", "", {}, "sha512-UrQVSUur14tNX6tiP4y8T4w4FeJAX3bi2cIv0pu/DTLFNxoq7z2Yh83Vfzztj6Px3X/lubqQ9IrPp7Bpn6p4MQ=="],
+
     "cosmiconfig": ["cosmiconfig@9.0.2", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
@@ -229,6 +234,8 @@
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
 
@@ -245,6 +252,8 @@
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
     "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
+
+    "escape-latex": ["escape-latex@1.2.0", "", {}, "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
@@ -291,6 +300,8 @@
     "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
 
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
+
+    "fraction.js": ["fraction.js@4.3.7", "", {}, "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew=="],
 
     "functional-red-black-tree": ["functional-red-black-tree@1.0.1", "", {}, "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g=="],
 
@@ -348,6 +359,8 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "javascript-natural-sort": ["javascript-natural-sort@0.7.1", "", {}, "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw=="],
+
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
@@ -393,6 +406,8 @@
     "markdownlint-cli2": ["markdownlint-cli2@0.22.1", "", { "dependencies": { "globby": "16.2.0", "js-yaml": "4.1.1", "jsonc-parser": "3.3.1", "jsonpointer": "5.0.1", "markdown-it": "14.1.1", "markdownlint": "0.40.0", "markdownlint-cli2-formatter-default": "0.0.6", "micromatch": "4.0.8", "smol-toml": "1.6.1" }, "bin": { "markdownlint-cli2": "markdownlint-cli2-bin.mjs" } }, "sha512-X14ZbytybDCXAViDmtN4DKLt9ZTrRn+oOrxTYlg3a65jS6QcYYbAkGPh/En2L/GDNbFYJ6lKaQSUNrrbN1bPrw=="],
 
     "markdownlint-cli2-formatter-default": ["markdownlint-cli2-formatter-default@0.0.6", "", { "peerDependencies": { "markdownlint-cli2": ">=0.0.4" } }, "sha512-VVDGKsq9sgzu378swJ0fcHfSicUnMxnL8gnLm/Q4J/xsNJ4e5bA6lvAz7PCzIl0/No0lHyaWdqVD2jotxOSFMQ=="],
+
+    "mathjs": ["mathjs@6.6.5", "", { "dependencies": { "complex.js": "^2.0.11", "decimal.js": "^10.2.0", "escape-latex": "^1.2.0", "fraction.js": "^4.0.12", "javascript-natural-sort": "^0.7.1", "seed-random": "^2.2.0", "tiny-emitter": "^2.1.0", "typed-function": "^1.1.1" }, "bin": { "mathjs": "bin/cli.js" } }, "sha512-jvRqk7eoEHBcx/lskmy05m+8M7xDHAJcJzRJoqIsqExtlTHPDQO0Zv85g5F0rasDAXF+DLog/70hcqCJijSzPQ=="],
 
     "mathml-tag-names": ["mathml-tag-names@4.0.0", "", {}, "sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ=="],
 
@@ -534,6 +549,8 @@
 
     "qified": ["qified@0.10.1", "", { "dependencies": { "hookified": "^2.1.1" } }, "sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA=="],
 
+    "quantum-circuit": ["quantum-circuit@0.9.247", "", { "dependencies": { "antlr4": "4.7.2", "mathjs": "^6.0.3" } }, "sha512-cEmAOeq8ZqDI6sPyjvxxFanbcuxZOLh/EoOk3oZJGBssnwImojREcv4AhJ78WzMRIrWkFAXopN2VB/21YJb96Q=="],
+
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
     "refa": ["refa@0.12.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.8.0" } }, "sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g=="],
@@ -549,6 +566,8 @@
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "scslre": ["scslre@0.3.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.8.0", "refa": "^0.12.0", "regexp-ast-analysis": "^0.7.0" } }, "sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ=="],
+
+    "seed-random": ["seed-random@2.2.0", "", {}, "sha512-34EQV6AAHQGhoc0tn/96a9Fsi6v2xdqe/dMUwljGRaFOzR3EgRmECvD0O8vi8X+/uQ50LGHfkNu/Eue5TPKZkQ=="],
 
     "semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
 
@@ -586,6 +605,8 @@
 
     "table": ["table@6.9.0", "", { "dependencies": { "ajv": "^8.0.1", "lodash.truncate": "^4.4.2", "slice-ansi": "^4.0.0", "string-width": "^4.2.3", "strip-ansi": "^6.0.1" } }, "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A=="],
 
+    "tiny-emitter": ["tiny-emitter@2.1.0", "", {}, "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="],
+
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
@@ -597,6 +618,8 @@
     "tweetnacl": ["tweetnacl@1.0.3", "", {}, "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "typed-function": ["typed-function@1.1.1", "", {}, "sha512-RbN7MaTQBZLJYzDENHPA0nUmWT0Ex80KHItprrgbTPufYhIlTePvCXZxyQK7wgn19FW5bnuaBIKcBb5mRWjB1Q=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 

--- a/docs/INSTALLED.md
+++ b/docs/INSTALLED.md
@@ -34,6 +34,12 @@ be able to recreate the environment from this doc.
 | **qsharp**        | 1.29.1  | Direct Q# package pin for `qsharp` / `%%qsharp` parity when producing `qsharp-golden.json` observables                   | Same optional quantum path as above                                                                                                                                                                                                               |
 | **azure-quantum** | 3.10.0  | Explicit pin for the optional Azure backend edge owned by `qdk[azure]`; local simulation remains the default oracle path | Same optional quantum path as above                                                                                                                                                                                                               |
 
+## NPM / Bun quantum simulator dependencies
+
+| Package             | Version | Why                                                                                               | How installed                                                                        |
+| ------------------- | ------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **quantum-circuit** | 0.9.247 | TypeScript quantum circuit simulator (second oracle) for Q# golden observables cross-verification | Installed via `bun add -d quantum-circuit` as part of `package.json` devDependencies |
+
 ## Project-specific binary artifacts (downloaded by `tools/setup/install.sh`)
 
 | Artifact                  | Version              | Path                                     | Why                                                      | Install command                                                                                                                               |

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "markdownlint-cli2": "0.22.1",
     "prettier": "3.8.3",
     "prettier-plugin-toml": "2.0.6",
+    "quantum-circuit": "0.9.247",
     "semver": "7.8.1",
     "stylelint": "17.12.0",
     "stylelint-config-standard": "40.0.0",

--- a/src/Core.Abstractions/IAsyncOperator.cs
+++ b/src/Core.Abstractions/IAsyncOperator.cs
@@ -5,5 +5,5 @@ namespace Zeta.Core;
 /// </summary>
 public interface IAsyncOperator
 {
-    bool IsAsync { get; }
+    public bool IsAsync { get; }
 }

--- a/src/Core.Abstractions/ICheckpointReader.cs
+++ b/src/Core.Abstractions/ICheckpointReader.cs
@@ -5,10 +5,10 @@ namespace Zeta.Core;
 /// </summary>
 public interface ICheckpointReader
 {
-    int ReadInt32();
-    long ReadInt64();
-    double ReadFloat();
-    bool ReadBool();
-    byte[] ReadBytes();
-    string ReadString();
+    public int ReadInt32();
+    public long ReadInt64();
+    public double ReadFloat();
+    public bool ReadBool();
+    public byte[] ReadBytes();
+    public string ReadString();
 }

--- a/src/Core.Abstractions/ICheckpointStore.cs
+++ b/src/Core.Abstractions/ICheckpointStore.cs
@@ -9,13 +9,13 @@ namespace Zeta.Core;
 /// </summary>
 public interface ICheckpointStore
 {
-    ValueTask SaveCheckpointAsync(
+    public ValueTask SaveCheckpointAsync(
         string circuitId,
         long tick,
         Tuple<int, ICheckpointable>[] states,
         CancellationToken ct);
 
-    ValueTask<CheckpointLoadResult?> LoadCheckpointAsync(
+    public ValueTask<CheckpointLoadResult?> LoadCheckpointAsync(
         string circuitId,
         CancellationToken ct);
 }

--- a/src/Core.Abstractions/ICheckpointWriter.cs
+++ b/src/Core.Abstractions/ICheckpointWriter.cs
@@ -5,10 +5,10 @@ namespace Zeta.Core;
 /// </summary>
 public interface ICheckpointWriter
 {
-    void WriteInt32(int value);
-    void WriteInt64(long value);
-    void WriteFloat(double value);
-    void WriteBool(bool value);
-    void WriteBytes(byte[] value);
-    void WriteString(string value);
+    public void WriteInt32(int value);
+    public void WriteInt64(long value);
+    public void WriteFloat(double value);
+    public void WriteBool(bool value);
+    public void WriteBytes(byte[] value);
+    public void WriteString(string value);
 }

--- a/src/Core.Abstractions/ICheckpointable.cs
+++ b/src/Core.Abstractions/ICheckpointable.cs
@@ -5,7 +5,7 @@ namespace Zeta.Core;
 /// </summary>
 public interface ICheckpointable
 {
-    void SaveState(ICheckpointWriter writer);
-    void LoadState(ICheckpointReader reader);
-    int StateVersion { get; }
+    public void SaveState(ICheckpointWriter writer);
+    public void LoadState(ICheckpointReader reader);
+    public int StateVersion { get; }
 }

--- a/src/Core.Abstractions/IContentHasher.cs
+++ b/src/Core.Abstractions/IContentHasher.cs
@@ -6,8 +6,8 @@ namespace Zeta.Core;
 public interface IContentHasher
 {
     /// <summary>A stable name for the algorithm (for golden-vector labelling + diagnostics).</summary>
-    string Name { get; }
+    public string Name { get; }
 
     /// <summary>Hash bytes to a MerkleHash content address.</summary>
-    MerkleHash Hash(byte[] value);
+    public MerkleHash Hash(byte[] value);
 }

--- a/src/Core.Abstractions/IDeltaCodec.cs
+++ b/src/Core.Abstractions/IDeltaCodec.cs
@@ -8,8 +8,8 @@ namespace Zeta.Core;
 public interface IDeltaCodec<TKey, TState>
 {
     /// <summary>Encode state to bytes.</summary>
-    byte[] Encode(TState state);
+    public byte[] Encode(TState state);
 
     /// <summary>Decode state from bytes.</summary>
-    TState Decode(byte[] bytes);
+    public TState Decode(byte[] bytes);
 }

--- a/src/Core.Abstractions/IDeltaLog.cs
+++ b/src/Core.Abstractions/IDeltaLog.cs
@@ -14,18 +14,18 @@ public interface IDeltaLog<TKey, TDelta>
     /// <summary>
     /// Append a committed delta; returns the assigned sequence number (monotonic, starting at 1).
     /// </summary>
-    ValueTask<long> AppendAsync(TDelta delta, IReadOnlyDictionary<string, string> captured, CancellationToken ct);
+    public ValueTask<long> AppendAsync(TDelta delta, IReadOnlyDictionary<string, string> captured, CancellationToken ct);
 
     /// <summary>
     /// Replay entries with seq strictly greater than <paramref name="fromSeqExclusive"/>, in order.
     /// </summary>
-    ValueTask<DeltaLogEntry<TKey, TDelta>[]> ReplayAsync(long fromSeqExclusive, CancellationToken ct);
+    public ValueTask<DeltaLogEntry<TKey, TDelta>[]> ReplayAsync(long fromSeqExclusive, CancellationToken ct);
 
     /// <summary>Highest assigned sequence number (0 if empty).</summary>
-    long HighWater { get; }
+    public long HighWater { get; }
 
     /// <summary>
     /// GC entries with seq &lt;= <paramref name="throughSeqInclusive"/> — the log tail a durable snapshot has already absorbed.
     /// </summary>
-    ValueTask TruncateAsync(long throughSeqInclusive, CancellationToken ct);
+    public ValueTask TruncateAsync(long throughSeqInclusive, CancellationToken ct);
 }

--- a/src/Core.Abstractions/IEntryCodec.cs
+++ b/src/Core.Abstractions/IEntryCodec.cs
@@ -8,8 +8,8 @@ namespace Zeta.Core;
 public interface IEntryCodec<TKey, TDelta>
 {
     /// <summary>Encode a DeltaLogEntry to bytes.</summary>
-    byte[] Encode(DeltaLogEntry<TKey, TDelta> entry);
+    public byte[] Encode(DeltaLogEntry<TKey, TDelta> entry);
 
     /// <summary>Decode a DeltaLogEntry from bytes.</summary>
-    DeltaLogEntry<TKey, TDelta> Decode(byte[] bytes);
+    public DeltaLogEntry<TKey, TDelta> Decode(byte[] bytes);
 }

--- a/src/Core.Abstractions/IGeospatial.cs
+++ b/src/Core.Abstractions/IGeospatial.cs
@@ -27,11 +27,11 @@ namespace Zeta.Core;
 public interface IGeospatial<TCoord>
 {
     /// <summary>Number of dimensions of the locality space (2 = lat/lon, 3 = x/y/z, N = the general topology).</summary>
-    int Dimensions { get; }
+    public int Dimensions { get; }
 
     /// <summary>The coordinate's position in the metric locality space the ray travels through.</summary>
-    IReadOnlyList<double> Position(TCoord at);
+    public IReadOnlyList<double> Position(TCoord at);
 
     /// <summary>Coordinates whose position lies within the axis-aligned box [min, max] (locality/region query).</summary>
-    IEnumerable<TCoord> Within(IReadOnlyList<double> min, IReadOnlyList<double> max);
+    public IEnumerable<TCoord> Within(IReadOnlyList<double> min, IReadOnlyList<double> max);
 }

--- a/src/Core.Abstractions/IGroup.cs
+++ b/src/Core.Abstractions/IGroup.cs
@@ -6,5 +6,5 @@ namespace Zeta.Core;
 public interface IGroup<T> : IMonoid<T>
 {
     /// <summary>Additive inverse.</summary>
-    T Inverse(T a);
+    public T Inverse(T a);
 }

--- a/src/Core.Abstractions/IIntrospectable.cs
+++ b/src/Core.Abstractions/IIntrospectable.cs
@@ -7,8 +7,8 @@ namespace Zeta.Core;
 public interface IIntrospectable<TCoord>
 {
     /// <summary>Whether a coordinate is defined (a node exists there).</summary>
-    bool Exists(TCoord at);
+    public bool Exists(TCoord at);
 
     /// <summary>The immediate next coordinates from <paramref name="at"/> (the ray's stepping options).</summary>
-    IEnumerable<TCoord> Neighbors(TCoord at);
+    public IEnumerable<TCoord> Neighbors(TCoord at);
 }

--- a/src/Core.Abstractions/IMonoid.cs
+++ b/src/Core.Abstractions/IMonoid.cs
@@ -6,8 +6,8 @@ namespace Zeta.Core;
 public interface IMonoid<T>
 {
     /// <summary>The identity element.</summary>
-    T Identity { get; }
+    public T Identity { get; }
 
     /// <summary>Associative combination operation.</summary>
-    T Combine(T a, T b);
+    public T Combine(T a, T b);
 }

--- a/src/Core.Abstractions/INestedFixpointParticipant.cs
+++ b/src/Core.Abstractions/INestedFixpointParticipant.cs
@@ -5,5 +5,5 @@ namespace Zeta.Core;
 /// </summary>
 public interface INestedFixpointParticipant
 {
-    bool Fixedpoint(int scope);
+    public bool Fixedpoint(int scope);
 }

--- a/src/Core.Abstractions/IOperator.cs
+++ b/src/Core.Abstractions/IOperator.cs
@@ -8,7 +8,7 @@ namespace Zeta.Core;
 /// </summary>
 public interface IOperator<out TOut>
 {
-    string Name { get; }
-    IStreamHandle[] ReadDependencies { get; }
-    ValueTask StepAsync(IOutputBuffer<TOut> output, CancellationToken ct);
+    public string Name { get; }
+    public IStreamHandle[] ReadDependencies { get; }
+    public ValueTask StepAsync(IOutputBuffer<TOut> output, CancellationToken ct);
 }

--- a/src/Core.Abstractions/IOutputBuffer.cs
+++ b/src/Core.Abstractions/IOutputBuffer.cs
@@ -5,5 +5,5 @@ namespace Zeta.Core;
 /// </summary>
 public interface IOutputBuffer<in TValue>
 {
-    void Publish(TValue value);
+    public void Publish(TValue value);
 }

--- a/src/Core.Abstractions/IRayTraceable.cs
+++ b/src/Core.Abstractions/IRayTraceable.cs
@@ -31,5 +31,5 @@ public interface IRayTraceable<TCoord, TValue> : ITensor<TCoord, TValue>, ISampl
     /// trace is replayable and the result is a **proof** (holds across self-propagating patterns, Zeta
     /// included), even when the field carries irreducible (soft) uncertainty.
     /// </summary>
-    TValue Trace(IFrame from, IReadOnlyList<TCoord> ray, ISemiring<TValue> accumulate);
+    public TValue Trace(IFrame from, IReadOnlyList<TCoord> ray, ISemiring<TValue> accumulate);
 }

--- a/src/Core.Abstractions/ISampleable.cs
+++ b/src/Core.Abstractions/ISampleable.cs
@@ -6,5 +6,5 @@ namespace Zeta.Core;
 public interface ISampleable<TCoord, TValue>
 {
     /// <summary>The value at a coordinate (the semiring Zero/default where absent).</summary>
-    TValue Sample(TCoord at);
+    public TValue Sample(TCoord at);
 }

--- a/src/Core.Abstractions/ISemiring.cs
+++ b/src/Core.Abstractions/ISemiring.cs
@@ -6,17 +6,17 @@ namespace Zeta.Core;
 public interface ISemiring<TWeight>
 {
     /// <summary>Additive identity.</summary>
-    TWeight Zero { get; }
+    public TWeight Zero { get; }
 
     /// <summary>Multiplicative identity.</summary>
-    TWeight One { get; }
+    public TWeight One { get; }
 
     /// <summary>Additive combination operation (⊕).</summary>
-    TWeight Add(TWeight a, TWeight b);
+    public TWeight Add(TWeight a, TWeight b);
 
     /// <summary>Multiplicative scaling/product operation (⊗).</summary>
-    TWeight Mul(TWeight a, TWeight b);
+    public TWeight Mul(TWeight a, TWeight b);
 
     /// <summary>Additive inverse operation (Negate).</summary>
-    TWeight Negate(TWeight a);
+    public TWeight Negate(TWeight a);
 }

--- a/src/Core.Abstractions/ISimulationEnvironment.cs
+++ b/src/Core.Abstractions/ISimulationEnvironment.cs
@@ -10,17 +10,17 @@ namespace Zeta.Core;
 public interface ISimulationEnvironment
 {
     /// <summary>Current logical time.</summary>
-    DateTimeOffset UtcNow();
+    public DateTimeOffset UtcNow();
 
     /// <summary>Monotonically-increasing ticks counter.</summary>
-    long Ticks();
+    public long Ticks();
 
     /// <summary>Next 64-bit integer from the environment's RNG.</summary>
-    long NextInt64();
+    public long NextInt64();
 
     /// <summary>Fresh GUID.</summary>
-    Guid NewGuid();
+    public Guid NewGuid();
 
     /// <summary>Wait timeout.</summary>
-    Task Delay(TimeSpan timeout, CancellationToken cancellationToken);
+    public Task Delay(TimeSpan timeout, CancellationToken cancellationToken);
 }

--- a/src/Core.Abstractions/ISnapshotStore.cs
+++ b/src/Core.Abstractions/ISnapshotStore.cs
@@ -11,11 +11,11 @@ namespace Zeta.Core;
 public interface ISnapshotStore<TKey, TState>
 {
     /// <summary>Persist state at seq; update the durable manifest; return the pointer.</summary>
-    Task<SnapshotPointer> WriteAsync(long seq, TState state, CancellationToken ct);
+    public Task<SnapshotPointer> WriteAsync(long seq, TState state, CancellationToken ct);
 
     /// <summary>Load a snapshot by pointer.</summary>
-    Task<TState> ReadAsync(SnapshotPointer snapshot, CancellationToken ct);
+    public Task<TState> ReadAsync(SnapshotPointer snapshot, CancellationToken ct);
 
     /// <summary>The latest snapshot pointer from the manifest, or null if none written.</summary>
-    Task<SnapshotPointer?> LatestAsync(CancellationToken ct);
+    public Task<SnapshotPointer?> LatestAsync(CancellationToken ct);
 }

--- a/src/Core.Abstractions/IStarRing.cs
+++ b/src/Core.Abstractions/IStarRing.cs
@@ -22,5 +22,5 @@ namespace Zeta.Core;
 public interface IStarRing<TWeight> : ISemiring<TWeight>
 {
     /// <summary>The involution (conjugation): identity on ℝ, complex conjugate on ℂ, recursive beyond.</summary>
-    TWeight Conj(TWeight a);
+    public TWeight Conj(TWeight a);
 }

--- a/src/Core.Abstractions/IStrictOperator.cs
+++ b/src/Core.Abstractions/IStrictOperator.cs
@@ -8,5 +8,5 @@ namespace Zeta.Core;
 /// </summary>
 public interface IStrictOperator<out TOut> : IOperator<TOut>
 {
-    ValueTask AfterStepAsync(CancellationToken ct);
+    public ValueTask AfterStepAsync(CancellationToken ct);
 }

--- a/src/Core.Abstractions/ITensor.cs
+++ b/src/Core.Abstractions/ITensor.cs
@@ -26,14 +26,14 @@ public interface ITensor<TCoord, TWeight>
     /// Number of explicitly-stored entries: the support size for sparse tensors, the full cell count for
     /// dense tensors.
     /// </summary>
-    long StoredCount { get; }
+    public long StoredCount { get; }
 
     /// <summary>True when storage is sparse (only nonzero / present coordinates are materialized).</summary>
-    bool IsSparse { get; }
+    public bool IsSparse { get; }
 
     /// <summary>
     /// The explicitly-stored (coordinate, value) entries: the support for sparse tensors, every cell for
     /// dense. Order is implementation-defined but stable (sparse: ordinal by coordinate).
     /// </summary>
-    IEnumerable<KeyValuePair<TCoord, TWeight>> StoredEntries { get; }
+    public IEnumerable<KeyValuePair<TCoord, TWeight>> StoredEntries { get; }
 }

--- a/src/Core.Abstractions/ITravelerFrame.cs
+++ b/src/Core.Abstractions/ITravelerFrame.cs
@@ -18,5 +18,5 @@ namespace Zeta.Core;
 public interface ITravelerFrame : IFrame
 {
     /// <summary>The DST guarantee — the trace from this frame replays identically, so its result is provable.</summary>
-    bool IsDeterministic { get; }
+    public bool IsDeterministic { get; }
 }

--- a/src/Core.CSharp.DynamicValue/DynamicValues.cs
+++ b/src/Core.CSharp.DynamicValue/DynamicValues.cs
@@ -653,46 +653,46 @@ public static class DynamicValues
             case 22:
                 return null; // value already Null
             case 25:
-            {
-                if (pos + 2 > b.Length)
                 {
-                    return DecodeError.UnexpectedEnd;
-                }
+                    if (pos + 2 > b.Length)
+                    {
+                        return DecodeError.UnexpectedEnd;
+                    }
 
-                ushort bits16 = (ushort)((b[pos] << 8) | b[pos + 1]);
-                pos += 2;
-                value = new DynamicValue.Float((double)BitConverter.UInt16BitsToHalf(bits16));
-                return null;
-            }
+                    ushort bits16 = (ushort)((b[pos] << 8) | b[pos + 1]);
+                    pos += 2;
+                    value = new DynamicValue.Float((double)BitConverter.UInt16BitsToHalf(bits16));
+                    return null;
+                }
             case 26:
-            {
-                if (pos + 4 > b.Length)
                 {
-                    return DecodeError.UnexpectedEnd;
-                }
+                    if (pos + 4 > b.Length)
+                    {
+                        return DecodeError.UnexpectedEnd;
+                    }
 
-                uint bits32 = ((uint)b[pos] << 24) | ((uint)b[pos + 1] << 16) | ((uint)b[pos + 2] << 8) | b[pos + 3];
-                pos += 4;
-                value = new DynamicValue.Float(BitConverter.UInt32BitsToSingle(bits32));
-                return null;
-            }
+                    uint bits32 = ((uint)b[pos] << 24) | ((uint)b[pos + 1] << 16) | ((uint)b[pos + 2] << 8) | b[pos + 3];
+                    pos += 4;
+                    value = new DynamicValue.Float(BitConverter.UInt32BitsToSingle(bits32));
+                    return null;
+                }
             case 27:
-            {
-                if (pos + 8 > b.Length)
                 {
-                    return DecodeError.UnexpectedEnd;
-                }
+                    if (pos + 8 > b.Length)
+                    {
+                        return DecodeError.UnexpectedEnd;
+                    }
 
-                ulong bits64 = 0;
-                for (int i = 0; i < 8; i++)
-                {
-                    bits64 = (bits64 << 8) | b[pos + i];
-                }
+                    ulong bits64 = 0;
+                    for (int i = 0; i < 8; i++)
+                    {
+                        bits64 = (bits64 << 8) | b[pos + i];
+                    }
 
-                pos += 8;
-                value = new DynamicValue.Float(BitConverter.UInt64BitsToDouble(bits64));
-                return null;
-            }
+                    pos += 8;
+                    value = new DynamicValue.Float(BitConverter.UInt64BitsToDouble(bits64));
+                    return null;
+                }
             default:
                 return DecodeError.Unsupported; // undefined / 1-byte simple value / reserved
         }

--- a/src/Core.CSharp.Mediator/IPublisher.cs
+++ b/src/Core.CSharp.Mediator/IPublisher.cs
@@ -8,6 +8,6 @@ public interface IPublisher
     /// <param name="notification">The notification to broadcast.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A task that completes when all handlers have run.</returns>
-    ValueTask Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default)
+    public ValueTask Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default)
         where TNotification : INotification;
 }

--- a/src/Core.CSharp.Mediator/ISender.cs
+++ b/src/Core.CSharp.Mediator/ISender.cs
@@ -8,12 +8,12 @@ public interface ISender
     /// <param name="request">The request to dispatch.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The handler's response.</returns>
-    ValueTask<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default);
+    public ValueTask<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default);
 
     /// <summary>Open a stream for <paramref name="request"/>, yielding its handler's elements.</summary>
     /// <typeparam name="TResponse">The element type streamed back.</typeparam>
     /// <param name="request">The stream request to dispatch.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The handler's asynchronous stream of responses.</returns>
-    IAsyncEnumerable<TResponse> CreateStream<TResponse>(IStreamRequest<TResponse> request, CancellationToken cancellationToken = default);
+    public IAsyncEnumerable<TResponse> CreateStream<TResponse>(IStreamRequest<TResponse> request, CancellationToken cancellationToken = default);
 }

--- a/src/Core.CSharp.Yaml/YamlDom.cs
+++ b/src/Core.CSharp.Yaml/YamlDom.cs
@@ -20,9 +20,9 @@ public static class YamlDom
         {
             ScalarKind.Null => ParseResult.Success(YamlValue.YNull.Instance),
             ScalarKind.Bool => ParseResult.Success(new YamlValue.YBool(
-                string.Equals(raw, "true",  StringComparison.Ordinal) ||
-                string.Equals(raw, "True",  StringComparison.Ordinal) ||
-                string.Equals(raw, "TRUE",  StringComparison.Ordinal))),
+                string.Equals(raw, "true", StringComparison.Ordinal) ||
+                string.Equals(raw, "True", StringComparison.Ordinal) ||
+                string.Equals(raw, "TRUE", StringComparison.Ordinal))),
             ScalarKind.Int =>
                 long.TryParse(raw, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out long iv)
                     ? ParseResult.Success(new YamlValue.YInt(iv))
@@ -72,7 +72,7 @@ public static class YamlDom
             YamlEvent? ev = Peek();
             if (ev is null) return ParseResult.Failure(YamlFeedback.UnsupportedConstruct);
             if (ev is YamlEvent.Scalar sc) { _pos++; return ScalarToValue(sc.Raw, sc.Kind); }
-            if (ev is YamlEvent.MappingStart)  return FoldMapping();
+            if (ev is YamlEvent.MappingStart) return FoldMapping();
             if (ev is YamlEvent.SequenceStart) return FoldSequence();
             return ParseResult.Failure(YamlFeedback.UnsupportedConstruct);
         }

--- a/src/Core.CSharp.Yaml/YamlReader.cs
+++ b/src/Core.CSharp.Yaml/YamlReader.cs
@@ -37,9 +37,9 @@ public static class YamlReader
         string.Equals(raw, "NULL", StringComparison.Ordinal);
 
     private static bool IsBoolLiteral(string raw) =>
-        string.Equals(raw, "true",  StringComparison.Ordinal) ||
-        string.Equals(raw, "True",  StringComparison.Ordinal) ||
-        string.Equals(raw, "TRUE",  StringComparison.Ordinal) ||
+        string.Equals(raw, "true", StringComparison.Ordinal) ||
+        string.Equals(raw, "True", StringComparison.Ordinal) ||
+        string.Equals(raw, "TRUE", StringComparison.Ordinal) ||
         string.Equals(raw, "false", StringComparison.Ordinal) ||
         string.Equals(raw, "False", StringComparison.Ordinal) ||
         string.Equals(raw, "FALSE", StringComparison.Ordinal);
@@ -84,7 +84,7 @@ public static class YamlReader
     {
         if (IsNullLiteral(raw)) return ScalarKind.Null;
         if (IsBoolLiteral(raw)) return ScalarKind.Bool;
-        if (IsIntLiteral(raw))  return ScalarKind.Int;
+        if (IsIntLiteral(raw)) return ScalarKind.Int;
         if (IsFloatLiteral(raw)) return ScalarKind.Float;
         return ScalarKind.Str;
     }
@@ -159,12 +159,12 @@ public static class YamlReader
                 switch (next)
                 {
                     case '\\': sb.Append('\\'); i += 2; break;
-                    case '"':  sb.Append('"');  i += 2; break;
-                    case 'n':  sb.Append('\n'); i += 2; break;
-                    case 't':  sb.Append('\t'); i += 2; break;
-                    case 'r':  sb.Append('\r'); i += 2; break;
-                    case '0':  sb.Append('\0'); i += 2; break;
-                    case '/':  sb.Append('/');  i += 2; break;
+                    case '"': sb.Append('"'); i += 2; break;
+                    case 'n': sb.Append('\n'); i += 2; break;
+                    case 't': sb.Append('\t'); i += 2; break;
+                    case 'r': sb.Append('\r'); i += 2; break;
+                    case '0': sb.Append('\0'); i += 2; break;
+                    case '/': sb.Append('/'); i += 2; break;
                     default:
                         return (false, string.Empty, YamlFeedback.UnexpectedCharacter);
                 }
@@ -238,14 +238,14 @@ public static class YamlReader
             while (indent < line.Length)
             {
                 char ch = line[indent];
-                if (ch == ' ')       indent++;
+                if (ch == ' ') indent++;
                 else if (ch == '\t') { sawTab = true; indent++; }
-                else                 break;
+                else break;
             }
 
             string body = line[indent..];
             if (body.Length == 0) continue;
-            if (body[0] == '#')  continue;
+            if (body[0] == '#') continue;
             if (sawTab) return (false, null, YamlFeedback.TabIndentation);
             result.Add(new ContentLine(indent, body));
         }
@@ -286,8 +286,8 @@ public static class YamlReader
                     i++;
                 }
             }
-            else if (ch == '\'') { inSingle = true;  i++; }
-            else if (ch == '"')  { inDouble = true;   i++; }
+            else if (ch == '\'') { inSingle = true; i++; }
+            else if (ch == '"') { inDouble = true; i++; }
             else if (ch == '#' && i > 0 && IsWhitespace(text[i - 1]))
                 return null; // comment before colon
             else if (ch == ':' && (i + 1 == text.Length || text[i + 1] == ' '))

--- a/tests/Tests.CSharp/MeshPongCrossVerifyTests.cs
+++ b/tests/Tests.CSharp/MeshPongCrossVerifyTests.cs
@@ -1,11 +1,11 @@
 // MeshPong cross-verify — the C# oracle replays the SAME game-state treaty session the F# oracle locked
 // (src/Core.TypeScript/mesh-pong/golden-vectors.lines): four compilers, one match, one world.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Xunit;
-using System;
 using Zeta.Core.CSharp;
 
 namespace Zeta.Tests.CSharp;

--- a/tests/Tests.CSharp/Sha256/CrossVerifyTests.cs
+++ b/tests/Tests.CSharp/Sha256/CrossVerifyTests.cs
@@ -2,8 +2,8 @@ using System.IO;
 using System.Text;
 using System.Text.Json;
 using Xunit;
-using Sha256Lib = Zeta.Core.CSharp.Sha256.Sha256;
 using Zeta.Core.CSharp.Yaml;
+using Sha256Lib = Zeta.Core.CSharp.Sha256.Sha256;
 
 namespace Zeta.Tests.CSharp.Sha256;
 

--- a/tests/Tests.CSharp/Yaml/CrossVerifyTests.cs
+++ b/tests/Tests.CSharp/Yaml/CrossVerifyTests.cs
@@ -44,36 +44,36 @@ public class CrossVerifyTests
 
     private static string KindName(ScalarKind k) => k switch
     {
-        ScalarKind.Null  => "Null",
-        ScalarKind.Bool  => "Bool",
-        ScalarKind.Int   => "Int",
+        ScalarKind.Null => "Null",
+        ScalarKind.Bool => "Bool",
+        ScalarKind.Int => "Int",
         ScalarKind.Float => "Float",
-        _                => "Str",
+        _ => "Str",
     };
 
     private static string StyleName(ScalarStyle s) => s switch
     {
         ScalarStyle.SingleQuoted => "SingleQuoted",
         ScalarStyle.DoubleQuoted => "DoubleQuoted",
-        _                        => "Plain",
+        _ => "Plain",
     };
 
     private static ScalarKind KindOfName(string name) => name switch
     {
-        "Null"  => ScalarKind.Null,
-        "Bool"  => ScalarKind.Bool,
-        "Int"   => ScalarKind.Int,
+        "Null" => ScalarKind.Null,
+        "Bool" => ScalarKind.Bool,
+        "Int" => ScalarKind.Int,
         "Float" => ScalarKind.Float,
-        "Str"   => ScalarKind.Str,
-        _       => throw new InvalidOperationException($"Unknown ScalarKind name: {name}"),
+        "Str" => ScalarKind.Str,
+        _ => throw new InvalidOperationException($"Unknown ScalarKind name: {name}"),
     };
 
     private static ScalarStyle StyleOfName(string name) => name switch
     {
         "SingleQuoted" => ScalarStyle.SingleQuoted,
         "DoubleQuoted" => ScalarStyle.DoubleQuoted,
-        "Plain"        => ScalarStyle.Plain,
-        _              => throw new InvalidOperationException($"Unknown ScalarStyle name: {name}"),
+        "Plain" => ScalarStyle.Plain,
+        _ => throw new InvalidOperationException($"Unknown ScalarStyle name: {name}"),
     };
 
     // -------------------------------------------------------------------------
@@ -85,12 +85,12 @@ public class CrossVerifyTests
         string tag = el.GetProperty("e").GetString()!;
         return tag switch
         {
-            "StreamStart"   => new YamlEvent.StreamStart(),
-            "StreamEnd"     => new YamlEvent.StreamEnd(),
-            "MappingStart"  => new YamlEvent.MappingStart(),
-            "MappingEnd"    => new YamlEvent.MappingEnd(),
+            "StreamStart" => new YamlEvent.StreamStart(),
+            "StreamEnd" => new YamlEvent.StreamEnd(),
+            "MappingStart" => new YamlEvent.MappingStart(),
+            "MappingEnd" => new YamlEvent.MappingEnd(),
             "SequenceStart" => new YamlEvent.SequenceStart(),
-            "SequenceEnd"   => new YamlEvent.SequenceEnd(),
+            "SequenceEnd" => new YamlEvent.SequenceEnd(),
             "Scalar" =>
                 new YamlEvent.Scalar(
                     el.GetProperty("raw").GetString()!,
@@ -108,20 +108,20 @@ public class CrossVerifyTests
         {
             // { "e": "Scalar", "raw": "...", "kind": "...", "style": "..." }
             // Use JsonSerializer to handle escaping of raw and kind/style strings.
-            string rawJson  = JsonSerializer.Serialize(sc.Raw);
+            string rawJson = JsonSerializer.Serialize(sc.Raw);
             string kindJson = JsonSerializer.Serialize(KindName(sc.Kind));
             string styleJson = JsonSerializer.Serialize(StyleName(sc.Style));
             return $"{{\"e\":\"Scalar\",\"raw\":{rawJson},\"kind\":{kindJson},\"style\":{styleJson}}}";
         }
         string tag = e switch
         {
-            YamlEvent.StreamStart   => "StreamStart",
-            YamlEvent.StreamEnd     => "StreamEnd",
-            YamlEvent.MappingStart  => "MappingStart",
-            YamlEvent.MappingEnd    => "MappingEnd",
+            YamlEvent.StreamStart => "StreamStart",
+            YamlEvent.StreamEnd => "StreamEnd",
+            YamlEvent.MappingStart => "MappingStart",
+            YamlEvent.MappingEnd => "MappingEnd",
             YamlEvent.SequenceStart => "SequenceStart",
-            YamlEvent.SequenceEnd   => "SequenceEnd",
-            _                       => throw new InvalidOperationException($"Unknown event: {e}"),
+            YamlEvent.SequenceEnd => "SequenceEnd",
+            _ => throw new InvalidOperationException($"Unknown event: {e}"),
         };
         return $"{{\"e\":\"{tag}\"}}";
     }
@@ -140,7 +140,7 @@ public class CrossVerifyTests
         var result = new List<Vector>();
         foreach (JsonElement v in doc.RootElement.GetProperty("vectors").EnumerateArray())
         {
-            string id   = v.GetProperty("id").GetString()!;
+            string id = v.GetProperty("id").GetString()!;
             string yaml = v.GetProperty("yaml").GetString()!;
             var expected = new List<YamlEvent>();
             foreach (JsonElement evEl in v.GetProperty("expected").EnumerateArray())
@@ -232,11 +232,11 @@ public class CrossVerifyTests
         {
             switch (ev)
             {
-                case YamlEvent.MappingStart:  result.Add(new DiffEvent(DiffTag.MapStart, null, default)); break;
-                case YamlEvent.MappingEnd:    result.Add(new DiffEvent(DiffTag.MapEnd,   null, default)); break;
+                case YamlEvent.MappingStart: result.Add(new DiffEvent(DiffTag.MapStart, null, default)); break;
+                case YamlEvent.MappingEnd: result.Add(new DiffEvent(DiffTag.MapEnd, null, default)); break;
                 case YamlEvent.SequenceStart: result.Add(new DiffEvent(DiffTag.SeqStart, null, default)); break;
-                case YamlEvent.SequenceEnd:   result.Add(new DiffEvent(DiffTag.SeqEnd,   null, default)); break;
-                case YamlEvent.Scalar sc:     result.Add(new DiffEvent(DiffTag.Scalar, sc.Raw, sc.Style)); break;
+                case YamlEvent.SequenceEnd: result.Add(new DiffEvent(DiffTag.SeqEnd, null, default)); break;
+                case YamlEvent.Scalar sc: result.Add(new DiffEvent(DiffTag.Scalar, sc.Raw, sc.Style)); break;
                 // StreamStart / StreamEnd skipped
                 default: break;
             }
@@ -248,7 +248,7 @@ public class CrossVerifyTests
     {
         YamlDotNet.Core.ScalarStyle.SingleQuoted => ScalarStyle.SingleQuoted,
         YamlDotNet.Core.ScalarStyle.DoubleQuoted => ScalarStyle.DoubleQuoted,
-        _                                         => ScalarStyle.Plain,
+        _ => ScalarStyle.Plain,
     };
 
     private static List<DiffEvent> VendorDiffStream(string yaml)
@@ -263,11 +263,11 @@ public class CrossVerifyTests
                 case YamlDotNet.Core.Events.MappingStart:
                     acc.Add(new DiffEvent(DiffTag.MapStart, null, default)); break;
                 case YamlDotNet.Core.Events.MappingEnd:
-                    acc.Add(new DiffEvent(DiffTag.MapEnd,   null, default)); break;
+                    acc.Add(new DiffEvent(DiffTag.MapEnd, null, default)); break;
                 case YamlDotNet.Core.Events.SequenceStart:
                     acc.Add(new DiffEvent(DiffTag.SeqStart, null, default)); break;
                 case YamlDotNet.Core.Events.SequenceEnd:
-                    acc.Add(new DiffEvent(DiffTag.SeqEnd,   null, default)); break;
+                    acc.Add(new DiffEvent(DiffTag.SeqEnd, null, default)); break;
                 case YamlDotNet.Core.Events.Scalar sc:
                     acc.Add(new DiffEvent(DiffTag.Scalar, sc.Value, VendorStyle(sc.Style))); break;
                 // Skip StreamStart/End, DocumentStart/End, and anything else.
@@ -287,7 +287,7 @@ public class CrossVerifyTests
             ReadResult r = YamlReader.ReadEvents(v.Yaml);
             Assert.True(r.Ok, $"vector {v.Id} declined unexpectedly: feedback={r.Feedback}");
 
-            List<DiffEvent> ours   = OurDiffStream(r.Events!);
+            List<DiffEvent> ours = OurDiffStream(r.Events!);
             List<DiffEvent> theirs = VendorDiffStream(v.Yaml);
 
             if (ours.Count != theirs.Count) { mismatches++; continue; }

--- a/tests/Tests.CSharp/Yaml/ReaderTests.cs
+++ b/tests/Tests.CSharp/Yaml/ReaderTests.cs
@@ -11,10 +11,10 @@ using Zeta.Core.CSharp.Yaml;
 // Shorthands to keep test bodies compact.
 file static class E
 {
-    public static YamlEvent SS  => new YamlEvent.StreamStart();
-    public static YamlEvent SE  => new YamlEvent.StreamEnd();
-    public static YamlEvent MS  => new YamlEvent.MappingStart();
-    public static YamlEvent ME  => new YamlEvent.MappingEnd();
+    public static YamlEvent SS => new YamlEvent.StreamStart();
+    public static YamlEvent SE => new YamlEvent.StreamEnd();
+    public static YamlEvent MS => new YamlEvent.MappingStart();
+    public static YamlEvent ME => new YamlEvent.MappingEnd();
     public static YamlEvent SQS => new YamlEvent.SequenceStart();
     public static YamlEvent SQE => new YamlEvent.SequenceEnd();
     public static YamlEvent Plain(string raw, ScalarKind kind) =>

--- a/tests/Tests.CSharp/ZetaId/PayloadTests.cs
+++ b/tests/Tests.CSharp/ZetaId/PayloadTests.cs
@@ -50,7 +50,7 @@ public class PayloadTests
     public void PackPayloadThrowsOnOutOfBoundsPayload()
     {
         UInt128 invalidPayload = UInt128.One << 119;
-        
+
         var contentPayload = new ZetaIdPayload.ContentAddress(IdVersion.V1, invalidPayload);
         Assert.Throws<ArgumentOutOfRangeException>(() => ZetaIdCodec.PackPayload(contentPayload, DeterministicEnv.Instance));
 

--- a/tools/ace/packages/qsharp-reference-oracle-0.1.0.json
+++ b/tools/ace/packages/qsharp-reference-oracle-0.1.0.json
@@ -4,9 +4,9 @@
     "name": "qsharp-reference-oracle",
     "version": "0.1.0",
     "description": "Declarative QDK/Q# Python dependency set for Zeta finite-resolution qubits reference-oracle tests.",
-    "content_hash": "sha256:07f5b7448ffd93c07b69c122ec8360ce2dddf235b43121982389ec9dfd00415d"
+    "content_hash": "sha256:b754b512282b5f19d9741cbc9ef79356bb76cac6f7e8263eb37e39fc624d4117"
   },
   "files": {
-    "qsharp-reference-oracle.deps.json": "{\n  \"schema\": \"zeta.ace.package-manager-pointers.v1\",\n  \"purpose\": \"QDK/Q# reference oracle for finite-resolution qubits observable golden vectors\",\n  \"realizer\": \"tools/setup/common/quantum.sh\",\n  \"manifest\": \"tools/setup/manifests/quantum\",\n  \"opt_in\": [\"ZETA_INSTALL_QUANTUM=1\", \"ZETA_INSTALL_FULL=1\"],\n  \"dependencies\": [\n    {\n      \"ecosystem\": \"pypi\",\n      \"spec\": \"qdk[azure]==1.29.1\",\n      \"role\": \"reference-oracle\",\n      \"lang\": \"q#\"\n    },\n    {\n      \"ecosystem\": \"pypi\",\n      \"spec\": \"qsharp==1.29.1\",\n      \"role\": \"reference-oracle\",\n      \"lang\": \"q#\"\n    },\n    {\n      \"ecosystem\": \"pypi\",\n      \"spec\": \"azure-quantum==3.10.0\",\n      \"role\": \"reference-oracle\",\n      \"lang\": \"q#\"\n    }\n  ]\n}\n"
+    "qsharp-reference-oracle.deps.json": "{\n  \"schema\": \"zeta.ace.package-manager-pointers.v1\",\n  \"purpose\": \"QDK/Q# reference oracle for finite-resolution qubits observable golden vectors\",\n  \"realizer\": \"tools/setup/common/quantum.sh\",\n  \"manifest\": \"tools/setup/manifests/quantum\",\n  \"dependencies\": [\n    {\n      \"ecosystem\": \"pypi\",\n      \"spec\": \"qdk[azure]==1.29.1\",\n      \"role\": \"reference-oracle\",\n      \"lang\": \"q#\"\n    },\n    {\n      \"ecosystem\": \"pypi\",\n      \"spec\": \"qsharp==1.29.1\",\n      \"role\": \"reference-oracle\",\n      \"lang\": \"q#\"\n    },\n    {\n      \"ecosystem\": \"pypi\",\n      \"spec\": \"azure-quantum==3.10.0\",\n      \"role\": \"reference-oracle\",\n      \"lang\": \"q#\"\n    },\n    {\n      \"ecosystem\": \"npm\",\n      \"spec\": \"quantum-circuit==0.9.247\",\n      \"role\": \"second-oracle\",\n      \"lang\": \"typescript\"\n    }\n  ],\n  \"opt_in\": [\n    \"ZETA_INSTALL_QUANTUM=1\",\n    \"ZETA_INSTALL_FULL=1\"\n  ]\n}\n"
   }
 }

--- a/tools/ace/registry.json
+++ b/tools/ace/registry.json
@@ -2,7 +2,7 @@
   "qsharp-reference-oracle": {
     "0.1.0": {
       "url": "https://raw.githubusercontent.com/Lucent-Financial-Group/Zeta/main/tools/ace/packages/qsharp-reference-oracle-0.1.0.json",
-      "package_hash": "sha256:8dc33e29da029ea104fbecb55a01f1663690cfb72cb2c93fcc68f1f79997d02c"
+      "package_hash": "sha256:0f911ad099e6c30a7dbdc5f9e72f667cf09dd11c449b6b29a8d64cd2c313d52e"
     }
   }
 }

--- a/tools/ace/setup-manifest.ts
+++ b/tools/ace/setup-manifest.ts
@@ -65,7 +65,7 @@ export function pointerFromSetupManifest(args: {
     manifest: args.manifest,
     dependencies: parseSetupManifest(args.text).map((entry) => {
       const dep: PackageManagerPointerDependency = {
-        ecosystem: args.ecosystem,
+        ecosystem: entry.attrs.ecosystem !== undefined ? entry.attrs.ecosystem : args.ecosystem,
         spec: entry.spec,
       };
       return {

--- a/tools/qsharp-oracle/quantum-circuit.d.ts
+++ b/tools/qsharp-oracle/quantum-circuit.d.ts
@@ -1,0 +1,15 @@
+declare module "quantum-circuit" {
+  export default class QuantumCircuit {
+    constructor(qubits: number);
+
+    readonly state: readonly unknown[];
+
+    appendGate(gate: string, wire: number | readonly number[], options?: { readonly params: readonly number[] }): void;
+
+    circuitMatrix(): readonly (readonly unknown[])[];
+
+    probabilities(): readonly number[];
+
+    run(): void;
+  }
+}

--- a/tools/qsharp-oracle/quantum-circuit.test.ts
+++ b/tools/qsharp-oracle/quantum-circuit.test.ts
@@ -1,59 +1,339 @@
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-return */
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-/* eslint-disable sonarjs/cognitive-complexity */
 import { describe, expect, test } from "bun:test";
-// @ts-expect-error: quantum-circuit has no official typings
 import QuantumCircuit from "quantum-circuit";
 import golden from "./qsharp-golden.json";
 
+interface Complex {
+  readonly real: number;
+  readonly imag: number;
+}
+
+type Matrix = Complex[][];
+type CircuitAction = (circuit: QuantumCircuit) => void;
+interface CorrelatorProbabilities {
+  readonly corr: number;
+  readonly pSame: number;
+  readonly pOpposite: number;
+}
+
 const qsharpDumpTolerance = 1e-5;
 const tolerance = 1e-6;
+
+const singleQubitActions = new Map<string, CircuitAction>([
+  [
+    "Zeta.ReferenceOracle.ApplyH",
+    (circuit) => {
+      append(circuit, "h", 0);
+    },
+  ],
+  [
+    "Zeta.ReferenceOracle.ApplyRyPiOver3",
+    (circuit) => {
+      append(circuit, "ry", 0, [Math.PI / 3]);
+    },
+  ],
+  [
+    "Zeta.ReferenceOracle.ApplyRyPiOver2",
+    (circuit) => {
+      append(circuit, "ry", 0, [Math.PI / 2]);
+    },
+  ],
+]);
+
+const machZehnderActions = new Map<string, CircuitAction>([
+  [
+    "Zeta.ReferenceOracle.ApplyMachZehnderOpen",
+    (circuit) => {
+      append(circuit, "h", 0);
+    },
+  ],
+  [
+    "Zeta.ReferenceOracle.ApplyMachZehnderClosedZeroPhase",
+    (circuit) => {
+      append(circuit, "h", 0);
+      append(circuit, "h", 0);
+    },
+  ],
+  [
+    "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiPhase",
+    (circuit) => {
+      append(circuit, "h", 0);
+      append(circuit, "z", 0);
+      append(circuit, "h", 0);
+    },
+  ],
+  [
+    "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiOver3Phase",
+    (circuit) => {
+      applyClosedPhaseMachZehnder(circuit, Math.PI / 3);
+    },
+  ],
+  [
+    "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiOver2Phase",
+    (circuit) => {
+      applyClosedPhaseMachZehnder(circuit, Math.PI / 2);
+    },
+  ],
+  [
+    "Zeta.ReferenceOracle.ApplyMachZehnderClosedTwoPiOver3Phase",
+    (circuit) => {
+      applyClosedPhaseMachZehnder(circuit, (2 * Math.PI) / 3);
+    },
+  ],
+]);
+
+const singleQubitGateActions = new Map<string, CircuitAction>([
+  [
+    "H",
+    (circuit) => {
+      append(circuit, "h", 0);
+    },
+  ],
+  [
+    "Ry(pi/2)",
+    (circuit) => {
+      append(circuit, "ry", 0, [Math.PI / 2]);
+    },
+  ],
+  [
+    "Ry(pi/3)",
+    (circuit) => {
+      append(circuit, "ry", 0, [Math.PI / 3]);
+    },
+  ],
+  [
+    "Rz(pi/3)",
+    (circuit) => {
+      append(circuit, "rz", 0, [Math.PI / 3]);
+    },
+  ],
+  [
+    "S",
+    (circuit) => {
+      append(circuit, "s", 0);
+    },
+  ],
+  [
+    "T",
+    (circuit) => {
+      append(circuit, "t", 0);
+    },
+  ],
+  [
+    "X",
+    (circuit) => {
+      append(circuit, "x", 0);
+    },
+  ],
+  [
+    "Y",
+    (circuit) => {
+      append(circuit, "y", 0);
+    },
+  ],
+  [
+    "Z",
+    (circuit) => {
+      append(circuit, "z", 0);
+    },
+  ],
+]);
+
+const pauliProductActions = new Map<string, CircuitAction>([
+  [
+    "Zeta.ReferenceOracle.ApplyPauliXAfterZ",
+    (circuit) => {
+      applyGates(circuit, "z", "x");
+    },
+  ],
+  [
+    "Zeta.ReferenceOracle.ApplyPauliZAfterX",
+    (circuit) => {
+      applyGates(circuit, "x", "z");
+    },
+  ],
+  [
+    "Zeta.ReferenceOracle.ApplyPauliXAfterY",
+    (circuit) => {
+      applyGates(circuit, "y", "x");
+    },
+  ],
+  [
+    "Zeta.ReferenceOracle.ApplyPauliYAfterX",
+    (circuit) => {
+      applyGates(circuit, "x", "y");
+    },
+  ],
+  [
+    "Zeta.ReferenceOracle.ApplyPauliYAfterZ",
+    (circuit) => {
+      applyGates(circuit, "z", "y");
+    },
+  ],
+  [
+    "Zeta.ReferenceOracle.ApplyPauliZAfterY",
+    (circuit) => {
+      applyGates(circuit, "y", "z");
+    },
+  ],
+]);
 
 function closeTo(actual: number, expected: number, epsilon = tolerance) {
   expect(Math.abs(actual - expected)).toBeLessThanOrEqual(epsilon);
 }
 
-function getAmplitudeProb(amp: any): number {
-  if (!amp) return 0;
-  if (typeof amp === "number") return amp * amp;
-  return amp.re * amp.re + amp.im * amp.im;
+function closeComplexTo(actual: Complex, expected: Complex, epsilon = tolerance) {
+  closeTo(actual.real, expected.real, epsilon);
+  closeTo(actual.imag, expected.imag, epsilon);
 }
 
-function normalizeComplex(val: any): { real: number; imag: number } {
-  if (typeof val === "number") {
-    return { real: val, imag: 0 };
-  } else if (val && typeof val === "object") {
-    if ("re" in val && "im" in val) {
-      return { real: val.re, imag: val.im };
-    }
-    if ("real" in val && "imag" in val) {
-      return { real: val.real, imag: val.imag };
-    }
+function expectDefined<T>(value: T | undefined, label: string): T {
+  expect(value, label).toBeDefined();
+  return value as T;
+}
+
+function append(circuit: QuantumCircuit, gate: string, wire: number | readonly number[], params?: readonly number[]) {
+  if (params === undefined) {
+    circuit.appendGate(gate, wire);
+    return;
   }
-  return { real: 0, imag: 0 };
+
+  circuit.appendGate(gate, wire, { params });
 }
 
-describe("quantum-circuit simulator (second oracle)", () => {
+function applyGates(circuit: QuantumCircuit, first: string, second: string) {
+  append(circuit, first, 0);
+  append(circuit, second, 0);
+}
+
+function applyClosedPhaseMachZehnder(circuit: QuantumCircuit, phase: number) {
+  append(circuit, "h", 0);
+  append(circuit, "rz", 0, [phase]);
+  append(circuit, "h", 0);
+}
+
+function applyKnownOperation(circuit: QuantumCircuit, operation: string, actions: ReadonlyMap<string, CircuitAction>) {
+  const action = expectDefined(actions.get(operation), `Unknown operation: ${operation}`);
+  action(circuit);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function numberField(record: Record<string, unknown>, field: string): number | undefined {
+  const value = record[field];
+  return typeof value === "number" ? value : undefined;
+}
+
+function normalizeComplex(value: unknown): Complex {
+  if (typeof value === "number") return { real: value, imag: 0 };
+
+  if (isRecord(value)) {
+    const re = numberField(value, "re");
+    const im = numberField(value, "im");
+    if (re !== undefined && im !== undefined) return { real: re, imag: im };
+
+    const real = numberField(value, "real");
+    const imag = numberField(value, "imag");
+    if (real !== undefined && imag !== undefined) return { real, imag };
+  }
+
+  throw new Error(`Unsupported quantum-circuit complex value: ${JSON.stringify(value)}`);
+}
+
+function normalizeMatrix(raw: readonly (readonly unknown[])[]): Matrix {
+  return raw.map((row) => row.map(normalizeComplex));
+}
+
+function matrixRow(matrix: Matrix, row: number): Complex[] {
+  return expectDefined(matrix[row], `missing matrix row ${String(row)}`);
+}
+
+function matrixAt(matrix: Matrix, row: number, col: number): Complex {
+  return expectDefined(matrixRow(matrix, row)[col], `missing matrix cell ${String(row)},${String(col)}`);
+}
+
+function probabilityOne(circuit: QuantumCircuit): number {
+  return expectDefined(circuit.probabilities()[0], "missing |1> probability");
+}
+
+function amplitudeProbability(circuit: QuantumCircuit, basisIndex: number): number {
+  const amplitude = normalizeComplex(
+    expectDefined(circuit.state[basisIndex], `missing basis amplitude ${String(basisIndex)}`),
+  );
+  return amplitude.real * amplitude.real + amplitude.imag * amplitude.imag;
+}
+
+function bellProbabilities(circuit: QuantumCircuit) {
+  const p00 = amplitudeProbability(circuit, 0);
+  const p01 = amplitudeProbability(circuit, 1);
+  const p10 = amplitudeProbability(circuit, 2);
+  const p11 = amplitudeProbability(circuit, 3);
+  return { p00, p01, p10, p11 };
+}
+
+function bellPhiPlusCircuit(a: number, b: number): QuantumCircuit {
+  const circuit = new QuantumCircuit(2);
+  append(circuit, "h", 0);
+  append(circuit, "cx", [0, 1]);
+  append(circuit, "ry", 0, [-a]);
+  append(circuit, "ry", 1, [-b]);
+  circuit.run();
+  return circuit;
+}
+
+function bellSingletCircuit(a: number, b: number): QuantumCircuit {
+  const circuit = new QuantumCircuit(2);
+  append(circuit, "h", 0);
+  append(circuit, "cx", [0, 1]);
+  append(circuit, "x", 1);
+  append(circuit, "z", 1);
+  append(circuit, "ry", 0, [-a]);
+  append(circuit, "ry", 1, [-b]);
+  circuit.run();
+  return circuit;
+}
+
+function phiPlusCorrelator(a: number, b: number): number {
+  const { p00, p01, p10, p11 } = bellProbabilities(bellPhiPlusCircuit(a, b));
+  return p00 + p11 - (p01 + p10);
+}
+
+function singletCorrelatorProbabilities(a: number, b: number): CorrelatorProbabilities {
+  const { p00, p01, p10, p11 } = bellProbabilities(bellSingletCircuit(a, b));
+  const pSame = p00 + p11;
+  const pOpposite = p01 + p10;
+  return { corr: pOpposite - pSame, pSame, pOpposite };
+}
+
+function makeGateCircuit(gateName: string): QuantumCircuit {
+  if (gateName === "BellPhiPlusPrep") {
+    const circuit = new QuantumCircuit(2);
+    append(circuit, "h", 0);
+    append(circuit, "cx", [0, 1]);
+    return circuit;
+  }
+
+  const circuit = new QuantumCircuit(1);
+  applyKnownOperation(circuit, gateName, singleQubitGateActions);
+  return circuit;
+}
+
+function circuitMatrix(circuit: QuantumCircuit): Matrix {
+  return normalizeMatrix(circuit.circuitMatrix());
+}
+
+// The TS simulator is a second implementation over the same observable
+// golden vectors as Q#. It checks measurable probabilities/matrices here;
+// Tsirelson maximality remains a cited/proved theorem, not a sampling claim.
+describe("quantum-circuit simulator (second observable oracle)", () => {
   test("single-qubit measurement observables match textbook probabilities", () => {
     for (const v of golden.vectors.singleQubitMeasurement) {
-      const c = new QuantumCircuit(1);
-      if (v.operation === "Zeta.ReferenceOracle.ApplyH") {
-        c.appendGate("h", 0);
-      } else if (v.operation === "Zeta.ReferenceOracle.ApplyRyPiOver3") {
-        c.appendGate("ry", 0, { params: [Math.PI / 3] });
-      } else if (v.operation === "Zeta.ReferenceOracle.ApplyRyPiOver2") {
-        c.appendGate("ry", 0, { params: [Math.PI / 2] });
-      } else {
-        throw new Error(`Unknown operation: ${v.operation}`);
-      }
-      c.run();
+      const circuit = new QuantumCircuit(1);
+      applyKnownOperation(circuit, v.operation, singleQubitActions);
+      circuit.run();
 
-      const probOne = c.probabilities()[0];
+      const probOne = probabilityOne(circuit);
       const probZero = 1 - probOne;
 
       closeTo(probZero, v.probabilities.Zero, qsharpDumpTolerance);
@@ -61,128 +341,61 @@ describe("quantum-circuit simulator (second oracle)", () => {
     }
   });
 
-  test("Bell/CHSH vector correlators and S parameter", () => {
+  test("Bell/CHSH vector correlators and S parameter match Q# observables", () => {
     const canonical = golden.vectors.bellChsh.canonical;
     const angles = canonical.anglesRadians;
 
-    const computeCorrelator = (a: number, b: number) => {
-      const c = new QuantumCircuit(2);
-      c.appendGate("h", 0);
-      c.appendGate("cx", [0, 1]);
-      c.appendGate("ry", 0, { params: [-a] });
-      c.appendGate("ry", 1, { params: [-b] });
-      c.run();
+    const eAb = phiPlusCorrelator(angles.a, angles.b);
+    const eAbPrime = phiPlusCorrelator(angles.a, angles.bPrime);
+    const eAPrimeB = phiPlusCorrelator(angles.aPrime, angles.b);
+    const eAPrimeBPrime = phiPlusCorrelator(angles.aPrime, angles.bPrime);
+    const s = eAb - eAbPrime + eAPrimeB + eAPrimeBPrime;
 
-      const p00 = getAmplitudeProb(c.state[0]);
-      const p01 = getAmplitudeProb(c.state[1]);
-      const p10 = getAmplitudeProb(c.state[2]);
-      const p11 = getAmplitudeProb(c.state[3]);
-      return p00 + p11 - (p01 + p10);
-    };
-
-    const E_ab = computeCorrelator(angles.a, angles.b);
-    const E_abPrime = computeCorrelator(angles.a, angles.bPrime);
-    const E_aPrimeb = computeCorrelator(angles.aPrime, angles.b);
-    const E_aPrimebPrime = computeCorrelator(angles.aPrime, angles.bPrime);
-
-    const s = E_ab - E_abPrime + E_aPrimeb + E_aPrimebPrime;
-
-    closeTo(E_ab, canonical.correlators["E(a,b)"], qsharpDumpTolerance);
-    closeTo(E_abPrime, canonical.correlators["E(a,bPrime)"], qsharpDumpTolerance);
-    closeTo(E_aPrimeb, canonical.correlators["E(aPrime,b)"], qsharpDumpTolerance);
-    closeTo(E_aPrimebPrime, canonical.correlators["E(aPrime,bPrime)"], qsharpDumpTolerance);
+    closeTo(eAb, canonical.correlators["E(a,b)"], qsharpDumpTolerance);
+    closeTo(eAbPrime, canonical.correlators["E(a,bPrime)"], qsharpDumpTolerance);
+    closeTo(eAPrimeB, canonical.correlators["E(aPrime,b)"], qsharpDumpTolerance);
+    closeTo(eAPrimeBPrime, canonical.correlators["E(aPrime,bPrime)"], qsharpDumpTolerance);
     closeTo(s, canonical.s, qsharpDumpTolerance);
   });
 
-  test("Bell/CHSH singlet corners", () => {
+  test("Bell/CHSH singlet corners match Q# observable treaty", () => {
     const singlet = golden.vectors.bellChsh.singletCorners;
-
-    const runSingletCircuit = (a: number, b: number) => {
-      const c = new QuantumCircuit(2);
-      c.appendGate("h", 0);
-      c.appendGate("cx", [0, 1]);
-      c.appendGate("x", 1);
-      c.appendGate("z", 1);
-      c.appendGate("ry", 0, { params: [-a] });
-      c.appendGate("ry", 1, { params: [-b] });
-      c.run();
-
-      const p00 = getAmplitudeProb(c.state[0]);
-      const p01 = getAmplitudeProb(c.state[1]);
-      const p10 = getAmplitudeProb(c.state[2]);
-      const p11 = getAmplitudeProb(c.state[3]);
-      const corr = p01 + p10 - (p00 + p11);
-      return { corr, pSame: p00 + p11, pOpposite: p01 + p10 };
-    };
-
     let s = 0;
+
     for (const corner of singlet.corners) {
       const angles = corner.anglesRadians;
-      const res = runSingletCircuit(angles.a, angles.b);
-      closeTo(res.corr, corner.correlator, qsharpDumpTolerance);
-      closeTo(res.pSame, corner.sameOutcomeProbability, qsharpDumpTolerance);
-      closeTo(res.pOpposite, corner.oppositeOutcomeProbability, qsharpDumpTolerance);
-      s += corner.coefficient * res.corr;
+      const result = singletCorrelatorProbabilities(angles.a, angles.b);
+
+      closeTo(result.corr, corner.correlator, qsharpDumpTolerance);
+      closeTo(result.pSame, corner.sameOutcomeProbability, qsharpDumpTolerance);
+      closeTo(result.pOpposite, corner.oppositeOutcomeProbability, qsharpDumpTolerance);
+      s += corner.coefficient * result.corr;
     }
+
     closeTo(s, singlet.s, qsharpDumpTolerance);
     closeTo(s, singlet.analytic, qsharpDumpTolerance);
   });
 
-  test("Bell coincidence probability outcomes", () => {
+  test("Bell coincidence probability outcomes match Q# observables", () => {
     for (const v of golden.vectors.bellCoincidence) {
-      const c = new QuantumCircuit(2);
-      c.appendGate("h", 0);
-      c.appendGate("cx", [0, 1]);
-
-      if (v.operation === "Zeta.ReferenceOracle.ApplyBellSingletAnalyzers") {
-        c.appendGate("x", 1);
-        c.appendGate("z", 1);
-      }
-
-      c.appendGate("ry", 0, { params: [-v.anglesRadians.a] });
-      c.appendGate("ry", 1, { params: [-v.anglesRadians.b] });
-      c.run();
-
-      const p00 = getAmplitudeProb(c.state[0]);
-      const p01 = getAmplitudeProb(c.state[1]);
-      const p10 = getAmplitudeProb(c.state[2]);
-      const p11 = getAmplitudeProb(c.state[3]);
-
+      const circuit =
+        v.operation === "Zeta.ReferenceOracle.ApplyBellSingletAnalyzers"
+          ? bellSingletCircuit(v.anglesRadians.a, v.anglesRadians.b)
+          : bellPhiPlusCircuit(v.anglesRadians.a, v.anglesRadians.b);
+      const { p00, p01, p10, p11 } = bellProbabilities(circuit);
       const actualProb = v.event === "sameOutcome" ? p00 + p11 : p01 + p10;
+
       closeTo(actualProb, v.probability, qsharpDumpTolerance);
     }
   });
 
-  test("interference visibility (Mach-Zehnder interferometer)", () => {
+  test("interference visibility matches Q# Mach-Zehnder observables", () => {
     for (const v of golden.vectors.interferenceVisibility) {
-      const c = new QuantumCircuit(1);
-      if (v.operation === "Zeta.ReferenceOracle.ApplyMachZehnderOpen") {
-        c.appendGate("h", 0);
-      } else if (v.operation === "Zeta.ReferenceOracle.ApplyMachZehnderClosedZeroPhase") {
-        c.appendGate("h", 0);
-        c.appendGate("h", 0);
-      } else if (v.operation === "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiPhase") {
-        c.appendGate("h", 0);
-        c.appendGate("z", 0);
-        c.appendGate("h", 0);
-      } else if (v.operation === "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiOver3Phase") {
-        c.appendGate("h", 0);
-        c.appendGate("rz", 0, { params: [Math.PI / 3] });
-        c.appendGate("h", 0);
-      } else if (v.operation === "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiOver2Phase") {
-        c.appendGate("h", 0);
-        c.appendGate("rz", 0, { params: [Math.PI / 2] });
-        c.appendGate("h", 0);
-      } else if (v.operation === "Zeta.ReferenceOracle.ApplyMachZehnderClosedTwoPiOver3Phase") {
-        c.appendGate("h", 0);
-        c.appendGate("rz", 0, { params: [(2 * Math.PI) / 3] });
-        c.appendGate("h", 0);
-      } else {
-        throw new Error(`Unknown operation: ${v.operation}`);
-      }
-      c.run();
+      const circuit = new QuantumCircuit(1);
+      applyKnownOperation(circuit, v.operation, machZehnderActions);
+      circuit.run();
 
-      const probOne = c.probabilities()[0];
+      const probOne = probabilityOne(circuit);
       const probZero = 1 - probOne;
 
       closeTo(probZero, v.probabilities.Zero, qsharpDumpTolerance);
@@ -190,110 +403,44 @@ describe("quantum-circuit simulator (second oracle)", () => {
     }
   });
 
-  test("gate unitary matrices match reference oracle exactly", () => {
+  test("gate unitary simulator sanity checks match Q# reference matrices", () => {
     const unitaries = golden.vectors.gateUnitaries;
 
     for (const [gateName, expectedMatrixRaw] of Object.entries(unitaries)) {
-      const expectedMatrix = expectedMatrixRaw as any[][];
-      let c: QuantumCircuit;
-      if (gateName === "BellPhiPlusPrep") {
-        c = new QuantumCircuit(2);
-        c.appendGate("h", 0);
-        c.appendGate("cx", [0, 1]);
-      } else {
-        c = new QuantumCircuit(1);
-        if (gateName === "H") {
-          c.appendGate("h", 0);
-        } else if (gateName === "Ry(pi/2)") {
-          c.appendGate("ry", 0, { params: [Math.PI / 2] });
-        } else if (gateName === "Ry(pi/3)") {
-          c.appendGate("ry", 0, { params: [Math.PI / 3] });
-        } else if (gateName === "Rz(pi/3)") {
-          c.appendGate("rz", 0, { params: [Math.PI / 3] });
-        } else if (gateName === "S") {
-          c.appendGate("s", 0);
-        } else if (gateName === "T") {
-          c.appendGate("t", 0);
-        } else if (gateName === "X") {
-          c.appendGate("x", 0);
-        } else if (gateName === "Y") {
-          c.appendGate("y", 0);
-        } else if (gateName === "Z") {
-          c.appendGate("z", 0);
-        } else {
-          throw new Error(`Unknown gate unitary key: ${gateName}`);
-        }
-      }
-
-      const actualRawMatrix = c.circuitMatrix();
-      const actualMatrix = actualRawMatrix.map((row: any) => row.map(normalizeComplex));
+      const expectedMatrix = normalizeMatrix(expectedMatrixRaw);
+      const actualMatrix = circuitMatrix(makeGateCircuit(gateName));
 
       expect(actualMatrix.length).toBe(expectedMatrix.length);
-      for (let r = 0; r < expectedMatrix.length; r++) {
-        const expectedRow = expectedMatrix[r]!;
-        const actualRow = actualMatrix[r]!;
-        expect(actualRow.length).toBe(expectedRow.length);
-        for (let col = 0; col < expectedRow.length; col++) {
-          const act = actualRow[col];
-          const exp = expectedRow[col];
-          if (act && exp) {
-            closeTo(act.real, exp.real, qsharpDumpTolerance);
-            closeTo(act.imag, exp.imag, qsharpDumpTolerance);
-          }
+      for (let row = 0; row < expectedMatrix.length; row++) {
+        expect(matrixRow(actualMatrix, row).length).toBe(matrixRow(expectedMatrix, row).length);
+
+        for (let col = 0; col < matrixRow(expectedMatrix, row).length; col++) {
+          closeComplexTo(matrixAt(actualMatrix, row, col), matrixAt(expectedMatrix, row, col), qsharpDumpTolerance);
         }
       }
     }
   });
 
-  test("Q# Pauli products anticommutation relations", () => {
+  test("Pauli product matrices match Q# hardware-side anticommutation signs", () => {
     for (const item of golden.vectors.pauliAnticommutation) {
-      const runCircuit = (opName: string) => {
-        const c = new QuantumCircuit(1);
-        if (opName === "Zeta.ReferenceOracle.ApplyPauliXAfterZ") {
-          c.appendGate("z", 0);
-          c.appendGate("x", 0);
-        } else if (opName === "Zeta.ReferenceOracle.ApplyPauliZAfterX") {
-          c.appendGate("x", 0);
-          c.appendGate("z", 0);
-        } else if (opName === "Zeta.ReferenceOracle.ApplyPauliXAfterY") {
-          c.appendGate("y", 0);
-          c.appendGate("x", 0);
-        } else if (opName === "Zeta.ReferenceOracle.ApplyPauliYAfterX") {
-          c.appendGate("x", 0);
-          c.appendGate("y", 0);
-        } else if (opName === "Zeta.ReferenceOracle.ApplyPauliYAfterZ") {
-          c.appendGate("z", 0);
-          c.appendGate("y", 0);
-        } else if (opName === "Zeta.ReferenceOracle.ApplyPauliZAfterY") {
-          c.appendGate("y", 0);
-          c.appendGate("z", 0);
-        } else {
-          throw new Error(`Unknown Pauli operation: ${opName}`);
-        }
-        return c.circuitMatrix().map((row: any) => row.map(normalizeComplex));
-      };
+      const lhsCircuit = new QuantumCircuit(1);
+      const rhsCircuit = new QuantumCircuit(1);
+      applyKnownOperation(lhsCircuit, item.lhsOperation, pauliProductActions);
+      applyKnownOperation(rhsCircuit, item.rhsOperation, pauliProductActions);
 
-      const lhs = runCircuit(item.lhsOperation);
-      const rhs = runCircuit(item.rhsOperation);
+      const lhs = circuitMatrix(lhsCircuit);
+      const rhs = circuitMatrix(rhsCircuit);
+      const expectedLhs = normalizeMatrix(item.lhsMatrix);
+      const expectedRhs = normalizeMatrix(item.rhsMatrix);
 
-      for (let r = 0; r < lhs.length; r++) {
-        const lhsRow = lhs[r] as any[];
-        const rhsRow = rhs[r] as any[];
-        const expectedLhsRow = item.lhsMatrix[r] as any[];
-        const expectedRhsRow = item.rhsMatrix[r] as any[];
-        for (let col = 0; col < lhsRow.length; col++) {
-          const lVal = lhsRow[col];
-          const rVal = rhsRow[col];
-          const expectedLVal = normalizeComplex(expectedLhsRow[col]);
-          const expectedRVal = normalizeComplex(expectedRhsRow[col]);
+      for (let row = 0; row < lhs.length; row++) {
+        for (let col = 0; col < matrixRow(lhs, row).length; col++) {
+          const lhsValue = matrixAt(lhs, row, col);
+          const rhsValue = matrixAt(rhs, row, col);
 
-          closeTo(lVal.real, expectedLVal.real, qsharpDumpTolerance);
-          closeTo(lVal.imag, expectedLVal.imag, qsharpDumpTolerance);
-          closeTo(rVal.real, expectedRVal.real, qsharpDumpTolerance);
-          closeTo(rVal.imag, expectedRVal.imag, qsharpDumpTolerance);
-
-          closeTo(lVal.real, -rVal.real, qsharpDumpTolerance);
-          closeTo(lVal.imag, -rVal.imag, qsharpDumpTolerance);
+          closeComplexTo(lhsValue, matrixAt(expectedLhs, row, col), qsharpDumpTolerance);
+          closeComplexTo(rhsValue, matrixAt(expectedRhs, row, col), qsharpDumpTolerance);
+          closeComplexTo(lhsValue, { real: -rhsValue.real, imag: -rhsValue.imag }, qsharpDumpTolerance);
         }
       }
     }

--- a/tools/qsharp-oracle/quantum-circuit.test.ts
+++ b/tools/qsharp-oracle/quantum-circuit.test.ts
@@ -1,0 +1,301 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* eslint-disable sonarjs/cognitive-complexity */
+import { describe, expect, test } from "bun:test";
+// @ts-expect-error: quantum-circuit has no official typings
+import QuantumCircuit from "quantum-circuit";
+import golden from "./qsharp-golden.json";
+
+const qsharpDumpTolerance = 1e-5;
+const tolerance = 1e-6;
+
+function closeTo(actual: number, expected: number, epsilon = tolerance) {
+  expect(Math.abs(actual - expected)).toBeLessThanOrEqual(epsilon);
+}
+
+function getAmplitudeProb(amp: any): number {
+  if (!amp) return 0;
+  if (typeof amp === "number") return amp * amp;
+  return amp.re * amp.re + amp.im * amp.im;
+}
+
+function normalizeComplex(val: any): { real: number; imag: number } {
+  if (typeof val === "number") {
+    return { real: val, imag: 0 };
+  } else if (val && typeof val === "object") {
+    if ("re" in val && "im" in val) {
+      return { real: val.re, imag: val.im };
+    }
+    if ("real" in val && "imag" in val) {
+      return { real: val.real, imag: val.imag };
+    }
+  }
+  return { real: 0, imag: 0 };
+}
+
+describe("quantum-circuit simulator (second oracle)", () => {
+  test("single-qubit measurement observables match textbook probabilities", () => {
+    for (const v of golden.vectors.singleQubitMeasurement) {
+      const c = new QuantumCircuit(1);
+      if (v.operation === "Zeta.ReferenceOracle.ApplyH") {
+        c.appendGate("h", 0);
+      } else if (v.operation === "Zeta.ReferenceOracle.ApplyRyPiOver3") {
+        c.appendGate("ry", 0, { params: [Math.PI / 3] });
+      } else if (v.operation === "Zeta.ReferenceOracle.ApplyRyPiOver2") {
+        c.appendGate("ry", 0, { params: [Math.PI / 2] });
+      } else {
+        throw new Error(`Unknown operation: ${v.operation}`);
+      }
+      c.run();
+
+      const probOne = c.probabilities()[0];
+      const probZero = 1 - probOne;
+
+      closeTo(probZero, v.probabilities.Zero, qsharpDumpTolerance);
+      closeTo(probOne, v.probabilities.One, qsharpDumpTolerance);
+    }
+  });
+
+  test("Bell/CHSH vector correlators and S parameter", () => {
+    const canonical = golden.vectors.bellChsh.canonical;
+    const angles = canonical.anglesRadians;
+
+    const computeCorrelator = (a: number, b: number) => {
+      const c = new QuantumCircuit(2);
+      c.appendGate("h", 0);
+      c.appendGate("cx", [0, 1]);
+      c.appendGate("ry", 0, { params: [-a] });
+      c.appendGate("ry", 1, { params: [-b] });
+      c.run();
+
+      const p00 = getAmplitudeProb(c.state[0]);
+      const p01 = getAmplitudeProb(c.state[1]);
+      const p10 = getAmplitudeProb(c.state[2]);
+      const p11 = getAmplitudeProb(c.state[3]);
+      return p00 + p11 - (p01 + p10);
+    };
+
+    const E_ab = computeCorrelator(angles.a, angles.b);
+    const E_abPrime = computeCorrelator(angles.a, angles.bPrime);
+    const E_aPrimeb = computeCorrelator(angles.aPrime, angles.b);
+    const E_aPrimebPrime = computeCorrelator(angles.aPrime, angles.bPrime);
+
+    const s = E_ab - E_abPrime + E_aPrimeb + E_aPrimebPrime;
+
+    closeTo(E_ab, canonical.correlators["E(a,b)"], qsharpDumpTolerance);
+    closeTo(E_abPrime, canonical.correlators["E(a,bPrime)"], qsharpDumpTolerance);
+    closeTo(E_aPrimeb, canonical.correlators["E(aPrime,b)"], qsharpDumpTolerance);
+    closeTo(E_aPrimebPrime, canonical.correlators["E(aPrime,bPrime)"], qsharpDumpTolerance);
+    closeTo(s, canonical.s, qsharpDumpTolerance);
+  });
+
+  test("Bell/CHSH singlet corners", () => {
+    const singlet = golden.vectors.bellChsh.singletCorners;
+
+    const runSingletCircuit = (a: number, b: number) => {
+      const c = new QuantumCircuit(2);
+      c.appendGate("h", 0);
+      c.appendGate("cx", [0, 1]);
+      c.appendGate("x", 1);
+      c.appendGate("z", 1);
+      c.appendGate("ry", 0, { params: [-a] });
+      c.appendGate("ry", 1, { params: [-b] });
+      c.run();
+
+      const p00 = getAmplitudeProb(c.state[0]);
+      const p01 = getAmplitudeProb(c.state[1]);
+      const p10 = getAmplitudeProb(c.state[2]);
+      const p11 = getAmplitudeProb(c.state[3]);
+      const corr = p01 + p10 - (p00 + p11);
+      return { corr, pSame: p00 + p11, pOpposite: p01 + p10 };
+    };
+
+    let s = 0;
+    for (const corner of singlet.corners) {
+      const angles = corner.anglesRadians;
+      const res = runSingletCircuit(angles.a, angles.b);
+      closeTo(res.corr, corner.correlator, qsharpDumpTolerance);
+      closeTo(res.pSame, corner.sameOutcomeProbability, qsharpDumpTolerance);
+      closeTo(res.pOpposite, corner.oppositeOutcomeProbability, qsharpDumpTolerance);
+      s += corner.coefficient * res.corr;
+    }
+    closeTo(s, singlet.s, qsharpDumpTolerance);
+    closeTo(s, singlet.analytic, qsharpDumpTolerance);
+  });
+
+  test("Bell coincidence probability outcomes", () => {
+    for (const v of golden.vectors.bellCoincidence) {
+      const c = new QuantumCircuit(2);
+      c.appendGate("h", 0);
+      c.appendGate("cx", [0, 1]);
+
+      if (v.operation === "Zeta.ReferenceOracle.ApplyBellSingletAnalyzers") {
+        c.appendGate("x", 1);
+        c.appendGate("z", 1);
+      }
+
+      c.appendGate("ry", 0, { params: [-v.anglesRadians.a] });
+      c.appendGate("ry", 1, { params: [-v.anglesRadians.b] });
+      c.run();
+
+      const p00 = getAmplitudeProb(c.state[0]);
+      const p01 = getAmplitudeProb(c.state[1]);
+      const p10 = getAmplitudeProb(c.state[2]);
+      const p11 = getAmplitudeProb(c.state[3]);
+
+      const actualProb = v.event === "sameOutcome" ? p00 + p11 : p01 + p10;
+      closeTo(actualProb, v.probability, qsharpDumpTolerance);
+    }
+  });
+
+  test("interference visibility (Mach-Zehnder interferometer)", () => {
+    for (const v of golden.vectors.interferenceVisibility) {
+      const c = new QuantumCircuit(1);
+      if (v.operation === "Zeta.ReferenceOracle.ApplyMachZehnderOpen") {
+        c.appendGate("h", 0);
+      } else if (v.operation === "Zeta.ReferenceOracle.ApplyMachZehnderClosedZeroPhase") {
+        c.appendGate("h", 0);
+        c.appendGate("h", 0);
+      } else if (v.operation === "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiPhase") {
+        c.appendGate("h", 0);
+        c.appendGate("z", 0);
+        c.appendGate("h", 0);
+      } else if (v.operation === "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiOver3Phase") {
+        c.appendGate("h", 0);
+        c.appendGate("rz", 0, { params: [Math.PI / 3] });
+        c.appendGate("h", 0);
+      } else if (v.operation === "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiOver2Phase") {
+        c.appendGate("h", 0);
+        c.appendGate("rz", 0, { params: [Math.PI / 2] });
+        c.appendGate("h", 0);
+      } else if (v.operation === "Zeta.ReferenceOracle.ApplyMachZehnderClosedTwoPiOver3Phase") {
+        c.appendGate("h", 0);
+        c.appendGate("rz", 0, { params: [(2 * Math.PI) / 3] });
+        c.appendGate("h", 0);
+      } else {
+        throw new Error(`Unknown operation: ${v.operation}`);
+      }
+      c.run();
+
+      const probOne = c.probabilities()[0];
+      const probZero = 1 - probOne;
+
+      closeTo(probZero, v.probabilities.Zero, qsharpDumpTolerance);
+      closeTo(probOne, v.probabilities.One, qsharpDumpTolerance);
+    }
+  });
+
+  test("gate unitary matrices match reference oracle exactly", () => {
+    const unitaries = golden.vectors.gateUnitaries;
+
+    for (const [gateName, expectedMatrixRaw] of Object.entries(unitaries)) {
+      const expectedMatrix = expectedMatrixRaw as any[][];
+      let c: QuantumCircuit;
+      if (gateName === "BellPhiPlusPrep") {
+        c = new QuantumCircuit(2);
+        c.appendGate("h", 0);
+        c.appendGate("cx", [0, 1]);
+      } else {
+        c = new QuantumCircuit(1);
+        if (gateName === "H") {
+          c.appendGate("h", 0);
+        } else if (gateName === "Ry(pi/2)") {
+          c.appendGate("ry", 0, { params: [Math.PI / 2] });
+        } else if (gateName === "Ry(pi/3)") {
+          c.appendGate("ry", 0, { params: [Math.PI / 3] });
+        } else if (gateName === "Rz(pi/3)") {
+          c.appendGate("rz", 0, { params: [Math.PI / 3] });
+        } else if (gateName === "S") {
+          c.appendGate("s", 0);
+        } else if (gateName === "T") {
+          c.appendGate("t", 0);
+        } else if (gateName === "X") {
+          c.appendGate("x", 0);
+        } else if (gateName === "Y") {
+          c.appendGate("y", 0);
+        } else if (gateName === "Z") {
+          c.appendGate("z", 0);
+        } else {
+          throw new Error(`Unknown gate unitary key: ${gateName}`);
+        }
+      }
+
+      const actualRawMatrix = c.circuitMatrix();
+      const actualMatrix = actualRawMatrix.map((row: any) => row.map(normalizeComplex));
+
+      expect(actualMatrix.length).toBe(expectedMatrix.length);
+      for (let r = 0; r < expectedMatrix.length; r++) {
+        const expectedRow = expectedMatrix[r]!;
+        const actualRow = actualMatrix[r]!;
+        expect(actualRow.length).toBe(expectedRow.length);
+        for (let col = 0; col < expectedRow.length; col++) {
+          const act = actualRow[col];
+          const exp = expectedRow[col];
+          if (act && exp) {
+            closeTo(act.real, exp.real, qsharpDumpTolerance);
+            closeTo(act.imag, exp.imag, qsharpDumpTolerance);
+          }
+        }
+      }
+    }
+  });
+
+  test("Q# Pauli products anticommutation relations", () => {
+    for (const item of golden.vectors.pauliAnticommutation) {
+      const runCircuit = (opName: string) => {
+        const c = new QuantumCircuit(1);
+        if (opName === "Zeta.ReferenceOracle.ApplyPauliXAfterZ") {
+          c.appendGate("z", 0);
+          c.appendGate("x", 0);
+        } else if (opName === "Zeta.ReferenceOracle.ApplyPauliZAfterX") {
+          c.appendGate("x", 0);
+          c.appendGate("z", 0);
+        } else if (opName === "Zeta.ReferenceOracle.ApplyPauliXAfterY") {
+          c.appendGate("y", 0);
+          c.appendGate("x", 0);
+        } else if (opName === "Zeta.ReferenceOracle.ApplyPauliYAfterX") {
+          c.appendGate("x", 0);
+          c.appendGate("y", 0);
+        } else if (opName === "Zeta.ReferenceOracle.ApplyPauliYAfterZ") {
+          c.appendGate("z", 0);
+          c.appendGate("y", 0);
+        } else if (opName === "Zeta.ReferenceOracle.ApplyPauliZAfterY") {
+          c.appendGate("y", 0);
+          c.appendGate("z", 0);
+        } else {
+          throw new Error(`Unknown Pauli operation: ${opName}`);
+        }
+        return c.circuitMatrix().map((row: any) => row.map(normalizeComplex));
+      };
+
+      const lhs = runCircuit(item.lhsOperation);
+      const rhs = runCircuit(item.rhsOperation);
+
+      for (let r = 0; r < lhs.length; r++) {
+        const lhsRow = lhs[r] as any[];
+        const rhsRow = rhs[r] as any[];
+        const expectedLhsRow = item.lhsMatrix[r] as any[];
+        const expectedRhsRow = item.rhsMatrix[r] as any[];
+        for (let col = 0; col < lhsRow.length; col++) {
+          const lVal = lhsRow[col];
+          const rVal = rhsRow[col];
+          const expectedLVal = normalizeComplex(expectedLhsRow[col]);
+          const expectedRVal = normalizeComplex(expectedRhsRow[col]);
+
+          closeTo(lVal.real, expectedLVal.real, qsharpDumpTolerance);
+          closeTo(lVal.imag, expectedLVal.imag, qsharpDumpTolerance);
+          closeTo(rVal.real, expectedRVal.real, qsharpDumpTolerance);
+          closeTo(rVal.imag, expectedRVal.imag, qsharpDumpTolerance);
+
+          closeTo(lVal.real, -rVal.real, qsharpDumpTolerance);
+          closeTo(lVal.imag, -rVal.imag, qsharpDumpTolerance);
+        }
+      }
+    }
+  });
+});

--- a/tools/setup/common/quantum.sh
+++ b/tools/setup/common/quantum.sh
@@ -33,7 +33,7 @@ UV_BIN="$(command -v uv)"
 
 SPECS="$(awk '
   { sub(/#.*$/, ""); gsub(/^[[:space:]]+|[[:space:]]+$/, "") }
-  NF > 0 { print $1 }
+  NF > 0 && !/ecosystem=npm/ { print $1 }
 ' "$MANIFEST")"
 
 if [ -z "$SPECS" ]; then

--- a/tools/setup/manifests/quantum
+++ b/tools/setup/manifests/quantum
@@ -26,6 +26,7 @@
 qdk[azure]==1.29.1     role=reference-oracle lang=q#
 qsharp==1.29.1         role=reference-oracle lang=q#
 azure-quantum==3.10.0  role=reference-oracle lang=q#
+quantum-circuit==0.9.247 role=second-oracle lang=typescript ecosystem=npm
 #
 # The rest of the quantum-language oracle remains intentionally deferred until
 # the Q# reference vectors exist; uncomment with verified pins when those cells


### PR DESCRIPTION
## Summary

- Integrates Lior's `quantum-circuit` TypeScript oracle branch on top of latest `origin/main`.
- Adds the second observable oracle for the Q# golden vectors: single-qubit probabilities, Bell/CHSH correlators and singlet corners, Bell coincidences, Mach-Zehnder interference, gate unitaries, and Pauli anticommutation signs.
- Keeps the Q# boundary honest: Tsirelson maximality stays cited/proved, not sampled.
- Carries Lior's solution-wide IDE0040 accessibility-modifier formatting cleanup.
- Wires `quantum-circuit@0.9.247` into the root Bun dependency graph and replaces broad unsafe test suppressions with a small local declaration file.

## Verification

- `bunx eslint tools/qsharp-oracle/quantum-circuit.test.ts tools/qsharp-oracle/quantum-circuit.d.ts`
- `bun test tools/qsharp-oracle/quantum-circuit.test.ts tools/qsharp-oracle/qsharp-golden.test.ts`
- `bun --bun tsc --noEmit -p tsconfig.json`
- `bun test tools/ace/`
- `bunx prettier --check tools/qsharp-oracle/quantum-circuit.test.ts tools/qsharp-oracle/quantum-circuit.d.ts package.json docs/INSTALLED.md tools/ace/packages/qsharp-reference-oracle-0.1.0.json tools/ace/registry.json tools/ace/setup-manifest.ts`
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test Zeta.sln -c Release`
