### PR TITLE
feat(wset): three oracles on one interferometer — WSet ships + B-1033 hexagonal inference port filed

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -976,6 +976,8 @@ are closed (status: closed in frontmatter)._
 - [ ] **[B-1028](backlog/P2/B-1028-mips-emulator-treaty-room-like-chip8-maxs-machine-hennessy-lineage-aaron-2026-06-11.md)** MIPS emulator as a treaty room — like our CHIP-8, for Max (Hennessy lineage; the B-1025 fan-out's second machine)
 - [ ] **[B-1029](backlog/P2/B-1029-quirk-craft-school-toy-layer-and-quantum-circuit-ts-second-oracle-with-qsharp-export-lior-owner-aaron-2026-06-12.md)** The TS quantum lane — quantum-circuit as second oracle (Q# export, the three Vera jobs) + Quirk as the craft-school toy layer
 - [ ] **[B-1031](backlog/P2/B-1031-drw-clip-vs-wrap-cosmac-vip-correct-edge-semantics-four-oracle-coordinated-golden-regen-aaron-2026-06-13.md)** DRW edge semantics — clip (COSMAC VIP correct) not wrap; a coordinated four-oracle golden change
+- [ ] **[B-1032](backlog/P2/B-1032-wset-ring-generic-circuit-three-rings-one-calculus-dbsp-quantum-inference-gdl-anchor-aaron-2026-06-13.md)** WSet<'K,'W> — three rings, one calculus (DBSP ℤ · quantum ℂ · inference ℝ≥0); GDL-anchored; first demo SHIPPED (the three-oracle Mach-Zehnder)
+- [ ] **[B-1033](backlog/P2/B-1033-hexagonal-inference-port-own-the-interface-zeta-bayesian-and-infer-net-as-adapters-plugin-system-convergence-aaron-2026-06-13.md)** Hexagonal inference port — own the interface; Zeta.Bayesian + Infer.NET as the two adapters (theirs tests ours); plugin-system convergence audit
 
 ## P3 — convenience / deferred
 

--- a/docs/backlog/P2/B-1033-hexagonal-inference-port-own-the-interface-zeta-bayesian-and-infer-net-as-adapters-plugin-system-convergence-aaron-2026-06-13.md
+++ b/docs/backlog/P2/B-1033-hexagonal-inference-port-own-the-interface-zeta-bayesian-and-infer-net-as-adapters-plugin-system-convergence-aaron-2026-06-13.md
@@ -1,0 +1,45 @@
+---
+id: B-1033
+title: Hexagonal inference port — own the interface; Zeta.Bayesian + Infer.NET as the two adapters (theirs tests ours); plugin-system convergence audit
+priority: P2
+status: open
+tier: verification-substrate
+tags: [hexagonal, ports-adapters, infer-net, bayesian, ep, bp-16, plugins, convergence]
+created: 2026-06-13
+owner: open (pairs with B-1032; the Bayesian module is ours already)
+---
+
+# B-1033 — hexagonal the Infer.NET types (Aaron 2026-06-13)
+
+Aaron: "we should hexagonal the Infer.NET types — make them follow OUR standards, own the
+interface, plug them in, and use them to test ours; we have two impls. We already have a plugin
+system — and we might have multiple plugin systems that need to converge."
+
+## The port (ports-and-adapters — Cockburn's hexagonal architecture, the Beacon anchor)
+
+1. **We own the interface**: `IInferenceEngine` (working name) in our Abstractions register, on
+   OUR standards — Result-over-exception, DST-deterministic message schedules, culture-invariant,
+   ZetaId'd. Shape: declare-model (factor graph in OUR terms — `Zeta.Bayesian.FactorGraph` is the
+   native vocabulary) → run-to-fixpoint → read marginals; the EP projection is the port's stated
+   boundary nonlinearity (B-1032's one-law table).
+2. **Adapter A — ours**: `Zeta.Bayesian` (FactorGraph/Message/Ep — already written, already DST).
+3. **Adapter B — theirs**: `dotnet/infer` (MIT — license-clean to depend on in a TEST/adapter
+   project, never in Core). The Infer.NET model compiler consumes the same declared model.
+4. **Theirs tests ours (BP-16 made structural)**: every conformance case runs through BOTH
+   adapters; marginals must agree within stated tolerance. Divergence = a finding on one of the
+   two (Minka's engine is the senior oracle; ours is the one we can fix). The acceptance gate
+   pattern applies: cases live as data, verdicts per adapter.
+
+## The plugin-system convergence audit (the second half of the ask)
+
+We have at least FOUR plug-shaped systems, grown separately: `PluginApi`/`PluginHarness` (Core),
+MediaLines io resolution (Live/Injected/Adapted/Mock + the toolbox adapters), GeneratorRegistry
+(ZetaId-addressed generators), MagneticPorts (typed ports + findAdapter). DV2 lens: these are one
+HUB concept (a port: an interface we own, resolved against capabilities at load) with different
+satellites. Audit task: map all four onto one vocabulary, name what converges (the resolution
+ladder + the adapter economy look like the shared core) and what legitimately stays distinct
+(pixel-physics snapping vs process-level plugins). Output: a convergence capture + the one
+interface the next plugin system MUST use instead of growing a fifth.
+
+Start gate: prior-art = hexagonal architecture (Cockburn 2005), Infer.NET docs (How to add a new
+factor / Compiler overview); deps: dotnet/infer NuGet (test-side only).

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -226,6 +226,7 @@
     <Compile Include="SwarmBoardAnsi.fs" />
     <Compile Include="ZetaMax.fs" />
     <Compile Include="Chip9Phys.fs" />
+    <Compile Include="WSet.fs" />
     <Compile Include="TimeGen.fs" />
     <Compile Include="Braid.fs" />
     <Compile Include="MediaLines.fs" />

--- a/src/Core/WSet.fs
+++ b/src/Core/WSet.fs
@@ -1,0 +1,89 @@
+namespace Zeta.Core
+
+open Zeta.Core.Abstractions
+
+/// WSet — **the ring-generic weighted set: three rings, one circuit calculus** (B-1032; Aaron
+/// 2026-06-13: "can we connect ZSet circuit to quantum circuit?" / "Infer.NET circuits the same
+/// way?" — same answer, one type). A `WSet<'K,'W>` is a Z-set whose weights live in ANY *-ring:
+///
+///   'W = ℤ  → the DBSP Z-set (signed counts; boundary nonlinearity = Distinct)
+///   'W = ℂ  → amplitudes      (interference;  boundary nonlinearity = measurement/Born)
+///   'W = ℝ≥0 → probabilities  (sum-product;   boundary nonlinearity = EP projection)
+///
+/// The unifying theorem is the Generalized Distributive Law (Aji–McEliece 2000): sum-product,
+/// max-product, FFT and friends are ONE algorithm over different commutative semirings. The
+/// circuit discipline carried over from `RecursiveSignedDelta`: every operator here is
+/// 'W-LINEAR; the ring's nonlinear step (Distinct / measurement / projection) is applied at the
+/// OUTER BOUNDARY only, never inside the loop.
+///
+/// Honest scope: this is the CONNECTION layer, kept lean — unconsolidated (key×weight) lists with
+/// ring-parameterized consolidation. `ZSet` remains the optimized ℤ workhorse; `WSet` is where
+/// the rings MEET (and the cross-oracle demos live). Float-weighted rings consolidate with an
+/// epsilon `isZero` the CALLER supplies — exact cancellation is the ring's business, not ours.
+[<RequireQualifiedAccess>]
+module WSet =
+
+    /// A weighted set: keys with ring weights, possibly unconsolidated (duplicate keys pending merge).
+    type WSet<'K, 'W when 'K: comparison> = ('K * 'W) list
+
+    /// Consolidate: sum weights per key under the ring's Add; drop keys whose total isZero.
+    /// THIS is where interference/retraction happens — opposite weights annihilate here.
+    let consolidate (ring: IStarRing<'W>) (isZero: 'W -> bool) (s: WSet<'K, 'W>) : WSet<'K, 'W> =
+        s
+        |> List.groupBy fst
+        |> List.map (fun (k, ws) -> k, ws |> List.map snd |> List.fold (fun a w -> ring.Add(a, w)) ring.Zero)
+        |> List.filter (fun (_, w) -> not (isZero w))
+        |> List.sortBy fst
+
+    /// The linear-operator application (a matrix row per key): each key maps to a WSet of
+    /// successors; incoming weight multiplies through (ring.Mul). 'W-linear by construction.
+    let apply (ring: IStarRing<'W>) (op: 'K -> WSet<'K, 'W>) (s: WSet<'K, 'W>) : WSet<'K, 'W> =
+        s |> List.collect (fun (k, w) -> op k |> List.map (fun (k2, w2) -> k2, ring.Mul(w, w2)))
+
+    /// Pointwise sum (concatenate; consolidate at your boundary of choice).
+    let plus (a: WSet<'K, 'W>) (b: WSet<'K, 'W>) : WSet<'K, 'W> = a @ b
+
+    /// THE BOUNDARY MEASUREMENT (ℂ ring): Born probabilities |w|²/Σ|w|² per key — the ONE
+    /// nonlinear step, outside the linear ops above (the same law as Distinct and EP projection).
+    let bornProb (magSq: 'W -> float) (s: WSet<'K, 'W>) : ('K * float) list =
+        let total = s |> List.sumBy (fun (_, w) -> magSq w)
+        if total <= 1e-18 then []
+        else s |> List.map (fun (k, w) -> k, magSq w / total)
+
+/// The Mach-Zehnder interferometer as a TWO-KEY WSet circuit over the ℂ ring — the literal
+/// ZSet↔quantum connection, cross-checked against THREE oracles (F# analytic, AmplitudeEmu,
+/// Vera's Q# treaty transcript) in the suite. Convention matches the Q# treaty: H · R1(φ) · H on
+/// |0⟩ ⇒ P(0) = cos²(φ/2).
+[<RequireQualifiedAccess>]
+module MachZehnderWSet =
+
+    let private ring = ImaginaryStack.complex
+    let private r (x: float) : Complex = Doubled.make x 0.0
+    let private isZero (z: Complex) = abs z.Real < 1e-12 && abs z.Imag < 1e-12
+    let private invSqrt2 = r (1.0 / sqrt 2.0)
+
+    /// The Hadamard as a linear map on detector keys 0/1 (the real-valued H).
+    let private hadamard (k: int) : WSet.WSet<int, Complex> =
+        if k = 0 then [ 0, invSqrt2; 1, invSqrt2 ]
+        else [ 0, invSqrt2; 1, ring.Negate invSqrt2 ]
+
+    /// The phase plate: e^{iφ} on arm 1, identity on arm 0.
+    let private phasePlate (phi: float) (k: int) : WSet.WSet<int, Complex> =
+        if k = 1 then [ 1, Doubled.make (cos phi) (sin phi) ] else [ 0, ring.One ]
+
+    /// CLOSED interferometer: H · R1(φ) · H on |0⟩, consolidated (the interference), then the
+    /// boundary measurement. Linear ops inside; Born at the edge — the discipline, demonstrated.
+    let closed (phi: float) : (int * float) list =
+        [ 0, ring.One ]
+        |> WSet.apply ring hadamard
+        |> WSet.apply ring (phasePlate phi)
+        |> WSet.apply ring hadamard
+        |> WSet.consolidate ring isZero
+        |> WSet.bornProb (fun z -> z.Real * z.Real + z.Imag * z.Imag)
+
+    /// OPEN interferometer: one beamsplitter, no recombination — equal halves, no interference.
+    let openArm () : (int * float) list =
+        [ 0, ring.One ]
+        |> WSet.apply ring hadamard
+        |> WSet.consolidate ring isZero
+        |> WSet.bornProb (fun z -> z.Real * z.Real + z.Imag * z.Imag)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -180,6 +180,7 @@
     <Compile Include="ShapeCartridge.Tests.fs" />
     <Compile Include="ShapeAcceptance.Tests.fs" />
     <Compile Include="DeterminismLint.Tests.fs" />
+    <Compile Include="WSet.MachZehnder.Tests.fs" />
     <Compile Include="WaveSim.Tests.fs" />
     <Compile Include="AdinkraViz.Tests.fs" />
     <Compile Include="SpectralPivot.Tests.fs" />

--- a/tests/Tests.FSharp/WSet.MachZehnder.Tests.fs
+++ b/tests/Tests.FSharp/WSet.MachZehnder.Tests.fs
@@ -1,0 +1,67 @@
+module Zeta.Tests.WSetMachZehnderTests
+
+// THREE ORACLES ON ONE INTERFEROMETER (B-1032 first demo, Aaron's "yes please too"):
+// the Mach-Zehnder as a two-key WSet circuit over the ℂ ring, cross-checked against
+//   (1) the F# analytic law  P(0) = cos²(φ/2)                    — exact
+//   (2) AmplitudeEmu          (the in-tree ℂ-weighted instance)   — exact
+//   (3) Vera's Q# treaty transcript (sampled hardware-shape runs) — within sampling tolerance
+// One linear calculus, the Born rule only at the boundary — the ZSet↔quantum connection, literal.
+
+open System.IO
+open System.Text.Json
+open global.Xunit
+open Zeta.Core
+
+let private repoRoot () =
+    let mutable dir = DirectoryInfo(System.AppContext.BaseDirectory)
+    while not (isNull dir) && not (File.Exists(Path.Combine(dir.FullName, "Zeta.sln"))) do
+        dir <- dir.Parent
+    dir.FullName
+
+let private probFor (k: int) (ps: (int * float) list) =
+    ps |> List.filter (fun (key, _) -> key = k) |> List.sumBy snd
+
+[<Fact>]
+let ``ORACLE 1 — analytic: the WSet interferometer reproduces P(0) = cos²(φ/2) across the phase sweep, exactly`` () =
+    for phi in [ 0.0; System.Math.PI / 3.0; System.Math.PI / 2.0; 2.0 * System.Math.PI / 3.0; System.Math.PI ] do
+        let ps = MachZehnderWSet.closed phi
+        let expected = cos (phi / 2.0) ** 2.0
+        Assert.True(abs (probFor 0 ps - expected) < 1e-12, sprintf "phi=%f" phi)
+        Assert.True(abs (probFor 1 ps - (1.0 - expected)) < 1e-12, sprintf "phi=%f (one)" phi)
+    // the OPEN arm: no recombination, no interference — equal halves
+    let openPs = MachZehnderWSet.openArm ()
+    Assert.True(abs (probFor 0 openPs - 0.5) < 1e-12)
+
+[<Fact>]
+let ``ORACLE 2 — AmplitudeEmu: the WSet circuit and the frame-ensemble emulator agree (two in-tree ℂ instances, one number)`` () =
+    let ring = ImaginaryStack.complex
+    let frame (seed: uint64) = Chip8Cow.create seed
+    let half = Doubled.make 0.5 0.0
+    let phase (theta: float) = Doubled.make (cos theta) (sin theta)
+    for phi in [ 0.0; System.Math.PI / 3.0; System.Math.PI / 2.0; System.Math.PI ] do
+        // the emulator's closed interferometer (the QSharpOracle construction, two frames as detectors)
+        let amp: AmplitudeEmu.Amp =
+            [ frame 0UL, ring.Mul(half, phase (-phi / 2.0))
+              frame 0UL, ring.Mul(half, phase (phi / 2.0))
+              frame 1UL, ring.Mul(half, phase (-phi / 2.0))
+              frame 1UL, ring.Negate(ring.Mul(half, phase (phi / 2.0))) ]
+        let emuProbs = amp |> AmplitudeEmu.merge |> AmplitudeEmu.bornProb
+        let emuZero = emuProbs |> List.filter (fun (f, _) -> f = frame 0UL) |> List.sumBy snd
+        let ws = MachZehnderWSet.closed phi
+        Assert.True(abs (probFor 0 ws - emuZero) < 1e-9, sprintf "phi=%f" phi)
+
+[<Fact>]
+let ``ORACLE 3 — the Q# treaty transcript: the WSet circuit lands inside the sampled grid's tolerance, row by row`` () =
+    let path = Path.Combine(repoRoot (), "src", "Core.QSharp.ReferenceOracle", "treaty-transcript.json")
+    let jobs = JsonDocument.Parse(File.ReadAllText path).RootElement.GetProperty "jobs"
+    let results = jobs.GetProperty("interferenceGrid").GetProperty("results").EnumerateArray() |> Seq.toArray
+    Assert.True(results.Length >= 6)
+    for res in results do
+        let isOpen = res.GetProperty("operation").GetString().EndsWith "Open"
+        let qsZero = res.GetProperty("qsharp").GetProperty("Zero").GetDouble()
+        let ws =
+            if isOpen then MachZehnderWSet.openArm ()
+            else
+                let p = res.GetProperty "phase"
+                MachZehnderWSet.closed (if p.ValueKind = JsonValueKind.Null then 0.0 else p.GetDouble())
+        Assert.True(abs (probFor 0 ws - qsZero) < 1e-3, res.GetProperty("id").GetString()) // sampled oracle: sampling tolerance


### PR DESCRIPTION
WSet<'K,'W> over any IStarRing — the ring-generic connection layer (ℤ/ℂ/ℝ≥0; GDL-anchored; one boundary-nonlinearity law). The Mach-Zehnder as a two-key WSet circuit, cross-checked against the analytic law (1e-12), AmplitudeEmu (1e-9), and Vera's Q# treaty transcript (sampling tolerance) — the literal ZSet↔quantum connection as a passing suite. B-1033: hexagonal inference port (own the interface; Zeta.Bayesian + dotnet/infer as adapters, theirs tests ours) + the four-plugin-systems convergence audit. 3012 green, 0 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)