### PR TITLE
fix(docs): repair BUGS markdownlint blanks

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -113,7 +113,6 @@ tempted to ship.
   check at registration (cheap, additive), and the lint's resolution gap stays covered by THE
   CATALOG LAW test.
 
-
 ### BloomBench.fs referenced but not on disk
 
 **STATUS (triage 2026-06-12): FIXED.** `bench/Benchmarks/BloomBench.fs` exists and was run (see the TECH-RADAR entry below).
@@ -264,7 +263,6 @@ tempted to ship.
   occurrence COUNTS (width-only exemptions; the contains-disjunct excuse); shine dim-assertions;
   self-agreement family literal pins; FluxView full-suffix + monotone recovery; MediaLines hedged
   dimension contract; healthy() boundary case; hand-written HTML golden fragments.
-
 
 ### MerkleTree.LeafDiff is flat O(N), not the branch-pruning walk its docstring claims
 


### PR DESCRIPTION
## Summary

- Remove duplicate blank lines in `docs/BUGS.md` that broke the whole-repo markdownlint gate after the round-3 BUGS update.

## Validation

- `mise exec -- markdownlint-cli2 docs/BUGS.md`
- `git ls-files -z '*.md' | xargs -0 mise exec -- markdownlint-cli2`
