### PR TITLE
fix(round3b): the falsifier found a LIVE injection hole in HtmlCssBinding + exact-count determinism allowlist + pong serveDir

### DIFF
--- a/src/Core/CorrespondencePong.fs
+++ b/src/Core/CorrespondencePong.fs
@@ -50,16 +50,21 @@ module CorrespondencePong =
     /// The match outcome both ends watch: rally length and which side conceded (None = survived).
     type Outcome = { Rally: int; Conceded: string option }
 
-    /// Play the round: both paddles run MetaControl.pongPolicy under their committed objectives;
-    /// pure function of (left, right, serveDir, steps) — DETERMINISTIC: this is the correspondence
-    /// integrity (and why retries are free: call it as many times as you like before you reply).
-    let play (left: Turn) (right: Turn) (steps: int) : Outcome =
+    /// Play the round from an explicit serve direction (+1 = toward the right player, −1 = toward
+    /// the left): both paddles run MetaControl.pongPolicy under their committed objectives; pure
+    /// function of (left, right, serveDir, steps) — DETERMINISTIC: the correspondence integrity
+    /// (retries are free: call it as many times as you like before you reply). Round-3 fix (Kira):
+    /// the old doc promised serveDir/seed parameters the signature lacked while hard-coding a
+    /// rightward serve — the right player ALWAYS defended first, a structural asymmetry the docs
+    /// denied. Fair play alternates serves across rounds: `playFrom -1` for the return game.
+    let playFrom (serveDir: int) (left: Turn) (right: Turn) (steps: int) : Outcome =
         let w, h = P.ofInt 64, P.ofInt 32
         let mutable lp = { P.Pos = P.v2 (P.ofInt 2) (P.ofInt 13); P.Size = P.v2 P.one (P.ofInt 6); P.Vel = P.v2 0 0 }
         let mutable rp = { P.Pos = P.v2 (P.ofInt 61) (P.ofInt 13); P.Size = P.v2 P.one (P.ofInt 6); P.Vel = P.v2 0 0 }
         // vx = 1 px/tick: no tunneling past a 1-px paddle (the integer physics is exact, so the
         // court geometry must respect the step size — a real constraint, honestly held)
-        let mutable ball = { P.Pos = P.v2 (P.ofInt 32) (P.ofInt 16); P.Size = P.v2 P.one P.one; P.Vel = P.v2 P.one (P.one / 4) }
+        let serve = if serveDir >= 0 then P.one else -P.one
+        let mutable ball = { P.Pos = P.v2 (P.ofInt 32) (P.ofInt 16); P.Size = P.v2 P.one P.one; P.Vel = P.v2 serve (P.one / 4) }
         let mutable rally = 0
         let mutable conceded: string option = None
         let mutable i = 0
@@ -84,3 +89,7 @@ module CorrespondencePong =
             i <- i + 1
 
         { Rally = rally; Conceded = conceded }
+
+    /// The rightward-serve convenience (the original behavior, now an HONEST default rather than
+    /// a hidden asymmetry — alternate with `playFrom -1` for fair correspondence play).
+    let play (left: Turn) (right: Turn) (steps: int) : Outcome = playFrom 1 left right steps

--- a/src/Core/HtmlCssBinding.fs
+++ b/src/Core/HtmlCssBinding.fs
@@ -70,16 +70,18 @@ module HtmlCssBinding =
 
         let divs =
             (MediaLines.ofKind "glyph" d @ MediaLines.ofKind "frame" d)
-            |> List.map (fun e -> sprintf "  <div class=\"px-%s\" title=\"%s\"></div>" e.Name e.Name)
+            |> List.map (fun e -> sprintf "  <div class=\"px-%s\" title=\"%s\"></div>" (ShapeRender.escapeXml e.Name) (ShapeRender.escapeXml e.Name))
 
         String.concat "\n"
             [ "<!doctype html>"
-              sprintf "<html lang=\"en\"><head><meta charset=\"utf-8\"><title>%s</title><style>" title
+              sprintf "<html lang=\"en\"><head><meta charset=\"utf-8\"><title>%s</title><style>" (ShapeRender.escapeXml title)
               paletteCss
               yield! sprites
               yield! anims
               "</style></head><body>"
-              sprintf "<h1>%s</h1>" title
-              (match motto with Some m -> sprintf "<p>%s</p>" m | None -> "")
+              sprintf "<h1>%s</h1>" (ShapeRender.escapeXml title)
+              (match motto with
+               | Some m -> sprintf "<p>%s</p>" (ShapeRender.escapeXml m) // r3b: the falsifier found a LIVE hole here — a hostile motto smuggled script through the no-JS page
+               | None -> "")
               yield! divs
               "</body></html>" ]

--- a/src/Core/PixelLens.fs
+++ b/src/Core/PixelLens.fs
@@ -28,7 +28,10 @@ module PixelLens =
     /// A sub-pixel cell: the 32-bit deep pixel.
     type Cell = uint32
 
-    /// Pack (color, payload, uncertainty) into a cell — masked to their fields (total; no overflow).
+    /// Pack (color, payload, uncertainty) into a cell — MASKED to their fields. Total in the
+    /// never-throws sense ONLY: out-of-range inputs silently truncate to field width (pack _ -1 _
+    /// round-trips payload as 8191 — r3 doc fix: "no overflow" overstated this as no-loss).
+    /// Callers needing refusal-on-overflow validate before packing.
     let pack (color: byte) (payload: int) (uncertaintyMilli: int) : Cell =
         (uint32 color &&& 0x7u)
         ||| ((uint32 payload &&& 0x1FFFu) <<< 3)

--- a/tests/Tests.FSharp/DeterminismLint.Tests.fs
+++ b/tests/Tests.FSharp/DeterminismLint.Tests.fs
@@ -28,24 +28,24 @@ let private banned =
 /// means adding a row HERE, with a reason a reviewer can refuse.
 let private allowlist =
     [ // the wall-clock door itself: the ONE place ambient time/entropy is abstracted behind IEnvironment
-      "Environment.fs", "DateTime.UtcNow", "the docstring NAMES the ambient sources this interface fences off"
-      "Environment.fs", "Guid.NewGuid", "the ambient implementation of IEnvironment.NewGuid — the fenced door"
-      "Environment.fs", "Random.Shared", "docstring reference to what is being fenced"
-      "Environment.fs", "Environment.TickCount", "the ambient implementation of IEnvironment.Ticks"
+      "Environment.fs", "DateTime.UtcNow", 1, "the docstring NAMES the ambient sources this interface fences off"
+      "Environment.fs", "Guid.NewGuid", 2, "the ambient implementation of IEnvironment.NewGuid — the fenced door"
+      "Environment.fs", "Random.Shared", 3, "docstring reference to what is being fenced"
+      "Environment.fs", "Environment.TickCount", 1, "the ambient implementation of IEnvironment.Ticks"
       // seeded by construction: System.Random(seed + i) — deterministic per seed, the LawRunner contract
-      "LawRunner.fs", "System.Random(", "every instance is seeded (seed + sampleIndex); reproducible by design"
+      "LawRunner.fs", "System.Random(", 3, "every instance is seeded (seed + sampleIndex); reproducible by design"
       // IO-infrastructure edges: temp-file / instance names (affect disk layout, never logical state)
-      "Checkpoint.fs", "Guid.NewGuid", "tmp-file suffix for atomic rename — IO edge, not logical state"
-      "DiskSpine.fs", "Guid.NewGuid", "per-instance disk prefix — IO edge, not logical state"
-      "DiskSpineAsync.fs", "Guid.NewGuid", "per-instance disk prefix — IO edge, not logical state"
+      "Checkpoint.fs", "Guid.NewGuid", 1, "tmp-file suffix for atomic rename — IO edge, not logical state"
+      "DiskSpine.fs", "Guid.NewGuid", 1, "per-instance disk prefix — IO edge, not logical state"
+      "DiskSpineAsync.fs", "Guid.NewGuid", 1, "per-instance disk prefix — IO edge, not logical state"
       // interactive-edge convenience overload, documented as non-replayable; seeded overload exists
-      "Crdt.fs", "Guid.NewGuid", "OrSet.Add ambient overload — documented wall-clock edge; the seeded Add(elem, tag) is the DST path"
+      "Crdt.fs", "Guid.NewGuid", 2, "OrSet.Add ambient overload — documented wall-clock edge; the seeded Add(elem, tag) is the DST path"
       // the ambient wall-clock EDGES of consensus (the DST paths are transitionAt/prToVoteAt)
-      "Consensus.fs", "DateTimeOffset.UtcNow", "two documented ambient wrappers (transition/prToVote); injected -At variants are the DST paths"
-      "Environment.fs", "DateTimeOffset.UtcNow", "the ambient implementation of IEnvironment.Now — the fenced door"
-      "Injection.fs", "DateTimeOffset.UtcNow", "wall-time instrumentation at the injection edge — observability only"
+      "Consensus.fs", "DateTimeOffset.UtcNow", 4, "two documented ambient wrappers (transition/prToVote) + their two doc-comment mentions; injected -At variants are the DST paths"
+      "Environment.fs", "DateTimeOffset.UtcNow", 1, "the ambient implementation of IEnvironment.Now — the fenced door"
+      "Injection.fs", "DateTimeOffset.UtcNow", 2, "wall-time instrumentation at the injection edge — observability only"
       // timing instrumentation at the injection boundary (observability, not logic)
-      "Injection.fs", "Stopwatch.StartNew", "wall-time instrumentation at the injection edge — observability only" ]
+      "Injection.fs", "Stopwatch.StartNew", 1, "wall-time instrumentation at the injection edge — observability only" ]
 
 [<Fact>]
 let ``THE DETERMINISM LINT: no ambient entropy in src/Core outside the named, justified edges`` () =
@@ -57,16 +57,24 @@ let ``THE DETERMINISM LINT: no ambient entropy in src/Core outside the named, ju
               for i in 0 .. lines.Length - 1 do
                   for pat in banned do
                       if lines.[i].Contains pat then
-                          let allowed = allowlist |> List.exists (fun (f, p, _) -> f = name && pat.StartsWith p || (f = name && lines.[i].Contains p))
+                          let allowed = allowlist |> List.exists (fun (f, p, _, _) -> f = name && p = pat) // exact rows only (the old contains-disjunct excused pattern Y on any line mentioning X)
                           if not allowed then
                               yield sprintf "%s:%d uses '%s' — ambient entropy in Core; seed it, fence it behind IEnvironment, or add a justified allowlist row" name (i + 1) pat ]
     Assert.True(List.isEmpty violations, String.concat "\n" violations)
 
 [<Fact>]
-let ``the allowlist rows all still exist — a stale exemption is a hole waiting for a new occupant`` () =
+let ``the allowlist pins EXACT occurrence counts — a third wall clock cannot slide in behind two justified ones`` () =
     let core = Path.Combine(repoRoot (), "src", "Core")
-    for (file, pat, _why) in allowlist do
+    for (file, pat, expected, _why) in allowlist do
         let path = Path.Combine(core, file)
         Assert.True(File.Exists path, file + " vanished — remove its allowlist rows")
-        let contains = (File.ReadAllText path).Contains pat
-        Assert.True(contains, sprintf "%s no longer contains '%s' — remove the stale allowlist row" file pat)
+        let actual =
+            File.ReadAllLines path
+            |> Array.sumBy (fun (l: string) ->
+                let mutable c = 0
+                let mutable i = l.IndexOf(pat)
+                while i >= 0 do
+                    c <- c + 1
+                    i <- l.IndexOf(pat, i + 1)
+                c)
+        Assert.True((actual = expected), sprintf "%s: '%s' occurs %d times, allowlist pins %d — justify the new edge with a count bump and a WHY, or remove the stale row" file pat actual expected)

--- a/tests/Tests.FSharp/ShapeAcceptance.Tests.fs
+++ b/tests/Tests.FSharp/ShapeAcceptance.Tests.fs
@@ -227,3 +227,13 @@ let ``VF IS THE FLAG, EVEN WHEN VF IS AN OPERAND: 8F05 with x=F keeps the flag w
     let cow = Chip8Cow.create 7UL |> Chip8Cow.loadRom rom
     let f = [ 1..3 ] |> List.fold (fun s _ -> Chip8Cow.step s) cow
     Assert.Equal(1uy, f.V.[0xF]) // the flag, not the difference
+
+
+[<Fact>]
+let ``HTMLCSSBINDING INJECTION FALSIFIER: a hostile motto cannot smuggle script through render (test-gap #2)`` () =
+    let hostile = "meta\tname\tx\nmeta\tmotto\t</style><script>alert(1)</script>\nframe\tidle\tff\nanim\tbreathe\tidle\npalette\t1\tred\n"
+    match MediaLines.parse hostile with
+    | Error e -> Assert.True(false, e)
+    | Ok d ->
+        let html = HtmlCssBinding.render d
+        Assert.DoesNotContain("<script", html)


### PR DESCRIPTION
Writing the injection falsifier the test-gap audit asked for immediately found a real hole: a hostile motto smuggled live <script> through the no-JS page (the old test was structurally true — it never saw hostile input). All sinks now escape; the falsifier gates it. Determinism allowlist pins exact occurrence counts (no third wall clock slides in behind two justified ones). Pong's doc-promised serveDir exists (play = stated rightward default). PixelLens pack doc truthful. 3001 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)