### PR TITLE
feat(quantum): generate Q# exports and add treaty transcript validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "tally:substrates": "bun ./tools/invariant-substrates/tally.ts",
+    "generate:transcript": "bun ./src/Core.QSharp.ReferenceOracle/generate-treaty-transcript.ts",
     "lint:typescript": "eslint .",
     "lint:markdown": "markdownlint-cli2",
     "lint:css": "stylelint \"**/*.css\" --allow-empty-input",

--- a/src/Core.QSharp.ReferenceOracle/generate-treaty-transcript.ts
+++ b/src/Core.QSharp.ReferenceOracle/generate-treaty-transcript.ts
@@ -1,0 +1,279 @@
+import { readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import QuantumCircuit from "quantum-circuit";
+
+// Path resolution
+const currentDir = import.meta.dir;
+const goldenPath = join(currentDir, "qsharp-golden.json");
+const outputPath = join(currentDir, "treaty-transcript.json");
+
+// Read qsharp-golden.json
+const goldenRaw = readFileSync(goldenPath, "utf-8");
+interface GoldenData {
+  vectors: {
+    singleQubitMeasurement: {
+      id: string;
+      operation: string;
+      probabilities: { Zero: number; One: number };
+    }[];
+    bellChsh: {
+      singletCorners: {
+        s: number;
+        analytic: number;
+        corners: {
+          id: string;
+          operation: string;
+          anglesRadians: { a: number; b: number; delta: number };
+          oppositeOutcomeProbability: number;
+          sameOutcomeProbability: number;
+          correlator: number;
+          coefficient: number;
+        }[];
+      };
+    };
+    bellCoincidence: {
+      id: string;
+      state: string;
+      operation: string;
+      anglesRadians: { a: number; b: number; delta: number };
+      event: string;
+      probability: number;
+    }[];
+    interferenceVisibility: {
+      id: string;
+      operation: string;
+      probabilities: { Zero: number; One: number };
+      phaseRadians?: number;
+    }[];
+  };
+}
+const golden = JSON.parse(goldenRaw) as GoldenData;
+
+const tolerance = 1e-5;
+
+// Helper to calculate amplitude probability from state vector element
+interface ComplexNumber {
+  re: number;
+  im: number;
+}
+function getProb(amp: unknown): number {
+  if (!amp) return 0;
+  if (typeof amp === "number") return amp * amp;
+  const c = amp as ComplexNumber;
+  return c.re * c.re + c.im * c.im;
+}
+
+// 1. CHSH Corners Job
+const chshResults = [];
+let tsChshS = 0;
+const chshQSharpCodeMap: Record<string, string> = {};
+
+for (const corner of golden.vectors.bellChsh.singletCorners.corners) {
+  const { a, b } = corner.anglesRadians;
+  const circuit = new QuantumCircuit(2);
+  // Prepare Singlet State (PsiMinus)
+  circuit.appendGate("h", 0);
+  circuit.appendGate("cx", [0, 1]);
+  circuit.appendGate("x", 1);
+  circuit.appendGate("z", 1);
+  // Apply analyzers
+  circuit.appendGate("ry", 0, { params: { theta: -a } });
+  circuit.appendGate("ry", 1, { params: { theta: -b } });
+  circuit.run();
+
+  const p00 = getProb(circuit.state[0]);
+  const p01 = getProb(circuit.state[1]);
+  const p10 = getProb(circuit.state[2]);
+  const p11 = getProb(circuit.state[3]);
+
+  const pSame = p00 + p11;
+  const pOpposite = p01 + p10;
+  const correlator = pOpposite - pSame;
+
+  tsChshS += corner.coefficient * correlator;
+
+  // Compute F# / Analytic expected values
+  const fsharpOpposite = Math.cos((a - b) / 2) ** 2;
+  const fsharpSame = 1 - fsharpOpposite;
+  const fsharpCorrelator = Math.cos(a - b);
+
+  // Assert TS vs Q# vs F#/Analytic are within tolerance
+  if (Math.abs(pOpposite - corner.oppositeOutcomeProbability) > tolerance) {
+    throw new Error(`CHSH TS/Q# mismatch on ${corner.id}`);
+  }
+  if (Math.abs(pOpposite - fsharpOpposite) > tolerance) {
+    throw new Error(`CHSH TS/Analytic mismatch on ${corner.id}`);
+  }
+
+  const qsharpExport = circuit.exportToQSharp();
+  chshQSharpCodeMap[corner.id] = qsharpExport;
+
+  chshResults.push({
+    id: corner.id,
+    operation: corner.operation,
+    angles: { a, b, delta: a - b },
+    coefficient: corner.coefficient,
+    ts: {
+      probabilities: { "|00>": p00, "|01>": p01, "|10>": p10, "|11>": p11 },
+      pSame,
+      pOpposite,
+      correlator,
+    },
+    qsharp: {
+      pSame: corner.sameOutcomeProbability,
+      pOpposite: corner.oppositeOutcomeProbability,
+      correlator: corner.correlator,
+    },
+    fsharpAnalytic: {
+      pSame: fsharpSame,
+      pOpposite: fsharpOpposite,
+      correlator: fsharpCorrelator,
+    },
+  });
+}
+
+// 2. Bell Coincidence Probability Job
+const coincidenceResults = [];
+const coincidenceQSharpCodeMap: Record<string, string> = {};
+
+for (const v of golden.vectors.bellCoincidence) {
+  const { a, b } = v.anglesRadians;
+  const circuit = new QuantumCircuit(2);
+
+  // Prepare state depending on state type
+  circuit.appendGate("h", 0);
+  circuit.appendGate("cx", [0, 1]);
+
+  if (v.state === "Singlet") {
+    circuit.appendGate("x", 1);
+    circuit.appendGate("z", 1);
+  }
+
+  // Apply analyzers
+  circuit.appendGate("ry", 0, { params: { theta: -a } });
+  circuit.appendGate("ry", 1, { params: { theta: -b } });
+  circuit.run();
+
+  const p00 = getProb(circuit.state[0]);
+  const p01 = getProb(circuit.state[1]);
+  const p10 = getProb(circuit.state[2]);
+  const p11 = getProb(circuit.state[3]);
+
+  const tsProb = v.event === "sameOutcome" ? p00 + p11 : p01 + p10;
+  const fsharpProb = Math.cos((a - b) / 2) ** 2;
+
+  if (Math.abs(tsProb - v.probability) > tolerance) {
+    throw new Error(`Coincidence TS/Q# mismatch on ${v.id}`);
+  }
+  if (Math.abs(tsProb - fsharpProb) > tolerance) {
+    throw new Error(`Coincidence TS/Analytic mismatch on ${v.id}`);
+  }
+
+  const qsharpExport = circuit.exportToQSharp();
+  coincidenceQSharpCodeMap[v.id] = qsharpExport;
+
+  coincidenceResults.push({
+    id: v.id,
+    state: v.state,
+    operation: v.operation,
+    angles: { a, b, delta: a - b },
+    event: v.event,
+    ts: tsProb,
+    qsharp: v.probability,
+    fsharpAnalytic: fsharpProb,
+  });
+}
+
+// 3. Interference Grid Job
+const interferenceResults = [];
+const interferenceQSharpCodeMap: Record<string, string> = {};
+
+for (const v of golden.vectors.interferenceVisibility) {
+  const circuit = new QuantumCircuit(1);
+  const phase = v.phaseRadians;
+
+  if (v.operation.endsWith("ApplyMachZehnderOpen")) {
+    circuit.appendGate("h", 0);
+  } else if (v.operation.endsWith("ClosedZeroPhase")) {
+    circuit.appendGate("h", 0);
+    circuit.appendGate("h", 0);
+  } else if (v.operation.endsWith("ClosedPiPhase")) {
+    circuit.appendGate("h", 0);
+    circuit.appendGate("z", 0);
+    circuit.appendGate("h", 0);
+  } else if (phase !== undefined) {
+    circuit.appendGate("h", 0);
+    circuit.appendGate("rz", 0, { params: { phi: phase } });
+    circuit.appendGate("h", 0);
+  } else {
+    throw new Error(`Unknown Mach-Zehnder operation: ${v.operation}`);
+  }
+
+  circuit.run();
+
+  const probOne = circuit.probabilities()[0] ?? 0;
+  const probZero = 1 - probOne;
+
+  let fsharpZero = 0.5;
+  if (phase !== undefined) {
+    fsharpZero = Math.cos(phase / 2) ** 2;
+  } else if (!v.operation.endsWith("Open")) {
+    fsharpZero = 1.0;
+  }
+  const fsharpOne = 1 - fsharpZero;
+
+  if (Math.abs(probZero - v.probabilities.Zero) > tolerance) {
+    throw new Error(`Interference TS/Q# mismatch on ${v.id}`);
+  }
+  if (Math.abs(probZero - fsharpZero) > tolerance) {
+    throw new Error(`Interference TS/Analytic mismatch on ${v.id}`);
+  }
+
+  const qsharpExport = circuit.exportToQSharp();
+  interferenceQSharpCodeMap[v.id] = qsharpExport;
+
+  interferenceResults.push({
+    id: v.id,
+    operation: v.operation,
+    phase: phase ?? null,
+    ts: { Zero: probZero, One: probOne },
+    qsharp: v.probabilities,
+    fsharpAnalytic: { Zero: fsharpZero, One: fsharpOne },
+  });
+}
+
+// Create Treaty Transcript JSON object
+const transcript = {
+  schema: "zeta.qsharp.treaty-transcript.v1",
+  metadata: {
+    generatedBy: "src/Core.QSharp.ReferenceOracle/generate-treaty-transcript.ts",
+    timestamp: new Date().toISOString(),
+    tolerances: {
+      chsh: tolerance,
+      coincidence: tolerance,
+      interference: tolerance,
+    },
+  },
+  jobs: {
+    chshCorners: {
+      sParameter: {
+        ts: tsChshS,
+        qsharp: golden.vectors.bellChsh.singletCorners.s,
+        fsharpAnalytic: golden.vectors.bellChsh.singletCorners.analytic,
+      },
+      results: chshResults,
+      qsharpCircuits: chshQSharpCodeMap,
+    },
+    bellCoincidence: {
+      results: coincidenceResults,
+      qsharpCircuits: coincidenceQSharpCodeMap,
+    },
+    interferenceGrid: {
+      results: interferenceResults,
+      qsharpCircuits: interferenceQSharpCodeMap,
+    },
+  },
+};
+
+writeFileSync(outputPath, JSON.stringify(transcript, null, 2) + "\n", "utf-8");
+console.log(`Successfully generated treaty-transcript.json at ${outputPath}`);

--- a/src/Core.QSharp.ReferenceOracle/quantum-circuit.d.ts
+++ b/src/Core.QSharp.ReferenceOracle/quantum-circuit.d.ts
@@ -11,5 +11,7 @@ declare module "quantum-circuit" {
     probabilities(): readonly number[];
 
     run(): void;
+
+    exportToQSharp(): string;
   }
 }

--- a/src/Core.QSharp.ReferenceOracle/quantum-circuit.test.ts
+++ b/src/Core.QSharp.ReferenceOracle/quantum-circuit.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import QuantumCircuit from "quantum-circuit";
 import golden from "./qsharp-golden.json";
+import transcript from "./treaty-transcript.json";
 
 interface Complex {
   readonly real: number;
@@ -449,6 +450,48 @@ describe("quantum-circuit simulator (second observable oracle)", () => {
           closeComplexTo(lhsValue, { real: -rhsValue.real, imag: -rhsValue.imag }, qsharpDumpTolerance);
         }
       }
+    }
+  });
+
+  test("treaty transcript integrity: TS, Q#, and F#/Analytic values match within tolerance", () => {
+    expect(transcript.schema).toBe("zeta.qsharp.treaty-transcript.v1");
+
+    const t = 1e-5;
+
+    // Check CHSH corners
+    const chsh = transcript.jobs.chshCorners;
+    closeTo(chsh.sParameter.ts, chsh.sParameter.fsharpAnalytic, t);
+    closeTo(chsh.sParameter.ts, chsh.sParameter.qsharp, 1e-4);
+
+    for (const res of chsh.results) {
+      closeTo(res.ts.pOpposite, res.fsharpAnalytic.pOpposite, t);
+      closeTo(res.ts.pOpposite, res.qsharp.pOpposite, t);
+      closeTo(res.ts.correlator, res.fsharpAnalytic.correlator, t);
+      closeTo(res.ts.correlator, res.qsharp.correlator, t);
+
+      const qsharp = chsh.qsharpCircuits[res.id as keyof typeof chsh.qsharpCircuits];
+      expect(qsharp).toBeDefined();
+      expect(qsharp).toContain("operation Circuit()");
+    }
+
+    // Check Bell coincidence
+    for (const res of transcript.jobs.bellCoincidence.results) {
+      closeTo(res.ts, res.fsharpAnalytic, t);
+      closeTo(res.ts, res.qsharp, t);
+
+      const qsharp = transcript.jobs.bellCoincidence.qsharpCircuits[res.id as keyof typeof transcript.jobs.bellCoincidence.qsharpCircuits];
+      expect(qsharp).toBeDefined();
+      expect(qsharp).toContain("operation Circuit()");
+    }
+
+    // Check Interference visibility
+    for (const res of transcript.jobs.interferenceGrid.results) {
+      closeTo(res.ts.Zero, res.fsharpAnalytic.Zero, t);
+      closeTo(res.ts.Zero, res.qsharp.Zero, t);
+
+      const qsharp = transcript.jobs.interferenceGrid.qsharpCircuits[res.id as keyof typeof transcript.jobs.interferenceGrid.qsharpCircuits];
+      expect(qsharp).toBeDefined();
+      expect(qsharp).toContain("operation Circuit()");
     }
   });
 });

--- a/src/Core.QSharp.ReferenceOracle/treaty-transcript.json
+++ b/src/Core.QSharp.ReferenceOracle/treaty-transcript.json
@@ -1,0 +1,333 @@
+{
+  "schema": "zeta.qsharp.treaty-transcript.v1",
+  "metadata": {
+    "generatedBy": "src/Core.QSharp.ReferenceOracle/generate-treaty-transcript.ts",
+    "timestamp": "2026-06-11T19:47:38.182Z",
+    "tolerances": {
+      "chsh": 0.00001,
+      "coincidence": 0.00001,
+      "interference": 0.00001
+    }
+  },
+  "jobs": {
+    "chshCorners": {
+      "sParameter": {
+        "ts": 2.82842712474619,
+        "qsharp": 2.828419669116,
+        "fsharpAnalytic": 2.828427124746
+      },
+      "results": [
+        {
+          "id": "E(a0,b0)",
+          "operation": "Zeta.ReferenceOracle.ApplyBellSingletChshA0B0",
+          "angles": {
+            "a": 0,
+            "b": 0.785398163397,
+            "delta": -0.785398163397
+          },
+          "coefficient": 1,
+          "ts": {
+            "probabilities": {
+              "|00>": 0.07322330470328385,
+              "|01>": 0.42677669529671614,
+              "|10>": 0.42677669529671614,
+              "|11>": 0.07322330470328385
+            },
+            "pSame": 0.1464466094065677,
+            "pOpposite": 0.8535533905934323,
+            "correlator": 0.7071067811868645
+          },
+          "qsharp": {
+            "pSame": 0.146446555208,
+            "pOpposite": 0.853552129922,
+            "correlator": 0.707104259844
+          },
+          "fsharpAnalytic": {
+            "pSame": 0.14644660940656773,
+            "pOpposite": 0.8535533905934323,
+            "correlator": 0.7071067811868645
+          }
+        },
+        {
+          "id": "E(a0,b1)",
+          "operation": "Zeta.ReferenceOracle.ApplyBellSingletChshA0B1",
+          "angles": {
+            "a": 0,
+            "b": -0.785398163397,
+            "delta": 0.785398163397
+          },
+          "coefficient": 1,
+          "ts": {
+            "probabilities": {
+              "|00>": 0.07322330470328385,
+              "|01>": 0.42677669529671614,
+              "|10>": 0.42677669529671614,
+              "|11>": 0.07322330470328385
+            },
+            "pSame": 0.1464466094065677,
+            "pOpposite": 0.8535533905934323,
+            "correlator": 0.7071067811868645
+          },
+          "qsharp": {
+            "pSame": 0.146446555208,
+            "pOpposite": 0.853552129922,
+            "correlator": 0.707104259844
+          },
+          "fsharpAnalytic": {
+            "pSame": 0.14644660940656773,
+            "pOpposite": 0.8535533905934323,
+            "correlator": 0.7071067811868645
+          }
+        },
+        {
+          "id": "E(a1,b0)",
+          "operation": "Zeta.ReferenceOracle.ApplyBellSingletChshA1B0",
+          "angles": {
+            "a": 1.570796326795,
+            "b": 0.785398163397,
+            "delta": 0.7853981633980001
+          },
+          "coefficient": 1,
+          "ts": {
+            "probabilities": {
+              "|00>": 0.07322330470346067,
+              "|01>": 0.4267766952965393,
+              "|10>": 0.4267766952965393,
+              "|11>": 0.07322330470346067
+            },
+            "pSame": 0.14644660940692134,
+            "pOpposite": 0.8535533905930786,
+            "correlator": 0.7071067811861572
+          },
+          "qsharp": {
+            "pSame": 0.146446555208,
+            "pOpposite": 0.853552129922,
+            "correlator": 0.707104259844
+          },
+          "fsharpAnalytic": {
+            "pSame": 0.14644660940692134,
+            "pOpposite": 0.8535533905930787,
+            "correlator": 0.7071067811861573
+          }
+        },
+        {
+          "id": "E(a1,b1)",
+          "operation": "Zeta.ReferenceOracle.ApplyBellSingletChshA1B1",
+          "angles": {
+            "a": 1.570796326795,
+            "b": -0.785398163397,
+            "delta": 2.3561944901920002
+          },
+          "coefficient": -1,
+          "ts": {
+            "probabilities": {
+              "|00>": 0.42677669529657597,
+              "|01>": 0.07322330470342409,
+              "|10>": 0.07322330470342409,
+              "|11>": 0.42677669529657597
+            },
+            "pSame": 0.8535533905931519,
+            "pOpposite": 0.14644660940684817,
+            "correlator": -0.7071067811863038
+          },
+          "qsharp": {
+            "pSame": 0.853552129922,
+            "pOpposite": 0.146446555208,
+            "correlator": -0.707106889584
+          },
+          "fsharpAnalytic": {
+            "pSame": 0.8535533905931519,
+            "pOpposite": 0.1464466094068481,
+            "correlator": -0.7071067811863038
+          }
+        }
+      ],
+      "qsharpCircuits": {
+        "E(a0,b0)": "namespace Quantum {\n    open Microsoft.Quantum.Intrinsic;\n    open Microsoft.Quantum.Canon;\n    open Microsoft.Quantum.Math;\n    open Microsoft.Quantum.Convert;\n\n    function SetBitValue(reg: Int, bit: Int, value: Bool): Int {\n        if(value) {\n            return reg ||| (1 <<< bit);\n        } else {\n            return reg &&& ~~~(1 <<< bit);\n        }\n    }\n    \n    operation Circuit() : Unit {\n        using(qubits = Qubit[2]) {\n            H(qubits[0]);\n            CNOT(qubits[0], qubits[1]);\n            Ry(qubits[0]);\n            X(qubits[1]);\n            Z(qubits[1]);\n            Ry(-0.785398163397, qubits[1]);\n            ResetAll(qubits);\n        }\n    }\n}\n",
+        "E(a0,b1)": "namespace Quantum {\n    open Microsoft.Quantum.Intrinsic;\n    open Microsoft.Quantum.Canon;\n    open Microsoft.Quantum.Math;\n    open Microsoft.Quantum.Convert;\n\n    function SetBitValue(reg: Int, bit: Int, value: Bool): Int {\n        if(value) {\n            return reg ||| (1 <<< bit);\n        } else {\n            return reg &&& ~~~(1 <<< bit);\n        }\n    }\n    \n    operation Circuit() : Unit {\n        using(qubits = Qubit[2]) {\n            H(qubits[0]);\n            CNOT(qubits[0], qubits[1]);\n            Ry(qubits[0]);\n            X(qubits[1]);\n            Z(qubits[1]);\n            Ry(0.785398163397, qubits[1]);\n            ResetAll(qubits);\n        }\n    }\n}\n",
+        "E(a1,b0)": "namespace Quantum {\n    open Microsoft.Quantum.Intrinsic;\n    open Microsoft.Quantum.Canon;\n    open Microsoft.Quantum.Math;\n    open Microsoft.Quantum.Convert;\n\n    function SetBitValue(reg: Int, bit: Int, value: Bool): Int {\n        if(value) {\n            return reg ||| (1 <<< bit);\n        } else {\n            return reg &&& ~~~(1 <<< bit);\n        }\n    }\n    \n    operation Circuit() : Unit {\n        using(qubits = Qubit[2]) {\n            H(qubits[0]);\n            CNOT(qubits[0], qubits[1]);\n            Ry(-1.570796326795, qubits[0]);\n            X(qubits[1]);\n            Z(qubits[1]);\n            Ry(-0.785398163397, qubits[1]);\n            ResetAll(qubits);\n        }\n    }\n}\n",
+        "E(a1,b1)": "namespace Quantum {\n    open Microsoft.Quantum.Intrinsic;\n    open Microsoft.Quantum.Canon;\n    open Microsoft.Quantum.Math;\n    open Microsoft.Quantum.Convert;\n\n    function SetBitValue(reg: Int, bit: Int, value: Bool): Int {\n        if(value) {\n            return reg ||| (1 <<< bit);\n        } else {\n            return reg &&& ~~~(1 <<< bit);\n        }\n    }\n    \n    operation Circuit() : Unit {\n        using(qubits = Qubit[2]) {\n            H(qubits[0]);\n            CNOT(qubits[0], qubits[1]);\n            Ry(-1.570796326795, qubits[0]);\n            X(qubits[1]);\n            Z(qubits[1]);\n            Ry(0.785398163397, qubits[1]);\n            ResetAll(qubits);\n        }\n    }\n}\n"
+      }
+    },
+    "bellCoincidence": {
+      "results": [
+        {
+          "id": "PhiPlus same-outcome a=0 b=pi/4",
+          "state": "PhiPlus",
+          "operation": "Zeta.ReferenceOracle.ApplyBellPhiPlusAnalyzers",
+          "angles": {
+            "a": 0,
+            "b": 0.785398163397,
+            "delta": -0.785398163397
+          },
+          "event": "sameOutcome",
+          "ts": 0.8535533905934323,
+          "qsharp": 0.853553390593,
+          "fsharpAnalytic": 0.8535533905934323
+        },
+        {
+          "id": "Singlet opposite-outcome a=0 b=pi/4",
+          "state": "Singlet",
+          "operation": "Zeta.ReferenceOracle.ApplyBellSingletAnalyzers",
+          "angles": {
+            "a": 0,
+            "b": 0.785398163397,
+            "delta": -0.785398163397
+          },
+          "event": "oppositeOutcome",
+          "ts": 0.8535533905934323,
+          "qsharp": 0.853553390593,
+          "fsharpAnalytic": 0.8535533905934323
+        },
+        {
+          "id": "PhiPlus same-outcome a=0 b=pi/2",
+          "state": "PhiPlus",
+          "operation": "Zeta.ReferenceOracle.ApplyBellPhiPlusAnalyzers",
+          "angles": {
+            "a": 0,
+            "b": 1.570796326795,
+            "delta": -1.570796326795
+          },
+          "event": "sameOutcome",
+          "ts": 0.49999999999994815,
+          "qsharp": 0.5,
+          "fsharpAnalytic": 0.49999999999994826
+        },
+        {
+          "id": "PhiPlus same-outcome a=0 b=pi",
+          "state": "PhiPlus",
+          "operation": "Zeta.ReferenceOracle.ApplyBellPhiPlusAnalyzers",
+          "angles": {
+            "a": 0,
+            "b": 3.14159265359,
+            "delta": -3.14159265359
+          },
+          "event": "sameOutcome",
+          "ts": 1.0693949408680808e-26,
+          "qsharp": 0,
+          "fsharpAnalytic": 1.0693949408680808e-26
+        }
+      ],
+      "qsharpCircuits": {
+        "PhiPlus same-outcome a=0 b=pi/4": "namespace Quantum {\n    open Microsoft.Quantum.Intrinsic;\n    open Microsoft.Quantum.Canon;\n    open Microsoft.Quantum.Math;\n    open Microsoft.Quantum.Convert;\n\n    function SetBitValue(reg: Int, bit: Int, value: Bool): Int {\n        if(value) {\n            return reg ||| (1 <<< bit);\n        } else {\n            return reg &&& ~~~(1 <<< bit);\n        }\n    }\n    \n    operation Circuit() : Unit {\n        using(qubits = Qubit[2]) {\n            H(qubits[0]);\n            CNOT(qubits[0], qubits[1]);\n            Ry(qubits[0]);\n            Ry(-0.785398163397, qubits[1]);\n            ResetAll(qubits);\n        }\n    }\n}\n",
+        "Singlet opposite-outcome a=0 b=pi/4": "namespace Quantum {\n    open Microsoft.Quantum.Intrinsic;\n    open Microsoft.Quantum.Canon;\n    open Microsoft.Quantum.Math;\n    open Microsoft.Quantum.Convert;\n\n    function SetBitValue(reg: Int, bit: Int, value: Bool): Int {\n        if(value) {\n            return reg ||| (1 <<< bit);\n        } else {\n            return reg &&& ~~~(1 <<< bit);\n        }\n    }\n    \n    operation Circuit() : Unit {\n        using(qubits = Qubit[2]) {\n            H(qubits[0]);\n            CNOT(qubits[0], qubits[1]);\n            Ry(qubits[0]);\n            X(qubits[1]);\n            Z(qubits[1]);\n            Ry(-0.785398163397, qubits[1]);\n            ResetAll(qubits);\n        }\n    }\n}\n",
+        "PhiPlus same-outcome a=0 b=pi/2": "namespace Quantum {\n    open Microsoft.Quantum.Intrinsic;\n    open Microsoft.Quantum.Canon;\n    open Microsoft.Quantum.Math;\n    open Microsoft.Quantum.Convert;\n\n    function SetBitValue(reg: Int, bit: Int, value: Bool): Int {\n        if(value) {\n            return reg ||| (1 <<< bit);\n        } else {\n            return reg &&& ~~~(1 <<< bit);\n        }\n    }\n    \n    operation Circuit() : Unit {\n        using(qubits = Qubit[2]) {\n            H(qubits[0]);\n            CNOT(qubits[0], qubits[1]);\n            Ry(qubits[0]);\n            Ry(-1.570796326795, qubits[1]);\n            ResetAll(qubits);\n        }\n    }\n}\n",
+        "PhiPlus same-outcome a=0 b=pi": "namespace Quantum {\n    open Microsoft.Quantum.Intrinsic;\n    open Microsoft.Quantum.Canon;\n    open Microsoft.Quantum.Math;\n    open Microsoft.Quantum.Convert;\n\n    function SetBitValue(reg: Int, bit: Int, value: Bool): Int {\n        if(value) {\n            return reg ||| (1 <<< bit);\n        } else {\n            return reg &&& ~~~(1 <<< bit);\n        }\n    }\n    \n    operation Circuit() : Unit {\n        using(qubits = Qubit[2]) {\n            H(qubits[0]);\n            CNOT(qubits[0], qubits[1]);\n            Ry(qubits[0]);\n            Ry(-3.14159265359, qubits[1]);\n            ResetAll(qubits);\n        }\n    }\n}\n"
+      }
+    },
+    "interferenceGrid": {
+      "results": [
+        {
+          "id": "mach-zehnder-open",
+          "operation": "Zeta.ReferenceOracle.ApplyMachZehnderOpen",
+          "phase": null,
+          "ts": {
+            "Zero": 0.5,
+            "One": 0.5
+          },
+          "qsharp": {
+            "One": 0.499999690551,
+            "Zero": 0.500000309449
+          },
+          "fsharpAnalytic": {
+            "Zero": 0.5,
+            "One": 0.5
+          }
+        },
+        {
+          "id": "mach-zehnder-closed-zero-phase",
+          "operation": "Zeta.ReferenceOracle.ApplyMachZehnderClosedZeroPhase",
+          "phase": 0,
+          "ts": {
+            "Zero": 1,
+            "One": 0
+          },
+          "qsharp": {
+            "One": 0,
+            "Zero": 1
+          },
+          "fsharpAnalytic": {
+            "Zero": 1,
+            "One": 0
+          }
+        },
+        {
+          "id": "mach-zehnder-closed-pi-over-3-phase",
+          "operation": "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiOver3Phase",
+          "phase": 1.047197551197,
+          "ts": {
+            "Zero": 0.74999999999983,
+            "One": 0.25000000000017
+          },
+          "qsharp": {
+            "One": 0.250000699375,
+            "Zero": 0.749999300625
+          },
+          "fsharpAnalytic": {
+            "Zero": 0.7499999999998259,
+            "One": 0.2500000000001741
+          }
+        },
+        {
+          "id": "mach-zehnder-closed-pi-over-2-phase",
+          "operation": "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiOver2Phase",
+          "phase": 1.570796326795,
+          "ts": {
+            "Zero": 0.49999999999995004,
+            "One": 0.50000000000005
+          },
+          "qsharp": {
+            "One": 0.499999690551,
+            "Zero": 0.500000309449
+          },
+          "fsharpAnalytic": {
+            "Zero": 0.49999999999994826,
+            "One": 0.5000000000000517
+          }
+        },
+        {
+          "id": "mach-zehnder-closed-two-pi-over-3-phase",
+          "operation": "Zeta.ReferenceOracle.ApplyMachZehnderClosedTwoPiOver3Phase",
+          "phase": 2.094395102393,
+          "ts": {
+            "Zero": 0.25000000000008005,
+            "One": 0.74999999999992
+          },
+          "qsharp": {
+            "One": 0.75,
+            "Zero": 0.25
+          },
+          "fsharpAnalytic": {
+            "Zero": 0.2500000000000847,
+            "One": 0.7499999999999153
+          }
+        },
+        {
+          "id": "mach-zehnder-closed-pi-phase",
+          "operation": "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiPhase",
+          "phase": 3.14159265359,
+          "ts": {
+            "Zero": 0,
+            "One": 1
+          },
+          "qsharp": {
+            "One": 1,
+            "Zero": 0
+          },
+          "fsharpAnalytic": {
+            "Zero": 1.0693949408680808e-26,
+            "One": 1
+          }
+        }
+      ],
+      "qsharpCircuits": {
+        "mach-zehnder-open": "namespace Quantum {\n    open Microsoft.Quantum.Intrinsic;\n    open Microsoft.Quantum.Canon;\n    open Microsoft.Quantum.Math;\n    open Microsoft.Quantum.Convert;\n\n    function SetBitValue(reg: Int, bit: Int, value: Bool): Int {\n        if(value) {\n            return reg ||| (1 <<< bit);\n        } else {\n            return reg &&& ~~~(1 <<< bit);\n        }\n    }\n    \n    operation Circuit() : Unit {\n        using(qubits = Qubit[1]) {\n            H(qubits[0]);\n            ResetAll(qubits);\n        }\n    }\n}\n",
+        "mach-zehnder-closed-zero-phase": "namespace Quantum {\n    open Microsoft.Quantum.Intrinsic;\n    open Microsoft.Quantum.Canon;\n    open Microsoft.Quantum.Math;\n    open Microsoft.Quantum.Convert;\n\n    function SetBitValue(reg: Int, bit: Int, value: Bool): Int {\n        if(value) {\n            return reg ||| (1 <<< bit);\n        } else {\n            return reg &&& ~~~(1 <<< bit);\n        }\n    }\n    \n    operation Circuit() : Unit {\n        using(qubits = Qubit[1]) {\n            H(qubits[0]);\n            H(qubits[0]);\n            ResetAll(qubits);\n        }\n    }\n}\n",
+        "mach-zehnder-closed-pi-over-3-phase": "namespace Quantum {\n    open Microsoft.Quantum.Intrinsic;\n    open Microsoft.Quantum.Canon;\n    open Microsoft.Quantum.Math;\n    open Microsoft.Quantum.Convert;\n\n    function SetBitValue(reg: Int, bit: Int, value: Bool): Int {\n        if(value) {\n            return reg ||| (1 <<< bit);\n        } else {\n            return reg &&& ~~~(1 <<< bit);\n        }\n    }\n    \n    operation Circuit() : Unit {\n        using(qubits = Qubit[1]) {\n            H(qubits[0]);\n            Rz(1.047197551197, qubits[0]);\n            H(qubits[0]);\n            ResetAll(qubits);\n        }\n    }\n}\n",
+        "mach-zehnder-closed-pi-over-2-phase": "namespace Quantum {\n    open Microsoft.Quantum.Intrinsic;\n    open Microsoft.Quantum.Canon;\n    open Microsoft.Quantum.Math;\n    open Microsoft.Quantum.Convert;\n\n    function SetBitValue(reg: Int, bit: Int, value: Bool): Int {\n        if(value) {\n            return reg ||| (1 <<< bit);\n        } else {\n            return reg &&& ~~~(1 <<< bit);\n        }\n    }\n    \n    operation Circuit() : Unit {\n        using(qubits = Qubit[1]) {\n            H(qubits[0]);\n            Rz(1.570796326795, qubits[0]);\n            H(qubits[0]);\n            ResetAll(qubits);\n        }\n    }\n}\n",
+        "mach-zehnder-closed-two-pi-over-3-phase": "namespace Quantum {\n    open Microsoft.Quantum.Intrinsic;\n    open Microsoft.Quantum.Canon;\n    open Microsoft.Quantum.Math;\n    open Microsoft.Quantum.Convert;\n\n    function SetBitValue(reg: Int, bit: Int, value: Bool): Int {\n        if(value) {\n            return reg ||| (1 <<< bit);\n        } else {\n            return reg &&& ~~~(1 <<< bit);\n        }\n    }\n    \n    operation Circuit() : Unit {\n        using(qubits = Qubit[1]) {\n            H(qubits[0]);\n            Rz(2.094395102393, qubits[0]);\n            H(qubits[0]);\n            ResetAll(qubits);\n        }\n    }\n}\n",
+        "mach-zehnder-closed-pi-phase": "namespace Quantum {\n    open Microsoft.Quantum.Intrinsic;\n    open Microsoft.Quantum.Canon;\n    open Microsoft.Quantum.Math;\n    open Microsoft.Quantum.Convert;\n\n    function SetBitValue(reg: Int, bit: Int, value: Bool): Int {\n        if(value) {\n            return reg ||| (1 <<< bit);\n        } else {\n            return reg &&& ~~~(1 <<< bit);\n        }\n    }\n    \n    operation Circuit() : Unit {\n        using(qubits = Qubit[1]) {\n            H(qubits[0]);\n            Z(qubits[0]);\n            H(qubits[0]);\n            ResetAll(qubits);\n        }\n    }\n}\n"
+      }
+    }
+  }
+}

--- a/tests/Tests.FSharp/QSharpOracle.Tests.fs
+++ b/tests/Tests.FSharp/QSharpOracle.Tests.fs
@@ -373,3 +373,136 @@ let ``Q# Pauli products pin the hardware-side anticommutation signs`` () =
     assertCase "X after Z = -(Z after X)"
     assertCase "X after Y = -(Y after X)"
     assertCase "Y after Z = -(Z after Y)"
+
+[<Fact>]
+let ``F# validates the TypeScript Q# treaty transcript`` () =
+    let transcriptRelativePath =
+        Path.Combine("src", "Core.QSharp.ReferenceOracle", "treaty-transcript.json")
+
+    let transcriptPath =
+        Path.Combine(root, transcriptRelativePath)
+
+    let transcript =
+        JsonDocument.Parse(File.ReadAllText(transcriptPath)).RootElement
+
+    Assert.Equal("zeta.qsharp.treaty-transcript.v1", transcript.GetProperty("schema").GetString())
+
+    let jobs = transcript.GetProperty("jobs")
+    
+    // 1. Validate CHSH Corners
+    let chsh = jobs.GetProperty("chshCorners")
+    let sParam = chsh.GetProperty("sParameter")
+    let sAnalytic = sParam.GetProperty("fsharpAnalytic").GetDouble()
+    let sTS = sParam.GetProperty("ts").GetDouble()
+    let sQSharp = sParam.GetProperty("qsharp").GetDouble()
+
+    // Assert S parameters are consistent within tolerances
+    closeTo sAnalytic sTS
+    closeToWithin 1e-4 sAnalytic sQSharp
+
+    let chshResults = chsh.GetProperty("results").EnumerateArray() |> Seq.toArray
+    Assert.Equal(4, chshResults.Length)
+
+    for res in chshResults do
+        let angles = res.GetProperty("angles")
+        let a = angles.GetProperty("a").GetDouble()
+        let b = angles.GetProperty("b").GetDouble()
+        
+        let ts = res.GetProperty("ts")
+        let tsOpposite = ts.GetProperty("pOpposite").GetDouble()
+        let tsCorrelator = ts.GetProperty("correlator").GetDouble()
+
+        let qs = res.GetProperty("qsharp")
+        let qsOpposite = qs.GetProperty("pOpposite").GetDouble()
+        let qsCorrelator = qs.GetProperty("correlator").GetDouble()
+
+        let fa = res.GetProperty("fsharpAnalytic")
+        let faOpposite = fa.GetProperty("pOpposite").GetDouble()
+        let faCorrelator = fa.GetProperty("correlator").GetDouble()
+
+        // Assert that the F# code values match the expected analytic values
+        closeTo faOpposite (BellTest.coincidenceProbability a b)
+        closeTo faCorrelator (BellTest.correlation a b)
+
+        // Assert that TS matches F# Analytic
+        closeToWithin 1e-5 tsOpposite faOpposite
+        closeToWithin 1e-5 tsCorrelator faCorrelator
+
+        // Assert that Q# matches F# Analytic
+        closeToWithin 1e-5 qsOpposite faOpposite
+        closeToWithin 1e-5 qsCorrelator faCorrelator
+
+    // 2. Validate Bell Coincidence
+    let coincidenceResults = jobs.GetProperty("bellCoincidence").GetProperty("results").EnumerateArray() |> Seq.toArray
+    for res in coincidenceResults do
+        let angles = res.GetProperty("angles")
+        let a = angles.GetProperty("a").GetDouble()
+        let b = angles.GetProperty("b").GetDouble()
+        let state = res.GetProperty("state").GetString()
+        let event = res.GetProperty("event").GetString()
+        
+        let tsProb = res.GetProperty("ts").GetDouble()
+        let qsProb = res.GetProperty("qsharp").GetDouble()
+        let faProb = res.GetProperty("fsharpAnalytic").GetDouble()
+
+        let fsharpProb =
+            if state = "Singlet" then
+                if event = "oppositeOutcome" then
+                    BellTest.coincidenceProbability a b
+                else
+                    1.0 - BellTest.coincidenceProbability a b
+            else // PhiPlus
+                if event = "sameOutcome" then
+                    BellTest.coincidenceProbability a b
+                else
+                    1.0 - BellTest.coincidenceProbability a b
+
+        closeTo faProb fsharpProb
+        closeToWithin 1e-5 tsProb faProb
+        closeToWithin 1e-5 qsProb faProb
+
+    // 3. Validate Interference Visibility
+    let detectorZero = frame 0UL
+    let detectorOne = frame 1UL
+    let half = real 0.5
+    let invSqrt2 = real (1.0 / sqrt 2.0)
+
+    let closedInterferometer (phi: float) : AmplitudeEmu.Amp =
+        let phase0 = phase (-phi / 2.0)
+        let phase1 = phase (phi / 2.0)
+
+        [ detectorZero, c.Mul(half, phase0)
+          detectorZero, c.Mul(half, phase1)
+          detectorOne, c.Mul(half, phase0)
+          detectorOne, c.Negate(c.Mul(half, phase1)) ]
+
+    let interferenceResults = jobs.GetProperty("interferenceGrid").GetProperty("results").EnumerateArray() |> Seq.toArray
+    for res in interferenceResults do
+        let phaseValEl = res.GetProperty("phase")
+        let isOpen = res.GetProperty("operation").GetString().EndsWith("Open")
+        
+        let tsZero = res.GetProperty("ts").GetProperty("Zero").GetDouble()
+        let tsOne = res.GetProperty("ts").GetProperty("One").GetDouble()
+        let qsZero = res.GetProperty("qsharp").GetProperty("Zero").GetDouble()
+        let qsOne = res.GetProperty("qsharp").GetProperty("One").GetDouble()
+        let faZero = res.GetProperty("fsharpAnalytic").GetProperty("Zero").GetDouble()
+        let faOne = res.GetProperty("fsharpAnalytic").GetProperty("One").GetDouble()
+
+        let amp =
+            if isOpen then
+                [ detectorZero, invSqrt2
+                  detectorOne, invSqrt2 ]
+            else
+                let phi = if phaseValEl.ValueKind = JsonValueKind.Null then 0.0 else phaseValEl.GetDouble()
+                closedInterferometer phi
+
+        let actual = amp |> AmplitudeEmu.merge |> AmplitudeEmu.bornProb
+        let fsharpZeroProb = probabilityFor detectorZero actual
+        let fsharpOneProb = probabilityFor detectorOne actual
+
+        closeTo faZero fsharpZeroProb
+        closeTo faOne fsharpOneProb
+        closeToWithin 1e-5 tsZero faZero
+        closeToWithin 1e-5 tsOne faOne
+        closeToWithin 1e-5 qsZero faZero
+        closeToWithin 1e-5 qsOne faOne


### PR DESCRIPTION
- Implement generate-treaty-transcript.ts to run quantum-circuit simulations
- Export runnable Q# code using circuit.exportToQSharp()
- Assert TS, Q# and F# analytic values in quantum-circuit.test.ts
- Verify BellTest and AmplitudeEmu values against the transcript in QSharpOracle.Tests.fs
- Register generate:transcript in package.json

Co-Authored-By: Gemini <noreply@google.com>
