### PR TITLE
docs(research): Infer.NET circuits — half the engine is already ours; three rings, one calculus (B-1032)

### DIFF
--- a/docs/backlog/P2/B-1032-wset-ring-generic-circuit-three-rings-one-calculus-dbsp-quantum-inference-gdl-anchor-aaron-2026-06-13.md
+++ b/docs/backlog/P2/B-1032-wset-ring-generic-circuit-three-rings-one-calculus-dbsp-quantum-inference-gdl-anchor-aaron-2026-06-13.md
@@ -1,0 +1,32 @@
+---
+id: B-1032
+title: WSet<'K,'W> — the ring-generic circuit; three rings, one calculus (DBSP ℤ · quantum ℂ · inference ℝ≥0), GDL-anchored
+priority: P2
+status: open
+tier: treaty-substrate
+tags: [wset, semiring, gdl, quantum, infer-net, ep, factor-graph, bayesian, circuit, bp-16]
+created: 2026-06-13
+owner: open (pairs with B-1029 Lior's quantum lane; Zeta.Bayesian is the inference oracle)
+---
+
+# B-1032 — the ring-generic circuit (Aaron's two questions, one slice)
+
+Aaron asked "can we connect ZSet circuit to quantum circuit?" and "are there Infer.NET circuits we
+can do the same with?" — same answer, one build: generalize the ZSet weight ring.
+
+1. `WSet<'K,'W>` over any commutative (semi)ring via the existing `Semiring`/`IStarRing`
+   abstractions; `ZSet = WSet<_, ℤ>` (compat shim or parallel module — decide at start gate).
+2. Ring demos on ONE circuit shape, each with an independent oracle (BP-16):
+   - ℝ≥0: discrete sum-product on a 3-node chain vs `Zeta.Bayesian.FactorGraph` marginals
+     (the GDL instance; deterministic message schedule — DST).
+   - ℂ: Mach-Zehnder vs `AmplitudeEmu` + Vera's Q# job 3 (three oracles).
+   - ℤ: the existing suite (free).
+3. The boundary-nonlinearity law stated ONCE and enforced per ring: Distinct (ℤ) / measurement
+   (ℂ) / EP-projection (ℝ≥0) — never inside the linear loop (the RecursiveSignedDelta discipline,
+   generalized).
+4. Beacon: Aji–McEliece GDL 2000 (the unifying theorem); Kschischang–Frey–Loeliger 2001; Minka
+   EP 2001 + α-divergences; Winn–Bishop VMP 2005; DBSP VLDB 2023; dotnet/infer (MIT — reference,
+   not dependency; our engine is src/Bayesian, already written).
+
+Start gate notes: prior-art search done (the 2026-06-13 capture); deps: none new (Semiring,
+Bayesian, AmplitudeEmu all in-tree).

--- a/docs/research/2026-06-13-infer-net-circuits-minka-ep-factor-graphs-the-third-ring-of-one-circuit-calculus.md
+++ b/docs/research/2026-06-13-infer-net-circuits-minka-ep-factor-graphs-the-third-ring-of-one-circuit-calculus.md
@@ -1,0 +1,59 @@
+# Infer.NET circuits — Minka's EP, factor graphs, and the THIRD ring of one circuit calculus
+
+Aaron 2026-06-13: "are there any kind of Infer.NET circuits we can do the same with? research the
+guy behind it and his latest papers — we can write our own code if they have a similar way to
+connect a circuit-like thing."
+
+## The people and the lineage (researched, verified)
+
+**Tom Minka** — Expectation Propagation (UAI 2001), Power EP, "Divergence measures and message
+passing" (the α-divergence unification); **John Winn** — Variational Message Passing (Winn &
+Bishop, JMLR 2005) and the Model-Based Machine Learning book. Infer.NET is their engine: a model
+COMPILES to a FACTOR GRAPH and inference runs as MESSAGE PASSING over it. It is MIT-licensed, a
+.NET Foundation project, alive at dotnet/infer. The deepest anchor under all of it:
+**Aji & McEliece, "The Generalized Distributive Law" (IEEE IT 2000)** + Kschischang–Frey–Loeliger
+factor graphs (2001) — sum-product, max-product, Viterbi, FFT, and Turbo decoding are ONE
+algorithm over different commutative semirings. The GDL is the theorem our whole circuit thesis
+rides on.
+
+## The answer: yes — and HALF OF IT IS ALREADY IN OUR TREE
+
+`Zeta.Bayesian` already carries the Infer.NET shape, written by us: `FactorGraph.fs` (with
+`runToFixpoint` — the message-passing fixpoint driver), `Message.fs`, `MessageBatch.fs`, and
+`Ep.fs` — a real EP step (cavity = marginal/f_message → project to the exponential family →
+divide = new message), Minka's loop verbatim. So Aaron's "we can write our own code" is DONE for
+the engine core; what's missing is the CONNECTION to the DBSP `Circuit` — and that connection is
+the same one the quantum answer named yesterday:
+
+| ring | circuit | weights | the boundary nonlinearity |
+|---|---|---|---|
+| ℤ | DBSP / ZSet | signed counts | **Distinct** (clamp after convergence) |
+| ℂ | quantum / AmplitudeEmu | amplitudes | **measurement** (Born rule) |
+| ℝ≥0 (or log-semiring) | factor graph / sum-product | probabilities (messages) | **EP projection** (moment-match to the family) |
+
+Three rings, ONE calculus (the GDL says so with a proof); three boundary nonlinearities, one
+discipline — the nonlinear step never lives inside the linear loop. Minka's EP projection is to
+inference what Distinct is to DBSP and measurement is to quantum: the lossy step, quarantined at
+the boundary (EP literally alternates linear message products with a projection — and the
+α-divergence paper is the knob between them).
+
+## What we build (B-1032, the named slice — shared with the quantum one)
+
+`WSet<'K,'W>` over any commutative semiring (we carry `Semiring`/`ProbabilitySemiring`/`IStarRing`
+already), then ONE demo per ring on the SAME circuit shape: (a) discrete sum-product on a 3-node
+chain as a Circuit instance with 'W = probability, marginals cross-checked against
+`Zeta.Bayesian.FactorGraph` (two independent engines, BP-16); (b) the Mach-Zehnder with 'W = ℂ
+vs AmplitudeEmu + Vera's Q# job 3; (c) 'W = ℤ is the existing ZSet (free). Honest limits: EP is
+APPROXIMATE off-tree (loopy graphs — convergence not guaranteed, Minka says so himself); the
+sum-product/Circuit equivalence is exact only on trees/fixed schedules; we state schedules
+explicitly (DST: deterministic message order).
+
+Sources: [Minka's site](https://tminka.github.io/) · [EP, UAI 2001](https://arxiv.org/pdf/1301.2294) ·
+[Power EP](https://tminka.github.io/papers/minka-power-ep.pdf) · [dotnet/infer](https://github.com/dotnet/infer) ·
+[Infer.NET compiler overview](https://dotnet.github.io/infer/development/Compiler%20overview.html) ·
+Aji & McEliece 2000 · Winn & Bishop 2005
+
+## Pointers
+
+- `src/Bayesian/` (FactorGraph/Message/Ep — ours, already written) · `Circuit.RecursiveSignedDelta`
+  (the ℤ ring's newest law) · the quantum-bridge capture (2026-06-13) · B-1029 (Lior's lane)


### PR DESCRIPTION
Minka/Winn researched (EP/VMP; MIT; alive at dotnet/infer); the GDL (Aji–McEliece 2000) is the unifying theorem — sum-product over semirings. Discovery: src/Bayesian already carries the Infer.NET shape (FactorGraph.runToFixpoint + a real Ep.fs — Minka's cavity→project→divide). B-1032 files WSet<'K,'W>: three rings (ℤ/ℂ/ℝ≥0), one circuit calculus, one boundary-nonlinearity law (Distinct/measurement/EP-projection). Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)