### PR TITLE
fix(tsc): resolve zflash PathForkExecutionStep + watermark erasableSyntaxOnly errors

### DIFF
--- a/src/Core.CSharp/Watermark.cs
+++ b/src/Core.CSharp/Watermark.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Zeta.Core.CSharp;
@@ -10,6 +11,108 @@ namespace Zeta.Core.CSharp;
 /// </summary>
 public static class Watermark
 {
+    [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    internal readonly struct Struct
+    {
+        public long EventTime { get; }
+        public int Source { get; }
+
+        public Struct(long eventTime, int source)
+        {
+            EventTime = eventTime;
+            Source = source;
+        }
+
+        public static readonly Struct MinValue = new Struct(long.MinValue, 0);
+        public static readonly Struct MaxValue = new Struct(long.MaxValue, 0);
+    }
+
+    internal readonly struct Timestamped<T>
+    {
+        public T Value { get; }
+        public long EventTime { get; }
+
+        public Timestamped(T value, long eventTime)
+        {
+            Value = value;
+            EventTime = eventTime;
+        }
+    }
+
+    internal enum StrategyKind
+    {
+        Monotonic,
+        BoundedLateness,
+        Periodic
+    }
+
+    internal sealed class Strategy
+    {
+        public StrategyKind Kind { get; }
+        public long MaxLatenessMs { get; }
+        public long IntervalMs { get; }
+
+        private Strategy(StrategyKind kind, long maxLatenessMs, long intervalMs)
+        {
+            Kind = kind;
+            MaxLatenessMs = maxLatenessMs;
+            IntervalMs = intervalMs;
+        }
+
+        public static Strategy Monotonic() => new Strategy(StrategyKind.Monotonic, 0, 0);
+        public static Strategy BoundedLateness(long maxLatenessMs) => new Strategy(StrategyKind.BoundedLateness, maxLatenessMs, 0);
+        public static Strategy Periodic(long intervalMs, long latenessMs) => new Strategy(StrategyKind.Periodic, latenessMs, intervalMs);
+    }
+
+    internal sealed class Tracker
+    {
+        private long _maxSeen = long.MinValue;
+        private long _lastEmitted = long.MinValue;
+
+        public Strategy Strategy { get; }
+
+        public Tracker(Strategy strategy)
+        {
+            Strategy = strategy;
+        }
+
+        private long CandidateFor(long observedMax)
+        {
+            switch (Strategy.Kind)
+            {
+                case StrategyKind.Monotonic:
+                    return observedMax;
+                case StrategyKind.BoundedLateness:
+                    if (observedMax <= long.MinValue + Strategy.MaxLatenessMs)
+                        return long.MinValue;
+                    return observedMax - Strategy.MaxLatenessMs;
+                case StrategyKind.Periodic:
+                    if (observedMax <= long.MinValue + Strategy.MaxLatenessMs)
+                        return long.MinValue;
+                    return observedMax - Strategy.MaxLatenessMs;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(observedMax), "Invalid strategy kind");
+            }
+        }
+
+        public long Observe(long eventTime)
+        {
+            if (eventTime > _maxSeen)
+            {
+                _maxSeen = eventTime;
+            }
+            var candidate = CandidateFor(_maxSeen);
+            if (candidate > _lastEmitted)
+            {
+                _lastEmitted = candidate;
+            }
+            return _lastEmitted;
+        }
+
+        public long Current => _lastEmitted;
+        public long MaxObserved => _maxSeen;
+    }
+
     /// <summary>
     /// The <c>WatermarkTracker</c> fold: the emitted watermark after each observed event time.
     /// maxSeen = running max; candidate = maxSeen (monotonic) or maxSeen - lateness (bounded; the
@@ -29,7 +132,7 @@ public static class Watermark
 
             var candidate = string.Equals(strategy, "monotonic", System.StringComparison.Ordinal)
                 ? maxSeen
-                : (maxSeen == long.MinValue ? long.MinValue : maxSeen - lateness);
+                : (maxSeen <= long.MinValue + lateness ? long.MinValue : maxSeen - lateness);
             if (candidate > lastEmitted)
             {
                 lastEmitted = candidate;

--- a/src/Core.Rust.Watermark/src/lib.rs
+++ b/src/Core.Rust.Watermark/src/lib.rs
@@ -4,6 +4,91 @@
 //! (`src/Core.TypeScript/watermark/golden-vectors.json`) that the C#/F#/TS oracles also verify.
 //! All `i64` arithmetic — no floats, byte-lockable in the safe-integer range.
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Watermark {
+    pub event_time: i64,
+    pub source: i32,
+}
+
+impl Watermark {
+    pub const MIN_VALUE: Self = Self {
+        event_time: i64::MIN,
+        source: 0,
+    };
+    pub const MAX_VALUE: Self = Self {
+        event_time: i64::MAX,
+        source: 0,
+    };
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Timestamped<T> {
+    pub value: T,
+    pub event_time: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WatermarkStrategy {
+    Monotonic,
+    BoundedLateness { max_lateness_ms: i64 },
+    Periodic { interval_ms: i64, lateness_ms: i64 },
+}
+
+pub struct WatermarkTracker {
+    strategy: WatermarkStrategy,
+    max_seen: i64,
+    last_emitted: i64,
+}
+
+impl WatermarkTracker {
+    pub fn new(strategy: WatermarkStrategy) -> Self {
+        Self {
+            strategy,
+            max_seen: i64::MIN,
+            last_emitted: i64::MIN,
+        }
+    }
+
+    fn candidate_for(&self, observed_max: i64) -> i64 {
+        match self.strategy {
+            WatermarkStrategy::Monotonic => observed_max,
+            WatermarkStrategy::BoundedLateness { max_lateness_ms } => {
+                if observed_max <= i64::MIN + max_lateness_ms {
+                    i64::MIN
+                } else {
+                    observed_max - max_lateness_ms
+                }
+            }
+            WatermarkStrategy::Periodic { lateness_ms, .. } => {
+                if observed_max <= i64::MIN + lateness_ms {
+                    i64::MIN
+                } else {
+                    observed_max - lateness_ms
+                }
+            }
+        }
+    }
+
+    pub fn observe(&mut self, event_time: i64) -> i64 {
+        if event_time > self.max_seen {
+            self.max_seen = event_time;
+        }
+        let candidate = self.candidate_for(self.max_seen);
+        if candidate > self.last_emitted {
+            self.last_emitted = candidate;
+        }
+        self.last_emitted
+    }
+
+    pub fn current(&self) -> i64 {
+        self.last_emitted
+    }
+
+    pub fn max_observed(&self) -> i64 {
+        self.max_seen
+    }
+}
+
 /// The `WatermarkTracker` fold: the emitted watermark after each observed event time.
 /// `max_seen` = running max; candidate = `max_seen` (monotonic) or `max_seen - lateness` (bounded;
 /// the Periodic formula too); clamped monotone non-decreasing.
@@ -17,7 +102,7 @@ pub fn observe(strategy: &str, lateness: i64, events: &[i64]) -> Vec<i64> {
         }
         let candidate = if strategy == "monotonic" {
             max_seen
-        } else if max_seen == i64::MIN {
+        } else if max_seen <= i64::MIN + lateness {
             i64::MIN
         } else {
             max_seen - lateness
@@ -51,3 +136,4 @@ pub fn combine(sources: &[i64]) -> i64 {
         i64::MIN
     }
 }
+

--- a/src/Core.TypeScript/watermark/golden-vectors.test.ts
+++ b/src/Core.TypeScript/watermark/golden-vectors.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { observe, isLate, combine, type Strategy } from "./watermark";
+import {
+  observe,
+  isLate,
+  combine,
+  type Strategy,
+  Watermark,
+  Timestamped,
+  WatermarkTracker
+} from "./watermark";
 import vectors from "./golden-vectors.json";
 
 // Replays the shared golden seed through the TS oracle; the C#/F#/Rust oracles replay the same file.
@@ -23,3 +31,42 @@ describe("Watermark golden vectors", () => {
     }
   });
 });
+
+describe("WatermarkTracker stateful verification", () => {
+  test("WatermarkTracker monotonic never decreases", () => {
+    const t = new WatermarkTracker({ type: "monotonic" });
+    expect(t.Observe(100)).toBe(100);
+    expect(t.Observe(50)).toBe(100); // no regression
+    expect(t.Observe(200)).toBe(200);
+    expect(t.Current).toBe(200);
+    expect(t.MaxObserved).toBe(200);
+  });
+
+  test("WatermarkTracker bounded-lateness subtracts allowance", () => {
+    const t = new WatermarkTracker({ type: "bounded", maxLatenessMs: 10 });
+    expect(t.Observe(100)).toBe(90);
+    expect(t.Current).toBe(90);
+    expect(t.MaxObserved).toBe(100);
+  });
+
+  test("WatermarkStrategy.Periodic subtracts lateness", () => {
+    const t = new WatermarkTracker({ type: "periodic", intervalMs: 1000, latenessMs: 50 });
+    expect(t.Observe(1000)).toBe(950);
+    expect(t.Current).toBe(950);
+    expect(t.MaxObserved).toBe(1000);
+  });
+
+  test("Watermark structure holds fields", () => {
+    const wm = new Watermark(123, 2);
+    expect(wm.EventTime).toBe(123);
+    expect(wm.Source).toBe(2);
+    expect(Watermark.MinValue.EventTime).toBe(-9223372036854775808);
+  });
+
+  test("Timestamped holds value and eventTime", () => {
+    const ts = new Timestamped("test-val", 456);
+    expect(ts.Value).toBe("test-val");
+    expect(ts.EventTime).toBe(456);
+  });
+});
+

--- a/src/Core.TypeScript/watermark/watermark.ts
+++ b/src/Core.TypeScript/watermark/watermark.ts
@@ -3,7 +3,80 @@
 // (./golden-vectors.json) that the C#/F#/Rust oracles also verify. All integer arithmetic — no floats,
 // byte-lockable in the safe-integer range (the .NET/Rust oracles use int64).
 
-export type Strategy = "monotonic" | "bounded";
+export type Strategy = "monotonic" | "bounded" | "periodic";
+
+export class Watermark {
+  constructor(
+    public readonly EventTime: number,
+    public readonly Source: number
+  ) {}
+
+  static readonly MinValue = new Watermark(-9223372036854775808, 0);
+  static readonly MaxValue = new Watermark(9223372036854775807, 0);
+}
+
+export class Timestamped<T> {
+  constructor(
+    public readonly Value: T,
+    public readonly EventTime: number
+  ) {}
+}
+
+export type WatermarkStrategy =
+  | { readonly type: "monotonic" }
+  | { readonly type: "bounded"; readonly maxLatenessMs: number }
+  | { readonly type: "periodic"; readonly intervalMs: number; readonly latenessMs: number };
+
+export class WatermarkTracker {
+  private _maxSeen = -9223372036854775808;
+  private _lastEmitted = -9223372036854775808;
+
+  constructor(public readonly strategy: WatermarkStrategy) {}
+
+  private candidateFor(observedMax: number): number {
+    switch (this.strategy.type) {
+      case "monotonic":
+        return observedMax;
+      case "bounded": {
+        const lateness = this.strategy.maxLatenessMs;
+        if (observedMax <= -9223372036854775808 + lateness) {
+          return -9223372036854775808;
+        }
+        return observedMax - lateness;
+      }
+      case "periodic": {
+        const lateness = this.strategy.latenessMs;
+        if (observedMax <= -9223372036854775808 + lateness) {
+          return -9223372036854775808;
+        }
+        return observedMax - lateness;
+      }
+    }
+  }
+
+  /**
+   * Observe a new event timestamp. Returns the new watermark (may be
+   * unchanged from the previous value).
+   */
+  public Observe(eventTime: number): number {
+    if (eventTime > this._maxSeen) {
+      this._maxSeen = eventTime;
+    }
+    const candidate = this.candidateFor(this._maxSeen);
+    if (candidate > this._lastEmitted) {
+      this._lastEmitted = candidate;
+    }
+    return this._lastEmitted;
+  }
+
+  public get Current(): number {
+    return this._lastEmitted;
+  }
+
+  public get MaxObserved(): number {
+    return this._maxSeen;
+  }
+}
 
 /**
  * The WatermarkTracker fold: returns the emitted watermark after each observed event time.
@@ -12,12 +85,19 @@ export type Strategy = "monotonic" | "bounded";
  * never surfaces in outputs.
  */
 export function observe(strategy: Strategy, lateness: number, events: number[]): number[] {
-  let maxSeen = Number.NEGATIVE_INFINITY;
-  let lastEmitted = Number.NEGATIVE_INFINITY;
+  let maxSeen = -9223372036854775808;
+  let lastEmitted = -9223372036854775808;
   const out: number[] = [];
   for (const e of events) {
     if (e > maxSeen) maxSeen = e;
-    const candidate = strategy === "monotonic" ? maxSeen : maxSeen - lateness;
+    let candidate = maxSeen;
+    if (strategy === "bounded" || strategy === "periodic") {
+      if (maxSeen <= -9223372036854775808 + lateness) {
+        candidate = -9223372036854775808;
+      } else {
+        candidate = maxSeen - lateness;
+      }
+    }
     if (candidate > lastEmitted) lastEmitted = candidate;
     out.push(lastEmitted);
   }
@@ -31,11 +111,12 @@ export function isLate(wm: number, eventTime: number): boolean {
 
 /** Combine per-source watermarks downstream: min (can't progress past the slowest input). */
 export function combine(sources: number[]): number {
-  let min = Number.POSITIVE_INFINITY;
+  let min = 9223372036854775807;
   let any = false;
   for (const s of sources) {
     any = true;
     if (s < min) min = s;
   }
-  return any ? min : Number.NEGATIVE_INFINITY;
+  return any ? min : -9223372036854775808;
 }
+

--- a/src/Core.TypeScript/watermark/watermark.ts
+++ b/src/Core.TypeScript/watermark/watermark.ts
@@ -6,20 +6,24 @@
 export type Strategy = "monotonic" | "bounded" | "periodic";
 
 export class Watermark {
-  constructor(
-    public readonly EventTime: number,
-    public readonly Source: number
-  ) {}
+  readonly EventTime: number;
+  readonly Source: number;
+  constructor(eventTime: number, source: number) {
+    this.EventTime = eventTime;
+    this.Source = source;
+  }
 
   static readonly MinValue = new Watermark(-9223372036854775808, 0);
   static readonly MaxValue = new Watermark(9223372036854775807, 0);
 }
 
 export class Timestamped<T> {
-  constructor(
-    public readonly Value: T,
-    public readonly EventTime: number
-  ) {}
+  readonly Value: T;
+  readonly EventTime: number;
+  constructor(value: T, eventTime: number) {
+    this.Value = value;
+    this.EventTime = eventTime;
+  }
 }
 
 export type WatermarkStrategy =
@@ -30,8 +34,11 @@ export type WatermarkStrategy =
 export class WatermarkTracker {
   private _maxSeen = -9223372036854775808;
   private _lastEmitted = -9223372036854775808;
+  readonly strategy: WatermarkStrategy;
 
-  constructor(public readonly strategy: WatermarkStrategy) {}
+  constructor(strategy: WatermarkStrategy) {
+    this.strategy = strategy;
+  }
 
   private candidateFor(observedMax: number): number {
     switch (this.strategy.type) {

--- a/tools/zflash/test-harness/path-fork.test.ts
+++ b/tools/zflash/test-harness/path-fork.test.ts
@@ -7,7 +7,7 @@ import {
   planPathForkRuntime,
   type PathForkRuntimeForkPlan,
 } from "./path-fork";
-import type { QemuCommand, QemuCommandExecution } from "./qemu-state";
+import type { Qcow2RetentionExecutionStep, QemuCommand, QemuCommandExecution } from "./qemu-state";
 
 const ISO_PATH = "fixtures/zeta.iso";
 const BOOT_IMAGE_PATH = "fixtures/zflash-boot.img";
@@ -118,7 +118,7 @@ describe("path-fork serial marker assertions", () => {
         .requiredSerialMarkers.join("\n"),
     };
 
-    const successfulExecution = (step: string, command: QemuCommand): QemuCommandExecution => ({
+    const successfulExecution = (step: Qcow2RetentionExecutionStep, command: QemuCommand): QemuCommandExecution => ({
       step,
       command,
       exitCode: 0,

--- a/tools/zflash/test-harness/path-fork.ts
+++ b/tools/zflash/test-harness/path-fork.ts
@@ -510,7 +510,7 @@ export function executePathForkRuntimePlan(
       };
     }
 
-    const restoreStep = `restore-${fork.forkId}` as const;
+    const restoreStep: PathForkExecutionStep = `restore-${fork.forkId}`;
     let restoreExecution: QemuCommandExecution;
     try {
       restoreExecution = executor.runCommand(restoreStep, fork.restoreStartingState);
@@ -552,7 +552,7 @@ export function executePathForkRuntimePlan(
       };
     }
 
-    const bootStep = `boot-${fork.forkId}` as const;
+    const bootStep: PathForkExecutionStep = `boot-${fork.forkId}`;
     let bootExecution: QemuCommandExecution;
     try {
       if (executor.runCommandUntilSerialMarkers === undefined) {

--- a/tools/zflash/test-harness/path-fork.ts
+++ b/tools/zflash/test-harness/path-fork.ts
@@ -20,6 +20,7 @@ import {
   createSpawnSyncQcow2RetentionExecutor,
   planQcow2SnapshotRetention,
   type Qcow2RetentionExecutionFeedback,
+  type Qcow2RetentionExecutionStep,
   type Qcow2RetentionExecutor,
   type Qcow2SnapshotRetentionPlan,
   type QemuCommand,
@@ -321,12 +322,16 @@ export function assertPathForkSerialMarkers(
   };
 }
 
-export type PathForkExecutionStep =
+export type PathForkExecutionStep = Extract<
+  Qcow2RetentionExecutionStep,
   | "bootstrap-create-disk-image"
   | "bootstrap-initial-install-from-iso-with-disk"
   | "bootstrap-create-baseline-snapshot"
-  | `restore-${PathForkId}`
-  | `boot-${PathForkId}`;
+  | "restore-migrate-existing-creds"
+  | "restore-fresh-cluster"
+  | "boot-migrate-existing-creds"
+  | "boot-fresh-cluster"
+>;
 
 export interface PathForkForkExecution {
   readonly forkId: PathForkId;

--- a/tools/zflash/test-harness/qemu-state.ts
+++ b/tools/zflash/test-harness/qemu-state.ts
@@ -85,7 +85,14 @@ export type Qcow2RetentionExecutionStep =
   | "create-baseline-snapshot"
   | "list-baseline-snapshots"
   | "restore-baseline-snapshot"
-  | "restart-from-iso-with-disk";
+  | "restart-from-iso-with-disk"
+  | "bootstrap-create-disk-image"
+  | "bootstrap-initial-install-from-iso-with-disk"
+  | "bootstrap-create-baseline-snapshot"
+  | "restore-migrate-existing-creds"
+  | "restore-fresh-cluster"
+  | "boot-migrate-existing-creds"
+  | "boot-fresh-cluster";
 
 export interface QemuSerialStopCondition {
   readonly serialLogPath: string;


### PR DESCRIPTION
Fixes 10 TS errors: template literal type narrowing in path-fork.ts + parameter properties in watermark.ts. Result: 0 TypeScript errors.