### PR TITLE
docs(research): the plugin-convergence audit — four systems, one port grammar (B-1033 audit half)

### DIFF
--- a/docs/backlog/P2/B-1033-hexagonal-inference-port-own-the-interface-zeta-bayesian-and-infer-net-as-adapters-plugin-system-convergence-aaron-2026-06-13.md
+++ b/docs/backlog/P2/B-1033-hexagonal-inference-port-own-the-interface-zeta-bayesian-and-infer-net-as-adapters-plugin-system-convergence-aaron-2026-06-13.md
@@ -54,3 +54,11 @@ THEIRS-TESTS-OURS (C#): both adapters agree on every case to 1e-6 (single prior 
 fusion / equality chain). REMAINING: more case families (observed-value likelihoods, EP truncation
 cases through Ep.fs, loopy-graph honesty cases); the plugin-system convergence audit (the second
 half of this row).
+
+## Progress 2 (2026-06-13, the audit half)
+
+DONE: the plugin-convergence audit — docs/research/2026-06-13-the-plugin-convergence-audit-*.md.
+Verdict: converge the VOCABULARY, not the implementations (ZetaId port names · the
+Live/Injected/Adapted/Mock ladder · the red-light glance form · findAdapter for what's-missing);
+the rule for system five stated; IInferenceEngine named the first customer (engine ZetaIds + a
+ladder-shaped resolution = the remaining follow-up alongside richer case families).

--- a/docs/research/2026-06-13-the-plugin-convergence-audit-four-plug-shaped-systems-one-port-grammar.md
+++ b/docs/research/2026-06-13-the-plugin-convergence-audit-four-plug-shaped-systems-one-port-grammar.md
@@ -1,0 +1,55 @@
+# The plugin-convergence audit — four plug-shaped systems, one port grammar (B-1033 second half)
+
+Aaron 2026-06-13: "we already have a plugin system, and they are set up — we might have multiple
+plugin systems that need to converge." Audited. We have FOUR, grown separately and honestly; the
+DV2 lens says they are one HUB concept with four satellites, and the audit's job is to name the
+shared grammar so the fifth system reuses it instead of growing.
+
+## The four, as they stand
+
+| system | the port (interface we own) | the adapter | resolution | nonconformance |
+|---|---|---|---|---|
+| **PluginApi/Harness** (operator plugins) | `IOperator`/`IStrictOperator`/`IAsyncOperator` + capability interfaces (C#, Abstractions) | `PluginOperatorAdapter` wraps a plugin into a circuit `Op` | capability checks ONCE at wiring (`asStrict`/`asAsync` probes) | wiring-time refusal |
+| **MediaLines io** (cartridge capabilities) | the `io` line: a ZetaId-named interface | host capability / door grant / toolbox piece | THE LADDER: Live → Injected → Adapted(via, from) → Mock | honest degradation (Mock = rehearsal; the red light shows it) |
+| **GeneratorRegistry** (content-addressed generators) | the ZetaId itself (name@version → 128-bit id) | the registered implementation per oracle language | `byId` lookup; version bump = NEW id (never silent) | dangling id = catalog-law test failure; collisions gated |
+| **MagneticPorts** (typed snap, kid-UX) | `Port.TypeId` (a ZetaId) | a `Piece` (two-faced: sink type → source type) | `compatible` (the magnet) + `findAdapter` (the missing piece) | REPULSION — visible, physical, constructive refusal |
+| *(new, today)* **IInferenceEngine** | the Gaussian port (Abstractions) | ZetaBayesianEngine / InferNetEngine | direct construction (no resolution yet) | conformance-test divergence |
+
+## The shared grammar (what converges)
+
+Every system above is the same five-part sentence:
+1. **A port we OWN**, named by a stable identity (interface type or ZetaId — and the ZetaId IS
+   the more general one: content-addressed, version-bumped, language-neutral).
+2. **Adapters** supplying the port (ours and theirs; the hexagonal rule — theirs never enters Core).
+3. **A resolution step** binding port → adapter against what the host actually has.
+4. **An honesty register on the binding** — this is the part only MediaLines does fully (the
+   ladder + the red light: Live/Adapted/Mock VISIBLE), and every other system should inherit:
+   a plugin that bound via a capability probe, a generator that resolved by id, an inference
+   engine that's the mock — each should be able to SAY so in one glance form.
+5. **A refusal mode that teaches** — MagneticPorts does this best (repulsion + the missing-piece
+   suggestion); PluginApi refuses at wiring; the registry fails a test; the port grammar should
+   make "what piece is missing" a standard answer, not a per-system invention.
+
+## The convergence verdict (what to do, what NOT to do)
+
+- **CONVERGE the vocabulary, not the implementations.** The four runtimes serve different physics
+  (process-level operators vs text-format capabilities vs id lookup vs pixel snapping) — merging
+  code would be unearned coupling. What converges is the GRAMMAR: ZetaId as the universal port
+  name; the Live/Injected/Adapted/Mock LADDER as the universal binding result; the red-light
+  glance form as the universal honesty register; findAdapter as the universal missing-piece
+  answer. (Interfaces are free; the rules of the game are interfaces.)
+- **The rule for system five:** new plug-shaped surfaces MUST name their port by ZetaId, return a
+  ladder-shaped binding, render its light, and answer "what's missing" via the toolbox — or carve
+  an explicit exception. IInferenceEngine is the first customer: its adapters should register
+  ZetaIds (engine.zeta-bayesian / engine.infer-net) and its construction should become a ladder
+  resolution (the named follow-up on B-1033).
+- Beacon: Cockburn's hexagonal architecture (ports/adapters); Fowler's plugin pattern; OSGi/MEF
+  as the cautionary maximal versions we are NOT building (capability ladders without the
+  framework weight).
+
+## Pointers
+
+- `PluginApi.fs`/`PluginHarness.fs` · `MediaLines` (resolveIoWith/bindingsReport/bindingLight) ·
+  `GeneratorRegistry` (idOf/collisions) · `MagneticPorts` (compatible/findAdapter) ·
+  `IInferenceEngine` (the first customer of the converged grammar) · B-1033 (this closes its
+  audit half; the engine-ZetaId + ladder follow-up stays on the row)


### PR DESCRIPTION
PluginApi, MediaLines io, GeneratorRegistry, MagneticPorts (+ IInferenceEngine) mapped onto one five-part grammar. Verdict: converge the vocabulary, not the implementations — ZetaId port names, the binding ladder, the red-light glance form, findAdapter for what's-missing; the rule for system five; IInferenceEngine named first customer. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)