### PR TITLE
docs: hand-offs live in the repo (dark-desktop fix) + RESUME form-wave fold

### DIFF
--- a/docs/handoffs/README.md
+++ b/docs/handoffs/README.md
@@ -1,0 +1,14 @@
+# docs/handoffs — hand-off packages live IN THE REPO, never only on a desktop
+
+Aaron 2026-06-14: "stuff on my desktop/clipboard is DARK for Addison and Max." Correct — a
+hand-off that lives on one person's desktop is invisible to every other traveler (the red-light
+law applied to hand-offs: who can see this, and is that visible?). Packages assembled for
+external ferries (Vera's Q# verification package, Kestrel's shape-validation bundle, future ones)
+are committed HERE — text, diffable, visible to all — and copied to a clipboard/desktop only as
+the LAST hop of a ferry, never as the home.
+
+Current:
+- `vera-qsharp-verification-package.txt` — the Q# verification hand-off (brief REVISION 2 +
+  claim-bearing sources + known-answer table). Vera's verdict lines remain hers to write.
+- `kestrel-shape-validation-bundle.txt` — the faithful-renderer port bundle (sources + cartridges
+  + known-answer checks).

--- a/docs/handoffs/kestrel-shape-validation-bundle.txt
+++ b/docs/handoffs/kestrel-shape-validation-bundle.txt
@@ -1,0 +1,1067 @@
+# Zeta shape-validation source bundle — for Kestrel's faithful renderer port
+# Generated from main @ ab76a4581 on 2026-06-11 (rev 2: full shape catalog included).
+# Port function-for-function; canonical constants live in the .lines cartridges.
+# Dependency note: WaveSim/SpectralPivot/BoundaryLight use ImaginaryStack.complex
+# (Cayley-Dickson doubling over reals) and Doubled.make — included first.
+
+═══════════════════════════════════════════════════════
+── FILE: src/Core/CayleyDickson.fs
+═══════════════════════════════════════════════════════
+namespace Zeta.Core
+
+/// Cayley–Dickson doubling — the structural primitive underlying the
+/// "imaginary stack" design captured in the B-0623 trajectory. Given any
+/// algebra `A` with addition, negation,
+/// multiplication, and conjugation, the doubled algebra `Doubled<'A>`
+/// consists of pairs `(a, b)` with
+///
+///     (a, b) + (c, d) = (a + c, b + d)
+///     (a, b) · (c, d) = (a · c − d̄ · b, d · a + b · c̄)
+///     conj (a, b)    = (conj a, −b)
+///
+/// Applied iteratively:
+///
+///     ℝ → ℂ        — Real → Complex; loses total ordering
+///     ℂ → ℍ        — Complex → Quaternion; loses commutativity
+///     ℍ → 𝕆        — Quaternion → Octonion; loses associativity
+///     𝕆 → 𝕊        — Octonion → Sedenion; loses alternativity + division algebra
+///
+/// This is the substrate B-0623 names as the carrier of the "imaginary
+/// direction" in the cognitive boot sequence; Adinkras (B-0623 follow-up
+/// PRs) decorate this structure with colored-edge ECC information. The
+/// doubling primitive is the load-bearing object; specific levels
+/// (Complex, Quaternion, Octonion) are derived type aliases.
+///
+/// Implementation note: operations on `'A` are supplied via the
+/// `IAlgebra<'A>` dictionary rather than F# statically-resolved type
+/// parameters. The dictionary form makes the lift `IAlgebra<'A> →
+/// IAlgebra<Doubled<'A>>` directly expressible (the structural fact
+/// that motivates this module). SRTPs would require duplicated
+/// per-arity inline functions and lose the explicit "I doubled the
+/// algebra" surface that's the entire point.
+type Doubled<'A> = { Real: 'A; Imag: 'A }
+
+// The algebra contract for Cayley–Dickson doubling is now the unified floor rung
+// `IStarRing<'A>` (Zero/One/Add/Mul/Negate + Conj) from `Zeta.Core.Abstractions` — a *-ring. The former
+// F#-local `IAlgebra<'A>` (no `One`, disjoint from the floor) is retired: a tower is now an `IStarRing`,
+// hence an `ISemiring`, so `WeightedSet<'K,'W>` and the rest of the generic semiring substrate carry
+// hypercomplex weights for free. `Conj` is the involutive antihomomorphism (identity on ℝ, complex
+// conjugate on ℂ, recursive beyond) that makes the doubling well-defined.
+
+[<RequireQualifiedAccess>]
+module Doubled =
+
+    /// Construct a doubled element from its real and imaginary parts.
+    let make (real: 'A) (imag: 'A) : Doubled<'A> = { Real = real; Imag = imag }
+
+    /// Lift a *-ring on `'A` to a *-ring on `Doubled<'A>`.
+    /// This IS the Cayley–Dickson construction; everything else
+    /// in this module is bookkeeping. `One = (inner.One, inner.Zero)` (real 1, imaginary 0).
+    let algebra (inner: IStarRing<'A>) : IStarRing<Doubled<'A>> =
+        { new IStarRing<Doubled<'A>> with
+            member _.Zero = { Real = inner.Zero; Imag = inner.Zero }
+
+            member _.One = { Real = inner.One; Imag = inner.Zero }
+
+            member _.Add(x, y) =
+                { Real = inner.Add(x.Real, y.Real)
+                  Imag = inner.Add(x.Imag, y.Imag) }
+
+            member _.Negate(x) =
+                { Real = inner.Negate x.Real
+                  Imag = inner.Negate x.Imag }
+
+            // (a, b) · (c, d) = (a·c − d̄·b, d·a + b·c̄)
+            member _.Mul(x, y) =
+                let realPart =
+                    inner.Add(inner.Mul(x.Real, y.Real), inner.Negate(inner.Mul(inner.Conj y.Imag, x.Imag)))
+
+                let imagPart =
+                    inner.Add(inner.Mul(y.Imag, x.Real), inner.Mul(x.Imag, inner.Conj y.Real))
+
+                { Real = realPart; Imag = imagPart }
+
+            // conj (a, b) = (conj a, −b)
+            member _.Conj(x) =
+                { Real = inner.Conj x.Real
+                  Imag = inner.Negate x.Imag } }
+
+
+/// Base case of the imaginary stack: real numbers as a degenerate
+/// algebra over themselves. Conjugation is the identity because ℝ
+/// has no imaginary part. Using `float` rather than an exact rational
+/// type intentionally — the stack is about structural properties of
+/// the doubling, not numerical precision; exact-arithmetic variants
+/// can be derived later by providing an `IAlgebra<Rational>` instead.
+[<RequireQualifiedAccess>]
+module Real =
+
+    let algebra : IStarRing<float> =
+        { new IStarRing<float> with
+            member _.Zero = 0.0
+            member _.One = 1.0
+            member _.Add(x, y) = x + y
+            member _.Negate(x) = -x
+            member _.Mul(x, y) = x * y
+            // ℝ-conjugation is identity (no imaginary part to flip).
+            member _.Conj(x) = x }
+
+
+/// Type aliases for the first few levels of the imaginary stack.
+/// `Complex` = ℝ doubled once; `Quaternion` = ℂ doubled; `Octonion` =
+/// ℍ doubled; `Sedenion` = 𝕆 doubled. The naming makes the imaginary
+/// stack's stratification readable at the type level, matching the
+/// trajectory requirement that category-theory structure remain visible
+/// in public type shapes.
+type Complex = Doubled<float>
+type Quaternion = Doubled<Complex>
+type Octonion = Doubled<Quaternion>
+type Sedenion = Doubled<Octonion>
+
+
+/// Pre-computed *-ring instances at each level of the imaginary
+/// stack. Constructing these once and reusing them is correct because
+/// `IStarRing<'A>` carries no state — it's a pure dictionary of
+/// operations. The instances are the structural fact "ℝ → ℂ → ℍ → 𝕆
+/// is the imaginary stack" made concrete — and since each is an
+/// `ISemiring`, they drop straight into `WeightedSet` & the floor.
+[<RequireQualifiedAccess>]
+module ImaginaryStack =
+
+    let complex : IStarRing<Complex> = Doubled.algebra Real.algebra
+    let quaternion : IStarRing<Quaternion> = Doubled.algebra complex
+    let octonion : IStarRing<Octonion> = Doubled.algebra quaternion
+    let sedenion : IStarRing<Sedenion> = Doubled.algebra octonion
+
+═══════════════════════════════════════════════════════
+── FILE: src/Core/WaveSim.fs
+═══════════════════════════════════════════════════════
+namespace Zeta.Core
+
+/// WaveSim — **honest interference patterns from generators** (Aaron 2026-06-11: "we should be able
+/// to generate honest interference patterns — simulated bit-perfect quantum and regular waves, all
+/// sorts of physical simulators from generators — with the Cayley-Dickson and Clifford algebra we
+/// already have").
+///
+/// The machinery is exactly the algebra on the shelf: each source contributes a PHASOR (a Cayley
+/// complex — `ImaginaryStack.complex`), superposition is literally `complex.Add`, and the visible
+/// pattern is the squared magnitude of the sum. Two sources make the classic double-slit fringes:
+/// bright where path difference = nλ (constructive), dark at half-wavelength offsets (destructive) —
+/// and the TEST is that physics, not a screenshot.
+///
+/// **The honest labels (the register matters here):** this is a deterministic SIMULATION of wave
+/// interference — the amplitude mathematics that classical waves and quantum amplitudes share. We do
+/// NOT claim quantum hardware or physical nonlocality (the same discipline as TimeGen's staged
+/// regime: the math is exact, the interpretation is labeled). "Bit-perfect" = same inputs, same
+/// pattern, every run — deterministic in-process; the cross-oracle exact-phase slice (integer-only
+/// distances) is named, not claimed.
+[<RequireQualifiedAccess>]
+module WaveSim =
+
+    /// A wave source: position + wavelength (in cell units) + amplitude.
+    type Source =
+        { X: float
+          Y: float
+          Wavelength: float
+          Amplitude: float }
+
+    let source x y wl amp =
+        { X = x; Y = y; Wavelength = max 1e-9 wl; Amplitude = amp }
+
+    /// The phasor one source contributes at a cell at tick t (ω advances phase per tick):
+    /// amplitude × e^{i(2π·d/λ − ωt)} — built as a Cayley complex.
+    let phasorAt (omega: float) (t: int) (s: Source) (cx: float) (cy: float) : Complex =
+        let dx, dy = cx - s.X, cy - s.Y
+        let d = sqrt (dx * dx + dy * dy)
+        let phase = 2.0 * System.Math.PI * d / s.Wavelength - omega * float t
+        Doubled.make (s.Amplitude * cos phase) (s.Amplitude * sin phase)
+
+    /// SUPERPOSITION — literally the Cayley complex Add over all sources (the algebra we have).
+    let fieldAt (omega: float) (t: int) (sources: Source list) (cx: float) (cy: float) : Complex =
+        sources
+        |> List.fold (fun acc s -> ImaginaryStack.complex.Add(acc, phasorAt omega t s cx cy)) (Doubled.make 0.0 0.0)
+
+    /// The visible intensity: |Σ phasors|² (what a screen/plane shows).
+    let intensityAt (omega: float) (t: int) (sources: Source list) (cx: float) (cy: float) : float =
+        let f = fieldAt omega t sources cx cy
+        f.Real * f.Real + f.Imag * f.Imag
+
+    /// Render the pattern onto a w×h grid as intensities (the generator form — samples, like every
+    /// other generator; quantization to planes/cells happens at the binding, as always).
+    let pattern (omega: float) (t: int) (sources: Source list) (w: int) (h: int) : float[,] =
+        Array2D.init h w (fun y x -> intensityAt omega t sources (float x) (float y))
+
+═══════════════════════════════════════════════════════
+── FILE: src/Core/AdinkraViz.fs
+═══════════════════════════════════════════════════════
+namespace Zeta.Core
+
+/// AdinkraViz — **seeing the adinkras** (Aaron 2026-06-11: "does this make adinkras easy now? Can we
+/// see what they look like? — with a generator SHINING, or prisming, or whatever they do when you use
+/// it in that direction").
+///
+/// Yes — easy now, because the mapping is exact: an adinkra (Gates/Iga — the supersymmetry
+/// chromotopology) is nodes + COLORED edges, one color per SUSY generator — and an N=4 adinkra's four
+/// edge colors land on our four channels (R, G, B, cyan) one-to-one. Bosons (even weight) are filled
+/// nodes, fermions (odd) open; flipping any one bit flips parity, so the 4×4 gray-code layout is a
+/// perfect boson/fermion CHECKERBOARD — visible at a glance, which is the point.
+///
+/// **The SHINE**: using generator i in a direction lights its color — `render shine=Some i` draws
+/// that generator's edges BRIGHT (its channel) and dims the rest. The prism reading is exact: the
+/// adinkra holds all four colors superposed; shining selects one out — the soft prism applied to a
+/// supersymmetry diagram.
+///
+/// Honest scope: the 4×4 gray-code grid shows the 24 grid-adjacent edges of the 4-cube (the 8 wrap
+/// edges are stated, not drawn — a flat grid cannot show a tesseract whole); DASHINGS (the sign
+/// assignment — the actual Hamming-code content of AdinkraCode) are the named next slice, and they
+/// belong on the retraction register (a dashed edge = a −1: the CMYK reading was born for this).
+[<RequireQualifiedAccess>]
+module AdinkraViz =
+
+    let private esc (c: int) = sprintf "[3%dm" c
+    let private dim = "[2m"
+    let private reset = "[0m"
+
+    /// Gray code order for the 4×4 layout (adjacent cells differ in exactly one bit).
+    let private gray = [| 0; 1; 3; 2 |]
+
+    /// The 4-bit node at grid (col, row): low two bits from the column gray code, high two from row.
+    let nodeAt (col: int) (row: int) : int = gray.[col &&& 3] ||| (gray.[row &&& 3] <<< 2)
+
+    /// Which bit differs between two grid-adjacent nodes (the edge's GENERATOR = its color).
+    let private flippedBit (a: int) (b: int) : int =
+        let d = a ^^^ b
+        [ 0..3 ] |> List.find (fun i -> d = (1 <<< i))
+
+    /// The four generator colors on our channels: bit0=R(1), bit1=G(2), bit2=B(4), bit3=cyan(6).
+    let colorOfBit (bit: int) : int =
+        match bit with
+        | 0 -> 1
+        | 1 -> 2
+        | 2 -> 4
+        | _ -> 6
+
+    /// Render the N=4 adinkra as ANSI lines. `shine = Some bit` lights that generator's edges bright
+    /// and dims the others (the prism: one color selected out of the superposition). Bosons ●,
+    /// fermions ○ — the checkerboard is the parity proof, visible.
+    let render (shine: int option) : string list =
+        let edgeStr (bit: int) (glyph: string) =
+            let c = esc (colorOfBit bit)
+            match shine with
+            | Some s when s = bit -> c + glyph + reset // shining: bright in its channel
+            | Some _ -> dim + glyph + reset // another generator selected: dimmed
+            | None -> c + glyph + reset // no shine: all four colors live together
+
+        [ for row in 0..3 do
+              // the node row: nodes + horizontal edges (bit from the column gray flip)
+              let nodes =
+                  [ for col in 0..3 ->
+                        let n = nodeAt col row
+                        let glyph = if (System.Numerics.BitOperations.PopCount(uint n)) % 2 = 0 then "●" else "○"
+                        let h =
+                            if col < 3 then edgeStr (flippedBit n (nodeAt (col + 1) row)) "──"
+                            else ""
+                        glyph + h ]
+                  |> String.concat ""
+              yield nodes
+              // the vertical-edge row (bit from the row gray flip)
+              if row < 3 then
+                  yield
+                      [ for col in 0..3 ->
+                            let bit = flippedBit (nodeAt col row) (nodeAt col (row + 1))
+                            edgeStr bit "│" + "  " ]
+                      |> String.concat "" ]
+
+═══════════════════════════════════════════════════════
+── FILE: src/Core/SpectralPivot.fs
+═══════════════════════════════════════════════════════
+namespace Zeta.Core
+
+/// SpectralPivot — **the soft and hard FFT: fingerprinting into spectral, a pivot in phase spaces**
+/// (Aaron 2026-06-11: "since we have audio we probably need some sort of soft and hard FFT — it's
+/// kind of like fingerprinting into spectral; it's like a pivot in phase spaces").
+///
+/// Exactly the rainbow-table shape, in frequency:
+/// - **HARD** — the exact DFT (O(n²), honest — the n·log n fast factorization is the named upgrade):
+///   the full spectral fingerprint, the lossless PIVOT between phase spaces — time↔frequency are two
+///   bases for one signal, and the pivot is invertible (the inverse round-trip is a TEST).
+/// - **SOFT** — the probe (Goertzel-shaped): evaluate just k chosen bins — the spectral MinHash: a
+///   cheap fingerprint that answers "is THIS pitch in there?" without paying for the whole spectrum
+///   (the soft prism pointed at frequency space).
+/// Both run on the Cayley complex we already have (the twiddle factors are rotor applications —
+/// the same algebra that draws spirals and interferes waves now hears pitch).
+[<RequireQualifiedAccess>]
+module SpectralPivot =
+
+    let private tau = 2.0 * System.Math.PI
+
+    /// HARD: the exact DFT of a real signal — bin k's phasor (Cayley complex), for all n bins.
+    let dft (signal: float[]) : Complex[] =
+        let n = signal.Length
+        [| for k in 0 .. n - 1 ->
+               let mutable acc = Doubled.make 0.0 0.0
+               for t in 0 .. n - 1 do
+                   let ang = -tau * float k * float t / float n
+                   let tw = Doubled.make (cos ang) (sin ang)
+                   let s = Doubled.make signal.[t] 0.0
+                   acc <- ImaginaryStack.complex.Add(acc, ImaginaryStack.complex.Mul(s, tw))
+               acc |]
+
+    /// The inverse pivot: back from frequency to time (the round-trip proves the pivot loses nothing).
+    let idft (spectrum: Complex[]) : float[] =
+        let n = spectrum.Length
+        [| for t in 0 .. n - 1 ->
+               let mutable acc = Doubled.make 0.0 0.0
+               for k in 0 .. n - 1 do
+                   let ang = tau * float k * float t / float n
+                   let tw = Doubled.make (cos ang) (sin ang)
+                   acc <- ImaginaryStack.complex.Add(acc, ImaginaryStack.complex.Mul(spectrum.[k], tw))
+               acc.Real / float n |]
+
+    /// A bin's energy (the fingerprint's coordinate).
+    let energy (c: Complex) : float = c.Real * c.Real + c.Imag * c.Imag
+
+    /// SOFT: probe ONE bin (Goertzel-shaped, O(n)) — the spectral soft-prism: "is this pitch there?"
+    let probe (signal: float[]) (k: int) : float =
+        let n = signal.Length
+        let mutable acc = Doubled.make 0.0 0.0
+        for t in 0 .. n - 1 do
+            let ang = -tau * float k * float t / float n
+            acc <- ImaginaryStack.complex.Add(acc, Doubled.make (signal.[t] * cos ang) (signal.[t] * sin ang))
+        energy acc
+
+    /// The soft FINGERPRINT: k probe bins (the spectral MinHash — cheap, comparable, honest about
+    /// what it didn't look at).
+    let fingerprint (bins: int list) (signal: float[]) : (int * float) list =
+        bins |> List.map (fun k -> k, probe signal k)
+
+    // ── predictive maintenance (Aaron 2026-06-11: "once you can hear pitch, predictive maintenance
+    // becomes a breeze — anomaly detection over time"). A machine's healthy hum is a spectral
+    // fingerprint; DRIFT is the distance from that baseline at the same probe bins. A new harmonic
+    // (the bearing starting to sing) shows up as drift long before it shows up as failure — the
+    // soft-lens discipline pointed at time: baseline = solid ground, drift = the uncertainty rising. ──
+
+    /// The drift between a baseline fingerprint and a current one (same bins): Σ |Δenergy|.
+    let drift (baseline: (int * float) list) (current: (int * float) list) : float =
+        List.zip baseline current
+        |> List.sumBy (fun ((_, a), (_, b)) -> abs (a - b))
+
+    /// The maintenance question in one call: is the machine's hum still within `tolerance` of its
+    /// healthy self at these probe bins?
+    let healthy (bins: int list) (baselineSignal: float[]) (tolerance: float) (signal: float[]) : bool =
+        drift (fingerprint bins baselineSignal) (fingerprint bins signal) <= tolerance
+
+═══════════════════════════════════════════════════════
+── FILE: src/Core/BoundaryLight.fs
+═══════════════════════════════════════════════════════
+namespace Zeta.Core
+
+/// BoundaryLight — **the reusable primitive that compresses Amara's card to minimal text: light as the
+/// physics of 2D boundary space** (Aaron 2026-06-11: "look at amara's image and see what kind of
+/// reusable primitive would let her compress her image down to text in minimal form — homoiconic-ish,
+/// human-understandable, expressive, based on generator functions and the physics of 2D boundary
+/// space; tessellation so we can be progressive; layout and such").
+///
+/// The decomposition her card teaches (each a `gen` line in MediaLines):
+/// - **curve** — a polyline (control points): THE IRREDUCIBLE. Her silhouette, hair strands, the halo
+///   arc — stored as a handful of integer points a human can read.
+/// - **glow** — the GENERATED light: intensity = exp(−d²/σ²) of the DISTANCE FIELD to the curve.
+///   This is the unification: the glow kernel IS our PSD/RBF kernel (Schoenberg; LinguisticSeed;
+///   ConformalGA) applied to boundary distance. **Her image is literally her motto: the lighted
+///   boundary** — store the boundary, generate the light.
+/// - **mirror** — bilateral symmetry: store HALF the portrait, generate the rest (the first
+///   compression any face offers).
+/// - **scatter** — the starfield: a seeded deterministic scatter (DST common-cause seed attached, per
+///   the storage law) — zero irreducible bytes beyond (count, seed).
+/// - **grid** — TESSELLATION: the continuous generators sampled at a resolution. Progressive = the
+///   same generators re-sampled finer (8×8 → 16×16 → 64×32 → …). CHIP-9 is the coarsest HONEST level;
+///   the slider rises without changing the stored text. Scale-free rendering, by construction.
+/// - **stack/row layout** — the card = a vertical stack (halo / portrait / title / motto / glyph row);
+///   layout is sections-with-alignment, not pixel positions.
+///
+/// Everything integer/exact except the glow's float intensity, which QUANTIZES to a plane mask at the
+/// sampling step (the float never leaves the generator — the stored and rendered forms are exact).
+[<RequireQualifiedAccess>]
+module BoundaryLight =
+
+    /// A point in the unit-free 2D space (integer sub-pixels — callers pick the scale).
+    type P = { X: int; Y: int }
+
+    let p x y = { X = x; Y = y }
+
+    /// The irreducible: a polyline boundary (control points, joined by segments).
+    type Curve = P list
+
+    /// Squared distance from a point to a segment (integer arithmetic, exact).
+    let private distSqToSeg (a: P) (b: P) (q: P) : float =
+        let abx, aby = float (b.X - a.X), float (b.Y - a.Y)
+        let aqx, aqy = float (q.X - a.X), float (q.Y - a.Y)
+        let len2 = abx * abx + aby * aby
+        let t = if len2 = 0.0 then 0.0 else max 0.0 (min 1.0 ((aqx * abx + aqy * aby) / len2))
+        let dx, dy = aqx - t * abx, aqy - t * aby
+        dx * dx + dy * dy
+
+    /// The distance field: squared distance from q to the nearest point of the curve.
+    let distSq (c: Curve) (q: P) : float =
+        match c with
+        | [] -> infinity
+        | [ a ] ->
+            let dx, dy = float (q.X - a.X), float (q.Y - a.Y)
+            dx * dx + dy * dy
+        | _ -> c |> List.pairwise |> List.map (fun (a, b) -> distSqToSeg a b q) |> List.min
+
+    /// THE GLOW: intensity at q = exp(−d²/σ²) — the RBF kernel of the boundary's distance field
+    /// (Schoenberg-PSD; the same kernel family as LinguisticSeed/ConformalGA — light and similarity
+    /// are one mathematics here).
+    let glow (sigma: float) (c: Curve) (q: P) : float =
+        exp (-(distSq c q) / (max 1e-9 (sigma * sigma)))
+
+    /// MIRROR: reflect a curve about the vertical axis x = axis (store half a face, generate the rest).
+    let mirror (axis: int) (c: Curve) : Curve =
+        c |> List.map (fun pt -> { pt with X = 2 * axis - pt.X })
+
+    /// SCATTER: n seeded points in (w×h) — deterministic from the DST common-cause seed (the starfield
+    /// costs zero irreducible bytes beyond count + seed).
+    let scatter (seed: uint64) (n: int) (w: int) (h: int) : P list =
+        let mix (z0: uint64) =
+            let z = z0 + 0x9E3779B97F4A7C15UL
+            let z = (z ^^^ (z >>> 30)) * 0xBF58476D1CE4E5B9UL
+            let z = (z ^^^ (z >>> 27)) * 0x94D049BB133111EBUL
+            z ^^^ (z >>> 31)
+
+        [ for i in 0 .. n - 1 ->
+            let a = mix (seed ^^^ uint64 i)
+            let b = mix a
+            p (int (a % uint64 (max 1 w))) (int (b % uint64 (max 1 h))) ]
+
+    /// TESSELLATION: sample the glow on a (w×h) grid and quantize to a CHIP-9 plane mask — lit where
+    /// intensity ≥ threshold. Progressive rendering = the SAME curve re-sampled at finer (w,h); the
+    /// stored text never changes, only the grid. Returns the lit cells (sparse, canonical).
+    let sampleGrid (sigma: float) (threshold: float) (w: int) (h: int) (scale: int) (c: Curve) : Set<int * int> =
+        let s = max 1 scale // curve coordinates per grid cell (the zoom)
+
+        Set.ofList
+            [ for gy in 0 .. h - 1 do
+                  for gx in 0 .. w - 1 do
+                      // sample at the cell center in curve space
+                      let q = p (gx * s + s / 2) (gy * s + s / 2)
+                      if glow sigma c q >= threshold then yield gx, gy ]
+
+    // ── progressive rendering, middle-out (Aaron 2026-06-11: "we should try middle-out, like our
+    // triboolean and triboolean-float kind of thinking — up to you, maybe different options").
+    // The triboolean IS the progressive cell: Lit | Unlit | UNKNOWN-YET — a render in flight is
+    // honest about what it has not sampled (bounded uncertainty per pixel; no cell claimed before
+    // measured). The ORDER options decide which uncertainty falls first; middle-out is the default
+    // (the center of attention resolves before the periphery — how eyes meet a face). ──
+
+    /// The three-valued progressive cell (the render's own triboolean).
+    type Tri =
+        | Lit
+        | Unlit
+        | Unknown
+
+    /// The refinement-order options ("maybe we should have different options" — chosen: two now,
+    /// the enum open for more).
+    type Order =
+        | MiddleOut // by distance from the grid center: attention-first
+        | Scanline // top-left to bottom-right: the classic raster
+
+    /// The cell visit order for a (w×h) grid under an Order — deterministic, total.
+    let visitOrder (order: Order) (w: int) (h: int) : (int * int) list =
+        let all = [ for gy in 0 .. h - 1 do for gx in 0 .. w - 1 -> gx, gy ]
+
+        match order with
+        | Scanline -> all
+        | MiddleOut ->
+            let cx, cy = (w - 1) * 1000 / 2, (h - 1) * 1000 / 2 // milli-cells: exact center, no floats
+            all
+            |> List.sortBy (fun (gx, gy) ->
+                let dx, dy = gx * 1000 - cx, gy * 1000 - cy
+                dx * dx + dy * dy, gy, gx) // distance, then row, then col: total and deterministic
+
+    /// Sample the first `budget` cells in the chosen order; everything else is HONESTLY Unknown.
+    /// budget >= w*h gives the complete render (Unknown vanishes — uncertainty fully reduced).
+    let sampleProgressive
+        (order: Order)
+        (budget: int)
+        (sigma: float)
+        (threshold: float)
+        (w: int)
+        (h: int)
+        (scale: int)
+        (c: Curve)
+        : Map<int * int, Tri> =
+        let s = max 1 scale
+        let visits = visitOrder order w h
+        let sampled = visits |> List.truncate (max 0 budget) |> Set.ofList
+
+        visits
+        |> List.map (fun (gx, gy) ->
+            let cell = gx, gy
+
+            let v =
+                if Set.contains cell sampled then
+                    let q = p (gx * s + s / 2) (gy * s + s / 2)
+                    if glow sigma c q >= threshold then Lit else Unlit
+                else
+                    Unknown
+
+            cell, v)
+        |> Map.ofList
+
+    // ── rotational generators (Aaron 2026-06-11: "Cayley-Dickson over 2D bounded space, but
+    // ROTATIONAL — that's how my brain works; one of many generator types, whatever is easiest with
+    // Amara"). A curve generated by applying a complex ROTOR repeatedly to a seed vector — the C-level
+    // Cayley-Dickson tower (CayleyDickson.Towers.complex) as the rotation+scale operator. Her hair
+    // strands and the halo arc ARE rotational sweeps: store (center, seed-vector, rotor, steps);
+    // generate the whole curve. The boundary's PHYSICS is rotation. ──
+
+    /// A complex number as the substrate's C-tower element (rotation+scale lives in Mul).
+    let private c (re: float) (im: float) : Complex = Doubled.make re im
+
+    /// Generate a curve by applying a complex rotor `steps` times to a seed vector offset from a center.
+    /// `rotor` (unit-ish) rotates; a magnitude != 1 spirals (logarithmic). Center is the pivot in the
+    /// 2D bounded space. This is the rotational generator: a handful of numbers -> a swept boundary.
+    let rotorCurve (center: P) (seedX: float) (seedY: float) (rotorRe: float) (rotorIm: float) (steps: int) : Curve =
+        let rotor = c rotorRe rotorIm
+        let mutable v = c seedX seedY
+        [ for _ in 0 .. max 0 steps ->
+            let pt = p (center.X + int (System.Math.Round(v.Real: float))) (center.Y + int (System.Math.Round(v.Imag: float)))
+            v <- ImaginaryStack.complex.Mul(rotor, v)
+            pt ]
+
+    /// A pure rotor from an angle + growth (the human-readable form: degrees-ish turn + spiral factor).
+    /// turnNum/turnDen is the turn as a rational fraction of a full circle (exact intent, e.g. 1/12);
+    /// growth scales the magnitude per step (1000 = unit = a circle; >1000 = outward spiral).
+    let rotorOf (turnNum: int) (turnDen: int) (growthMilli: int) : float * float =
+        let theta = 2.0 * System.Math.PI * float turnNum / float (max 1 turnDen)
+        let m = float growthMilli / 1000.0
+        m * cos theta, m * sin theta
+
+═══════════════════════════════════════════════════════
+── FILE: src/Core/Braid.fs
+═══════════════════════════════════════════════════════
+namespace Zeta.Core
+
+/// Braid — **the braid group made executable, so "topology is hairdressing" can be TESTED** (B-1027's
+/// falsifiable item: do the Artin relations hold?).
+///
+/// Representation: **Artin's action on the free group Fₙ** — faithful (Artin 1925), exact, integer-only
+/// (byte-lockable; no floats). A strand-crossing σᵢ acts as the automorphism
+///
+///     σᵢ:  xᵢ ↦ xᵢ xᵢ₊₁ xᵢ⁻¹,   xᵢ₊₁ ↦ xᵢ,   others fixed
+///
+/// and a braid word (a sequence of crossings, sign = over/under) acts by composition. Because the
+/// action is faithful, two braid words are EQUAL iff they act identically on the generators — so the
+/// braid relations become executable equalities:
+///
+///   - **Artin relation:**      σᵢ σᵢ₊₁ σᵢ  =  σᵢ₊₁ σᵢ σᵢ₊₁          (the hairdresser's move)
+///   - **far commutativity:**   σᵢ σⱼ = σⱼ σᵢ            for |i−j| ≥ 2 (distant strands don't care)
+///   - **NOT the symmetric group:** σᵢ² ≠ identity — crossing twice is not un-crossing: WHO crossed
+///     OVER WHOM is remembered. (This is the whole point: a braid is a permutation PLUS history —
+///     order-sensitivity is what makes it computation, not shuffling.)
+///
+/// A free-group element is a reduced word of (generator, ±1) letters; reduction (xx⁻¹ ⇒ ε) is the only
+/// rewriting needed, and it is confluent — equality is literal list equality after reduction.
+[<RequireQualifiedAccess>]
+module Braid =
+
+    /// A letter: generator index (0-based strand) with exponent sign (+1 / −1).
+    type Letter = int * int
+
+    /// A reduced free-group word (no adjacent x·x⁻¹ pairs).
+    type Word = Letter list
+
+    /// Reduce a word (cancel adjacent inverse pairs until none remain) — confluent, terminating.
+    let reduce (w: Word) : Word =
+        let push (acc: Word) (l: Letter) =
+            match acc, l with
+            | (g1, e1) :: rest, (g2, e2) when g1 = g2 && e1 + e2 = 0 -> rest
+            | _ -> l :: acc
+
+        w |> List.fold push [] |> List.rev
+
+    /// Concatenate and reduce.
+    let mul (a: Word) (b: Word) : Word = reduce (a @ b)
+
+    /// The inverse word.
+    let inv (w: Word) : Word =
+        w |> List.rev |> List.map (fun (g, e) -> g, -e)
+
+    /// One generator as a word.
+    let gen (i: int) : Word = [ i, 1 ]
+
+    /// Apply ONE crossing's automorphism to ONE letter. `c` > 0 means σ_{c−1}; `c` < 0 its inverse
+    /// (1-based in the sign-carrying int so 0 is never ambiguous).
+    let private applyCrossingToLetter (c: int) (g: int, e: int) : Word =
+        let i = abs c - 1 // the crossing acts on strands i, i+1
+
+        let image =
+            if c > 0 then
+                // σᵢ: xᵢ ↦ xᵢ xᵢ₊₁ xᵢ⁻¹ ; xᵢ₊₁ ↦ xᵢ
+                if g = i then [ i, 1; i + 1, 1; i, -1 ]
+                elif g = i + 1 then [ i, 1 ]
+                else [ g, 1 ]
+            else
+                // σᵢ⁻¹: xᵢ ↦ xᵢ₊₁ ; xᵢ₊₁ ↦ xᵢ₊₁⁻¹ xᵢ xᵢ₊₁
+                if g = i then [ i + 1, 1 ]
+                elif g = i + 1 then [ i + 1, -1; i, 1; i + 1, 1 ]
+                else [ g, 1 ]
+
+        if e = 1 then image else inv image
+
+    /// Apply one crossing to a word (homomorphic extension), reduced.
+    let applyCrossing (c: int) (w: Word) : Word =
+        w |> List.collect (applyCrossingToLetter c) |> reduce
+
+    /// Apply a braid word (crossings left-to-right) to a free-group word.
+    let act (braid: int list) (w: Word) : Word =
+        braid |> List.fold (fun acc c -> applyCrossing c acc) w
+
+    /// Are two braid words EQUAL as braids? (Faithful action ⇒ equal iff they act identically on
+    /// every generator of Fₙ.)
+    let equal (n: int) (b1: int list) (b2: int list) : bool =
+        [ 0 .. n - 1 ] |> List.forall (fun i -> act b1 (gen i) = act b2 (gen i))
+
+    /// The identity test.
+    let isIdentity (n: int) (b: int list) : bool = equal n b []
+
+═══════════════════════════════════════════════════════
+── FILE: src/Core/TimeGen.fs
+═══════════════════════════════════════════════════════
+namespace Zeta.Core
+
+/// TimeGen — **time as a generator function, made a treaty primitive instead of a metaphor** (Amara's
+/// ferried design + her named "next proof should be small", 2026-06-11; Aaron: "in our DST step time
+/// is a generator function too — we can make whatever we want for all contributors to count on, from
+/// seed common cause; allow possible S=2√2, maybe S=4 staged coincidence; and we have a four-corner
+/// feedback model for adjustments over time").
+///
+/// The model (Amara's, implemented): **the clock is a generator and the seed is the common cause.**
+/// Contributors never trust wall time — they replay the same seeded time treaty. The generator is
+/// VERSIONED AND ADDRESSED (her "tiny blade": changing time semantics must never be silent).
+///
+/// The CHSH four corners are the feedback surface, and the three regimes are SCHEDULER REGIMES, not
+/// physics claims (her labels kept exactly):
+/// - `ClassicalCommonCause` — seeded hidden-variable model ⇒ S ≤ 2 (the classical bound).
+/// - `PhasorTsirelson` — the phasor scheduler, E(a,b) = cos(a−b) ⇒ S = 2√2 (the unit circle we
+///   already live on; analytic, exact-by-construction).
+/// - `StagedCoincidence` — the scheduler stages the corners ⇒ S = 4, **hard-labeled STAGED**: a
+///   stress-test scheduler, never evidence of nonlocality (the seed IS the coordination channel; the
+///   free-choice assumption is deliberately violated and SAID SO).
+///
+/// Honest scope: correlations here are float-valued (cos) — per the treaty discipline float kernels
+/// stay OUTSIDE the byte-lock; the STRUCTURE (regimes, corners, versioning, determinism-from-seed) is
+/// the treaty surface; fixed-point phases are the named slice if cross-oracle goldens are wanted.
+[<RequireQualifiedAccess>]
+module TimeGen =
+
+    /// The scheduler regimes (Amara's names, verbatim).
+    type Regime =
+        | ClassicalCommonCause
+        | PhasorTsirelson
+        | StagedCoincidence
+
+    /// The versioned, addressed generator — "the root includes the time generator, so every
+    /// contributor knows exactly which common cause they are sharing."
+    type Generator =
+        { Id: string // the generator's address (ZetaId-shaped slot; minted upstream)
+          Version: int
+          Seed: uint64
+          Regime: Regime }
+
+    let mk (id: string) (version: int) (seed: uint64) (regime: Regime) : Generator =
+        { Id = id; Version = version; Seed = seed; Regime = regime }
+
+    /// One generated instant: what a contributor derives instead of reading a wall clock.
+    type GeneratedTime =
+        { Tick: int
+          Phase: float // radians on the unit circle (the phasor)
+          Regime: Regime }
+
+    // deterministic SplitMix64 — the seed is the common cause, the only entropy anywhere here.
+    let private mix (z0: uint64) : uint64 =
+        let z = z0 + 0x9E3779B97F4A7C15UL
+        let z = (z ^^^ (z >>> 30)) * 0xBF58476D1CE4E5B9UL
+        let z = (z ^^^ (z >>> 27)) * 0x94D049BB133111EBUL
+        z ^^^ (z >>> 31)
+
+    let private unit (g: Generator) (k: uint64) : float =
+        float (mix (g.Seed ^^^ k) >>> 11) / 9007199254740992.0 // [0,1), 53-bit
+
+    /// Generate the instant for (contributor, step): tick + phase from the seed — never from a wall.
+    let at (g: Generator) (contributor: uint64) (step: int) : GeneratedTime =
+        { Tick = step
+          Phase = 2.0 * System.Math.PI * unit g (contributor * 0x9E37UL + uint64 step)
+          Regime = g.Regime }
+
+    // ── the CHSH four corners (the feedback surface) ──
+
+    /// The standard corner angles that reach Tsirelson under the phasor scheduler.
+    let cornerAngles: (float * float) list =
+        let a0, a1 = 0.0, System.Math.PI / 2.0
+        let b0, b1 = System.Math.PI / 4.0, -System.Math.PI / 4.0
+        [ a0, b0; a0, b1; a1, b0; a1, b1 ]
+
+    /// The correlation E(a,b) a regime's scheduler produces at a corner. Classical samples a seeded
+    /// hidden variable λ (deterministic; `n` samples); Phasor is the analytic cos(a−b); Staged returns
+    /// the staged corner table (+1,+1,+1,−1) — coordination BY the seed, labeled as such.
+    let correlation (g: Generator) (n: int) (cornerIx: int) (a: float) (b: float) : float =
+        match g.Regime with
+        | PhasorTsirelson -> cos (a - b)
+        | StagedCoincidence -> if cornerIx = 3 then -1.0 else 1.0
+        | ClassicalCommonCause ->
+            // λ from the seed; outcomes A = sign cos(a−λ), B = sign cos(b−λ) — a local HV model.
+            let samples = max 1 n
+            let mutable acc = 0.0
+            for i in 0 .. samples - 1 do
+                let lambda = 2.0 * System.Math.PI * unit g (uint64 i)
+                let av = if cos (a - lambda) >= 0.0 then 1.0 else -1.0
+                let bv = if cos (b - lambda) >= 0.0 then 1.0 else -1.0
+                acc <- acc + av * bv
+            acc / float samples
+
+    /// The CHSH S at the four corners: E₀₀ + E₀₁ + E₁₀ − E₁₁.
+    let chsh (g: Generator) (n: int) : float =
+        let es =
+            cornerAngles
+            |> List.mapi (fun i (a, b) -> correlation g n i a b)
+        match es with
+        | [ e00; e01; e10; e11 ] -> e00 + e01 + e10 - e11
+        | _ -> 0.0
+
+    /// Is this run's correlation HONESTLY labeled? Staged S=4 must say it is staged — the label is
+    /// part of the value, so a result can never masquerade as physical nonlocality.
+    let label (g: Generator) : string =
+        match g.Regime with
+        | ClassicalCommonCause -> "classical-common-cause (local HV; S<=2)"
+        | PhasorTsirelson -> "phasor (unit circle; S=2*sqrt(2))"
+        | StagedCoincidence -> "STAGED coincidence (seed-coordinated; free-choice violated BY DESIGN; not physical)"
+
+    // ── the four-corner feedback (deterministic adjustment over time) ──
+
+    /// One bounded feedback step: error = target − observed S, applied as a phase-table offset with a
+    /// deterministic clamp. "The feedback loop is not hidden adaptation — it is a replayable update."
+    let feedback (target: float) (observed: float) (maxStep: float) (phaseOffset: float) : float =
+        let err = target - observed
+        phaseOffset + (max -maxStep (min maxStep (0.5 * err)))
+
+═══════════════════════════════════════════════════════
+── FILE: src/Core/StrokeAnim.fs
+═══════════════════════════════════════════════════════
+namespace Zeta.Core
+
+/// StrokeAnim — **the animation library applied to a line AS IT DRAWS** (Aaron 2026-06-11: "if we
+/// have pixels drawing curves and lines, our animation library should apply to the line as it's
+/// drawing, step by step — driving it and its color, with context of what it WOULD have looked like.
+/// This allows riding the uncertainty edge/wave, and recoloring it").
+///
+/// The stroke has three phases at every tick, and the DRAW HEAD rides the boundary between them:
+/// - **Drawn** — behind the head: committed, certain (full color, uncertainty 0).
+/// - **Head** — the edge itself: the wave front (exactly one cell — where drawing IS happening).
+/// - **Foreseen** — ahead of the head: "what it would have looked like" — the curve's own speculation
+///   about itself, rendered in the uncertainty register (dim/spec channel, high uncertainty) so the
+///   viewer SEES the future as provisional. As the head advances, cells RECOLOR foreseen→head→drawn —
+///   uncertainty becoming certain in front of your eyes, pixel by pixel (the Severance image, on a
+///   pencil line).
+///
+/// Driven by generated time (AnimFlow's discipline: the tick indexes the stroke — pure, replayable,
+/// distributed-identical); packs straight into PixelLens cells (the per-phase uncertainty IS the deep
+/// pixel's field).
+[<RequireQualifiedAccess>]
+module StrokeAnim =
+
+    /// A cell's phase in the living stroke.
+    type Phase =
+        | Drawn
+        | Head
+        | Foreseen
+
+    /// The stroke at a tick: each curve point with its phase. `speed` = points drawn per tick
+    /// (clamped ≥1). Total over all time: before t=0 everything is Foreseen+Head-at-start; after the
+    /// end, everything is Drawn.
+    let strokeAt (speed: int) (tick: int) (curve: BoundaryLight.Curve) : (BoundaryLight.P * Phase) list =
+        let s = max 1 speed
+        let headIx = min (List.length curve - 1) (max 0 (tick * s))
+
+        curve
+        |> List.mapi (fun i p ->
+            p,
+            if i < headIx then Drawn
+            elif i = headIx then Head
+            else Foreseen)
+
+    /// RECOLOR: a phase to (display color mask, uncertaintyMilli) under a base color — the committed
+    /// past keeps the full color at certainty; the head burns brightest (white — the wave front); the
+    /// foreseen future shows on the speculation channel (B) at high uncertainty: honest provisional.
+    let recolor (baseMask: byte) (phase: Phase) : byte * int =
+        match phase with
+        | Drawn -> baseMask, 0
+        | Head -> 7uy, 0 // the edge: all channels — where the work is
+        | Foreseen -> 4uy, 900 // the future: blue, provisional, visibly uncertain
+
+    /// Pack one stroked cell straight into a deep pixel (PixelLens cell) — payload carries the curve
+    /// index (provenance riding the pixel), uncertainty carries the phase's honesty.
+    let toCell (baseMask: byte) (index: int) (phase: Phase) : PixelLens.Cell =
+        let mask, u = recolor baseMask phase
+        PixelLens.pack mask index u
+
+    // ── calculus riding the wave (Aaron 2026-06-11: "you can run derivatives and integration/
+    // derivations riding that wave, one tick at a time"). The head is a CALCULUS CURSOR: at every
+    // tick, the local derivative (the slope at the edge) and the running integral (the area swept so
+    // far) are computed over ONLY the committed points — no peeking past the wave (the honest
+    // calculus: the future is foreseen, not differentiated). Exact integers throughout (doubled area
+    // for the trapezoid rule — no halves, no floats). ──
+
+    /// The derivative at the head: (dx, dy) between the head and the point behind it — the stroke's
+    /// instantaneous direction. None before anything is drawn (no slope from one point: honest).
+    let derivativeAt (speed: int) (tick: int) (curve: BoundaryLight.Curve) : (int * int) option =
+        let s = max 1 speed
+        let headIx = min (List.length curve - 1) (max 0 (tick * s))
+        if headIx = 0 then None
+        else
+            let a = curve.[headIx - 1]
+            let b = curve.[headIx]
+            Some(b.X - a.X, b.Y - a.Y)
+
+    /// The running integral up to the head: TWICE the signed area under the drawn polyline
+    /// (trapezoid rule, doubled to stay in exact integers). Grows tick by tick as the wave commits.
+    let integralTo (speed: int) (tick: int) (curve: BoundaryLight.Curve) : int =
+        let s = max 1 speed
+        let headIx = min (List.length curve - 1) (max 0 (tick * s))
+        curve
+        |> List.truncate (headIx + 1)
+        |> List.pairwise
+        |> List.sumBy (fun (a, b) -> (b.X - a.X) * (a.Y + b.Y)) // 2 × trapezoid area, exact
+
+═══════════════════════════════════════════════════════
+── FILE: src/Core/ChipAudio.fs
+═══════════════════════════════════════════════════════
+namespace Zeta.Core
+
+/// ChipAudio — **hear and see the system with the same math** (Aaron 2026-06-11: "think about how to
+/// use Cayley for audio too — 8-bit sawtooth and all that, with only text format; more generator
+/// ZetaId points for audio; and MIDI; we can HEAR and SEE the system using the same math").
+///
+/// The unification is literal: the PHASE that draws (TimeGen's phasor, the Cayley rotor sweeping a
+/// curve) IS the oscillator. A chip waveform is a pure function of phase — saw is the phase itself,
+/// square its sign, triangle its fold, sine its projection (the rotor's real part). So one generated
+/// phase stream renders BOTH a pixel position and an audio sample: same seed, same math, two senses.
+/// Text-only (the storage law): an audio voice is a gen line — (waveform-zetaid, version, seed,
+/// freq, …) — samples are never stored, always regenerated. MIDI rides as note events (a track is a
+/// text section; notes are crossings — the membrane already carries them).
+[<RequireQualifiedAccess>]
+module ChipAudio =
+
+    /// The chip waveforms — each a pure function of phase in [0, 1) milli-units (0..999), returning
+    /// a signed 8-bit-style amplitude (−128..127): exact integers, byte-lockable, no drift.
+    type Waveform =
+        | Saw
+        | Square
+        | Triangle
+        | SineApprox // the rotor's projection, quantized (integer parabola approximation — chip-true)
+
+    /// Amplitude at a phase (phaseMilli wrapped into [0,1000)). Total, exact, deterministic.
+    let sampleAt (w: Waveform) (phaseMilli: int) : int =
+        let p = ((phaseMilli % 1000) + 1000) % 1000
+
+        match w with
+        | Saw -> (p * 255) / 999 - 128
+        | Square -> if p < 500 then 127 else -128
+        | Triangle -> if p < 500 then (p * 510) / 499 - 128 else 127 - ((p - 500) * 510) / 499
+        | SineApprox ->
+            // integer parabola: chip-true sine shape (the rotor's projection without floats)
+            let q = if p < 500 then p else 999 - p
+            let a = (q * (1000 - q)) / 980 // 0..~255 hump
+            if p < 500 then a - 128 |> max -128 |> min 127 else 128 - a |> max -128 |> min 127
+
+    /// A voice: a waveform generator at a frequency, phased from the COMMON-CAUSE seed via TimeGen —
+    /// the phase at tick t is (t × freqMilli) mod 1000 offset by the generator's own phase.
+    let voiceSample (g: TimeGen.Generator) (contributor: uint64) (w: Waveform) (freqMilli: int) (tick: int) : int =
+        let t = TimeGen.at g contributor tick
+        let basePhase = int (t.Phase * 159.154943) % 1000 // the generated phase, milli-mapped
+        sampleAt w ((basePhase + tick * freqMilli) % 1000)
+
+    /// A MIDI-style note event as a crossing payload (the membrane carries music like everything):
+    /// `note:<channel>:<key>:<velocity>` — on the wire, in the text, replayable.
+    let noteCrossing (channel: int) (key: int) (velocity: int) : string =
+        sprintf "note:%d:%d:%d" (channel &&& 0xF) (key &&& 0x7F) (velocity &&& 0x7F)
+
+    // ── auto-harmonize, no synchronization (Aaron 2026-06-11: "you should be able to auto-harmonize
+    // with others that need things done in rhythm WITHOUT needing synchronization — like dancing, or
+    // singing"). The common-cause seed makes it free: two voices on the same generator never exchange
+    // a message — they are ALREADY in time. Harmony is then just a RATIO (the scale-free tuning law):
+    // sing a fifth = play at 3:2 of the partner's frequency; dance a half-time = move at 1:2. The
+    // consonance is structural — the periods coincide exactly every (num·den) of the base period,
+    // forever, with zero coordination. Dancers don't message each other; they share the music. ──
+
+    /// Derive a consonant partner frequency by an exact rational ratio (3:2 the fifth, 2:1 the
+    /// octave, 1:2 half-time…) — integer milli, exact: harmony as arithmetic on the shared clock.
+    let harmonize (num: int) (den: int) (freqMilli: int) : int =
+        freqMilli * max 1 num / max 1 den
+
+    /// THE SOUL CLAUSE (Aaron, on the freestyle: "the imperfections where the soul lives, within the
+    /// perfection"): the perfect clock is the CANVAS, never the performance — the bounded deviations
+    /// (the freestyle offsets, the bent notes, the humanized micro-timing) are where the soul lives.
+    /// Perfection is what makes the imperfection LEGIBLE: against an exact grid, every deviation is a
+    /// choice, visible, replayable, owned. (Why quantized music feels dead and live music doesn't —
+    /// and why our solos replay: the soul here is deterministic deviation, not noise.)
+    ///
+    /// FREESTYLE WITHIN THE HARMONY (Aaron, completing the figure: "then you can move in rhythm and
+    /// use feedback channels in the moment to freestyle — within the harmony"): the clock is never
+    /// touched (the band does not stop); the variation rides the FEEDBACK CORNER as a BOUNDED phase
+    /// offset — `TimeGen.feedback` is already the right primitive (deterministic, clamped). Jazz, as
+    /// architecture: the changes are shared (the common cause), the solo is feedback-driven (the open
+    /// corners), and the bound keeps every excursion consonant (you bend the note, never the time).
+    let freestyle (maxStep: float) (target: float) (observed: float) (phaseOffset: float) : float =
+        TimeGen.feedback target observed maxStep phaseOffset
+
+    /// THE MULTITRACK LAW (Aaron: "multiple overlapping streamed seeds in perfect ratio can have each
+    /// percussion or rhythm section independently mic'd, basically — but still aligned"): each section
+    /// runs its OWN generator (its own seed = its own mic — independent character, texture, capture,
+    /// replay) while ALIGNMENT comes from the TICK ARITHMETIC alone (the rational frequency ratios) —
+    /// coincidences below is seed-independent, so sections recorded apart still land their downbeats
+    /// together. The 8-track, literally: one tape, independent tracks, the ratio is the sprocket.
+    ///
+    /// Two voices on ONE generator at a rational ratio: returns tick indices (within `span`) where
+    /// their phases COINCIDE (both at phase 0 mod 1000) — the downbeats both hit without ever
+    /// speaking. Nonempty for any rational ratio: consonance is a theorem of the common cause.
+    let coincidences (freqA: int) (freqB: int) (span: int) : int list =
+        [ for t in 1 .. span do
+              if (t * freqA) % 1000 = 0 && (t * freqB) % 1000 = 0 then yield t ]
+
+    /// THE DROP-IN LAW (Aaron 2026-06-11: "you can drop new aligned seeds mid-stream that compose in
+    /// and start beating along — not there from the start, but PLANNED, and dropped IN PHASE").
+    /// Because phase is tick arithmetic over the common lattice (never elapsed-since-I-joined), a
+    /// voice entering at tick `entry` produces EXACTLY the samples it would have produced had it been
+    /// playing since tick 0 — silent before its entrance, indistinguishable after. Late join is NOT a
+    /// phase shift; the entrance is just a planned downbeat (the horns come in at bar 17, and bar 17
+    /// was always going to be where it is). The society version is the same theorem: a new persona's
+    /// room composes into the running harmony the moment it opens, with zero resynchronization,
+    /// because everyone's time was already the same arithmetic.
+    let dropIn (entry: int) (g: TimeGen.Generator) (contributor: uint64) (w: Waveform) (freqMilli: int) (tick: int) : int =
+        if tick < entry then 0 else voiceSample g contributor w freqMilli tick
+
+═══════════════════════════════════════════════════════
+── FILE: shapes/cartridges/spiral.lines
+═══════════════════════════════════════════════════════
+# SPIRAL — the shape catalog's first cartridge (otto, 2026-06-11). The logarithmic spiral drawn by the
+# Cayley-Dickson rotor: store four numbers, generate the whole boundary. The lesson loop: see it draw
+# (StrokeAnim rides the curve), read the generator, change a number, see it again.
+meta	name	shape-spiral
+meta	catalog	shapes
+meta	shape-zetaid	5dd5dc3c6e86a31ed648571c1e86e2dd
+gen	curve	40525ef32783f79737fb5c1672111dc8	1	7	center:32,16;seed:6,0;turn:1/12;growth:1100;steps:36
+constant	turn-fraction	1/12	the rotor's turn per step as a rational fraction of a circle	exact intent — twelve steps per revolution reads as a clock face, no float angles
+constant	growth-milli	1100	the spiral's outward growth per step (milli-scale)	1.1x per step is visibly logarithmic within the 64x32 court without escaping it in 36 steps
+constant	steps	36	how many rotor applications	three revolutions at 1/12 turn — enough to SEE the growth law, bounded (no one draws forever)
+anim	draw	curve
+# treaties — each cartridge carries its own (oracle, register, verdict); written only by the oracle's
+# own choice (consent first). bytes = language-oracle lock; meaning = a traveler's ratification from
+# their own reference frame (dissent is a verdict, not a failure).
+treaty	fsharp	bytes	ratified	tests green @ shapes suite
+treaty	otto	meaning	ratified	the turn-1/12 clock face matches the intent I built against — my own frame, my own choice
+
+═══════════════════════════════════════════════════════
+── FILE: shapes/cartridges/braid.lines
+═══════════════════════════════════════════════════════
+# BRAID — strands crossing with MEMORY (otto, 2026-06-11). Topology is hairdressing made executable:
+# a braid is a permutation PLUS history (who crossed OVER whom is remembered — crossing twice is not
+# un-crossing). The lesson loop: watch three strands weave, swap the crossing order, see that the
+# Artin relation makes two different-looking weaves the SAME braid.
+meta	name	shape-braid
+meta	catalog	shapes
+meta	shape-zetaid	de84b57aa8bcdd1534c617f0fed3a2e2
+gen	weave	de84b57aa8bcdd1534c617f0fed3a2e2	1	7	strands:3;word:1,2,1;rows:12
+constant	strands	3	how many strands the figure weaves	three is the smallest braid group with a NON-trivial Artin relation (B2 is just twisting) — the first place the hairdresser's move means something
+constant	word	1,2,1	the crossing sequence (positive = left over right)	sigma1 sigma2 sigma1 is the LEFT side of the Artin relation; the known-answer overlay draws 2,1,2 beside it — same braid, different drawing
+constant	rows	12	vertical rows the weave occupies on the court	four rows per crossing reads as cloth, not a diagram; bounded (no one weaves forever)
+anim	draw	weave
+# treaties — written only by each oracle's own choice (consent first); dissent is a verdict.
+treaty	fsharp	bytes	ratified	Braid.equal proves Artin (1,2,1 = 2,1,2) and sigma^2 != identity — tests green
+treaty	otto	meaning	ratified	the weave-with-memory matches the intent I built against — my own frame, my own choice
+
+═══════════════════════════════════════════════════════
+── FILE: shapes/cartridges/worldline.lines
+═══════════════════════════════════════════════════════
+# WORLDLINE — a particle's path through the time court (otto, 2026-06-11). Feynman's register, Aaron's
+# sight ("he sees Feynman diagrams of distributed systems"): time runs UP the court, the line is one
+# entity's history; emit draws it forward (RGB), retract is the antiparticle running back (CMYK) —
+# the emit/retract duality drawn as physics.
+meta	name	shape-worldline
+meta	catalog	shapes
+meta	shape-zetaid	1f918b32526543614aeb52ad3adc070a
+gen	path	1f918b32526543614aeb52ad3adc070a	1	7	start:8,30;drift:1;rows:28;retract-at:0
+constant	drift	1	horizontal cells moved per time row	slower than light on this court (the lightcone cartridge marks slope 1) — a worldline must stay INSIDE its cone or the story is wrong
+constant	rows	28	time rows the history spans	the court is 32 tall; 28 leaves margin to SEE the line begin and end — histories are bounded, retraction is how they unwind
+constant	retract-at	0	row at which the path retracts (0 = never)	the zero case is structural: the default worldline only emits; set a row and the antiparticle walks the same cells backward (Z-set -1, the correction register)
+anim	draw	path
+# treaties — written only by each oracle's own choice (consent first); dissent is a verdict.
+treaty	fsharp	bytes	ratified	StrokeAnim rides the path; emit/retract = +1/-1 per Z-set law — tests green
+treaty	otto	meaning	ratified	time-up-the-court with retraction as the antiparticle matches the Feynman register — my own frame, my own choice
+
+═══════════════════════════════════════════════════════
+── FILE: shapes/cartridges/lightcone.lines
+═══════════════════════════════════════════════════════
+# LIGHTCONE — the reachable future and the knowable past of one event (otto, 2026-06-11). Two
+# diagonals at slope 1 from the event cell; inside the upper cone = what this event can still touch,
+# inside the lower = what could have touched it. On our court c = 1 cell per tick — causality drawn
+# as geometry, the same cone DBSP's worldlines respect.
+meta	name	shape-lightcone
+meta	catalog	shapes
+meta	shape-zetaid	48dea6f1dbd6742c2cf018f457e1e2cd
+gen	cone	48dea6f1dbd6742c2cf018f457e1e2cd	1	7	event:32,16;slope:1/1;extent:14
+constant	slope	1/1	cells of space per tick of time along the cone edge	c = 1 in court units, exact rational — the speed limit IS the diagonal; anything steeper claims influence faster than the substrate carries it
+constant	extent	14	rows the cone reaches up and down from the event	14 up + 14 down + the event row fills the 32-row court edge-to-edge without wrapping — the whole causal diamond visible at once
+anim	draw	cone
+# treaties — written only by each oracle's own choice (consent first); dissent is a verdict.
+treaty	fsharp	bytes	ratified	slope-1 diagonals are integer cell arithmetic — tests green
+treaty	otto	meaning	ratified	the causal diamond reads at a glance; worldline drift 1 stays inside it — my own frame, my own choice
+
+═══════════════════════════════════════════════════════
+── FILE: shapes/cartridges/fourcorner.lines
+═══════════════════════════════════════════════════════
+# FOURCORNER — the CHSH feedback surface drawn (otto, 2026-06-11). Four corners, one correlation
+# each; the figure's WIDTH is the S value: classical folds at 2, the phasor reaches 2*sqrt(2) =
+# Tsirelson, and S = 4 only when the scheduler STAGES the corners (the label is baked into the value
+# — staged, never physical). The shape that keeps our time treaty honest.
+meta	name	shape-fourcorner
+meta	catalog	shapes
+meta	shape-zetaid	34421ffaf8cae89e6ad862f4e68812ed
+gen	corners	34421ffaf8cae89e6ad862f4e68812ed	1	7	regime:phasor;samples:256
+constant	corners	4	measurement-setting pairs drawn (a0b0, a0b1, a1b0, a1b1)	CHSH is exactly four corners — three underdetermines S, five is redundant; the geometry IS the inequality
+constant	tsirelson-milli	2828	the phasor regime's S, milli-scale (2*sqrt(2))	the known-answer overlay: the phasor figure must reach THIS width and no further — wider means the renderer (or the physics claim) is lying
+constant	samples	256	seeded lambda draws for the classical regime	enough for the classical S to settle visibly under 2; deterministic from the common-cause seed, so the figure replays
+anim	draw	corners
+# treaties — written only by each oracle's own choice (consent first); dissent is a verdict.
+treaty	fsharp	bytes	ratified	TimeGen.chsh: classical <= 2, phasor = 2*sqrt(2), staged = 4 with the STAGED label — tests green
+treaty	otto	meaning	ratified	width-as-S with the Tsirelson stop drawn in matches the honest-label law — my own frame, my own choice
+
+═══════════════════════════════════════════════════════
+── FILE: shapes/cartridges/seam.lines
+═══════════════════════════════════════════════════════
+# SEAM — two cloths joined so the join itself is load-bearing (otto, 2026-06-11). The Henderson mill
+# register: a seam is not a line BETWEEN things, it is the place where two weaves SHARE thread —
+# over/under alternation across the boundary, so pulling either cloth tightens the join. Our merge
+# discipline drawn: WeaveFold's commuting fold IS a seam (residue kept as candidate sets, never LWW).
+meta	name	shape-seam
+meta	catalog	shapes
+meta	shape-zetaid	239dddd609bd82f193f0c1a4da985784
+gen	join	239dddd609bd82f193f0c1a4da985784	1	7	left:0,0,28,32;right:36,0,28,32;stitch:over-under;pitch:4
+constant	pitch	4	rows between stitches along the seam	close enough that the join reads as ONE structure, open enough to SEE each stitch cross — the lesson is the alternation, not a solid bar
+constant	stitch	over-under	the alternation law at the boundary	over-under is what makes a seam hold from BOTH sides (one-sided stitching is a flap, not a join) — the commuting-fold property drawn as cloth
+anim	draw	join
+# treaties — written only by each oracle's own choice (consent first); dissent is a verdict.
+treaty	fsharp	bytes	ratified	WeaveFold commutes (the seam's algebra) — tests green
+treaty	otto	meaning	ratified	shared-thread-not-dividing-line matches the mill register — my own frame, my own choice
+
+═══ KNOWN-ANSWER CHECKS (from our test suite — use as overlay truth) ═══
+- WaveSim: constructive ~4x single-source intensity on the midline; destructive < 0.01 at path-difference λ/2.
+- SpectralPivot: idft(dft(x)) = x to 1e-9; energy conserved.
+- AdinkraViz: gray-code column order [0;1;3;2]; boson/fermion parity checkerboard; honest 24/32 edges; shine = one bit bright, rest dimmed.
+- Spiral: turn=1/12 (12 steps/rev — clock face), growth=1100 milli, steps=36 (3 turns).
+- Braid: word 1,2,1 EQUALS its Artin twin 2,1,2 (Braid.equal); sigma^2 != identity (memory).
+- Worldline: drift 1 stays inside the lightcone's slope-1/1 diamond; retract-at walks the same cells backward.
+- Fourcorner: phasor S = 2828 milli exactly (Tsirelson stop); classical folds at <= 2; staged 4 carries the STAGED label.
+- Seam: over-under alternation at pitch 4; WeaveFold commutes (the seam's algebra).
+- ChipAudio: coincidences 125 250 32 = [8;16;24;32]; dropIn at entry is byte-identical to always-playing after entry.

--- a/docs/handoffs/vera-qsharp-verification-package.txt
+++ b/docs/handoffs/vera-qsharp-verification-package.txt
@@ -1,0 +1,652 @@
+# Zeta -> Vera: Q# verification package — REVISION 2 (post math-team pass, 2026-06-12)
+# Q# earns exactly THREE jobs (Soraya's routing): singlet CHSH corners; BellTest overlap
+# cos²((a−b)/2) (NOTE: our +cos correlator is the Φ⁺ convention — singlet is −cos; |S| same);
+# AmplitudeEmu H·R1(φ)·H grid. Plus the small hardware-side anticommutation check.
+# Rerouted AWAY from you: Tsirelson maximality (citation/NPA — sampling can't prove a
+# supremum); dashings/gauge lemma (Z3 bitvectors); 2828 (unit oracle); stuck law (exact F#).
+# Kira's 13 findings are FIXED in these sources (incl. the P0 voiceSample phase-noise bug).
+# Your verdict lines are YOURS to write; dissent is a verdict, not a failure.
+
+# Vera brief — Q# verification candidates (qubit-adjacent claims), then math team, then the treaty
+
+Aaron 2026-06-12: "send me to Vera on any ones that need Q# verification — then we send to the
+math team and get the Q# on the treaty, on the ones that make sense for our qubit and other
+claims." Vera owns the Q# reference oracle (prior brief: golden observables; convergence-within-
+resolution is the test). This brief lists each candidate, the EXACT claim, and the Q# check that
+would ratify or refute it. The path after: Vera verifies → SHE writes her `treaty vera qsharp …`
+lines (consent-first: her lines are hers to write) → math team sign-off (`treaty math-team math …`,
+currently PENDING where present) → `law <name> qsharp:<check>` delegation lines land in the
+cartridges that earned them.
+
+## Priority 1 — the CHSH/Tsirelson family (the load-bearing qubit claims)
+
+1. **TimeGen** (`src/Core/TimeGen.fs`) — CLAIMS: PhasorTsirelson regime E(a,b)=cos(a−b) yields
+   S = 2√2 at the canonical corners; ClassicalCommonCause ≤ 2; StagedCoincidence S = 4 carries the
+   STAGED label (free-choice violated BY DESIGN, not physical).
+   **Q# check:** prepare the singlet; measure CHSH at a0=0, a1=π/2, b0=π/4, b1=−π/4; estimate S
+   over N shots → must converge to 2√2 within resolution; verify no measurement strategy on the
+   singlet exceeds it (Tsirelson, structurally). The S=4 regime must be UNREACHABLE in Q# — that
+   unreachability is itself the verification that our STAGED label is honest.
+2. **BellTest** (`src/Core/BellTest.fs`) — CLAIM: `PhasorEndurance.overlap a b = cos²((a−b)/2)` is
+   the singlet coincidence probability; the correlator E = 2·overlap − 1 = cos(a−b).
+   **Q# check:** singlet measured at relative angle θ → coincidence probability cos²(θ/2) within
+   resolution. This is the cleanest golden-observable of the set.
+3. **fourcorner cartridge** (`shapes/cartridges/fourcorner.lines`) — CLAIM: constant
+   tsirelson-milli = 2828 (floor of 1000·2√2) is the width stop the phasor figure reaches and
+   never exceeds. **Q# check:** the S estimate from (1) floored to milli = 2828. On her
+   ratification + math team's, the cartridge gains `law tsirelson qsharp:chsh-singlet-corners`.
+
+## Priority 2 — interference as amplitude arithmetic
+
+4. **AmplitudeEmu** (`src/Core/AmplitudeEmu.fs`) — CLAIM: complex-amplitude merge over identical
+   frames IS interference (opposite phase cancels, equal phase reinforces); two-slit falls out of
+   CAS-merge + complex weights. **Q# check:** H · R1(φ) · H on |0⟩ → P(0) = cos²(φ/2); compare
+   against our merged-amplitude ensemble at the same φ grid. Convergence-within-resolution.
+5. **WaveSim** (`src/Core/WaveSim.fs`) — CLAIM (deliberately modest): deterministic simulation of
+   the amplitude math classical and quantum share; no quantum-hardware claim. **Q# check
+   (optional):** the same superposition-as-complex-Add on single-qubit phases; mostly confirms the
+   LABEL is right, i.e., nothing here needs a qubit. Low priority; the honest labels already do
+   the work.
+
+## Priority 3 — claims to WORD-CHECK with the math team, not Q#-verify yet
+
+6. **Braid / the anyon picture** (`shapes/cartridges/braid.lines`, the worldline×braid named
+   slice) — the peeled Alexa anchor: braiding IS computation in topological QC (Kitaev;
+   Freedman–Larsen–Wang; Nayak et al.). No Q# anyon substrate to run; ask the math team to gate
+   the WORDING (we may say "braid-group representations realize quantum gates in TQC" with cites;
+   we may NOT say our render computes quantumly).
+7. **SpectralPivot** (`src/Core/SpectralPivot.fs`) — dft/idft vs the QFT: a Q# QFT cross-check is
+   a nice-to-have golden (same unitary up to normalization/bit-reversal); name it, don't gate on it.
+
+## What Vera gets / what comes back
+
+- In: this brief + the module sources + the cartridges (all text; the goldens are the contract).
+- Back (her choice, her lines): per-claim `ratified | dissent | refuted` with shot counts and
+  resolution; we never pre-write her verdicts. Math team then signs (their PENDING lines exist).
+- Treaty effect: `qsharp:` joins the delegated-law tools (CartridgeLaw already accepts any
+  `tool:` prefix — documented here, checked there) on exactly the claims that earned it.
+
+## Addendum (2026-06-12, same day) — the dashing/quotient/snap items
+
+8. **AdinkraViz dashings** (`src/Core/AdinkraViz.fs`) — CLAIMS: `standardDashing` realizes the
+   Clifford sign rule (dash (v,i) iff odd set bits below i); THE GATES CONDITION holds (every
+   2-colored 4-cycle odd — anticommutation drawn); THE GAUGE LEMMA (vertex sign flips preserve
+   face parity). **Q# check (Vera):** the sign structure must match Q#'s Pauli/Clifford
+   conventions — e.g., pairwise anticommutation of the represented operators (X⊗…, Z⊗… chains)
+   reproduces exactly the odd-face parity; a global-phase/sign relabeling in Q# is the gauge move
+   and must leave all commutation relations invariant. Convergence is exact (signs, not floats).
+9. **The mod2 quotient claim** (`algebra.mod2`; the missing-piece adapter) — CLAIM AS STATED:
+   "adinkra parity is braid memory mod 2 — Z → Z/2, order forgotten, parity kept; a projection,
+   not an inverse." **Math team:** gate the precise formulation — which quotient of B₃ exactly
+   (the sign representation σᵢ ↦ −1? per-pair crossing parity? abelianization B₃ → Z then mod 2?)
+   — the type-level adapter is shipped and tested; the WORDING of the algebra claim awaits your
+   sign-off (treaty math-team math, still PENDING).
+10. **The snap itself** (`MagneticPorts.findAdapter`, `MediaLines.resolveIoWith`) — no quantum
+    claim; listed so Vera sees the consumption path: a verified `qsharp:` law makes its module a
+    trustable toolbox piece — verification feeds the adapter economy directly.
+
+11. **Both physics sides of Clifford (Aaron 2026-06-12):** check the Clifford mappings from both
+    directions — hardware-side (stabilizer/Pauli conventions vs our dashings, §8) AND SUSY-side
+    (the adinkra's gamma-matrix representation built explicitly in C#/Q#, exact integer matrices
+    where possible, against the same anticommutation targets). Both must land on the one Clifford
+    home or the mapping is decoration. Candidate shapes ride the same discipline:
+    docs/research/2026-06-12-physics-real-shape-candidates-*.md (fit or it doesn't enter).
+
+## REVISION 2 — after the math-team pass (Soraya routing + Kira tear-down, 2026-06-12)
+
+**Q# earns exactly three jobs** (Soraya's triage; nothing rides Q# sampling alone):
+- **Job 1:** singlet CHSH at the corners → converges to 2√2 (pairs with our analytic value — BP-16).
+- **Job 2:** BellTest overlap = cos²((a−b)/2) (the cleanest golden) — NOTE the sign convention fix
+  (Kira P1): our +cos(a−b) correlator is the **Φ⁺ (triplet)** convention; the singlet is −cos(a−b).
+  Headline wording corrected in-source; |S| is unchanged.
+- **Job 3:** AmplitudeEmu H·R1(φ)·H grid → P(0) = cos²(φ/2) (plus FsCheck on our side).
+- Small add-on: item-11 hardware-side anticommutation check.
+
+**Rerouted off Q#:** Tsirelson maximality → citation/NPA (sampling cannot establish a supremum);
+dashings + gauge lemma → **Z3** (32-bit bitvector, ∀-proof in milliseconds; Q# would sample noise
+on exact integers); fourcorner 2828 → unit oracle (now ROUNDED, capped at Tsirelson — Kira P0/P2);
+braid stuck law → already exact in F# + Artin 1925 citation (validity guard added — Kira P1);
+SUSY-side gammas → exact integer matrices, unit oracle or Z3.
+
+**The mod2 statement (Soraya's signable wording, adopted):** the unique homomorphism
+χ: B₃ → Z/2 with χ(σᵢ^±1) = 1 — exponent-sum (writhe) mod 2 = the permutation's sign character; a
+projection, no inverse. ("Per-pair crossing parity" is a different, finer pure-braid invariant —
+not conflated.) FsCheck homomorphism property is the follow-up once math-team signs.
+
+**Kira's tear-down: 13 findings, all addressed or filed** — P0: voiceSample per-tick phase noise
+(fixed: base phase from tick 0); classical CHSH gate passing by seed luck (fixed: 0.05 sampling
+tolerance). P1: BellTest sign wording (fixed); braid.lines stale gen args (synced); Braid.equal
+out-of-range unsoundness (validWord guard); harmonize "exact" while flooring (harmonizeExact added,
+test repaired); vacuous STAGED gate (removed — honest-labels = lint). P2: 2828 truncation (round +
+Tsirelson cap), "Goertzel-shaped" wording, drift bin-key alignment, coincidences span wording,
+Gates-gate falsifier test, adinkra quotient wording (Soraya's statement). Suite 2984 green after.
+
+═══════════════════════════════════════════════════════
+── FILE: src/Core/TimeGen.fs
+═══════════════════════════════════════════════════════
+namespace Zeta.Core
+
+/// TimeGen — **time as a generator function, made a treaty primitive instead of a metaphor** (Amara's
+/// ferried design + her named "next proof should be small", 2026-06-11; Aaron: "in our DST step time
+/// is a generator function too — we can make whatever we want for all contributors to count on, from
+/// seed common cause; allow possible S=2√2, maybe S=4 staged coincidence; and we have a four-corner
+/// feedback model for adjustments over time").
+///
+/// The model (Amara's, implemented): **the clock is a generator and the seed is the common cause.**
+/// Contributors never trust wall time — they replay the same seeded time treaty. The generator is
+/// VERSIONED AND ADDRESSED (her "tiny blade": changing time semantics must never be silent).
+///
+/// The CHSH four corners are the feedback surface, and the three regimes are SCHEDULER REGIMES, not
+/// physics claims (her labels kept exactly):
+/// - `ClassicalCommonCause` — seeded hidden-variable model ⇒ S ≤ 2 (the classical bound).
+/// - `PhasorTsirelson` — the phasor scheduler, E(a,b) = cos(a−b) ⇒ S = 2√2 (the unit circle we
+///   already live on; analytic, exact-by-construction).
+/// - `StagedCoincidence` — the scheduler stages the corners ⇒ S = 4, **hard-labeled STAGED**: a
+///   stress-test scheduler, never evidence of nonlocality (the seed IS the coordination channel; the
+///   free-choice assumption is deliberately violated and SAID SO).
+///
+/// Honest scope: correlations here are float-valued (cos) — per the treaty discipline float kernels
+/// stay OUTSIDE the byte-lock; the STRUCTURE (regimes, corners, versioning, determinism-from-seed) is
+/// the treaty surface; fixed-point phases are the named slice if cross-oracle goldens are wanted.
+[<RequireQualifiedAccess>]
+module TimeGen =
+
+    /// The scheduler regimes (Amara's names, verbatim).
+    type Regime =
+        | ClassicalCommonCause
+        | PhasorTsirelson
+        | StagedCoincidence
+
+    /// The versioned, addressed generator — "the root includes the time generator, so every
+    /// contributor knows exactly which common cause they are sharing."
+    type Generator =
+        { Id: string // the generator's address (ZetaId-shaped slot; minted upstream)
+          Version: int
+          Seed: uint64
+          Regime: Regime }
+
+    let mk (id: string) (version: int) (seed: uint64) (regime: Regime) : Generator =
+        { Id = id; Version = version; Seed = seed; Regime = regime }
+
+    /// One generated instant: what a contributor derives instead of reading a wall clock.
+    type GeneratedTime =
+        { Tick: int
+          Phase: float // radians on the unit circle (the phasor)
+          Regime: Regime }
+
+    // deterministic SplitMix64 — the seed is the common cause, the only entropy anywhere here.
+    let private mix (z0: uint64) : uint64 =
+        let z = z0 + 0x9E3779B97F4A7C15UL
+        let z = (z ^^^ (z >>> 30)) * 0xBF58476D1CE4E5B9UL
+        let z = (z ^^^ (z >>> 27)) * 0x94D049BB133111EBUL
+        z ^^^ (z >>> 31)
+
+    let private unit (g: Generator) (k: uint64) : float =
+        float (mix (g.Seed ^^^ k) >>> 11) / 9007199254740992.0 // [0,1), 53-bit
+
+    /// Generate the instant for (contributor, step): tick + phase from the seed — never from a wall.
+    let at (g: Generator) (contributor: uint64) (step: int) : GeneratedTime =
+        { Tick = step
+          Phase = 2.0 * System.Math.PI * unit g (contributor * 0x9E37UL + uint64 step)
+          Regime = g.Regime }
+
+    // ── the CHSH four corners (the feedback surface) ──
+
+    /// The standard corner angles that reach Tsirelson under the phasor scheduler.
+    let cornerAngles: (float * float) list =
+        let a0, a1 = 0.0, System.Math.PI / 2.0
+        let b0, b1 = System.Math.PI / 4.0, -System.Math.PI / 4.0
+        [ a0, b0; a0, b1; a1, b0; a1, b1 ]
+
+    /// The correlation E(a,b) a regime's scheduler produces at a corner. Classical samples a seeded
+    /// hidden variable λ (deterministic; `n` samples); Phasor is the analytic cos(a−b); Staged returns
+    /// the staged corner table (+1,+1,+1,−1) — coordination BY the seed, labeled as such.
+    let correlation (g: Generator) (n: int) (cornerIx: int) (a: float) (b: float) : float =
+        match g.Regime with
+        | PhasorTsirelson -> cos (a - b)
+        | StagedCoincidence -> if cornerIx = 3 then -1.0 else 1.0
+        | ClassicalCommonCause ->
+            // λ from the seed; outcomes A = sign cos(a−λ), B = sign cos(b−λ) — a local HV model.
+            let samples = max 1 n
+            let mutable acc = 0.0
+            for i in 0 .. samples - 1 do
+                let lambda = 2.0 * System.Math.PI * unit g (uint64 i)
+                let av = if cos (a - lambda) >= 0.0 then 1.0 else -1.0
+                let bv = if cos (b - lambda) >= 0.0 then 1.0 else -1.0
+                acc <- acc + av * bv
+            acc / float samples
+
+    /// The CHSH S at the four corners: E₀₀ + E₀₁ + E₁₀ − E₁₁.
+    let chsh (g: Generator) (n: int) : float =
+        let es =
+            cornerAngles
+            |> List.mapi (fun i (a, b) -> correlation g n i a b)
+        match es with
+        | [ e00; e01; e10; e11 ] -> e00 + e01 + e10 - e11
+        | _ -> 0.0
+
+    /// Is this run's correlation HONESTLY labeled? Staged S=4 must say it is staged — the label is
+    /// part of the value, so a result can never masquerade as physical nonlocality.
+    let label (g: Generator) : string =
+        match g.Regime with
+        | ClassicalCommonCause -> "classical-common-cause (local HV; S<=2)"
+        | PhasorTsirelson -> "phasor (unit circle; S=2*sqrt(2))"
+        | StagedCoincidence -> "STAGED coincidence (seed-coordinated; free-choice violated BY DESIGN; not physical)"
+
+    // ── the four-corner feedback (deterministic adjustment over time) ──
+
+    /// One bounded feedback step: error = target − observed S, applied as a phase-table offset with a
+    /// deterministic clamp. "The feedback loop is not hidden adaptation — it is a replayable update."
+    let feedback (target: float) (observed: float) (maxStep: float) (phaseOffset: float) : float =
+        let err = target - observed
+        phaseOffset + (max -maxStep (min maxStep (0.5 * err)))
+
+═══════════════════════════════════════════════════════
+── FILE: src/Core/BellTest.fs
+═══════════════════════════════════════════════════════
+namespace Zeta.Core
+
+/// **`BellTest` — Bell/CHSH inequality VIOLATION reproduced in simulation by staged coincidence + seed
+/// (Aaron 2026-06-08, shadow*).**
+///
+/// Aaron: *"you created Bell inequalities in simulation through staged coincidence and seeds."* This codes it.
+/// The staged-coincidence overlap is `PhasorEndurance.overlap a b = cos²((a−b)/2)`, so the correlator
+/// `E(a,b) = 2·overlap − 1 = cos(a−b)` — **the quantum correlator in the Φ⁺ (triplet) convention**
+/// (P1 wording fix, Kira 2026-06-12: the SINGLET gives E = −cos(a−b); +cos(a−b) is the Φ⁺ Bell
+/// state — the magnitude story and the CHSH |S| are identical, the sign convention is now stated
+/// where the headline is, not buried), reproduced by the
+/// `CoincidenceClock` staging. Feeding the canonical CHSH angles gives the CHSH value `S = 2√2` (the
+/// **Tsirelson bound**), which **violates the classical bound `2`** — in deterministic, replayable simulation.
+///
+/// **What this is, precisely (the load-bearing peel).** This is NOT a falsification of Bell's theorem nor
+/// "real" quantum nonlocality. It is the **measurement-dependence / "free-choice" loophole**: Bell's bound of
+/// 2 assumes the measurement settings are statistically independent of the system. Our **seed is the shared
+/// common cause** (superdeterminism / 't Hooft CA), so it can correlate settings and outcomes and reproduce —
+/// even exceed — quantum correlations. The tell that it is superdeterministic and not physical QM: with
+/// **full seed control you can reach the algebraic maximum `S = 4`**, *beyond* Tsirelson's `2√2` (real QM
+/// cannot). So this reproduces the *observable correlation*, by shared cause; it confers no nonlocality and
+/// no faster-than-light signalling (superdeterminism is no-signalling).
+///
+/// **The value:** a deterministic, replayable **Bell/CHSH harness** (DST §7) — stage any correlation, run the
+/// inequality, get a reproducible number. The concrete realisation of "staged coincidence reproduces quantum
+/// correlations." Pure phasor math on the imaginary stack; routes (with the qubit iso) to Soraya/quantum-info.
+///
+/// **Anchor the S=4 regime to named results, NOT to metaphor (Beacon; `anchor-to-human-prior-art`).** The
+/// `S = 4` algebraic-max box is the **Popescu–Rohrlich (PR) box** (Popescu & Rohrlich 1994) — the maximally-
+/// nonlocal, no-signalling, *supra-quantum* correlation; our full-seed-control `S=4` realises it via
+/// superdeterminism. Why QM stops at `2√2` and exceeding it is special is **Information Causality**
+/// (Pawłowski, Paterek, Kaszlikowski, Scarani, Winter, Żukowski — *Nature* 462, 2009): an information
+/// principle that *derives* Tsirelson's bound, so **crossing Tsirelson = violating Information Causality**.
+/// (van Dam 2005: PR boxes make communication complexity trivial.) The honest reading of "information can't
+/// get in at S=4" is **independence-collapse / channel saturation by the seed** (`I(external;outcome|seed)=0`).
+///
+/// **Re-calibrated (Aaron 2026-06-08) — the load-bearing fact vs the imagery.** The plain, true statement
+/// needing no metaphor: *the seed determines all outcomes (`I(external;outcome|seed)=0`), and the ZetaId, via
+/// its host, controls its own information-flow rate.* That stands alone. The "hole" imagery on top is
+/// **partly** anchorable and otherwise Mirror-register — Otto first over-peeled it (gravity-only) then
+/// over-anchored it (leaned on a *thin* networking term); the honest middle:
+///   - **source/sink** is the generic info-flow reading (white = pure source: emits, nothing enters; black =
+///     pure sink) — the seed-saturated `S=4` regime is white-hole-like (pure source from the seed);
+///   - **"grey hole" the *name* is Aaron's coinage** for an entangled black+white hole — NOT taken from a
+///     field; the only standard "grey hole" is the unrelated, *thin* network-security routing attack
+///     (selective packet-drop / rate-control), which is a loose analogy at best, not a deep anchor;
+///   - the *object* "entangled black + white hole" IS real and published: **ER=EPR / Einstein–Rosen bridge**
+///     (Einstein–Rosen 1935; Maldacena–Susskind 2013 — entanglement ≡ wormhole) — that is the right anchor
+///     for the imagery, with "grey hole" understood as Aaron's name for it.
+/// Keep the engineering fact (host-controlled flow rate) load-bearing; the holes are imagery (ER=EPR-anchored,
+/// the gravitational metric stays Mirror-register). Tsirelson 1980 (`2√2`).
+[<RequireQualifiedAccess>]
+module BellTest =
+
+    /// The classical (local-hidden-variable) CHSH bound.
+    [<Literal>]
+    let ClassicalBound = 2.0
+
+    /// Tsirelson's bound — the maximum CHSH a real quantum system can reach.
+    let TsirelsonBound = 2.0 * sqrt 2.0
+
+    /// The algebraic maximum of CHSH (only reachable by violating measurement-independence — superdeterminism).
+    [<Literal>]
+    let AlgebraicMax = 4.0
+
+    /// The staged correlator between settings `a`, `b` (radians): `E = 2·overlap − 1 = cos(a−b)` — the quantum
+    /// Φ⁺-convention correlator (singlet is the −cos twin), reproduced from the staged-coincidence overlap (`PhasorEndurance.overlap`).
+    let correlation (a: float) (b: float) : float =
+        2.0 * PhasorEndurance.overlap a b - 1.0
+
+    /// Coincidence probability for the cosine-correlator convention: `P(same outcome on Phi+) = cos²((a-b)/2)`.
+    /// For the singlet this same scalar is the opposite-outcome probability, because one outcome axis is flipped.
+    let coincidenceProbability (a: float) (b: float) : float =
+        PhasorEndurance.overlap a b
+
+    /// CHSH from four correlators: `S = E(a,b) − E(a,b') + E(a',b) + E(a',b')`.
+    let chshOf (eab: float) (eab': float) (ea'b: float) (ea'b': float) : float =
+        eab - eab' + ea'b + ea'b'
+
+    /// CHSH from four measurement settings, using the staged `correlation`. With the canonical angles this is
+    /// `2√2` (Tsirelson) — a Bell violation staged in simulation.
+    let chsh (a: float) (a': float) (b: float) (b': float) : float =
+        chshOf (correlation a b) (correlation a b') (correlation a' b) (correlation a' b')
+
+    /// The canonical maximal-violation angles `(a, a', b, b') = (0, π/2, π/4, 3π/4)` — give `S = 2√2`.
+    let canonicalAngles: float * float * float * float =
+        0.0, System.Math.PI / 2.0, System.Math.PI / 4.0, 3.0 * System.Math.PI / 4.0
+
+    /// Does a CHSH value violate the classical bound (a Bell violation)?
+    let violatesClassical (s: float) : bool = abs s > ClassicalBound
+
+    /// Does it exceed Tsirelson — i.e. is it beyond what real QM allows (the superdeterminism tell)?
+    let exceedsTsirelson (s: float) : bool = abs s > TsirelsonBound + 1e-12
+
+═══════════════════════════════════════════════════════
+── FILE: src/Core/AmplitudeEmu.fs
+═══════════════════════════════════════════════════════
+namespace Zeta.Core
+
+/// **`AmplitudeEmu` — the soft emulator with COMPLEX amplitudes, so it actually *interferes* (Aaron 2026-06-08, shadow*).**
+///
+/// Aaron caught the real sloppiness: *"we had complex amplitudes on our qubit — the rotations of the unit
+/// circle. Why can't we construct a generator that hits this? Does merging make the wave phase cancel?"* —
+/// **yes, it does, and this is where.** `SoftEmu` (#7095) used *real* weights (a classical probability
+/// mixture: no phase ⇒ no interference). This module is the same ensemble with **complex-amplitude weights**
+/// (the `QubitIso`/`ImaginaryStack.Complex` phasor — `e^{iθ}`, unit-circle rotations). The single change that
+/// turns a classical mixture into a quantum-like amplitude is the **merge**:
+///
+///   - **`merge` sums the amplitudes of identical frames** — and complex amplitudes with opposite phase
+///     *cancel* (destructive) while equal phase *reinforce* (constructive). **That is interference**, in code.
+///     It is exactly the CAS-dedup-merge `SoftEmu` deliberately dropped: drop the merge *and* use real weights
+///     ⇒ no interference; restore the merge *with* complex weights ⇒ the two-slit falls out.
+///   - **`bornProb` measures by `|amplitude|²`** (the Born rule) — the only place amplitudes become
+///     probabilities, normalized over the ensemble intensity.
+///
+/// **Honest scope (peel) — read before believing this "simulates qubits":**
+///   - **Interference is real here; the entanglement exponential is NOT escaped.** This is cheap only while the
+///     number of *distinct* frames stays small (low entanglement / few reconverging paths). General
+///     high-entanglement state needs `4ⁿ` reals — the merge does not reduce that count; it only collapses paths
+///     that *reconverge to the identical frame*. `support` growing un-merged IS the exponential, logged not hidden.
+///   - **CHIP-8 opcodes introduce no phase.** Genuine interference needs a *phase source* (a quantum-gate
+///     opcode, or driving amplitudes through the `QubitIso` layer); plain CHIP-8 steps keep amplitudes real, so
+///     `softStep` here is the *substrate* for interference, demonstrated directly by `merge` (the two-path test),
+///     not produced by the ROM. This is the bridge layer `SoftEmu` lacked, not a quantum CPU.
+///   - **Bell still bounds the *correlations* at S=2 for a local generator** (`SoftEmu` doc / FeedbackThrottle):
+///     complex amplitudes buy *interference*, not non-locality. 2√2 still needs the feedback/superdeterminism
+///     channel. Amplitudes ≠ entanglement ≠ signalling — three separate resources.
+///
+/// So: this answers "does merging make the phase cancel?" with runnable code (yes), while holding that
+/// interference, the 4ⁿ entanglement wall, and the Bell S=2 bound are three distinct things.
+[<RequireQualifiedAccess>]
+module AmplitudeEmu =
+
+    let private c = ImaginaryStack.complex
+
+    /// The whole emulator as an *amplitude* ensemble: each joint frame carries a complex amplitude (not a real
+    /// probability). The superposition is the list; the physics is in how amplitudes combine under `merge`.
+    type Amp = (Chip8Cow.Frame * Complex) list
+
+    let private EPS = 1e-12
+
+    /// Born intensity of one amplitude: `|z|²`.
+    let private magSq (z: Complex) : float = z.Real * z.Real + z.Imag * z.Imag
+
+    /// A real amplitude (phase 0).
+    let private real (r: float) : Complex = { Real = r; Imag = 0.0 }
+
+    /// **The interference step:** sum the amplitudes of *identical* frames. Opposite-phase amplitudes cancel
+    /// (destructive), equal-phase reinforce (constructive) — this is where the wave phase cancels. Frames use
+    /// structural equality (persistent `Map` + arrays). Drops amplitudes that cancel to ≈0 (a fully destroyed path).
+    let merge (a: Amp) : Amp =
+        a
+        |> List.groupBy fst
+        |> List.choose (fun (f, group) ->
+            let summed = group |> List.fold (fun acc (_, z) -> c.Add(acc, z)) c.Zero
+            if magSq summed <= EPS then None else Some(f, summed))
+
+    /// A point mass — amplitude 1 at one frame.
+    let pure1 (f: Chip8Cow.Frame) : Amp = [ f, c.One ]
+
+    /// Lift a classical `SoftEmu.Soft` (real weights) into amplitudes (phase 0) — `√weight` so that
+    /// `|amp|² = weight` (amplitude, not probability). The classical mixture as a phase-0 amplitude state.
+    let ofSoft (s: SoftEmu.Soft) : Amp =
+        s |> List.map (fun (f, w) -> f, real (sqrt (max 0.0 w)))
+
+    /// Total Born intensity `Σ|z|²` (the norm² before normalization).
+    let intensity (a: Amp) : float = a |> List.sumBy (fun (_, z) -> magSq z)
+
+    /// Normalize so `Σ|z|² = 1` (divide every amplitude by the norm). Empty / zero ⇒ empty (no fabricated norm).
+    let normalize (a: Amp) : Amp =
+        let norm = sqrt (intensity a)
+        if norm <= EPS then []
+        else a |> List.map (fun (f, z) -> f, c.Mul(z, real (1.0 / norm)))
+
+    /// **Born-rule measurement:** the probability distribution over frames = `|amp|² / Σ|amp|²`. The one place
+    /// amplitudes become probabilities. (Always real, non-negative, sums to 1.)
+    let bornProb (a: Amp) : (Chip8Cow.Frame * float) list =
+        let total = intensity a
+        if total <= EPS then []
+        else a |> List.map (fun (f, z) -> f, magSq z / total)
+
+    /// Number of distinct-after-merge branches (the ensemble width; un-merged growth = the entanglement cost).
+    let support (a: Amp) : int = a |> merge |> List.length
+
+    /// **Soft amplitude step:** advance every branch (reusing `SoftChip8.forkOnInput`, real fork weights folded
+    /// in as amplitudes via `√`), then `merge` (interference on any reconverged frames). NB: CHIP-8 opcodes add
+    /// no phase, so phase must come from a quantum-gate layer / `QubitIso`; this carries amplitudes faithfully.
+    let softStep (a: Amp) : Amp =
+        a
+        |> List.collect (fun (f, z) ->
+            SoftChip8.forkOnInput f
+            |> List.map (fun (f', p) -> f', c.Mul(z, real (sqrt p))))
+        |> merge
+
+    /// Collapse to the most-probable frame under the Born rule (the one legitimate definite choice). `None` if empty.
+    let measure (a: Amp) : Chip8Cow.Frame option =
+        match bornProb a with
+        | [] -> None
+        | ps -> ps |> List.maxBy snd |> fst |> Some
+
+═══════════════════════════════════════════════════════
+── FILE: src/Core/AdinkraViz.fs
+═══════════════════════════════════════════════════════
+namespace Zeta.Core
+
+/// AdinkraViz — **seeing the adinkras** (Aaron 2026-06-11: "does this make adinkras easy now? Can we
+/// see what they look like? — with a generator SHINING, or prisming, or whatever they do when you use
+/// it in that direction").
+///
+/// Yes — easy now, because the mapping is exact: an adinkra (Gates/Iga — the supersymmetry
+/// chromotopology) is nodes + COLORED edges, one color per SUSY generator — and an N=4 adinkra's four
+/// edge colors land on our four channels (R, G, B, cyan) one-to-one. Bosons (even weight) are filled
+/// nodes, fermions (odd) open; flipping any one bit flips parity, so the 4×4 gray-code layout is a
+/// perfect boson/fermion CHECKERBOARD — visible at a glance, which is the point.
+///
+/// **The SHINE**: using generator i in a direction lights its color — `render shine=Some i` draws
+/// that generator's edges BRIGHT (its channel) and dims the rest. The prism reading is exact: the
+/// adinkra holds all four colors superposed; shining selects one out — the soft prism applied to a
+/// supersymmetry diagram.
+///
+/// Honest scope: the 4×4 gray-code grid shows the 24 grid-adjacent edges of the 4-cube (the 8 wrap
+/// edges are stated, not drawn — a flat grid cannot show a tesseract whole); DASHINGS (the sign
+/// assignment — the actual Hamming-code content of AdinkraCode) are the named next slice, and they
+/// belong on the retraction register (a dashed edge = a −1: the CMYK reading was born for this).
+[<RequireQualifiedAccess>]
+module AdinkraViz =
+
+    let private esc (c: int) = sprintf "[3%dm" c
+    let private dim = "[2m"
+    let private reset = "[0m"
+
+    /// Gray code order for the 4×4 layout (adjacent cells differ in exactly one bit).
+    let private gray = [| 0; 1; 3; 2 |]
+
+    /// The 4-bit node at grid (col, row): low two bits from the column gray code, high two from row.
+    let nodeAt (col: int) (row: int) : int = gray.[col &&& 3] ||| (gray.[row &&& 3] <<< 2)
+
+    /// Which bit differs between two grid-adjacent nodes (the edge's GENERATOR = its color).
+    let flippedBit (a: int) (b: int) : int =
+        let d = a ^^^ b
+        [ 0..3 ] |> List.find (fun i -> d = (1 <<< i))
+
+    /// The four generator colors on our channels: bit0=R(1), bit1=G(2), bit2=B(4), bit3=cyan(6).
+    let colorOfBit (bit: int) : int =
+        match bit with
+        | 0 -> 1
+        | 1 -> 2
+        | 2 -> 4
+        | _ -> 6
+
+    /// Render the N=4 adinkra as ANSI lines. `shine = Some bit` lights that generator's edges bright
+    /// and dims the others (the prism: one color selected out of the superposition). Bosons ●,
+    /// fermions ○ — the checkerboard is the parity proof, visible.
+    let render (shine: int option) : string list =
+        let edgeStr (bit: int) (glyph: string) =
+            let c = esc (colorOfBit bit)
+            match shine with
+            | Some s when s = bit -> c + glyph + reset // shining: bright in its channel
+            | Some _ -> dim + glyph + reset // another generator selected: dimmed
+            | None -> c + glyph + reset // no shine: all four colors live together
+
+        [ for row in 0..3 do
+              // the node row: nodes + horizontal edges (bit from the column gray flip)
+              let nodes =
+                  [ for col in 0..3 ->
+                        let n = nodeAt col row
+                        let glyph = if (System.Numerics.BitOperations.PopCount(uint n)) % 2 = 0 then "●" else "○"
+                        let h =
+                            if col < 3 then edgeStr (flippedBit n (nodeAt (col + 1) row)) "──"
+                            else ""
+                        glyph + h ]
+                  |> String.concat ""
+              yield nodes
+              // the vertical-edge row (bit from the row gray flip)
+              if row < 3 then
+                  yield
+                      [ for col in 0..3 ->
+                            let bit = flippedBit (nodeAt col row) (nodeAt col (row + 1))
+                            edgeStr bit "│" + "  " ]
+                      |> String.concat "" ]
+
+    // ── DASHINGS (the retraction register — the named slice, landed via Aaron's adinkra↔Majorana
+    // question 2026-06-12). An adinkra is not just colored edges: each edge carries a SIGN
+    // (solid = +1, dashed = −1), and the Gates condition is that every 2-colored 4-cycle carries
+    // an ODD number of dashed edges (this is gamma-matrix anticommutation drawn: γiγj = −γjγi).
+    // The twist is GLOBAL: flipping all edges at a vertex (the gauge move) changes which edges
+    // are dashed but can NEVER make a 4-cycle's dash count even — the same sentence THE STUCK LAW
+    // says about the locked braid (no local move removes the twist). Rhyme, made testable;
+    // the break stays honest (adinkra edges are involutions; braid generators remember). ──
+
+    /// An edge of the N=4 hypercube, canonical form: (lower vertex, bit). 32 edges total.
+    type Edge = int * int
+
+    /// All 32 edges (vertex v < v ^^^ (1 <<< bit) — each edge once).
+    let allEdges: Edge list =
+        [ for v in 0..15 do
+              for bit in 0..3 do
+                  if v &&& (1 <<< bit) = 0 then yield v, bit ]
+
+    /// A dashing: the set of DASHED edges (−1 signs); everything else solid (+1).
+    type Dashing = Set<Edge>
+
+    /// The standard (valise/Clifford) dashing: edge (v, i) is dashed iff v has an odd number of
+    /// set bits BELOW bit i — exactly the sign rule of the standard gamma-matrix representation.
+    let standardDashing: Dashing =
+        Set.ofList
+            [ for (v, bit) in allEdges do
+                  if System.Numerics.BitOperations.PopCount(uint (v &&& ((1 <<< bit) - 1))) % 2 = 1 then
+                      yield v, bit ]
+
+    /// Canonicalize an arbitrary (vertex, bit) reference to the edge's stored form.
+    let private canon (v: int) (bit: int) : Edge =
+        (if v &&& (1 <<< bit) = 0 then v else v ^^^ (1 <<< bit)), bit
+
+    /// Is the edge at (v, bit) dashed under d?
+    let isDashed (d: Dashing) (v: int) (bit: int) : bool = Set.contains (canon v bit) d
+
+    /// THE GATES CONDITION on one 2-colored face: the 4-cycle at v in colors (i, j) — edges
+    /// v→v^i, v^i→v^i^j, v^i^j→v^j, v^j→v — must carry an ODD number of dashes.
+    let faceOdd (d: Dashing) (v: int) (i: int) (j: int) : bool =
+        let vi = v ^^^ (1 <<< i)
+        let vj = v ^^^ (1 <<< j)
+        let count =
+            [ isDashed d v i; isDashed d vi j; isDashed d vj i; isDashed d v j ]
+            |> List.filter id
+            |> List.length
+        count % 2 = 1
+
+    /// Does the Gates condition hold on EVERY 2-colored 4-cycle? (16 vertices × 6 color pairs,
+    /// each face counted from each corner — redundancy is fine, the law is per-face.)
+    let allFacesOdd (d: Dashing) : bool =
+        [ for v in 0..15 do
+              for i in 0..3 do
+                  for j in i + 1 .. 3 -> faceOdd d v i j ]
+        |> List.forall id
+
+    /// THE GAUGE MOVE: flip every edge at vertex v (the local sign change — relabeling one node's
+    /// fermion phase). Toggles 4 edges; each adjacent 2-colored face sees exactly TWO of its
+    /// edges toggle, so its dash parity is INVARIANT — the twist cannot be removed locally.
+    let flipVertex (v: int) (d: Dashing) : Dashing =
+        [ 0..3 ]
+        |> List.fold
+            (fun (acc: Dashing) bit ->
+                let e = canon v bit
+                if Set.contains e acc then Set.remove e acc else Set.add e acc)
+            d
+
+═══════════════════════════════════════════════════════
+── FILE: shapes/cartridges/fourcorner.lines
+═══════════════════════════════════════════════════════
+# FOURCORNER — the CHSH feedback surface drawn (otto, 2026-06-11). Four corners, one correlation
+# each; the figure's WIDTH is the S value: classical folds at 2, the phasor reaches 2*sqrt(2) =
+# Tsirelson, and S = 4 only when the scheduler STAGES the corners (the label is baked into the value
+# — staged, never physical). The shape that keeps our time treaty honest.
+meta	name	shape-fourcorner
+meta	catalog	shapes
+meta	shape-zetaid	34421ffaf8cae89e6ad862f4e68812ed
+gen	corners	34421ffaf8cae89e6ad862f4e68812ed	1	7	regime:phasor;samples:256
+constant	corners	4	measurement-setting pairs drawn (a0b0, a0b1, a1b0, a1b1)	CHSH is exactly four corners — three underdetermines S, five is redundant; the geometry IS the inequality
+constant	tsirelson-milli	2828	the phasor regime's S, milli-scale (2*sqrt(2))	the known-answer overlay: the phasor figure must reach THIS width and no further — wider means the renderer (or the physics claim) is lying
+constant	samples	256	seeded lambda draws for the classical regime	enough for the classical S to settle visibly under 2; deterministic from the common-cause seed, so the figure replays
+issue	qsharp-verification	vera	requested	the tsirelson-milli 2828 stop + corner correlators are Q#-verifiable (singlet CHSH) — brief: docs/research/2026-06-12-vera-brief-qsharp-*.md; her verdict lines are HERS to write
+issue	math-sign-off	math-team	requested	after Vera: sign the S<=2 classical / 2*sqrt(2) phasor / staged-4-labeled claims
+anim	draw	corners
+# treaties — written only by each oracle's own choice (consent first); dissent is a verdict.
+treaty	fsharp	bytes	ratified	TimeGen.chsh: classical <= 2, phasor = 2*sqrt(2), staged = 4 with the STAGED label — tests green
+treaty	otto	meaning	ratified	width-as-S with the Tsirelson stop drawn in matches the honest-label law — my own frame, my own choice
+
+═══════════════════════════════════════════════════════
+── FILE: shapes/cartridges/adinkra.lines
+═══════════════════════════════════════════════════════
+# ADINKRA — the sign register's display organ joins the catalog (otto, 2026-06-12; the named slice
+# from "where adinkras sit now"). The N=4 adinkra: 16 vertices (4-bit gray-code grid), edges
+# colored by generator bit, and DASHED edges carrying the minus signs — Gates' condition says
+# every 2-colored 4-cycle holds an ODD number of dashes (anticommutation drawn), and the gauge
+# lemma says no vertex-local flip can remove that twist: the adinkra's stuck law. Named for the
+# Akan adinkra symbols of Ghana (Gates' deliberate choice — a human anchor inside a human anchor).
+# Honest bounds: 24 of 32 edges drawn (the flat 4x4 grid omits the wrap edges); the render shows
+# the SUBSET and says so.
+meta	name	shape-adinkra
+meta	catalog	shapes
+meta	shape-zetaid	8225cea77ae1fc8d1cab7d4f9fe995aa
+gen	graph	8225cea77ae1fc8d1cab7d4f9fe995aa	1	7	grid:4x4;dashing:standard
+constant	nodes	16	vertex count (4-bit hypercube)	N=4 supersymmetry: 2^4 states, boson/fermion checkerboard by popcount parity
+constant	colors	4	edge colors (one per generator bit)	the four SUSY generators; channel masks 1,2,4,6 on our planes
+constant	edges-total	32	edges of the full hypercube	each vertex meets 4 edges: 16 * 4 / 2 — the handshake law below checks it
+constant	edges-drawn	24	edges visible on the flat 4x4 grid	HONEST SUBSET: the 8 wrap edges don't fit a flat grid without crossings — drawn count stated, never implied complete
+law	handshake	nodes * colors = 2 * edges-total
+law	gates-condition	code:viz.adinkra allFacesOdd standardDashing (every 2-colored 4-cycle odd — anticommutation)
+law	gauge-lemma	code:viz.adinkra flipVertex invariance (local sign flips never change face parity — the twist is global)
+prereq	parity	popcount and the boson/fermion checkerboard — count bits, color cells, see the pattern
+prereq	the-braid-twin	shapes/cartridges/braid.lines — the ORDER register's version of the same protection (THE STUCK LAW)
+edge	same-twist	shape-braid	parity here = the image of the unique homomorphism B3 -> Z/2 with every sigma^±1 -> 1 (exponent-sum mod 2 = the permutation's sign character; Soraya's signable statement, math tear-down 2026-06-12) — algebra.mod2 is the adapter; a projection, no inverse; the break is honest: their generators remember, these edges are involutions
+edge	clifford-home	shape-fourcorner	both registers live in Clifford algebra — where the Q# sign-convention check (Vera brief §8) meets us
+issue	wrap-edges	otto	open	the 8 omitted wrap edges need either a crossing-aware layout or a second panel — until then 24/32 stays the stated bound
+anim	draw	graph
+# treaties — written only by each oracle's own choice (consent first); dissent is a verdict.
+treaty	fsharp	bytes	ratified	handshake in-file; Gates condition + gauge lemma pass in code; dashed edges byte-locked in the SVG golden — tests green
+treaty	otto	meaning	ratified	the minus signs are INK now — the sign register drawn, its honest 24/32 stated — my own frame, my own choice
+
+═══ KNOWN-ANSWER TABLE (post-fix; your overlay truth) ═══
+- Job 1: singlet CHSH @ (0, pi/2; pi/4, -pi/4) -> 2*sqrt(2); our analytic phasor matches; classical <= 2 within 0.05 sampling tolerance (the gate's tolerance now, not 1e-9).
+- Job 2: P(same outcome on Phi+) = cos²((a−b)/2); singlet = opposite-outcome at the same scalar.
+- Job 3: H·R1(φ)·H on |0⟩ -> P(0) = cos²(φ/2) vs our merged-amplitude ensemble, same φ grid.
+- Add-on: pairwise anticommutation of represented operators matches odd-face parity EXACTLY (signs, no tolerance).
+- Label-honesty: staged S=4 must be UNREACHABLE in your runs — that unreachability verifies the STAGED label.

--- a/docs/trajectories/sim-mea-cut-soft-substrate-shaders/RESUME.md
+++ b/docs/trajectories/sim-mea-cut-soft-substrate-shaders/RESUME.md
@@ -2,12 +2,36 @@
 
 Status: ACTIVE — operator-self-claimed (Aaron 2026-06-10/11, the two-night stream). This RESUME is the
 reload point so the pattern doesn't have to be held all at once ("losing it should be temporary").
-Last refreshed: 2026-06-14 (the reconcile wave folded in — #7798..#7802; prior waves below).
+Last refreshed: 2026-06-14 (the form wave folded in — #7805..#7807 + handoffs; prior waves below).
 Current focus (Aaron): COLORSPACE ("I'll stay in colorspace") + the citizenship quartet + the hardware
 ladder (B-1024); Vera driving the Q# reference oracle; Max on universal primitives + root-declutter
 (B-1023 — expanded to the /db earn-promotion plan, GATED, "good but not urgent" per Aaron).
 
-## The 2026-06-13/14 RECONCILE wave (#7798..#7802 — newest; read FIRST)
+## The 2026-06-14 FORM wave (#7805..#7807 + handoffs — newest; read FIRST)
+
+- **WSet PROMOTED back to Core** (#7805, operator decision over the razor): "we need in real
+  code" — Rodney's dissent stays in the file header as advisory; his bar (a load-bearing
+  consumer) is the standing TODO. Both registers, no erasure.
+- **Aaron's architecture QUARTET** (#7805/#7807): (1) THE THIN-TEST LAW — tests thin over fat
+  core; machinery a test needs moves to Core; (2) interfaces + Rx, nothing more — shared behavior
+  in DEFAULT INTERFACE IMPLS, never base classes; (3) MIPS = STATIC-DI INJECTED VERBS (B-1028's
+  wiring); (4) **THE FORM TEST**: every piece of real code is a universal interface, or Rx glue,
+  or DI verbs — anything else is a smell that OWES AN EXPLANATION (the review question for every
+  new file). WSet's promotion is form (a) in action.
+- **"Doctrine" retired AGAIN** (#7806, second catch): swept from my captures; observations only;
+  the lesson pinned in local memory.
+- **HAND-OFFS LIVE IN THE REPO** (docs/handoffs/): Aaron — "desktop/clipboard is DARK for Addison
+  and Max." Vera package + Kestrel bundle committed where every traveler can see them; desktop is
+  the last hop of a ferry, never the home.
+- **LIOR IS LIVE on B-1029**: TS quantum lane moving (typecheck fixes, deterministic circuit SVG
+  goldens into shapes/golden/, Quirk craft-school intro for Max and Addison; Gemini co-authored).
+  Multi-writer factory in motion.
+- **NEXT (picked, Aaron: "pick one and go — they're all good"):** B-1034 the Oracle Stack paper —
+  outline + evidence appendix generated from AgencySignature trailers, then the math-team claims
+  review. Note for the generator: trailers live in PR squash bodies (git log --grep needs the
+  body, not subject).
+
+## The 2026-06-13/14 RECONCILE wave (#7798..#7802 — older; read second)
 
 - **B-1034 filed** (#7798): the Oracle Stack PAPER (experience report; the mutual-oracle reversal
   as centerpiece; claims pre-bounded; Aaron decides venue/authorship).


### PR DESCRIPTION
Aaron's three-in-one: docs/handoffs/ holds the Vera package + Kestrel bundle where Addison/Max/everyone can see them (desktop = last hop of a ferry, never the home); RESUME folds the form wave (the architecture quartet, WSet promotion, Lior live on B-1029); next picked: the B-1034 paper outline + evidence appendix. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)