### PR TITLE
feat(dbsp): RecursiveSignedDelta ships — TLC-verified first, the refuted multi-tick case fixed by construction + the ZSet↔quantum bridge

### DIFF
--- a/docs/research/2026-06-13-signed-delta-ships-tlc-verified-and-the-zset-quantum-circuit-bridge.md
+++ b/docs/research/2026-06-13-signed-delta-ships-tlc-verified-and-the-zset-quantum-circuit-bridge.md
@@ -1,0 +1,57 @@
+# The signed-delta combinator SHIPS (TLC-verified, in order) — and the ZSet↔quantum-circuit bridge
+
+Two threads, one capture: Aaron's "let's do it" (the signed-delta work) and his question "can we
+connect ZSet circuit to quantum circuit?" — which turns out to be answered BY the work.
+
+## RecursiveSignedDelta — shipped per its own gate, in sequence
+
+The skeleton's stated graduation path was followed exactly: (1) the TLA+ spec's REAL step relation
+TLC-checked — Safety (S1 termination, S2 fixpoint `total = seed + body(total)`, S3/S3'
+gap-monotone/single-signed) green at all four seed weights (+1, −1, +2, −2); (2) the F# combinator
+landed at the planned home (`Circuit.RecursiveSignedDelta`, Recursive.fs) with the spec's exact
+recurrence — **the feedback cell carries the SIGNED DELTA, never the total**, so a seed delta
+(insert or retract) joins at its own tick and propagates linearly; (3) graduation tests: one-shot
+LFP exact; **the multi-tick case that REFUTED RecursiveCounting passes by construction**;
+insert-then-retract converges to zero everywhere — dip and recover, no tombstone pass. Suite 3009,
+zero skipped. (The removed FsCheck property's resurrection criterion is now MET in spirit — a
+SignedClosureTable wiring + the property re-aimed at the new combinator is the named follow-up.)
+Beacon: Feldera/DBSP VLDB 2023 §6.3 (the production shape); Bancilhon–Ramakrishnan 1986;
+Gupta–Mumick–Subrahmanian 1993; the plan doc §7.
+
+## "Can we connect ZSet circuit to quantum circuit?" — yes, and precisely HERE
+
+The honest mapping, with the load-bearing rhyme first:
+
+| | DBSP circuit | quantum circuit |
+|---|---|---|
+| state | ZSet: keys → ℤ weights | amplitudes: basis states → ℂ |
+| operators | Z-LINEAR (Plus/Join/Map distribute over +/−) | ℂ-linear (gates are linear maps) |
+| the nonlinear step | `Distinct` — FORBIDDEN inside the body, applied at the OUTER BOUNDARY after convergence | MEASUREMENT (Born rule) — nonlinear, applied at the boundary, never inside the unitary circuit |
+| cancellation | a −1 delta annihilates a +1 derivation (retraction) | opposite-phase amplitudes annihilate (interference) |
+| proof in-tree | RecursiveSignedDelta retraction test → exact zero | AmplitudeEmu.merge → the two-slit |
+
+The connection is not analogy — it is the SAME calculus over a different weight ring. `AmplitudeEmu`
+already IS a ℂ-weighted Z-set over machine frames (`Amp = (Frame × Complex) list`), its `merge` is
+ZSet consolidation with complex cancellation, and `bornProb` is the boundary measurement. What the
+signed-delta work just proved for ℤ (negative weights propagate linearly through the body and
+cancel exactly) is one ring-swap away from amplitude propagation: generalize `ZSet<'K>` weights
+from ℤ to any commutative ring 'W (we already carry `Semiring`/`ProbabilitySemiring`/`IStarRing`),
+and a quantum circuit is the SAME `Circuit` shape with 'W = ℂ and the operator set restricted to
+norm-preserving (unitary) maps. The Distinct-at-the-boundary discipline we enforce for correctness
+is literally the measurement-at-the-boundary discipline quantum mechanics enforces by law.
+
+HONEST LIMITS, stated: (a) unitarity is NOT free — circuit composition preserves linearity, not
+norm; a quantum lane needs the operator set gated (the acceptance-gate pattern applies); (b) this
+is SIMULATION of amplitude arithmetic (the AmplitudeEmu honesty note carries: distinct-frame
+count can grow exponentially — the merge only collapses reconverging paths); no hardware claim;
+(c) measurement nonlinearity means no measurement inside feedback loops — same rule as Distinct,
+enforced the same way.
+
+NAMED SLICE: `WSet<'K,'W>` (ring-generic Z-set) + a ℂ instance + the Mach-Zehnder drawn as a
+two-key DBSP circuit (Plus/Map only, merge at boundary) cross-checked against AmplitudeEmu and
+Vera's Q# job 3 — the literal connection, testable in three oracles.
+
+## Pointers
+
+- `Circuit.RecursiveSignedDelta` (Recursive.fs) · the TLA+ spec + cfg (all four seeds) ·
+  §SIGNED-DELTA tests · `AmplitudeEmu` · `Semiring`/`ProbabilitySemiring` · Vera brief job 3

--- a/src/Core/Recursive.fs
+++ b/src/Core/Recursive.fs
@@ -260,6 +260,49 @@ type RecursiveExtensions =
         fb.Connect next
         next
 
+    /// **Gap-monotone signed-delta semi-naive LFP** (option 7 of
+    /// `docs/research/retraction-safe-semi-naive.md`; the user's "let the feedback value dip,
+    /// then recover" proposal; Feldera's production shape — DBSP VLDB 2023 §6.3).
+    ///
+    /// SHIPPED 2026-06-13: the TLA+ spec `tools/tla/specs/RecursiveSignedSemiNaive.tla` carries a
+    /// REAL step relation and TLC verified S1 (termination), S2 (fixpoint: total = seed +
+    /// body(total)), S3/S3' (gap-monotone, single-signed) at all four configured seed weights
+    /// (+1, −1, +2, −2) — the skeleton's graduation gate, cleared. The recurrence below is the
+    /// spec's, exactly:
+    ///
+    ///   tick 0:   Δ = seed,            total = seed
+    ///   tick n>0: Δ' = seedΔ_n + body(Δ),  total' = total + Δ'
+    ///   converged when Δ' consolidates to 0.
+    ///
+    /// THE FEEDBACK CELL CARRIES THE SIGNED DELTA, NOT THE TOTAL — that is the entire fix for the
+    /// refuted multi-tick case: a seed delta arriving at tick n (insert OR retract) enters the
+    /// delta stream ONCE, at its own tick, and propagates through `body^i` linearly from there.
+    /// (`RecursiveCounting` re-reads the INTEGRATED seed against the accumulated total every
+    /// tick — the recurrence that diverged from the oracle on multi-tick seeds; its refutation
+    /// witness is pinned in `RecursiveCounting.MultiSeed.Tests.fs`.)
+    ///
+    /// PRECONDITIONS (the caller's contract, from the spec): body must be Z-LINEAR (P1:
+    /// body(a+b) = body(a)+body(b); P2: body(−a) = −body(a); P3 support-monotone). `Plus`,
+    /// `IndexedJoin`, `Map` qualify; **`Distinct` is FORBIDDEN inside body** (nonlinear) — clamp
+    /// at the OUTER boundary only, after convergence. Same discipline as quantum measurement:
+    /// the nonlinear step lives at the boundary, never inside the linear circuit.
+    ///
+    /// Output: the running signed TOTAL (the integral of the delta stream). Weights may dip
+    /// negative mid-convergence and recover — that is the gap-monotone discipline working, not a
+    /// bug; consolidate/clamp only at the boundary.
+    [<Extension>]
+    static member RecursiveSignedDelta<'K when 'K : comparison>
+        (this: Circuit,
+         seed: Stream<ZSet<'K>>,
+         body: Func<Stream<ZSet<'K>>, Stream<ZSet<'K>>>) : Stream<ZSet<'K>> =
+        // Δ' = seedΔ + body(Δ): the RAW seed stream (deltas, not integrated) joins the recurrence
+        // at its own tick; the feedback cell carries the previous delta only.
+        let fb = this.FeedbackZSet<'K>()
+        let delta = this.Plus(seed, body.Invoke fb.Stream)
+        fb.Connect delta
+        // total = ∫ Δ — the gap-monotone accumulator (signed; clamp at the boundary, never here).
+        this.IntegrateZSet delta
+
     /// **Semi-naive** recursive evaluation of a monotone Datalog-like
     /// rule. Instead of recomputing `body(current)` on the full integrated
     /// relation every iteration (O(n) per step × N iterations = O(n·N)),

--- a/src/Core/RecursiveSigned.fs
+++ b/src/Core/RecursiveSigned.fs
@@ -1,82 +1,29 @@
 namespace Zeta.Core
 
 // ============================================================================
-// RecursiveSigned — gap-monotone signed-delta semi-naïve LFP — SKELETON
+// RecursiveSigned — gap-monotone signed-delta semi-naïve LFP — SHIPPED
 // ============================================================================
 //
-// Round-35 stub. Sibling to `Recursive.RecursiveSemiNaive` and
-// `Recursive.RecursiveCounting`. The design lives in:
+// GRADUATED 2026-06-13. The round-35 skeleton's gate was: land the real TLA+
+// step relation, TLC-check S1-S3, then promote. Done, in order:
 //
-//   docs/research/retraction-safe-semi-naive.md  (§"Option 7 —
-//                                                  gap-monotone signed-delta")
-//   tools/tla/specs/RecursiveSignedSemiNaive.tla (TLA+ skeleton with
-//                                                  preconditions P1-P3 and
-//                                                  properties S1-S3)
+//   1. tools/tla/specs/RecursiveSignedSemiNaive.tla carries the REAL Step
+//      (successor-chain body satisfying P1-P3); TLC verified Safety (S1
+//      termination, S2 fixpoint total = seed + body(total), S3/S3'
+//      gap-monotone + single-signed) at ALL FOUR seed weights (+1, -1, +2, -2).
+//   2. The combinator shipped as `Circuit.RecursiveSignedDelta` in
+//      src/Core/Recursive.fs (the planned home) — the feedback cell carries
+//      the SIGNED DELTA, never the total; seed deltas join at their own tick.
+//   3. Graduation tests (RecursiveCounting.MultiSeed.Tests.fs §SIGNED-DELTA):
+//      one-shot LFP exact; MULTI-TICK seed correct (the case that REFUTED
+//      RecursiveCounting — fixed by construction); retraction converges to
+//      zero everywhere (dip-and-recover, no tombstones).
 //
-// The gap-monotone variant carries *signed deltas* through semi-naïve
-// iteration; unlike Gupta-Mumick counting, it does not carry
-// multiplicities. Termination is proven by a lex-product rank argument
-// in the TLA+ model, not by monotonicity-on-weights.
-//
-// Preconditions on `body` that the caller must guarantee:
-//
-//   P1. Z-linearity       — body(a + b) = body(a) + body(b)
-//   P2. Sign-distribution — body(-a)    = -body(a)
-//   P3. Support-monotone  — support(a) ⊆ support(b)
-//                           ⇒ support(body(a)) ⊆ support(body(b))
-//
-// Why not ship it today:
-//
-//   The TLA+ spec still has `Step` as a placeholder (iter counter +
-//   UNCHANGED vars). Until the real step relation is written and TLC
-//   checks properties S1-S3, any F# implementation would be an
-//   unverified guess at the recurrence shape. The responsible path is
-//   to park the F# module as a skeleton, land the real TLA+ step in
-//   round 36 against a concrete body satisfying P1-P3, and only then
-//   promote this module from skeleton to shipped. See
-//   docs/research/chain-rule-proof-log.md §"attack order" for the
-//   sequencing.
-//
-// Out of scope for this skeleton:
-//
-//   - Connecting to `Circuit` via an `[<Extension>]` static method on
-//     `Circuit`. That wiring lands only once the TLA+ step is verified
-//     and this module graduates from skeleton to shipped.
-//   - Performance comparisons against Feldera §6.3
-//     `nested_integrate_trace`. See TECH-RADAR "Gap-monotone vs
-//     Feldera" watchlist row; no benchmark until the algorithm ships.
-//
-// This file is intentionally NOT wired into Core.fsproj. It exists as
-// a pinned pointer between the TLA+ spec and the future F# home, so
-// the next-round author lands the code at a predictable path.
+// This file remains as the pinned pointer (not in Core.fsproj). Preconditions
+// P1-P3 and the Distinct-at-the-boundary discipline are documented on the
+// shipped member. Design: docs/research/retraction-safe-semi-naive.md §7.
 // ============================================================================
 
-module RecursiveSignedSkeleton =
-
-    /// Planned signature (round 36+, after TLA+ step lands):
-    ///
-    ///   static member RecursiveSignedDelta<'K when 'K : comparison>
-    ///       (this: Circuit,
-    ///        seed: Stream<ZSet<'K>>,
-    ///        body: Func<Stream<ZSet<'K>>, Stream<ZSet<'K>>>)
-    ///       : Stream<ZSet<'K>>
-    ///
-    /// Expected shape:
-    ///
-    ///   tick 0:  delta = seed
-    ///   tick n>0:
-    ///       newDelta = body(delta)  // Z-linear; signed weights pass through
-    ///       total   += newDelta     // gap-monotone accumulator
-    ///       delta    = newDelta
-    ///   terminates when delta = 0 (i.e. ∀k, delta[k] = 0)
-    ///
-    /// Distinct from `RecursiveSemiNaive`:
-    ///   - No `Distinct` clamp on delta — negative weights survive
-    ///     through iteration under P1-P3.
-    ///   - No integrated-seed step — the seed is absorbed into delta
-    ///     on tick 0 and never re-applied.
-    ///
-    /// Distinct from `RecursiveCounting`:
-    ///   - Does not carry derivation-count multiplicities; the
-    ///     accumulator `total` tracks signed weights only.
-    let plannedSignature = ()
+module RecursiveSignedShipped =
+    /// See `Circuit.RecursiveSignedDelta` (src/Core/Recursive.fs).
+    let shippedAt = "src/Core/Recursive.fs — Circuit.RecursiveSignedDelta (2026-06-13)"

--- a/tests/Tests.FSharp/Operators/RecursiveCounting.MultiSeed.Tests.fs
+++ b/tests/Tests.FSharp/Operators/RecursiveCounting.MultiSeed.Tests.fs
@@ -237,3 +237,59 @@ let ``REFUTATION WITNESS: multi-tick seed diverges from the ClosureTable oracle 
             diverged <- true
 
     Assert.True(diverged, "the pinned multi-tick witness no longer diverges — the defect may be FIXED: restore the skipped property and retire this pin (see its header)")
+
+// ─── RecursiveSignedDelta — the signed-delta combinator, SHIPPED (TLC-verified spec, 2026-06-13) ───
+//
+// The TLA+ spec's successor-chain body, in circuit form: body(T)[k] = T[k-1], keys bounded at 8.
+// Z-linear (Map is linear; the bound is support filtering, not weight logic) — precondition P1-P3.
+
+let private chainBody (c: Circuit) (s: Stream<ZSet<int>>) : Stream<ZSet<int>> =
+    c.FlatMap(s, fun k -> if k < 8 then ZSet.ofSeq [ k + 1, 1L ] else ZSet<int>.Empty)
+
+let private weightOf (z: ZSet<int>) (k: int) : int64 =
+    z.AsSpan().ToArray() |> Array.sumBy (fun (e: ZEntry<int>) -> if e.Key = k then e.Weight else 0L)
+
+[<Fact>]
+let ``SIGNED-DELTA one-shot: the chain LFP from a single seed matches the hand oracle (S2, in code)`` () =
+    let c = Circuit()
+    let input = c.ZSetInput<int>()
+    let stream = c.RecursiveSignedDelta(input.Stream, fun s -> chainBody c s)
+    let out = OutputHandle stream.Op
+    c.Build()
+    input.Send(ZSet.ofSeq [ 0, 1L ])
+    let struct (_, converged) = c.IterateToFixedPoint(stream, 40)
+    Assert.True(converged)
+    // total = seed + body(total): keys 0..8 all weight 1 (the chain, exactly)
+    for k in 0 .. 8 do
+        Assert.Equal(1L, weightOf out.Current k)
+
+[<Fact>]
+let ``SIGNED-DELTA multi-tick INSERT: a seed arriving at a later tick joins the LFP exactly once (the refuted case, fixed)`` () =
+    let c = Circuit()
+    let input = c.ZSetInput<int>()
+    let stream = c.RecursiveSignedDelta(input.Stream, fun s -> chainBody c s)
+    let out = OutputHandle stream.Op
+    c.Build()
+    input.Send(ZSet.ofSeq [ 0, 1L ])
+    c.IterateToFixedPoint(stream, 40) |> ignore
+    input.Send(ZSet.ofSeq [ 3, 1L ]) // mid-LFP second seed — THE multi-tick shape that refuted counting
+    c.IterateToFixedPoint(stream, 40) |> ignore
+    // keys 0..2: weight 1 (first chain only); keys 3..8: weight 2 (both chains pass through)
+    for k in 0 .. 2 do
+        Assert.Equal(1L, weightOf out.Current k)
+    for k in 3 .. 8 do
+        Assert.Equal(2L, weightOf out.Current k)
+
+[<Fact>]
+let ``SIGNED-DELTA RETRACTION: insert then retract converges to ZERO everywhere — the dip-and-recover discipline, no tombstones`` () =
+    let c = Circuit()
+    let input = c.ZSetInput<int>()
+    let stream = c.RecursiveSignedDelta(input.Stream, fun s -> chainBody c s)
+    let out = OutputHandle stream.Op
+    c.Build()
+    input.Send(ZSet.ofSeq [ 0, 1L ])
+    c.IterateToFixedPoint(stream, 40) |> ignore
+    input.Send(ZSet.ofSeq [ 0, -1L ]) // the retraction: a NEGATIVE delta through the same linear body
+    c.IterateToFixedPoint(stream, 40) |> ignore
+    for k in 0 .. 8 do
+        Assert.Equal(0L, weightOf out.Current k) // every derivation cancelled exactly


### PR DESCRIPTION
The skeleton's own graduation gate, in order: TLC green on the real Step at all four seed weights (S1/S2/S3); the combinator at its planned home — feedback carries the SIGNED DELTA (seed deltas join at their own tick; Distinct forbidden inside, boundary-only); graduation tests: one-shot exact, the refuted multi-tick case passes by construction, retraction → exact zero. 3009 green, 0 skipped. Plus the answer to 'can we connect ZSet circuit to quantum circuit': same calculus, different weight ring — Distinct-at-the-boundary IS measurement-at-the-boundary; AmplitudeEmu is the ℂ instance; WSet named slice; honest limits stated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)