### PR TITLE
feat(quantum): implement TS-F# symmetry for quantum observables (B-1029/B-1033)

### DIFF
--- a/src/Core.Abstractions/IInferenceEngine.cs
+++ b/src/Core.Abstractions/IInferenceEngine.cs
@@ -17,8 +17,8 @@ namespace Zeta.Core.Abstractions;
 public interface IInferenceEngine
 {
     /// <summary>Adapter name (for conformance reporting: which oracle said what).</summary>
-    string Name { get; }
+    public string Name { get; }
 
     /// <summary>Run Gaussian belief propagation to convergence (bounded) and read all marginals.</summary>
-    InferenceResult RunGaussian(GaussianModel model, int maxRounds, double tolerance);
+    public InferenceResult RunGaussian(GaussianModel model, int maxRounds, double tolerance);
 }

--- a/src/Core.TypeScript/quantum-observable/generate-quantum-transcript.ts
+++ b/src/Core.TypeScript/quantum-observable/generate-quantum-transcript.ts
@@ -1,0 +1,143 @@
+import { writeFileSync } from "fs";
+import { join } from "path";
+import { QuantumObservableOracle } from "./oracle";
+import { QuantumObservableDelta, QuantumObservableRow } from "./types";
+
+const currentDir = import.meta.dir;
+const outputPath = join(currentDir, "quantum-treaty-transcript.json");
+
+const oracle = new QuantumObservableOracle();
+
+// Batch 0: Insert all baseline quantum observable rows (weight = 1)
+const batch0Deltas: QuantumObservableDelta[] = [];
+
+// 1. Single Qubit measurements
+const singleQubitOps = [
+  { id: "H|0>", operation: "Zeta.ReferenceOracle.ApplyH" },
+  { id: "Ry(pi/3)|0>", operation: "Zeta.ReferenceOracle.ApplyRyPiOver3", theta: Math.PI / 3.0 },
+  { id: "Ry(pi/2)|0>", operation: "Zeta.ReferenceOracle.ApplyRyPiOver2", theta: Math.PI / 2.0 },
+];
+for (const op of singleQubitOps) {
+  const row: QuantumObservableRow = {
+    type: "SingleQubit",
+    value: oracle.runSingleQubit(op.id, op.operation, op.theta),
+  };
+  batch0Deltas.push({ row, weight: 1 });
+}
+
+// 2. Canonical CHSH
+const chshRow: QuantumObservableRow = {
+  type: "CanonicalChsh",
+  value: oracle.runCanonicalChsh(
+    "BellPhiPlus canonical CHSH",
+    0.0,
+    Math.PI / 2.0,
+    Math.PI / 4.0,
+    (3.0 * Math.PI) / 4.0
+  ),
+};
+batch0Deltas.push({ row: chshRow, weight: 1 });
+
+// 3. Singlet CHSH
+const corners = [
+  { id: "E(a0,b0)", operation: "Zeta.ReferenceOracle.ApplyBellSingletChshA0B0", a: 0.0, b: Math.PI / 4.0, coefficient: 1 },
+  { id: "E(a0,b1)", operation: "Zeta.ReferenceOracle.ApplyBellSingletChshA0B1", a: 0.0, b: -Math.PI / 4.0, coefficient: 1 },
+  { id: "E(a1,b0)", operation: "Zeta.ReferenceOracle.ApplyBellSingletChshA1B0", a: Math.PI / 2.0, b: Math.PI / 4.0, coefficient: 1 },
+  { id: "E(a1,b1)", operation: "Zeta.ReferenceOracle.ApplyBellSingletChshA1B1", a: Math.PI / 2.0, b: -Math.PI / 4.0, coefficient: -1 },
+];
+const singletRow: QuantumObservableRow = {
+  type: "SingletChsh",
+  value: oracle.runSingletChsh("BellSinglet CHSH corners", corners),
+};
+batch0Deltas.push({ row: singletRow, weight: 1 });
+
+// 4. Singlet Corners (individually)
+for (const corner of corners) {
+  const c = oracle.runSingletChsh("BellSinglet CHSH corners", [corner]).Corners[0]!;
+  const row: QuantumObservableRow = {
+    type: "BellCorner",
+    value: c,
+  };
+  batch0Deltas.push({ row, weight: 1 });
+}
+
+// 5. Bell Coincidences
+const coincidences = [
+  { id: "PhiPlus same-outcome a=0 b=pi/4", state: "PhiPlus", op: "Zeta.ReferenceOracle.ApplyBellPhiPlusAnalyzers", a: 0.0, b: Math.PI / 4.0, event: "sameOutcome" },
+  { id: "Singlet opposite-outcome a=0 b=pi/4", state: "Singlet", op: "Zeta.ReferenceOracle.ApplyBellSingletAnalyzers", a: 0.0, b: Math.PI / 4.0, event: "oppositeOutcome" },
+  { id: "PhiPlus same-outcome a=0 b=pi/2", state: "PhiPlus", op: "Zeta.ReferenceOracle.ApplyBellPhiPlusAnalyzers", a: 0.0, b: Math.PI / 2.0, event: "sameOutcome" },
+  { id: "PhiPlus same-outcome a=0 b=pi", state: "PhiPlus", op: "Zeta.ReferenceOracle.ApplyBellPhiPlusAnalyzers", a: 0.0, b: Math.PI, event: "sameOutcome" },
+];
+for (const c of coincidences) {
+  const row: QuantumObservableRow = {
+    type: "BellCoincidence",
+    value: oracle.runBellCoincidence(c.id, c.state, c.op, c.a, c.b, c.event),
+  };
+  batch0Deltas.push({ row, weight: 1 });
+}
+
+// 6. Interference Visibility (Mach-Zehnder)
+const mzInterferences = [
+  { id: "mach-zehnder-open", op: "Zeta.ReferenceOracle.ApplyMachZehnderOpen" },
+  { id: "mach-zehnder-closed-zero-phase", op: "Zeta.ReferenceOracle.ApplyMachZehnderClosedZeroPhase", phase: 0.0 },
+  { id: "mach-zehnder-closed-pi-over-3-phase", op: "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiOver3Phase", phase: Math.PI / 3.0 },
+  { id: "mach-zehnder-closed-pi-over-2-phase", op: "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiOver2Phase", phase: Math.PI / 2.0 },
+  { id: "mach-zehnder-closed-two-pi-over-3-phase", op: "Zeta.ReferenceOracle.ApplyMachZehnderClosedTwoPiOver3Phase", phase: (2.0 * Math.PI) / 3.0 },
+  { id: "mach-zehnder-closed-pi-phase", op: "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiPhase", phase: Math.PI },
+];
+for (const mz of mzInterferences) {
+  const row: QuantumObservableRow = {
+    type: "InterferenceVisibility",
+    value: oracle.runInterferenceVisibility(mz.id, mz.op, mz.phase),
+  };
+  batch0Deltas.push({ row, weight: 1 });
+}
+
+// Batch 1: Retract 2 Mach-Zehnder rows (weight = -1) and insert 1 new MZ row (weight = 1)
+const batch1Deltas: QuantumObservableDelta[] = [];
+
+// Retract mach-zehnder-open
+const mzOpenRetract: QuantumObservableRow = {
+  type: "InterferenceVisibility",
+  value: oracle.runInterferenceVisibility("mach-zehnder-open", "Zeta.ReferenceOracle.ApplyMachZehnderOpen"),
+};
+batch1Deltas.push({ row: mzOpenRetract, weight: -1 });
+
+// Retract mach-zehnder-closed-zero-phase
+const mzZeroRetract: QuantumObservableRow = {
+  type: "InterferenceVisibility",
+  value: oracle.runInterferenceVisibility("mach-zehnder-closed-zero-phase", "Zeta.ReferenceOracle.ApplyMachZehnderClosedZeroPhase", 0.0),
+};
+batch1Deltas.push({ row: mzZeroRetract, weight: -1 });
+
+// Insert mach-zehnder-closed-pi-over-6-phase (new phase phase = pi/6)
+const mzPiOver6Insert: QuantumObservableRow = {
+  type: "InterferenceVisibility",
+  value: oracle.runInterferenceVisibility(
+    "mach-zehnder-closed-pi-over-6-phase",
+    "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiOver6Phase", // custom/arbitrary name ending
+    Math.PI / 6.0
+  ),
+};
+batch1Deltas.push({ row: mzPiOver6Insert, weight: 1 });
+
+const transcript = {
+  schema: "zeta.quantum.zset-transcript.v1",
+  metadata: {
+    generatedBy: "src/Core.TypeScript/quantum-observable/generate-quantum-transcript.ts",
+    timestamp: new Date().toISOString(),
+  },
+  batches: [
+    {
+      batchId: 0,
+      deltas: batch0Deltas,
+    },
+    {
+      batchId: 1,
+      deltas: batch1Deltas,
+    },
+  ],
+};
+
+writeFileSync(outputPath, JSON.stringify(transcript, null, 2) + "\n", "utf-8");
+console.log(`Successfully generated quantum-treaty-transcript.json at ${outputPath}`);

--- a/src/Core.TypeScript/quantum-observable/index.ts
+++ b/src/Core.TypeScript/quantum-observable/index.ts
@@ -1,0 +1,3 @@
+export * from "./types";
+export * from "./oracle";
+export * from "./qsharp-exporter";

--- a/src/Core.TypeScript/quantum-observable/oracle.ts
+++ b/src/Core.TypeScript/quantum-observable/oracle.ts
@@ -1,0 +1,226 @@
+import QuantumCircuit from "quantum-circuit";
+import {
+  SingleQubitMeasurement,
+  CanonicalChsh,
+  SingletChsh,
+  BellCorner,
+  BellCoincidence,
+  InterferenceVisibility,
+} from "./types";
+
+export interface IQuantumObservableOracle {
+  runSingleQubit(id: string, operation: string, theta?: number): SingleQubitMeasurement;
+  runCanonicalChsh(id: string, a: number, aPrime: number, b: number, bPrime: number): CanonicalChsh;
+  runSingletChsh(
+    id: string,
+    corners: readonly {
+      readonly Id?: string; readonly id?: string;
+      readonly Operation?: string; readonly operation?: string;
+      readonly A?: number; readonly a?: number;
+      readonly B?: number; readonly b?: number;
+      readonly Coefficient?: number; readonly coefficient?: number;
+    }[]
+  ): SingletChsh;
+  runBellCoincidence(
+    id: string,
+    state: string,
+    operation: string,
+    a: number,
+    b: number,
+    event: string
+  ): BellCoincidence;
+  runInterferenceVisibility(id: string, operation: string, phase?: number): InterferenceVisibility;
+}
+
+function getProb(amp: unknown): number {
+  if (!amp) return 0;
+  if (typeof amp === "number") return amp * amp;
+  const c = amp as { re?: number; im?: number; real?: number; imag?: number };
+  const re = c.re !== undefined ? c.re : c.real !== undefined ? c.real : 0;
+  const im = c.im !== undefined ? c.im : c.imag !== undefined ? c.imag : 0;
+  return re * re + im * im;
+}
+
+export class QuantumObservableOracle implements IQuantumObservableOracle {
+  runSingleQubit(id: string, operation: string, theta?: number): SingleQubitMeasurement {
+    const circuit = new QuantumCircuit(1);
+    if (operation === "Zeta.ReferenceOracle.ApplyH") {
+      circuit.appendGate("h", 0);
+    } else if (operation === "Zeta.ReferenceOracle.ApplyRyPiOver3") {
+      circuit.appendGate("ry", 0, { params: { theta: Math.PI / 3.0 } });
+    } else if (operation === "Zeta.ReferenceOracle.ApplyRyPiOver2") {
+      circuit.appendGate("ry", 0, { params: { theta: Math.PI / 2.0 } });
+    } else if (theta !== undefined) {
+      circuit.appendGate("ry", 0, { params: { theta } });
+    } else {
+      throw new Error(`Unknown single qubit operation: ${operation}`);
+    }
+    circuit.run();
+    const probOne = circuit.probabilities()[0] ?? 0;
+    const probZero = 1 - probOne;
+    return {
+      Id: id,
+      Operation: operation,
+      ThetaRadians: theta,
+      Probabilities: { Zero: probZero, One: probOne },
+    };
+  }
+
+  runCanonicalChsh(id: string, a: number, aPrime: number, b: number, bPrime: number): CanonicalChsh {
+    const getCorr = (x: number, y: number) => {
+      const circuit = new QuantumCircuit(2);
+      circuit.appendGate("h", 0);
+      circuit.appendGate("cx", [0, 1]);
+      circuit.appendGate("ry", 0, { params: { theta: -x } });
+      circuit.appendGate("ry", 1, { params: { theta: -y } });
+      circuit.run();
+      const p00 = getProb(circuit.state[0]);
+      const p01 = getProb(circuit.state[1]);
+      const p10 = getProb(circuit.state[2]);
+      const p11 = getProb(circuit.state[3]);
+      return p00 + p11 - (p01 + p10);
+    };
+
+    const eAB = getCorr(a, b);
+    const eABPrime = getCorr(a, bPrime);
+    const eAPrimeB = getCorr(aPrime, b);
+    const eAPrimeBPrime = getCorr(aPrime, bPrime);
+    const s = eAB - eABPrime + eAPrimeB + eAPrimeBPrime;
+
+    return {
+      Id: id,
+      Angles: { A: a, APrime: aPrime, B: b, BPrime: bPrime },
+      Correlators: { EAB: eAB, EABPrime: eABPrime, EAPrimeB: eAPrimeB, EAPrimeBPrime: eAPrimeBPrime },
+      S: s,
+      Tsirelson: 2 * Math.sqrt(2),
+      ClassicalBound: 2.0,
+    };
+  }
+
+  runSingletChsh(
+    id: string,
+    cornersInput: readonly {
+      readonly Id?: string; readonly id?: string;
+      readonly Operation?: string; readonly operation?: string;
+      readonly A?: number; readonly a?: number;
+      readonly B?: number; readonly b?: number;
+      readonly Coefficient?: number; readonly coefficient?: number;
+    }[]
+  ): SingletChsh {
+    const corners: BellCorner[] = cornersInput.map((corner) => {
+      const a = corner.A !== undefined ? corner.A : corner.a !== undefined ? corner.a : 0;
+      const b = corner.B !== undefined ? corner.B : corner.b !== undefined ? corner.b : 0;
+      const coeff = corner.Coefficient !== undefined ? corner.Coefficient : corner.coefficient !== undefined ? corner.coefficient : 1;
+      const op = corner.Operation || corner.operation || "";
+      const cid = corner.Id || corner.id || "";
+
+      const circuit = new QuantumCircuit(2);
+      circuit.appendGate("h", 0);
+      circuit.appendGate("cx", [0, 1]);
+      circuit.appendGate("x", 1);
+      circuit.appendGate("z", 1);
+      circuit.appendGate("ry", 0, { params: { theta: -a } });
+      circuit.appendGate("ry", 1, { params: { theta: -b } });
+      circuit.run();
+
+      const p00 = getProb(circuit.state[0]);
+      const p01 = getProb(circuit.state[1]);
+      const p10 = getProb(circuit.state[2]);
+      const p11 = getProb(circuit.state[3]);
+
+      const pSame = p00 + p11;
+      const pOpposite = p01 + p10;
+      const correlator = pOpposite - pSame;
+
+      return {
+        Id: cid,
+        Operation: op,
+        A: a,
+        B: b,
+        Coefficient: coeff,
+        SameOutcomeProbability: pSame,
+        OppositeOutcomeProbability: pOpposite,
+        Correlator: correlator,
+      };
+    });
+
+    const s = corners.reduce((acc, c) => acc + c.Coefficient * c.Correlator, 0);
+
+    return {
+      Id: id,
+      Corners: corners,
+      S: s,
+      Analytic: 2 * Math.sqrt(2),
+      ClassicalBound: 2.0,
+    };
+  }
+
+  runBellCoincidence(
+    id: string,
+    state: string,
+    operation: string,
+    a: number,
+    b: number,
+    event: string
+  ): BellCoincidence {
+    const circuit = new QuantumCircuit(2);
+    circuit.appendGate("h", 0);
+    circuit.appendGate("cx", [0, 1]);
+    if (state === "Singlet") {
+      circuit.appendGate("x", 1);
+      circuit.appendGate("z", 1);
+    }
+    circuit.appendGate("ry", 0, { params: { theta: -a } });
+    circuit.appendGate("ry", 1, { params: { theta: -b } });
+    circuit.run();
+
+    const p00 = getProb(circuit.state[0]);
+    const p01 = getProb(circuit.state[1]);
+    const p10 = getProb(circuit.state[2]);
+    const p11 = getProb(circuit.state[3]);
+
+    const prob = event === "sameOutcome" ? p00 + p11 : p01 + p10;
+
+    return {
+      Id: id,
+      State: state,
+      Operation: operation,
+      A: a,
+      B: b,
+      Event: event,
+      Probability: prob,
+    };
+  }
+
+  runInterferenceVisibility(id: string, operation: string, phase?: number): InterferenceVisibility {
+    const circuit = new QuantumCircuit(1);
+    if (operation.endsWith("ApplyMachZehnderOpen")) {
+      circuit.appendGate("h", 0);
+    } else if (operation.endsWith("ClosedZeroPhase")) {
+      circuit.appendGate("h", 0);
+      circuit.appendGate("h", 0);
+    } else if (operation.endsWith("ClosedPiPhase")) {
+      circuit.appendGate("h", 0);
+      circuit.appendGate("z", 0);
+      circuit.appendGate("h", 0);
+    } else if (phase !== undefined) {
+      circuit.appendGate("h", 0);
+      circuit.appendGate("rz", 0, { params: { phi: phase } });
+      circuit.appendGate("h", 0);
+    } else {
+      throw new Error(`Unknown Mach-Zehnder operation: ${operation}`);
+    }
+    circuit.run();
+
+    const probOne = circuit.probabilities()[0] ?? 0;
+    const probZero = 1 - probOne;
+
+    return {
+      Id: id,
+      Operation: operation,
+      PhaseRadians: phase,
+      Probabilities: { Zero: probZero, One: probOne },
+      Visibility: operation.endsWith("Open") ? undefined : 1.0,
+    };
+  }
+}

--- a/src/Core.TypeScript/quantum-observable/qsharp-exporter.ts
+++ b/src/Core.TypeScript/quantum-observable/qsharp-exporter.ts
@@ -1,0 +1,27 @@
+import { ZSet } from "../z-set/z-set";
+
+/**
+ * EXPERIMENTAL: Sandbox Q# exporter representing a Z-set as a basis state.
+ * Takes a Z-set of basis state strings (e.g. "|00>", "|11>") with integer weights (amplitudes)
+ * and generates Q# code to prepare/represent this state sandbox.
+ */
+export function exportZSetToQSharpSandbox(zset: ZSet<string>): string {
+  let qs = `// ==================================================================\n`;
+  qs += `// EXPERIMENTAL SANDBOX: Z-Set as Quantum Basis State Exporter\n`;
+  qs += `// Generated: ${new Date().toISOString()}\n`;
+  qs += `// ==================================================================\n\n`;
+  qs += `namespace Zeta.ExperimentalSandbox {\n`;
+  qs += `    open Microsoft.Quantum.Diagnostics;\n`;
+  qs += `    open Microsoft.Quantum.Intrinsic;\n`;
+  qs += `    open Microsoft.Quantum.Canon;\n\n`;
+  qs += `    /// Represents the Z-set superposition state:\n`;
+  for (const entry of zset) {
+    qs += `    ///   Basis: ${entry.e} | Weight: ${entry.w}\n`;
+  }
+  qs += `    operation PrepareZSetState(qs : Qubit[]) : Unit {\n`;
+  qs += `        // Experimental state preparation sandbox for specified weights.\n`;
+  qs += `        Message("Preparing Z-set state with ${zset.length} elements...");\n`;
+  qs += `    }\n`;
+  qs += `}\n`;
+  return qs;
+}

--- a/src/Core.TypeScript/quantum-observable/quantum-observable.test.ts
+++ b/src/Core.TypeScript/quantum-observable/quantum-observable.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import { QuantumObservableOracle } from "./oracle";
+
+const tolerance = 1e-5;
+
+describe("QuantumObservableOracle simulator", () => {
+  const oracle = new QuantumObservableOracle();
+
+  test("SingleQubit measurements match expected probabilities", () => {
+    const h = oracle.runSingleQubit("H|0>", "Zeta.ReferenceOracle.ApplyH");
+    expect(h.Probabilities.Zero).toBeCloseTo(0.5, 5);
+    expect(h.Probabilities.One).toBeCloseTo(0.5, 5);
+
+    const ry3 = oracle.runSingleQubit("Ry(pi/3)|0>", "Zeta.ReferenceOracle.ApplyRyPiOver3", Math.PI / 3.0);
+    // Ry(pi/3) rotation on |0> prepares cos(pi/6)|0> + sin(pi/6)|1>
+    // P(0) = cos^2(pi/6) = 0.75, P(1) = sin^2(pi/6) = 0.25
+    expect(ry3.Probabilities.Zero).toBeCloseTo(0.75, 5);
+    expect(ry3.Probabilities.One).toBeCloseTo(0.25, 5);
+
+    const ry2 = oracle.runSingleQubit("Ry(pi/2)|0>", "Zeta.ReferenceOracle.ApplyRyPiOver2", Math.PI / 2.0);
+    // Ry(pi/2) prepares cos(pi/4)|0> + sin(pi/4)|1> -> equal probabilities
+    expect(ry2.Probabilities.Zero).toBeCloseTo(0.5, 5);
+    expect(ry2.Probabilities.One).toBeCloseTo(0.5, 5);
+  });
+
+  test("Canonical CHSH prepares PhiPlus and violates classical bounds", () => {
+    const a = 0.0;
+    const aPrime = Math.PI / 2.0;
+    const b = Math.PI / 4.0;
+    const bPrime = (3.0 * Math.PI) / 4.0;
+
+    const chsh = oracle.runCanonicalChsh("PhiPlus canonical CHSH", a, aPrime, b, bPrime);
+    // S should be close to Tsirelson bound (2 * sqrt(2) ≈ 2.8284)
+    expect(chsh.S).toBeCloseTo(2 * Math.sqrt(2), 5);
+    expect(chsh.ClassicalBound).toBe(2.0);
+    expect(chsh.Tsirelson).toBeCloseTo(2.828427, 5);
+  });
+
+  test("Singlet CHSH corners sum to Tsirelson bound", () => {
+    // Standard singlet CHSH configuration: angles a0=0, a1=pi/2, b0=pi/4, b1=-pi/4
+    const corners = [
+      { id: "E(a0,b0)", operation: "Zeta.ReferenceOracle.ApplyBellSingletChshA0B0", a: 0.0, b: Math.PI / 4.0, coefficient: 1 },
+      { id: "E(a0,b1)", operation: "Zeta.ReferenceOracle.ApplyBellSingletChshA0B1", a: 0.0, b: -Math.PI / 4.0, coefficient: 1 },
+      { id: "E(a1,b0)", operation: "Zeta.ReferenceOracle.ApplyBellSingletChshA1B0", a: Math.PI / 2.0, b: Math.PI / 4.0, coefficient: 1 },
+      { id: "E(a1,b1)", operation: "Zeta.ReferenceOracle.ApplyBellSingletChshA1B1", a: Math.PI / 2.0, b: -Math.PI / 4.0, coefficient: -1 }
+    ];
+
+    const singlet = oracle.runSingletChsh("BellSinglet CHSH corners", corners);
+    expect(singlet.S).toBeCloseTo(2 * Math.sqrt(2), 5);
+  });
+
+  test("Bell coincidence outcomes match analytic overlap", () => {
+    const c1 = oracle.runBellCoincidence(
+      "PhiPlus same-outcome a=0 b=pi/4",
+      "PhiPlus",
+      "Zeta.ReferenceOracle.ApplyBellPhiPlusAnalyzers",
+      0.0,
+      Math.PI / 4.0,
+      "sameOutcome"
+    );
+    // same outcome probability is cos^2((a-b)/2) = cos^2(pi/8) ≈ 0.85355
+    expect(c1.Probability).toBeCloseTo(Math.cos(Math.PI / 8.0) ** 2, 5);
+
+    const c2 = oracle.runBellCoincidence(
+      "Singlet opposite-outcome a=0 b=pi/4",
+      "Singlet",
+      "Zeta.ReferenceOracle.ApplyBellSingletAnalyzers",
+      0.0,
+      Math.PI / 4.0,
+      "oppositeOutcome"
+    );
+    // opposite outcome probability is cos^2((a-b)/2) = cos^2(pi/8) ≈ 0.85355
+    expect(c2.Probability).toBeCloseTo(Math.cos(Math.PI / 8.0) ** 2, 5);
+  });
+
+  test("Mach-Zehnder interference visibility matches analytic visibility", () => {
+    const openCase = oracle.runInterferenceVisibility(
+      "mach-zehnder-open",
+      "Zeta.ReferenceOracle.ApplyMachZehnderOpen"
+    );
+    expect(openCase.Probabilities.Zero).toBeCloseTo(0.5, 5);
+    expect(openCase.Probabilities.One).toBeCloseTo(0.5, 5);
+    expect(openCase.Visibility).toBeUndefined();
+
+    const closedZero = oracle.runInterferenceVisibility(
+      "mach-zehnder-closed-zero-phase",
+      "Zeta.ReferenceOracle.ApplyMachZehnderClosedZeroPhase",
+      0.0
+    );
+    expect(closedZero.Probabilities.Zero).toBeCloseTo(1.0, 5);
+    expect(closedZero.Probabilities.One).toBeCloseTo(0.0, 5);
+    expect(closedZero.Visibility).toBe(1.0);
+
+    const closedPi = oracle.runInterferenceVisibility(
+      "mach-zehnder-closed-pi-phase",
+      "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiPhase",
+      Math.PI
+    );
+    expect(closedPi.Probabilities.Zero).toBeCloseTo(0.0, 5);
+    expect(closedPi.Probabilities.One).toBeCloseTo(1.0, 5);
+  });
+});

--- a/src/Core.TypeScript/quantum-observable/quantum-treaty-transcript.json
+++ b/src/Core.TypeScript/quantum-observable/quantum-treaty-transcript.json
@@ -1,0 +1,405 @@
+{
+  "schema": "zeta.quantum.zset-transcript.v1",
+  "metadata": {
+    "generatedBy": "src/Core.TypeScript/quantum-observable/generate-quantum-transcript.ts",
+    "timestamp": "2026-06-11T21:48:35.880Z"
+  },
+  "batches": [
+    {
+      "batchId": 0,
+      "deltas": [
+        {
+          "row": {
+            "type": "SingleQubit",
+            "value": {
+              "Id": "H|0>",
+              "Operation": "Zeta.ReferenceOracle.ApplyH",
+              "Probabilities": {
+                "Zero": 0.5,
+                "One": 0.5
+              }
+            }
+          },
+          "weight": 1
+        },
+        {
+          "row": {
+            "type": "SingleQubit",
+            "value": {
+              "Id": "Ry(pi/3)|0>",
+              "Operation": "Zeta.ReferenceOracle.ApplyRyPiOver3",
+              "ThetaRadians": 1.0471975511965976,
+              "Probabilities": {
+                "Zero": 0.75,
+                "One": 0.25
+              }
+            }
+          },
+          "weight": 1
+        },
+        {
+          "row": {
+            "type": "SingleQubit",
+            "value": {
+              "Id": "Ry(pi/2)|0>",
+              "Operation": "Zeta.ReferenceOracle.ApplyRyPiOver2",
+              "ThetaRadians": 1.5707963267948966,
+              "Probabilities": {
+                "Zero": 0.5,
+                "One": 0.5
+              }
+            }
+          },
+          "weight": 1
+        },
+        {
+          "row": {
+            "type": "CanonicalChsh",
+            "value": {
+              "Id": "BellPhiPlus canonical CHSH",
+              "Angles": {
+                "A": 0,
+                "APrime": 1.5707963267948966,
+                "B": 0.7853981633974483,
+                "BPrime": 2.356194490192345
+              },
+              "Correlators": {
+                "EAB": 0.7071067811865474,
+                "EABPrime": -0.7071067811865472,
+                "EAPrimeB": 0.7071067811865475,
+                "EAPrimeBPrime": 0.7071067811865472
+              },
+              "S": 2.828427124746189,
+              "Tsirelson": 2.8284271247461903,
+              "ClassicalBound": 2
+            }
+          },
+          "weight": 1
+        },
+        {
+          "row": {
+            "type": "SingletChsh",
+            "value": {
+              "Id": "BellSinglet CHSH corners",
+              "Corners": [
+                {
+                  "Id": "E(a0,b0)",
+                  "Operation": "Zeta.ReferenceOracle.ApplyBellSingletChshA0B0",
+                  "A": 0,
+                  "B": 0.7853981633974483,
+                  "Coefficient": 1,
+                  "SameOutcomeProbability": 0.14644660940672619,
+                  "OppositeOutcomeProbability": 0.8535533905932735,
+                  "Correlator": 0.7071067811865474
+                },
+                {
+                  "Id": "E(a0,b1)",
+                  "Operation": "Zeta.ReferenceOracle.ApplyBellSingletChshA0B1",
+                  "A": 0,
+                  "B": -0.7853981633974483,
+                  "Coefficient": 1,
+                  "SameOutcomeProbability": 0.14644660940672619,
+                  "OppositeOutcomeProbability": 0.8535533905932735,
+                  "Correlator": 0.7071067811865474
+                },
+                {
+                  "Id": "E(a1,b0)",
+                  "Operation": "Zeta.ReferenceOracle.ApplyBellSingletChshA1B0",
+                  "A": 1.5707963267948966,
+                  "B": 0.7853981633974483,
+                  "Coefficient": 1,
+                  "SameOutcomeProbability": 0.14644660940672607,
+                  "OppositeOutcomeProbability": 0.8535533905932735,
+                  "Correlator": 0.7071067811865475
+                },
+                {
+                  "Id": "E(a1,b1)",
+                  "Operation": "Zeta.ReferenceOracle.ApplyBellSingletChshA1B1",
+                  "A": 1.5707963267948966,
+                  "B": -0.7853981633974483,
+                  "Coefficient": -1,
+                  "SameOutcomeProbability": 0.8535533905932735,
+                  "OppositeOutcomeProbability": 0.14644660940672632,
+                  "Correlator": -0.7071067811865472
+                }
+              ],
+              "S": 2.828427124746189,
+              "Analytic": 2.8284271247461903,
+              "ClassicalBound": 2
+            }
+          },
+          "weight": 1
+        },
+        {
+          "row": {
+            "type": "BellCorner",
+            "value": {
+              "Id": "E(a0,b0)",
+              "Operation": "Zeta.ReferenceOracle.ApplyBellSingletChshA0B0",
+              "A": 0,
+              "B": 0.7853981633974483,
+              "Coefficient": 1,
+              "SameOutcomeProbability": 0.14644660940672619,
+              "OppositeOutcomeProbability": 0.8535533905932735,
+              "Correlator": 0.7071067811865474
+            }
+          },
+          "weight": 1
+        },
+        {
+          "row": {
+            "type": "BellCorner",
+            "value": {
+              "Id": "E(a0,b1)",
+              "Operation": "Zeta.ReferenceOracle.ApplyBellSingletChshA0B1",
+              "A": 0,
+              "B": -0.7853981633974483,
+              "Coefficient": 1,
+              "SameOutcomeProbability": 0.14644660940672619,
+              "OppositeOutcomeProbability": 0.8535533905932735,
+              "Correlator": 0.7071067811865474
+            }
+          },
+          "weight": 1
+        },
+        {
+          "row": {
+            "type": "BellCorner",
+            "value": {
+              "Id": "E(a1,b0)",
+              "Operation": "Zeta.ReferenceOracle.ApplyBellSingletChshA1B0",
+              "A": 1.5707963267948966,
+              "B": 0.7853981633974483,
+              "Coefficient": 1,
+              "SameOutcomeProbability": 0.14644660940672607,
+              "OppositeOutcomeProbability": 0.8535533905932735,
+              "Correlator": 0.7071067811865475
+            }
+          },
+          "weight": 1
+        },
+        {
+          "row": {
+            "type": "BellCorner",
+            "value": {
+              "Id": "E(a1,b1)",
+              "Operation": "Zeta.ReferenceOracle.ApplyBellSingletChshA1B1",
+              "A": 1.5707963267948966,
+              "B": -0.7853981633974483,
+              "Coefficient": -1,
+              "SameOutcomeProbability": 0.8535533905932735,
+              "OppositeOutcomeProbability": 0.14644660940672632,
+              "Correlator": -0.7071067811865472
+            }
+          },
+          "weight": 1
+        },
+        {
+          "row": {
+            "type": "BellCoincidence",
+            "value": {
+              "Id": "PhiPlus same-outcome a=0 b=pi/4",
+              "State": "PhiPlus",
+              "Operation": "Zeta.ReferenceOracle.ApplyBellPhiPlusAnalyzers",
+              "A": 0,
+              "B": 0.7853981633974483,
+              "Event": "sameOutcome",
+              "Probability": 0.8535533905932735
+            }
+          },
+          "weight": 1
+        },
+        {
+          "row": {
+            "type": "BellCoincidence",
+            "value": {
+              "Id": "Singlet opposite-outcome a=0 b=pi/4",
+              "State": "Singlet",
+              "Operation": "Zeta.ReferenceOracle.ApplyBellSingletAnalyzers",
+              "A": 0,
+              "B": 0.7853981633974483,
+              "Event": "oppositeOutcome",
+              "Probability": 0.8535533905932735
+            }
+          },
+          "weight": 1
+        },
+        {
+          "row": {
+            "type": "BellCoincidence",
+            "value": {
+              "Id": "PhiPlus same-outcome a=0 b=pi/2",
+              "State": "PhiPlus",
+              "Operation": "Zeta.ReferenceOracle.ApplyBellPhiPlusAnalyzers",
+              "A": 0,
+              "B": 1.5707963267948966,
+              "Event": "sameOutcome",
+              "Probability": 0.5
+            }
+          },
+          "weight": 1
+        },
+        {
+          "row": {
+            "type": "BellCoincidence",
+            "value": {
+              "Id": "PhiPlus same-outcome a=0 b=pi",
+              "State": "PhiPlus",
+              "Operation": "Zeta.ReferenceOracle.ApplyBellPhiPlusAnalyzers",
+              "A": 0,
+              "B": 3.141592653589793,
+              "Event": "sameOutcome",
+              "Probability": 3.7493994566546427e-33
+            }
+          },
+          "weight": 1
+        },
+        {
+          "row": {
+            "type": "InterferenceVisibility",
+            "value": {
+              "Id": "mach-zehnder-open",
+              "Operation": "Zeta.ReferenceOracle.ApplyMachZehnderOpen",
+              "Probabilities": {
+                "Zero": 0.5,
+                "One": 0.5
+              }
+            }
+          },
+          "weight": 1
+        },
+        {
+          "row": {
+            "type": "InterferenceVisibility",
+            "value": {
+              "Id": "mach-zehnder-closed-zero-phase",
+              "Operation": "Zeta.ReferenceOracle.ApplyMachZehnderClosedZeroPhase",
+              "PhaseRadians": 0,
+              "Probabilities": {
+                "Zero": 1,
+                "One": 0
+              },
+              "Visibility": 1
+            }
+          },
+          "weight": 1
+        },
+        {
+          "row": {
+            "type": "InterferenceVisibility",
+            "value": {
+              "Id": "mach-zehnder-closed-pi-over-3-phase",
+              "Operation": "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiOver3Phase",
+              "PhaseRadians": 1.0471975511965976,
+              "Probabilities": {
+                "Zero": 0.75,
+                "One": 0.25
+              },
+              "Visibility": 1
+            }
+          },
+          "weight": 1
+        },
+        {
+          "row": {
+            "type": "InterferenceVisibility",
+            "value": {
+              "Id": "mach-zehnder-closed-pi-over-2-phase",
+              "Operation": "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiOver2Phase",
+              "PhaseRadians": 1.5707963267948966,
+              "Probabilities": {
+                "Zero": 0.5,
+                "One": 0.5
+              },
+              "Visibility": 1
+            }
+          },
+          "weight": 1
+        },
+        {
+          "row": {
+            "type": "InterferenceVisibility",
+            "value": {
+              "Id": "mach-zehnder-closed-two-pi-over-3-phase",
+              "Operation": "Zeta.ReferenceOracle.ApplyMachZehnderClosedTwoPiOver3Phase",
+              "PhaseRadians": 2.0943951023931953,
+              "Probabilities": {
+                "Zero": 0.25,
+                "One": 0.75
+              },
+              "Visibility": 1
+            }
+          },
+          "weight": 1
+        },
+        {
+          "row": {
+            "type": "InterferenceVisibility",
+            "value": {
+              "Id": "mach-zehnder-closed-pi-phase",
+              "Operation": "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiPhase",
+              "PhaseRadians": 3.141592653589793,
+              "Probabilities": {
+                "Zero": 0,
+                "One": 1
+              },
+              "Visibility": 1
+            }
+          },
+          "weight": 1
+        }
+      ]
+    },
+    {
+      "batchId": 1,
+      "deltas": [
+        {
+          "row": {
+            "type": "InterferenceVisibility",
+            "value": {
+              "Id": "mach-zehnder-open",
+              "Operation": "Zeta.ReferenceOracle.ApplyMachZehnderOpen",
+              "Probabilities": {
+                "Zero": 0.5,
+                "One": 0.5
+              }
+            }
+          },
+          "weight": -1
+        },
+        {
+          "row": {
+            "type": "InterferenceVisibility",
+            "value": {
+              "Id": "mach-zehnder-closed-zero-phase",
+              "Operation": "Zeta.ReferenceOracle.ApplyMachZehnderClosedZeroPhase",
+              "PhaseRadians": 0,
+              "Probabilities": {
+                "Zero": 1,
+                "One": 0
+              },
+              "Visibility": 1
+            }
+          },
+          "weight": -1
+        },
+        {
+          "row": {
+            "type": "InterferenceVisibility",
+            "value": {
+              "Id": "mach-zehnder-closed-pi-over-6-phase",
+              "Operation": "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiOver6Phase",
+              "PhaseRadians": 0.5235987755982988,
+              "Probabilities": {
+                "Zero": 0.93301270189222,
+                "One": 0.06698729810778
+              },
+              "Visibility": 1
+            }
+          },
+          "weight": 1
+        }
+      ]
+    }
+  ]
+}

--- a/src/Core.TypeScript/quantum-observable/quantum-treaty-transcript.test.ts
+++ b/src/Core.TypeScript/quantum-observable/quantum-treaty-transcript.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import transcript from "./quantum-treaty-transcript.json";
+import { QuantumObservableOracle } from "./oracle";
+
+const tolerance = 1e-5;
+
+describe("Quantum treaty transcript integrity", () => {
+  const oracle = new QuantumObservableOracle();
+
+  test("transcript schema is correct", () => {
+    expect(transcript.schema).toBe("zeta.quantum.zset-transcript.v1");
+    expect(transcript.batches.length).toBe(2);
+  });
+
+  test("batch 0 deltas match simulator expectations", () => {
+    const batch = transcript.batches[0]!;
+    expect(batch.batchId).toBe(0);
+
+    for (const delta of batch.deltas) {
+      expect(delta.weight).toBe(1);
+      const row = delta.row;
+
+      switch (row.type) {
+        case "SingleQubit": {
+          const expected = row.value;
+          const actual = oracle.runSingleQubit(expected.Id, expected.Operation, expected.ThetaRadians);
+          expect(actual.Probabilities.Zero).toBeCloseTo(expected.Probabilities.Zero, 5);
+          expect(actual.Probabilities.One).toBeCloseTo(expected.Probabilities.One, 5);
+          break;
+        }
+        case "CanonicalChsh": {
+          const expected = row.value;
+          const actual = oracle.runCanonicalChsh(
+            expected.Id,
+            expected.Angles.A,
+            expected.Angles.APrime,
+            expected.Angles.B,
+            expected.Angles.BPrime
+          );
+          expect(actual.Correlators.EAB).toBeCloseTo(expected.Correlators.EAB, 5);
+          expect(actual.Correlators.EABPrime).toBeCloseTo(expected.Correlators.EABPrime, 5);
+          expect(actual.Correlators.EAPrimeB).toBeCloseTo(expected.Correlators.EAPrimeB, 5);
+          expect(actual.Correlators.EAPrimeBPrime).toBeCloseTo(expected.Correlators.EAPrimeBPrime, 5);
+          expect(actual.S).toBeCloseTo(expected.S, 5);
+          break;
+        }
+        case "SingletChsh": {
+          const expected = row.value;
+          const actual = oracle.runSingletChsh(expected.Id, expected.Corners);
+          expect(actual.S).toBeCloseTo(expected.S, 5);
+          break;
+        }
+        case "BellCorner": {
+          const expected = row.value;
+          // We can test a corner by wrapping it as a single-element list in runSingletChsh
+          const actualSinglet = oracle.runSingletChsh("dummy", [expected]);
+          const actual = actualSinglet.Corners[0]!;
+          expect(actual.SameOutcomeProbability).toBeCloseTo(expected.SameOutcomeProbability, 5);
+          expect(actual.OppositeOutcomeProbability).toBeCloseTo(expected.OppositeOutcomeProbability, 5);
+          expect(actual.Correlator).toBeCloseTo(expected.Correlator, 5);
+          break;
+        }
+        case "BellCoincidence": {
+          const expected = row.value;
+          const actual = oracle.runBellCoincidence(
+            expected.Id,
+            expected.State,
+            expected.Operation,
+            expected.A,
+            expected.B,
+            expected.Event
+          );
+          expect(actual.Probability).toBeCloseTo(expected.Probability, 5);
+          break;
+        }
+        case "InterferenceVisibility": {
+          const expected = row.value;
+          const actual = oracle.runInterferenceVisibility(expected.Id, expected.Operation, expected.PhaseRadians);
+          expect(actual.Probabilities.Zero).toBeCloseTo(expected.Probabilities.Zero, 5);
+          expect(actual.Probabilities.One).toBeCloseTo(expected.Probabilities.One, 5);
+          expect(actual.Visibility).toBe(expected.Visibility);
+          break;
+        }
+      }
+    }
+  });
+
+  test("batch 1 deltas match simulator expectations", () => {
+    const batch = transcript.batches[1]!;
+    expect(batch.batchId).toBe(1);
+
+    for (const delta of batch.deltas) {
+      const row = delta.row;
+      if (delta.weight === -1) {
+        expect(row.type).toBe("InterferenceVisibility");
+        const expected = row.value;
+        const actual = oracle.runInterferenceVisibility(expected.Id, expected.Operation, expected.PhaseRadians);
+        expect(actual.Probabilities.Zero).toBeCloseTo(expected.Probabilities.Zero, 5);
+        expect(actual.Probabilities.One).toBeCloseTo(expected.Probabilities.One, 5);
+      } else {
+        expect(delta.weight).toBe(1);
+        expect(row.type).toBe("InterferenceVisibility");
+        const expected = row.value;
+        const actual = oracle.runInterferenceVisibility(expected.Id, expected.Operation, expected.PhaseRadians);
+        expect(actual.Probabilities.Zero).toBeCloseTo(expected.Probabilities.Zero, 5);
+        expect(actual.Probabilities.One).toBeCloseTo(expected.Probabilities.One, 5);
+      }
+    }
+  });
+});

--- a/src/Core.TypeScript/quantum-observable/types.ts
+++ b/src/Core.TypeScript/quantum-observable/types.ts
@@ -1,0 +1,239 @@
+export interface Probabilities {
+  readonly Zero: number;
+  readonly One: number;
+}
+
+export interface SingleQubitMeasurement {
+  readonly Id: string;
+  readonly Operation: string;
+  readonly ThetaRadians?: number;
+  readonly Probabilities: Probabilities;
+}
+
+export interface ChshAngles {
+  readonly A: number;
+  readonly APrime: number;
+  readonly B: number;
+  readonly BPrime: number;
+}
+
+export interface ChshCorrelators {
+  readonly EAB: number;
+  readonly EABPrime: number;
+  readonly EAPrimeB: number;
+  readonly EAPrimeBPrime: number;
+}
+
+export interface CanonicalChsh {
+  readonly Id: string;
+  readonly Angles: ChshAngles;
+  readonly Correlators: ChshCorrelators;
+  readonly S: number;
+  readonly Tsirelson: number;
+  readonly ClassicalBound: number;
+}
+
+export interface BellCorner {
+  readonly Id: string;
+  readonly Operation: string;
+  readonly A: number;
+  readonly B: number;
+  readonly Coefficient: number;
+  readonly SameOutcomeProbability: number;
+  readonly OppositeOutcomeProbability: number;
+  readonly Correlator: number;
+}
+
+export interface SingletChsh {
+  readonly Id: string;
+  readonly Corners: readonly BellCorner[];
+  readonly S: number;
+  readonly Analytic: number;
+  readonly ClassicalBound: number;
+}
+
+export interface BellCoincidence {
+  readonly Id: string;
+  readonly State: string;
+  readonly Operation: string;
+  readonly A: number;
+  readonly B: number;
+  readonly Event: string;
+  readonly Probability: number;
+}
+
+export interface InterferenceVisibility {
+  readonly Id: string;
+  readonly Operation: string;
+  readonly PhaseRadians?: number;
+  readonly Probabilities: Probabilities;
+  readonly Visibility?: number;
+}
+
+export type QuantumObservableRow =
+  | { readonly type: "SingleQubit"; readonly value: SingleQubitMeasurement }
+  | { readonly type: "CanonicalChsh"; readonly value: CanonicalChsh }
+  | { readonly type: "SingletChsh"; readonly value: SingletChsh }
+  | { readonly type: "BellCorner"; readonly value: BellCorner }
+  | { readonly type: "BellCoincidence"; readonly value: BellCoincidence }
+  | { readonly type: "InterferenceVisibility"; readonly value: InterferenceVisibility };
+
+export interface QuantumObservableDelta {
+  readonly row: QuantumObservableRow;
+  readonly weight: number;
+}
+
+function compareStrings(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+function compareNumbers(a?: number, b?: number): number {
+  if (a === undefined && b === undefined) return 0;
+  if (a === undefined) return -1;
+  if (b === undefined) return 1;
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function tagOrder(type: QuantumObservableRow["type"]): number {
+  switch (type) {
+    case "SingleQubit": return 0;
+    case "CanonicalChsh": return 1;
+    case "SingletChsh": return 2;
+    case "BellCorner": return 3;
+    case "BellCoincidence": return 4;
+    case "InterferenceVisibility": return 5;
+  }
+}
+
+export function compareQuantumObservableRow(a: QuantumObservableRow, b: QuantumObservableRow): number {
+  if (a.type !== b.type) {
+    return tagOrder(a.type) - tagOrder(b.type);
+  }
+
+  // Compare Ids first
+  const idA = a.value.Id;
+  const idB = b.value.Id;
+  const cmpId = compareStrings(idA, idB);
+  if (cmpId !== 0) return cmpId;
+
+  // Compare other fields depending on tag
+  switch (a.type) {
+    case "SingleQubit": {
+      const va = a.value;
+      const vb = b.value as SingleQubitMeasurement;
+      let cmp = compareStrings(va.Operation, vb.Operation);
+      if (cmp !== 0) return cmp;
+      cmp = compareNumbers(va.ThetaRadians, vb.ThetaRadians);
+      if (cmp !== 0) return cmp;
+      cmp = compareNumbers(va.Probabilities.Zero, vb.Probabilities.Zero);
+      if (cmp !== 0) return cmp;
+      return compareNumbers(va.Probabilities.One, vb.Probabilities.One);
+    }
+    case "CanonicalChsh": {
+      const va = a.value;
+      const vb = b.value as CanonicalChsh;
+      let cmp = compareNumbers(va.Angles.A, vb.Angles.A);
+      if (cmp !== 0) return cmp;
+      cmp = compareNumbers(va.Angles.APrime, vb.Angles.APrime);
+      if (cmp !== 0) return cmp;
+      cmp = compareNumbers(va.Angles.B, vb.Angles.B);
+      if (cmp !== 0) return cmp;
+      cmp = compareNumbers(va.Angles.BPrime, vb.Angles.BPrime);
+      if (cmp !== 0) return cmp;
+      cmp = compareNumbers(va.Correlators.EAB, vb.Correlators.EAB);
+      if (cmp !== 0) return cmp;
+      cmp = compareNumbers(va.Correlators.EABPrime, vb.Correlators.EABPrime);
+      if (cmp !== 0) return cmp;
+      cmp = compareNumbers(va.Correlators.EAPrimeB, vb.Correlators.EAPrimeB);
+      if (cmp !== 0) return cmp;
+      cmp = compareNumbers(va.Correlators.EAPrimeBPrime, vb.Correlators.EAPrimeBPrime);
+      if (cmp !== 0) return cmp;
+      cmp = compareNumbers(va.S, vb.S);
+      if (cmp !== 0) return cmp;
+      cmp = compareNumbers(va.Tsirelson, vb.Tsirelson);
+      if (cmp !== 0) return cmp;
+      return compareNumbers(va.ClassicalBound, vb.ClassicalBound);
+    }
+    case "SingletChsh": {
+      const va = a.value;
+      const vb = b.value as SingletChsh;
+      let cmp = compareNumbers(va.S, vb.S);
+      if (cmp !== 0) return cmp;
+      cmp = compareNumbers(va.Analytic, vb.Analytic);
+      if (cmp !== 0) return cmp;
+      cmp = compareNumbers(va.ClassicalBound, vb.ClassicalBound);
+      if (cmp !== 0) return cmp;
+      const lenA = va.Corners.length;
+      const lenB = vb.Corners.length;
+      if (lenA !== lenB) return lenA - lenB;
+      for (let i = 0; i < lenA; i++) {
+        const ca = va.Corners[i]!;
+        const cb = vb.Corners[i]!;
+        let cmpC = compareStrings(ca.Id, cb.Id);
+        if (cmpC !== 0) return cmpC;
+        cmpC = compareStrings(ca.Operation, cb.Operation);
+        if (cmpC !== 0) return cmpC;
+        cmpC = compareNumbers(ca.A, cb.A);
+        if (cmpC !== 0) return cmpC;
+        cmpC = compareNumbers(ca.B, cb.B);
+        if (cmpC !== 0) return cmpC;
+        cmpC = ca.Coefficient - cb.Coefficient;
+        if (cmpC !== 0) return cmpC;
+        cmpC = compareNumbers(ca.SameOutcomeProbability, cb.SameOutcomeProbability);
+        if (cmpC !== 0) return cmpC;
+        cmpC = compareNumbers(ca.OppositeOutcomeProbability, cb.OppositeOutcomeProbability);
+        if (cmpC !== 0) return cmpC;
+        cmpC = compareNumbers(ca.Correlator, cb.Correlator);
+        if (cmpC !== 0) return cmpC;
+      }
+      return 0;
+    }
+    case "BellCorner": {
+      const va = a.value;
+      const vb = b.value as BellCorner;
+      let cmp = compareStrings(va.Operation, vb.Operation);
+      if (cmp !== 0) return cmp;
+      cmp = compareNumbers(va.A, vb.A);
+      if (cmp !== 0) return cmp;
+      cmp = compareNumbers(va.B, vb.B);
+      if (cmp !== 0) return cmp;
+      cmp = va.Coefficient - vb.Coefficient;
+      if (cmp !== 0) return cmp;
+      cmp = compareNumbers(va.SameOutcomeProbability, vb.SameOutcomeProbability);
+      if (cmp !== 0) return cmp;
+      cmp = compareNumbers(va.OppositeOutcomeProbability, vb.OppositeOutcomeProbability);
+      if (cmp !== 0) return cmp;
+      return compareNumbers(va.Correlator, vb.Correlator);
+    }
+    case "BellCoincidence": {
+      const va = a.value;
+      const vb = b.value as BellCoincidence;
+      let cmp = compareStrings(va.State, vb.State);
+      if (cmp !== 0) return cmp;
+      cmp = compareStrings(va.Operation, vb.Operation);
+      if (cmp !== 0) return cmp;
+      cmp = compareNumbers(va.A, vb.A);
+      if (cmp !== 0) return cmp;
+      cmp = compareNumbers(va.B, vb.B);
+      if (cmp !== 0) return cmp;
+      cmp = compareStrings(va.Event, vb.Event);
+      if (cmp !== 0) return cmp;
+      return compareNumbers(va.Probability, vb.Probability);
+    }
+    case "InterferenceVisibility": {
+      const va = a.value;
+      const vb = b.value as InterferenceVisibility;
+      let cmp = compareStrings(va.Operation, vb.Operation);
+      if (cmp !== 0) return cmp;
+      cmp = compareNumbers(va.PhaseRadians, vb.PhaseRadians);
+      if (cmp !== 0) return cmp;
+      cmp = compareNumbers(va.Probabilities.Zero, vb.Probabilities.Zero);
+      if (cmp !== 0) return cmp;
+      cmp = compareNumbers(va.Probabilities.One, vb.Probabilities.One);
+      if (cmp !== 0) return cmp;
+      return compareNumbers(va.Visibility, vb.Visibility);
+    }
+  }
+}

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -249,6 +249,7 @@
     <Compile Include="SoftEmu.fs" />
     <Compile Include="AmplitudeEmu.fs" />
     <Compile Include="QuantumObservableTreaty.fs" />
+    <Compile Include="QuantumObservableDbsp.fs" />
     <Compile Include="SoftMem.fs" />
     <Compile Include="SoftDrive.fs" />
     <Compile Include="SoftScope.fs" />

--- a/src/Core/QuantumObservableDbsp.Tests.fs
+++ b/src/Core/QuantumObservableDbsp.Tests.fs
@@ -1,0 +1,152 @@
+module Zeta.Tests.QuantumObservableDbspTests
+
+open System
+open System.IO
+open System.Text.Json
+open global.Xunit
+open Zeta.Core
+
+let private repoRoot () =
+    let mutable dir = DirectoryInfo(System.AppContext.BaseDirectory)
+    while not (isNull dir) && not (File.Exists(Path.Combine(dir.FullName, "Zeta.sln"))) do
+        dir <- dir.Parent
+    dir.FullName
+
+let private tolerance = 1e-5
+
+let private probFor (k: int) (ps: (int * float) list) =
+    ps |> List.filter (fun (key, _) -> key = k) |> List.sumBy snd
+
+[<Fact>]
+let ``F# parses quantum Z-set transcript and verifies parity under DBSP updates`` () =
+    let path = Path.Combine(repoRoot (), "src", "Core.TypeScript", "quantum-observable", "quantum-treaty-transcript.json")
+    let json = File.ReadAllText path
+    let transcript = JsonSerializer.Deserialize<Transcript>(json)
+
+    Assert.Equal("zeta.quantum.zset-transcript.v1", transcript.Schema)
+    Assert.Equal(2, transcript.Batches.Length)
+
+    // Batch 0
+    let batch0 = transcript.Batches.[0]
+    Assert.Equal(0, batch0.BatchId)
+
+    let batch0Z =
+        batch0.Deltas
+        |> List.map (fun d -> d.Row, d.Weight)
+        |> ZSet.ofSeq
+
+    // Initial state after Batch 0
+    let state = batch0Z
+    Assert.Equal(19, ZSet.count state) // 19 distinct rows
+
+    // Query 1: Filter Mach-Zehnder interference rows
+    let interferenceRows =
+        state
+        |> ZSet.filter (fun r ->
+            match r with
+            | QuantumObservableRow.InterferenceVisibility _ -> true
+            | _ -> false)
+
+    Assert.Equal(6, ZSet.count interferenceRows)
+
+    // Check Mach-Zehnder probabilities
+    for kv in interferenceRows do
+        match kv.Key with
+        | QuantumObservableRow.InterferenceVisibility v ->
+            let ws =
+                if v.Operation.EndsWith("Open", StringComparison.Ordinal) then
+                    MachZehnderWSet.openArm ()
+                else
+                    let phase =
+                        match v.PhaseRadians with
+                        | Some p -> p
+                        | None -> 0.0
+                    MachZehnderWSet.closed phase
+            
+            // Expected Zero probability from Mach-Zehnder WSet
+            let expectedZero = probFor 0 ws
+            let expectedOne = 1.0 - expectedZero
+
+            Assert.True(abs (v.Probabilities.Zero - expectedZero) <= tolerance, sprintf "%s Zero expected %f, got %f" v.Id expectedZero v.Probabilities.Zero)
+            Assert.True(abs (v.Probabilities.One - expectedOne) <= tolerance, sprintf "%s One expected %f, got %f" v.Id expectedOne v.Probabilities.One)
+        | _ -> Assert.Fail("Expected InterferenceVisibility row")
+
+    // Query 2: Filter Bell Coincidence rows
+    let coincidenceRows =
+        state
+        |> ZSet.filter (fun r ->
+            match r with
+            | QuantumObservableRow.BellCoincidence _ -> true
+            | _ -> false)
+
+    Assert.Equal(4, ZSet.count coincidenceRows)
+
+    for kv in coincidenceRows do
+        match kv.Key with
+        | QuantumObservableRow.BellCoincidence v ->
+            let expected =
+                if v.State = "Singlet" then
+                    if v.Event = "oppositeOutcome" then
+                        BellTest.coincidenceProbability v.A v.B
+                    else
+                        1.0 - BellTest.coincidenceProbability v.A v.B
+                else // PhiPlus
+                    if v.Event = "sameOutcome" then
+                        BellTest.coincidenceProbability v.A v.B
+                    else
+                        1.0 - BellTest.coincidenceProbability v.A v.B
+
+            Assert.True(abs (v.Probability - expected) <= tolerance, sprintf "%s probability expected %f, got %f" v.Id expected v.Probability)
+        | _ -> Assert.Fail("Expected BellCoincidence row")
+
+    // Batch 1: Retractions and updates
+    let batch1 = transcript.Batches.[1]
+    Assert.Equal(1, batch1.BatchId)
+
+    let batch1Z =
+        batch1.Deltas
+        |> List.map (fun d -> d.Row, d.Weight)
+        |> ZSet.ofSeq
+
+    // Apply incremental update (DBSP state update)
+    let state' = state + batch1Z
+
+    // Validate retractions (deleted entries must have weight 0 and be dropped from the Z-set)
+    let interferenceRows' =
+        state'
+        |> ZSet.filter (fun r ->
+            match r with
+            | QuantumObservableRow.InterferenceVisibility _ -> true
+            | _ -> false)
+
+    // 6 original MZ rows - 2 retracted + 1 new = 5 rows
+    Assert.Equal(5, ZSet.count interferenceRows')
+
+    // Assert retracted keys are completely gone
+    for kv in interferenceRows' do
+        match kv.Key with
+        | QuantumObservableRow.InterferenceVisibility v ->
+            Assert.NotEqual<string>("mach-zehnder-open", v.Id)
+            Assert.NotEqual<string>("mach-zehnder-closed-zero-phase", v.Id)
+        | _ -> ()
+
+    // Verify new row is present and correct
+    let piOver6RowOpt =
+        interferenceRows'
+        |> ZSet.filter (fun r ->
+            match r with
+            | QuantumObservableRow.InterferenceVisibility v -> v.Id = "mach-zehnder-closed-pi-over-6-phase"
+            | _ -> false)
+
+    Assert.Equal(1, ZSet.count piOver6RowOpt)
+    
+    // Validate new row probabilities against F# analytic
+    let piOver6Key = (Seq.head piOver6RowOpt).Key
+    match piOver6Key with
+    | QuantumObservableRow.InterferenceVisibility v ->
+        let ws = MachZehnderWSet.closed (System.Math.PI / 6.0)
+        let expectedZero = probFor 0 ws
+        let expectedOne = 1.0 - expectedZero
+        Assert.True(abs (v.Probabilities.Zero - expectedZero) <= tolerance)
+        Assert.True(abs (v.Probabilities.One - expectedOne) <= tolerance)
+    | _ -> Assert.Fail("Expected InterferenceVisibility row")

--- a/src/Core/QuantumObservableDbsp.fs
+++ b/src/Core/QuantumObservableDbsp.fs
@@ -1,0 +1,84 @@
+namespace Zeta.Core
+
+open System
+open System.Text.Json
+open System.Text.Json.Serialization
+
+type QuantumObservableRowConverter() =
+    inherit JsonConverter<QuantumObservableRow>()
+
+    override _.Read(reader: byref<Utf8JsonReader>, typeToConvert: Type, options: JsonSerializerOptions) =
+        let doc = JsonDocument.ParseValue(&reader)
+        let root = doc.RootElement
+        let typ = root.GetProperty("type").GetString()
+        let valueVal = root.GetProperty("value")
+
+        match typ with
+        | "SingleQubit" ->
+            let v = JsonSerializer.Deserialize<QuantumObservableTreaty.SingleQubitMeasurement>(valueVal.GetRawText(), options)
+            QuantumObservableRow.SingleQubit v
+        | "CanonicalChsh" ->
+            let v = JsonSerializer.Deserialize<QuantumObservableTreaty.CanonicalChsh>(valueVal.GetRawText(), options)
+            QuantumObservableRow.CanonicalChsh v
+        | "SingletChsh" ->
+            let v = JsonSerializer.Deserialize<QuantumObservableTreaty.SingletChsh>(valueVal.GetRawText(), options)
+            QuantumObservableRow.SingletChsh v
+        | "BellCorner" ->
+            let v = JsonSerializer.Deserialize<QuantumObservableTreaty.BellCorner>(valueVal.GetRawText(), options)
+            QuantumObservableRow.BellCorner v
+        | "BellCoincidence" ->
+            let v = JsonSerializer.Deserialize<QuantumObservableTreaty.BellCoincidence>(valueVal.GetRawText(), options)
+            QuantumObservableRow.BellCoincidence v
+        | "InterferenceVisibility" ->
+            let v = JsonSerializer.Deserialize<QuantumObservableTreaty.InterferenceVisibility>(valueVal.GetRawText(), options)
+            QuantumObservableRow.InterferenceVisibility v
+        | _ -> failwithf "Unknown quantum observable row type: %s" typ
+
+    override _.Write(writer: Utf8JsonWriter, value: QuantumObservableRow, options: JsonSerializerOptions) =
+        writer.WriteStartObject()
+        match value with
+        | QuantumObservableRow.SingleQubit v ->
+            writer.WriteString("type", "SingleQubit")
+            writer.WritePropertyName("value")
+            JsonSerializer.Serialize(writer, v, options)
+        | QuantumObservableRow.CanonicalChsh v ->
+            writer.WriteString("type", "CanonicalChsh")
+            writer.WritePropertyName("value")
+            JsonSerializer.Serialize(writer, v, options)
+        | QuantumObservableRow.SingletChsh v ->
+            writer.WriteString("type", "SingletChsh")
+            writer.WritePropertyName("value")
+            JsonSerializer.Serialize(writer, v, options)
+        | QuantumObservableRow.BellCorner v ->
+            writer.WriteString("type", "BellCorner")
+            writer.WritePropertyName("value")
+            JsonSerializer.Serialize(writer, v, options)
+        | QuantumObservableRow.BellCoincidence v ->
+            writer.WriteString("type", "BellCoincidence")
+            writer.WritePropertyName("value")
+            JsonSerializer.Serialize(writer, v, options)
+        | QuantumObservableRow.InterferenceVisibility v ->
+            writer.WriteString("type", "InterferenceVisibility")
+            writer.WritePropertyName("value")
+            JsonSerializer.Serialize(writer, v, options)
+        writer.WriteEndObject()
+
+and [<JsonConverter(typeof<QuantumObservableRowConverter>)>] QuantumObservableRow =
+    | SingleQubit of QuantumObservableTreaty.SingleQubitMeasurement
+    | CanonicalChsh of QuantumObservableTreaty.CanonicalChsh
+    | SingletChsh of QuantumObservableTreaty.SingletChsh
+    | BellCorner of QuantumObservableTreaty.BellCorner
+    | BellCoincidence of QuantumObservableTreaty.BellCoincidence
+    | InterferenceVisibility of QuantumObservableTreaty.InterferenceVisibility
+
+type QuantumObservableDelta =
+    { [<JsonPropertyName("row")>] Row: QuantumObservableRow
+      [<JsonPropertyName("weight")>] Weight: int64 }
+
+type Batch =
+    { [<JsonPropertyName("batchId")>] BatchId: int
+      [<JsonPropertyName("deltas")>] Deltas: QuantumObservableDelta list }
+
+type Transcript =
+    { [<JsonPropertyName("schema")>] Schema: string
+      [<JsonPropertyName("batches")>] Batches: Batch list }

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -437,6 +437,7 @@
     <Compile Include="Sha256/CrossVerifyTests.fs" />
     <Compile Include="CanonicalJson/CrossVerifyTests.fs" />
     <Compile Include="../../src/Core/WorkflowEngine.Tests.fs" />
+    <Compile Include="../../src/Core/QuantumObservableDbsp.Tests.fs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR contains the TS-F# symmetry slice for the quantum observable lane (B-1029/B-1033). It implements TS QuantumObservableRow/Delta, IQuantumObservableOracle interface wrapping quantum-circuit, signed Z-set transcript generation, cross-check assertions, and experimental Q# exporter.