### PR TITLE
fix(greenfield): hot-path totality + the FAULT REGISTER + DRW-clip filed as a four-oracle change

### DIFF
--- a/docs/backlog/P2/B-1031-drw-clip-vs-wrap-cosmac-vip-correct-edge-semantics-four-oracle-coordinated-golden-regen-aaron-2026-06-13.md
+++ b/docs/backlog/P2/B-1031-drw-clip-vs-wrap-cosmac-vip-correct-edge-semantics-four-oracle-coordinated-golden-regen-aaron-2026-06-13.md
@@ -1,0 +1,47 @@
+---
+id: B-1031
+title: DRW edge semantics — clip (COSMAC VIP correct) not wrap; a coordinated four-oracle golden change
+priority: P2
+status: open
+tier: treaty-substrate
+tags: [chip8, chip9, drw, four-oracles, golden-vectors, greenfield, treaty]
+created: 2026-06-13
+owner: open (needs all four toolchains verified in one pass — not an autonomous-tick change)
+---
+
+# B-1031 — DRW should CLIP at edges, not wrap (greenfield-correct, treaty-coordinated)
+
+Aaron 2026-06-13: "do the right long-term thing — we are greenfield, we don't have to worry about
+backward compatibility yet, just us." The right long-term DRW semantic is the original COSMAC VIP:
+**wrap the sprite ORIGIN modulo the screen, then CLIP individual pixels at the right/bottom edge**
+(do not wrap pixels around). Our `Chip8Cow.fs` (and the `Chip8.fs` oracle) currently wrap BOTH
+origin and pixels — internally consistent and cross-checked, but quirks-test ROMs flag it, and it
+is not the reference behavior.
+
+## Why this is NOT a one-file fix (the reason it's filed, not done)
+
+DRW is a **four-oracle treaty primitive**: F# locks `src/Core.TypeScript/chip9/golden-vectors.lines`
+and C#/TS/Rust replay it byte-identically (`Chip9Treaty.Tests.fs` + each language's own
+golden-vector test). Changing only F# would DESYNC the four oracles on edge-crossing draws — a
+latent treaty divergence even though TODAY'S goldens (which draw near the top-left, no edge cross)
+would not catch it. The treaty's whole point is byte-identical behavior; introducing a known,
+golden-uncovered divergence violates it.
+
+## The coordinated plan (do all of it in one verified pass)
+
+1. F#: in `Chip8Cow.fs` and `Chip8.fs`, change the pixel index from
+   `((ox+col) % W, (oy+row) % H)` to: wrap the ORIGIN (`ox = vx % W`, `oy = vy % H`, already done)
+   then SKIP the pixel when `ox+col >= W || oy+row >= H` (clip).
+2. C#/TS/Rust Chip9: make the identical change in each implementation.
+3. Add an EDGE-CROSSING golden ROM (a sprite drawn at x=60 so it crosses the right edge) to
+   `golden-vectors.lines` — this is the vector that LOCKS clip vs wrap; regenerate from F#.
+4. Cross-verify: `Chip9Treaty.Tests.fs` (F#) + `dotnet test Tests.CSharp` + `cargo test` (Rust
+   Chip9) + `bun test` (TS chip9) all green against the new goldens.
+5. Note in the treaty doc that this is the COSMAC VIP reference behavior (Beacon anchor).
+
+## Why now-ish
+
+Greenfield window: there are no external consumers, so the golden break is free — but it must be a
+single atomic change across all four oracles + goldens, verified, or it desyncs the treaty. Best
+done when all four toolchains can be run and cross-checked together (a human-attended or
+full-CI pass), not piecemeal.

--- a/src/Core/Chip8Cow.fs
+++ b/src/Core/Chip8Cow.fs
@@ -44,7 +44,12 @@ module Chip8Cow =
           Plane: byte
           /// CHIP-9: the higher planes' per-pixel bitmask (bits 1-2; plane 0 lives in `Display`,
           /// untouched, so every existing mono consumer is unaffected). Canonical: zero ⇒ absent.
-          Extra: Map<int, byte> }
+          Extra: Map<int, byte>
+          /// THE FAULT REGISTER (greenfield right-thing 2026-06-13): None = healthy. A machine
+          /// fault (stack underflow on 00EE, …) is RECORDED here instead of silently swallowed —
+          /// the trace/DAG/honest-register layers can see it (no secrets in that area). Set-once
+          /// per fault; the program keeps running (a ROM bug should be visible, not fatal).
+          Fault: string option }
 
     let private rd (addr: int) (f: Frame) : byte =
         Map.tryFind addr f.Mem |> Option.defaultValue 0uy
@@ -86,7 +91,8 @@ module Chip8Cow =
           Keys = Array.zeroCreate 16
           Rng = seed
           Plane = 1uy
-          Extra = Map.empty }
+          Extra = Map.empty
+          Fault = None }
 
     /// Load a ROM at `0x200` (COW writes).
     let loadRom (rom: byte[]) (f: Frame) : Frame =
@@ -136,6 +142,7 @@ module Chip8Cow =
             | 0x00EE ->
                 match f.Stack with
                 | top :: rest -> { f with PC = top; Stack = rest }
+                | [] when f.Fault = None -> { f with Fault = Some "stack underflow: 00EE (RET) on empty stack" }
                 | [] -> f
             | _ -> f
         | 0x1000 -> { f with PC = nnn }

--- a/src/Core/Chip9Phys.fs
+++ b/src/Core/Chip9Phys.fs
@@ -30,11 +30,23 @@ module Chip9Phys =
     let ofInt (i: int) : Fix = i * one
     let toIntFloor (f: Fix) : int = int (System.Math.Floor(float f / 65536.0))
 
-    /// fix16 multiply (64-bit intermediate — no overflow inside the screen's range).
-    let mul (a: Fix) (b: Fix) : Fix = int ((int64 a * int64 b) >>> 16)
+    /// Saturating cast of a 64-bit fix result to Fix (greenfield right-thing: the int cast used to
+    /// silently truncate quotients/products past ±32767px — clamp instead of wrap).
+    let private satFix (x: int64) : Fix =
+        if x > int64 System.Int32.MaxValue then System.Int32.MaxValue
+        elif x < int64 System.Int32.MinValue then System.Int32.MinValue
+        else int x
 
-    /// fix16 divide.
-    let div (a: Fix) (b: Fix) : Fix = int ((int64 a <<< 16) / int64 b)
+    /// fix16 multiply (64-bit intermediate; saturating cast — no wrap inside OR past screen range).
+    let mul (a: Fix) (b: Fix) : Fix = satFix ((int64 a * int64 b) >>> 16)
+
+    /// fix16 divide — TOTAL (Result-over-exception / no exceptions on hot paths, greenfield fix):
+    /// divide-by-zero saturates to ±max by the dividend's sign (physically: a velocity/position
+    /// "to infinity" clamped to the field) instead of throwing DivideByZeroException; the quotient
+    /// cast saturates too. A divide-by-zero is a caller bug, but the hot path never throws.
+    let div (a: Fix) (b: Fix) : Fix =
+        if b = 0 then (if a >= 0 then System.Int32.MaxValue else System.Int32.MinValue)
+        else satFix ((int64 a <<< 16) / int64 b)
 
     /// A 2D fixed-point vector.
     type V2 = { X: Fix; Y: Fix }

--- a/src/Core/CorrespondencePong.fs
+++ b/src/Core/CorrespondencePong.fs
@@ -50,16 +50,21 @@ module CorrespondencePong =
     /// The match outcome both ends watch: rally length and which side conceded (None = survived).
     type Outcome = { Rally: int; Conceded: string option }
 
-    /// Play the round: both paddles run MetaControl.pongPolicy under their committed objectives;
-    /// pure function of (left, right, serveDir, steps) — DETERMINISTIC: this is the correspondence
-    /// integrity (and why retries are free: call it as many times as you like before you reply).
-    let play (left: Turn) (right: Turn) (steps: int) : Outcome =
+    /// Play the round from an explicit serve direction (+1 = toward the right player, −1 = toward
+    /// the left): both paddles run MetaControl.pongPolicy under their committed objectives; pure
+    /// function of (left, right, serveDir, steps) — DETERMINISTIC: the correspondence integrity
+    /// (retries are free: call it as many times as you like before you reply). Round-3 fix (Kira):
+    /// the old doc promised serveDir/seed parameters the signature lacked while hard-coding a
+    /// rightward serve — the right player ALWAYS defended first, a structural asymmetry the docs
+    /// denied. Fair play alternates serves across rounds: `playFrom -1` for the return game.
+    let playFrom (serveDir: int) (left: Turn) (right: Turn) (steps: int) : Outcome =
         let w, h = P.ofInt 64, P.ofInt 32
         let mutable lp = { P.Pos = P.v2 (P.ofInt 2) (P.ofInt 13); P.Size = P.v2 P.one (P.ofInt 6); P.Vel = P.v2 0 0 }
         let mutable rp = { P.Pos = P.v2 (P.ofInt 61) (P.ofInt 13); P.Size = P.v2 P.one (P.ofInt 6); P.Vel = P.v2 0 0 }
         // vx = 1 px/tick: no tunneling past a 1-px paddle (the integer physics is exact, so the
         // court geometry must respect the step size — a real constraint, honestly held)
-        let mutable ball = { P.Pos = P.v2 (P.ofInt 32) (P.ofInt 16); P.Size = P.v2 P.one P.one; P.Vel = P.v2 P.one (P.one / 4) }
+        let serve = if serveDir >= 0 then P.one else -P.one
+        let mutable ball = { P.Pos = P.v2 (P.ofInt 32) (P.ofInt 16); P.Size = P.v2 P.one P.one; P.Vel = P.v2 serve (P.one / 4) }
         let mutable rally = 0
         let mutable conceded: string option = None
         let mutable i = 0
@@ -84,3 +89,7 @@ module CorrespondencePong =
             i <- i + 1
 
         { Rally = rally; Conceded = conceded }
+
+    /// The rightward-serve convenience (the original behavior, now an HONEST default rather than
+    /// a hidden asymmetry — alternate with `playFrom -1` for fair correspondence play).
+    let play (left: Turn) (right: Turn) (steps: int) : Outcome = playFrom 1 left right steps

--- a/src/Core/HtmlCssBinding.fs
+++ b/src/Core/HtmlCssBinding.fs
@@ -70,16 +70,18 @@ module HtmlCssBinding =
 
         let divs =
             (MediaLines.ofKind "glyph" d @ MediaLines.ofKind "frame" d)
-            |> List.map (fun e -> sprintf "  <div class=\"px-%s\" title=\"%s\"></div>" e.Name e.Name)
+            |> List.map (fun e -> sprintf "  <div class=\"px-%s\" title=\"%s\"></div>" (ShapeRender.escapeXml e.Name) (ShapeRender.escapeXml e.Name))
 
         String.concat "\n"
             [ "<!doctype html>"
-              sprintf "<html lang=\"en\"><head><meta charset=\"utf-8\"><title>%s</title><style>" title
+              sprintf "<html lang=\"en\"><head><meta charset=\"utf-8\"><title>%s</title><style>" (ShapeRender.escapeXml title)
               paletteCss
               yield! sprites
               yield! anims
               "</style></head><body>"
-              sprintf "<h1>%s</h1>" title
-              (match motto with Some m -> sprintf "<p>%s</p>" m | None -> "")
+              sprintf "<h1>%s</h1>" (ShapeRender.escapeXml title)
+              (match motto with
+               | Some m -> sprintf "<p>%s</p>" (ShapeRender.escapeXml m) // r3b: the falsifier found a LIVE hole here — a hostile motto smuggled script through the no-JS page
+               | None -> "")
               yield! divs
               "</body></html>" ]

--- a/src/Core/PixelLens.fs
+++ b/src/Core/PixelLens.fs
@@ -28,7 +28,10 @@ module PixelLens =
     /// A sub-pixel cell: the 32-bit deep pixel.
     type Cell = uint32
 
-    /// Pack (color, payload, uncertainty) into a cell — masked to their fields (total; no overflow).
+    /// Pack (color, payload, uncertainty) into a cell — MASKED to their fields. Total in the
+    /// never-throws sense ONLY: out-of-range inputs silently truncate to field width (pack _ -1 _
+    /// round-trips payload as 8191 — r3 doc fix: "no overflow" overstated this as no-loss).
+    /// Callers needing refusal-on-overflow validate before packing.
     let pack (color: byte) (payload: int) (uncertaintyMilli: int) : Cell =
         (uint32 color &&& 0x7u)
         ||| ((uint32 payload &&& 0x1FFFu) <<< 3)

--- a/tests/Tests.FSharp/Chip9SelfTrace.Tests.fs
+++ b/tests/Tests.FSharp/Chip9SelfTrace.Tests.fs
@@ -85,3 +85,25 @@ let ``THE DEEP VIEW (SelfTrace x PixelLens): the drawn past survives honest colo
         Assert.Equal(PixelLens.color.Get c &&& 1uy, PixelLens.colorize 500 c) // mono stays the program's
     // and the payload rides with the pixel: the slot index is readable through the lens
     Assert.Equal(gy * 64 + gx, PixelLens.payload.Get gCell)
+
+// ── greenfield correctness pass (2026-06-13): hot-path totality + the fault register ──
+
+[<Fact>]
+let ``TOTAL DIV: fix16 divide-by-zero saturates by sign, never throws (Result-over-exception on the hot path)`` () =
+    Assert.Equal(System.Int32.MaxValue, Chip9Phys.div (Chip9Phys.ofInt 5) 0)
+    Assert.Equal(System.Int32.MinValue, Chip9Phys.div (Chip9Phys.ofInt -5) 0)
+    Assert.Equal(System.Int32.MaxValue, Chip9Phys.div 0 0) // 0 >= 0 -> +max, deterministic
+    // and a normal divide still works
+    Assert.Equal(Chip9Phys.ofInt 2, Chip9Phys.div (Chip9Phys.ofInt 6) (Chip9Phys.ofInt 3))
+
+[<Fact>]
+let ``THE FAULT REGISTER: 00EE on an empty stack is RECORDED, not silently swallowed (the machine never hides a fault)`` () =
+    // 00EE (RET) as the very first instruction: nothing was ever CALLed, so the stack is empty
+    let rom = [| 0x00uy; 0xEEuy |]
+    let f = Chip8Cow.create 7UL |> Chip8Cow.loadRom rom |> Chip8Cow.step
+    match f.Fault with
+    | Some msg -> Assert.Contains("underflow", msg)
+    | None -> Assert.True(false, "stack underflow was swallowed — the fault register stayed None")
+    // a healthy program keeps Fault = None
+    let healthy = Chip8Cow.create 7UL |> Chip8Cow.loadRom [| 0x60uy; 0x05uy |] |> Chip8Cow.step
+    Assert.Equal<string option>(None, healthy.Fault)

--- a/tests/Tests.FSharp/DeterminismLint.Tests.fs
+++ b/tests/Tests.FSharp/DeterminismLint.Tests.fs
@@ -28,24 +28,24 @@ let private banned =
 /// means adding a row HERE, with a reason a reviewer can refuse.
 let private allowlist =
     [ // the wall-clock door itself: the ONE place ambient time/entropy is abstracted behind IEnvironment
-      "Environment.fs", "DateTime.UtcNow", "the docstring NAMES the ambient sources this interface fences off"
-      "Environment.fs", "Guid.NewGuid", "the ambient implementation of IEnvironment.NewGuid — the fenced door"
-      "Environment.fs", "Random.Shared", "docstring reference to what is being fenced"
-      "Environment.fs", "Environment.TickCount", "the ambient implementation of IEnvironment.Ticks"
+      "Environment.fs", "DateTime.UtcNow", 1, "the docstring NAMES the ambient sources this interface fences off"
+      "Environment.fs", "Guid.NewGuid", 2, "the ambient implementation of IEnvironment.NewGuid — the fenced door"
+      "Environment.fs", "Random.Shared", 3, "docstring reference to what is being fenced"
+      "Environment.fs", "Environment.TickCount", 1, "the ambient implementation of IEnvironment.Ticks"
       // seeded by construction: System.Random(seed + i) — deterministic per seed, the LawRunner contract
-      "LawRunner.fs", "System.Random(", "every instance is seeded (seed + sampleIndex); reproducible by design"
+      "LawRunner.fs", "System.Random(", 3, "every instance is seeded (seed + sampleIndex); reproducible by design"
       // IO-infrastructure edges: temp-file / instance names (affect disk layout, never logical state)
-      "Checkpoint.fs", "Guid.NewGuid", "tmp-file suffix for atomic rename — IO edge, not logical state"
-      "DiskSpine.fs", "Guid.NewGuid", "per-instance disk prefix — IO edge, not logical state"
-      "DiskSpineAsync.fs", "Guid.NewGuid", "per-instance disk prefix — IO edge, not logical state"
+      "Checkpoint.fs", "Guid.NewGuid", 1, "tmp-file suffix for atomic rename — IO edge, not logical state"
+      "DiskSpine.fs", "Guid.NewGuid", 1, "per-instance disk prefix — IO edge, not logical state"
+      "DiskSpineAsync.fs", "Guid.NewGuid", 1, "per-instance disk prefix — IO edge, not logical state"
       // interactive-edge convenience overload, documented as non-replayable; seeded overload exists
-      "Crdt.fs", "Guid.NewGuid", "OrSet.Add ambient overload — documented wall-clock edge; the seeded Add(elem, tag) is the DST path"
+      "Crdt.fs", "Guid.NewGuid", 2, "OrSet.Add ambient overload — documented wall-clock edge; the seeded Add(elem, tag) is the DST path"
       // the ambient wall-clock EDGES of consensus (the DST paths are transitionAt/prToVoteAt)
-      "Consensus.fs", "DateTimeOffset.UtcNow", "two documented ambient wrappers (transition/prToVote); injected -At variants are the DST paths"
-      "Environment.fs", "DateTimeOffset.UtcNow", "the ambient implementation of IEnvironment.Now — the fenced door"
-      "Injection.fs", "DateTimeOffset.UtcNow", "wall-time instrumentation at the injection edge — observability only"
+      "Consensus.fs", "DateTimeOffset.UtcNow", 4, "two documented ambient wrappers (transition/prToVote) + their two doc-comment mentions; injected -At variants are the DST paths"
+      "Environment.fs", "DateTimeOffset.UtcNow", 1, "the ambient implementation of IEnvironment.Now — the fenced door"
+      "Injection.fs", "DateTimeOffset.UtcNow", 2, "wall-time instrumentation at the injection edge — observability only"
       // timing instrumentation at the injection boundary (observability, not logic)
-      "Injection.fs", "Stopwatch.StartNew", "wall-time instrumentation at the injection edge — observability only" ]
+      "Injection.fs", "Stopwatch.StartNew", 1, "wall-time instrumentation at the injection edge — observability only" ]
 
 [<Fact>]
 let ``THE DETERMINISM LINT: no ambient entropy in src/Core outside the named, justified edges`` () =
@@ -57,16 +57,24 @@ let ``THE DETERMINISM LINT: no ambient entropy in src/Core outside the named, ju
               for i in 0 .. lines.Length - 1 do
                   for pat in banned do
                       if lines.[i].Contains pat then
-                          let allowed = allowlist |> List.exists (fun (f, p, _) -> f = name && pat.StartsWith p || (f = name && lines.[i].Contains p))
+                          let allowed = allowlist |> List.exists (fun (f, p, _, _) -> f = name && p = pat) // exact rows only (the old contains-disjunct excused pattern Y on any line mentioning X)
                           if not allowed then
                               yield sprintf "%s:%d uses '%s' — ambient entropy in Core; seed it, fence it behind IEnvironment, or add a justified allowlist row" name (i + 1) pat ]
     Assert.True(List.isEmpty violations, String.concat "\n" violations)
 
 [<Fact>]
-let ``the allowlist rows all still exist — a stale exemption is a hole waiting for a new occupant`` () =
+let ``the allowlist pins EXACT occurrence counts — a third wall clock cannot slide in behind two justified ones`` () =
     let core = Path.Combine(repoRoot (), "src", "Core")
-    for (file, pat, _why) in allowlist do
+    for (file, pat, expected, _why) in allowlist do
         let path = Path.Combine(core, file)
         Assert.True(File.Exists path, file + " vanished — remove its allowlist rows")
-        let contains = (File.ReadAllText path).Contains pat
-        Assert.True(contains, sprintf "%s no longer contains '%s' — remove the stale allowlist row" file pat)
+        let actual =
+            File.ReadAllLines path
+            |> Array.sumBy (fun (l: string) ->
+                let mutable c = 0
+                let mutable i = l.IndexOf(pat)
+                while i >= 0 do
+                    c <- c + 1
+                    i <- l.IndexOf(pat, i + 1)
+                c)
+        Assert.True((actual = expected), sprintf "%s: '%s' occurs %d times, allowlist pins %d — justify the new edge with a count bump and a WHY, or remove the stale row" file pat actual expected)

--- a/tests/Tests.FSharp/ShapeAcceptance.Tests.fs
+++ b/tests/Tests.FSharp/ShapeAcceptance.Tests.fs
@@ -227,3 +227,13 @@ let ``VF IS THE FLAG, EVEN WHEN VF IS AN OPERAND: 8F05 with x=F keeps the flag w
     let cow = Chip8Cow.create 7UL |> Chip8Cow.loadRom rom
     let f = [ 1..3 ] |> List.fold (fun s _ -> Chip8Cow.step s) cow
     Assert.Equal(1uy, f.V.[0xF]) // the flag, not the difference
+
+
+[<Fact>]
+let ``HTMLCSSBINDING INJECTION FALSIFIER: a hostile motto cannot smuggle script through render (test-gap #2)`` () =
+    let hostile = "meta\tname\tx\nmeta\tmotto\t</style><script>alert(1)</script>\nframe\tidle\tff\nanim\tbreathe\tidle\npalette\t1\tred\n"
+    match MediaLines.parse hostile with
+    | Error e -> Assert.True(false, e)
+    | Ok d ->
+        let html = HtmlCssBinding.render d
+        Assert.DoesNotContain("<script", html)


### PR DESCRIPTION
Aaron's greenfield authorization, taken on the parked error-register items. Shipped (treaty-safe): Chip9Phys.div is total (divide-by-zero saturates by sign, no throw; mul/div saturate the cast); the FAULT REGISTER (Frame.Fault) records 00EE stack underflow instead of swallowing it — the red-light law applied to machine faults. Filed not fired (B-1031): DRW clip-vs-wrap is the correct COSMAC VIP semantic but a four-oracle treaty change — doing only F# would desync the oracles; it needs one atomic verified pass + an edge-crossing golden. 3003 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)