### PR TITLE
feat(inference): InferenceLadder — universal/port's first customer complete

### DIFF
--- a/docs/backlog/P2/B-1033-hexagonal-inference-port-own-the-interface-zeta-bayesian-and-infer-net-as-adapters-plugin-system-convergence-aaron-2026-06-13.md
+++ b/docs/backlog/P2/B-1033-hexagonal-inference-port-own-the-interface-zeta-bayesian-and-infer-net-as-adapters-plugin-system-convergence-aaron-2026-06-13.md
@@ -64,3 +64,5 @@ the rule for system five stated; IInferenceEngine named the first customer (engi
 ladder-shaped resolution = the remaining follow-up alongside richer case families).
 
 ## Progress 3 (2026-06-13): the grammar filed as universal/port.md (Aaron's "smells like universal interfaces" — it was; extension.md is the senior half). Remaining: engine ZetaIds + ladder resolution for IInferenceEngine; richer case families.
+
+## Progress 4 (2026-06-13): InferenceLadder shipped — engine ZetaIds minted (zeta-bayesian/infer-net/mock-flat), ladder resolution (Live/Injected/Mock; Adapted carved when an engine-adapter piece exists), the red light, and the HONEST Mock (flat marginals, Converged=false — a rehearsal that cannot masquerade). universal/port instance row complete. Remaining: richer case families only.

--- a/src/Core/ComplexityRegistry.fs
+++ b/src/Core/ComplexityRegistry.fs
@@ -95,6 +95,9 @@ module ComplexityRegistry =
               ("shape.exchange-worldlines", "draw"), c "O(crossings·strands)" "O(strands)" Derived // the braid drawn as spacetime: strands + one event diamond per exchange
               ("shape.kitaev-chain", "draw"), c "O(sites)" "O(sites)" Derived // two panels, one arc per pairing; the end modes are the two strokes the topological panel leaves unpaired
               ("shape.crossing", "draw"), c "O(1)" "O(1)" Derived // THE ATOM: two strands, one crossing — constant everything; every braided shape is a word in this generator
+              ("engine.zeta-bayesian", "run"), c "O(rounds·factors)" "O(vars+factors)" Derived // BP passes over the graph until moved < tol
+              ("engine.infer-net", "run"), c "O(rounds·factors)" "O(model)" Derived // Minka's engine behind OUR port (test-side adapter); cost shape mirrors ours by design
+              ("engine.mock-flat", "run"), c "O(vars)" "O(vars)" Derived // the REHEARSAL engine: flat marginals, Converged=false — the ladder's honest Mock rung
               ("binding.html-css", "render"), c "O(entries·pixels)" "O(output)" Derived
               ("sim.wave-interference", "pattern"), c "O(w·h·sources)" "O(w·h)" Derived
               ("viz.adinkra", "render"), c "O(nodes)" "O(nodes)" Derived

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -227,6 +227,7 @@
     <Compile Include="ZetaMax.fs" />
     <Compile Include="Chip9Phys.fs" />
     <Compile Include="WSet.fs" />
+    <Compile Include="InferenceLadder.fs" />
     <Compile Include="TimeGen.fs" />
     <Compile Include="Braid.fs" />
     <Compile Include="MediaLines.fs" />

--- a/src/Core/GeneratorRegistry.fs
+++ b/src/Core/GeneratorRegistry.fs
@@ -87,6 +87,9 @@ module GeneratorRegistry =
           register "shape.exchange-worldlines" 1
           register "shape.kitaev-chain" 1
           register "shape.crossing" 1
+          register "engine.zeta-bayesian" 1
+          register "engine.infer-net" 1
+          register "engine.mock-flat" 1
           register "binding.html-css" 1
           register "sim.wave-interference" 1
           register "viz.adinkra" 1

--- a/src/Core/InferenceLadder.fs
+++ b/src/Core/InferenceLadder.fs
@@ -1,0 +1,50 @@
+namespace Zeta.Core
+
+open Zeta.Core.Abstractions
+
+/// InferenceLadder — `universal/port` implemented for the inference port (B-1033 follow-up; the
+/// FIRST CUSTOMER of the converged plug grammar). Name = engine ZetaIds on the shelf
+/// (engine.zeta-bayesian / engine.infer-net / engine.mock-flat); Ladder = Live → Injected → Mock
+/// (no Adapted rung yet — an engine-to-engine adapter piece has no instance; carve it when one
+/// exists, never speculatively); Light = the red-light glance form; Missing = the registered ids
+/// the host could install. The Mock is HONEST: flat marginals with Converged=false — a rehearsal
+/// engine that can never masquerade as inference (the value says so).
+[<RequireQualifiedAccess>]
+module InferenceLadder =
+
+    /// The rehearsal engine — the ladder's Mock rung: flat (uninformative) marginals,
+    /// Converged = false ALWAYS. Nothing real was inferred and the result says so.
+    type MockFlatEngine() =
+        interface IInferenceEngine with
+            member _.Name = "mock-flat"
+            member _.RunGaussian(model, _maxRounds, _tolerance) =
+                let flat = [| for v in 0 .. model.VariableCount - 1 -> GaussianMarginal(v, 0.0, 1e8) |]
+                InferenceResult(false, 0, flat)
+
+    /// An engine binding, ladder-shaped (mirrors MediaLines.IoBinding — the universal grammar).
+    type EngineBinding =
+        | Live of zetaId: string * engine: IInferenceEngine
+        | Injected of zetaId: string * engine: IInferenceEngine
+        | Mock of requestedZetaId: string * engine: IInferenceEngine
+
+    /// Resolve a requested engine ZetaId against the host's live factories and the door's grants.
+    /// Total: absent everywhere ⇒ the rehearsal engine, never an error (the expansion law).
+    let resolve
+        (hostLive: Map<string, unit -> IInferenceEngine>)
+        (granted: Map<string, unit -> IInferenceEngine>)
+        (zetaId: string)
+        : EngineBinding =
+        match Map.tryFind zetaId hostLive with
+        | Some make -> Live(zetaId, make ())
+        | None ->
+            match Map.tryFind zetaId granted with
+            | Some make -> Injected(zetaId, make ())
+            | None -> Mock(zetaId, MockFlatEngine() :> IInferenceEngine)
+
+    /// THE LIGHT (universal/port `Light`): the binding's truth in one glance —
+    /// `[REC ●]` something real runs; `[off ○]` rehearsal, nothing real is inferred.
+    let light (b: EngineBinding) : string =
+        match b with
+        | Live(zid, e) -> sprintf "[REC ●] inference LIVE %s (%s)" e.Name zid
+        | Injected(zid, e) -> sprintf "[REC ●] inference INJECTED %s (%s)" e.Name zid
+        | Mock(zid, _) -> sprintf "[off ○] inference MOCK for %s (rehearsal — nothing real is inferred; Converged=false by construction)" zid

--- a/tests/Bayesian.Tests/BayesianTests.fs
+++ b/tests/Bayesian.Tests/BayesianTests.fs
@@ -177,3 +177,26 @@ let ``PORT determinism: same model, same marginals, byte-stable order (the DST c
         let model = GaussianModel(2, [| GaussianPrior(0, 1.0, 2.0); GaussianPrior(1, 5.0, 3.0) |], [| EqualityFactor([| 0; 1 |]) |])
         (engine.RunGaussian(model, 100, 1e-9)).Marginals |> Seq.map (fun m -> m.Variable, m.Mean, m.Variance) |> List.ofSeq
     Assert.Equal<(int * float * float) list>(run (), run ())
+
+// ─── the inference LADDER (universal/port's first customer — B-1033 follow-up) ───
+
+[<Fact>]
+let ``LADDER: a live engine binds Live with its light ON; an absent one binds the HONEST Mock (rehearsal, Converged=false)`` () =
+    let zid = GeneratorRegistry.idOf "engine.zeta-bayesian" 1
+    let live = Map.ofList [ zid, fun () -> Zeta.Bayesian.ZetaBayesianEngine() :> IInferenceEngine ]
+    match InferenceLadder.resolve live Map.empty zid with
+    | InferenceLadder.Live(_, e) ->
+        Assert.Equal("zeta-bayesian", e.Name)
+        Assert.Contains("[REC ●]", InferenceLadder.light (InferenceLadder.resolve live Map.empty zid))
+    | other -> Assert.True(false, sprintf "expected Live, got %A" other)
+    // absent everywhere: the rehearsal engine — flat marginals, NEVER converged
+    let wanted = GeneratorRegistry.idOf "engine.infer-net" 1
+    match InferenceLadder.resolve live Map.empty wanted with
+    | InferenceLadder.Mock(_, e) ->
+        let r = e.RunGaussian(GaussianModel(2, [| GaussianPrior(0, 3.0, 1.0) |], [||]), 10, 1e-9)
+        Assert.False r.Converged // the mock cannot masquerade as inference
+        Assert.Contains("[off ○]", InferenceLadder.light (InferenceLadder.resolve live Map.empty wanted))
+    | other -> Assert.True(false, sprintf "expected Mock, got %A" other)
+    // and all three engine ids are minted on the shelf, collision-free
+    for name in [ "engine.zeta-bayesian"; "engine.infer-net"; "engine.mock-flat" ] do
+        Assert.True(GeneratorRegistry.byName name |> Option.isSome)

--- a/universal/port.md
+++ b/universal/port.md
@@ -39,7 +39,7 @@ a sixth. (Interfaces are free; the rules of the game are interfaces.)
 | MagneticPorts (kid UX) | Port.TypeId | compatible/snap | repulsion is the light | findAdapter ✓ |
 | GeneratorRegistry | the ZetaId itself | byId (Live-or-dangling) | catalog-law test | collisions() gate |
 | PluginApi/Harness | capability interfaces | wiring-time probes | (inherit: add the light) | (inherit) |
-| IInferenceEngine (newest) | (follow-up: engine ZetaIds) | (follow-up: ladder resolution) | (inherit) | conformance divergence |
+| IInferenceEngine (newest) | engine.* ZetaIds ✓ | InferenceLadder.resolve ✓ (Live/Injected/Mock; Adapted carved-when-instanced) | light ✓ (Mock = "nothing real is inferred") | conformance divergence + the honest Mock (Converged=false by construction) |
 
 ## Pointers
 


### PR DESCRIPTION
Engine ZetaIds minted + cost-declared; ladder resolution (Live/Injected/Mock — Adapted carved only when an instance exists); the red light per binding; the honest Mock (flat marginals, Converged=false by construction — a rehearsal that cannot masquerade). universal/port's IInferenceEngine row complete; B-1033 remaining: richer case families only. Bayesian 90 + F# 3013 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)