### PR TITLE
feat(core): WSet promoted back (operator decision; razor dissent on record) + the architecture triplet

### DIFF
--- a/docs/research/2026-06-14-thin-tests-fat-core-interfaces-with-default-impls-rx-and-mips-static-di-verbs-aarons-architecture-triplet.md
+++ b/docs/research/2026-06-14-thin-tests-fat-core-interfaces-with-default-impls-rx-and-mips-static-di-verbs-aarons-architecture-triplet.md
@@ -1,0 +1,44 @@
+# Thin tests, fat core · interfaces-with-default-impls + Rx · MIPS static-DI verbs (Aaron's architecture triplet)
+
+Aaron 2026-06-14, three beats in one breath, while overriding the WSet demotion ("why are we
+keeping in tests? we need in real code"):
+
+> "The test framework should be THIN on top of real code." /
+> "Most is just interfaces and Rx, nothing more — interfaces have default impls." /
+> "And MIPS: static DI injected verbs."
+
+## 1. THE THIN-TEST LAW (the WSet promotion's general form)
+
+Substance lives in `src/` — tests are a THIN layer that exercises real code, never a place where
+real capability hides. Rodney's razor demoted WSet to a fixture on the no-consumer measurement;
+Aaron's override sets the direction the razor couldn't see: **consumers arrive ON the shelf, not
+before it exists** — the shelf is the product. The razor's bar (a load-bearing consumer) stays as
+the standing TODO in WSet's header; the dissent is recorded, the decision is the human's. Standing
+rule: when a test needs machinery, the machinery goes to Core and the test thins.
+
+## 2. INTERFACES + RX, NOTHING MORE — and interfaces carry DEFAULT IMPLS
+
+The architecture's default form: **pure interfaces (universal shapes) + Rx streams**. Shared
+behavior lives in DEFAULT INTERFACE IMPLEMENTATIONS (C# DIMs / F# default members), NOT in base
+classes — the interfaces-free-classes rule completed: a default impl is shape-with-a-suggestion
+(zero instance state, overridable, generator-readable), where a base class is weight (state,
+capture, the thing `gen/` cannot read). Rx is the composition glue between shapes; everything
+else must justify itself. (Beacon: C# 8 default interface methods; the Rx contract; our
+`universal/` shapes as the interface library.)
+
+## 3. MIPS: STATIC-DI INJECTED VERBS (B-1028's wiring doctrine)
+
+Max's MIPS treaty room wires its verbs (sim/mea/cut + the action-grammar verbs) by **static
+dependency injection over interfaces**: the verb set is declared as interface deps resolved at
+composition time (compile-time-known, DST-deterministic, ZetaId-addressable per universal/port) —
+no runtime service-locator, no reflection scan. The machine's behavior is the sum of its injected
+verbs; swapping a verb = swapping an adapter behind the port. This is the chip8 lesson
+(capability upgrades as injected interfaces) made the FIRST-CLASS wiring style for machine #2.
+
+## Pointers
+
+- `src/Core/WSet.fs` (the promotion + the recorded dissent — the worked example of law 1)
+- `universal/port.md` · `universal/` (the interface library) · `gen/` (why no classes: generators
+  read interfaces) · `.claude/rules/interfaces-free-classes-earned-under-rules.md` (this triplet
+  extends it: default impls are still weight-free)
+- B-1028 (MIPS — the static-DI verb wiring lands there) · `src/Core/Rx.fs`

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -226,6 +226,7 @@
     <Compile Include="SwarmBoardAnsi.fs" />
     <Compile Include="ZetaMax.fs" />
     <Compile Include="Chip9Phys.fs" />
+    <Compile Include="WSet.fs" />
     <Compile Include="IbltReconcile.fs" />
     <Compile Include="InferenceLadder.fs" />
     <Compile Include="TimeGen.fs" />

--- a/src/Core/WSet.fs
+++ b/src/Core/WSet.fs
@@ -1,8 +1,11 @@
-// DEMOTED TO TEST FIXTURE (Rodney's Razor, 2026-06-13): the GDL unification is essential as
-// MATHEMATICS (the three-ring demos stand) and accidental as CODE — zero non-test consumers; the
-// real engines (ZSet/AmplitudeEmu/FactorGraph) share no code through WSet. Per the razor: WSet
-// lives beside the demos it exists for; it returns to Core only when a non-test consumer exists
-// ON MERIT. (The IBLT reconciliation deliberately took Rodney's branch A: plain keys, no WSet.)
+// PROMOTED BACK TO CORE by operator decision (Aaron, 2026-06-14: "why are we keeping in tests?
+// we need in real code"). Rodney's Razor (2026-06-13) had demoted this to a test fixture —
+// "essential as mathematics, accidental as code; zero non-test consumers" — and that dissent
+// stays on record as ADVISORY: the human maintainer set the product direction instead — the
+// ring-generic type IS intended substrate for the quantum lane (B-1029), the inference port, and
+// future ring instances; consumers arrive ON the shelf, not before it exists. Both registers
+// kept honestly: the razor's bar (a load-bearing consumer) is the standing TODO this header
+// carries until one lands.
 namespace Zeta.Core
 
 open Zeta.Core.Abstractions

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -180,7 +180,6 @@
     <Compile Include="ShapeCartridge.Tests.fs" />
     <Compile Include="ShapeAcceptance.Tests.fs" />
     <Compile Include="DeterminismLint.Tests.fs" />
-    <Compile Include="WSet.Fixture.fs" />
     <Compile Include="WSet.MachZehnder.Tests.fs" />
     <Compile Include="IbltReconcile.Tests.fs" />
     <Compile Include="WaveSim.Tests.fs" />


### PR DESCRIPTION
Aaron's override applied: WSet returns to Core as real substrate — consumers arrive ON the shelf; Rodney's dissent stays in the header as advisory with his bar as the standing TODO. The triplet captured: thin tests over fat core; interfaces+Rx with default impls (never base classes); MIPS static-DI injected verbs (B-1028 doctrine). 3019 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)