### PR TITLE
docs(universal): universal/port.md — the plug grammar filed as a universal shape (extension.md is the senior half)

### DIFF
--- a/docs/backlog/P2/B-1033-hexagonal-inference-port-own-the-interface-zeta-bayesian-and-infer-net-as-adapters-plugin-system-convergence-aaron-2026-06-13.md
+++ b/docs/backlog/P2/B-1033-hexagonal-inference-port-own-the-interface-zeta-bayesian-and-infer-net-as-adapters-plugin-system-convergence-aaron-2026-06-13.md
@@ -62,3 +62,5 @@ Verdict: converge the VOCABULARY, not the implementations (ZetaId port names · 
 Live/Injected/Adapted/Mock ladder · the red-light glance form · findAdapter for what's-missing);
 the rule for system five stated; IInferenceEngine named the first customer (engine ZetaIds + a
 ladder-shaped resolution = the remaining follow-up alongside richer case families).
+
+## Progress 3 (2026-06-13): the grammar filed as universal/port.md (Aaron's "smells like universal interfaces" — it was; extension.md is the senior half). Remaining: engine ZetaIds + ladder resolution for IInferenceEngine; richer case families.

--- a/docs/research/2026-06-13-the-plugin-convergence-audit-four-plug-shaped-systems-one-port-grammar.md
+++ b/docs/research/2026-06-13-the-plugin-convergence-audit-four-plug-shaped-systems-one-port-grammar.md
@@ -53,3 +53,12 @@ Every system above is the same five-part sentence:
   `GeneratorRegistry` (idOf/collisions) · `MagneticPorts` (compatible/findAdapter) ·
   `IInferenceEngine` (the first customer of the converged grammar) · B-1033 (this closes its
   audit half; the engine-ZetaId + ladder follow-up stays on the row)
+
+## Addendum (same day) — Aaron: "we have universal interfaces too; this smells like that"
+
+Correct, and SENIOR: `universal/extension.md` already carried Probe/Zero/Vectors — the resolution,
+the honest zero-case binding, and the conformance halves of this grammar, written before the audit.
+The verdict therefore lands where it belongs: the converged vocabulary is now a UNIVERSAL SHAPE —
+[`universal/port.md`](../../universal/port.md) (Name/Adapters/Ladder/Light/Missing, cross-anchored
+to extension.md) — not a research-doc convention. The rule for system five becomes: implement
+universal/port, or carve the exception.

--- a/universal/port.md
+++ b/universal/port.md
@@ -1,0 +1,49 @@
+# universal/port — Universal Port Interface (plug-shaped systems, one grammar)
+
+> **Universal Port Interface** — the universal SHAPE of every plug-shaped surface: a **port we
+> OWN** named by stable identity (ZetaId), **adapters** supplying it (theirs never in Core), a
+> **resolution ladder** binding port→adapter against what the host actually has
+> (Live → Injected → Adapted(via, from) → Mock), an **honesty register on the binding** (the red
+> light: `[REC ●]`/`[off ○]` — a binding's truth is always visible), and a **refusal that
+> teaches** (repulsion + the missing piece via `findAdapter`, never a bare no).
+
+Aaron 2026-06-13: *"we have universal interfaces too — this smells like that."* Correct, and
+senior: the plugin-convergence audit (docs/research/2026-06-13-the-plugin-convergence-audit-*)
+found four plug-shaped systems sharing one grammar — and that grammar was already living here:
+[`universal/extension.md`](extension.md)'s **Probe** is this port's resolution, its **Zero** is
+this port's Mock ("not yet," never a crash), its **Vectors** are this port's conformance cases.
+This file names the rest of the shape so the next plug-shaped system reuses it instead of growing
+a sixth. (Interfaces are free; the rules of the game are interfaces.)
+
+## The contract (pure shape)
+
+- **`Name`** — the port's stable identity is a **ZetaId** (content-addressed, version-bumped —
+  never silent; `GeneratorRegistry.idOf` is the mint).
+- **`Adapters`** — implementations register against the Name; OUR engine and THEIR engine are
+  peers behind it (hexagonal: the external one never enters Core; it exists to TEST ours —
+  conformance cases run through both, divergence is a finding).
+- **`Ladder`** — resolution returns Live | Injected | Adapted(viaPiece, fromCapability) | Mock,
+  in that order; Adapted carries its provenance IN the value; absence is Mock, never an error
+  (the expansion law for capabilities).
+- **`Light`** — every binding renders its red-light glance form; a recording-capable binding
+  without its light shown is a consent violation (manifesto §6), and a Mock says "rehearsal —
+  nothing real is heard."
+- **`Missing`** — when two ends repel, the answer is the toolbox piece that would complete the
+  flow (`findAdapter`), or the honest gap — constructive refusal, the GraphEdit feel.
+
+## Instances (running)
+
+| system | Name | Ladder | Light | Missing |
+|---|---|---|---|---|
+| MediaLines io (cartridges) | io line ZetaId | resolveIoWith (full ladder) | bindingLight ✓ | toolbox adapters ✓ |
+| MagneticPorts (kid UX) | Port.TypeId | compatible/snap | repulsion is the light | findAdapter ✓ |
+| GeneratorRegistry | the ZetaId itself | byId (Live-or-dangling) | catalog-law test | collisions() gate |
+| PluginApi/Harness | capability interfaces | wiring-time probes | (inherit: add the light) | (inherit) |
+| IInferenceEngine (newest) | (follow-up: engine ZetaIds) | (follow-up: ladder resolution) | (inherit) | conformance divergence |
+
+## Pointers
+
+- [`universal/extension.md`](extension.md) — Probe/Zero/Vectors (the senior half of this shape)
+- `src/Core/MediaLines.fs` (the fullest instance) · `MagneticPorts.findAdapter` ·
+  `GeneratorRegistry` · `IInferenceEngine` (first new customer)
+- docs/research/2026-06-13-the-plugin-convergence-audit-*.md — the audit this file crystallizes


### PR DESCRIPTION
Aaron caught it: the convergence grammar was universal/ all along — extension.md's Probe/Zero/Vectors are the senior half. universal/port.md files the rest: Name (ZetaId) / Adapters / Ladder / Light / Missing, with the instance table and the rule for system five. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)