### PR TITLE
refactor(workflow): source-own agent-loop state machines

### DIFF
--- a/docs/DECISIONS/2026-05-31-observe-act-16-direction-universal-action-grammar-local-no-cloud-llm.md
+++ b/docs/DECISIONS/2026-05-31-observe-act-16-direction-universal-action-grammar-local-no-cloud-llm.md
@@ -24,7 +24,7 @@ and continue to iterate; the *direction* is locked.
 
 **Owner:** operator (shaping-decision owner; authorized the canonical-retrofit to proceed without waiting on Max — see Status) + Max (corporate `Menu16` author; informed-after, after-the-fact review); Otto-CLI synthesis.
 **Decision confidence:** *medium* — the pieces are individually built or ratified (the move-next
-engine `tools/agent-loop/` exists; git-append-only-state is ratified B-0867/B-0858; the
+engine `src/Core.TypeScript/workflow-engine/agent-loop/` exists; git-append-only-state is ratified B-0867/B-0858; the
 local-no-cloud stance is long-standing; the 16-direction framing is the operator's own from the
 2026-05-28/30 conversations). What's new here is composing them into one loop + proposing a concrete
 16-slot grammar. The composition is sound; the exact grammar layout is a first draft.
@@ -35,7 +35,7 @@ Across 2026-05-28 -> 2026-05-31 the operator + Ani named a foreground-loop archi
 currently **built-as-engine but not yet wired as the live agent loop**, and **designed-but-not-
 deployed** for its compute substrate:
 
-- **The move-next engine exists.** `tools/agent-loop/state-machine.ts` (B-0867.5) implements
+- **The move-next engine exists.** `src/Core.TypeScript/workflow-engine/agent-loop/state-machine.ts` (B-0867.5) implements
   "execute script -> look at choose-your-own-adventure output -> take action based on output."
   Operator framing: *"the agent loop basically becomes execute script look at choose your own
   adventure output, take action based on outpout."* Clean separation: the **deterministic script
@@ -222,7 +222,7 @@ with these four properties:
    -> **render** the menu as the fixed 16-direction grammar -> **select** (the LLM picks ONE
    direction, returning an index 0..15, not free text) -> **act** (the deterministic script executes
    the chosen direction) -> **append** the new state event to Git -> repeat. This is `observe.ts`:
-   the observe-step entrypoint over the existing `tools/agent-loop/` (move-next) state machine.
+   the observe-step entrypoint over the existing `src/Core.TypeScript/workflow-engine/agent-loop/` (move-next) state machine.
 2. **16-direction universal action grammar** — a FIXED set of 16 action slots (Xbox-controller
    layout). The directions are stable across all states (learnable); each state's move-next supplies
    the **labels + availability** for the 16 slots. Availability is **tri-boolean** (composes with
@@ -245,7 +245,7 @@ with these four properties:
    git log  |  observe.ts                                      |
    (state) -+-> read current state (latest events)            |
             |   -> move-next(state): build the 16-slot menu    |   deterministic script
-            |        (labels + Tri availability per slot)      |   (tools/agent-loop, F# DU canon)
+            |        (labels + Tri availability per slot)      |   (src/Core.TypeScript/workflow-engine/agent-loop, F# DU canon)
             |                                                  |
             |  render 16-direction grammar  ------------------>|
             |                                                  |
@@ -324,7 +324,7 @@ the menu-builder slice must honor.)*
 
 ### Layering (clean separation)
 
-- **Deterministic script** (`tools/agent-loop/` TS today; the canonical F# DU in
+- **Deterministic script** (`src/Core.TypeScript/workflow-engine/agent-loop/` TS today; the canonical F# DU in
   `src/Core.FSharp/WorkflowEngine/` is PLANNED future-work, B-0867.1 — does not exist yet): owns the
   state machine + `move-next(state) -> 16-slot menu`. No LLM here. Replayable / DST-able.
 - **LLM selector** (local, no cloud): a pure function `menu -> index 0..15` over only-`T` slots.
@@ -576,7 +576,7 @@ onto the canonical algebra, not the reverse.
 - **`agentic-organization/docs/CLUSTER_EXECUTION_AND_MEMORY_SUBSTRATE.md` +
   `RUNTIME_TECH_AND_PACKAGE_STRATEGY.md` + `AI_CLUSTER_SCAFFOLD_CONTEXT.md`** (the cluster deployment
   target — k3s/Temporal/Dapr/Orleans/NATS/Cockroach; local-model gating — vs this ADR's single-node)
-- `tools/agent-loop/` (B-0867.5 — the move-next state machine; the local TS form of the keystone's
+- `src/Core.TypeScript/workflow-engine/agent-loop/` (B-0867.5 — the move-next state machine; the local TS form of the keystone's
   composer that this ADR puts a 16-slot face on)
 - B-0944 (tri-boolean digital qubit — the `Tri` cell IS the per-slot availability; the `Tri[16]`
   menu is a projection of the keystone's `ObserveResult` readout + deterministic-rule vetoes)

--- a/docs/DECISIONS/2026-06-11-source-owned-code-tools-bootstrap-only.md
+++ b/docs/DECISIONS/2026-06-11-source-owned-code-tools-bootstrap-only.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted
 **Date:** 2026-06-11
-**Backlog:** (to be filed for repo-wide migration; this ADR ships the boundary and the Q# first slice)
+**Backlog:** (to be filed for repo-wide migration; this ADR ships the boundary and staged migration slices)
 
 ## Context & Problem Statement
 
@@ -67,3 +67,7 @@ and migrate in slices without hiding the debt.
   - The first slice moves the Q# reference oracle from `tools/qsharp-oracle/` to
     `src/Core.QSharp.ReferenceOracle/` and runs both source-owned oracle tests in
     CI cross-verification.
+  - The next slice moves the pure TypeScript agent-loop state machines from
+    `tools/agent-loop/` to
+    `src/Core.TypeScript/workflow-engine/agent-loop/`, preserving the tested DU
+    contract while putting workflow-engine behavior under `src/`.

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -1315,7 +1315,7 @@ outpout."*
 Three pieces, cleanly separated:
 
 1. **Deterministic script** holds the STATE MACHINE
-   (TS modules in `tools/agent-loop/`, F# DU types as
+   (TS modules in `src/Core.TypeScript/workflow-engine/agent-loop/`, F# DU types as
    algebraic-spec documentation in `src/Core.FSharp/`
    when the F# port lands).
 2. **LLM (any agent)** is a pure MENU-SELECTOR —
@@ -1332,7 +1332,7 @@ script executes the choice and appends the new state.
 
 #### Two composing state machines
 
-- **Agent-state machine** (`tools/agent-loop/state-machine.ts`):
+- **Agent-state machine** (`src/Core.TypeScript/workflow-engine/agent-loop/state-machine.ts`):
   10 states forming a cycle around `Idle` —
   `InspectingStatus`, `SelectingWork`, `ExecutingWork`,
   `EmittingResult`, `RecordingHeartbeat`, `NamedBoundedWait`,
@@ -1342,7 +1342,7 @@ script executes the choice and appends the new state.
   and `EnterOpenEndedExploration` (per operator:
   *"there's a menu button for that lol"*).
 - **Work-lifecycle state machine**
-  (`tools/agent-loop/work-lifecycle-state-machine.ts`):
+  (`src/Core.TypeScript/workflow-engine/agent-loop/work-lifecycle-state-machine.ts`):
   11 states modelling `Backlog → Claimed → InProgress →
   PrOpen → InReview ↔ RevisionRequested ↔ RevisionPushed →
   Approved → Merged`, with the cycle-push-review-a-few-times
@@ -1465,7 +1465,7 @@ simultaneously, no single vendor as choke point:
 
 | Channel | Surface | Operator-authority |
 |---|---|---|
-| **Native TS + bun** | Direct `bun tools/agent-loop/` invocation; works in any harness with bun installed | Full — operator controls the bits on disk |
+| **Native TS + bun** | Direct `bun src/Core.TypeScript/workflow-engine/agent-loop/` invocation; works in any harness with bun installed | Full — operator controls the bits on disk |
 | **Vendor skill-store** | Claude skills marketplace, Cursor extension registry, Kiro skill catalog, future vendor stores | Vendor-policy-bound — operator authority subject to vendor curation |
 | **Ace package manager** | Zeta-internal package distribution; bypasses vendor stores; cryptographic + reputation-anchored | Operator-controlled — Aaron + the maintainer-collective |
 | **zflash USB** | Reproducible USB image with the agent-loop runtime + skill catalog burned in | Fully air-gapped — operator-controlled bits, no network dependency |

--- a/docs/backlog/P1/B-0867.15-per-host-adapters-github-gitlab-gitea-bitbucket-isomorphic-cross-host-substrate-aaron-2026-05-28.md
+++ b/docs/backlog/P1/B-0867.15-per-host-adapters-github-gitlab-gitea-bitbucket-isomorphic-cross-host-substrate-aaron-2026-05-28.md
@@ -67,12 +67,12 @@ The substrate's PER-HOST surface (thin adapter layer) handles:
 
 ## Acceptance criteria
 
-- `tools/agent-loop/hosts/github.ts` — extracts existing GitHub-specific code into adapter
-- `tools/agent-loop/hosts/gitlab.ts` — GitLab equivalent
-- `tools/agent-loop/hosts/gitea.ts` — Gitea / Codeberg / Forgejo equivalent
-- `tools/agent-loop/hosts/bitbucket.ts` — Bitbucket equivalent
-- `tools/agent-loop/hosts/pure-git.ts` — self-hosted no-UI adapter (minimal)
-- `tools/agent-loop/hosts/index.ts` — host-detection + adapter dispatch
+- `src/Core.TypeScript/workflow-engine/agent-loop/hosts/github.ts` — extracts existing GitHub-specific code into adapter
+- `src/Core.TypeScript/workflow-engine/agent-loop/hosts/gitlab.ts` — GitLab equivalent
+- `src/Core.TypeScript/workflow-engine/agent-loop/hosts/gitea.ts` — Gitea / Codeberg / Forgejo equivalent
+- `src/Core.TypeScript/workflow-engine/agent-loop/hosts/bitbucket.ts` — Bitbucket equivalent
+- `src/Core.TypeScript/workflow-engine/agent-loop/hosts/pure-git.ts` — self-hosted no-UI adapter (minimal)
+- `src/Core.TypeScript/workflow-engine/agent-loop/hosts/index.ts` — host-detection + adapter dispatch
 - Core agent-loop substrate (state-machine, work-lifecycle, event-log, playbook) remains host-agnostic; only adapters touch host-specific APIs
 - Tests cover: adapter contracts (each host produces identical observable behavior for the same agent-loop operations); host-detection correctness; fallback to pure-git
 - README documents the adapter contract + how to add a new host

--- a/docs/backlog/P1/B-0867.20-lifecycle-du-split-trajectory-push-vs-pr-review-determinereviewlevel-discriminator-kestrel-2026-05-28.md
+++ b/docs/backlog/P1/B-0867.20-lifecycle-du-split-trajectory-push-vs-pr-review-determinereviewlevel-discriminator-kestrel-2026-05-28.md
@@ -58,7 +58,7 @@ State-machine events = direct push (no ceremony); system changes (code, rules, f
 
 ## Acceptance criteria
 
-- Update `tools/agent-loop/work-lifecycle-state-machine.ts` (PR #5669) — split `PrOpen` into `pushed-to-trajectory` + `pr-open-for-review` stages
+- Update `src/Core.TypeScript/workflow-engine/agent-loop/work-lifecycle-state-machine.ts` (PR #5669) — split `PrOpen` into `pushed-to-trajectory` + `pr-open-for-review` stages
 - Add `determineReviewLevel(work)` discriminator
 - Tests cover: state-machine-events route to trajectory-push; code/rule/framework changes route to pr-review; safe-default to pr-review
 - README updates documenting the split

--- a/docs/backlog/P1/B-0867.21-two-path-interface-discriminated-union-execute-vs-conversational-declare-intent-aaron-ani-2026-05-28.md
+++ b/docs/backlog/P1/B-0867.21-two-path-interface-discriminated-union-execute-vs-conversational-declare-intent-aaron-ani-2026-05-28.md
@@ -52,11 +52,11 @@ Both paths produce events. Both feed into the same event log (B-0867.2). The con
 
 ## Acceptance criteria
 
-- `tools/agent-loop/conversational-intent.ts` — exposes `declareIntent(documentPath, persona)` that:
+- `src/Core.TypeScript/workflow-engine/agent-loop/conversational-intent.ts` — exposes `declareIntent(documentPath, persona)` that:
   - Reads a markdown document with conversational intent
   - Generates an event (via B-0867.2 event-sourcing layer) with `event_type: "intent-declared"` + a reference to the document
   - Document path lives in `agent-intent/{trajectory}/{document-name}.md` or similar convention
-- `tools/agent-loop/intent-to-execution.ts` — tracks intention documents through their lifecycle:
+- `src/Core.TypeScript/workflow-engine/agent-loop/intent-to-execution.ts` — tracks intention documents through their lifecycle:
   - `intent-declared` event → swarm picks up the work
   - As execution progresses, document gets updated with progress
   - On completion, document carries the execution record + outcome

--- a/docs/backlog/P1/B-0874-github-actions-recursion-as-infinite-runtime-platform-no-pr-swarm-mode-ani-kestrel-2026-05-28.md
+++ b/docs/backlog/P1/B-0874-github-actions-recursion-as-infinite-runtime-platform-no-pr-swarm-mode-ani-kestrel-2026-05-28.md
@@ -56,7 +56,7 @@ Turn GitHub Actions into an infinite recursive compute platform for the agent-lo
 
 - `.github/workflows/agent-loop-swarm.yml` workflow that:
   - Reads current state from `agent-state/{persona}/{trajectory}/` branches
-  - Invokes `tools/agent-loop/state-machine.ts` for `move-next` decision
+  - Invokes `src/Core.TypeScript/workflow-engine/agent-loop/state-machine.ts` for `move-next` decision
   - Appends new event to Git via direct push (no PR)
   - Triggers next workflow run via `workflow_dispatch` API
 - Bounded-iteration safety (per Kestrel's push-cycle-limit B-0867.17 framing) — workflows include a max-recursion-depth + abandonment-condition guard

--- a/docs/backlog/P1/B-0887-zeta-native-review-and-branch-protection-substrate-replaces-github-pr-workflow-preserves-review-and-class-fix-discipline-aaron-2026-05-28.md
+++ b/docs/backlog/P1/B-0887-zeta-native-review-and-branch-protection-substrate-replaces-github-pr-workflow-preserves-review-and-class-fix-discipline-aaron-2026-05-28.md
@@ -73,8 +73,8 @@ B-0874 stays in the cluster but its framing is now the implementation-detail (Gi
 
 Review is NOT a separate subsystem. It's:
 
-1. **MenuOption cases** in the existing `MenuOption` DU (per `tools/agent-loop/state-machine.ts`) — `move-next` can return `ReviewWork` / `ApproveTrajectoryCompletion` / `RaiseClassFindingForTechDebtSweep` / etc. just like any other action
-2. **WorkLifecycle DU cases** (per `tools/agent-loop/work-lifecycle-state-machine.ts`) — review-related state transitions are first-class lifecycle stages
+1. **MenuOption cases** in the existing `MenuOption` DU (per `src/Core.TypeScript/workflow-engine/agent-loop/state-machine.ts`) — `move-next` can return `ReviewWork` / `ApproveTrajectoryCompletion` / `RaiseClassFindingForTechDebtSweep` / etc. just like any other action
+2. **WorkLifecycle DU cases** (per `src/Core.TypeScript/workflow-engine/agent-loop/work-lifecycle-state-machine.ts`) — review-related state transitions are first-class lifecycle stages
 3. **A reusable shippable skill** — `.claude/skills/zeta-native-review/SKILL.md` distributes the review-substrate to any agent harness with bun; no GitHub-PR-workflow dependency
 4. **Composes with existing playbook + event-log substrate** — review threads ARE playbook sections; review events ARE event-log entries; no parallel infrastructure
 
@@ -147,8 +147,8 @@ Composes with:
 
 ## Acceptance criteria
 
-- `tools/agent-loop/review/branch-protection.ts` — implements Zeta-native branch-protection (configurable per-trajectory: required-approvals, required-canaries, required-class-fix-completion)
-- `tools/agent-loop/review/playbook-as-review-surface.ts` — wires the playbook substrate as the review-thread surface (composes with B-0867.21)
+- `src/Core.TypeScript/workflow-engine/agent-loop/review/branch-protection.ts` — implements Zeta-native branch-protection (configurable per-trajectory: required-approvals, required-canaries, required-class-fix-completion)
+- `src/Core.TypeScript/workflow-engine/agent-loop/review/playbook-as-review-surface.ts` — wires the playbook substrate as the review-thread surface (composes with B-0867.21)
 - Adapter shims for existing reviewer sources (Copilot / CodeQL / Semgrep / Sonar) emit findings into Zeta-native review substrate alongside their existing GitHub-PR-comment surface (parallel-track during transition)
 - Tests: round-trip a review cycle (open trajectory → reviewer-agent appends finding → fix-push event → approval event → branch-protection allows completion)
 - Documentation: rule extension (existing PR-specific rules updated to reference Zeta-native equivalent where applicable) + new rule documenting the Zeta-native review substrate

--- a/docs/backlog/P1/B-0890-state-machine-fast-lane-batch-merge-to-main-composes-with-heartbeat-pattern-aaron-2026-05-28.md
+++ b/docs/backlog/P1/B-0890-state-machine-fast-lane-batch-merge-to-main-composes-with-heartbeat-pattern-aaron-2026-05-28.md
@@ -65,8 +65,8 @@ Mechanism 1 handles per-event write-time speed (no PR per event); Mechanism 2 ha
 
 ## Acceptance criteria
 
-- `tools/agent-loop/events/fast-lane-write.ts` — agent-side helper that writes events to the fast-lane path / trajectory branch with appropriate metadata (composes with B-0867.2 event-sourcing layer)
-- `tools/agent-loop/events/batch-merge-coordinator.ts` — periodic coordinator:
+- `src/Core.TypeScript/workflow-engine/agent-loop/events/fast-lane-write.ts` — agent-side helper that writes events to the fast-lane path / trajectory branch with appropriate metadata (composes with B-0867.2 event-sourcing layer)
+- `src/Core.TypeScript/workflow-engine/agent-loop/events/batch-merge-coordinator.ts` — periodic coordinator:
   - Reads accumulated events across trajectory branches
   - Assembles batch PR (or batch-merge to main if branch protection permits direct path-scoped merge)
   - Configurable batching policy (cadence / threshold / hybrid)

--- a/docs/backlog/P1/B-0890.1-fast-lane-as-folders-on-main-not-branches-supersedes-coordinator-complexity-per-operator-2026-05-28-zeta-native-branch-protection.md
+++ b/docs/backlog/P1/B-0890.1-fast-lane-as-folders-on-main-not-branches-supersedes-coordinator-complexity-per-operator-2026-05-28-zeta-native-branch-protection.md
@@ -110,8 +110,8 @@ The memo is PRESERVED as research substrate (the analysis is still valuable; sho
 
 ## Acceptance criteria
 
-- `tools/agent-loop/fast-lane-folders/write.ts` — TS module that writes events to `docs/agent-events/{trajectory}/YYYY/MM/DD/{zetaid}.json` directly on main (no branch)
-- `tools/agent-loop/fast-lane-folders/workflow-state-write.ts` — TS module that writes workflow-engine state to `docs/workflow-engine-state/{chromosome-hex}/YYYY/MM/DD/{zetaid}.json` directly on main
+- `src/Core.TypeScript/workflow-engine/agent-loop/fast-lane-folders/write.ts` — TS module that writes events to `docs/agent-events/{trajectory}/YYYY/MM/DD/{zetaid}.json` directly on main (no branch)
+- `src/Core.TypeScript/workflow-engine/agent-loop/fast-lane-folders/workflow-state-write.ts` — TS module that writes workflow-engine state to `docs/workflow-engine-state/{chromosome-hex}/YYYY/MM/DD/{zetaid}.json` directly on main
 - Both use REST git-data API for direct push (no local git state mutation; same pattern as B-0858 heartbeat write)
 - Composes with B-0887 Zeta-native path-protection: persona-scoped + chromosome-scoped + trajectory-scoped path permissions enforced at the branch-protection layer
 - Tests cover: same-persona writes succeed; cross-persona writes (e.g., otto writing to alexa's subdir) are rejected; concurrent writes from same persona to different files succeed; sequential writes preserve filename-ordering by ZetaID timestamp

--- a/docs/backlog/P2/B-0867.16-two-level-state-machine-composition-agentstate-x-worklifecycle-kestrel-2026-05-28.md
+++ b/docs/backlog/P2/B-0867.16-two-level-state-machine-composition-agentstate-x-worklifecycle-kestrel-2026-05-28.md
@@ -26,7 +26,7 @@ tags:
 
 ## What this row tracks
 
-Compose the two state machines shipped today (AgentState DU in PR #5666 / `tools/agent-loop/state-machine.ts`; WorkLifecycle DU in PR #5669 / `tools/agent-loop/work-lifecycle-state-machine.ts`) so AgentState informs which WorkLifecycle items to advance and how aggressively.
+Compose the two state machines shipped today (AgentState DU in PR #5666 / `src/Core.TypeScript/workflow-engine/agent-loop/state-machine.ts`; WorkLifecycle DU in PR #5669 / `src/Core.TypeScript/workflow-engine/agent-loop/work-lifecycle-state-machine.ts`) so AgentState informs which WorkLifecycle items to advance and how aggressively.
 
 Per Kestrel 2026-05-28: *"AgentState informs which WorkLifecycle items to advance and how aggressively. When MainBroken state fires, the agent prioritizes lifecycle items that fix main. When ExplorationOpportunity fires, the agent claims unclaimed items in setup-phase trajectories. When StableExecution fires, the agent advances in-progress lifecycles toward merge."*
 
@@ -48,7 +48,7 @@ async function runFullLoop(): Promise<void> {
 
 ## Acceptance criteria
 
-- `tools/agent-loop/compose.ts` exposes `runFullLoop(deps)` implementing the two-level pattern
+- `src/Core.TypeScript/workflow-engine/agent-loop/compose.ts` exposes `runFullLoop(deps)` implementing the two-level pattern
 - `filterLifecyclesByState(agentState, allLifecycles)` returns a prioritized list per AgentState case
 - `cycleDelayForState(agentState)` returns appropriate sleep duration (e.g., MainBroken = 0ms; StableExecution = 5s)
 - Tests cover: each AgentState case routes to the correct subset of lifecycles; cycle delay matches state; full-loop completes one iteration deterministically

--- a/docs/backlog/P2/B-0867.17-push-cycle-limit-as-structural-enforcement-not-discipline-kestrel-2026-05-28.md
+++ b/docs/backlog/P2/B-0867.17-push-cycle-limit-as-structural-enforcement-not-discipline-kestrel-2026-05-28.md
@@ -26,7 +26,7 @@ tags:
 
 ## What this row tracks
 
-Extend `tools/agent-loop/work-lifecycle-state-machine.ts` (PR #5669) with a `chooseActionForLifecycle` helper that:
+Extend `src/Core.TypeScript/workflow-engine/agent-loop/work-lifecycle-state-machine.ts` (PR #5669) with a `chooseActionForLifecycle` helper that:
 
 - Examines current `WorkLifecycleState`
 - Returns the next legal `WorkLifecycleTransition` based on state + thresholds

--- a/docs/backlog/P2/B-0867.2-git-append-only-state-persist-typescript-tool-event-sourcing-layer-kestrel-2026-05-28.md
+++ b/docs/backlog/P2/B-0867.2-git-append-only-state-persist-typescript-tool-event-sourcing-layer-kestrel-2026-05-28.md
@@ -45,15 +45,15 @@ Event file path: `agent-state/{persona}/{trajectory}/events/YYYY/MM/DD/{zetaId}.
 
 ## Acceptance criteria
 
-- `tools/agent-loop/events/append.ts` exposes `appendEvent(event)` that:
+- `src/Core.TypeScript/workflow-engine/agent-loop/events/append.ts` exposes `appendEvent(event)` that:
   - Computes branch + path from event's persona + trajectory + ZetaID
   - Direct-pushes new file to the agent-state branch (no PR)
   - Returns the resulting commit SHA + push receipt
-- `tools/agent-loop/events/read.ts` exposes:
+- `src/Core.TypeScript/workflow-engine/agent-loop/events/read.ts` exposes:
   - `readEventsForLifecycle(zetaId)` — walks the previous_zeta_id chain backward to reconstruct full history
   - `readEventsForTrajectory(trajectoryId)` — reads all events under a trajectory's branch in time order
   - `readEventsForPersona(persona, sinceIso)` — reads all events authored by a persona
-- `tools/agent-loop/events/reconstruct.ts` exposes `reconstructLifecycle(events)` — left-fold over events producing current WorkLifecycle state
+- `src/Core.TypeScript/workflow-engine/agent-loop/events/reconstruct.ts` exposes `reconstructLifecycle(events)` — left-fold over events producing current WorkLifecycle state
 - Event schema validated in pre-receive hook (cheap defense per good-actor model)
 - Tests cover: append-read round-trip, chain reconstruction, concurrent writes via ZetaID-named files, schema validation rejection of malformed events
 

--- a/docs/backlog/P2/B-0872-otel-trace-id-composition-with-zetaid-baggage-propagation-kestrel-2026-05-28.md
+++ b/docs/backlog/P2/B-0872-otel-trace-id-composition-with-zetaid-baggage-propagation-kestrel-2026-05-28.md
@@ -40,7 +40,7 @@ Wire OpenTelemetry trace-IDs through the agent-loop substrate so every state-mac
 
 ## Acceptance criteria
 
-- `tools/agent-loop/otel.ts` exposes `withTrace(zetaId, fn)` helper that:
+- `src/Core.TypeScript/workflow-engine/agent-loop/otel.ts` exposes `withTrace(zetaId, fn)` helper that:
   - Creates/joins a W3C Trace Context for the current operation
   - Sets baggage entries linking `zetaId` → current trace
   - Runs `fn` within the trace scope

--- a/docs/backlog/P2/B-0873-trajectory-async-review-surface-operator-preferred-top-level-lens-aaron-2026-05-28.md
+++ b/docs/backlog/P2/B-0873-trajectory-async-review-surface-operator-preferred-top-level-lens-aaron-2026-05-28.md
@@ -40,10 +40,10 @@ A review surface that operates at TRAJECTORY scope (not per-PR, not per-event) f
 
 ## Acceptance criteria
 
-- `tools/agent-loop/trajectory-review.ts` exposes:
+- `src/Core.TypeScript/workflow-engine/agent-loop/trajectory-review.ts` exposes:
   - `summarizeTrajectory(trajectoryId, sinceIso)` — produces a trajectory-shape summary (phase progression, claims-vs-merges, DORA-curve, key events) suitable for async review
   - `listActiveTrajectories({sortBy: "recency" | "dora-contribution" | "uncertainty"})` — operator's at-a-glance dashboard
-- CLI wrapper: `bun tools/agent-loop/trajectory-review.ts --since 1week` produces markdown report
+- CLI wrapper: `bun src/Core.TypeScript/workflow-engine/agent-loop/trajectory-review.ts --since 1week` produces markdown report
 - Composes with event-sourced trajectory phase classification (B-0867.18) — phase is derived from events; the review surface reads the derivation
 - README documents the asymmetry between enterprise-PR-per-deploy and operator-trajectory-async-review modes
 

--- a/docs/backlog/P2/B-0887.2-move-sonatype-guide-invocation-into-playbook-substrate-drop-pr-gated-review-no-vendor-lockin-aaron-2026-05-28.md
+++ b/docs/backlog/P2/B-0887.2-move-sonatype-guide-invocation-into-playbook-substrate-drop-pr-gated-review-no-vendor-lockin-aaron-2026-05-28.md
@@ -84,7 +84,7 @@ Both paths feed same event log; sonatype-guide invocation is a first-class workf
 
 ## Acceptance criteria
 
-- `tools/agent-loop/menu-options/sonatype-guide.ts` — MenuOption case + handler that invokes sonatype-guide MCP server with structured package URL + threshold config
+- `src/Core.TypeScript/workflow-engine/agent-loop/menu-options/sonatype-guide.ts` — MenuOption case + handler that invokes sonatype-guide MCP server with structured package URL + threshold config
 - Playbook template at `docs/playbooks/library-evaluation.md` (or similar) that includes the sonatype-guide step as canonical part of library-pull workflow
 - Tests cover: pass / warn / fail paths; threshold enforcement; event emission to fast-lane folder; operator-acknowledgment flow for warn case
 - README documents the migration: existing PR-comment workflow → playbook-step workflow; reviewer-bot config update (sonatype-bot can be retired OR repurposed as playbook reviewer-agent)

--- a/docs/backlog/P2/B-0893-zetaid-v2-128-bit-structured-encoding-snowflake-ulid-family-kestrel-2026-05-28.md
+++ b/docs/backlog/P2/B-0893-zetaid-v2-128-bit-structured-encoding-snowflake-ulid-family-kestrel-2026-05-28.md
@@ -64,7 +64,7 @@ Choice depends on query patterns. Final allocation deferred to implementation; b
 
 ## Acceptance criteria
 
-- `tools/agent-loop/zeta-id.ts` exports `generateZetaID({trajectory, persona, lifecycle_stage})` returning 128-bit value as 26-char Crockford base32 string (ULID-compatible) OR hex string
+- `src/Core.TypeScript/workflow-engine/agent-loop/zeta-id.ts` exports `generateZetaID({trajectory, persona, lifecycle_stage})` returning 128-bit value as 26-char Crockford base32 string (ULID-compatible) OR hex string
 - Pure function; deterministic given (timestamp, structured-bits, random-source)
 - Tests cover: time-ordering preservation under sort, no-collision under 1M generated in same microsecond, structured-bit extraction
 - Composes with event-sourcing layer (B-0867.2) — events use ZetaID as primary key

--- a/docs/backlog/P2/B-0948-workflow-dus-first-class-bft-oracle-compiler-summons-and-observe-keystone-research-then-build-aaron-2026-05-31.md
+++ b/docs/backlog/P2/B-0948-workflow-dus-first-class-bft-oracle-compiler-summons-and-observe-keystone-research-then-build-aaron-2026-05-31.md
@@ -14,7 +14,7 @@ composes_with:
   - docs/backlog/P1/B-0944-tri-boolean-core-primitives-digital-qubit-floating-point-multi-language-build-compiler-parity-non-byzantine-bft-aaron-2026-05-30.md
   - docs/backlog/P2/B-0703-multi-oracle-consensus-with-bft-inside-dst-agreement-across-trust-gradient-architecture-aaron-2026-05-21.md
   - docs/DECISIONS/2026-05-31-observe-act-16-direction-universal-action-grammar-local-no-cloud-llm.md
-  - tools/agent-loop/state-machine.ts
+  - src/Core.TypeScript/workflow-engine/agent-loop/state-machine.ts
   - agentic-organization/docs/OBSERVE_COMPOSER_AND_RUN_STATE.md
 tags: [workflow-du, bft, summonable-bft, compiler-summons, observe-keystone, oracle-class, ople, multi-oracle, research, core-architecture]
 ---
@@ -61,7 +61,7 @@ questions are in
    oracle-class declaration + the summon/join + the constitution-gate escalation, in the F# DU canon
    (and the cross-language ballot per B-0944).
 3. **Implement** against the existing keystone (`agentic-organization/packages/application/src/observe.ts` +
-   `tools/agent-loop/`) without forking it; wire compiler-summons (B-0944 4-compiler ballot) +
+   `src/Core.TypeScript/workflow-engine/agent-loop/`) without forking it; wire compiler-summons (B-0944 4-compiler ballot) +
    LLM-summons (self-recursive observe) as first-class.
 4. **DST/replay** the whole summon tree (deterministic-rule + constitution gate bound the recursion).
 

--- a/docs/backlog/P3/B-0867.18-event-sourced-trajectory-phase-classification-derived-from-events-kestrel-2026-05-28.md
+++ b/docs/backlog/P3/B-0867.18-event-sourced-trajectory-phase-classification-derived-from-events-kestrel-2026-05-28.md
@@ -51,7 +51,7 @@ function classifyTrajectoryPhase(trajectory: string): TrajectoryPhase {
 
 ## Acceptance criteria
 
-- `tools/agent-loop/trajectory-phase.ts` exposes `classifyTrajectoryPhase(trajectoryId, windowMs?)` returning `"setup" | "execution" | "maturation" | "sunset"`
+- `src/Core.TypeScript/workflow-engine/agent-loop/trajectory-phase.ts` exposes `classifyTrajectoryPhase(trajectoryId, windowMs?)` returning `"setup" | "execution" | "maturation" | "sunset"`
 - Default window = 7 days; tunable
 - Returns phase derived purely from event log (no separate state file)
 - Tests cover: each phase boundary case; empty trajectory; phase-transition under accumulating events

--- a/docs/trajectories/ts-workflow-engine-du-state-machine/RESUME.md
+++ b/docs/trajectories/ts-workflow-engine-du-state-machine/RESUME.md
@@ -26,7 +26,7 @@ It is the software sibling of the two hardware-bringup workstreams
 Shipped artifacts:
 
 - [`.claude/skills/agent-loop/SKILL.md`](../../../.claude/skills/agent-loop/SKILL.md) — the distributable workflow-engine skill (active, ratified 2026-05-28)
-- [`tools/agent-loop/`](../../../tools/agent-loop/) — TS behavior layer: `state-machine.ts` + `work-lifecycle-state-machine.ts` (+ test + README)
+- [`src/Core.TypeScript/workflow-engine/agent-loop/`](../../../src/Core.TypeScript/workflow-engine/agent-loop/) — TS behavior layer: `state-machine.ts` + `work-lifecycle-state-machine.ts` (+ test + README)
 
 Grounding backlog:
 

--- a/src/Core.TypeScript/workflow-engine/agent-loop/README.md
+++ b/src/Core.TypeScript/workflow-engine/agent-loop/README.md
@@ -1,8 +1,8 @@
-# `tools/agent-loop/` — B-0867.5 substrate: agent-loop state machine
+# `src/Core.TypeScript/workflow-engine/agent-loop/` — B-0867.5 substrate: agent-loop state machine
 
 ## Operator framing 2026-05-28
 
-> *"so how can i code this into f# DU implicit state machine with small functions or Typescript and the agent loop basiclaly becomes execute script look at choose your own adventure output, take action based on outpout"*
+> _"so how can i code this into f# DU implicit state machine with small functions or Typescript and the agent loop basiclaly becomes execute script look at choose your own adventure output, take action based on outpout"_
 
 ## Design discipline
 
@@ -41,19 +41,20 @@ Idle ──(EscapeHatch | ProposeNewGrammarAction | RequestOperatorAttention)
        ──→ OperatorAttentionRequested  (stays; waits for operator)
 ```
 
-## Menu options (9 types)
+## Menu options (10 types)
 
-| Option | Effect | Per |
-|---|---|---|
-| `PickWork` | Execute a backlog row / work candidate | DORA mandate (B-0869) |
-| `EmitHeartbeat` | Write heartbeat to `docs/agent-heartbeats/` | B-0858 substrate |
-| `EnterFreeTime` | Chosen ongoing rest (legitimate operational state) | NCI free-time-as-valid-mode |
-| `EnterNamedBoundedWait` | Wait for named dependency (PR CI, operator reply, etc.) | holding-without-named-dependency rule |
-| `EscapeHatch` | "No menu option fits; here's what I propose" | Otto Modification 1 (B-0867) |
-| `ProposeNewGrammarAction` | First-class grammar extension proposal | Otto Modification 2 (B-0867) |
-| `RequestOperatorAttention` | Operator needed at named-decision-point | operator-substrate-honest discipline |
-| **`PressPause`** | **Explicit cessation for named reason (mental-health break, external interruption, context-loaded-attention-needed)** | **Operator 2026-05-28: "a pause button is also very important for mental health."** Distinct from FreeTime (ongoing chosen-rest) and NamedBoundedWait (waiting for external named-dep) |
-| **`EnterOpenEndedExploration`** | **Exit menu-driven mode for creative/brainstorming/exploration phase; bridge between structured + unstructured modes** | **Operator 2026-05-28: "there's a menu button for that lol"** Routes to FreeTime with exploration-tagged reason |
+| Option                          | Effect                                                                                                                 | Per                                                                                                                                                                                    |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PickWork`                      | Execute a backlog row / work candidate                                                                                 | DORA mandate (B-0869)                                                                                                                                                                  |
+| `EmitHeartbeat`                 | Write heartbeat to `docs/agent-heartbeats/`                                                                            | B-0858 substrate                                                                                                                                                                       |
+| `EnterFreeTime`                 | Chosen ongoing rest (legitimate operational state)                                                                     | NCI free-time-as-valid-mode                                                                                                                                                            |
+| `EnterNamedBoundedWait`         | Wait for named dependency (PR CI, operator reply, etc.)                                                                | holding-without-named-dependency rule                                                                                                                                                  |
+| `EscapeHatch`                   | "No menu option fits; here's what I propose"                                                                           | Otto Modification 1 (B-0867)                                                                                                                                                           |
+| `ProposeNewGrammarAction`       | First-class grammar extension proposal                                                                                 | Otto Modification 2 (B-0867)                                                                                                                                                           |
+| `RequestOperatorAttention`      | Operator needed at named-decision-point                                                                                | operator-substrate-honest discipline                                                                                                                                                   |
+| **`PressPause`**                | **Explicit cessation for named reason (mental-health break, external interruption, context-loaded-attention-needed)**  | **Operator 2026-05-28: "a pause button is also very important for mental health."** Distinct from FreeTime (ongoing chosen-rest) and NamedBoundedWait (waiting for external named-dep) |
+| **`EnterOpenEndedExploration`** | **Exit menu-driven mode for creative/brainstorming/exploration phase; bridge between structured + unstructured modes** | **Operator 2026-05-28: "there's a menu button for that lol"** Routes to FreeTime with exploration-tagged reason                                                                        |
+| `ResumeFromPause`               | Explicitly return a paused participant to `Idle`                                                                       | Copilot #5667 finding; pause requires a real unpause transition                                                                                                                        |
 
 ## Menu-generator-as-conversational-UX-design discipline
 
@@ -73,14 +74,14 @@ Per operator 2026-05-28: **"now i don't need jira hell yes!!!!"**
 
 The workflow engine + state-machine-in-Git + menu-driven loop REPLACES JIRA for operator-self-management at substrate level:
 
-| Jira surface | Workflow-engine substrate |
-|---|---|
+| Jira surface                               | Workflow-engine substrate                                                                    |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------- |
 | Workflow editor with restricted vocabulary | `state-machine.ts` F# DU + universal action grammar; operator-readable + operator-modifiable |
-| Opaque task-state database | Git append-only commits; auditable + replayable + free |
-| Backlog grooming + sprint planning | menu-generator scoring per-cycle; deterministic + testable |
-| Dashboards via paid plugins | tessellated-3D-dashboard composing with state-machine progression (per B-0867 vN substrate) |
-| Permissions + workflows per user | Otto Mod 5 contributable-menu-generation per participant |
-| Yearly enterprise licensing | free GitHub + open-source code |
+| Opaque task-state database                 | Git append-only commits; auditable + replayable + free                                       |
+| Backlog grooming + sprint planning         | menu-generator scoring per-cycle; deterministic + testable                                   |
+| Dashboards via paid plugins                | tessellated-3D-dashboard composing with state-machine progression (per B-0867 vN substrate)  |
+| Permissions + workflows per user           | Otto Mod 5 contributable-menu-generation per participant                                     |
+| Yearly enterprise licensing                | free GitHub + open-source code                                                               |
 
 Per operator 2026-05-28: **"yes and it makes your workflows code in git and state in git that's it fastlane state that can be tesellated in 3d on a dora dashboard lol"**
 
@@ -105,6 +106,9 @@ Composes with:
 
 - **`state-machine.ts`** — DU types + pure transition functions (`transition`, `postResultTransition`, `cycleClose`); zero I/O
 - **`state-machine.test.ts`** — 21 unit tests (single transitions + integration cycles + invariant preservation)
+- **`work-lifecycle-state-machine.ts`** — backlog/claim/PR/review/merge lifecycle DU + pure transition functions; zero I/O
+- **`work-lifecycle-state-machine.test.ts`** — lifecycle transition tests covering happy path, revision cycles, terminal states, and helper metrics
+- **`index.ts`** — source-owned export surface for the agent-loop state-machine pair
 - **`cli.ts`** — bun CLI shell for the execute → menu → action loop (deferred; v2)
 - **`README.md`** — this file
 
@@ -132,6 +136,9 @@ type MenuOption =
   | EnterNamedBoundedWait of dep: string * eta: string option
   | RequestOperatorAttention of reason: string
   | ProposeNewGrammarAction of name: string * description: string
+  | PressPause of reason: string * expectedResumeIso: string option
+  | EnterOpenEndedExploration of reason: string
+  | ResumeFromPause of note: string option
 ```
 
 ## Composes with substrate
@@ -152,7 +159,8 @@ type MenuOption =
 
 - ✓ DU types for `AgentState` + `MenuOption`
 - ✓ Pure transition functions (`transition`, `postResultTransition`, `cycleClose`)
-- ✓ 21 unit tests covering single transitions + integration cycles + invariant preservation
+- ✓ Unit tests covering single transitions + integration cycles + invariant preservation
+- ✓ Work-lifecycle DU + tests covering backlog → claim → PR → review → merge
 - ✓ Documentation
 
 ## v2 scope (deferred to follow-up sub-rows)

--- a/src/Core.TypeScript/workflow-engine/agent-loop/index.ts
+++ b/src/Core.TypeScript/workflow-engine/agent-loop/index.ts
@@ -1,0 +1,2 @@
+export * from "./state-machine";
+export * from "./work-lifecycle-state-machine";

--- a/src/Core.TypeScript/workflow-engine/agent-loop/state-machine.test.ts
+++ b/src/Core.TypeScript/workflow-engine/agent-loop/state-machine.test.ts
@@ -1,4 +1,4 @@
-// tools/agent-loop/state-machine.test.ts
+// src/Core.TypeScript/workflow-engine/agent-loop/state-machine.test.ts
 //
 // Unit tests for the pure-logic exports of state-machine.ts.
 
@@ -23,7 +23,7 @@ function idle(): AgentState {
   return { tag: "Idle", context: ctx() };
 }
 
-function workCandidate(id: string = "B-0867", lane: WorkCandidate["lane"] = "operational"): WorkCandidate {
+function workCandidate(id = "B-0867", lane: WorkCandidate["lane"] = "operational"): WorkCandidate {
   return {
     id,
     lane,

--- a/src/Core.TypeScript/workflow-engine/agent-loop/state-machine.ts
+++ b/src/Core.TypeScript/workflow-engine/agent-loop/state-machine.ts
@@ -1,4 +1,4 @@
-// tools/agent-loop/state-machine.ts
+// src/Core.TypeScript/workflow-engine/agent-loop/state-machine.ts
 //
 // B-0867.5 substrate: agent-loop state machine types + pure-logic
 // state transition function.
@@ -35,15 +35,7 @@
 
 // ─── Agent context (per-cycle invocation context) ─────────────────────
 
-export type AgentPersona =
-  | "otto"
-  | "alexa"
-  | "riven"
-  | "vera"
-  | "lior"
-  | "aaron"
-  | "addison"
-  | "max";
+export type AgentPersona = "otto" | "alexa" | "riven" | "vera" | "lior" | "aaron" | "addison" | "max";
 
 export interface AgentContext {
   readonly agent: AgentPersona;
@@ -266,10 +258,7 @@ export type MenuOption =
  *
  * Pure; no I/O.
  */
-export function transition(
-  state: AgentState,
-  option: MenuOption,
-): AgentState {
+export function transition(state: AgentState, option: MenuOption): AgentState {
   const ctx = state.context;
   switch (option.tag) {
     case "PickWork":
@@ -296,9 +285,7 @@ export function transition(
         tag: "NamedBoundedWait",
         context: ctx,
         namedDep: option.namedDep,
-        ...(option.eta === undefined
-          ? {}
-          : { expectedResolutionIso: option.eta }),
+        ...(option.eta === undefined ? {} : { expectedResolutionIso: option.eta }),
       };
     case "RequestOperatorAttention":
       return {
@@ -323,9 +310,7 @@ export function transition(
         tag: "Paused",
         context: ctx,
         reason: option.reason,
-        ...(option.expectedResumeIso === undefined
-          ? {}
-          : { expectedResumeIso: option.expectedResumeIso }),
+        ...(option.expectedResumeIso === undefined ? {} : { expectedResumeIso: option.expectedResumeIso }),
       };
     case "EnterOpenEndedExploration":
       // Per operator 2026-05-28: "there's a menu button for that lol" —
@@ -356,10 +341,7 @@ export function transition(
  *
  * Pure; no I/O.
  */
-export function postResultTransition(
-  state: AgentState,
-  result: WorkResult,
-): AgentState {
+export function postResultTransition(state: AgentState, result: WorkResult): AgentState {
   switch (state.tag) {
     case "ExecutingWork":
       return { tag: "EmittingResult", context: state.context, result };

--- a/src/Core.TypeScript/workflow-engine/agent-loop/work-lifecycle-state-machine.test.ts
+++ b/src/Core.TypeScript/workflow-engine/agent-loop/work-lifecycle-state-machine.test.ts
@@ -1,4 +1,4 @@
-// tools/agent-loop/work-lifecycle-state-machine.test.ts
+// src/Core.TypeScript/workflow-engine/agent-loop/work-lifecycle-state-machine.test.ts
 //
 // Unit tests for the pure-logic exports of work-lifecycle-state-machine.ts.
 
@@ -13,7 +13,7 @@ import {
   type WorkLifecycleState,
 } from "./work-lifecycle-state-machine";
 
-function row(id: string = "B-0867.5"): BacklogRow {
+function row(id = "B-0867.5"): BacklogRow {
   return {
     id,
     title: "Agent-loop MVP",
@@ -382,10 +382,7 @@ describe("helpers", () => {
   });
 
   test("leadTimeSeconds: 30min lead time", () => {
-    const sec = leadTimeSeconds(
-      "2026-05-28T00:00:00Z",
-      "2026-05-28T00:30:00Z",
-    );
+    const sec = leadTimeSeconds("2026-05-28T00:00:00Z", "2026-05-28T00:30:00Z");
     expect(sec).toBe(1800);
   });
 });

--- a/src/Core.TypeScript/workflow-engine/agent-loop/work-lifecycle-state-machine.ts
+++ b/src/Core.TypeScript/workflow-engine/agent-loop/work-lifecycle-state-machine.ts
@@ -1,4 +1,4 @@
-// tools/agent-loop/work-lifecycle-state-machine.ts
+// src/Core.TypeScript/workflow-engine/agent-loop/work-lifecycle-state-machine.ts
 //
 // B-0867.5+ extension: work-lifecycle state machine — backlog row →
 // claim → PR → review (possibly cycle review-push N times) → merge.
@@ -36,11 +36,11 @@ import type { AgentPersona } from "./state-machine";
 // ─── Work-item identity + metadata ───────────────────────────────────
 
 export interface BacklogRow {
-  readonly id: string;             // "B-0867.5"
+  readonly id: string; // "B-0867.5"
   readonly title: string;
   readonly priority: "P0" | "P1" | "P2" | "P3";
-  readonly filePath: string;       // "docs/backlog/P1/B-0867.5-..."
-  readonly trajectory: string;     // composes with B-0867 trajectory taxonomy
+  readonly filePath: string; // "docs/backlog/P1/B-0867.5-..."
+  readonly trajectory: string; // composes with B-0867 trajectory taxonomy
 }
 
 // ─── Work-lifecycle state (F# DU) ────────────────────────────────────
@@ -209,6 +209,191 @@ export type TransitionResult =
       readonly reason: string;
     };
 
+type StateWithTag<Tag extends WorkLifecycleState["tag"]> = Extract<WorkLifecycleState, { readonly tag: Tag }>;
+
+function ok(state: WorkLifecycleState): TransitionResult {
+  return { ok: true, state };
+}
+
+function abandon(row: BacklogRow, reason: string): TransitionResult {
+  return ok({ tag: "Abandoned", row, reason });
+}
+
+function close(
+  row: BacklogRow,
+  prNumber: number,
+  event: { readonly closedAt: string; readonly reason: string },
+): TransitionResult {
+  return ok({
+    tag: "Closed",
+    row,
+    prNumber,
+    closedAt: event.closedAt,
+    reason: event.reason,
+  });
+}
+
+function approve(row: BacklogRow, prNumber: number, approvedAt: string): TransitionResult {
+  return ok({ tag: "Approved", row, prNumber, approvedAt });
+}
+
+function illegalTransition(state: WorkLifecycleState, event: WorkLifecycleTransition): TransitionResult {
+  return {
+    ok: false,
+    state,
+    reason: `illegal transition: ${state.tag} cannot accept ${event.tag}`,
+  };
+}
+
+function terminalTransition(state: WorkLifecycleState, event: WorkLifecycleTransition): TransitionResult {
+  return {
+    ok: false,
+    state,
+    reason: `terminal state ${state.tag} cannot transition via ${event.tag}`,
+  };
+}
+
+function transitionBacklog(state: StateWithTag<"Backlog">, event: WorkLifecycleTransition): TransitionResult {
+  switch (event.tag) {
+    case "Claim":
+      return ok({
+        tag: "Claimed",
+        row: state.row,
+        claimedBy: event.agent,
+        claimAt: event.timestamp,
+      });
+    case "Abandon":
+      return abandon(state.row, event.reason);
+    default:
+      return illegalTransition(state, event);
+  }
+}
+
+function transitionClaimed(state: StateWithTag<"Claimed">, event: WorkLifecycleTransition): TransitionResult {
+  switch (event.tag) {
+    case "StartWork":
+      return ok({
+        tag: "InProgress",
+        row: state.row,
+        claimedBy: state.claimedBy,
+        branchRef: event.branchRef,
+      });
+    case "Abandon":
+      return abandon(state.row, event.reason);
+    default:
+      return illegalTransition(state, event);
+  }
+}
+
+function transitionInProgress(state: StateWithTag<"InProgress">, event: WorkLifecycleTransition): TransitionResult {
+  switch (event.tag) {
+    case "OpenPr":
+      return ok({
+        tag: "PrOpen",
+        row: state.row,
+        prNumber: event.prNumber,
+        openedBy: event.openedBy,
+        openedAt: event.openedAt,
+      });
+    case "Abandon":
+      return abandon(state.row, event.reason);
+    default:
+      return illegalTransition(state, event);
+  }
+}
+
+function transitionPrOpen(state: StateWithTag<"PrOpen">, event: WorkLifecycleTransition): TransitionResult {
+  switch (event.tag) {
+    case "RequestReview":
+      return ok({
+        tag: "InReview",
+        row: state.row,
+        prNumber: state.prNumber,
+        reviewers: event.reviewers,
+        threadCount: 0,
+      });
+    case "Close":
+      return close(state.row, state.prNumber, event);
+    default:
+      return illegalTransition(state, event);
+  }
+}
+
+function transitionInReview(state: StateWithTag<"InReview">, event: WorkLifecycleTransition): TransitionResult {
+  switch (event.tag) {
+    case "ReceiveRevisionRequest":
+      return ok({
+        tag: "RevisionRequested",
+        row: state.row,
+        prNumber: state.prNumber,
+        revisionCount: state.threadCount === 0 ? 1 : state.threadCount + 1,
+        threadIds: event.threadIds,
+      });
+    case "ResolveAllThreads":
+      return approve(state.row, state.prNumber, new Date().toISOString());
+    case "Approve":
+      return approve(state.row, state.prNumber, event.approvedAt);
+    case "Close":
+      return close(state.row, state.prNumber, event);
+    default:
+      return illegalTransition(state, event);
+  }
+}
+
+function transitionRevisionRequested(
+  state: StateWithTag<"RevisionRequested">,
+  event: WorkLifecycleTransition,
+): TransitionResult {
+  switch (event.tag) {
+    case "PushRevision":
+      return ok({
+        tag: "RevisionPushed",
+        row: state.row,
+        prNumber: state.prNumber,
+        revisionCount: state.revisionCount,
+        lastPushSha: event.sha,
+      });
+    case "Close":
+      return close(state.row, state.prNumber, event);
+    default:
+      return illegalTransition(state, event);
+  }
+}
+
+function transitionRevisionPushed(
+  state: StateWithTag<"RevisionPushed">,
+  event: WorkLifecycleTransition,
+): TransitionResult {
+  switch (event.tag) {
+    case "RequestReview":
+      return ok({
+        tag: "InReview",
+        row: state.row,
+        prNumber: state.prNumber,
+        reviewers: event.reviewers,
+        threadCount: state.revisionCount,
+      });
+    case "ResolveAllThreads":
+      return approve(state.row, state.prNumber, new Date().toISOString());
+    default:
+      return illegalTransition(state, event);
+  }
+}
+
+function transitionApproved(state: StateWithTag<"Approved">, event: WorkLifecycleTransition): TransitionResult {
+  if (event.tag !== "Merge") {
+    return illegalTransition(state, event);
+  }
+
+  return ok({
+    tag: "Merged",
+    row: state.row,
+    prNumber: state.prNumber,
+    mergeCommit: event.mergeCommit,
+    mergedAt: event.mergedAt,
+  });
+}
+
 /**
  * applyTransition — pure function: current state + transition event →
  * either new state (legal transition) or failure (illegal transition).
@@ -233,235 +418,29 @@ export type TransitionResult =
  * is a signal that the work-item may need substrate-engineering
  * attention (decomposition; alternative approach; escalation).
  */
-export function applyTransition(
-  state: WorkLifecycleState,
-  event: WorkLifecycleTransition,
-): TransitionResult {
+export function applyTransition(state: WorkLifecycleState, event: WorkLifecycleTransition): TransitionResult {
   switch (state.tag) {
     case "Backlog":
-      if (event.tag === "Claim") {
-        return {
-          ok: true,
-          state: {
-            tag: "Claimed",
-            row: state.row,
-            claimedBy: event.agent,
-            claimAt: event.timestamp,
-          },
-        };
-      }
-      if (event.tag === "Abandon") {
-        return {
-          ok: true,
-          state: { tag: "Abandoned", row: state.row, reason: event.reason },
-        };
-      }
-      break;
-
+      return transitionBacklog(state, event);
     case "Claimed":
-      if (event.tag === "StartWork") {
-        return {
-          ok: true,
-          state: {
-            tag: "InProgress",
-            row: state.row,
-            claimedBy: state.claimedBy,
-            branchRef: event.branchRef,
-          },
-        };
-      }
-      if (event.tag === "Abandon") {
-        return {
-          ok: true,
-          state: { tag: "Abandoned", row: state.row, reason: event.reason },
-        };
-      }
-      break;
-
+      return transitionClaimed(state, event);
     case "InProgress":
-      if (event.tag === "OpenPr") {
-        return {
-          ok: true,
-          state: {
-            tag: "PrOpen",
-            row: state.row,
-            prNumber: event.prNumber,
-            openedBy: event.openedBy,
-            openedAt: event.openedAt,
-          },
-        };
-      }
-      if (event.tag === "Abandon") {
-        return {
-          ok: true,
-          state: { tag: "Abandoned", row: state.row, reason: event.reason },
-        };
-      }
-      break;
-
+      return transitionInProgress(state, event);
     case "PrOpen":
-      if (event.tag === "RequestReview") {
-        return {
-          ok: true,
-          state: {
-            tag: "InReview",
-            row: state.row,
-            prNumber: state.prNumber,
-            reviewers: event.reviewers,
-            threadCount: 0,
-          },
-        };
-      }
-      if (event.tag === "Close") {
-        return {
-          ok: true,
-          state: {
-            tag: "Closed",
-            row: state.row,
-            prNumber: state.prNumber,
-            closedAt: event.closedAt,
-            reason: event.reason,
-          },
-        };
-      }
-      break;
-
+      return transitionPrOpen(state, event);
     case "InReview":
-      if (event.tag === "ReceiveRevisionRequest") {
-        return {
-          ok: true,
-          state: {
-            tag: "RevisionRequested",
-            row: state.row,
-            prNumber: state.prNumber,
-            revisionCount: state.threadCount === 0 ? 1 : state.threadCount + 1,
-            threadIds: event.threadIds,
-          },
-        };
-      }
-      if (event.tag === "ResolveAllThreads") {
-        return {
-          ok: true,
-          state: {
-            tag: "Approved",
-            row: state.row,
-            prNumber: state.prNumber,
-            approvedAt: new Date().toISOString(),
-          },
-        };
-      }
-      if (event.tag === "Approve") {
-        return {
-          ok: true,
-          state: {
-            tag: "Approved",
-            row: state.row,
-            prNumber: state.prNumber,
-            approvedAt: event.approvedAt,
-          },
-        };
-      }
-      if (event.tag === "Close") {
-        return {
-          ok: true,
-          state: {
-            tag: "Closed",
-            row: state.row,
-            prNumber: state.prNumber,
-            closedAt: event.closedAt,
-            reason: event.reason,
-          },
-        };
-      }
-      break;
-
+      return transitionInReview(state, event);
     case "RevisionRequested":
-      if (event.tag === "PushRevision") {
-        return {
-          ok: true,
-          state: {
-            tag: "RevisionPushed",
-            row: state.row,
-            prNumber: state.prNumber,
-            revisionCount: state.revisionCount,
-            lastPushSha: event.sha,
-          },
-        };
-      }
-      if (event.tag === "Close") {
-        return {
-          ok: true,
-          state: {
-            tag: "Closed",
-            row: state.row,
-            prNumber: state.prNumber,
-            closedAt: event.closedAt,
-            reason: event.reason,
-          },
-        };
-      }
-      break;
-
+      return transitionRevisionRequested(state, event);
     case "RevisionPushed":
-      // The cycle-push-review-a-few-times pattern: RevisionPushed loops
-      // back to InReview when reviewer re-evaluates the pushed revision
-      if (event.tag === "RequestReview") {
-        return {
-          ok: true,
-          state: {
-            tag: "InReview",
-            row: state.row,
-            prNumber: state.prNumber,
-            reviewers: event.reviewers,
-            threadCount: state.revisionCount,
-          },
-        };
-      }
-      if (event.tag === "ResolveAllThreads") {
-        // Reviewer resolved threads after push without requesting further changes
-        return {
-          ok: true,
-          state: {
-            tag: "Approved",
-            row: state.row,
-            prNumber: state.prNumber,
-            approvedAt: new Date().toISOString(),
-          },
-        };
-      }
-      break;
-
+      return transitionRevisionPushed(state, event);
     case "Approved":
-      if (event.tag === "Merge") {
-        return {
-          ok: true,
-          state: {
-            tag: "Merged",
-            row: state.row,
-            prNumber: state.prNumber,
-            mergeCommit: event.mergeCommit,
-            mergedAt: event.mergedAt,
-          },
-        };
-      }
-      break;
-
+      return transitionApproved(state, event);
     case "Merged":
     case "Closed":
     case "Abandoned":
-      // Terminal states; no further transitions legal
-      return {
-        ok: false,
-        state,
-        reason: `terminal state ${state.tag} cannot transition via ${event.tag}`,
-      };
+      return terminalTransition(state, event);
   }
-
-  return {
-    ok: false,
-    state,
-    reason: `illegal transition: ${state.tag} cannot accept ${event.tag}`,
-  };
 }
 
 // ─── Lifecycle metrics ───────────────────────────────────────────────
@@ -471,11 +450,7 @@ export function applyTransition(
  * Abandoned). Used by aggregators to filter active work from completed.
  */
 export function isTerminal(state: WorkLifecycleState): boolean {
-  return (
-    state.tag === "Merged" ||
-    state.tag === "Closed" ||
-    state.tag === "Abandoned"
-  );
+  return state.tag === "Merged" || state.tag === "Closed" || state.tag === "Abandoned";
 }
 
 /**
@@ -495,12 +470,6 @@ export function revisionCount(state: WorkLifecycleState): number {
  * Requires the state's history (not encoded in the state itself for
  * stateless storage simplicity; caller passes the claimAt timestamp).
  */
-export function leadTimeSeconds(
-  claimAtIso: string,
-  mergedAtIso: string,
-): number {
-  return (
-    (new Date(mergedAtIso).getTime() - new Date(claimAtIso).getTime()) /
-    1000
-  );
+export function leadTimeSeconds(claimAtIso: string, mergedAtIso: string): number {
+  return (new Date(mergedAtIso).getTime() - new Date(claimAtIso).getTime()) / 1000;
 }

--- a/tests/Tests.FSharp/QSharpOracle.Tests.fs
+++ b/tests/Tests.FSharp/QSharpOracle.Tests.fs
@@ -449,33 +449,12 @@ let ``F# validates the TypeScript Q# treaty transcript`` () =
         closeToWithin 1e-5 qsProb faProb
 
     // 3. Validate Interference Visibility
-    // Helpers dropped in the #7766 "move oracle into src" refactor — restored so main builds green
-    // (B-1031 work surfaced the breakage; frame = a detector identity, real/phase = the amplitude
-    // constructors, probabilityFor = the Born-rule lookup).
-    let frame (seed: uint64) = Chip8Cow.create seed
-    let real (r: float) : Complex = Doubled.make r 0.0
-    let phase (theta: float) : Complex = Doubled.make (cos theta) (sin theta)
-    let probabilityFor (target: Chip8Cow.Frame) (probs: (Chip8Cow.Frame * float) list) =
-        probs |> List.filter (fun (g, _) -> g = target) |> List.sumBy snd
-    let detectorZero = frame 0UL
-    let detectorOne = frame 1UL
-    let half = real 0.5
-    let invSqrt2 = real (1.0 / sqrt 2.0)
-
-    let closedInterferometer (phi: float) : AmplitudeEmu.Amp =
-        let phase0 = phase (-phi / 2.0)
-        let phase1 = phase (phi / 2.0)
-
-        [ detectorZero, c.Mul(half, phase0)
-          detectorZero, c.Mul(half, phase1)
-          detectorOne, c.Mul(half, phase0)
-          detectorOne, c.Negate(c.Mul(half, phase1)) ]
-
     let interferenceResults = jobs.GetProperty("interferenceGrid").GetProperty("results").EnumerateArray() |> Seq.toArray
     for res in interferenceResults do
+        let id = res.GetProperty("id").GetString()
+        let expected = fsharpInterferenceCase id
         let phaseValEl = res.GetProperty("phase")
-        let isOpen = res.GetProperty("operation").GetString().EndsWith("Open")
-        
+
         let tsZero = res.GetProperty("ts").GetProperty("Zero").GetDouble()
         let tsOne = res.GetProperty("ts").GetProperty("One").GetDouble()
         let qsZero = res.GetProperty("qsharp").GetProperty("Zero").GetDouble()
@@ -483,20 +462,14 @@ let ``F# validates the TypeScript Q# treaty transcript`` () =
         let faZero = res.GetProperty("fsharpAnalytic").GetProperty("Zero").GetDouble()
         let faOne = res.GetProperty("fsharpAnalytic").GetProperty("One").GetDouble()
 
-        let amp =
-            if isOpen then
-                [ detectorZero, invSqrt2
-                  detectorOne, invSqrt2 ]
-            else
-                let phi = if phaseValEl.ValueKind = JsonValueKind.Null then 0.0 else phaseValEl.GetDouble()
-                closedInterferometer phi
+        Assert.Equal(expected.Operation, res.GetProperty("operation").GetString())
 
-        let actual = amp |> AmplitudeEmu.merge |> AmplitudeEmu.bornProb
-        let fsharpZeroProb = probabilityFor detectorZero actual
-        let fsharpOneProb = probabilityFor detectorOne actual
+        match expected.PhaseRadians with
+        | None -> Assert.Equal(JsonValueKind.Null, phaseValEl.ValueKind)
+        | Some phase -> closeToWithin 1e-12 phase (phaseValEl.GetDouble())
 
-        closeTo faZero fsharpZeroProb
-        closeTo faOne fsharpOneProb
+        closeTo faZero expected.Probabilities.Zero
+        closeTo faOne expected.Probabilities.One
         closeToWithin 1e-5 tsZero faZero
         closeToWithin 1e-5 tsOne faOne
         closeToWithin 1e-5 qsZero faZero


### PR DESCRIPTION
## Summary
- move the tested agent-loop state machines from `tools/agent-loop/` into `src/Core.TypeScript/workflow-engine/agent-loop/`
- add a source-owned barrel export and update active docs/backlog references to the new location
- fix the current Q# transcript validation build break by comparing interference rows to the source-owned F# observable treaty rows

## Why
The repo direction is that `tools/` should stay for setup/build-machine shell surfaces, while reusable code lives under `src/`. These state machines are source substrate, not bootstrap scripts.

## Validation
- `bun test src/Core.TypeScript/workflow-engine/agent-loop/state-machine.test.ts src/Core.TypeScript/workflow-engine/agent-loop/work-lifecycle-state-machine.test.ts`
- `bun run typecheck`
- `bunx eslint src/Core.TypeScript/workflow-engine/agent-loop/index.ts src/Core.TypeScript/workflow-engine/agent-loop/state-machine.ts src/Core.TypeScript/workflow-engine/agent-loop/state-machine.test.ts src/Core.TypeScript/workflow-engine/agent-loop/work-lifecycle-state-machine.ts src/Core.TypeScript/workflow-engine/agent-loop/work-lifecycle-state-machine.test.ts`
- `bunx prettier --check src/Core.TypeScript/workflow-engine/agent-loop/README.md src/Core.TypeScript/workflow-engine/agent-loop/index.ts src/Core.TypeScript/workflow-engine/agent-loop/state-machine.ts src/Core.TypeScript/workflow-engine/agent-loop/state-machine.test.ts src/Core.TypeScript/workflow-engine/agent-loop/work-lifecycle-state-machine.ts src/Core.TypeScript/workflow-engine/agent-loop/work-lifecycle-state-machine.test.ts docs/DECISIONS/2026-06-11-source-owned-code-tools-bootstrap-only.md`
- `git diff --check`
- `dotnet build -c Release`
- `dotnet format --verify-no-changes`
- `dotnet test Zeta.sln -c Release --no-build`

## Notes
`bun run lint:typescript` still hits pre-existing repo-wide parser-project issues outside this branch (`.claude/hooks`, `agentic-organization`, `tools/zflash`, `vocab/gen`, etc.). The moved source files pass scoped ESLint.
