### PR TITLE
fix(zflash): path-fork tsc execution step union (#7808 follow-up)

### DIFF
--- a/tools/zflash/test-harness/path-fork.test.ts
+++ b/tools/zflash/test-harness/path-fork.test.ts
@@ -7,7 +7,7 @@ import {
   planPathForkRuntime,
   type PathForkRuntimeForkPlan,
 } from "./path-fork";
-import type { QemuCommand, QemuCommandExecution } from "./qemu-state";
+import type { Qcow2RetentionExecutionStep, QemuCommand, QemuCommandExecution } from "./qemu-state";
 
 const ISO_PATH = "fixtures/zeta.iso";
 const BOOT_IMAGE_PATH = "fixtures/zflash-boot.img";
@@ -118,7 +118,7 @@ describe("path-fork serial marker assertions", () => {
         .requiredSerialMarkers.join("\n"),
     };
 
-    const successfulExecution = (step: string, command: QemuCommand): QemuCommandExecution => ({
+    const successfulExecution = (step: Qcow2RetentionExecutionStep, command: QemuCommand): QemuCommandExecution => ({
       step,
       command,
       exitCode: 0,

--- a/tools/zflash/test-harness/path-fork.ts
+++ b/tools/zflash/test-harness/path-fork.ts
@@ -20,6 +20,7 @@ import {
   createSpawnSyncQcow2RetentionExecutor,
   planQcow2SnapshotRetention,
   type Qcow2RetentionExecutionFeedback,
+  type Qcow2RetentionExecutionStep,
   type Qcow2RetentionExecutor,
   type Qcow2SnapshotRetentionPlan,
   type QemuCommand,
@@ -321,12 +322,16 @@ export function assertPathForkSerialMarkers(
   };
 }
 
-export type PathForkExecutionStep =
+export type PathForkExecutionStep = Extract<
+  Qcow2RetentionExecutionStep,
   | "bootstrap-create-disk-image"
   | "bootstrap-initial-install-from-iso-with-disk"
   | "bootstrap-create-baseline-snapshot"
-  | `restore-${PathForkId}`
-  | `boot-${PathForkId}`;
+  | "restore-migrate-existing-creds"
+  | "restore-fresh-cluster"
+  | "boot-migrate-existing-creds"
+  | "boot-fresh-cluster"
+>;
 
 export interface PathForkForkExecution {
   readonly forkId: PathForkId;

--- a/tools/zflash/test-harness/qemu-state.ts
+++ b/tools/zflash/test-harness/qemu-state.ts
@@ -85,7 +85,14 @@ export type Qcow2RetentionExecutionStep =
   | "create-baseline-snapshot"
   | "list-baseline-snapshots"
   | "restore-baseline-snapshot"
-  | "restart-from-iso-with-disk";
+  | "restart-from-iso-with-disk"
+  | "bootstrap-create-disk-image"
+  | "bootstrap-initial-install-from-iso-with-disk"
+  | "bootstrap-create-baseline-snapshot"
+  | "restore-migrate-existing-creds"
+  | "restore-fresh-cluster"
+  | "boot-migrate-existing-creds"
+  | "boot-fresh-cluster";
 
 export interface QemuSerialStopCondition {
   readonly serialLogPath: string;


### PR DESCRIPTION
## Summary
- Follow-up to #7808 — extends `Qcow2RetentionExecutionStep` with path-fork restore/boot + bootstrap steps so `lint (tsc TypeScript)` passes under `erasableSyntaxOnly`.
- Aligns `PathForkExecutionStep` as an `Extract<>` of the shared union and fixes the path-fork unit-test mock step typing.

## Test plan
- [x] `bun test tools/zflash/test-harness/`
- [ ] CI `lint (tsc TypeScript)` green


Made with [Cursor](https://cursor.com)