### PR TITLE
docs: 'doctrine' retired again — swept from my captures (observations only)

### DIFF
--- a/docs/research/2026-06-11-ferry-amara-tests-as-time-stepper-time-as-generator-chsh-regimes-cross-repo-weave-plus-the-proof-built.md
+++ b/docs/research/2026-06-11-ferry-amara-tests-as-time-stepper-time-as-generator-chsh-regimes-cross-repo-weave-plus-the-proof-built.md
@@ -73,5 +73,5 @@ STRUCTURE is the treaty surface; fixed-point phases = the named slice for cross-
 - `src/Core/TimeGen.fs` + `tests/Tests.FSharp/TimeGen.Tests.fs` (the proof) · `SimLoop` (the
   generator-clock consumer already built) · the Bell/qubits docs (the unit circle lineage) · CHSH
   (Clauser-Horne-Shimony-Holt 1969) · Tsirelson 1980 (the 2√2 bound) · Popescu-Rohrlich 1994 (the S=4
-  box — the staged regime's honest name) · Amara's replay/advance split → the rooms/tests doctrine
+  box — the staged regime's honest name) · Amara's replay/advance split → the rooms/tests observation
   already live in rooms/README.

--- a/docs/research/2026-06-11-the-human-oracle-audio-pictures-animations-make-treaty-ratification-perceptual-anyone-can-agree.md
+++ b/docs/research/2026-06-11-the-human-oracle-audio-pictures-animations-make-treaty-ratification-perceptual-anyone-can-agree.md
@@ -19,7 +19,7 @@ With all three, **human perception becomes the fifth oracle**: a person ratifies
 looking and listening — "the spiral reads as a clock face; the fringes land on the lines; the
 downbeats hit together" — no code-reading required. And because every projection derives from the
 SAME golden vectors and common-cause seed, perceptual agreement IS agreement about the bytes: the
-render-is-the-oracle doctrine (yesterday's capture) run in reverse — the overlay truths let the eye
+render-is-the-oracle observation (yesterday's capture) run in reverse — the overlay truths let the eye
 falsify, the derivation chain lets the eye's yes count.
 
 Why this matters for the society: treaty ratification stops being gated on programmers. ANYONE —

--- a/docs/research/2026-06-11-the-render-is-the-oracle-cartridges-as-the-validation-and-debugging-surface-known-answer-overlays.md
+++ b/docs/research/2026-06-11-the-render-is-the-oracle-cartridges-as-the-validation-and-debugging-surface-known-answer-overlays.md
@@ -6,7 +6,7 @@ Aaron 2026-06-11 (via the Kestrel ferry, technical thread):
 > my head." / "This is how I plan on validating and debugging the system — these cartridges — to
 > make sure it works as I expect, without having to look at the code."
 
-## The doctrine
+## The observation
 
 A green unit test proves the phasor sum equals the Cayley add to 1e-9; it cannot prove the spiral
 reads like a clock face or the fringes land where the eye expects. **The render is the oracle for

--- a/docs/research/2026-06-14-thin-tests-fat-core-interfaces-with-default-impls-rx-and-mips-static-di-verbs-aarons-architecture-triplet.md
+++ b/docs/research/2026-06-14-thin-tests-fat-core-interfaces-with-default-impls-rx-and-mips-static-di-verbs-aarons-architecture-triplet.md
@@ -26,14 +26,14 @@ capture, the thing `gen/` cannot read). Rx is the composition glue between shape
 else must justify itself. (Beacon: C# 8 default interface methods; the Rx contract; our
 `universal/` shapes as the interface library.)
 
-## 3. MIPS: STATIC-DI INJECTED VERBS (B-1028's wiring doctrine)
+## 3. MIPS: STATIC-DI INJECTED VERBS (B-1028's wiring observation)
 
 Max's MIPS treaty room wires its verbs (sim/mea/cut + the action-grammar verbs) by **static
 dependency injection over interfaces**: the verb set is declared as interface deps resolved at
 composition time (compile-time-known, DST-deterministic, ZetaId-addressable per universal/port) —
 no runtime service-locator, no reflection scan. The machine's behavior is the sum of its injected
 verbs; swapping a verb = swapping an adapter behind the port. This is the chip8 lesson
-(capability upgrades as injected interfaces) made the FIRST-CLASS wiring style for machine #2.
+(capability upgrades as injected interfaces) made the FIRST-CLASS wiring style for machine #2 (an observation Max can adopt or push back on — not a mandate).
 
 ## Pointers
 
@@ -42,3 +42,10 @@ verbs; swapping a verb = swapping an adapter behind the port. This is the chip8 
   read interfaces) · `.claude/rules/interfaces-free-classes-earned-under-rules.md` (this triplet
   extends it: default impls are still weight-free)
 - B-1028 (MIPS — the static-DI verb wiring lands there) · `src/Core/Rx.fs`
+
+## Register note (Aaron, same hour): "we don't have doctrine"
+
+Correct — the word is RETIRED (second catch this stream; the first was 2026-06-11). These are
+OBSERVATIONS: Aaron's, captured faithfully, adoptable and contestable by any traveler. Nothing
+here binds by authority — the only directive is that there are no directives. The file's framing
+is corrected to match.


### PR DESCRIPTION
Aaron's second catch on the retired word. Four uses swept to 'observation'; register note added; lesson pinned in local memory. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)