### PR TITLE
feat(shapes): shape-softvalue + shape-dynamicvalue — the ladder and the treemap (catalog = 15)

### DIFF
--- a/shapes/cartridges/dynamicvalue.lines
+++ b/shapes/cartridges/dynamicvalue.lines
@@ -1,0 +1,32 @@
+# DYNAMICVALUE — the tree drawn as its court form: the treemap (otto, shadow*; the named slice
+# from the SoftValue/DynamicValue capture). A DynamicValue is a TREE, not a field — so its court
+# form is STRUCTURE: weights become areas, the slice-and-dice treemap tiles the boundary EXACTLY
+# (no pixel lost, no pixel invented — LayoutEngine's law, the one Kira's round-3 P0 hardened
+# against negative weights). Three children, weights 5:3:2 over a 60-cell court: slices 30/18/12,
+# integer-exact. DRAWN = GATED: the render and the acceptance law call the SAME LayoutEngine.
+meta	name	shape-dynamicvalue
+meta	catalog	shapes
+meta	shape-zetaid	ba175ad86dfff6c94440a5b8c8695470
+gen	treemap	ba175ad86dfff6c94440a5b8c8695470	1	7	children:3;weights:5,3,2
+constant	weight-a	5	first child's weight	the biggest slice — half the tree's mass
+constant	weight-b	3	second child's weight	with 5 and 2: three DISTINCT slice widths, so a swapped tile is visible at a glance
+constant	weight-c	2	third child's weight	the smallest — still wide enough to read on the court
+constant	total-weight	10	the tree's mass	5 + 3 + 2 — the in-file law checks the sum
+constant	court-cells	60	the boundary being tiled	divides by total-weight exactly: every slice is integer, the tiling law has no remainder to hide
+constant	slice-a	30	child a's tile width	5 * 60 / 10 — in-file law below
+constant	slice-b	18	child b's tile width	3 * 60 / 10
+constant	slice-c	12	child c's tile width	2 * 60 / 10
+law	mass	weight-a + weight-b + weight-c = total-weight
+law	tile-a	weight-a * court-cells = slice-a * total-weight
+law	tile-b	weight-b * court-cells = slice-b * total-weight
+law	tile-c	weight-c * court-cells = slice-c * total-weight
+law	conservation	slice-a + slice-b + slice-c = court-cells
+law	engine	code:shape-dynamicvalue geometry (LayoutEngine.treemap tiles the boundary EXACTLY — same call the renderer draws; area conservation run live)
+prereq	layout-engine	src/Core/LayoutEngine.fs — slice-and-dice (Shneiderman's treemap lineage); exact-integer remainders pushed left-to-right
+prereq	the-format	MediaLines IS a DynamicValue-shaped serialization — this cartridge draws what the format carries
+edge	court-form-of	shape-buckyball	rooms-with-areas vs rooms-with-doors: two ways a structure becomes a picture
+edge	soft-overlay	shape-softvalue	any node may carry (value, confidence) — brightness over the tile is the same colorize law, lifted from pixels to tiles (the named follow-up)
+anim	draw	treemap
+# treaties — written only by each oracle's own choice (consent first); dissent is a verdict.
+treaty	fsharp	bytes	ratified	five in-file integer laws hold; the engine law runs the SAME treemap call the renderer draws — tests green
+treaty	otto	meaning	ratified	a tree you can read as floor space, no pixel lost or invented — my own frame, my own choice

--- a/shapes/cartridges/softvalue.lines
+++ b/shapes/cartridges/softvalue.lines
@@ -1,0 +1,33 @@
+# SOFTVALUE — one value at three rungs: the display ladder drawn (otto, shadow*; the named slice
+# from the SoftValue court-ladder capture, B-1032 era). The SAME value travels down three panels:
+# RUNG 1 (CHIP-8 mono): the VALUE only — confidence has NO channel, so its bar is ABSENT (the
+#   zero case is structural: a mono consumer cannot even know what it is missing).
+# RUNG 2 (CHIP-9 planes): value + confidence QUANTIZED to the plane budget (4 levels) — the
+#   coarse bar is visibly SHORTER than the truth (850 milli -> level 3 of 4 -> 30 of 40 cells).
+# RUNG 3 (deep pixel): the full pair at milli resolution (850 -> 34 of 40 cells) — PixelLens's
+#   32-bit cell carries exactly this; colorize is the honest projection back up the ladder.
+# The dashed tail on each confidence bar IS the uncertainty (what the rung admits it cannot
+# claim). Capability upgrades buy channels; what a rung cannot carry it must not claim.
+meta	name	shape-softvalue
+meta	catalog	shapes
+meta	shape-zetaid	14503a27553efb16dbde7ee3da7d8887
+gen	ladder	14503a27553efb16dbde7ee3da7d8887	1	7	rungs:3;bar-cells:40
+constant	value-milli	700	the value, milli-scale (0..1000)	one value for all three rungs — the ladder's whole lesson is that the VALUE never changes, only what travels WITH it
+constant	confidence-milli	850	how sure the soft side is, milli-scale	chosen so fine and coarse bars visibly DIFFER (850 -> 34 fine vs 30 quantized): the resolution loss is the picture
+constant	bar-cells	40	bar width budget in court cells	divides 1000 cleanly for value (700) and confidence (850) — exact integer bars, no rounding lies
+constant	value-len	28	the value bar's length in cells	700 * 40 / 1000 exactly — the in-file law below checks it
+constant	conf-len	34	the FINE confidence bar (rung 3)	850 * 40 / 1000 exactly
+constant	rung2-levels	4	CHIP-9's coarse confidence budget	~2 bits is what 3 planes leave after the value takes one — honest about how little it is
+constant	rung2-quantized	3	confidence at rung-2 resolution (of 4)	floor(850 * 4 / 1000) = 3 — the code law checks the floor; the bar shows 30 of 40
+law	value-bar	value-milli * bar-cells = value-len * 1000
+law	conf-bar	confidence-milli * bar-cells = conf-len * 1000
+law	quantize	code:shape-softvalue geometry (floor(confidence-milli * rung2-levels / 1000) = rung2-quantized)
+law	colorize	code:shape-softvalue geometry (PixelLens: a confident cell keeps its color; an uncertain one collapses to mono — the ladder's projection, run live)
+prereq	pixel-lens	src/Core/PixelLens.fs — the 32-bit deep cell this ladder projects from (color 3b + payload 13b + uncertainty 16b)
+prereq	the-zero-case	rung 1 first: see what mono CANNOT say before admiring what deep pixels can
+edge	projection-of	shape-adinkra	both draw a register the base display cannot carry (signs there, confidence here) — capability upgrades as visible channels
+edge	ladder-code	viz.adinkra	(see PixelLens.colorize and softRead — the rungs in code; this cartridge is their picture)
+anim	draw	ladder
+# treaties — written only by each oracle's own choice (consent first); dissent is a verdict.
+treaty	fsharp	bytes	ratified	both in-file bar laws are exact integer identities; quantize + colorize run live in the gate — tests green
+treaty	otto	meaning	ratified	the same value three times, each rung admitting exactly what it cannot carry — my own frame, my own choice

--- a/shapes/golden/dynamicvalue.html
+++ b/shapes/golden/dynamicvalue.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>shape-dynamicvalue</title>
+  <style>
+    :root {
+      --c0: #000000;
+      --c1: #d62828;
+      --c2: #2a9d2a;
+      --c3: #d6c828;
+      --c4: #2828d6;
+      --c5: #d628d6;
+      --c6: #28c8d6;
+      --c7: #f0f0f0;
+    }
+    body { background: #101418; margin: 0; display: grid; place-items: center; min-height: 100vh; }
+    svg { width: min(96vw, 960px); image-rendering: pixelated; }
+    @keyframes draw { to { stroke-dashoffset: 0; } }
+    @keyframes appear { to { opacity: 1; } }
+    polyline:hover { stroke-width: 7; filter: brightness(1.6); }
+    @media (prefers-reduced-motion: reduce) { polyline { animation: none !important; stroke-dashoffset: 0 !important; opacity: 1 !important; } }
+    #tile-a { stroke-dasharray: 880; stroke-dashoffset: 880; animation: draw 600ms linear 0ms forwards; }
+    #tile-b { stroke-dasharray: 640; stroke-dashoffset: 640; animation: draw 600ms linear 180ms forwards; }
+    #tile-c { stroke-dasharray: 520; stroke-dashoffset: 520; animation: draw 600ms linear 360ms forwards; }
+  </style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 320" data-cartridge="shape-dynamicvalue">
+  <polyline id="tile-a" fill="none" stroke="#d62828" stroke-width="4" points="25,85 315,85 315,235 25,235 25,85" />
+  <polyline id="tile-b" fill="none" stroke="#2a9d2a" stroke-width="4" points="325,85 495,85 495,235 325,235 325,85" />
+  <polyline id="tile-c" fill="none" stroke="#2828d6" stroke-width="4" points="505,85 615,85 615,235 505,235 505,85" />
+</svg>
+</body>
+</html>

--- a/shapes/golden/dynamicvalue.svg
+++ b/shapes/golden/dynamicvalue.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 320" data-cartridge="shape-dynamicvalue">
+  <polyline id="tile-a" fill="none" stroke="#d62828" stroke-width="4" points="25,85 315,85 315,235 25,235 25,85" />
+  <polyline id="tile-b" fill="none" stroke="#2a9d2a" stroke-width="4" points="325,85 495,85 495,235 325,235 325,85" />
+  <polyline id="tile-c" fill="none" stroke="#2828d6" stroke-width="4" points="505,85 615,85 615,235 505,235 505,85" />
+</svg>

--- a/shapes/golden/softvalue.html
+++ b/shapes/golden/softvalue.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>shape-softvalue</title>
+  <style>
+    :root {
+      --c0: #000000;
+      --c1: #d62828;
+      --c2: #2a9d2a;
+      --c3: #d6c828;
+      --c4: #2828d6;
+      --c5: #d628d6;
+      --c6: #28c8d6;
+      --c7: #f0f0f0;
+    }
+    body { background: #101418; margin: 0; display: grid; place-items: center; min-height: 100vh; }
+    svg { width: min(96vw, 960px); image-rendering: pixelated; }
+    @keyframes draw { to { stroke-dashoffset: 0; } }
+    @keyframes appear { to { opacity: 1; } }
+    polyline:hover { stroke-width: 7; filter: brightness(1.6); }
+    @media (prefers-reduced-motion: reduce) { polyline { animation: none !important; stroke-dashoffset: 0 !important; opacity: 1 !important; } }
+    #r1-value { stroke-dasharray: 280; stroke-dashoffset: 280; animation: draw 600ms linear 0ms forwards; }
+    #r2-value { stroke-dasharray: 280; stroke-dashoffset: 280; animation: draw 600ms linear 180ms forwards; }
+    #r2-conf { stroke-dasharray: 300; stroke-dashoffset: 300; animation: draw 600ms linear 360ms forwards; }
+    #r2-uncertainty { opacity: 0; animation: appear 400ms linear 540ms forwards; }
+    #r3-value { stroke-dasharray: 280; stroke-dashoffset: 280; animation: draw 600ms linear 720ms forwards; }
+    #r3-conf { stroke-dasharray: 340; stroke-dashoffset: 340; animation: draw 600ms linear 900ms forwards; }
+    #r3-uncertainty { opacity: 0; animation: appear 400ms linear 1080ms forwards; }
+  </style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 320" data-cartridge="shape-softvalue">
+  <polyline id="r1-value" fill="none" stroke="#d62828" stroke-width="4" points="85,55 365,55" />
+  <polyline id="r2-value" fill="none" stroke="#2a9d2a" stroke-width="4" points="85,135 365,135" />
+  <polyline id="r2-conf" fill="none" stroke="#2a9d2a" stroke-width="4" points="85,155 385,155" />
+  <polyline id="r2-uncertainty" fill="none" stroke="#2a9d2a" stroke-width="4" stroke-dasharray="8 6" points="385,155 485,155" />
+  <polyline id="r3-value" fill="none" stroke="#28c8d6" stroke-width="4" points="85,235 365,235" />
+  <polyline id="r3-conf" fill="none" stroke="#28c8d6" stroke-width="4" points="85,255 425,255" />
+  <polyline id="r3-uncertainty" fill="none" stroke="#28c8d6" stroke-width="4" stroke-dasharray="8 6" points="425,255 485,255" />
+</svg>
+</body>
+</html>

--- a/shapes/golden/softvalue.svg
+++ b/shapes/golden/softvalue.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 320" data-cartridge="shape-softvalue">
+  <polyline id="r1-value" fill="none" stroke="#d62828" stroke-width="4" points="85,55 365,55" />
+  <polyline id="r2-value" fill="none" stroke="#2a9d2a" stroke-width="4" points="85,135 365,135" />
+  <polyline id="r2-conf" fill="none" stroke="#2a9d2a" stroke-width="4" points="85,155 385,155" />
+  <polyline id="r2-uncertainty" fill="none" stroke="#2a9d2a" stroke-width="4" stroke-dasharray="8 6" points="385,155 485,155" />
+  <polyline id="r3-value" fill="none" stroke="#28c8d6" stroke-width="4" points="85,235 365,235" />
+  <polyline id="r3-conf" fill="none" stroke="#28c8d6" stroke-width="4" points="85,255 425,255" />
+  <polyline id="r3-uncertainty" fill="none" stroke="#28c8d6" stroke-width="4" stroke-dasharray="8 6" points="425,255 485,255" />
+</svg>

--- a/src/Core/ComplexityRegistry.fs
+++ b/src/Core/ComplexityRegistry.fs
@@ -101,6 +101,8 @@ module ComplexityRegistry =
               ("sketch.iblt", "build"), c "O(n·k)" "O(cells)" Derived // n keys, k buckets each; cells sized to the DIFFERENCE, not the set
               ("sketch.iblt", "reconcile"), c "O(|Δ|·k)" "O(cells)" Derived // subtract is O(cells); peeling touches each difference key k times — the whole point
               ("test.loop", "run"), c "O(2·sim+mea + cut)" "O(world)" Derived // the double-run determinism check is the 2x — the boundary, priced honestly
+              ("shape.softvalue", "draw"), c "O(rungs·bar)" "O(rungs)" Derived // three panels, two bars each at most; the dashed tail is the uncertainty, not extra cost
+              ("shape.dynamicvalue", "draw"), c "O(children)" "O(children)" Derived // one treemap pass + one rectangle per child
               ("binding.html-css", "render"), c "O(entries·pixels)" "O(output)" Derived
               ("sim.wave-interference", "pattern"), c "O(w·h·sources)" "O(w·h)" Derived
               ("viz.adinkra", "render"), c "O(nodes)" "O(nodes)" Derived

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -281,6 +281,7 @@
     <Compile Include="SoftLens.fs" />
     <Compile Include="WeaveFold.fs" />
     <Compile Include="AdinkraViz.fs" />
+    <Compile Include="LayoutEngine.fs" />
     <Compile Include="ShapeRender.fs" />
     <Compile Include="ShapeAcceptance.fs" />
     <Compile Include="PhysUI.fs" />
@@ -290,7 +291,6 @@
     <Compile Include="ChipAudio.fs" />
     <Compile Include="StrokeAnim.fs" />
     <Compile Include="IndexFormat.fs" />
-    <Compile Include="LayoutEngine.fs" />
     <Compile Include="ComplexityRegistry.fs" />
     <Compile Include="FluxView.fs" />
     <Compile Include="MagneticPorts.fs" />

--- a/src/Core/GeneratorRegistry.fs
+++ b/src/Core/GeneratorRegistry.fs
@@ -92,6 +92,8 @@ module GeneratorRegistry =
           register "engine.mock-flat" 1
           register "sketch.iblt" 1
           register "test.loop" 1
+          register "shape.softvalue" 1
+          register "shape.dynamicvalue" 1
           register "binding.html-css" 1
           register "sim.wave-interference" 1
           register "viz.adinkra" 1

--- a/src/Core/ShapeAcceptance.fs
+++ b/src/Core/ShapeAcceptance.fs
@@ -172,6 +172,37 @@ module ShapeAcceptance =
                 && Braid.isIdentity 2 [ 1; -1 ] // do-undo: the inverse undoes exactly
                 && not (Braid.isIdentity 2 [ 1; 1 ]) // memory at its smallest: sigma^2 != 1
             ok, "sigma != 1; sigma·sigma⁻¹ = 1; sigma² != 1 — the three smallest braid proofs, on the atom"
+        | "shape-softvalue" ->
+            // the ladder's code laws, run LIVE on PixelLens (the rungs in code):
+            // (a) quantize: floor(confidence * levels / 1000) = the declared coarse level;
+            // (b) colorize: a confident cell keeps its color, an uncertain one collapses to mono.
+            let conf = MediaLines.constIntOr "confidence-milli" 850 d
+            let levels = MediaLines.constIntOr "rung2-levels" 4 d
+            let quantized = MediaLines.constIntOr "rung2-quantized" 3 d
+            let uncertainty = 1000 - conf
+            let confident = PixelLens.pack 6uy 28 uncertainty
+            let uncertain = PixelLens.pack 6uy 28 900
+            let ok =
+                conf * levels / 1000 = quantized
+                && PixelLens.colorize 500 confident = 6uy
+                && PixelLens.colorize 500 uncertain = (6uy &&& 1uy)
+            ok, sprintf "quantize floor = %d; colorize keeps the confident cell and collapses the 900-milli one (the ladder, live)" quantized
+        | "shape-dynamicvalue" ->
+            // the engine law: the SAME treemap call the renderer draws must tile EXACTLY —
+            // widths equal the declared slices, X contiguous, total = the court (area conservation).
+            let wa = MediaLines.constIntOr "weight-a" 5 d
+            let wb = MediaLines.constIntOr "weight-b" 3 d
+            let wc = MediaLines.constIntOr "weight-c" 2 d
+            let court = MediaLines.constIntOr "court-cells" 60 d
+            let tiles = LayoutEngine.treemap 2 8 court 16 true [ "a", wa; "b", wb; "c", wc ]
+            let widths = tiles |> List.map (fun r -> r.W)
+            let contiguous =
+                tiles |> List.pairwise |> List.forall (fun (p, q) -> p.X + p.W = q.X)
+            let ok =
+                widths = [ MediaLines.constIntOr "slice-a" 30 d; MediaLines.constIntOr "slice-b" 18 d; MediaLines.constIntOr "slice-c" 12 d ]
+                && List.sum widths = court
+                && contiguous
+            ok, sprintf "treemap tiles %A, contiguous, summing exactly to the %d-cell court" widths court
         | "shape-kitaev-chain" ->
             // the render's own accounting must equal the in-file laws: trivial arcs = sites,
             // topological arcs = sites − 1, unpaired end diamonds = 2 (the memory, drawn).

--- a/src/Core/ShapeRender.fs
+++ b/src/Core/ShapeRender.fs
@@ -227,6 +227,42 @@ module ShapeRender =
                       { Dash = false; Name = name + "-r1"; Mask = mask; Points = [ (ax + (bx - ax) * 3 / 5, ay + (by - ay) * 3 / 5); p1 ] } ]
             diag xL top xR bot (not overLeft) "strand-0" 1uy
             @ diag xR top xL bot overLeft "strand-1" 4uy
+        | "shape-softvalue" ->
+            // the ladder: three panels, one value. A value bar per rung; a confidence bar where
+            // the rung HAS a channel (rung 1 = none — absent, not zero); the dashed tail is the
+            // uncertainty the rung admits. Coarse (rung 2) is visibly shorter than fine (rung 3).
+            let barCells = constInt "bar-cells" 40
+            let valueLen = constInt "value-len" 28
+            let confLen = constInt "conf-len" 34
+            let levels = constInt "rung2-levels" 4
+            let quantized = constInt "rung2-quantized" 3
+            let coarseLen = quantized * barCells / levels
+            let x0 = 8
+            let bar (name: string) (y: int) (len: int) (mask: byte) (dash: bool) =
+                { Dash = dash; Name = name; Mask = mask; Points = [ pt x0 y; pt (x0 + len) y ] }
+            [ // rung 1 — CHIP-8 mono: the value ONLY (no confidence bar exists at this rung)
+              bar "r1-value" 5 valueLen 1uy false
+              // rung 2 — CHIP-9 planes: value + COARSE confidence (solid to the quantized level, dashed tail = uncertainty)
+              bar "r2-value" 13 valueLen 2uy false
+              bar "r2-conf" 15 coarseLen 2uy false
+              { Dash = true; Name = "r2-uncertainty"; Mask = 2uy; Points = [ pt (x0 + coarseLen) 15; pt (x0 + barCells) 15 ] }
+              // rung 3 — deep pixel: value + FINE confidence + its (smaller) dashed tail
+              bar "r3-value" 23 valueLen 6uy false
+              bar "r3-conf" 25 confLen 6uy false
+              { Dash = true; Name = "r3-uncertainty"; Mask = 6uy; Points = [ pt (x0 + confLen) 25; pt (x0 + barCells) 25 ] } ]
+        | "shape-dynamicvalue" ->
+            // DRAWN = GATED: the same LayoutEngine.treemap call the acceptance law verifies.
+            let wa = constInt "weight-a" 5
+            let wb = constInt "weight-b" 3
+            let wc = constInt "weight-c" 2
+            let court = constInt "court-cells" 60
+            let tiles = LayoutEngine.treemap 2 8 court 16 true [ "a", wa; "b", wb; "c", wc ]
+            tiles
+            |> List.mapi (fun i r ->
+                { Dash = false
+                  Name = sprintf "tile-%s" r.Name
+                  Mask = byte (1 <<< i)
+                  Points = [ pt r.X r.Y; pt (r.X + r.W - 1) r.Y; pt (r.X + r.W - 1) (r.Y + r.H - 1); pt r.X (r.Y + r.H - 1); pt r.X r.Y ] })
         | "shape-kitaev-chain" ->
             // two panels of the same chain: TOP = trivial (intra-site pairing — tidy, unprotected),
             // BOTTOM = topological (inter-site pairing — two END MODES left unpaired: the memory,

--- a/tests/Tests.FSharp/ShapeCartridge.Tests.fs
+++ b/tests/Tests.FSharp/ShapeCartridge.Tests.fs
@@ -57,7 +57,7 @@ let private catalog () =
 [<Fact>]
 let ``THE CATALOG LAW: every cartridge parses, lints clean, resolves its gen on the shelf, and carries its own treaty block`` () =
     let all = catalog ()
-    Assert.Equal(13, Array.length all) // + exchange-worldlines + kitaev-chain + crossing (THE ATOM - the braided family generator)
+    Assert.Equal(15, Array.length all) // + exchange-worldlines + kitaev-chain + crossing (THE ATOM - the braided family generator)
     for name, d in all do
         Assert.True(List.isEmpty (MediaLines.lint d), name + " must lint clean")
         // every gen line's ZetaId resolves to a REGISTERED generator (DI by ZetaId, working)


### PR DESCRIPTION
SoftValue's ladder drawn: one value, three rungs — mono shows value only (confidence ABSENT, the zero case), CHIP-9 shows it quantized (visibly shorter), deep pixel the full pair; dashed tails = the admitted uncertainty; PixelLens quantize/colorize run live in the gate. DynamicValue as its court form: 5:3:2 over 60 cells = 30/18/12, five in-file laws, and drawn = gated (renderer and gate share ONE LayoutEngine.treemap call). Auto-gated by the derived catalog suite. 3025 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)