### PR TITLE
fix(final-sweep): ZERO skipped tests + last test-gap items + registry collision gate (one audit finding falsified)

### DIFF
--- a/src/Core/Chip9SelfTrace.fs
+++ b/src/Core/Chip9SelfTrace.fs
@@ -22,7 +22,9 @@ namespace Zeta.Core
 /// **The self-reflective jewel — no new opcodes needed:** the trace lands in the machine's OWN plane
 /// memory, and DRW's collision flag (VF) reports XOR hits per selected plane — so a ROM can ASK
 /// "have I been here?" by drawing a probe sprite on the R plane at any cell and reading VF. The
-/// machine reads its own worldline THROUGH its own instruction set. Self-reflection in soft mode,
+/// machine reads its own worldline THROUGH its own instruction set. (B-1031 note: DRW now CLIPS
+/// at edges, so a probe sprite at columns 57-63 loses its over-edge tail — probe within the court
+/// or accept the narrowed read; the clip never wraps a probe onto cells it did not ask about.) Self-reflection in soft mode,
 /// full ISA to the bone; the QEMU/microkernel rung gets the same trace surface at metal (named slice).
 [<RequireQualifiedAccess>]
 module Chip9SelfTrace =

--- a/src/Core/GeneratorRegistry.fs
+++ b/src/Core/GeneratorRegistry.fs
@@ -94,6 +94,16 @@ module GeneratorRegistry =
           register "spectral.soft-probe" 1 ]
 
     /// Look a generator up by its ZetaId (the filetype's reverse direction: id -> what it is).
+    /// Registry-side collision guard (BUGS.md idOf finding, the cheap additive piece: the full
+    /// hash-lane fix is a treaty-scale migration since ids are pinned in cartridges). Two DISTINCT
+    /// names sharing one ZetaId on the shelf = a collision the first-match byId would silently
+    /// shadow — this surfaces it as a checkable fact (the suite asserts it stays empty).
+    let collisions () : (string * string list) list =
+        known
+        |> List.groupBy (fun e -> e.ZetaId)
+        |> List.filter (fun (_, es) -> (es |> List.map (fun e -> e.Name) |> List.distinct |> List.length) > 1)
+        |> List.map (fun (zid, es) -> zid, es |> List.map (fun e -> e.Name))
+
     let byId (zetaId: string) : Entry option =
         known |> List.tryFind (fun e -> e.ZetaId = zetaId)
 

--- a/tests/Tests.FSharp/FluxView.Tests.fs
+++ b/tests/Tests.FSharp/FluxView.Tests.fs
@@ -38,6 +38,10 @@ let ``the flux timeline breathes: bursts drain the columns, idle ticks recover t
     let line = FluxView.timeline 12 load t0
     Assert.Equal(12, line.Length)
     Assert.True(line.[3] < line.[11]) // drained low during the burst, recovered by the end (block chars order by height)
+    // r3-final (test-gap #12): one pair passes non-recovering noise — the idle stretch must be
+    // MONOTONE non-decreasing (the tank refills, never dips, with zero load)
+    for i in 5 .. 10 do
+        Assert.True(line.[i] <= line.[i + 1], sprintf "recovery dipped at tick %d" i)
 
 [<Fact>]
 let ``the interrupt grid shows the switchboard: who matched, who passed, when it was silent`` () =
@@ -52,10 +56,11 @@ let ``the interrupt grid shows the switchboard: who matched, who passed, when it
     let grid = FluxView.interruptGrid handlers source 4
     Assert.Equal(2, List.length grid)
     Assert.Contains("chip8-input", grid.[0])
-    // input handler: passed(timer only), silent, matched, silent => "· ■ "
-    Assert.True(grid.[0].EndsWith "· ■ ")
-    // timer handler: matched, silent, matched, silent => "■ ■ "
-    Assert.True(grid.[1].EndsWith "■ ■ ")
+    // r3-final: audited as "half-pinned" (test-gap #7) — FALSE POSITIVE: cells are single-char,
+    // so this 4-char suffix IS all four ticks: passed(·), silent( ), matched(■), silent( ).
+    // The passed glyph was always pinned. Documented so the next audit doesn't re-flag it.
+    Assert.True(grid.[0].EndsWith "· ■ ", "input handler: passed, silent, matched, silent")
+    Assert.True(grid.[1].EndsWith "■ ■ ", "timer handler: matched, silent, matched, silent")
 
 [<Fact>]
 let ``the views are registered, cost-declared, and the budget lint still holds shelf-wide`` () =

--- a/tests/Tests.FSharp/MediaLines.Tests.fs
+++ b/tests/Tests.FSharp/MediaLines.Tests.fs
@@ -144,12 +144,14 @@ let ``a constant without WHAT and WHY is a magic number — the lint refuses it`
 let ``a dimension REBINDS the deep-pixel field — declared, never assumed; lint checks the declaration`` () =
     let ok = "dimension\tdepth\tuncertainty-field\tpsych-z-from-contrast-pairs"
     let bad = "dimension\tdepth"
+    // r3-final (test-gap #8): the old hedged match accepted EITHER refusal mechanism, so the
+    // contract could silently migrate. Pinned: a fieldless dimension PARSES (kind+name suffice
+    // structurally) and the LINT is the refusal layer (exactly one finding).
     match MediaLines.parse ok, MediaLines.parse bad with
-    | Ok o, Error _ -> Assert.Equal<MediaLines.LintFinding list>([], MediaLines.lint o)
     | Ok o, Ok b ->
         Assert.Equal<MediaLines.LintFinding list>([], MediaLines.lint o)
         Assert.Equal(1, List.length (MediaLines.lint b))
-    | _ -> failwith "parse failed"
+    | _ -> failwith "contract: both forms must PARSE; the lint owns the refusal"
 
 [<Fact>]
 let ``the lint enforces DI-from-the-start: gen/io first fields must be 32-hex ZetaIds`` () =

--- a/tests/Tests.FSharp/Operators/RecursiveCounting.MultiSeed.Tests.fs
+++ b/tests/Tests.FSharp/Operators/RecursiveCounting.MultiSeed.Tests.fs
@@ -189,62 +189,13 @@ let private buildDelta (ops: EdgeDelta list) : ZSet<struct (int * int)> =
     |> ZSet.ofSeq
 
 
-// ─── Skipped while multi-tick-seed behaviour is under research ─────
-//
-// FsCheck on this property reliably finds disagreement on insert-retract
-// sequences such as
-//   [[InsertEdge(0,6); InsertEdge(4,5)];
-//    [InsertEdge(5,6); InsertEdge(2,4)];
-//    [InsertEdge(2,3)]]
-//
-// matching exactly the "multi-tick seed mid-LFP" limitation that
-// `RecursiveCounting`'s docstring in `src/Zeta.Core/Recursive.fs` flags
-// as OPEN RESEARCH (see `docs/BUGS.md` §"RecursiveCounting multi-tick-seed
-// behaviour unproven" and `docs/research/retraction-safe-semi-naive.md`).
-//
-// Tests 1-3 above ARE the one-shot-seed + strictly paired-delta cases
-// that the docstring promises to cover; they pass. This property probes
-// the unproven multi-tick-seed path and is skipped until the
-// gap-monotone signed-delta combinator (`RecursiveSignedSemiNaive`)
-// lands.  Remove the Skip once the research completes.
-[<Property(Arbitrary = [| typeof<MultiTickArb> |], MaxTest = 25,
-           Skip = "Multi-tick is REFUTED, not open research (witness pinned as the \
-                   unskipped REFUTATION WITNESS Fact below); this property stays \
-                   skipped until the signed-delta replacement lands — then unskip.")>]
-let ``CountingClosureTable clamped to Distinct matches ClosureTable oracle``
-    (ops: MultiTickEdges) =
-    // Build two parallel circuits: one using the counting variant,
-    // one using the boolean oracle. Apply the same sequence of
-    // deltas to both and compare the clamped counting output
-    // against the oracle at each outer tick.
-    let counting = Circuit()
-    let countIn = counting.ZSetInput<struct (int * int)>()
-    let countStream = counting.CountingClosureTable(countIn.Stream)
-    let countOut = OutputHandle countStream.Op
-    counting.Build()
-
-    let oracle = Circuit()
-    let oracleIn = oracle.ZSetInput<struct (int * int)>()
-    let oracleStream = oracle.ClosureTable(oracleIn.Stream)
-    let oracleOut = OutputHandle oracleStream.Op
-    oracle.Build()
-
-    let mutable allAgree = true
-    for tick in ops.Ticks do
-        if not (List.isEmpty tick) then
-            let delta = buildDelta tick
-            countIn.Send delta
-            oracleIn.Send delta
-            let struct (_, convC) =
-                counting.IterateToFixedPoint(countStream, 40)
-            let struct (_, convO) =
-                oracle.IterateToFixedPoint(oracleStream, 40)
-            if convC && convO then
-                let clamped = clampToSet countOut.Current
-                let oracleMap = clampToSet oracleOut.Current
-                if clamped <> oracleMap then
-                    allAgree <- false
-    allAgree
+// ─── The multi-tick FsCheck property was REMOVED here (Aaron 2026-06-13: "why do we have a
+// skipped test? we should fix or remove that"). Removed, not fixed, because its job is DONE:
+// the divergence it found is pinned as the deterministic, UNSKIPPED `REFUTATION WITNESS` Fact
+// below — a Skip'd property was a zombie guarding knowledge the witness already gates. The
+// property RETURNS (unskipped) when the signed-delta combinator lands
+// (docs/research/retraction-safe-semi-naive.md §7); its text lives in git history at this file,
+// and the witness Fact's header says exactly when to resurrect it. ───
 
 // ─── THE PINNED WITNESS (Soraya's routing, math-team triage 2026-06-12) ─────
 //

--- a/tests/Tests.FSharp/ShapeAcceptance.Tests.fs
+++ b/tests/Tests.FSharp/ShapeAcceptance.Tests.fs
@@ -237,3 +237,7 @@ let ``HTMLCSSBINDING INJECTION FALSIFIER: a hostile motto cannot smuggle script 
     | Ok d ->
         let html = HtmlCssBinding.render d
         Assert.DoesNotContain("<script", html)
+
+[<Fact>]
+let ``the generator shelf has ZERO ZetaId collisions (distinct names never share an id — byId shadowing surfaced, not silent)`` () =
+    Assert.Equal<(string * string list) list>([], GeneratorRegistry.collisions ())

--- a/tests/Tests.FSharp/SpectralPivot.Tests.fs
+++ b/tests/Tests.FSharp/SpectralPivot.Tests.fs
@@ -124,3 +124,17 @@ let ``GOERTZEL = NAIVE: the recurrence and the reference single-bin DFT agree to
                + 0.5 * cos (2.0 * System.Math.PI * 11.0 * float t / float n) |]
     for k in [ 0; 1; 5; 11; 31 ] do
         Assert.True(abs (SpectralPivot.probe signal k - SpectralPivot.probeNaive signal k) < 1e-9, sprintf "bin %d" k)
+
+[<Fact>]
+let ``HEALTHY has a real boundary: a small perturbation passes under tolerance and a larger one fails over it (test-gap #9)`` () =
+    let n = 32
+    let baseline = [| for t in 0 .. n - 1 -> sin (2.0 * System.Math.PI * 3.0 * float t / float n) |]
+    let perturbed (amp: float) = [| for t in 0 .. n - 1 -> baseline.[t] + amp * sin (2.0 * System.Math.PI * 9.0 * float t / float n) |]
+    let bins = [ 3; 9 ]
+    // tolerance sized between the two perturbations' drifts — the boundary is exercised from both sides
+    let small = SpectralPivot.drift (SpectralPivot.fingerprint bins baseline) (SpectralPivot.fingerprint bins (perturbed 0.05))
+    let large = SpectralPivot.drift (SpectralPivot.fingerprint bins baseline) (SpectralPivot.fingerprint bins (perturbed 0.5))
+    Assert.True(small < large)
+    let tol = (small + large) / 2.0
+    Assert.True(SpectralPivot.healthy bins baseline tol (perturbed 0.05)) // under: healthy
+    Assert.False(SpectralPivot.healthy bins baseline tol (perturbed 0.5)) // over: the bearing sings


### PR DESCRIPTION
The skip removed (its knowledge lives in the unskipped REFUTATION WITNESS, which says when to resurrect the property); shine/dimension/healthy/timeline strengthenings; audit #7 falsified honestly (single-char cells — the suffix already pinned all four ticks); GeneratorRegistry.collisions() gate (the cheap piece of the idOf finding). 3006 passed, 0 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)