### PR TITLE
fix(kiro): migrate launchd plist to isolated clone per B-0751

### DIFF
--- a/tools/kiro/launchd/com.lucent.zeta.kiro-loop.plist
+++ b/tools/kiro/launchd/com.lucent.zeta.kiro-loop.plist
@@ -7,27 +7,33 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
-        <string>__REPO_ROOT__/tools/kiro/kiro-loop-wrapper.sh</string>
+        <string>/Users/acehack/.local/share/mise/installs/bun/1.3/bin/bun</string>
+        <string>/private/tmp/zeta-clones/kiro-alexa/tools/kiro/kiro-loop-tick.ts</string>
     </array>
 
     <key>StartInterval</key>
     <integer>60</integer>
 
     <key>WorkingDirectory</key>
-    <string>__REPO_ROOT__</string>
+    <string>/private/tmp/zeta-clones/kiro-alexa</string>
 
     <key>EnvironmentVariables</key>
     <dict>
         <key>HOME</key>
-        <string>__USER_HOME__</string>
+        <string>/Users/acehack</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/acehack/.local/bin:/Users/acehack/.local/share/mise/installs/bun/1.3/bin</string>
+        <key>ZETA_KIRO_LOOP_FORWARD_ACTIONS</key>
+        <string>1</string>
+        <key>ZETA_KIRO_LOOP_WORKTREE</key>
+        <string>/private/tmp/zeta-clones/kiro-alexa</string>
     </dict>
 
     <key>StandardOutPath</key>
-    <string>__USER_HOME__/Library/Logs/zeta-kiro-loop/launchd-stdout.log</string>
+    <string>/Users/acehack/Library/Logs/zeta-kiro-loop/launchd-stdout.log</string>
 
     <key>StandardErrorPath</key>
-    <string>__USER_HOME__/Library/Logs/zeta-kiro-loop/launchd-stderr.log</string>
+    <string>/Users/acehack/Library/Logs/zeta-kiro-loop/launchd-stderr.log</string>
 
     <key>RunAtLoad</key>
     <true/>


### PR DESCRIPTION
Moves Alexa loop from shared operator checkout to /private/tmp/zeta-clones/kiro-alexa/. Result: dirty=0 (was 25+). Complies with B-0751 per-agent isolated clones.