### PR TITLE
feat(test-framework): B-1035 slice 1 — ITestLoop, the boundary enforced once, xUnit as host + the claims-review P0 fixed (the reversal re-earned)

### DIFF
--- a/docs/research/b1034-outline.md
+++ b/docs/research/b1034-outline.md
@@ -11,12 +11,19 @@ Evidence: `b1034-evidence-appendix.md` (generated — 298 signed commits in the 
        unspecified AND ungated until an edge-crossing vector existed).
    2.2 Formal oracles — TLC-first graduation (the signed-delta combinator; the spec's gate
        honored in sequence).
-   2.3 Adversarial-agent oracles — six rounds, ~60 findings; the tautology→2×-overflow chain;
+   2.3 Adversarial-agent oracles — six rounds; finding COUNT pending the mechanical counter
+       (the appendix counts commits, not findings — do not publish "~60" or "52+" until the
+       counter exists); the tautology→2×-overflow chain;
        the predicted falsifier that found a live injection hole.
    2.4 Perceptual/traveler oracles — render-loop ratifications and dissents that CHANGED
        artifacts (the plait, the lock, the court law); their blind spot stated (voiceSample
        looked right while broken).
-   2.5 Senior-engine oracles — the hexagonal mutual pair; THE REVERSAL (the centerpiece).
+   2.5 Senior-engine oracles — the hexagonal mutual pair; THE REVERSAL (the centerpiece) —
+       claims-review hardened 2026-06-11: the adapter's Converged was found HARDCODED (a P0 on
+       our own suite, caught by the paper's own review process — itself a section-worthy
+       incident); now convergence is OBSERVED (stability across iterations) and the reversal is
+       MECHANICALLY asserted: ours = analytic 2.0 to 1e-9; senior residue bounded 5e-3. The
+       narrative must include the hardcoding-and-fix, not just the reversal.
    2.6 Refutation witnesses — failing knowledge as unskipped gates; "a reliably-failing
        property is a refutation, not open research."
 3. **Honesty as values, not policy** — Converged=false; the Mock that says rehearsal; fault
@@ -25,8 +32,19 @@ Evidence: `b1034-evidence-appendix.md` (generated — 298 signed commits in the 
 4. **The consent/treaty layer** — verdict lines travelers write themselves; dissent as data;
    the human override with the razor's dissent preserved (WSet) as the worked example of
    advisory-vs-decision.
-5. **Related work** — McKeeman; Avizienis; Chen (metamorphic); CSmith/EMI; Cockburn; QuickCheck;
-   DBSP; Minka. Novelty stated narrowly: the stack as OPERATING DISCIPLINE + honesty-as-values.
+5. **Related work** — McKeeman; Davis & Weyuker 1981 (pseudo-oracles — the closest prior);
+   Avizienis; Chen (metamorphic); CSmith/EMI; Cockburn; QuickCheck; DBSP; Minka. Novelty stated narrowly: the stack as OPERATING DISCIPLINE + honesty-as-values.
 6. **Threats to validity** — single factory, single window, the authors are the subjects; the
-   evidence appendix is mechanical but the narrative selection is not.
+   evidence appendix is mechanical but the narrative selection is not. ADDED per claims review:
+   (a) the agent that selected the incidents also authored the fixes — selection bias is
+   structural; (b) survivorship — fizzled findings are unrecorded, hit rates uncomputable without
+   the findings counter; (c) the "senior oracle" runs through OUR adapter and OUR model
+   translation — its catches are observations of the translation layer too (the hardcoded-
+   Converged incident is the proof); (d) novelty: pseudo-oracles (Davis & Weyuker 1981) and
+   back-to-back/N-version testing already stack oracles — cite them and claim only the
+   OPERATING-DISCIPLINE + honesty-as-values composition. Claims table (from the review): TLA
+   correspondence = spec-first discipline, NOT verified-combinator; DRW byte-identity = this
+   ROM's trace, nothing wider; Weiss-Freeman = explanatory citation; IBLT soundness = now an
+   FsCheck PROPERTY (200 random rooms/geometries); honesty mechanisms = 2 falsifiers + 3
+   examples — say "demonstrated," not "structural," until falsifiers exist for all five.
 7. **Authorship** (a section candidate per the backlog row): personas + the human maintainer.

--- a/src/Core/ComplexityRegistry.fs
+++ b/src/Core/ComplexityRegistry.fs
@@ -100,6 +100,7 @@ module ComplexityRegistry =
               ("engine.mock-flat", "run"), c "O(vars)" "O(vars)" Derived // the REHEARSAL engine: flat marginals, Converged=false — the ladder's honest Mock rung
               ("sketch.iblt", "build"), c "O(n·k)" "O(cells)" Derived // n keys, k buckets each; cells sized to the DIFFERENCE, not the set
               ("sketch.iblt", "reconcile"), c "O(|Δ|·k)" "O(cells)" Derived // subtract is O(cells); peeling touches each difference key k times — the whole point
+              ("test.loop", "run"), c "O(2·sim+mea + cut)" "O(world)" Derived // the double-run determinism check is the 2x — the boundary, priced honestly
               ("binding.html-css", "render"), c "O(entries·pixels)" "O(output)" Derived
               ("sim.wave-interference", "pattern"), c "O(w·h·sources)" "O(w·h)" Derived
               ("viz.adinkra", "render"), c "O(nodes)" "O(nodes)" Derived

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -226,6 +226,7 @@
     <Compile Include="SwarmBoardAnsi.fs" />
     <Compile Include="ZetaMax.fs" />
     <Compile Include="Chip9Phys.fs" />
+    <Compile Include="TestLoop.fs" />
     <Compile Include="WSet.fs" />
     <Compile Include="IbltReconcile.fs" />
     <Compile Include="InferenceLadder.fs" />

--- a/src/Core/GeneratorRegistry.fs
+++ b/src/Core/GeneratorRegistry.fs
@@ -91,6 +91,7 @@ module GeneratorRegistry =
           register "engine.infer-net" 1
           register "engine.mock-flat" 1
           register "sketch.iblt" 1
+          register "test.loop" 1
           register "binding.html-css" 1
           register "sim.wave-interference" 1
           register "viz.adinkra" 1

--- a/src/Core/TestLoop.fs
+++ b/src/Core/TestLoop.fs
@@ -1,0 +1,96 @@
+namespace Zeta.Core
+
+/// TestLoop — **B-1035 slice 1: tests are sim·mea·cut loops on OUR interface; the boundary is
+/// enforced ONCE, here** (Aaron: "move tests to our own interfaces, hexagonal, slowly… be anal
+/// about before/after, enforce the boundary… every room won't have to do it itself").
+///
+/// THE PORT (form test, form (a) — a universal shape): a test declares
+///   `Sim`  — arrange: build the world FROM THE SEED (the seed is REQUIRED by the type: a test
+///            that cannot say its seed cannot exist on this interface),
+///   `Mea`  — act + observe: bank the measurement (must be equatable — see why below),
+///   `Cut`  — assert: the closure condition as a `Result` (failures are VALUES; an exception
+///            escaping any phase is caught at the boundary and reported, never thrown onward).
+///
+/// THE BOUNDARY, ENFORCED ONCE (what every migrated test inherits with zero per-test code):
+///   1. Seed capture + a replay line in every verdict (DST: the failure is reproducible by
+///      construction — the line says exactly how).
+///   2. THE DOUBLE-RUN CHECK: the framework runs Sim+Mea TWICE from the same seed and requires
+///      byte-equal measurements — ambient nondeterminism inside a loop is now a mechanical
+///      failure, not a review convention (the determinism lint's runtime twin).
+///   3. Result-over-exception at the rim: any throw in Sim/Mea/Cut becomes a Failure verdict
+///      with the phase named.
+/// Later slices (per the B-1035 row, not here): Reticulum-only syscall sealing, golden-lock and
+/// red-light integration, budget metering, the chip9-board host.
+///
+/// F# cannot DEFINE default interface members, so per house idiom the "default impls" the
+/// quartet names live as THIS module's functions over the interface — same weight-free shape.
+/// xUnit is a HOST ADAPTER in the test project (one thin shim), never referenced from Core.
+type ITestLoop<'World, 'Mea when 'Mea: equality> =
+    /// The loop's name (the verdict's key; keep it sentence-honest like our test names).
+    abstract Name: string
+    /// THE DST SEED — required by the interface; the world may only be built from this.
+    abstract Seed: uint64
+    /// Arrange: the seeded world. No ambient entropy — the double-run check will catch it.
+    abstract Sim: uint64 -> 'World
+    /// Act + observe: the banked measurement (equatable so the boundary can compare runs).
+    abstract Mea: 'World -> 'Mea
+    /// Assert: Ok () = the cut holds; Error = the honest failure text.
+    abstract Cut: 'Mea -> Result<unit, string>
+
+[<RequireQualifiedAccess>]
+module TestLoop =
+
+    /// The verdict — everything the boundary tracked, as a value.
+    type Verdict =
+        { Name: string
+          Seed: uint64
+          Passed: bool
+          Failure: string option
+          /// The replay line (DST): how to rerun THIS loop at THIS seed.
+          Replay: string
+          /// Did Sim+Mea replay byte-equal? (false = ambient entropy inside the loop — a
+          /// boundary violation regardless of whether the cut passed.)
+          Deterministic: bool }
+
+    /// Run one loop with the boundary enforced (see the type doc — this is the ONE place).
+    let run (loop: ITestLoop<'w, 'm>) : Verdict =
+        let replay = sprintf "TestLoop.run %s @ seed 0x%X" loop.Name loop.Seed
+        let attempt (phase: string) (f: unit -> 'a) : Result<'a, string> =
+            try Ok(f ())
+            with e -> Error(sprintf "%s threw (%s: %s) — exceptions stop at the boundary" phase (e.GetType().Name) e.Message)
+
+        match attempt "Sim" (fun () -> loop.Sim loop.Seed) with
+        | Error f -> { Name = loop.Name; Seed = loop.Seed; Passed = false; Failure = Some f; Replay = replay; Deterministic = true }
+        | Ok world ->
+            match attempt "Mea" (fun () -> loop.Mea world) with
+            | Error f -> { Name = loop.Name; Seed = loop.Seed; Passed = false; Failure = Some f; Replay = replay; Deterministic = true }
+            | Ok mea ->
+                // THE DOUBLE-RUN CHECK: same seed, fresh world, measurements must agree.
+                let deterministic =
+                    match attempt "Sim(replay)" (fun () -> loop.Mea(loop.Sim loop.Seed)) with
+                    | Ok mea2 -> mea2 = mea
+                    | Error _ -> false
+                let cut =
+                    match attempt "Cut" (fun () -> loop.Cut mea) with
+                    | Ok r -> r
+                    | Error f -> Error f
+                let failure =
+                    match cut, deterministic with
+                    | Error f, _ -> Some f
+                    | Ok (), false -> Some "BOUNDARY: Sim+Mea did not replay byte-equal from the same seed — ambient entropy inside the loop"
+                    | Ok (), true -> None
+                { Name = loop.Name
+                  Seed = loop.Seed
+                  Passed = failure.IsNone
+                  Failure = failure
+                  Replay = replay
+                  Deterministic = deterministic }
+
+    /// Inline constructor — most loops are three lambdas and a seed (keep migration cheap).
+    let make (name: string) (seed: uint64) (sim: uint64 -> 'w) (mea: 'w -> 'm) (cut: 'm -> Result<unit, string>) : ITestLoop<'w, 'm> =
+        { new ITestLoop<'w, 'm> with
+            member _.Name = name
+            member _.Seed = seed
+            member _.Sim s = sim s
+            member _.Mea w = mea w
+            member _.Cut m = cut m }

--- a/tests/Tests.CSharp/InferNetEngine.cs
+++ b/tests/Tests.CSharp/InferNetEngine.cs
@@ -19,7 +19,7 @@ public sealed class InferNetEngine : IInferenceEngine
 {
     public string Name => "infer-net";
 
-    public InferenceResult RunGaussian(GaussianModel model, int maxRounds, double tolerance)
+    private static Variable<double>[] BuildVariables(GaussianModel model)
     {
         var vars = new Variable<double>[model.VariableCount];
         var priorsPerVar = new List<GaussianPrior>[model.VariableCount];
@@ -66,15 +66,35 @@ public sealed class InferNetEngine : IInferenceEngine
             }
         }
 
-        var engine = new InferenceEngine { ShowProgress = false, NumberOfIterations = maxRounds };
+        return vars;
+    }
+
+    public InferenceResult RunGaussian(GaussianModel model, int maxRounds, double tolerance)
+    {
+        var vars = BuildVariables(model);
+
+        // P0 fix (claims review 2026-06-11): the first version HARDCODED Converged=true and
+        // ignored `tolerance` — half the conformance suite's "senior oracle" verdicts were a
+        // constant we wrote. Convergence is now OBSERVED: infer at maxRounds and at maxRounds-1;
+        // converged ⇔ every marginal stable within tolerance (one extra iteration changes
+        // nothing on a converged model; a drifting loop fails honestly).
+        var atFull = new InferenceEngine { ShowProgress = false, NumberOfIterations = maxRounds };
+        var atLess = new InferenceEngine { ShowProgress = false, NumberOfIterations = Math.Max(1, maxRounds - 1) };
         var marginals = new GaussianMarginal[model.VariableCount];
+        var converged = true;
         for (var v = 0; v < model.VariableCount; v++)
         {
-            var g = engine.Infer<Gaussian>(vars[v]);
+            var g = atFull.Infer<Gaussian>(vars[v]);
+            var gLess = atLess.Infer<Gaussian>(vars[v]);
             marginals[v] = new GaussianMarginal(v, g.GetMean(), g.GetVariance());
+            if (Math.Abs(g.GetMean() - gLess.GetMean()) > tolerance
+                || Math.Abs(g.GetVariance() - gLess.GetVariance()) > tolerance)
+            {
+                converged = false;
+            }
         }
 
-        return new InferenceResult(Converged: true, Rounds: maxRounds, Marginals: marginals);
+        return new InferenceResult(converged, maxRounds, marginals);
     }
 }
 

--- a/tests/Tests.CSharp/InferenceEnginePortTests.cs
+++ b/tests/Tests.CSharp/InferenceEnginePortTests.cs
@@ -77,22 +77,19 @@ public sealed class InferenceEnginePortTests
 
             if (string.Equals(id, "loopy-equality-cycle", StringComparison.Ordinal))
             {
-                // THE HONESTY CASE, behaving as designed: on a Gaussian equality CYCLE, loopy BP
-                // overcounts precision around the loop — means are exact but variances are
-                // overconfident and our raw-BP engine keeps moving (Weiss & Freeman 2001, the
-                // canonical result). OURS reports Converged=false — TRUTHFULLY (the port makes
-                // non-convergence a value, never a throw); Infer.NET's scheduler settles. So this
-                // case asserts the honesty contract + the means-exact theorem, and variance
-                // comparison is N/A by the literature. Damping is the named upgrade on B-1033.
-                Assert.False(a.Converged, $"{id}: ours claimed convergence on a loop its raw-BP schedule cannot settle — the honesty contract broke");
-                Assert.True(b.Converged, $"{id}: the senior oracle failed its own loop");
+                // THE HONESTY CASE, now mechanically asserted (P0 fix: the senior's Converged was
+                // previously hardcoded; the "reversal" lived in a comment). The truths we assert:
+                // (a) OURS refuses to claim convergence on the leak-free loop (Weiss & Freeman:
+                //     precision overcounts; non-convergence is a value);
+                // (b) means: OURS lands the analytic 2.0 EXACTLY (1e-9); the senior's schedule
+                //     residue is bounded (5e-3) — whatever its convergence flag now honestly says.
+                Assert.False(a.Converged, $"{id}: ours claimed convergence on a loop raw BP cannot settle");
                 for (var v = 0; v < model.VariableCount; v++)
                 {
-                    // delicious reversal, observed 2026-06-13: OURS lands the exact 2.0; the
-                    // senior oracle's loop scheduler stops at 2.0025 — the junior out-precised
-                    // the senior on this case. 5e-3 covers their scheduler residue.
-                    Assert.True(Math.Abs(a.Marginals[v].Mean - b.Marginals[v].Mean) < 5e-3,
-                        $"{id} v{v} mean (means are exact on Gaussian loops): ours={a.Marginals[v].Mean} infer-net={b.Marginals[v].Mean}");
+                    Assert.True(Math.Abs(a.Marginals[v].Mean - 2.0) < 1e-9,
+                        $"{id} v{v}: ours must land the analytic mean 2.0 exactly; got {a.Marginals[v].Mean}");
+                    Assert.True(Math.Abs(b.Marginals[v].Mean - 2.0) < 5e-3,
+                        $"{id} v{v}: senior mean outside its residue bound; got {b.Marginals[v].Mean}");
                 }
 
                 continue;

--- a/tests/Tests.FSharp/IbltReconcile.Tests.fs
+++ b/tests/Tests.FSharp/IbltReconcile.Tests.fs
@@ -62,3 +62,33 @@ let ``O(|Δ|) IS THE POINT: a 10k-key room with a 3-key difference reconciles th
         Assert.Equal<uint64 list>(keys [ 90001 ], onlyA)
         Assert.Equal<uint64 list>(keys [ 90002; 90003 ], onlyB)
     | IbltReconcile.Partial(_, _, n) -> Assert.True(false, sprintf "16 cells should decode |Δ|=3; %d stuck" n)
+
+// ── the PROPERTY (claims-review upgrade #2): Partial/Decoded soundness over RANDOM rooms ──
+open FsCheck
+open FsCheck.FSharp
+open FsCheck.Xunit
+
+type IbltRoomsArb() =
+    static member Rooms() : Arbitrary<Set<uint64> * Set<uint64> * int> =
+        gen {
+            let! shared = Gen.listOf (Gen.choose (1, 500)) |> Gen.map (List.map uint64 >> Set.ofList)
+            let! onlyA = Gen.listOf (Gen.choose (501, 700)) |> Gen.map (List.map uint64 >> Set.ofList)
+            let! onlyB = Gen.listOf (Gen.choose (701, 900)) |> Gen.map (List.map uint64 >> Set.ofList)
+            let! cells = Gen.choose (3, 64)
+            return Set.union shared onlyA, Set.union shared onlyB, cells
+        }
+        |> Arb.fromGen
+
+[<Property(Arbitrary = [| typeof<IbltRoomsArb> |], MaxTest = 200)>]
+let ``SOUNDNESS PROPERTY: for ANY rooms and ANY geometry, every recovered key is truly in the symmetric difference — and a full Decode is exactly it`` (data: Set<uint64> * Set<uint64> * int) =
+    let roomA, roomB, cells = data
+    let trueOnlyA = Set.difference roomA roomB
+    let trueOnlyB = Set.difference roomB roomA
+    match IbltReconcile.reconcile cells 3 roomA roomB with
+    | IbltReconcile.Decoded(a, b) ->
+        // full decode: EXACTLY the symmetric difference, both sides
+        Set.ofList a = trueOnlyA && Set.ofList b = trueOnlyB
+    | IbltReconcile.Partial(a, b, _) ->
+        // partial: SOUND — never a key that isn't truly in the difference, never side-swapped
+        (a |> List.forall (fun k -> Set.contains k trueOnlyA))
+        && (b |> List.forall (fun k -> Set.contains k trueOnlyB))

--- a/tests/Tests.FSharp/TestLoop.Host.fs
+++ b/tests/Tests.FSharp/TestLoop.Host.fs
@@ -1,0 +1,102 @@
+module Zeta.Tests.TestLoopHostTests
+
+// THE XUNIT HOST ADAPTER + the first three migrated loops (B-1035 slice 1). xUnit is demoted to
+// host: one thin shim runs any ITestLoop; CI/IDE tooling unchanged. All three exemplars are
+// SEALED (no disk, no git, no tools — modeling the Reticulum-only clause before Reticulum):
+// inputs are inline; the world is built from the seed.
+
+open global.Xunit
+open Zeta.Core
+
+/// The whole adapter — the host owes the framework nothing but a pass/fail surface.
+let private host (loop: ITestLoop<'w, 'm>) =
+    let v = TestLoop.run loop
+    Assert.True(v.Passed, sprintf "%s — %s [%s]" v.Name (defaultArg v.Failure "?") v.Replay)
+
+// ── exemplar 1: a shape-acceptance loop (sealed — inline cartridge, no repoRoot/disk) ──
+[<Fact>]
+let ``LOOP 1 (acceptance): a minimal in-memory cartridge passes the hard gate — sim parses, mea gates, cut reads the verdicts`` () =
+    host (
+        TestLoop.make
+            "acceptance: minimal cartridge through the hard gate"
+            4UL
+            (fun _ ->
+                // the world: an inline cartridge (no file IO inside the loop — the sealed model)
+                "meta\tname\tshape-vibes-free\nconstant\tn\t4\twhat\twhy\ntreaty\tfsharp\tbytes\tratified\tinline\n"
+                |> MediaLines.parse)
+            (fun world ->
+                match world with
+                | Ok d -> MediaLines.lint d |> List.length, MediaLines.treatiesOf d
+                | Error e -> failwith e)
+            (fun (lintCount, treaties) ->
+                if lintCount <> 0 then Error(sprintf "%d lint findings on a clean cartridge" lintCount)
+                elif not (treaties |> List.exists (fun (o, r, v) -> o = "fsharp" && r = "bytes" && v = "ratified")) then Error "treaty line lost"
+                else Ok()))
+
+// ── exemplar 2: a DST replay loop (chip8 from seed; the double-run check does the DST claim) ──
+[<Fact>]
+let ``LOOP 2 (DST): a chip8 run from the seed measures a stable display digest — replay equality is enforced BY the framework, not asserted by me`` () =
+    host (
+        TestLoop.make
+            "dst: chip8 16-step display digest from seed"
+            7UL
+            (fun seed ->
+                Chip8Cow.create seed
+                |> Chip8Cow.loadRom [| 0xA3uy; 0x00uy; 0x60uy; 0x05uy; 0x61uy; 0x03uy; 0xD0uy; 0x14uy |]
+                |> fun f -> { f with Mem = [ 0..3 ] |> List.fold (fun m k -> Map.add (0x300 + k) 0xF0uy m) f.Mem })
+            (fun f0 ->
+                let final = [ 1..16 ] |> List.fold (fun f _ -> Chip8Cow.step f) f0
+                // the measurement: a textual digest of the lit cells (equatable, byte-comparable)
+                [ for y in 0..31 do
+                      for x in 0..63 do
+                          if Chip8Cow.colorAt x y final <> 0uy then yield sprintf "%d,%d" x y ]
+                |> String.concat ";")
+            (fun digest ->
+                if digest.Contains "5,3" then Ok() // the sprite's origin cell lit
+                else Error(sprintf "expected the sprite at (5,3); digest=%s" digest)))
+
+// ── exemplar 3: an io/red-light loop (sealed — in-memory capability sets) ──
+[<Fact>]
+let ``LOOP 3 (red light): the binding ladder renders honest lights — REC for live, off for mock`` () =
+    host (
+        TestLoop.make
+            "red light: ladder bindings render their truth"
+            4UL
+            (fun _ ->
+                let have = GeneratorRegistry.idOf "algebra.braid-memory" 1
+                let want = GeneratorRegistry.idOf "algebra.z2-parity" 1
+                have, want)
+            (fun (have, want) ->
+                let d =
+                    sprintf "meta\tname\tdemo\nio\ttape\t%s\nio\tmic\t%s\n" have want
+                    |> MediaLines.parse
+                    |> function Ok d -> d | Error e -> failwith e
+                MediaLines.bindingsReport (MediaLines.resolveIo (Set.ofList [ have ]) Set.empty) d
+                |> List.map MediaLines.bindingLight
+                |> String.concat "\n")
+            (fun lights ->
+                if not (lights.Contains "[REC ●] tape LIVE") then Error "live binding lost its light"
+                elif not (lights.Contains "[off ○] mic MOCK") then Error "mock binding failed to declare itself"
+                else Ok()))
+
+// ── the boundary's own falsifiers (a gate never seen rejecting proves nothing) ──
+[<Fact>]
+let ``THE BOUNDARY REJECTS: an ambient-entropy loop fails the double-run check even though its cut passes`` () =
+    let v =
+        TestLoop.run (
+            TestLoop.make "entropy smuggler" 4UL
+                (fun _ -> ())
+                (fun () -> System.Guid.NewGuid().ToString()) // ambient — exactly what the boundary exists to catch
+                (fun _ -> Ok()))
+    Assert.False v.Passed
+    Assert.False v.Deterministic
+    Assert.Contains("ambient entropy", v.Failure |> Option.defaultValue "")
+
+[<Fact>]
+let ``THE BOUNDARY CATCHES THROWS: an exception in Mea becomes a named-phase Failure value, never an escaped throw`` () =
+    let v =
+        TestLoop.run (
+            TestLoop.make "thrower" 4UL (fun _ -> ()) (fun () -> failwith "boom" |> ignore; 1) (fun _ -> Ok()))
+    Assert.False v.Passed
+    Assert.Contains("Mea threw", v.Failure |> Option.defaultValue "")
+    Assert.Contains("seed 0x4", v.Replay)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -182,6 +182,7 @@
     <Compile Include="DeterminismLint.Tests.fs" />
     <Compile Include="WSet.MachZehnder.Tests.fs" />
     <Compile Include="IbltReconcile.Tests.fs" />
+    <Compile Include="TestLoop.Host.fs" />
     <Compile Include="WaveSim.Tests.fs" />
     <Compile Include="AdinkraViz.Tests.fs" />
     <Compile Include="SpectralPivot.Tests.fs" />


### PR DESCRIPTION
Slice 1: ITestLoop (DST seed required by the type); TestLoop.run enforces the boundary once — replay line, THE DOUBLE-RUN determinism check, Result-over-exception at the rim; xUnit = one thin host shim; three sealed exemplar migrations + the boundary's own falsifiers. AND the claims review caught a P0 in our own suite: InferNetEngine hardcoded Converged=true — fixed to observed convergence; the loopy reversal now MECHANICALLY asserted (ours = 2.0 to 1e-9) and survived. IBLT soundness upgraded to an FsCheck property (200 random cases). Outline hardened (4 new threats, Davis & Weyuker cited, counts embargoed). F# 3025 + C# 295 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)