### PR TITLE
feat(core): make WSet feed quantum observable rows

### DIFF
--- a/src/Core/QuantumObservableDbsp.Tests.fs
+++ b/src/Core/QuantumObservableDbsp.Tests.fs
@@ -14,8 +14,31 @@ let private repoRoot () =
 
 let private tolerance = 1e-5
 
-let private probFor (k: int) (ps: (int * float) list) =
-    ps |> List.filter (fun (key, _) -> key = k) |> List.sumBy snd
+let private interferenceRowsById (rows: ZSet<QuantumObservableRow>) =
+    rows
+    |> Seq.choose (fun kv ->
+        match kv.Key with
+        | QuantumObservableRow.InterferenceVisibility v -> Some(v.Id, v)
+        | _ -> None)
+    |> Map.ofSeq
+
+let private assertInterferenceNear
+    (actual: QuantumObservableTreaty.InterferenceVisibility)
+    (expected: QuantumObservableTreaty.InterferenceVisibility)
+    =
+    Assert.Equal(expected.Operation, actual.Operation)
+    Assert.Equal<float option>(expected.PhaseRadians, actual.PhaseRadians)
+    Assert.Equal<float option>(expected.Visibility, actual.Visibility)
+
+    Assert.True(
+        abs (actual.Probabilities.Zero - expected.Probabilities.Zero) <= tolerance,
+        sprintf "%s Zero expected %f, got %f" actual.Id expected.Probabilities.Zero actual.Probabilities.Zero
+    )
+
+    Assert.True(
+        abs (actual.Probabilities.One - expected.Probabilities.One) <= tolerance,
+        sprintf "%s One expected %f, got %f" actual.Id expected.Probabilities.One actual.Probabilities.One
+    )
 
 [<Fact>]
 let ``F# parses quantum Z-set transcript and verifies parity under DBSP updates`` () =
@@ -49,26 +72,15 @@ let ``F# parses quantum Z-set transcript and verifies parity under DBSP updates`
 
     Assert.Equal(6, ZSet.count interferenceRows)
 
-    // Check Mach-Zehnder probabilities
+    let wsetInterferenceRows = QuantumObservableDbsp.machZehnderZSet () |> interferenceRowsById
+    Assert.Equal(6, wsetInterferenceRows.Count)
+
+    // Check Mach-Zehnder probabilities against the source-owned WSet→observable-row bridge.
     for kv in interferenceRows do
         match kv.Key with
         | QuantumObservableRow.InterferenceVisibility v ->
-            let ws =
-                if v.Operation.EndsWith("Open", StringComparison.Ordinal) then
-                    MachZehnderWSet.openArm ()
-                else
-                    let phase =
-                        match v.PhaseRadians with
-                        | Some p -> p
-                        | None -> 0.0
-                    MachZehnderWSet.closed phase
-            
-            // Expected Zero probability from Mach-Zehnder WSet
-            let expectedZero = probFor 0 ws
-            let expectedOne = 1.0 - expectedZero
-
-            Assert.True(abs (v.Probabilities.Zero - expectedZero) <= tolerance, sprintf "%s Zero expected %f, got %f" v.Id expectedZero v.Probabilities.Zero)
-            Assert.True(abs (v.Probabilities.One - expectedOne) <= tolerance, sprintf "%s One expected %f, got %f" v.Id expectedOne v.Probabilities.One)
+            let expected = wsetInterferenceRows.[v.Id]
+            assertInterferenceNear v expected
         | _ -> Assert.Fail("Expected InterferenceVisibility row")
 
     // Query 2: Filter Bell Coincidence rows
@@ -144,9 +156,13 @@ let ``F# parses quantum Z-set transcript and verifies parity under DBSP updates`
     let piOver6Key = (Seq.head piOver6RowOpt).Key
     match piOver6Key with
     | QuantumObservableRow.InterferenceVisibility v ->
-        let ws = MachZehnderWSet.closed (System.Math.PI / 6.0)
-        let expectedZero = probFor 0 ws
-        let expectedOne = 1.0 - expectedZero
-        Assert.True(abs (v.Probabilities.Zero - expectedZero) <= tolerance)
-        Assert.True(abs (v.Probabilities.One - expectedOne) <= tolerance)
+        let expected =
+            QuantumObservableDbsp.machZehnderClosedRow
+                "mach-zehnder-closed-pi-over-6-phase"
+                "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiOver6Phase"
+                (System.Math.PI / 6.0)
+
+        match expected with
+        | QuantumObservableRow.InterferenceVisibility expectedVisibility -> assertInterferenceNear v expectedVisibility
+        | _ -> Assert.Fail("Expected InterferenceVisibility row")
     | _ -> Assert.Fail("Expected InterferenceVisibility row")

--- a/src/Core/QuantumObservableDbsp.fs
+++ b/src/Core/QuantumObservableDbsp.fs
@@ -82,3 +82,65 @@ type Batch =
 type Transcript =
     { [<JsonPropertyName("schema")>] Schema: string
       [<JsonPropertyName("batches")>] Batches: Batch list }
+
+[<RequireQualifiedAccess>]
+module QuantumObservableDbsp =
+
+    let private probabilityFor (key: int) (probabilities: (int * float) list) : float =
+        probabilities
+        |> List.filter (fun (candidate, _) -> candidate = key)
+        |> List.sumBy snd
+
+    let private probabilitiesFromWSet (probabilities: (int * float) list) : QuantumObservableTreaty.Probabilities =
+        { Zero = probabilityFor 0 probabilities
+          One = probabilityFor 1 probabilities }
+
+    let interferenceVisibilityFromWSet
+        (id: string)
+        (operation: string)
+        (phaseRadians: float option)
+        (visibility: float option)
+        (probabilities: (int * float) list)
+        : QuantumObservableRow =
+        QuantumObservableRow.InterferenceVisibility
+            { Id = id
+              Operation = operation
+              PhaseRadians = phaseRadians
+              Probabilities = probabilitiesFromWSet probabilities
+              Visibility = visibility }
+
+    let machZehnderOpenRow () : QuantumObservableRow =
+        MachZehnderWSet.openArm ()
+        |> interferenceVisibilityFromWSet "mach-zehnder-open" "Zeta.ReferenceOracle.ApplyMachZehnderOpen" None None
+
+    let machZehnderClosedRow (id: string) (operation: string) (phaseRadians: float) : QuantumObservableRow =
+        MachZehnderWSet.closed phaseRadians
+        |> interferenceVisibilityFromWSet id operation (Some phaseRadians) (Some 1.0)
+
+    let machZehnderRows () : QuantumObservableRow list =
+        [ machZehnderOpenRow ()
+          machZehnderClosedRow "mach-zehnder-closed-zero-phase" "Zeta.ReferenceOracle.ApplyMachZehnderClosedZeroPhase" 0.0
+          machZehnderClosedRow
+              "mach-zehnder-closed-pi-over-3-phase"
+              "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiOver3Phase"
+              (Math.PI / 3.0)
+          machZehnderClosedRow
+              "mach-zehnder-closed-pi-over-2-phase"
+              "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiOver2Phase"
+              (Math.PI / 2.0)
+          machZehnderClosedRow
+              "mach-zehnder-closed-two-pi-over-3-phase"
+              "Zeta.ReferenceOracle.ApplyMachZehnderClosedTwoPiOver3Phase"
+              (2.0 * Math.PI / 3.0)
+          machZehnderClosedRow "mach-zehnder-closed-pi-phase" "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiPhase" Math.PI ]
+
+    let delta (row: QuantumObservableRow) (weight: int64) : QuantumObservableDelta = { Row = row; Weight = weight }
+
+    let zsetOfDeltas (deltas: QuantumObservableDelta seq) : ZSet<QuantumObservableRow> =
+        deltas |> Seq.map (fun d -> d.Row, d.Weight) |> ZSet.ofSeq
+
+    let machZehnderDeltas () : QuantumObservableDelta list =
+        machZehnderRows () |> List.map (fun row -> delta row 1L)
+
+    let machZehnderZSet () : ZSet<QuantumObservableRow> =
+        machZehnderDeltas () |> zsetOfDeltas

--- a/src/Core/WSet.fs
+++ b/src/Core/WSet.fs
@@ -3,9 +3,9 @@
 // "essential as mathematics, accidental as code; zero non-test consumers" — and that dissent
 // stays on record as ADVISORY: the human maintainer set the product direction instead — the
 // ring-generic type IS intended substrate for the quantum lane (B-1029), the inference port, and
-// future ring instances; consumers arrive ON the shelf, not before it exists. Both registers
-// kept honestly: the razor's bar (a load-bearing consumer) is the standing TODO this header
-// carries until one lands.
+// future ring instances; consumers arrive ON the shelf, not before it exists. Both registers are
+// kept honestly: the razor's bar is now met by the source-side `QuantumObservableDbsp` bridge, which
+// turns `MachZehnderWSet` output into observable rows and a `ZSet<QuantumObservableRow>`.
 namespace Zeta.Core
 
 open Zeta.Core.Abstractions


### PR DESCRIPTION
Summary
- Keeps WSet in src/Core as a real source primitive, not a test-only fixture.
- Adds QuantumObservableDbsp helpers that derive Mach-Zehnder InterferenceVisibility rows from MachZehnderWSet and expose them as QuantumObservableDelta / ZSet<QuantumObservableRow>.
- Updates the DBSP transcript test to compare Q#/TS transcript rows against the source-owned WSet bridge instead of manufacturing WSet rows only in test code.
- Updates the WSet header to point at the new load-bearing core consumer while preserving the demotion dissent as historical context.

Verification
- dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter FullyQualifiedName~QuantumObservableDbsp|FullyQualifiedName~WSetMachZehnder
- dotnet build -c Release
- dotnet format --verify-no-changes

Note
- The first build attempt was run in parallel with the focused test and hit a shared bin output copy race. Rerunning sequentially passed with 0 warnings and 0 errors.