### PR TITLE
feat(zflash): --test flag + B-0891 scenario-4 path-fork QEMU executor

### DIFF
--- a/.github/workflows/zflash-qemu-test.yml
+++ b/.github/workflows/zflash-qemu-test.yml
@@ -24,6 +24,7 @@ on:
       - 'tools/ci/audit-installer-iso-content.ts'
       - 'full-ai-cluster/tools/zflash.ts'
       - 'full-ai-cluster/tools/zflash-lib.ts'
+      - 'full-ai-cluster/tools/zflash-file-backed.ts'
       - 'docs/backlog/P1/B-0891-zflash-done-acceptance-criteria-qemu-test-harness-5-scenarios-initial-format-cluster-up-reformat-with-retention-reformat-from-scratch-cluster-joining-aaron-2026-05-28.md'
       - '.github/workflows/zflash-qemu-test.yml'
       - 'package.json'
@@ -37,6 +38,7 @@ on:
       - 'tools/ci/audit-installer-iso-content.ts'
       - 'full-ai-cluster/tools/zflash.ts'
       - 'full-ai-cluster/tools/zflash-lib.ts'
+      - 'full-ai-cluster/tools/zflash-file-backed.ts'
       - 'docs/backlog/P1/B-0891-zflash-done-acceptance-criteria-qemu-test-harness-5-scenarios-initial-format-cluster-up-reformat-with-retention-reformat-from-scratch-cluster-joining-aaron-2026-05-28.md'
       - '.github/workflows/zflash-qemu-test.yml'
       - 'package.json'
@@ -87,5 +89,21 @@ jobs:
           fi
           if ! grep -Fq "fails closed" retention-runtime.json; then
             echo "::error::retention runtime output did not document the fail-closed opt-in guard"
+            exit 1
+          fi
+
+      - name: Validate path-fork runtime fails closed by default
+        run: |
+          set +e
+          bun tools/zflash/test-harness/run.ts --scenario reformat-from-scratch zflash-qemu-path-fork-placeholder.iso > path-fork-runtime.json
+          exit_code="$?"
+          set -e
+          cat path-fork-runtime.json
+          if [ "$exit_code" -ne 1 ]; then
+            echo "::error::expected path-fork runtime to exit 1 without ZFLASH_QEMU_PATH_FORK_EXECUTE=1; got $exit_code"
+            exit 1
+          fi
+          if ! grep -Fq "fails closed" path-fork-runtime.json; then
+            echo "::error::path-fork runtime output did not document the fail-closed opt-in guard"
             exit 1
           fi

--- a/full-ai-cluster/tools/zflash-file-backed.ts
+++ b/full-ai-cluster/tools/zflash-file-backed.ts
@@ -1,12 +1,17 @@
 #!/usr/bin/env bun
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   createNodeFileBackedZflashImageExecutor,
   createNodeFileBackedZflashInlineStagingDirectory,
 } from "./zflash-file-backed-runtime";
 import {
+  composeAuthorizedKeysFileContent,
   executeFileBackedZflashImageExecutionPlan,
   planFileBackedZflashImage,
   planFileBackedZflashImageExecution,
+  ZETA_TEST_INFRA_PUBKEY_REPO_RELATIVE_PATH,
 } from "./zflash-lib";
 import type {
   FileBackedZflashImageExecution,
@@ -20,6 +25,7 @@ export interface FileBackedZflashCliOptions {
   readonly outputImagePath: string;
   readonly espOffsetBytes: number;
   readonly pubkeyPath?: string;
+  readonly testMode?: boolean;
   readonly hostname?: string;
   readonly credentialBlobPath?: string;
   readonly inlineStagingDirectory?: string;
@@ -47,9 +53,43 @@ export type FileBackedZflashCliRunResult =
 const USAGE =
   "Usage: bun full-ai-cluster/tools/zflash-file-backed.ts --iso <installer.iso> --output <raw.img> --esp-offset-bytes <bytes> [ESP writes]\n" +
   "  --ssh-key <path>             write /zeta-authorized-keys.pub from a public key file\n" +
+  "  --test                       QEMU/CI-only: union zeta-test-infra.pub with --ssh-key content\n" +
   "  --host <name>                write /zeta-hostname.txt with an RFC1123 hostname\n" +
   "  --credential-blob <path>     write /zeta-creds.enc from an encrypted credential blob\n" +
   "  --inline-staging-dir <path>  optional staging root for inline content files\n";
+
+function resolveTestInfraPubkeyPath(): string {
+  const scriptDir = dirname(fileURLToPath(import.meta.url));
+  return resolve(scriptDir, "../../", ZETA_TEST_INFRA_PUBKEY_REPO_RELATIVE_PATH);
+}
+
+function resolveAuthorizedKeysContent(
+  pubkeyPath: string | undefined,
+  testMode: boolean,
+): string | { readonly error: string } {
+  if (pubkeyPath === undefined && !testMode) {
+    return { error: "at least one of --ssh-key or --test is required for /zeta-authorized-keys.pub" };
+  }
+  const lines: string[] = [];
+  if (pubkeyPath !== undefined) {
+    if (!existsSync(pubkeyPath)) {
+      return { error: `ssh pubkey not found: ${pubkeyPath}` };
+    }
+    lines.push(readFileSync(pubkeyPath, "utf8"));
+  }
+  if (testMode) {
+    const testInfraPath = resolveTestInfraPubkeyPath();
+    if (!existsSync(testInfraPath)) {
+      return { error: `test-infra pubkey not found: ${testInfraPath}` };
+    }
+    lines.push(readFileSync(testInfraPath, "utf8"));
+  }
+  const composed = composeAuthorizedKeysFileContent(lines);
+  if (!composed.ok) {
+    return { error: composed.error };
+  }
+  return composed.value;
+}
 
 function requireValue(args: readonly string[], index: number, flag: string): string | { readonly error: string } {
   const value = args[index + 1];
@@ -67,10 +107,15 @@ export function parseFileBackedZflashArgs(args: readonly string[]): FileBackedZf
   let hostname: string | undefined;
   let credentialBlobPath: string | undefined;
   let inlineStagingDirectory: string | undefined;
+  let testMode = false;
 
   for (let index = 0; index < args.length; index++) {
     const arg = args[index]!;
     if (arg === "-h" || arg === "--help") return { kind: "help" };
+    if (arg === "--test") {
+      testMode = true;
+      continue;
+    }
 
     if (arg === "--iso" || arg === "--output" || arg === "--esp-offset-bytes" || arg === "--ssh-key" || arg === "--host" || arg === "--credential-blob" || arg === "--inline-staging-dir") {
       const value = requireValue(args, index, arg);
@@ -105,6 +150,7 @@ export function parseFileBackedZflashArgs(args: readonly string[]): FileBackedZf
       outputImagePath,
       espOffsetBytes,
       ...(pubkeyPath === undefined ? {} : { pubkeyPath }),
+      ...(testMode ? { testMode: true } : {}),
       ...(hostname === undefined ? {} : { hostname }),
       ...(credentialBlobPath === undefined ? {} : { credentialBlobPath }),
       ...(inlineStagingDirectory === undefined ? {} : { inlineStagingDirectory }),
@@ -131,11 +177,23 @@ export function runFileBackedZflashCli(
   options: FileBackedZflashCliOptions,
   deps: FileBackedZflashCliRunDeps = {},
 ): FileBackedZflashCliRunResult {
+  let authorizedKeysContent: string | undefined;
+  if (options.testMode === true) {
+    const authorizedKeys = resolveAuthorizedKeysContent(options.pubkeyPath, true);
+    if (typeof authorizedKeys !== "string") {
+      return { ok: false, error: authorizedKeys.error };
+    }
+    authorizedKeysContent = authorizedKeys;
+  }
+
   const planInput: FileBackedZflashImagePlanInput = {
     isoPath: options.isoPath,
     outputImagePath: options.outputImagePath,
     espOffsetBytes: options.espOffsetBytes,
-    ...(options.pubkeyPath === undefined ? {} : { pubkeyPath: options.pubkeyPath }),
+    ...(authorizedKeysContent === undefined ? {} : { authorizedKeysContent }),
+    ...(authorizedKeysContent === undefined && options.pubkeyPath !== undefined
+      ? { pubkeyPath: options.pubkeyPath }
+      : {}),
     ...(options.hostname === undefined ? {} : { hostname: options.hostname }),
     ...(options.credentialBlobPath === undefined ? {} : { credentialBlobPath: options.credentialBlobPath }),
   };

--- a/full-ai-cluster/tools/zflash-lib.test.ts
+++ b/full-ai-cluster/tools/zflash-lib.test.ts
@@ -17,6 +17,7 @@
 
 import { describe, expect, test } from "bun:test";
 import {
+  composeAuthorizedKeysFileContent,
   executeFileBackedZflashImageExecutionPlan,
   generateRandomNodeName,
   isValidHostname,
@@ -256,7 +257,44 @@ describe("generateRandomNodeName", () => {
   });
 });
 
+describe("composeAuthorizedKeysFileContent", () => {
+  test("joins multiple valid OpenSSH pubkey lines", () => {
+    const operator = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIoperator operator@example";
+    const testInfra = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAItestinfra zeta-test-infra";
+    const result = composeAuthorizedKeysFileContent([operator, testInfra]);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error);
+    expect(result.value).toBe(`${operator}\n${testInfra}\n`);
+  });
+
+  test("rejects empty input", () => {
+    const result = composeAuthorizedKeysFileContent([]);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.error).toContain("at least one");
+  });
+});
+
 describe("planFileBackedZflashImage", () => {
+  test("prefers authorizedKeysContent over pubkeyPath for ESP write", () => {
+    const result = planFileBackedZflashImage({
+      authorizedKeysContent: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIoperator operator@example\n",
+      espOffsetBytes: 1_048_576,
+      isoPath: "artifacts/zeta-installer.iso",
+      outputImagePath: "artifacts/zflash-baked.img",
+      pubkeyPath: "fixtures/id_ed25519.pub",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error);
+    expect(result.value.espWrites).toEqual([
+      {
+        content: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIoperator operator@example\n",
+        destination: "/zeta-authorized-keys.pub",
+      },
+    ]);
+  });
+
   test("plans a qemu-img raw copy plus ESP writes for QEMU boot media", () => {
     const result = planFileBackedZflashImage({
       credentialBlobPath: "artifacts/zeta-creds.enc",

--- a/full-ai-cluster/tools/zflash-lib.ts
+++ b/full-ai-cluster/tools/zflash-lib.ts
@@ -25,6 +25,43 @@
  */
 export const VALID_HOSTNAME_REGEX = /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$/;
 
+/**
+ * Repo-relative path to the committed QEMU-only test-infra public key.
+ * The matching private key lives in the GitHub secret `ZETA_TEST_INFRA_SSH_KEY`
+ * and is injected only when `--test` is passed.
+ */
+export const ZETA_TEST_INFRA_PUBKEY_REPO_RELATIVE_PATH =
+  "tools/zflash/test-harness/keys/zeta-test-infra.pub";
+
+/**
+ * Structural validator for a single OpenSSH authorized_keys line.
+ * Mirrors the zflash.ts iter-4.2 inject check so production + QEMU paths
+ * stay aligned.
+ */
+export const OPENSSH_PUBKEY_LINE_REGEX =
+  /^(ssh-(ed25519|rsa|dss)|ecdsa-sha2-\S+|sk-ssh-ed25519@\S+|sk-ecdsa-sha2-\S+)\s+\S+/;
+
+export type AuthorizedKeysComposeResult =
+  | { readonly ok: true; readonly value: string }
+  | { readonly ok: false; readonly error: string };
+
+/** Validate + normalize one-or-more OpenSSH pubkey lines for ESP write. */
+export function composeAuthorizedKeysFileContent(lines: readonly string[]): AuthorizedKeysComposeResult {
+  const normalized = lines
+    .flatMap((line) => line.split("\n"))
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  if (normalized.length === 0) {
+    return { ok: false, error: "at least one non-empty OpenSSH pubkey line is required" };
+  }
+  for (const line of normalized) {
+    if (!OPENSSH_PUBKEY_LINE_REGEX.test(line)) {
+      return { ok: false, error: `not a recognized OpenSSH pubkey line: ${line}` };
+    }
+  }
+  return { ok: true, value: `${normalized.join("\n")}\n` };
+}
+
 /** Convenience wrapper around the regex. */
 export function isValidHostname(s: string): boolean {
   return VALID_HOSTNAME_REGEX.test(s);
@@ -116,6 +153,8 @@ export interface FileBackedZflashImagePlanInput {
   readonly outputImagePath: string;
   readonly espOffsetBytes: number;
   readonly pubkeyPath?: string;
+  /** When set, writes /zeta-authorized-keys.pub from inline content instead of pubkeyPath. */
+  readonly authorizedKeysContent?: string;
   readonly hostname?: string;
   readonly credentialBlobPath?: string;
 }
@@ -227,12 +266,24 @@ export function planFileBackedZflashImage(
   }
 
   const espWrites: FileBackedEspWrite[] = [];
-  const pubkeyPath = input.pubkeyPath?.trim();
-  if (pubkeyPath !== undefined && pubkeyPath.length > 0) {
+  const authorizedKeysContent = input.authorizedKeysContent?.trim();
+  if (authorizedKeysContent !== undefined && authorizedKeysContent.length > 0) {
+    const composed = composeAuthorizedKeysFileContent(authorizedKeysContent.split("\n"));
+    if (!composed.ok) {
+      return { ok: false, error: composed.error };
+    }
     espWrites.push({
       destination: "/zeta-authorized-keys.pub",
-      sourcePath: pubkeyPath,
+      content: composed.value,
     });
+  } else {
+    const pubkeyPath = input.pubkeyPath?.trim();
+    if (pubkeyPath !== undefined && pubkeyPath.length > 0) {
+      espWrites.push({
+        destination: "/zeta-authorized-keys.pub",
+        sourcePath: pubkeyPath,
+      });
+    }
   }
   const hostname = input.hostname?.trim();
   if (hostname !== undefined && hostname.length > 0) {

--- a/full-ai-cluster/tools/zflash.ts
+++ b/full-ai-cluster/tools/zflash.ts
@@ -72,7 +72,11 @@ import {
   composeBundle,
   parseArgs as parsePersistArgs,
 } from "../../tools/installer/zeta-creds-persist";
-import { parseUuidFromDiskutilInfo } from "./zflash-lib";
+import {
+  composeAuthorizedKeysFileContent,
+  parseUuidFromDiskutilInfo,
+  ZETA_TEST_INFRA_PUBKEY_REPO_RELATIVE_PATH,
+} from "./zflash-lib";
 
 const ISO_GLOB_PREFIX = "zeta-installer-";
 const DEFAULT_SSH_KEY = join(homedir(), ".ssh", "id_ed25519.pub");
@@ -693,12 +697,38 @@ function writeCredBlobToEsp(mountPoint: string, espPart: string, credBake: CredB
   process.stdout.write(`B-0852: wrote encrypted credential blob to ${target} (USB UUID ${usbUuid})\n`);
 }
 
+function resolveTestInfraPubkeyPath(): string {
+  const scriptDir = dirname(fileURLToPath(import.meta.url));
+  return resolve(scriptDir, "../../", ZETA_TEST_INFRA_PUBKEY_REPO_RELATIVE_PATH);
+}
+
+function readAuthorizedKeysContent(pubkeyPath: string, testMode: boolean): string {
+  const lines = [readFileSync(pubkeyPath, "utf8")];
+  if (testMode) {
+    const testInfraPath = resolveTestInfraPubkeyPath();
+    if (!existsSync(testInfraPath)) {
+      bail(3, `--test inject failed: test-infra pubkey not found at ${testInfraPath}`);
+    }
+    lines.push(readFileSync(testInfraPath, "utf8"));
+    process.stdout.write(`test-mode: ALSO injecting ${testInfraPath} into authorized_keys union\n`);
+  }
+  const composed = composeAuthorizedKeysFileContent(lines);
+  if (!composed.ok) {
+    bail(3, `iter-4.2 inject failed: ${composed.error}`);
+  }
+  return composed.value;
+}
+
 async function injectPubkeyToUsb(
   pubkeyPath: string,
   hostOverride: string | null,
   credBake: CredBakeOptions,
+  testMode: boolean,
 ): Promise<void> {
   process.stdout.write(`\niter-4.2: injecting ${pubkeyPath} into freshly-flashed USB ESP ...\n`);
+  if (testMode) {
+    process.stdout.write("test-mode: authorized_keys will be operator pubkey ∪ zeta-test-infra (QEMU-only)\n");
+  }
   if (hostOverride !== null) {
     process.stdout.write(`iter-5.2: ALSO injecting hostname '${hostOverride}' into ESP ...\n`);
   }
@@ -750,20 +780,7 @@ async function injectPubkeyToUsb(
   const mountPoint = mountResult.mountPoint;
   process.stdout.write(`iter-4.2: mounted at ${mountPoint} (via ${mountResult.method})\n`);
 
-  // Read pubkey content
-  const pubkey = readFileSync(pubkeyPath, "utf8").trim();
-  const firstLine = pubkey.split("\n")[0] ?? "";
-  // Per #5083 Copilot P1: broaden to all OpenSSH pubkey type tokens
-  // per sshd(8) AuthorizedKeysFile. Validates structurally: type token
-  // (one of ssh-*, ecdsa-sha2-*, sk-ssh-*, sk-ecdsa-sha2-*) + space +
-  // base64-shaped material (allow any non-whitespace; the actual base64
-  // decode happens on the cluster side).
-  const VALID_PUBKEY = /^(ssh-(ed25519|rsa|dss)|ecdsa-sha2-\S+|sk-ssh-ed25519@\S+|sk-ecdsa-sha2-\S+)\s+\S+/;
-  if (!VALID_PUBKEY.test(firstLine)) {
-    unmountEsp(espPart, mountResult);
-    dumpDiagnostics(`${pubkeyPath} first line is not a recognized OpenSSH pubkey (expected ssh-ed25519 / ssh-rsa / ssh-dss / ecdsa-sha2-* / sk-ssh-ed25519@* / sk-ecdsa-sha2-*)`);
-    bail(3, `iter-4.2 inject failed: ${pubkeyPath} is not a recognized SSH pubkey format.`);
-  }
+  const authorizedKeysContent = readAuthorizedKeysContent(pubkeyPath, testMode);
 
   // Write via sudo tee (stdin avoids shell-quoting hazards). sudo is
   // required for the mount_msdos path (mount is root-owned); harmless
@@ -771,7 +788,7 @@ async function injectPubkeyToUsb(
   const target = join(mountPoint, "zeta-authorized-keys.pub");
   try {
     execFileSync("sudo", ["tee", target], {
-      input: pubkey + "\n",
+      input: authorizedKeysContent,
       stdio: ["pipe", "ignore", "inherit"],
     });
   } catch (e) {
@@ -859,6 +876,7 @@ async function main() {
     "--skip-iso-pull",
     "--host",
     "--agent",
+    "--test",
     "--bake-cred",
     "--bake-passphrase-file",
     "--bake-passphrase-env",
@@ -873,6 +891,7 @@ async function main() {
   let skipIsoPull = false;
   let hostOverride: string | null = null;
   let agentMode = false;
+  let testMode = false;
   const bakeCredArgs: string[] = [];
   let bakePassphraseFile: string | null = null;
   let bakePassphraseEnv: string | null = null;
@@ -911,6 +930,10 @@ async function main() {
     }
     if (a === "--agent") {
       agentMode = true;
+      continue;
+    }
+    if (a === "--test") {
+      testMode = true;
       continue;
     }
     if (a === "--host") {
@@ -1036,6 +1059,9 @@ async function main() {
         "                            operator's Mac (cannot be agent-bypassed). Use when running\n" +
         "                            zflash through a pipe ('| tail', '2>&1 >log', etc.) which\n" +
         "                            breaks the default readline.question stdin-from-terminal flow.\n" +
+        "  --test                    QEMU/CI-only: inject zeta-test-infra.pub alongside the operator\n" +
+        "                            pubkey into /zeta-authorized-keys.pub. Production USB/ISO builds\n" +
+        "                            must omit this flag so prod never trusts the ephemeral test key.\n" +
         "  --bake-cred <id=value>    B-0852 write encrypted /zeta-creds.enc to USB ESP\n" +
         "                            after flashing; repeatable. Values use the existing\n" +
         "                            zeta-creds-persist credential handlers.\n" +
@@ -1211,7 +1237,7 @@ async function main() {
   }
 
   if (willInject) {
-    await injectPubkeyToUsb(pubkeyPath, hostOverride, credBake);
+    await injectPubkeyToUsb(pubkeyPath, hostOverride, credBake, testMode);
   } else {
     process.stdout.write("\n(iter-4.2 inject skipped per --no-inject or missing pubkey)\n");
     if (hostOverride !== null) {

--- a/tools/zflash/test-harness/README.md
+++ b/tools/zflash/test-harness/README.md
@@ -10,9 +10,10 @@ explicit scenario-3 process-executor wiring, scenario-4 path-fork command
 planning, and serial-marker lifecycle stop conditions for QEMU boot phases.
 
 **NOT in PoC** (deferred to follow-up): default-on QEMU snapshot/restart
-execution for scenarios 3-5 (state preservation between boots); scenario-4
-process execution + identity comparison proof; multi-VM orchestration for
-scenario 5 (cluster-joining); GitHub Actions workflow integration.
+execution for scenarios 3-5 in PR-time CI (state preservation between
+boots is opt-in via env vars); multi-VM orchestration for scenario 5
+(cluster-joining); full SSH/trust assertions after `--test` zflash images
+boot in QEMU.
 
 Operator clarification, 2026-05-31: this harness proves USB/ISO behavior,
 not Kubernetes or ArgoCD health. The USB lane should cover zflash, boot,
@@ -95,12 +96,19 @@ its required success markers, the run fails fast instead of waiting for the
 full QEMU timeout.
 
 Runtime attempts for scenario 4 now emit a two-branch path-fork plan and
-still fail closed with exit `1` until a process executor and identity
-comparison proof consume both forks:
+still fail closed with exit `1` unless the operator explicitly opts into
+the real process executor:
 
 ```bash
-bun tools/zflash/test-harness/run.ts --scenario reformat-from-scratch <iso-path>
+ZFLASH_QEMU_PATH_FORK_EXECUTE=1 \
+ZFLASH_QEMU_PATH_FORK_BOOTSTRAP=1 \
+ZFLASH_QEMU_PATH_FORK_BOOT_IMAGE=/path/to/zflash-boot.img \
+  bun tools/zflash/test-harness/run.ts --scenario reformat-from-scratch <iso-path>
 ```
+
+`ZFLASH_QEMU_PATH_FORK_BOOTSTRAP=1` creates the baseline qcow2 disk +
+`post-initial-format` snapshot before exercising both forks. The boot-image
+env var supplies the zflash-prepared USB artifact for the migrate fork.
 
 By default the migrate-existing-creds fork records a missing runtime
 requirement because it needs a zflash-prepared boot image containing

--- a/tools/zflash/test-harness/path-fork.test.ts
+++ b/tools/zflash/test-harness/path-fork.test.ts
@@ -3,9 +3,11 @@ import {
   FRESH_CLUSTER_SERIAL_MARKERS,
   MIGRATE_EXISTING_CREDS_SERIAL_MARKERS,
   assertPathForkSerialMarkers,
+  executePathForkRuntimePlan,
   planPathForkRuntime,
   type PathForkRuntimeForkPlan,
 } from "./path-fork";
+import type { QemuCommand, QemuCommandExecution } from "./qemu-state";
 
 const ISO_PATH = "fixtures/zeta.iso";
 const BOOT_IMAGE_PATH = "fixtures/zflash-boot.img";
@@ -93,6 +95,48 @@ describe("path-fork serial marker assertions", () => {
       expect(result.error.forkId).toBe("migrate-existing-creds");
       expect(result.error.presentMarkers).toEqual(FRESH_CLUSTER_SERIAL_MARKERS);
     }
+  });
+
+  test("executePathForkRuntimePlan runs both forks through an injected executor", () => {
+    const planned = planPathForkRuntime({
+      isoPath: ISO_PATH,
+      bootImagePath: BOOT_IMAGE_PATH,
+      startingDiskPath: STARTING_DISK_PATH,
+      migrateSerialLogPath: MIGRATE_SERIAL_LOG_PATH,
+      freshSerialLogPath: FRESH_SERIAL_LOG_PATH,
+    });
+    if ("error" in planned) {
+      throw new Error(planned.error.reason);
+    }
+
+    const serialOutputs: Record<string, string> = {
+      [MIGRATE_SERIAL_LOG_PATH]: planned.ok.forks
+        .find((fork) => fork.forkId === "migrate-existing-creds")!
+        .requiredSerialMarkers.join("\n"),
+      [FRESH_SERIAL_LOG_PATH]: planned.ok.forks
+        .find((fork) => fork.forkId === "fresh-cluster")!
+        .requiredSerialMarkers.join("\n"),
+    };
+
+    const successfulExecution = (step: string, command: QemuCommand): QemuCommandExecution => ({
+      step,
+      command,
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+    });
+
+    const executed = executePathForkRuntimePlan(planned.ok, {
+      runCommand: successfulExecution,
+      runCommandUntilSerialMarkers: successfulExecution,
+      readSerialOutput: (path) => serialOutputs[path] ?? "",
+    });
+
+    expect("ok" in executed).toBe(true);
+    if (!("ok" in executed)) {
+      throw new Error(JSON.stringify(executed.error));
+    }
+    expect(executed.ok.forkExecutions).toHaveLength(2);
   });
 
   test("rejects forbidden migrate markers in the fresh fork", () => {

--- a/tools/zflash/test-harness/path-fork.ts
+++ b/tools/zflash/test-harness/path-fork.ts
@@ -17,7 +17,13 @@ import {
   RETENTION_ABSENT_TERMINAL_MARKERS,
   RETENTION_FAILURE_SERIAL_MARKERS,
   buildQemuSystemBootArgs,
+  createSpawnSyncQcow2RetentionExecutor,
+  planQcow2SnapshotRetention,
+  type Qcow2RetentionExecutionFeedback,
+  type Qcow2RetentionExecutor,
+  type Qcow2SnapshotRetentionPlan,
   type QemuCommand,
+  type QemuCommandExecution,
   type QemuSerialStopCondition,
 } from "./qemu-state";
 
@@ -314,3 +320,314 @@ export function assertPathForkSerialMarkers(
     },
   };
 }
+
+export type PathForkExecutionStep =
+  | "bootstrap-create-disk-image"
+  | "bootstrap-initial-install-from-iso-with-disk"
+  | "bootstrap-create-baseline-snapshot"
+  | `restore-${PathForkId}`
+  | `boot-${PathForkId}`;
+
+export interface PathForkForkExecution {
+  readonly forkId: PathForkId;
+  readonly commandExecutions: readonly QemuCommandExecution[];
+  readonly serialAssertion: PathForkSerialMarkerAssertion;
+}
+
+export type PathForkExecutionFeedback =
+  | {
+      readonly kind: "missing-runtime-requirements";
+      readonly forkId: PathForkId;
+      readonly requirements: readonly string[];
+      readonly commandExecutions: readonly QemuCommandExecution[];
+    }
+  | {
+      readonly kind: "command-failed";
+      readonly step: PathForkExecutionStep;
+      readonly forkId?: PathForkId;
+      readonly command: QemuCommand;
+      readonly exitCode: number | null;
+      readonly stderr: string;
+      readonly commandExecutions: readonly QemuCommandExecution[];
+    }
+  | {
+      readonly kind: "executor-threw";
+      readonly step: PathForkExecutionStep;
+      readonly forkId?: PathForkId;
+      readonly reason: string;
+      readonly commandExecutions: readonly QemuCommandExecution[];
+    }
+  | {
+      readonly kind: "serial-marker-failed";
+      readonly forkId: PathForkId;
+      readonly assertion: PathForkSerialMarkerFeedback;
+      readonly commandExecutions: readonly QemuCommandExecution[];
+    }
+  | {
+      readonly kind: "bootstrap-failed";
+      readonly bootstrapError: Qcow2RetentionExecutionFeedback;
+      readonly commandExecutions: readonly QemuCommandExecution[];
+    };
+
+export type PathForkExecutionResult =
+  | {
+      readonly ok: {
+        readonly forkExecutions: readonly PathForkForkExecution[];
+        readonly commandExecutions: readonly QemuCommandExecution[];
+      };
+    }
+  | { readonly error: PathForkExecutionFeedback };
+
+export interface PathForkBaselineBootstrapInput {
+  readonly isoPath: string;
+  readonly startingDiskPath: string;
+  readonly baselineSerialLogPath: string;
+  readonly snapshotName?: string;
+  readonly diskSizeGB?: number;
+  readonly memoryMB?: number;
+  readonly cpuCount?: number;
+  readonly kvmAvailable?: boolean;
+}
+
+export function planPathForkBaselineBootstrap(
+  input: PathForkBaselineBootstrapInput,
+): Qcow2SnapshotRetentionPlan | { readonly error: string } {
+  const planned = planQcow2SnapshotRetention({
+    isoPath: input.isoPath,
+    diskPath: input.startingDiskPath,
+    serialLogPath: input.baselineSerialLogPath,
+    snapshotName: input.snapshotName ?? DEFAULT_SNAPSHOT_NAME,
+    ...(input.diskSizeGB === undefined ? {} : { diskSizeGB: input.diskSizeGB }),
+    ...(input.memoryMB === undefined ? {} : { memoryMB: input.memoryMB }),
+    ...(input.cpuCount === undefined ? {} : { cpuCount: input.cpuCount }),
+    ...(input.kvmAvailable === undefined ? {} : { kvmAvailable: input.kvmAvailable }),
+  });
+  if ("error" in planned) {
+    return { error: `${planned.error.field}: ${planned.error.reason}` };
+  }
+  return planned.ok;
+}
+
+function bootstrapExecutionSteps(
+  bootstrapPlan: Qcow2SnapshotRetentionPlan,
+): readonly {
+  readonly step: PathForkExecutionStep;
+  readonly command: QemuCommand;
+  readonly stopCondition?: QemuSerialStopCondition;
+}[] {
+  return [
+    { step: "bootstrap-create-disk-image", command: bootstrapPlan.createDiskImage },
+    {
+      step: "bootstrap-initial-install-from-iso-with-disk",
+      command: bootstrapPlan.initialInstallFromIsoWithDisk,
+      stopCondition: bootstrapPlan.initialInstallStopCondition,
+    },
+    { step: "bootstrap-create-baseline-snapshot", command: bootstrapPlan.createBaselineSnapshot },
+  ];
+}
+
+export function executePathForkRuntimePlan(
+  plan: PathForkRuntimePlan,
+  executor: Qcow2RetentionExecutor,
+  options: { readonly bootstrapPlan?: Qcow2SnapshotRetentionPlan } = {},
+): PathForkExecutionResult {
+  const commandExecutions: QemuCommandExecution[] = [];
+
+  if (options.bootstrapPlan !== undefined) {
+    for (const { step, command, stopCondition } of bootstrapExecutionSteps(options.bootstrapPlan)) {
+      let execution: QemuCommandExecution;
+      try {
+        if (stopCondition !== undefined) {
+          if (executor.runCommandUntilSerialMarkers === undefined) {
+            return {
+              error: {
+                kind: "bootstrap-failed",
+                bootstrapError: {
+                  kind: "command-failed",
+                  step: "initial-install-from-iso-with-disk",
+                  command,
+                  exitCode: null,
+                  stderr: `missing runCommandUntilSerialMarkers executor for bootstrap step ${step}`,
+                  commandExecutions,
+                },
+                commandExecutions,
+              },
+            };
+          }
+          execution = executor.runCommandUntilSerialMarkers(step, command, stopCondition);
+        } else {
+          execution = executor.runCommand(step, command);
+        }
+      } catch (error) {
+        return {
+          error: {
+            kind: "bootstrap-failed",
+            bootstrapError: {
+              kind: "executor-threw",
+              step: "initial-install-from-iso-with-disk",
+              reason: error instanceof Error ? error.message : String(error),
+              commandExecutions,
+            },
+            commandExecutions,
+          },
+        };
+      }
+      commandExecutions.push(execution);
+      if (execution.exitCode !== 0) {
+        return {
+          error: {
+            kind: "bootstrap-failed",
+            bootstrapError: {
+              kind: "command-failed",
+              step: "initial-install-from-iso-with-disk",
+              command,
+              exitCode: execution.exitCode,
+              stderr: execution.stderr,
+              commandExecutions,
+            },
+            commandExecutions,
+          },
+        };
+      }
+    }
+  }
+
+  const forkExecutions: PathForkForkExecution[] = [];
+  for (const fork of plan.forks) {
+    if (fork.missingRuntimeRequirements.length > 0) {
+      return {
+        error: {
+          kind: "missing-runtime-requirements",
+          forkId: fork.forkId,
+          requirements: fork.missingRuntimeRequirements,
+          commandExecutions,
+        },
+      };
+    }
+
+    const restoreStep = `restore-${fork.forkId}` as const;
+    let restoreExecution: QemuCommandExecution;
+    try {
+      restoreExecution = executor.runCommand(restoreStep, fork.restoreStartingState);
+    } catch (error) {
+      return {
+        error: {
+          kind: "executor-threw",
+          step: restoreStep,
+          forkId: fork.forkId,
+          reason: error instanceof Error ? error.message : String(error),
+          commandExecutions,
+        },
+      };
+    }
+    commandExecutions.push(restoreExecution);
+    if (restoreExecution.exitCode !== 0) {
+      return {
+        error: {
+          kind: "command-failed",
+          step: restoreStep,
+          forkId: fork.forkId,
+          command: fork.restoreStartingState,
+          exitCode: restoreExecution.exitCode,
+          stderr: restoreExecution.stderr,
+          commandExecutions,
+        },
+      };
+    }
+
+    const bootCommand = fork.qemuBootCommand;
+    if (bootCommand === undefined) {
+      return {
+        error: {
+          kind: "missing-runtime-requirements",
+          forkId: fork.forkId,
+          requirements: ["qemu boot command"],
+          commandExecutions,
+        },
+      };
+    }
+
+    const bootStep = `boot-${fork.forkId}` as const;
+    let bootExecution: QemuCommandExecution;
+    try {
+      if (executor.runCommandUntilSerialMarkers === undefined) {
+        return {
+          error: {
+            kind: "executor-threw",
+            step: bootStep,
+            forkId: fork.forkId,
+            reason: `missing runCommandUntilSerialMarkers executor for ${bootStep}`,
+            commandExecutions,
+          },
+        };
+      }
+      bootExecution = executor.runCommandUntilSerialMarkers(bootStep, bootCommand, fork.stopCondition);
+    } catch (error) {
+      return {
+        error: {
+          kind: "executor-threw",
+          step: bootStep,
+          forkId: fork.forkId,
+          reason: error instanceof Error ? error.message : String(error),
+          commandExecutions,
+        },
+      };
+    }
+    commandExecutions.push(bootExecution);
+    if (bootExecution.exitCode !== 0) {
+      return {
+        error: {
+          kind: "command-failed",
+          step: bootStep,
+          forkId: fork.forkId,
+          command: bootCommand,
+          exitCode: bootExecution.exitCode,
+          stderr: bootExecution.stderr,
+          commandExecutions,
+        },
+      };
+    }
+
+    let serialOutput: string;
+    try {
+      serialOutput = executor.readSerialOutput(fork.stopCondition.serialLogPath);
+    } catch (error) {
+      return {
+        error: {
+          kind: "executor-threw",
+          step: bootStep,
+          forkId: fork.forkId,
+          reason: error instanceof Error ? error.message : String(error),
+          commandExecutions,
+        },
+      };
+    }
+
+    const assertion = assertPathForkSerialMarkers(fork, serialOutput);
+    if ("error" in assertion) {
+      return {
+        error: {
+          kind: "serial-marker-failed",
+          forkId: fork.forkId,
+          assertion: assertion.error,
+          commandExecutions,
+        },
+      };
+    }
+
+    forkExecutions.push({
+      forkId: fork.forkId,
+      commandExecutions: [restoreExecution, bootExecution],
+      serialAssertion: assertion.ok,
+    });
+  }
+
+  return {
+    ok: {
+      forkExecutions,
+      commandExecutions,
+    },
+  };
+}
+
+export { createSpawnSyncQcow2RetentionExecutor };

--- a/tools/zflash/test-harness/run.test.ts
+++ b/tools/zflash/test-harness/run.test.ts
@@ -97,6 +97,7 @@ describe("B-0891 test-harness dispatcher", () => {
     expect(parsed.summary.scaffolded).toBe(0);
     expect(scenarioResult.status).toBe("failed");
     expect(scenarioResult.message).toContain("fails closed");
+    expect(scenarioResult.message).toContain("ZFLASH_QEMU_PATH_FORK_EXECUTE=1");
     expect(scenarioResult.message).toContain("zflash-prepared boot image");
     expect(scenarioResult.pathForkPlan.forks).toHaveLength(2);
 
@@ -200,6 +201,38 @@ describe("B-0891 test-harness dispatcher", () => {
     expect(result.qemuRetentionPlan?.diskPath).toBe(join(runDirectory, "zeta.iso.scenario3.qcow2"));
     expect(result.qemuRetentionPlan?.serialLogPath).toBe(join(runDirectory, "zeta.iso.scenario3.serial.log"));
     expect(result.qemuRetentionPlan?.diskPath.startsWith(resolve("/nix/store/read-only"))).toBe(false);
+  });
+
+  test("path-fork runtime executes through an injected QEMU executor when explicitly enabled", () => {
+    const result = runPathForkRuntime("/tmp/zeta.iso", {
+      execute: true,
+      bootImagePath: "/tmp/zflash-boot.img",
+      executor: {
+        runCommand: successfulExecution,
+        runCommandUntilSerialMarkers: successfulExecution,
+        readSerialOutput: (path) => {
+          if (path.includes("migrate.serial.log")) {
+            return [
+              "[iter-5.1]",
+              "[B-0891-retention]   found pre-baked zeta-creds.enc on boot USB ESP",
+              "[B-0891-retention]   Step 6.95-picker will skip account re-entry",
+            ].join("\n");
+          }
+          return [
+            "[iter-5.1]",
+            "[B-0891-retention]   no pre-baked zeta-creds.enc on boot USB ESP; Step 6.95-picker remains normal",
+          ].join("\n");
+        },
+      },
+    });
+
+    expect(result.status).toBe("passed");
+    expect(result.pathForkExecution).toBeDefined();
+    if (result.pathForkExecution && "ok" in result.pathForkExecution) {
+      expect(result.pathForkExecution.ok.forkExecutions).toHaveLength(2);
+    } else {
+      throw new Error("expected path-fork execution success");
+    }
   });
 
   test("retention runtime stays failed when QEMU output does not prove retention", () => {

--- a/tools/zflash/test-harness/run.ts
+++ b/tools/zflash/test-harness/run.ts
@@ -60,7 +60,12 @@ import {
   type Qcow2SnapshotRetentionPlan,
 } from "./qemu-state";
 import {
+  createSpawnSyncQcow2RetentionExecutor as createSpawnSyncPathForkExecutor,
+  executePathForkRuntimePlan,
+  planPathForkBaselineBootstrap,
   planPathForkRuntime,
+  type PathForkExecutionFeedback,
+  type PathForkExecutionResult,
   type PathForkRuntimePlan,
 } from "./path-fork";
 
@@ -80,6 +85,7 @@ export interface ScenarioResult {
   readonly qemuRetentionPlan?: Qcow2SnapshotRetentionPlan;
   readonly qemuRetentionExecution?: Qcow2RetentionExecutionResult;
   readonly pathForkPlan?: PathForkRuntimePlan;
+  readonly pathForkExecution?: PathForkExecutionResult;
 }
 
 export interface RetentionRuntimeOptions {
@@ -93,6 +99,11 @@ export interface RetentionRuntimeOptions {
 }
 
 export interface PathForkRuntimeOptions {
+  readonly execute?: boolean;
+  readonly bootstrap?: boolean;
+  readonly executor?: Qcow2RetentionExecutor;
+  readonly cwd?: string;
+  readonly timeoutMs?: number;
   readonly bootImagePath?: string;
   readonly runDirectory?: string;
   readonly kvmAvailable?: boolean;
@@ -105,6 +116,9 @@ const RETENTION_BOOT_IMAGE_ENV = "ZFLASH_QEMU_RETENTION_BOOT_IMAGE";
 const RETENTION_RUN_DIRECTORY_ENV = "ZFLASH_QEMU_RETENTION_RUN_DIR";
 const PATH_FORK_BOOT_IMAGE_ENV = "ZFLASH_QEMU_PATH_FORK_BOOT_IMAGE";
 const PATH_FORK_RUN_DIRECTORY_ENV = "ZFLASH_QEMU_PATH_FORK_RUN_DIR";
+const PATH_FORK_EXECUTION_ENV = "ZFLASH_QEMU_PATH_FORK_EXECUTE";
+const PATH_FORK_BOOTSTRAP_ENV = "ZFLASH_QEMU_PATH_FORK_BOOTSTRAP";
+const PATH_FORK_TIMEOUT_ENV = "ZFLASH_QEMU_PATH_FORK_TIMEOUT_MS";
 const KVM_PATH = "/dev/kvm";
 
 function parseArgs(argv: ReadonlyArray<string>): ParsedArgs | { error: string } {
@@ -260,6 +274,24 @@ function reportScaffolded(scenario: Scenario): ScenarioResult {
   };
 }
 
+function describePathForkExecutionError(error: PathForkExecutionFeedback): string {
+  switch (error.kind) {
+    case "missing-runtime-requirements":
+      return `QEMU path-fork missing runtime requirement(s) for ${error.forkId}: ${error.requirements.join(", ")}`;
+    case "command-failed":
+      return `QEMU path-fork command failed at ${error.step}${error.forkId === undefined ? "" : ` (${error.forkId})`} with exit ${error.exitCode ?? "unknown"}: ${error.stderr || "no stderr"}`;
+    case "executor-threw":
+      return `QEMU path-fork executor threw at ${error.step}${error.forkId === undefined ? "" : ` (${error.forkId})`}: ${error.reason}`;
+    case "serial-marker-failed":
+      if (error.assertion.kind === "missing-serial-markers") {
+        return `QEMU path-fork fork ${error.forkId} missing serial markers: ${error.assertion.missingMarkers.join(", ")}`;
+      }
+      return `QEMU path-fork fork ${error.forkId} observed forbidden serial markers: ${error.assertion.presentMarkers.join(", ")}`;
+    case "bootstrap-failed":
+      return `QEMU path-fork baseline bootstrap failed: ${describeRetentionExecutionError(error.bootstrapError)}`;
+  }
+}
+
 function describeRetentionExecutionError(error: Qcow2RetentionExecutionFeedback): string {
   switch (error.kind) {
     case "command-failed":
@@ -290,6 +322,23 @@ function retentionBootImagePathFromEnv(): string | undefined {
     return undefined;
   }
   return resolve(raw);
+}
+
+function pathForkExecutionEnabledFromEnv(): boolean {
+  return process.env[PATH_FORK_EXECUTION_ENV] === "1";
+}
+
+function pathForkBootstrapEnabledFromEnv(): boolean {
+  return process.env[PATH_FORK_BOOTSTRAP_ENV] === "1";
+}
+
+function pathForkTimeoutMsFromEnv(): number | undefined {
+  const raw = process.env[PATH_FORK_TIMEOUT_ENV];
+  if (raw === undefined || raw.trim().length === 0) {
+    return undefined;
+  }
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
 }
 
 function pathForkBootImagePathFromEnv(): string | undefined {
@@ -341,12 +390,14 @@ function retentionArtifactPaths(absIsoPath: string, runDirectory: string): {
 
 function pathForkArtifactPaths(absIsoPath: string, runDirectory: string): {
   readonly startingDiskPath: string;
+  readonly baselineSerialLogPath: string;
   readonly migrateSerialLogPath: string;
   readonly freshSerialLogPath: string;
 } {
   const artifactStem = basename(absIsoPath);
   return {
     startingDiskPath: join(runDirectory, `${artifactStem}.scenario4.qcow2`),
+    baselineSerialLogPath: join(runDirectory, `${artifactStem}.scenario4.bootstrap.serial.log`),
     migrateSerialLogPath: join(runDirectory, `${artifactStem}.scenario4.migrate.serial.log`),
     freshSerialLogPath: join(runDirectory, `${artifactStem}.scenario4.fresh.serial.log`),
   };
@@ -457,11 +508,65 @@ export function runPathForkRuntime(
     ? ""
     : ` Missing runtime requirement(s): ${[...new Set(missingRequirements)].join(", ")}.`;
 
+  if (options.execute !== true) {
+    return {
+      id: "reformat-from-scratch",
+      status: "failed",
+      message: `QEMU path-fork plan generated; set ${PATH_FORK_EXECUTION_ENV}=1 to run the real QEMU process executor. Without that explicit opt-in, the scenario fails closed.${requirementSuffix}`,
+      pathForkPlan: planned.ok,
+    };
+  }
+
+  const executorOptions = options.timeoutMs === undefined
+    ? { cwd: options.cwd ?? REPO_ROOT }
+    : { cwd: options.cwd ?? REPO_ROOT, timeoutMs: options.timeoutMs };
+  const executor = options.executor ?? createSpawnSyncPathForkExecutor(executorOptions);
+  const bootstrapPlan = options.bootstrap === true
+    ? (() => {
+        const plannedBootstrap = planPathForkBaselineBootstrap({
+          isoPath: absIsoPath,
+          startingDiskPath: artifacts.startingDiskPath,
+          baselineSerialLogPath: artifacts.baselineSerialLogPath,
+          kvmAvailable: options.kvmAvailable ?? existsSync(KVM_PATH),
+        });
+        if ("error" in plannedBootstrap) {
+          return { error: plannedBootstrap.error };
+        }
+        return { ok: plannedBootstrap };
+      })()
+    : undefined;
+
+  if (bootstrapPlan !== undefined && "error" in bootstrapPlan) {
+    return {
+      id: "reformat-from-scratch",
+      status: "failed",
+      message: `could not plan QEMU path-fork baseline bootstrap: ${bootstrapPlan.error}`,
+      pathForkPlan: planned.ok,
+    };
+  }
+
+  const executed = executePathForkRuntimePlan(
+    planned.ok,
+    executor,
+    bootstrapPlan === undefined ? {} : { bootstrapPlan: bootstrapPlan.ok },
+  );
+
+  if ("error" in executed) {
+    return {
+      id: "reformat-from-scratch",
+      status: "failed",
+      message: describePathForkExecutionError(executed.error),
+      pathForkPlan: planned.ok,
+      pathForkExecution: executed,
+    };
+  }
+
   return {
     id: "reformat-from-scratch",
-    status: "failed",
-    message: `QEMU path-fork plan generated; scenario 4 still fails closed until a process executor and identity-comparison proof consume both forks.${requirementSuffix}`,
+    status: "passed",
+    message: "QEMU path-fork execution observed both migrate-existing-creds and fresh-cluster serial marker contracts.",
     pathForkPlan: planned.ok,
+    pathForkExecution: executed,
   };
 }
 
@@ -486,7 +591,18 @@ function runScenario(scenarioId: ScenarioId, isoPath: string): ScenarioResult {
         return runRetentionRuntime(isoPath, options);
       }
       if (scenario.id === "reformat-from-scratch") {
-        return runPathForkRuntime(isoPath);
+        const timeoutMs = pathForkTimeoutMsFromEnv();
+        const pathForkOptions = timeoutMs === undefined
+          ? {
+              execute: pathForkExecutionEnabledFromEnv(),
+              bootstrap: pathForkBootstrapEnabledFromEnv(),
+            }
+          : {
+              execute: pathForkExecutionEnabledFromEnv(),
+              bootstrap: pathForkBootstrapEnabledFromEnv(),
+              timeoutMs,
+            };
+        return runPathForkRuntime(isoPath, pathForkOptions);
       }
       return reportScaffolded(scenario);
     case "operator-runtime":


### PR DESCRIPTION
## Summary
- Adds `zflash --test` and `zflash-file-backed --test` to union the committed `zeta-test-infra.pub` with operator SSH keys on ESP write — production builds omit the flag so prod never trusts the ephemeral QEMU key.
- Implements B-0891 scenario 4 path-fork process executor with opt-in env vars (`ZFLASH_QEMU_PATH_FORK_EXECUTE`, `ZFLASH_QEMU_PATH_FORK_BOOTSTRAP`, `ZFLASH_QEMU_PATH_FORK_BOOT_IMAGE`) mirroring scenario 3's fail-closed discipline.
- Extends `zflash-qemu-test.yml` CI to validate path-fork fail-closed behavior alongside retention.

## Test plan
- [x] `bun test tools/zflash/test-harness/`
- [x] `bun test full-ai-cluster/tools/zflash-lib.test.ts full-ai-cluster/tools/zflash-file-backed.test.ts`
- [ ] CI `zflash-qemu-test` workflow green on PR
- [ ] Optional local: `ZFLASH_QEMU_PATH_FORK_EXECUTE=1` with boot image against a built ISO


Made with [Cursor](https://cursor.com)