### PR TITLE
feat(quantum): add F# observable treaty

### DIFF
--- a/src/Core.QSharp.ReferenceOracle/README.md
+++ b/src/Core.QSharp.ReferenceOracle/README.md
@@ -12,6 +12,8 @@ Files:
 - `qsharp-golden.json` is the committed reference fixture ordinary CI checks.
 - `qsharp-golden.test.ts` verifies the fixture schema and load-bearing values
   without requiring QDK on every lane.
+- `QuantumObservableTreaty.fs` under `src/Core` names the F#/analytic
+  observable rows that must stay symmetric with this Q# fixture.
 
 Regenerate after changing the Q# source:
 

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -245,6 +245,7 @@
     <Compile Include="SoftDashboard.fs" />
     <Compile Include="SoftEmu.fs" />
     <Compile Include="AmplitudeEmu.fs" />
+    <Compile Include="QuantumObservableTreaty.fs" />
     <Compile Include="SoftMem.fs" />
     <Compile Include="SoftDrive.fs" />
     <Compile Include="SoftScope.fs" />

--- a/src/Core/QuantumObservableTreaty.fs
+++ b/src/Core/QuantumObservableTreaty.fs
@@ -1,0 +1,237 @@
+namespace Zeta.Core
+
+/// Source-owned observable rows shared by the F# finite-resolution substrate and
+/// external quantum oracles. Q# remains the continuous-amplitude oracle; this
+/// module names the F#/analytic side so other language lanes can mirror the
+/// same rows without re-deriving the treaty in tests.
+[<RequireQualifiedAccess>]
+module QuantumObservableTreaty =
+
+    type Probabilities =
+        { Zero: float
+          One: float }
+
+    type SingleQubitMeasurement =
+        { Id: string
+          Operation: string
+          ThetaRadians: float option
+          Probabilities: Probabilities }
+
+    type ChshAngles =
+        { A: float
+          APrime: float
+          B: float
+          BPrime: float }
+
+    type ChshCorrelators =
+        { EAB: float
+          EABPrime: float
+          EAPrimeB: float
+          EAPrimeBPrime: float }
+
+    type CanonicalChsh =
+        { Id: string
+          Angles: ChshAngles
+          Correlators: ChshCorrelators
+          S: float
+          Tsirelson: float
+          ClassicalBound: float }
+
+    type BellCorner =
+        { Id: string
+          Operation: string
+          A: float
+          B: float
+          Coefficient: int
+          SameOutcomeProbability: float
+          OppositeOutcomeProbability: float
+          Correlator: float }
+
+    type SingletChsh =
+        { Id: string
+          Corners: BellCorner list
+          S: float
+          Analytic: float
+          ClassicalBound: float }
+
+    type BellCoincidence =
+        { Id: string
+          State: string
+          Operation: string
+          A: float
+          B: float
+          Event: string
+          Probability: float }
+
+    type InterferenceVisibility =
+        { Id: string
+          Operation: string
+          PhaseRadians: float option
+          Probabilities: Probabilities
+          Visibility: float option }
+
+    let private c = ImaginaryStack.complex
+
+    let private real (value: float) : Complex =
+        { Real = value; Imag = 0.0 }
+
+    let private phase (angle: float) : Complex =
+        { Real = cos angle; Imag = sin angle }
+
+    let private probabilitiesFromState (state: QubitIso.JoinState) : Probabilities =
+        let one = QubitIso.measureOne state
+        { Zero = 1.0 - one; One = one }
+
+    let private zero =
+        QubitIso.ofQubit c.One c.Zero
+
+    let singleQubitMeasurements () : SingleQubitMeasurement list =
+        [ { Id = "H|0>"
+            Operation = "Zeta.ReferenceOracle.ApplyH"
+            ThetaRadians = None
+            Probabilities = zero |> QubitIso.hadamard |> probabilitiesFromState }
+          { Id = "Ry(pi/3)|0>"
+            Operation = "Zeta.ReferenceOracle.ApplyRyPiOver3"
+            ThetaRadians = Some(System.Math.PI / 3.0)
+            Probabilities = zero |> QubitIso.ry (System.Math.PI / 3.0) |> probabilitiesFromState }
+          { Id = "Ry(pi/2)|0>"
+            Operation = "Zeta.ReferenceOracle.ApplyRyPiOver2"
+            ThetaRadians = Some(System.Math.PI / 2.0)
+            Probabilities = zero |> QubitIso.ry (System.Math.PI / 2.0) |> probabilitiesFromState } ]
+
+    let canonicalChsh () : CanonicalChsh =
+        let a, aPrime, b, bPrime = BellTest.canonicalAngles
+
+        { Id = "BellPhiPlus canonical CHSH"
+          Angles =
+            { A = a
+              APrime = aPrime
+              B = b
+              BPrime = bPrime }
+          Correlators =
+            { EAB = BellTest.correlation a b
+              EABPrime = BellTest.correlation a bPrime
+              EAPrimeB = BellTest.correlation aPrime b
+              EAPrimeBPrime = BellTest.correlation aPrime bPrime }
+          S = BellTest.chsh a aPrime b bPrime
+          Tsirelson = BellTest.TsirelsonBound
+          ClassicalBound = BellTest.ClassicalBound }
+
+    let private singletCornerOperation index =
+        match index with
+        | 0 -> "Zeta.ReferenceOracle.ApplyBellSingletChshA0B0"
+        | 1 -> "Zeta.ReferenceOracle.ApplyBellSingletChshA0B1"
+        | 2 -> "Zeta.ReferenceOracle.ApplyBellSingletChshA1B0"
+        | _ -> "Zeta.ReferenceOracle.ApplyBellSingletChshA1B1"
+
+    let singletChsh () : SingletChsh =
+        let corners =
+            TimeGen.cornerAngles
+            |> List.mapi (fun index (a, b) ->
+                let opposite = BellTest.coincidenceProbability a b
+                let coefficient = if index = 3 then -1 else 1
+
+                { Id =
+                    match index with
+                    | 0 -> "E(a0,b0)"
+                    | 1 -> "E(a0,b1)"
+                    | 2 -> "E(a1,b0)"
+                    | _ -> "E(a1,b1)"
+                  Operation = singletCornerOperation index
+                  A = a
+                  B = b
+                  Coefficient = coefficient
+                  SameOutcomeProbability = 1.0 - opposite
+                  OppositeOutcomeProbability = opposite
+                  Correlator = BellTest.correlation a b })
+
+        { Id = "BellSinglet CHSH corners"
+          Corners = corners
+          S = corners |> List.sumBy (fun corner -> float corner.Coefficient * corner.Correlator)
+          Analytic = BellTest.TsirelsonBound
+          ClassicalBound = BellTest.ClassicalBound }
+
+    let bellCoincidences () : BellCoincidence list =
+        [ { Id = "PhiPlus same-outcome a=0 b=pi/4"
+            State = "PhiPlus"
+            Operation = "Zeta.ReferenceOracle.ApplyBellPhiPlusAnalyzers"
+            A = 0.0
+            B = System.Math.PI / 4.0
+            Event = "sameOutcome"
+            Probability = BellTest.coincidenceProbability 0.0 (System.Math.PI / 4.0) }
+          { Id = "Singlet opposite-outcome a=0 b=pi/4"
+            State = "Singlet"
+            Operation = "Zeta.ReferenceOracle.ApplyBellSingletAnalyzers"
+            A = 0.0
+            B = System.Math.PI / 4.0
+            Event = "oppositeOutcome"
+            Probability = BellTest.coincidenceProbability 0.0 (System.Math.PI / 4.0) }
+          { Id = "PhiPlus same-outcome a=0 b=pi/2"
+            State = "PhiPlus"
+            Operation = "Zeta.ReferenceOracle.ApplyBellPhiPlusAnalyzers"
+            A = 0.0
+            B = System.Math.PI / 2.0
+            Event = "sameOutcome"
+            Probability = BellTest.coincidenceProbability 0.0 (System.Math.PI / 2.0) }
+          { Id = "PhiPlus same-outcome a=0 b=pi"
+            State = "PhiPlus"
+            Operation = "Zeta.ReferenceOracle.ApplyBellPhiPlusAnalyzers"
+            A = 0.0
+            B = System.Math.PI
+            Event = "sameOutcome"
+            Probability = BellTest.coincidenceProbability 0.0 System.Math.PI } ]
+
+    let private frame (seed: uint64) =
+        Chip8Cow.create seed |> Chip8Cow.loadRom [| 0x60uy; byte seed |]
+
+    let private probabilityFor frame probabilities =
+        probabilities
+        |> List.tryFind (fun (f, _) -> f = frame)
+        |> Option.map snd
+        |> Option.defaultValue 0.0
+
+    let private probabilitiesFromAmp (amp: AmplitudeEmu.Amp) : Probabilities =
+        let detectorZero = frame 0UL
+        let detectorOne = frame 1UL
+        let actual = amp |> AmplitudeEmu.merge |> AmplitudeEmu.bornProb
+        { Zero = probabilityFor detectorZero actual
+          One = probabilityFor detectorOne actual }
+
+    let private closedInterferometer (phi: float) : AmplitudeEmu.Amp =
+        let detectorZero = frame 0UL
+        let detectorOne = frame 1UL
+        let half = real 0.5
+        let phase0 = phase (-phi / 2.0)
+        let phase1 = phase (phi / 2.0)
+
+        [ detectorZero, c.Mul(half, phase0)
+          detectorZero, c.Mul(half, phase1)
+          detectorOne, c.Mul(half, phase0)
+          detectorOne, c.Negate(c.Mul(half, phase1)) ]
+
+    let interferenceVisibility () : InterferenceVisibility list =
+        let detectorZero = frame 0UL
+        let detectorOne = frame 1UL
+        let invSqrt2 = real (1.0 / sqrt 2.0)
+
+        let openCase =
+            [ detectorZero, invSqrt2
+              detectorOne, invSqrt2 ]
+
+        let closed id operation phase =
+            { Id = id
+              Operation = operation
+              PhaseRadians = Some phase
+              Probabilities = closedInterferometer phase |> probabilitiesFromAmp
+              Visibility = Some 1.0 }
+
+        [ { Id = "mach-zehnder-open"
+            Operation = "Zeta.ReferenceOracle.ApplyMachZehnderOpen"
+            PhaseRadians = None
+            Probabilities = openCase |> probabilitiesFromAmp
+            Visibility = None }
+          closed "mach-zehnder-closed-zero-phase" "Zeta.ReferenceOracle.ApplyMachZehnderClosedZeroPhase" 0.0
+          closed "mach-zehnder-closed-pi-over-3-phase" "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiOver3Phase" (System.Math.PI / 3.0)
+          closed "mach-zehnder-closed-pi-over-2-phase" "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiOver2Phase" (System.Math.PI / 2.0)
+          closed "mach-zehnder-closed-two-pi-over-3-phase" "Zeta.ReferenceOracle.ApplyMachZehnderClosedTwoPiOver3Phase" (2.0 * System.Math.PI / 3.0)
+          closed "mach-zehnder-closed-pi-phase" "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiPhase" System.Math.PI ]

--- a/tests/Tests.FSharp/QSharpOracle.Tests.fs
+++ b/tests/Tests.FSharp/QSharpOracle.Tests.fs
@@ -11,14 +11,6 @@ let private qsharpDumpTolerance = 1e-5
 
 let private c = ImaginaryStack.complex
 
-let private real (value: float) : Complex = { Real = value; Imag = 0.0 }
-
-let private phase (angle: float) : Complex =
-    { Real = cos angle; Imag = sin angle }
-
-let private frame (seed: uint64) =
-    Chip8Cow.create seed |> Chip8Cow.loadRom [| 0x60uy; byte seed |]
-
 let private goldenRelativePath =
     Path.Combine("src", "Core.QSharp.ReferenceOracle", "qsharp-golden.json")
 
@@ -130,6 +122,22 @@ let private probabilities (case: JsonElement) =
     let p = case.GetProperty("probabilities")
     p.GetProperty("Zero").GetDouble(), p.GetProperty("One").GetDouble()
 
+let private fsharpSingleQubitCase id =
+    QuantumObservableTreaty.singleQubitMeasurements()
+    |> List.find (fun item -> item.Id = id)
+
+let private fsharpSingletCorner id =
+    (QuantumObservableTreaty.singletChsh()).Corners
+    |> List.find (fun item -> item.Id = id)
+
+let private fsharpBellCoincidenceCase id =
+    QuantumObservableTreaty.bellCoincidences()
+    |> List.find (fun item -> item.Id = id)
+
+let private fsharpInterferenceCase id =
+    QuantumObservableTreaty.interferenceVisibility()
+    |> List.find (fun item -> item.Id = id)
+
 let private assertQSharpColumn (matrix: JsonElement) col (state: QubitIso.JoinState) =
     complexCloseTo (matrixEntry matrix 0 col) state.A
     complexCloseTo (matrixEntry matrix 1 col) state.B
@@ -139,12 +147,6 @@ let private assertQSharpBellColumn (matrix: JsonElement) col (state: BellState.S
     complexCloseTo (matrixEntry matrix 1 col) state.ZeroOne
     complexCloseTo (matrixEntry matrix 2 col) state.OneZero
     complexCloseTo (matrixEntry matrix 3 col) state.OneOne
-
-let private probabilityFor frame probabilities =
-    probabilities
-    |> List.tryFind (fun (f, _) -> f = frame)
-    |> Option.map snd
-    |> Option.defaultValue 0.0
 
 [<Fact>]
 let ``F# reads the committed Q# observable treaty without depending on QDK at test time`` () =
@@ -228,47 +230,50 @@ let ``BellTest canonical CHSH observables match the Q# golden vector`` () =
     let canonical = vectors.GetProperty("bellChsh").GetProperty("canonical")
     let angles = canonical.GetProperty("anglesRadians")
     let correlators = canonical.GetProperty("correlators")
+    let fsharp = QuantumObservableTreaty.canonicalChsh ()
 
-    let a = angles.GetProperty("a").GetDouble()
-    let a' = angles.GetProperty("aPrime").GetDouble()
-    let b = angles.GetProperty("b").GetDouble()
-    let b' = angles.GetProperty("bPrime").GetDouble()
+    closeTo (angles.GetProperty("a").GetDouble()) fsharp.Angles.A
+    closeTo (angles.GetProperty("aPrime").GetDouble()) fsharp.Angles.APrime
+    closeTo (angles.GetProperty("b").GetDouble()) fsharp.Angles.B
+    closeTo (angles.GetProperty("bPrime").GetDouble()) fsharp.Angles.BPrime
 
-    closeTo (correlators.GetProperty("E(a,b)").GetDouble()) (BellTest.correlation a b)
-    closeTo (correlators.GetProperty("E(a,bPrime)").GetDouble()) (BellTest.correlation a b')
-    closeTo (correlators.GetProperty("E(aPrime,b)").GetDouble()) (BellTest.correlation a' b)
-    closeTo (correlators.GetProperty("E(aPrime,bPrime)").GetDouble()) (BellTest.correlation a' b')
-    closeTo (canonical.GetProperty("s").GetDouble()) (BellTest.chsh a a' b b')
-    closeTo (canonical.GetProperty("tsirelson").GetDouble()) BellTest.TsirelsonBound
+    closeTo (correlators.GetProperty("E(a,b)").GetDouble()) fsharp.Correlators.EAB
+    closeTo (correlators.GetProperty("E(a,bPrime)").GetDouble()) fsharp.Correlators.EABPrime
+    closeTo (correlators.GetProperty("E(aPrime,b)").GetDouble()) fsharp.Correlators.EAPrimeB
+    closeTo (correlators.GetProperty("E(aPrime,bPrime)").GetDouble()) fsharp.Correlators.EAPrimeBPrime
+    closeTo (canonical.GetProperty("s").GetDouble()) fsharp.S
+    closeTo (canonical.GetProperty("tsirelson").GetDouble()) fsharp.Tsirelson
+    closeTo (canonical.GetProperty("classicalBound").GetDouble()) fsharp.ClassicalBound
 
 [<Fact>]
 let ``TimeGen phasor CHSH matches Q# singlet corner observables and the analytic value`` () =
     let singlet = vectors.GetProperty("bellChsh").GetProperty("singletCorners")
     let corners = singlet.GetProperty("corners").EnumerateArray() |> Seq.toArray
+    let fsharp = QuantumObservableTreaty.singletChsh ()
 
     Assert.Equal(4, corners.Length)
+    Assert.Equal(corners.Length, fsharp.Corners.Length)
     Assert.Contains("Tsirelson maximality is cited/proved separately", singlet.GetProperty("scope").GetString())
 
-    let mutable observedS = 0.0
-
     for corner in corners do
+        let id = corner.GetProperty("id").GetString()
         let angles = corner.GetProperty("anglesRadians")
-        let a = angles.GetProperty("a").GetDouble()
-        let b = angles.GetProperty("b").GetDouble()
-        let expectedOpposite = corner.GetProperty("oppositeOutcomeProbability").GetDouble()
-        let expectedCorrelation = corner.GetProperty("correlator").GetDouble()
-        let coefficient = corner.GetProperty("coefficient").GetInt32()
+        let expected = fsharpSingletCorner id
 
-        closeToWithin qsharpDumpTolerance expectedOpposite (BellTest.coincidenceProbability a b)
-        closeToWithin qsharpDumpTolerance expectedCorrelation (BellTest.correlation a b)
-        observedS <- observedS + float coefficient * expectedCorrelation
+        closeTo (angles.GetProperty("a").GetDouble()) expected.A
+        closeTo (angles.GetProperty("b").GetDouble()) expected.B
+        closeToWithin qsharpDumpTolerance (corner.GetProperty("oppositeOutcomeProbability").GetDouble()) expected.OppositeOutcomeProbability
+        closeToWithin qsharpDumpTolerance (corner.GetProperty("sameOutcomeProbability").GetDouble()) expected.SameOutcomeProbability
+        closeToWithin qsharpDumpTolerance (corner.GetProperty("correlator").GetDouble()) expected.Correlator
+        Assert.Equal(expected.Coefficient, corner.GetProperty("coefficient").GetInt32())
+        Assert.Equal(expected.Operation, corner.GetProperty("operation").GetString())
 
     let generator = TimeGen.mk "qsharp-singlet-corners" 1 0UL TimeGen.PhasorTsirelson
     let analytic = singlet.GetProperty("analytic").GetDouble()
 
-    closeTo analytic (TimeGen.chsh generator 1)
-    closeToWithin qsharpDumpTolerance analytic observedS
-    closeToWithin qsharpDumpTolerance analytic (singlet.GetProperty("s").GetDouble())
+    closeTo analytic fsharp.Analytic
+    closeTo fsharp.Analytic (TimeGen.chsh generator 1)
+    closeToWithin qsharpDumpTolerance (singlet.GetProperty("s").GetDouble()) fsharp.S
 
 [<Fact>]
 let ``BellState PhiPlus preparation matches the Q# two-qubit oracle`` () =
@@ -291,13 +296,16 @@ let ``BellTest coincidence probability matches Q# Bell analyzer observables`` ()
     let assertCase id =
         let item = bellCoincidenceCase id
         let angles = item.GetProperty("anglesRadians")
-        let a = angles.GetProperty("a").GetDouble()
-        let b = angles.GetProperty("b").GetDouble()
-        let expected = item.GetProperty("probability").GetDouble()
+        let expected = fsharpBellCoincidenceCase id
 
-        closeTo expected (BellTest.coincidenceProbability a b)
-        closeTo expected (PhasorEndurance.overlap a b)
-        closeTo (2.0 * expected - 1.0) (BellTest.correlation a b)
+        Assert.Equal(expected.State, item.GetProperty("state").GetString())
+        Assert.Equal(expected.Operation, item.GetProperty("operation").GetString())
+        Assert.Equal(expected.Event, item.GetProperty("event").GetString())
+        closeTo (angles.GetProperty("a").GetDouble()) expected.A
+        closeTo (angles.GetProperty("b").GetDouble()) expected.B
+        closeTo (item.GetProperty("probability").GetDouble()) expected.Probability
+        closeTo expected.Probability (PhasorEndurance.overlap expected.A expected.B)
+        closeTo (2.0 * expected.Probability - 1.0) (BellTest.correlation expected.A expected.B)
 
     assertCase "PhiPlus same-outcome a=0 b=pi/4"
     assertCase "Singlet opposite-outcome a=0 b=pi/4"
@@ -306,54 +314,33 @@ let ``BellTest coincidence probability matches Q# Bell analyzer observables`` ()
 
 [<Fact>]
 let ``single-qubit probability formulas match the Q# observable treaty`` () =
-    let assertCase id expectedZero expectedOne =
+    let assertCase id =
         let actualZero, actualOne = singleQubitCase id |> probabilities
-        closeTo expectedZero actualZero
-        closeTo expectedOne actualOne
+        let expected = fsharpSingleQubitCase id
 
-    assertCase "H|0>" 0.5 0.5
+        closeTo expected.Probabilities.Zero actualZero
+        closeTo expected.Probabilities.One actualOne
 
-    let ryPiOver3 = singleQubitCase "Ry(pi/3)|0>"
-    let theta3 = ryPiOver3.GetProperty("thetaRadians").GetDouble()
-    assertCase "Ry(pi/3)|0>" ((cos (theta3 / 2.0)) ** 2.0) ((sin (theta3 / 2.0)) ** 2.0)
+    assertCase "H|0>"
+    assertCase "Ry(pi/3)|0>"
+    assertCase "Ry(pi/2)|0>"
 
-    let ryPiOver2 = singleQubitCase "Ry(pi/2)|0>"
-    let theta2 = ryPiOver2.GetProperty("thetaRadians").GetDouble()
-    assertCase "Ry(pi/2)|0>" ((cos (theta2 / 2.0)) ** 2.0) ((sin (theta2 / 2.0)) ** 2.0)
 
 [<Fact>]
 let ``AmplitudeEmu interference observables match the Q# Mach-Zehnder treaty`` () =
-    let detectorZero = frame 0UL
-    let detectorOne = frame 1UL
-    let half = real 0.5
-    let invSqrt2 = real (1.0 / sqrt 2.0)
-
-    let closedInterferometer (phi: float) : AmplitudeEmu.Amp =
-        let phase0 = phase (-phi / 2.0)
-        let phase1 = phase (phi / 2.0)
-
-        [ detectorZero, c.Mul(half, phase0)
-          detectorZero, c.Mul(half, phase1)
-          detectorOne, c.Mul(half, phase0)
-          detectorOne, c.Negate(c.Mul(half, phase1)) ]
-
-    let assertCase id (amp: AmplitudeEmu.Amp) =
+    let assertCase id =
         let expectedZero, expectedOne = interferenceCase id |> probabilities
-        let actual = amp |> AmplitudeEmu.merge |> AmplitudeEmu.bornProb
-        closeTo expectedZero (probabilityFor detectorZero actual)
-        closeTo expectedOne (probabilityFor detectorOne actual)
+        let actual = fsharpInterferenceCase id
+        closeTo expectedZero actual.Probabilities.Zero
+        closeTo expectedOne actual.Probabilities.One
 
-    assertCase
-        "mach-zehnder-open"
-        [ detectorZero, invSqrt2
-          detectorOne, invSqrt2 ]
-
-    [ "mach-zehnder-closed-zero-phase", 0.0
-      "mach-zehnder-closed-pi-over-3-phase", Math.PI / 3.0
-      "mach-zehnder-closed-pi-over-2-phase", Math.PI / 2.0
-      "mach-zehnder-closed-two-pi-over-3-phase", 2.0 * Math.PI / 3.0
-      "mach-zehnder-closed-pi-phase", Math.PI ]
-    |> List.iter (fun (id, phi) -> assertCase id (closedInterferometer phi))
+    [ "mach-zehnder-open"
+      "mach-zehnder-closed-zero-phase"
+      "mach-zehnder-closed-pi-over-3-phase"
+      "mach-zehnder-closed-pi-over-2-phase"
+      "mach-zehnder-closed-two-pi-over-3-phase"
+      "mach-zehnder-closed-pi-phase" ]
+    |> List.iter assertCase
 
 [<Fact>]
 let ``Q# Pauli products pin the hardware-side anticommutation signs`` () =


### PR DESCRIPTION
## What changed

Adds `QuantumObservableTreaty` under `src/Core` as the F#/analytic observable side of the Q# reference-oracle treaty.

The Q# oracle remains the continuous-amplitude reference. This F# module now names the same row set for:

- single-qubit measurement probabilities
- canonical PhiPlus CHSH correlators
- singlet CHSH corner rows
- Bell coincidence rows
- Mach-Zehnder interference visibility rows

The existing F# Q# oracle tests now compare the committed Q# golden fixture against those source-owned F# rows instead of re-deriving formulas inline in the test file.

## Why

This gives the F#, Q#, and TS lanes a shared observable contract. Lior can mirror these row IDs on the TypeScript side for the B-1029 quantum-circuit treaty transcript without guessing which formulas or conventions the F# side considers canonical.

## Validation

- `dotnet build src/Core/Core.fsproj -c Release`
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter QSharpOracleTests --no-build`
- `bun test src/Core.QSharp.ReferenceOracle/qsharp-golden.test.ts src/Core.QSharp.ReferenceOracle/quantum-circuit.test.ts`
- `dotnet build -c Release`
- `dotnet test Zeta.sln -c Release --no-build`
- `dotnet format --verify-no-changes`
- `bun --bun tsc --noEmit -p tsconfig.json`
- `bun --bun markdownlint-cli2 src/Core.QSharp.ReferenceOracle/README.md`
- `bun --bun prettier --check src/Core.QSharp.ReferenceOracle/README.md`
