### PR TITLE
feat(sync): IBLT room reconciliation (O(|Δ|), BP-peeled, honest Partial) + Rodney's razor applied

### DIFF
--- a/docs/research/2026-06-13-infer-net-circuits-minka-ep-factor-graphs-the-third-ring-of-one-circuit-calculus.md
+++ b/docs/research/2026-06-13-infer-net-circuits-minka-ep-factor-graphs-the-third-ring-of-one-circuit-calculus.md
@@ -32,7 +32,7 @@ the same one the quantum answer named yesterday:
 | ℝ≥0 (or log-semiring) | factor graph / sum-product | probabilities (messages) | **EP projection** (moment-match to the family) |
 
 Three rings, ONE calculus (the GDL says so with a proof); three boundary nonlinearities, one
-discipline — the nonlinear step never lives inside the linear loop. Minka's EP projection is to
+discipline — ENFORCED SEPARATELY per engine (no generic code enforcement; Rodney 2026-06-13: the connection is demonstrated, not shared-coded) — the nonlinear step never lives inside the linear loop. Minka's EP projection is to
 inference what Distinct is to DBSP and measurement is to quantum: the lossy step, quarantined at
 the boundary (EP literally alternates linear message products with a projection — and the
 α-divergence paper is the knob between them).

--- a/docs/research/2026-06-13-signed-delta-ships-tlc-verified-and-the-zset-quantum-circuit-bridge.md
+++ b/docs/research/2026-06-13-signed-delta-ships-tlc-verified-and-the-zset-quantum-circuit-bridge.md
@@ -39,6 +39,9 @@ from ℤ to any commutative ring 'W (we already carry `Semiring`/`ProbabilitySem
 and a quantum circuit is the SAME `Circuit` shape with 'W = ℂ and the operator set restricted to
 norm-preserving (unitary) maps. The Distinct-at-the-boundary discipline we enforce for correctness
 is literally the measurement-at-the-boundary discipline quantum mechanics enforces by law.
+(Razor note 2026-06-13: ONE discipline, enforced SEPARATELY per engine — no generic enforcement
+exists in code; the law lives in three review conventions and this prose. A shared boundary-typed
+seam is the upgrade if drift ever appears.)
 
 HONEST LIMITS, stated: (a) unitarity is NOT free — circuit composition preserves linearity, not
 norm; a quantum lane needs the operator set gated (the acceptance-gate pattern applies); (b) this

--- a/src/Core/ComplexityRegistry.fs
+++ b/src/Core/ComplexityRegistry.fs
@@ -98,6 +98,8 @@ module ComplexityRegistry =
               ("engine.zeta-bayesian", "run"), c "O(rounds·factors)" "O(vars+factors)" Derived // BP passes over the graph until moved < tol
               ("engine.infer-net", "run"), c "O(rounds·factors)" "O(model)" Derived // Minka's engine behind OUR port (test-side adapter); cost shape mirrors ours by design
               ("engine.mock-flat", "run"), c "O(vars)" "O(vars)" Derived // the REHEARSAL engine: flat marginals, Converged=false — the ladder's honest Mock rung
+              ("sketch.iblt", "build"), c "O(n·k)" "O(cells)" Derived // n keys, k buckets each; cells sized to the DIFFERENCE, not the set
+              ("sketch.iblt", "reconcile"), c "O(|Δ|·k)" "O(cells)" Derived // subtract is O(cells); peeling touches each difference key k times — the whole point
               ("binding.html-css", "render"), c "O(entries·pixels)" "O(output)" Derived
               ("sim.wave-interference", "pattern"), c "O(w·h·sources)" "O(w·h)" Derived
               ("viz.adinkra", "render"), c "O(nodes)" "O(nodes)" Derived

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -226,7 +226,7 @@
     <Compile Include="SwarmBoardAnsi.fs" />
     <Compile Include="ZetaMax.fs" />
     <Compile Include="Chip9Phys.fs" />
-    <Compile Include="WSet.fs" />
+    <Compile Include="IbltReconcile.fs" />
     <Compile Include="InferenceLadder.fs" />
     <Compile Include="TimeGen.fs" />
     <Compile Include="Braid.fs" />

--- a/src/Core/GeneratorRegistry.fs
+++ b/src/Core/GeneratorRegistry.fs
@@ -90,6 +90,7 @@ module GeneratorRegistry =
           register "engine.zeta-bayesian" 1
           register "engine.infer-net" 1
           register "engine.mock-flat" 1
+          register "sketch.iblt" 1
           register "binding.html-css" 1
           register "sim.wave-interference" 1
           register "viz.adinkra" 1

--- a/src/Core/IbltReconcile.fs
+++ b/src/Core/IbltReconcile.fs
@@ -1,0 +1,108 @@
+namespace Zeta.Core
+
+/// IbltReconcile — **O(|Δ|) set reconciliation between rooms** (Aaron 2026-06-13: "yep lets do
+/// this" — the named slice from the fingerprint↔factor-graph capture). An Invertible Bloom
+/// Lookup Table (Goodrich & Mitzenmacher 2011): each side summarizes its key set into m cells
+/// (count, keySum, hashSum) under k deterministic hash functions; SUBTRACT the two tables and the
+/// difference table encodes exactly the symmetric difference; PEEL pure cells to recover it.
+///
+/// THE PEELING IS BELIEF PROPAGATION WITH HARD MESSAGES — the same decoder family as LDPC
+/// (Gallager 1962) and fountain codes (Luby): a "pure" cell is a factor with one unresolved
+/// neighbor; resolving it sends a hard message that may purify others. This module is the
+/// meeting point of our forward fingerprints and our inverse factor graphs, running as code.
+///
+/// Disciplines: DST (SplitMix64 with FIXED seeds — same sets, same cells, byte-stable);
+/// exact integers (XOR sums, no floats); Result-over-exception (an undersized table yields
+/// `Partial` — the recovered prefix plus the honest flag — NEVER a wrong answer or a throw);
+/// O(|Δ|) decode (cells ~ 1.5–2× |Δ|, k=3 — the standard regime).
+[<RequireQualifiedAccess>]
+module IbltReconcile =
+
+    /// One cell: how many keys landed here (signed after subtraction), XOR of keys, XOR of key-hashes.
+    type Cell = { Count: int; KeySum: uint64; HashSum: uint64 }
+
+    /// The table: cells + the fixed geometry (cells.Length, k) — both sides MUST agree on geometry.
+    type Table = { Cells: Cell[]; K: int }
+
+    let private emptyCell = { Count = 0; KeySum = 0UL; HashSum = 0UL }
+
+    // deterministic mixers (SplitMix64 family; fixed seeds = the DST treaty)
+    let private mix (seed: uint64) (z0: uint64) : uint64 =
+        let z = (z0 ^^^ seed) + 0x9E3779B97F4A7C15UL
+        let z = (z ^^^ (z >>> 30)) * 0xBF58476D1CE4E5B9UL
+        let z = (z ^^^ (z >>> 27)) * 0x94D049BB133111EBUL
+        z ^^^ (z >>> 31)
+
+    /// The check-hash guarding purity (seed disjoint from bucket seeds).
+    let private checkHash (key: uint64) : uint64 = mix 0xC0FFEEUL key
+
+    /// The k bucket indices for a key — PARTITIONED sub-tables (the standard IBLT geometry:
+    /// segment i gets one bucket, so a key's k cells are DISTINCT by construction; the naive
+    /// k-hashes-over-one-range version let two hashes land on the same cell, double-XORing the
+    /// key into it — which CANCELS it and strands the peeling; caught by the first test run).
+    let private buckets (k: int) (cells: int) (key: uint64) : int list =
+        let seg = max 1 (cells / k)
+        [ for i in 0 .. k - 1 -> i * seg + int (mix (uint64 (0xB000 + i)) key % uint64 seg) ]
+
+    /// Build a table from a key set. Geometry: `cells` should be ≥ ~2× the EXPECTED difference
+    /// (not the set size — that is the whole point); k = 3 is the standard regime.
+    let build (cells: int) (k: int) (keys: seq<uint64>) : Table =
+        let arr = Array.create (max 1 cells) emptyCell
+        for key in keys do
+            for b in buckets k arr.Length key do
+                let c = arr.[b]
+                arr.[b] <- { Count = c.Count + 1; KeySum = c.KeySum ^^^ key; HashSum = c.HashSum ^^^ checkHash key }
+        { Cells = arr; K = k }
+
+    /// Cell-wise subtraction: the result encodes the symmetric difference of the two key sets
+    /// (shared keys cancel exactly — XOR and count both annihilate).
+    let subtract (a: Table) (b: Table) : Table =
+        { a with
+            Cells =
+                Array.init a.Cells.Length (fun i ->
+                    { Count = a.Cells.[i].Count - b.Cells.[i].Count
+                      KeySum = a.Cells.[i].KeySum ^^^ b.Cells.[i].KeySum
+                      HashSum = a.Cells.[i].HashSum ^^^ b.Cells.[i].HashSum }) }
+
+    /// The decode outcome — total and honest: `Partial` carries what WAS recovered plus the fact
+    /// that cells remain (undersized table / hash collision residue); never a wrong answer.
+    type Reconciliation =
+        | Decoded of onlyInA: uint64 list * onlyInB: uint64 list
+        | Partial of onlyInA: uint64 list * onlyInB: uint64 list * cellsRemaining: int
+
+    /// PEEL the difference table (BP with hard messages): a pure cell (count ±1 and the check
+    /// hash matches its keySum) yields one key for one side; remove it everywhere; repeat until
+    /// the table empties (Decoded) or no pure cell remains (Partial — honest).
+    let peel (diff: Table) : Reconciliation =
+        let arr = Array.copy diff.Cells
+        let onlyA = ResizeArray<uint64>()
+        let onlyB = ResizeArray<uint64>()
+
+        let isPure (c: Cell) =
+            (c.Count = 1 || c.Count = -1) && checkHash c.KeySum = c.HashSum
+
+        let remove (key: uint64) (sign: int) =
+            for b in buckets diff.K arr.Length key do
+                let c = arr.[b]
+                arr.[b] <- { Count = c.Count - sign; KeySum = c.KeySum ^^^ key; HashSum = c.HashSum ^^^ checkHash key }
+
+        let mutable progressing = true
+        while progressing do
+            progressing <- false
+            for i in 0 .. arr.Length - 1 do
+                let c = arr.[i]
+                if isPure c then
+                    let key = c.KeySum
+                    if c.Count = 1 then onlyA.Add key else onlyB.Add key
+                    remove key c.Count
+                    progressing <- true
+
+        let remaining = arr |> Array.filter (fun c -> c.Count <> 0 || c.KeySum <> 0UL || c.HashSum <> 0UL) |> Array.length
+        let a = onlyA |> List.ofSeq |> List.sort
+        let b = onlyB |> List.ofSeq |> List.sort
+        if remaining = 0 then Decoded(a, b) else Partial(a, b, remaining)
+
+    /// The whole protocol in one call: each room builds, one subtract, one peel — O(|Δ|) wire
+    /// cost (the tables, sized to the difference) and O(|Δ|) decode.
+    let reconcile (cells: int) (k: int) (roomA: seq<uint64>) (roomB: seq<uint64>) : Reconciliation =
+        peel (subtract (build cells k roomA) (build cells k roomB))

--- a/tests/Bayesian.Tests/BayesianTests.fs
+++ b/tests/Bayesian.Tests/BayesianTests.fs
@@ -233,25 +233,17 @@ let ``DAMPING never breaks the easy case: on a TREE, damped agrees with undamped
         Assert.Equal(undamped.Marginals.[v].Mean, damped.Marginals.[v].Mean, 6)
         Assert.Equal(undamped.Marginals.[v].Variance, damped.Marginals.[v].Variance, 6)
 
-// ─── THE THIRD RING: discrete sum-product as a WSet circuit vs Zeta.Bayesian (the GDL instance) ───
-// Closes the three-rings table (B-1032): ℤ=DBSP, ℂ=Mach-Zehnder, ℝ≥0=THIS. Aji-McEliece 2000:
-// belief propagation IS a semiring circuit. Two independent engines (WSet over the probability
-// semiring vs our FactorGraph on a 2-state Bernoulli-ish discrete message), one marginal.
+// ─── THE THIRD RING: discrete sum-product over the ℝ semiring vs the analytic marginal ───
+// The GDL instance (Aji-McEliece 2000) demonstrated with the RING DIRECTLY — no connective type
+// (Rodney's razor 2026-06-13: WSet demoted to test fixture; the demo needs only the semiring).
+// ℤ=DBSP, ℂ=Mach-Zehnder (WSet.Fixture in Tests.FSharp), ℝ≥0=THIS: one calculus, three rings.
 
 [<Fact>]
-let ``GDL ring demo: discrete sum-product as a WSet circuit equals the Bayesian marginal (ℝ≥0 ring, the third oracle)`` () =
-    // a 2-state variable, two soft "votes" (unnormalized likelihoods) multiplied then normalized —
-    // the sum-product marginal of x given two independent observations.
-    // WSet over ℝ≥0 (probabilities): keys 0/1, weights multiply (apply), consolidate sums, normalize.
-    let ring = Zeta.Core.Real.algebra   // ℝ as an IStarRing (Add=+, Mul=*); we stay in ℝ≥0
-    let isZero w = abs w < 1e-15
-    // vote A: [0,0.7; 1,0.3]; vote B: [0,0.4; 1,0.6] — fuse by pointwise product then normalize
-    let voteA : Zeta.Core.WSet.WSet<int, float> = [ 0, 0.7; 1, 0.3 ]
-    let voteB = [ 0, 0.4; 1, 0.6 ]
-    let fused =
-        Zeta.Core.WSet.apply ring (fun k -> voteB |> List.filter (fun (k2, _) -> k2 = k)) voteA
-        |> Zeta.Core.WSet.consolidate ring isZero
-    let total = fused |> List.sumBy snd
-    let wsetP0 = (fused |> List.find (fun (k, _) -> k = 0) |> snd) / total
-    // the analytic marginal: 0.7*0.4 / (0.7*0.4 + 0.3*0.6) = 0.28/0.46
-    Assert.Equal(0.28 / 0.46, wsetP0, 9)
+let ``GDL ring demo: discrete sum-product over the real semiring equals the analytic Bayesian marginal (the third ring)`` () =
+    let ring = Zeta.Core.Real.algebra // Add=+, Mul=* — the ℝ *-ring; we stay in ℝ≥0
+    // two soft votes on a 2-state variable, fused by the semiring product, normalized at the boundary
+    let voteA = [| 0.7; 0.3 |]
+    let voteB = [| 0.4; 0.6 |]
+    let fused = Array.init 2 (fun s -> ring.Mul(voteA.[s], voteB.[s])) // sum-product's product step
+    let total = fused |> Array.fold (fun acc w -> ring.Add(acc, w)) ring.Zero // the sum step
+    Assert.Equal(0.28 / 0.46, fused.[0] / total, 9)

--- a/tests/Tests.FSharp/IbltReconcile.Tests.fs
+++ b/tests/Tests.FSharp/IbltReconcile.Tests.fs
@@ -1,0 +1,64 @@
+module Zeta.Tests.IbltReconcileTests
+
+// O(|Δ|) ROOM RECONCILIATION (Aaron: "yep lets do this") — the IBLT, peeled by BP-with-hard-
+// messages. The laws: exact recovery when sized to the difference; HONEST Partial when not
+// (never a wrong answer); deterministic (DST); shared keys always cancel.
+
+open global.Xunit
+open Zeta.Core
+
+let private keys (ints: int list) = ints |> List.map uint64
+
+[<Fact>]
+let ``RECONCILE: two rooms differing by a few keys recover the EXACT symmetric difference, sides correct`` () =
+    let shared = keys [ 1..100 ]
+    let roomA = shared @ keys [ 1001; 1002; 1003 ] // A's extras
+    let roomB = shared @ keys [ 2001; 2002 ] // B's extras
+    // geometry note from the first run: at 16 cells (seg=5) keys 1002/1003 formed a 2-core and
+    // the decoder answered PARTIAL — honestly, with every recovered key correct. IBLT decode is
+    // probabilistic by design (w.h.p. at ~1.5-2x |Δ|); 24 cells clears this Δ comfortably.
+    match IbltReconcile.reconcile 24 3 roomA roomB with
+    | IbltReconcile.Decoded(onlyA, onlyB) ->
+        Assert.Equal<uint64 list>(keys [ 1001; 1002; 1003 ], onlyA)
+        Assert.Equal<uint64 list>(keys [ 2001; 2002 ], onlyB)
+    | IbltReconcile.Partial(_, _, n) -> Assert.True(false, sprintf "expected full decode; %d cells stuck" n)
+
+[<Fact>]
+let ``THE CANCELLATION LAW: identical rooms reconcile to EMPTY — a thousand shared keys cost nothing in the difference`` () =
+    let room = keys [ 1..1000 ]
+    match IbltReconcile.reconcile 8 3 room room with
+    | IbltReconcile.Decoded([], []) -> ()
+    | other -> Assert.True(false, sprintf "expected empty decode, got %A" other)
+
+[<Fact>]
+let ``HONEST PARTIAL: an undersized table refuses to lie — Partial with the stuck-cell count, never a wrong answer`` () =
+    let roomA = keys [ 1..200 ]
+    let roomB = keys [ 101..300 ] // |Δ| = 200, table of 8 cells: hopeless — must say so
+    match IbltReconcile.reconcile 8 3 roomA roomB with
+    | IbltReconcile.Partial(onlyA, onlyB, remaining) ->
+        Assert.True(remaining > 0)
+        // everything it DID recover must be correct (sound, even when incomplete)
+        for k in onlyA do Assert.True(k <= 100UL && k >= 1UL)
+        for k in onlyB do Assert.True(k >= 201UL && k <= 300UL)
+    | IbltReconcile.Decoded(a, b) ->
+        // a lucky full decode at this size would still need to be CORRECT
+        Assert.Equal(100, List.length a)
+        Assert.Equal(100, List.length b)
+
+[<Fact>]
+let ``DST: same rooms, same geometry, same bytes — reconciliation replays exactly`` () =
+    let roomA = keys [ 1..50 ] @ keys [ 7001; 7002 ]
+    let roomB = keys [ 1..50 ] @ keys [ 8001 ]
+    let run () = IbltReconcile.reconcile 12 3 roomA roomB
+    Assert.Equal(run (), run ())
+
+[<Fact>]
+let ``O(|Δ|) IS THE POINT: a 10k-key room with a 3-key difference reconciles through a 16-cell table`` () =
+    let shared = keys [ 1..10000 ]
+    let roomA = shared @ keys [ 90001 ]
+    let roomB = shared @ keys [ 90002; 90003 ]
+    match IbltReconcile.reconcile 16 3 roomA roomB with
+    | IbltReconcile.Decoded(onlyA, onlyB) ->
+        Assert.Equal<uint64 list>(keys [ 90001 ], onlyA)
+        Assert.Equal<uint64 list>(keys [ 90002; 90003 ], onlyB)
+    | IbltReconcile.Partial(_, _, n) -> Assert.True(false, sprintf "16 cells should decode |Δ|=3; %d stuck" n)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -180,7 +180,9 @@
     <Compile Include="ShapeCartridge.Tests.fs" />
     <Compile Include="ShapeAcceptance.Tests.fs" />
     <Compile Include="DeterminismLint.Tests.fs" />
+    <Compile Include="WSet.Fixture.fs" />
     <Compile Include="WSet.MachZehnder.Tests.fs" />
+    <Compile Include="IbltReconcile.Tests.fs" />
     <Compile Include="WaveSim.Tests.fs" />
     <Compile Include="AdinkraViz.Tests.fs" />
     <Compile Include="SpectralPivot.Tests.fs" />

--- a/tests/Tests.FSharp/WSet.Fixture.fs
+++ b/tests/Tests.FSharp/WSet.Fixture.fs
@@ -1,3 +1,8 @@
+// DEMOTED TO TEST FIXTURE (Rodney's Razor, 2026-06-13): the GDL unification is essential as
+// MATHEMATICS (the three-ring demos stand) and accidental as CODE — zero non-test consumers; the
+// real engines (ZSet/AmplitudeEmu/FactorGraph) share no code through WSet. Per the razor: WSet
+// lives beside the demos it exists for; it returns to Core only when a non-test consumer exists
+// ON MERIT. (The IBLT reconciliation deliberately took Rodney's branch A: plain keys, no WSet.)
 namespace Zeta.Core
 
 open Zeta.Core.Abstractions


### PR DESCRIPTION
The reconciliation ships on Rodney's surviving branch A (plain keys — built that way before his verdict arrived; convergent). Partitioned-hash IBLT, peel = BP with hard messages; DST replay-exact; honest PARTIAL on undersized tables (a live 2-core demonstrated it answering honestly with every recovered key correct). Rodney's verdicts applied: WSet demoted to test fixture (essential as math, accidental as code — zero non-test consumers), GDL demo rewritten on the ring directly, the one-discipline claims tightened to enforced-separately-per-engine. F# 3018 + Bayesian 94 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)