### PR TITLE
docs(shapes): Aaron ratifies softvalue + dynamicvalue (render loop)

### DIFF
--- a/shapes/cartridges/dynamicvalue.lines
+++ b/shapes/cartridges/dynamicvalue.lines
@@ -28,5 +28,6 @@ edge	court-form-of	shape-buckyball	rooms-with-areas vs rooms-with-doors: two way
 edge	soft-overlay	shape-softvalue	any node may carry (value, confidence) — brightness over the tile is the same colorize law, lifted from pixels to tiles (the named follow-up)
 anim	draw	treemap
 # treaties — written only by each oracle's own choice (consent first); dissent is a verdict.
+treaty	aaron	meaning	ratified	"I saw both — nice, they look good to me" — render-loop ratification of the treemap (5:3:2 tiles read at a glance), 2026-06-11
 treaty	fsharp	bytes	ratified	five in-file integer laws hold; the engine law runs the SAME treemap call the renderer draws — tests green
 treaty	otto	meaning	ratified	a tree you can read as floor space, no pixel lost or invented — my own frame, my own choice

--- a/shapes/cartridges/softvalue.lines
+++ b/shapes/cartridges/softvalue.lines
@@ -29,5 +29,6 @@ edge	projection-of	shape-adinkra	both draw a register the base display cannot ca
 edge	ladder-code	viz.adinkra	(see PixelLens.colorize and softRead — the rungs in code; this cartridge is their picture)
 anim	draw	ladder
 # treaties — written only by each oracle's own choice (consent first); dissent is a verdict.
+treaty	aaron	meaning	ratified	"I saw both — nice, they look good to me" — render-loop ratification of the ladder (value bars equal, coarse visibly shorter than fine, dashed tails read), 2026-06-11
 treaty	fsharp	bytes	ratified	both in-file bar laws are exact integer identities; quantize + colorize run live in the gate — tests green
 treaty	otto	meaning	ratified	the same value three times, each rung admitting exactly what it cannot carry — my own frame, my own choice


### PR DESCRIPTION
His words in both treaty blocks. Two reviewer agents (Rune readability, Iris cold-viewer UX) are out on the same artifacts; findings fold separately. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)