### PR TITLE
feat(inference): the hexagonal port ships — IInferenceEngine ours; Zeta.Bayesian + Infer.NET adapters; theirs tests ours, 1e-6 agreement

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,6 +16,7 @@
          assertionless tests) that need a cleanup pass first.
          Version pinned here so the BACKLOG'd cleanup round can
          flip the switch by adding one ItemGroup line. -->
+    <PackageVersion Include="Microsoft.ML.Probabilistic.Compiler" Version="0.4.2504.701" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.19.0.132793" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/docs/backlog/P2/B-1033-hexagonal-inference-port-own-the-interface-zeta-bayesian-and-infer-net-as-adapters-plugin-system-convergence-aaron-2026-06-13.md
+++ b/docs/backlog/P2/B-1033-hexagonal-inference-port-own-the-interface-zeta-bayesian-and-infer-net-as-adapters-plugin-system-convergence-aaron-2026-06-13.md
@@ -2,7 +2,7 @@
 id: B-1033
 title: Hexagonal inference port — own the interface; Zeta.Bayesian + Infer.NET as the two adapters (theirs tests ours); plugin-system convergence audit
 priority: P2
-status: open
+status: in-progress
 tier: verification-substrate
 tags: [hexagonal, ports-adapters, infer-net, bayesian, ep, bp-16, plugins, convergence]
 created: 2026-06-13
@@ -43,3 +43,14 @@ interface the next plugin system MUST use instead of growing a fifth.
 
 Start gate: prior-art = hexagonal architecture (Cockburn 2005), Infer.NET docs (How to add a new
 factor / Compiler overview); deps: dotnet/infer NuGet (test-side only).
+
+## Progress (2026-06-13, same day)
+
+SHIPPED: the port (`IInferenceEngine` + neutral Gaussian model types in Core.Abstractions, house
+analyzer style); Adapter A (`ZetaBayesianEngine`, src/Bayesian/EngineAdapter.fs — deterministic by
+construction); Adapter B (`InferNetEngine`, tests/Tests.CSharp — Microsoft.ML.Probabilistic MIT
+package, TEST-SIDE only as planned); conformance: 4 port tests vs the analytic oracle (F#) +
+THEIRS-TESTS-OURS (C#): both adapters agree on every case to 1e-6 (single prior / two-prior
+fusion / equality chain). REMAINING: more case families (observed-value likelihoods, EP truncation
+cases through Ep.fs, loopy-graph honesty cases); the plugin-system convergence audit (the second
+half of this row).

--- a/docs/trajectories/sim-mea-cut-soft-substrate-shaders/RESUME.md
+++ b/docs/trajectories/sim-mea-cut-soft-substrate-shaders/RESUME.md
@@ -2,12 +2,42 @@
 
 Status: ACTIVE — operator-self-claimed (Aaron 2026-06-10/11, the two-night stream). This RESUME is the
 reload point so the pattern doesn't have to be held all at once ("losing it should be temporary").
-Last refreshed: 2026-06-13 (the greenfield wave folded in — #7771..#7775; prior waves below).
+Last refreshed: 2026-06-13 (the rings wave folded in — #7777..#7785; prior waves below).
 Current focus (Aaron): COLORSPACE ("I'll stay in colorspace") + the citizenship quartet + the hardware
 ladder (B-1024); Vera driving the Q# reference oracle; Max on universal primitives + root-declutter
 (B-1023 — expanded to the /db earn-promotion plan, GATED, "good but not urgent" per Aaron).
 
-## The 2026-06-13 GREENFIELD wave (#7771..#7775 — newest; read FIRST)
+## The 2026-06-13 RINGS wave (#7777..#7785 — newest; read FIRST)
+
+- **DRW CLIPS at edges** (#7777, B-1031 DONE — the reviewed treaty change): Kira + Viktor
+  pre-change reviews (GO with conditions, all folded BEFORE code); wrap-origin/clip-pixels
+  (COSMAC VIP) identical across F#/TS/C#/Rust; the new edge ROM locks right/bottom/corner/
+  color-plane clips AND the VF collision semantic (a marker drawn iff the edge draw did NOT
+  collide) AND n=0; the golden header carries the written DRW clause + VIP anchor (Viktor: the
+  behavior was unspecified and UNGATED before — now the treaty actually enforces it). En route:
+  owned main's RED (QSharpOracle helpers dropped by #7766 refactor — restored).
+- **ZERO SKIPPED TESTS** (#7781): the multi-tick property removed (a zombie — the unskipped
+  REFUTATION WITNESS carries its knowledge; resurrects with the signed-delta ClosureTable);
+  one audit finding FALSIFIED honestly (single-char grid cells).
+- **RecursiveSignedDelta SHIPS** (#7782, "lets do it"): TLC verified the spec's real Step at all
+  four seed weights FIRST (S1/S2/S3), then the combinator at its planned home — THE FEEDBACK CELL
+  CARRIES THE SIGNED DELTA, never the total (seed deltas join at their own tick); the refuted
+  multi-tick case passes BY CONSTRUCTION; retraction converges to exact zero (dip-and-recover).
+  Distinct forbidden inside the body — boundary only.
+- **THE THREE-RINGS THESIS** (#7782/#7783/#7785): ZSet↔quantum↔Infer.NET is ONE calculus over
+  different weight rings (GDL, Aji–McEliece 2000), with ONE boundary-nonlinearity law: Distinct
+  (ℤ) / measurement (ℂ) / EP-projection (ℝ≥0) — never inside the linear loop. Discoveries:
+  src/Bayesian ALREADY carries the Infer.NET shape (FactorGraph.runToFixpoint + real Ep.fs —
+  Minka's cavity→project→divide, ours). **WSet<'K,'W> shipped** (#7785) + THE THREE-ORACLE
+  MACH-ZEHNDER: one interferometer checked against the analytic law (1e-12), AmplitudeEmu (1e-9),
+  and Vera's Q# treaty transcript — passing.
+- **Filed:** B-1032 (ring demos; first one DONE) · B-1033 (hexagonal inference port — own
+  IInferenceEngine; Zeta.Bayesian + dotnet/infer as adapters, theirs tests ours; + the
+  four-plugin-systems convergence audit: PluginApi / MediaLines io / GeneratorRegistry /
+  MagneticPorts = one hub concept, map before a fifth grows).
+- Suite 3012, ZERO skipped. Six bug rounds + two treaty changes this arc.
+
+## The 2026-06-13 GREENFIELD wave (#7771..#7775 — older; read second)
 
 - **Round 3b** (#7771): writing the injection falsifier the test-gap audit asked for IMMEDIATELY
   found a LIVE hole — a hostile meta motto put live <script> through HtmlCssBinding's no-JS page

--- a/src/Bayesian/Bayesian.fsproj
+++ b/src/Bayesian/Bayesian.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="FactorGraph.fs" />
     <Compile Include="Ep.fs" />
     <Compile Include="BayesianAggregate.fs" />
+    <Compile Include="EngineAdapter.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bayesian/EngineAdapter.fs
+++ b/src/Bayesian/EngineAdapter.fs
@@ -1,0 +1,46 @@
+namespace Zeta.Bayesian
+
+open Zeta.Core.Abstractions
+
+/// ADAPTER A of the hexagonal inference port (B-1033): OUR engine (FactorGraph + Gaussian
+/// messages) behind the `IInferenceEngine` interface WE own. Deterministic by construction —
+/// `FactorGraph.passOnce` walks factors in id order, no ambient entropy anywhere (the
+/// determinism lint fences Core; this module inherits the discipline). Adapter B (dotnet/infer,
+/// Minka & Winn) implements the SAME port test-side; conformance cases run through both —
+/// theirs tests ours.
+type ZetaBayesianEngine() =
+
+    interface IInferenceEngine with
+        member _.Name = "zeta-bayesian"
+
+        member _.RunGaussian(model: GaussianModel, maxRounds: int, tolerance: float) : InferenceResult =
+            let algebra = Gaussian.algebra
+
+            // model -> our factor graph: priors first (factor ids 0..), then equality factors.
+            let g0 = FactorGraph.empty algebra
+
+            let withPriors =
+                model.Priors
+                |> Seq.indexed
+                |> Seq.fold
+                    (fun g (i, p) ->
+                        FactorGraph.addFactor i (Factor.prior p.Variable (Gaussian.ofMeanVariance p.Mean p.Variance)) g)
+                    g0
+
+            let graph =
+                model.Equalities
+                |> Seq.indexed
+                |> Seq.fold
+                    (fun g (i, e) ->
+                        FactorGraph.addFactor (Seq.length model.Priors + i) (Factor.equality algebra (List.ofSeq e.Variables)) g)
+                    withPriors
+
+            let final, rounds, converged =
+                FactorGraph.runToFixpoint Gaussian.distance tolerance maxRounds graph
+
+            let marginals =
+                [| for v in 0 .. model.VariableCount - 1 ->
+                       let m = FactorGraph.marginal v final
+                       GaussianMarginal(v, Gaussian.mean m, Gaussian.variance m) |]
+
+            InferenceResult(converged, rounds, marginals)

--- a/src/Core.Abstractions/EqualityFactor.cs
+++ b/src/Core.Abstractions/EqualityFactor.cs
@@ -1,0 +1,12 @@
+// Part of IInferenceEngine — THE HEXAGONAL INFERENCE PORT (B-1033). See IInferenceEngine.cs
+// for the port doctrine (we own the interface; Zeta.Bayesian + dotnet/infer are adapters;
+// conformance runs through BOTH — theirs tests ours).
+
+namespace Zeta.Core.Abstractions;
+
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+/// <summary>An equality factor: the listed variables are constrained equal (messages multiply).</summary>
+[StructLayout(LayoutKind.Auto)]
+public readonly record struct EqualityFactor(IReadOnlyList<int> Variables);

--- a/src/Core.Abstractions/GaussianMarginal.cs
+++ b/src/Core.Abstractions/GaussianMarginal.cs
@@ -1,0 +1,11 @@
+// Part of IInferenceEngine — THE HEXAGONAL INFERENCE PORT (B-1033). See IInferenceEngine.cs
+// for the port doctrine (we own the interface; Zeta.Bayesian + dotnet/infer are adapters;
+// conformance runs through BOTH — theirs tests ours).
+
+namespace Zeta.Core.Abstractions;
+
+using System.Runtime.InteropServices;
+
+/// <summary>One variable's posterior marginal.</summary>
+[StructLayout(LayoutKind.Auto)]
+public readonly record struct GaussianMarginal(int Variable, double Mean, double Variance);

--- a/src/Core.Abstractions/GaussianModel.cs
+++ b/src/Core.Abstractions/GaussianModel.cs
@@ -1,0 +1,13 @@
+// Part of IInferenceEngine — THE HEXAGONAL INFERENCE PORT (B-1033). See IInferenceEngine.cs
+// for the port doctrine (we own the interface; Zeta.Bayesian + dotnet/infer are adapters;
+// conformance runs through BOTH — theirs tests ours).
+
+namespace Zeta.Core.Abstractions;
+
+using System.Collections.Generic;
+
+/// <summary>The v1 model: a Gaussian factor graph in neutral terms (no engine vocabulary).</summary>
+public sealed record GaussianModel(
+    int VariableCount,
+    IReadOnlyList<GaussianPrior> Priors,
+    IReadOnlyList<EqualityFactor> Equalities);

--- a/src/Core.Abstractions/GaussianPrior.cs
+++ b/src/Core.Abstractions/GaussianPrior.cs
@@ -1,0 +1,11 @@
+// Part of IInferenceEngine — THE HEXAGONAL INFERENCE PORT (B-1033). See IInferenceEngine.cs
+// for the port doctrine (we own the interface; Zeta.Bayesian + dotnet/infer are adapters;
+// conformance runs through BOTH — theirs tests ours).
+
+namespace Zeta.Core.Abstractions;
+
+using System.Runtime.InteropServices;
+
+/// <summary>A Gaussian prior on one variable: variable index + (mean, variance).</summary>
+[StructLayout(LayoutKind.Auto)]
+public readonly record struct GaussianPrior(int Variable, double Mean, double Variance);

--- a/src/Core.Abstractions/IInferenceEngine.cs
+++ b/src/Core.Abstractions/IInferenceEngine.cs
@@ -1,0 +1,24 @@
+// IInferenceEngine — THE HEXAGONAL INFERENCE PORT (B-1033; Aaron 2026-06-13: "hexagonal the
+// Infer.NET types — make them follow OUR standards, own the interface, plug them in, and use
+// them to test ours; we have two impls"). WE own this interface; engines are adapters:
+//   Adapter A — Zeta.Bayesian (ours: FactorGraph/Message/Ep — DST-deterministic schedules).
+//   Adapter B — dotnet/infer (Minka & Winn's engine; MIT; TEST-SIDE only, never in Core).
+// Conformance cases run through BOTH adapters and must agree within stated tolerance — BP-16
+// made structural (theirs tests ours; Minka's engine is the senior oracle, ours is the one we
+// can fix). v1 scope is the GAUSSIAN LANE deliberately: priors + equality factors -> marginals —
+// expressible in both engines and hand-checkable analytically (precision-weighted products).
+// Our standards hold at the port: deterministic (fixed schedule, no ambient entropy), total
+// (failures are values, not exceptions), culture-invariant.
+
+namespace Zeta.Core.Abstractions;
+
+/// <summary>The port. Implementations MUST be deterministic for a fixed model (DST: same model,
+/// same marginals, byte-stable ordering by variable index).</summary>
+public interface IInferenceEngine
+{
+    /// <summary>Adapter name (for conformance reporting: which oracle said what).</summary>
+    string Name { get; }
+
+    /// <summary>Run Gaussian belief propagation to convergence (bounded) and read all marginals.</summary>
+    InferenceResult RunGaussian(GaussianModel model, int maxRounds, double tolerance);
+}

--- a/src/Core.Abstractions/InferenceResult.cs
+++ b/src/Core.Abstractions/InferenceResult.cs
@@ -1,0 +1,13 @@
+// Part of IInferenceEngine — THE HEXAGONAL INFERENCE PORT (B-1033). See IInferenceEngine.cs
+// for the port doctrine (we own the interface; Zeta.Bayesian + dotnet/infer are adapters;
+// conformance runs through BOTH — theirs tests ours).
+
+namespace Zeta.Core.Abstractions;
+
+using System.Collections.Generic;
+
+/// <summary>The run outcome — total: Converged=false is a VALUE, never a throw.</summary>
+public sealed record InferenceResult(
+    bool Converged,
+    int Rounds,
+    IReadOnlyList<GaussianMarginal> Marginals);

--- a/tests/Bayesian.Tests/BayesianTests.fs
+++ b/tests/Bayesian.Tests/BayesianTests.fs
@@ -128,3 +128,52 @@ let ``BayesianRateOp narrows credible interval as evidence accumulates`` () =
         let narrowWidth = lHi - lLo
         narrowWidth |> should be (lessThan wideWidth)
     }
+
+// ─── THE HEXAGONAL PORT, ADAPTER A (B-1033): conformance through IInferenceEngine ───
+// Cases are hand-checkable: combining Gaussians under equality = precision-weighted product
+// (tau = tau1 + tau2; mean = (tau1*mu1 + tau2*mu2)/tau). The same cases run through Adapter B
+// (dotnet/infer) in Tests.CSharp — theirs tests ours across the port WE own.
+
+open Zeta.Core.Abstractions
+
+[<Fact>]
+let ``PORT C1: a single prior round-trips — the marginal IS the prior`` () =
+    let engine = Zeta.Bayesian.ZetaBayesianEngine() :> IInferenceEngine
+    let model = GaussianModel(1, [| GaussianPrior(0, 3.0, 2.0) |], [||])
+    let r = engine.RunGaussian(model, 50, 1e-9)
+    Assert.True r.Converged
+    Assert.Equal(3.0, r.Marginals.[0].Mean, 9)
+    Assert.Equal(2.0, r.Marginals.[0].Variance, 9)
+
+[<Fact>]
+let ``PORT C2: two priors on one variable fuse as the precision-weighted product (the analytic oracle)`` () =
+    let engine = Zeta.Bayesian.ZetaBayesianEngine() :> IInferenceEngine
+    // N(0, 1) * N(4, 1) -> tau = 2, mean = 2, variance = 0.5
+    let model = GaussianModel(1, [| GaussianPrior(0, 0.0, 1.0); GaussianPrior(0, 4.0, 1.0) |], [||])
+    let r = engine.RunGaussian(model, 50, 1e-9)
+    Assert.True r.Converged
+    Assert.Equal(2.0, r.Marginals.[0].Mean, 9)
+    Assert.Equal(0.5, r.Marginals.[0].Variance, 9)
+
+[<Fact>]
+let ``PORT C3: an equality chain carries belief — var0's prior meets var2's prior and ALL marginals agree`` () =
+    let engine = Zeta.Bayesian.ZetaBayesianEngine() :> IInferenceEngine
+    // priors on 0 and 2; equality (0,1,2): every marginal = N(0,1)*N(4,1) fused = mean 2, var 0.5
+    let model =
+        GaussianModel(
+            3,
+            [| GaussianPrior(0, 0.0, 1.0); GaussianPrior(2, 4.0, 1.0) |],
+            [| EqualityFactor([| 0; 1; 2 |]) |])
+    let r = engine.RunGaussian(model, 100, 1e-9)
+    Assert.True r.Converged
+    for v in 0 .. 2 do
+        Assert.Equal(2.0, r.Marginals.[v].Mean, 6)
+        Assert.Equal(0.5, r.Marginals.[v].Variance, 6)
+
+[<Fact>]
+let ``PORT determinism: same model, same marginals, byte-stable order (the DST clause of the port contract)`` () =
+    let run () =
+        let engine = Zeta.Bayesian.ZetaBayesianEngine() :> IInferenceEngine
+        let model = GaussianModel(2, [| GaussianPrior(0, 1.0, 2.0); GaussianPrior(1, 5.0, 3.0) |], [| EqualityFactor([| 0; 1 |]) |])
+        (engine.RunGaussian(model, 100, 1e-9)).Marginals |> Seq.map (fun m -> m.Variable, m.Mean, m.Variance) |> List.ofSeq
+    Assert.Equal<(int * float * float) list>(run (), run ())

--- a/tests/Tests.CSharp/InferNetEngine.cs
+++ b/tests/Tests.CSharp/InferNetEngine.cs
@@ -1,0 +1,68 @@
+// THE HEXAGONAL PORT, ADAPTER B + CROSS-CONFORMANCE (B-1033, Aaron 2026-06-13): dotnet/infer
+// (Minka & Winn's Infer.NET, MIT, TEST-SIDE only) behind the IInferenceEngine interface WE own —
+// and the same Gaussian cases run through BOTH adapters: theirs tests ours. Divergence beyond
+// tolerance is a finding on one of the two engines (Minka's is the senior oracle).
+
+namespace Zeta.Tests.CSharp;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.ML.Probabilistic.Distributions;
+using Microsoft.ML.Probabilistic.Models;
+using Xunit;
+using Zeta.Core.Abstractions;
+
+/// <summary>Adapter B: Infer.NET behind our port. Lives in tests by design — the MIT engine
+/// never enters Core; it exists here to TEST ours.</summary>
+public sealed class InferNetEngine : IInferenceEngine
+{
+    public string Name => "infer-net";
+
+    public InferenceResult RunGaussian(GaussianModel model, int maxRounds, double tolerance)
+    {
+        var vars = new Variable<double>[model.VariableCount];
+        var priorsPerVar = new List<GaussianPrior>[model.VariableCount];
+        for (var v = 0; v < model.VariableCount; v++)
+        {
+            priorsPerVar[v] = new List<GaussianPrior>();
+        }
+
+        foreach (var p in model.Priors)
+        {
+            priorsPerVar[p.Variable].Add(p);
+        }
+
+        for (var v = 0; v < model.VariableCount; v++)
+        {
+            // first prior (or flat) defines the variable; further priors attach as constraints
+            var first = priorsPerVar[v].Count > 0
+                ? priorsPerVar[v][0]
+                : new GaussianPrior(v, 0.0, 1e8);
+            vars[v] = Variable.GaussianFromMeanAndVariance(first.Mean, first.Variance).Named($"v{v}");
+            foreach (var extra in priorsPerVar[v].Skip(1))
+            {
+                Variable.ConstrainEqualRandom(vars[v], Gaussian.FromMeanAndVariance(extra.Mean, extra.Variance));
+            }
+        }
+
+        foreach (var eq in model.Equalities)
+        {
+            for (var i = 1; i < eq.Variables.Count; i++)
+            {
+                Variable.ConstrainEqual(vars[eq.Variables[0]], vars[eq.Variables[i]]);
+            }
+        }
+
+        var engine = new InferenceEngine { ShowProgress = false, NumberOfIterations = maxRounds };
+        var marginals = new GaussianMarginal[model.VariableCount];
+        for (var v = 0; v < model.VariableCount; v++)
+        {
+            var g = engine.Infer<Gaussian>(vars[v]);
+            marginals[v] = new GaussianMarginal(v, g.GetMean(), g.GetVariance());
+        }
+
+        return new InferenceResult(Converged: true, Rounds: maxRounds, Marginals: marginals);
+    }
+}
+

--- a/tests/Tests.CSharp/InferenceEnginePortTests.cs
+++ b/tests/Tests.CSharp/InferenceEnginePortTests.cs
@@ -1,0 +1,51 @@
+// THE HEXAGONAL PORT, ADAPTER B + CROSS-CONFORMANCE (B-1033, Aaron 2026-06-13): dotnet/infer
+// (Minka & Winn's Infer.NET, MIT, TEST-SIDE only) behind the IInferenceEngine interface WE own —
+// and the same Gaussian cases run through BOTH adapters: theirs tests ours. Divergence beyond
+// tolerance is a finding on one of the two engines (Minka's is the senior oracle).
+
+namespace Zeta.Tests.CSharp;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.ML.Probabilistic.Distributions;
+using Microsoft.ML.Probabilistic.Models;
+using Xunit;
+using Zeta.Core.Abstractions;
+
+public sealed class InferenceEnginePortTests
+{
+    private static readonly int[] ChainVars = { 0, 1, 2 };
+
+    private static IEnumerable<(string Id, GaussianModel Model)> ConformanceCases()
+    {
+        yield return ("single-prior", new GaussianModel(
+            1, new[] { new GaussianPrior(0, 3.0, 2.0) }, Array.Empty<EqualityFactor>()));
+        yield return ("two-priors-fuse", new GaussianModel(
+            1, new[] { new GaussianPrior(0, 0.0, 1.0), new GaussianPrior(0, 4.0, 1.0) }, Array.Empty<EqualityFactor>()));
+        yield return ("equality-chain", new GaussianModel(
+            3,
+            new[] { new GaussianPrior(0, 0.0, 1.0), new GaussianPrior(2, 4.0, 1.0) },
+            new[] { new EqualityFactor(ChainVars) }));
+    }
+
+    [Fact]
+    public void TheirsTestsOursBothAdaptersAgreeOnEveryConformanceCase()
+    {
+        IInferenceEngine ours = new Zeta.Bayesian.ZetaBayesianEngine();
+        var theirs = new InferNetEngine();
+        foreach (var (id, model) in ConformanceCases())
+        {
+            var a = ours.RunGaussian(model, 200, 1e-10);
+            var b = theirs.RunGaussian(model, 200, 1e-10);
+            Assert.True(a.Converged, $"{id}: ours did not converge");
+            for (var v = 0; v < model.VariableCount; v++)
+            {
+                Assert.True(Math.Abs(a.Marginals[v].Mean - b.Marginals[v].Mean) < 1e-6,
+                    $"{id} v{v} mean: ours={a.Marginals[v].Mean} infer-net={b.Marginals[v].Mean}");
+                Assert.True(Math.Abs(a.Marginals[v].Variance - b.Marginals[v].Variance) < 1e-6,
+                    $"{id} v{v} var: ours={a.Marginals[v].Variance} infer-net={b.Marginals[v].Variance}");
+            }
+        }
+    }
+}

--- a/tests/Tests.CSharp/Tests.CSharp.csproj
+++ b/tests/Tests.CSharp/Tests.CSharp.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Bayesian\Bayesian.fsproj" />
     <ProjectReference Include="..\..\src\Core\Core.fsproj" />
     <ProjectReference Include="..\..\src\Core.CSharp\Core.CSharp.csproj" />
     <ProjectReference Include="..\..\src\Core.CSharp.ZetaId\Zeta.Core.CSharp.ZetaId.csproj" />
@@ -30,6 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.ML.Probabilistic.Compiler" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="YamlDotNet" />


### PR DESCRIPTION
B-1033 first slice complete: the port in Core.Abstractions (our standards — DST clause in the contract, totality, house style); ZetaBayesianEngine (Adapter A) green vs the analytic oracle; InferNetEngine (Adapter B — Microsoft.ML.Probabilistic, MIT, test-side only) behind the same port; THEIRS TESTS OURS: both adapters agree on every conformance case to 1e-6. F# 3013 + Bayesian 89 + C# 295 green, zero skipped. Remaining: richer case families + the plugin-convergence audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)