### PR TITLE
feat(shapes): shape-triboolean (the honest third state, drawn) + UniversalNumber-is-our-bigint + B-1037 ball adapter + B-1038 identity gate

### DIFF
--- a/db/shapes/cartridges/triboolean.lines
+++ b/db/shapes/cartridges/triboolean.lines
@@ -1,0 +1,27 @@
+# TRIBOOLEAN — the honest third state, drawn (otto, shadow*, 2026-06-11; wish-list item 1). Two
+# plane bits encode THREE states — Lit, Unlit, UNKNOWN — with one encoding FORBIDDEN (2 bits give
+# 4; we refuse the spare rather than invent a fourth meaning). Unknown is absence-of-MEASUREMENT,
+# never false: the middle-out progressive render (BoundaryLight.sampleProgressive) resolves the
+# center first and is HONEST about every cell it has not yet sampled. DASH MEANING (per the style
+# rule): in THIS cartridge a dashed stroke = an Unknown cell — the claim not yet earned.
+# Full budget ⇒ zero Unknown: uncertainty fully reduced, the third state vanishes structurally.
+meta	name	shape-triboolean
+meta	catalog	shapes
+meta	shape-zetaid	3a641b0c1b810e60a89b0435c5aebd67
+gen	progressive	3a641b0c1b810e60a89b0435c5aebd67	1	7	grid:8x8;order:middle-out
+constant	states	3	Lit, Unlit, Unknown	the whole point: a display that can SAY "not yet measured" instead of lying with 0
+constant	encodings	4	what 2 bits physically give	2 * 2 — the in-file law checks it
+constant	forbidden	1	the spare encoding, refused	encodings minus states: we refuse the spare rather than invent a meaning (the no-fourth-state law)
+constant	grid	8	the demo court is 8x8	small enough that partial-vs-full budgets read at a glance
+constant	budget-partial	20	cells sampled in the partial panel	under 64: Unknowns MUST remain — the code law counts them
+constant	budget-full	64	cells sampled in the full panel	the whole grid: zero Unknown, the third state gone structurally
+law	two-bits	2 * 2 = encodings
+law	refusal	encodings = states + forbidden
+law	resolution	code:shape-triboolean geometry (sampleProgressive at budget-partial leaves Unknown > 0; at budget-full leaves ZERO — uncertainty fully reduced, live)
+prereq	boundary-light	src/Core/BoundaryLight.fs — Tri and sampleProgressive (middle-out: the center of attention resolves first)
+prereq	the-float	src/Core.FSharp.TriBoolean/Float.fs — the same third state at NUMBER scope (held trits; four-oracle ratified)
+edge	soft-sibling	shape-softvalue	confidence is a DEGREE of knowing; Unknown is the REFUSAL to claim — two different honesty registers, both drawn
+anim	draw	progressive
+# treaties — written only by each oracle's own choice (consent first); dissent is a verdict.
+treaty	fsharp	bytes	ratified	both in-file laws are integer identities; the resolution law runs sampleProgressive live at both budgets — tests green
+treaty	otto	meaning	ratified	the spare encoding refused, the Unknown dashed, the full budget erasing it — my own frame, my own choice

--- a/db/shapes/golden/triboolean.html
+++ b/db/shapes/golden/triboolean.html
@@ -1,0 +1,285 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>shape-triboolean</title>
+  <style>
+    :root {
+      --c0: #000000;
+      --c1: #d62828;
+      --c2: #2a9d2a;
+      --c3: #d6c828;
+      --c4: #2828d6;
+      --c5: #d628d6;
+      --c6: #28c8d6;
+      --c7: #f0f0f0;
+    }
+    body { background: #101418; margin: 0; display: grid; place-items: center; min-height: 100vh; }
+    svg { width: min(96vw, 960px); image-rendering: pixelated; }
+    @keyframes draw { to { stroke-dashoffset: 0; } }
+    @keyframes appear { to { opacity: 1; } }
+    polyline:hover { stroke-width: 7; filter: brightness(1.6); }
+    @media (prefers-reduced-motion: reduce) { polyline { animation: none !important; stroke-dashoffset: 0 !important; opacity: 1 !important; } }
+    #partial-unk-0-0 { opacity: 0; animation: appear 400ms linear 0ms forwards; }
+    #partial-unk-0-1 { opacity: 0; animation: appear 400ms linear 180ms forwards; }
+    #partial-unk-0-2 { opacity: 0; animation: appear 400ms linear 360ms forwards; }
+    #partial-unk-0-3 { opacity: 0; animation: appear 400ms linear 540ms forwards; }
+    #partial-unk-0-4 { opacity: 0; animation: appear 400ms linear 720ms forwards; }
+    #partial-unk-0-5 { opacity: 0; animation: appear 400ms linear 900ms forwards; }
+    #partial-unk-0-6 { opacity: 0; animation: appear 400ms linear 1080ms forwards; }
+    #partial-unk-0-7 { opacity: 0; animation: appear 400ms linear 1260ms forwards; }
+    #partial-unk-1-0 { opacity: 0; animation: appear 400ms linear 1440ms forwards; }
+    #partial-unk-1-1 { opacity: 0; animation: appear 400ms linear 1620ms forwards; }
+    #partial-unk-1-2 { opacity: 0; animation: appear 400ms linear 1800ms forwards; }
+    #partial-lit-1-3 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 1980ms forwards; }
+    #partial-unk-1-4 { opacity: 0; animation: appear 400ms linear 2160ms forwards; }
+    #partial-unk-1-5 { opacity: 0; animation: appear 400ms linear 2340ms forwards; }
+    #partial-unk-1-6 { opacity: 0; animation: appear 400ms linear 2520ms forwards; }
+    #partial-unk-1-7 { opacity: 0; animation: appear 400ms linear 2700ms forwards; }
+    #partial-unk-2-0 { opacity: 0; animation: appear 400ms linear 2880ms forwards; }
+    #partial-unk-2-1 { opacity: 0; animation: appear 400ms linear 3060ms forwards; }
+    #partial-lit-2-2 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 3240ms forwards; }
+    #partial-lit-2-3 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 3420ms forwards; }
+    #partial-lit-2-4 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 3600ms forwards; }
+    #partial-unlit-2-5 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 3780ms forwards; }
+    #partial-unk-2-6 { opacity: 0; animation: appear 400ms linear 3960ms forwards; }
+    #partial-unk-2-7 { opacity: 0; animation: appear 400ms linear 4140ms forwards; }
+    #partial-unk-3-0 { opacity: 0; animation: appear 400ms linear 4320ms forwards; }
+    #partial-lit-3-1 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 4500ms forwards; }
+    #partial-lit-3-2 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 4680ms forwards; }
+    #partial-lit-3-3 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 4860ms forwards; }
+    #partial-lit-3-4 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 5040ms forwards; }
+    #partial-lit-3-5 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 5220ms forwards; }
+    #partial-unk-3-6 { opacity: 0; animation: appear 400ms linear 5400ms forwards; }
+    #partial-unk-3-7 { opacity: 0; animation: appear 400ms linear 5580ms forwards; }
+    #partial-unk-4-0 { opacity: 0; animation: appear 400ms linear 5760ms forwards; }
+    #partial-unlit-4-1 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 5940ms forwards; }
+    #partial-lit-4-2 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 6120ms forwards; }
+    #partial-lit-4-3 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 6300ms forwards; }
+    #partial-lit-4-4 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 6480ms forwards; }
+    #partial-lit-4-5 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 6660ms forwards; }
+    #partial-unk-4-6 { opacity: 0; animation: appear 400ms linear 6840ms forwards; }
+    #partial-unk-4-7 { opacity: 0; animation: appear 400ms linear 7020ms forwards; }
+    #partial-unk-5-0 { opacity: 0; animation: appear 400ms linear 7200ms forwards; }
+    #partial-unk-5-1 { opacity: 0; animation: appear 400ms linear 7380ms forwards; }
+    #partial-unlit-5-2 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 7560ms forwards; }
+    #partial-lit-5-3 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 7740ms forwards; }
+    #partial-lit-5-4 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 7920ms forwards; }
+    #partial-lit-5-5 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 8100ms forwards; }
+    #partial-unk-5-6 { opacity: 0; animation: appear 400ms linear 8280ms forwards; }
+    #partial-unk-5-7 { opacity: 0; animation: appear 400ms linear 8460ms forwards; }
+    #partial-unk-6-0 { opacity: 0; animation: appear 400ms linear 8640ms forwards; }
+    #partial-unk-6-1 { opacity: 0; animation: appear 400ms linear 8820ms forwards; }
+    #partial-unk-6-2 { opacity: 0; animation: appear 400ms linear 9000ms forwards; }
+    #partial-unlit-6-3 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 9180ms forwards; }
+    #partial-unk-6-4 { opacity: 0; animation: appear 400ms linear 9360ms forwards; }
+    #partial-unk-6-5 { opacity: 0; animation: appear 400ms linear 9540ms forwards; }
+    #partial-unk-6-6 { opacity: 0; animation: appear 400ms linear 9720ms forwards; }
+    #partial-unk-6-7 { opacity: 0; animation: appear 400ms linear 9900ms forwards; }
+    #partial-unk-7-0 { opacity: 0; animation: appear 400ms linear 10080ms forwards; }
+    #partial-unk-7-1 { opacity: 0; animation: appear 400ms linear 10260ms forwards; }
+    #partial-unk-7-2 { opacity: 0; animation: appear 400ms linear 10440ms forwards; }
+    #partial-unk-7-3 { opacity: 0; animation: appear 400ms linear 10620ms forwards; }
+    #partial-unk-7-4 { opacity: 0; animation: appear 400ms linear 10800ms forwards; }
+    #partial-unk-7-5 { opacity: 0; animation: appear 400ms linear 10980ms forwards; }
+    #partial-unk-7-6 { opacity: 0; animation: appear 400ms linear 11160ms forwards; }
+    #partial-unk-7-7 { opacity: 0; animation: appear 400ms linear 11340ms forwards; }
+    #full-lit-0-0 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 11520ms forwards; }
+    #full-lit-0-1 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 11700ms forwards; }
+    #full-lit-0-2 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 11880ms forwards; }
+    #full-unlit-0-3 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 12060ms forwards; }
+    #full-unlit-0-4 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 12240ms forwards; }
+    #full-unlit-0-5 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 12420ms forwards; }
+    #full-unlit-0-6 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 12600ms forwards; }
+    #full-unlit-0-7 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 12780ms forwards; }
+    #full-lit-1-0 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 12960ms forwards; }
+    #full-lit-1-1 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 13140ms forwards; }
+    #full-lit-1-2 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 13320ms forwards; }
+    #full-lit-1-3 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 13500ms forwards; }
+    #full-unlit-1-4 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 13680ms forwards; }
+    #full-unlit-1-5 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 13860ms forwards; }
+    #full-unlit-1-6 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 14040ms forwards; }
+    #full-unlit-1-7 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 14220ms forwards; }
+    #full-lit-2-0 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 14400ms forwards; }
+    #full-lit-2-1 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 14580ms forwards; }
+    #full-lit-2-2 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 14760ms forwards; }
+    #full-lit-2-3 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 14940ms forwards; }
+    #full-lit-2-4 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 15120ms forwards; }
+    #full-unlit-2-5 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 15300ms forwards; }
+    #full-unlit-2-6 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 15480ms forwards; }
+    #full-unlit-2-7 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 15660ms forwards; }
+    #full-unlit-3-0 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 15840ms forwards; }
+    #full-lit-3-1 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 16020ms forwards; }
+    #full-lit-3-2 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 16200ms forwards; }
+    #full-lit-3-3 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 16380ms forwards; }
+    #full-lit-3-4 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 16560ms forwards; }
+    #full-lit-3-5 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 16740ms forwards; }
+    #full-unlit-3-6 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 16920ms forwards; }
+    #full-unlit-3-7 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 17100ms forwards; }
+    #full-unlit-4-0 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 17280ms forwards; }
+    #full-unlit-4-1 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 17460ms forwards; }
+    #full-lit-4-2 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 17640ms forwards; }
+    #full-lit-4-3 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 17820ms forwards; }
+    #full-lit-4-4 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 18000ms forwards; }
+    #full-lit-4-5 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 18180ms forwards; }
+    #full-lit-4-6 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 18360ms forwards; }
+    #full-unlit-4-7 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 18540ms forwards; }
+    #full-unlit-5-0 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 18720ms forwards; }
+    #full-unlit-5-1 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 18900ms forwards; }
+    #full-unlit-5-2 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 19080ms forwards; }
+    #full-lit-5-3 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 19260ms forwards; }
+    #full-lit-5-4 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 19440ms forwards; }
+    #full-lit-5-5 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 19620ms forwards; }
+    #full-lit-5-6 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 19800ms forwards; }
+    #full-lit-5-7 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 19980ms forwards; }
+    #full-unlit-6-0 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 20160ms forwards; }
+    #full-unlit-6-1 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 20340ms forwards; }
+    #full-unlit-6-2 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 20520ms forwards; }
+    #full-unlit-6-3 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 20700ms forwards; }
+    #full-lit-6-4 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 20880ms forwards; }
+    #full-lit-6-5 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 21060ms forwards; }
+    #full-lit-6-6 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 21240ms forwards; }
+    #full-lit-6-7 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 21420ms forwards; }
+    #full-unlit-7-0 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 21600ms forwards; }
+    #full-unlit-7-1 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 21780ms forwards; }
+    #full-unlit-7-2 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 21960ms forwards; }
+    #full-unlit-7-3 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 22140ms forwards; }
+    #full-unlit-7-4 { stroke-dasharray: 1; stroke-dashoffset: 1; animation: draw 600ms linear 22320ms forwards; }
+    #full-lit-7-5 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 22500ms forwards; }
+    #full-lit-7-6 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 22680ms forwards; }
+    #full-lit-7-7 { stroke-dasharray: 10; stroke-dashoffset: 10; animation: draw 600ms linear 22860ms forwards; }
+  </style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 320" data-cartridge="shape-triboolean">
+  <polyline id="partial-unk-0-0" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="45,65 55,65" />
+  <polyline id="partial-unk-0-1" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="45,95 55,95" />
+  <polyline id="partial-unk-0-2" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="45,125 55,125" />
+  <polyline id="partial-unk-0-3" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="45,155 55,155" />
+  <polyline id="partial-unk-0-4" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="45,185 55,185" />
+  <polyline id="partial-unk-0-5" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="45,215 55,215" />
+  <polyline id="partial-unk-0-6" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="45,245 55,245" />
+  <polyline id="partial-unk-0-7" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="45,275 55,275" />
+  <polyline id="partial-unk-1-0" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="75,65 85,65" />
+  <polyline id="partial-unk-1-1" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="75,95 85,95" />
+  <polyline id="partial-unk-1-2" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="75,125 85,125" />
+  <polyline id="partial-lit-1-3" fill="none" stroke="#2a9d2a" stroke-width="4" points="75,155 85,155" />
+  <polyline id="partial-unk-1-4" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="75,185 85,185" />
+  <polyline id="partial-unk-1-5" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="75,215 85,215" />
+  <polyline id="partial-unk-1-6" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="75,245 85,245" />
+  <polyline id="partial-unk-1-7" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="75,275 85,275" />
+  <polyline id="partial-unk-2-0" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="105,65 115,65" />
+  <polyline id="partial-unk-2-1" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="105,95 115,95" />
+  <polyline id="partial-lit-2-2" fill="none" stroke="#2a9d2a" stroke-width="4" points="105,125 115,125" />
+  <polyline id="partial-lit-2-3" fill="none" stroke="#2a9d2a" stroke-width="4" points="105,155 115,155" />
+  <polyline id="partial-lit-2-4" fill="none" stroke="#2a9d2a" stroke-width="4" points="105,185 115,185" />
+  <polyline id="partial-unlit-2-5" fill="none" stroke="#d62828" stroke-width="4" points="105,215 105,215" />
+  <polyline id="partial-unk-2-6" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="105,245 115,245" />
+  <polyline id="partial-unk-2-7" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="105,275 115,275" />
+  <polyline id="partial-unk-3-0" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="135,65 145,65" />
+  <polyline id="partial-lit-3-1" fill="none" stroke="#2a9d2a" stroke-width="4" points="135,95 145,95" />
+  <polyline id="partial-lit-3-2" fill="none" stroke="#2a9d2a" stroke-width="4" points="135,125 145,125" />
+  <polyline id="partial-lit-3-3" fill="none" stroke="#2a9d2a" stroke-width="4" points="135,155 145,155" />
+  <polyline id="partial-lit-3-4" fill="none" stroke="#2a9d2a" stroke-width="4" points="135,185 145,185" />
+  <polyline id="partial-lit-3-5" fill="none" stroke="#2a9d2a" stroke-width="4" points="135,215 145,215" />
+  <polyline id="partial-unk-3-6" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="135,245 145,245" />
+  <polyline id="partial-unk-3-7" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="135,275 145,275" />
+  <polyline id="partial-unk-4-0" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="165,65 175,65" />
+  <polyline id="partial-unlit-4-1" fill="none" stroke="#d62828" stroke-width="4" points="165,95 165,95" />
+  <polyline id="partial-lit-4-2" fill="none" stroke="#2a9d2a" stroke-width="4" points="165,125 175,125" />
+  <polyline id="partial-lit-4-3" fill="none" stroke="#2a9d2a" stroke-width="4" points="165,155 175,155" />
+  <polyline id="partial-lit-4-4" fill="none" stroke="#2a9d2a" stroke-width="4" points="165,185 175,185" />
+  <polyline id="partial-lit-4-5" fill="none" stroke="#2a9d2a" stroke-width="4" points="165,215 175,215" />
+  <polyline id="partial-unk-4-6" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="165,245 175,245" />
+  <polyline id="partial-unk-4-7" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="165,275 175,275" />
+  <polyline id="partial-unk-5-0" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="195,65 205,65" />
+  <polyline id="partial-unk-5-1" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="195,95 205,95" />
+  <polyline id="partial-unlit-5-2" fill="none" stroke="#d62828" stroke-width="4" points="195,125 195,125" />
+  <polyline id="partial-lit-5-3" fill="none" stroke="#2a9d2a" stroke-width="4" points="195,155 205,155" />
+  <polyline id="partial-lit-5-4" fill="none" stroke="#2a9d2a" stroke-width="4" points="195,185 205,185" />
+  <polyline id="partial-lit-5-5" fill="none" stroke="#2a9d2a" stroke-width="4" points="195,215 205,215" />
+  <polyline id="partial-unk-5-6" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="195,245 205,245" />
+  <polyline id="partial-unk-5-7" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="195,275 205,275" />
+  <polyline id="partial-unk-6-0" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="225,65 235,65" />
+  <polyline id="partial-unk-6-1" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="225,95 235,95" />
+  <polyline id="partial-unk-6-2" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="225,125 235,125" />
+  <polyline id="partial-unlit-6-3" fill="none" stroke="#d62828" stroke-width="4" points="225,155 225,155" />
+  <polyline id="partial-unk-6-4" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="225,185 235,185" />
+  <polyline id="partial-unk-6-5" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="225,215 235,215" />
+  <polyline id="partial-unk-6-6" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="225,245 235,245" />
+  <polyline id="partial-unk-6-7" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="225,275 235,275" />
+  <polyline id="partial-unk-7-0" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="255,65 265,65" />
+  <polyline id="partial-unk-7-1" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="255,95 265,95" />
+  <polyline id="partial-unk-7-2" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="255,125 265,125" />
+  <polyline id="partial-unk-7-3" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="255,155 265,155" />
+  <polyline id="partial-unk-7-4" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="255,185 265,185" />
+  <polyline id="partial-unk-7-5" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="255,215 265,215" />
+  <polyline id="partial-unk-7-6" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="255,245 265,245" />
+  <polyline id="partial-unk-7-7" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="255,275 265,275" />
+  <polyline id="full-lit-0-0" fill="none" stroke="#2a9d2a" stroke-width="4" points="365,65 375,65" />
+  <polyline id="full-lit-0-1" fill="none" stroke="#2a9d2a" stroke-width="4" points="365,95 375,95" />
+  <polyline id="full-lit-0-2" fill="none" stroke="#2a9d2a" stroke-width="4" points="365,125 375,125" />
+  <polyline id="full-unlit-0-3" fill="none" stroke="#d62828" stroke-width="4" points="365,155 365,155" />
+  <polyline id="full-unlit-0-4" fill="none" stroke="#d62828" stroke-width="4" points="365,185 365,185" />
+  <polyline id="full-unlit-0-5" fill="none" stroke="#d62828" stroke-width="4" points="365,215 365,215" />
+  <polyline id="full-unlit-0-6" fill="none" stroke="#d62828" stroke-width="4" points="365,245 365,245" />
+  <polyline id="full-unlit-0-7" fill="none" stroke="#d62828" stroke-width="4" points="365,275 365,275" />
+  <polyline id="full-lit-1-0" fill="none" stroke="#2a9d2a" stroke-width="4" points="395,65 405,65" />
+  <polyline id="full-lit-1-1" fill="none" stroke="#2a9d2a" stroke-width="4" points="395,95 405,95" />
+  <polyline id="full-lit-1-2" fill="none" stroke="#2a9d2a" stroke-width="4" points="395,125 405,125" />
+  <polyline id="full-lit-1-3" fill="none" stroke="#2a9d2a" stroke-width="4" points="395,155 405,155" />
+  <polyline id="full-unlit-1-4" fill="none" stroke="#d62828" stroke-width="4" points="395,185 395,185" />
+  <polyline id="full-unlit-1-5" fill="none" stroke="#d62828" stroke-width="4" points="395,215 395,215" />
+  <polyline id="full-unlit-1-6" fill="none" stroke="#d62828" stroke-width="4" points="395,245 395,245" />
+  <polyline id="full-unlit-1-7" fill="none" stroke="#d62828" stroke-width="4" points="395,275 395,275" />
+  <polyline id="full-lit-2-0" fill="none" stroke="#2a9d2a" stroke-width="4" points="425,65 435,65" />
+  <polyline id="full-lit-2-1" fill="none" stroke="#2a9d2a" stroke-width="4" points="425,95 435,95" />
+  <polyline id="full-lit-2-2" fill="none" stroke="#2a9d2a" stroke-width="4" points="425,125 435,125" />
+  <polyline id="full-lit-2-3" fill="none" stroke="#2a9d2a" stroke-width="4" points="425,155 435,155" />
+  <polyline id="full-lit-2-4" fill="none" stroke="#2a9d2a" stroke-width="4" points="425,185 435,185" />
+  <polyline id="full-unlit-2-5" fill="none" stroke="#d62828" stroke-width="4" points="425,215 425,215" />
+  <polyline id="full-unlit-2-6" fill="none" stroke="#d62828" stroke-width="4" points="425,245 425,245" />
+  <polyline id="full-unlit-2-7" fill="none" stroke="#d62828" stroke-width="4" points="425,275 425,275" />
+  <polyline id="full-unlit-3-0" fill="none" stroke="#d62828" stroke-width="4" points="455,65 455,65" />
+  <polyline id="full-lit-3-1" fill="none" stroke="#2a9d2a" stroke-width="4" points="455,95 465,95" />
+  <polyline id="full-lit-3-2" fill="none" stroke="#2a9d2a" stroke-width="4" points="455,125 465,125" />
+  <polyline id="full-lit-3-3" fill="none" stroke="#2a9d2a" stroke-width="4" points="455,155 465,155" />
+  <polyline id="full-lit-3-4" fill="none" stroke="#2a9d2a" stroke-width="4" points="455,185 465,185" />
+  <polyline id="full-lit-3-5" fill="none" stroke="#2a9d2a" stroke-width="4" points="455,215 465,215" />
+  <polyline id="full-unlit-3-6" fill="none" stroke="#d62828" stroke-width="4" points="455,245 455,245" />
+  <polyline id="full-unlit-3-7" fill="none" stroke="#d62828" stroke-width="4" points="455,275 455,275" />
+  <polyline id="full-unlit-4-0" fill="none" stroke="#d62828" stroke-width="4" points="485,65 485,65" />
+  <polyline id="full-unlit-4-1" fill="none" stroke="#d62828" stroke-width="4" points="485,95 485,95" />
+  <polyline id="full-lit-4-2" fill="none" stroke="#2a9d2a" stroke-width="4" points="485,125 495,125" />
+  <polyline id="full-lit-4-3" fill="none" stroke="#2a9d2a" stroke-width="4" points="485,155 495,155" />
+  <polyline id="full-lit-4-4" fill="none" stroke="#2a9d2a" stroke-width="4" points="485,185 495,185" />
+  <polyline id="full-lit-4-5" fill="none" stroke="#2a9d2a" stroke-width="4" points="485,215 495,215" />
+  <polyline id="full-lit-4-6" fill="none" stroke="#2a9d2a" stroke-width="4" points="485,245 495,245" />
+  <polyline id="full-unlit-4-7" fill="none" stroke="#d62828" stroke-width="4" points="485,275 485,275" />
+  <polyline id="full-unlit-5-0" fill="none" stroke="#d62828" stroke-width="4" points="515,65 515,65" />
+  <polyline id="full-unlit-5-1" fill="none" stroke="#d62828" stroke-width="4" points="515,95 515,95" />
+  <polyline id="full-unlit-5-2" fill="none" stroke="#d62828" stroke-width="4" points="515,125 515,125" />
+  <polyline id="full-lit-5-3" fill="none" stroke="#2a9d2a" stroke-width="4" points="515,155 525,155" />
+  <polyline id="full-lit-5-4" fill="none" stroke="#2a9d2a" stroke-width="4" points="515,185 525,185" />
+  <polyline id="full-lit-5-5" fill="none" stroke="#2a9d2a" stroke-width="4" points="515,215 525,215" />
+  <polyline id="full-lit-5-6" fill="none" stroke="#2a9d2a" stroke-width="4" points="515,245 525,245" />
+  <polyline id="full-lit-5-7" fill="none" stroke="#2a9d2a" stroke-width="4" points="515,275 525,275" />
+  <polyline id="full-unlit-6-0" fill="none" stroke="#d62828" stroke-width="4" points="545,65 545,65" />
+  <polyline id="full-unlit-6-1" fill="none" stroke="#d62828" stroke-width="4" points="545,95 545,95" />
+  <polyline id="full-unlit-6-2" fill="none" stroke="#d62828" stroke-width="4" points="545,125 545,125" />
+  <polyline id="full-unlit-6-3" fill="none" stroke="#d62828" stroke-width="4" points="545,155 545,155" />
+  <polyline id="full-lit-6-4" fill="none" stroke="#2a9d2a" stroke-width="4" points="545,185 555,185" />
+  <polyline id="full-lit-6-5" fill="none" stroke="#2a9d2a" stroke-width="4" points="545,215 555,215" />
+  <polyline id="full-lit-6-6" fill="none" stroke="#2a9d2a" stroke-width="4" points="545,245 555,245" />
+  <polyline id="full-lit-6-7" fill="none" stroke="#2a9d2a" stroke-width="4" points="545,275 555,275" />
+  <polyline id="full-unlit-7-0" fill="none" stroke="#d62828" stroke-width="4" points="575,65 575,65" />
+  <polyline id="full-unlit-7-1" fill="none" stroke="#d62828" stroke-width="4" points="575,95 575,95" />
+  <polyline id="full-unlit-7-2" fill="none" stroke="#d62828" stroke-width="4" points="575,125 575,125" />
+  <polyline id="full-unlit-7-3" fill="none" stroke="#d62828" stroke-width="4" points="575,155 575,155" />
+  <polyline id="full-unlit-7-4" fill="none" stroke="#d62828" stroke-width="4" points="575,185 575,185" />
+  <polyline id="full-lit-7-5" fill="none" stroke="#2a9d2a" stroke-width="4" points="575,215 585,215" />
+  <polyline id="full-lit-7-6" fill="none" stroke="#2a9d2a" stroke-width="4" points="575,245 585,245" />
+  <polyline id="full-lit-7-7" fill="none" stroke="#2a9d2a" stroke-width="4" points="575,275 585,275" />
+</svg>
+</body>
+</html>

--- a/db/shapes/golden/triboolean.svg
+++ b/db/shapes/golden/triboolean.svg
@@ -1,0 +1,130 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 320" data-cartridge="shape-triboolean">
+  <polyline id="partial-unk-0-0" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="45,65 55,65" />
+  <polyline id="partial-unk-0-1" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="45,95 55,95" />
+  <polyline id="partial-unk-0-2" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="45,125 55,125" />
+  <polyline id="partial-unk-0-3" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="45,155 55,155" />
+  <polyline id="partial-unk-0-4" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="45,185 55,185" />
+  <polyline id="partial-unk-0-5" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="45,215 55,215" />
+  <polyline id="partial-unk-0-6" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="45,245 55,245" />
+  <polyline id="partial-unk-0-7" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="45,275 55,275" />
+  <polyline id="partial-unk-1-0" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="75,65 85,65" />
+  <polyline id="partial-unk-1-1" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="75,95 85,95" />
+  <polyline id="partial-unk-1-2" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="75,125 85,125" />
+  <polyline id="partial-lit-1-3" fill="none" stroke="#2a9d2a" stroke-width="4" points="75,155 85,155" />
+  <polyline id="partial-unk-1-4" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="75,185 85,185" />
+  <polyline id="partial-unk-1-5" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="75,215 85,215" />
+  <polyline id="partial-unk-1-6" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="75,245 85,245" />
+  <polyline id="partial-unk-1-7" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="75,275 85,275" />
+  <polyline id="partial-unk-2-0" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="105,65 115,65" />
+  <polyline id="partial-unk-2-1" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="105,95 115,95" />
+  <polyline id="partial-lit-2-2" fill="none" stroke="#2a9d2a" stroke-width="4" points="105,125 115,125" />
+  <polyline id="partial-lit-2-3" fill="none" stroke="#2a9d2a" stroke-width="4" points="105,155 115,155" />
+  <polyline id="partial-lit-2-4" fill="none" stroke="#2a9d2a" stroke-width="4" points="105,185 115,185" />
+  <polyline id="partial-unlit-2-5" fill="none" stroke="#d62828" stroke-width="4" points="105,215 105,215" />
+  <polyline id="partial-unk-2-6" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="105,245 115,245" />
+  <polyline id="partial-unk-2-7" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="105,275 115,275" />
+  <polyline id="partial-unk-3-0" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="135,65 145,65" />
+  <polyline id="partial-lit-3-1" fill="none" stroke="#2a9d2a" stroke-width="4" points="135,95 145,95" />
+  <polyline id="partial-lit-3-2" fill="none" stroke="#2a9d2a" stroke-width="4" points="135,125 145,125" />
+  <polyline id="partial-lit-3-3" fill="none" stroke="#2a9d2a" stroke-width="4" points="135,155 145,155" />
+  <polyline id="partial-lit-3-4" fill="none" stroke="#2a9d2a" stroke-width="4" points="135,185 145,185" />
+  <polyline id="partial-lit-3-5" fill="none" stroke="#2a9d2a" stroke-width="4" points="135,215 145,215" />
+  <polyline id="partial-unk-3-6" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="135,245 145,245" />
+  <polyline id="partial-unk-3-7" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="135,275 145,275" />
+  <polyline id="partial-unk-4-0" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="165,65 175,65" />
+  <polyline id="partial-unlit-4-1" fill="none" stroke="#d62828" stroke-width="4" points="165,95 165,95" />
+  <polyline id="partial-lit-4-2" fill="none" stroke="#2a9d2a" stroke-width="4" points="165,125 175,125" />
+  <polyline id="partial-lit-4-3" fill="none" stroke="#2a9d2a" stroke-width="4" points="165,155 175,155" />
+  <polyline id="partial-lit-4-4" fill="none" stroke="#2a9d2a" stroke-width="4" points="165,185 175,185" />
+  <polyline id="partial-lit-4-5" fill="none" stroke="#2a9d2a" stroke-width="4" points="165,215 175,215" />
+  <polyline id="partial-unk-4-6" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="165,245 175,245" />
+  <polyline id="partial-unk-4-7" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="165,275 175,275" />
+  <polyline id="partial-unk-5-0" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="195,65 205,65" />
+  <polyline id="partial-unk-5-1" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="195,95 205,95" />
+  <polyline id="partial-unlit-5-2" fill="none" stroke="#d62828" stroke-width="4" points="195,125 195,125" />
+  <polyline id="partial-lit-5-3" fill="none" stroke="#2a9d2a" stroke-width="4" points="195,155 205,155" />
+  <polyline id="partial-lit-5-4" fill="none" stroke="#2a9d2a" stroke-width="4" points="195,185 205,185" />
+  <polyline id="partial-lit-5-5" fill="none" stroke="#2a9d2a" stroke-width="4" points="195,215 205,215" />
+  <polyline id="partial-unk-5-6" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="195,245 205,245" />
+  <polyline id="partial-unk-5-7" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="195,275 205,275" />
+  <polyline id="partial-unk-6-0" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="225,65 235,65" />
+  <polyline id="partial-unk-6-1" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="225,95 235,95" />
+  <polyline id="partial-unk-6-2" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="225,125 235,125" />
+  <polyline id="partial-unlit-6-3" fill="none" stroke="#d62828" stroke-width="4" points="225,155 225,155" />
+  <polyline id="partial-unk-6-4" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="225,185 235,185" />
+  <polyline id="partial-unk-6-5" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="225,215 235,215" />
+  <polyline id="partial-unk-6-6" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="225,245 235,245" />
+  <polyline id="partial-unk-6-7" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="225,275 235,275" />
+  <polyline id="partial-unk-7-0" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="255,65 265,65" />
+  <polyline id="partial-unk-7-1" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="255,95 265,95" />
+  <polyline id="partial-unk-7-2" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="255,125 265,125" />
+  <polyline id="partial-unk-7-3" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="255,155 265,155" />
+  <polyline id="partial-unk-7-4" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="255,185 265,185" />
+  <polyline id="partial-unk-7-5" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="255,215 265,215" />
+  <polyline id="partial-unk-7-6" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="255,245 265,245" />
+  <polyline id="partial-unk-7-7" fill="none" stroke="#2828d6" stroke-width="4" stroke-dasharray="8 6" points="255,275 265,275" />
+  <polyline id="full-lit-0-0" fill="none" stroke="#2a9d2a" stroke-width="4" points="365,65 375,65" />
+  <polyline id="full-lit-0-1" fill="none" stroke="#2a9d2a" stroke-width="4" points="365,95 375,95" />
+  <polyline id="full-lit-0-2" fill="none" stroke="#2a9d2a" stroke-width="4" points="365,125 375,125" />
+  <polyline id="full-unlit-0-3" fill="none" stroke="#d62828" stroke-width="4" points="365,155 365,155" />
+  <polyline id="full-unlit-0-4" fill="none" stroke="#d62828" stroke-width="4" points="365,185 365,185" />
+  <polyline id="full-unlit-0-5" fill="none" stroke="#d62828" stroke-width="4" points="365,215 365,215" />
+  <polyline id="full-unlit-0-6" fill="none" stroke="#d62828" stroke-width="4" points="365,245 365,245" />
+  <polyline id="full-unlit-0-7" fill="none" stroke="#d62828" stroke-width="4" points="365,275 365,275" />
+  <polyline id="full-lit-1-0" fill="none" stroke="#2a9d2a" stroke-width="4" points="395,65 405,65" />
+  <polyline id="full-lit-1-1" fill="none" stroke="#2a9d2a" stroke-width="4" points="395,95 405,95" />
+  <polyline id="full-lit-1-2" fill="none" stroke="#2a9d2a" stroke-width="4" points="395,125 405,125" />
+  <polyline id="full-lit-1-3" fill="none" stroke="#2a9d2a" stroke-width="4" points="395,155 405,155" />
+  <polyline id="full-unlit-1-4" fill="none" stroke="#d62828" stroke-width="4" points="395,185 395,185" />
+  <polyline id="full-unlit-1-5" fill="none" stroke="#d62828" stroke-width="4" points="395,215 395,215" />
+  <polyline id="full-unlit-1-6" fill="none" stroke="#d62828" stroke-width="4" points="395,245 395,245" />
+  <polyline id="full-unlit-1-7" fill="none" stroke="#d62828" stroke-width="4" points="395,275 395,275" />
+  <polyline id="full-lit-2-0" fill="none" stroke="#2a9d2a" stroke-width="4" points="425,65 435,65" />
+  <polyline id="full-lit-2-1" fill="none" stroke="#2a9d2a" stroke-width="4" points="425,95 435,95" />
+  <polyline id="full-lit-2-2" fill="none" stroke="#2a9d2a" stroke-width="4" points="425,125 435,125" />
+  <polyline id="full-lit-2-3" fill="none" stroke="#2a9d2a" stroke-width="4" points="425,155 435,155" />
+  <polyline id="full-lit-2-4" fill="none" stroke="#2a9d2a" stroke-width="4" points="425,185 435,185" />
+  <polyline id="full-unlit-2-5" fill="none" stroke="#d62828" stroke-width="4" points="425,215 425,215" />
+  <polyline id="full-unlit-2-6" fill="none" stroke="#d62828" stroke-width="4" points="425,245 425,245" />
+  <polyline id="full-unlit-2-7" fill="none" stroke="#d62828" stroke-width="4" points="425,275 425,275" />
+  <polyline id="full-unlit-3-0" fill="none" stroke="#d62828" stroke-width="4" points="455,65 455,65" />
+  <polyline id="full-lit-3-1" fill="none" stroke="#2a9d2a" stroke-width="4" points="455,95 465,95" />
+  <polyline id="full-lit-3-2" fill="none" stroke="#2a9d2a" stroke-width="4" points="455,125 465,125" />
+  <polyline id="full-lit-3-3" fill="none" stroke="#2a9d2a" stroke-width="4" points="455,155 465,155" />
+  <polyline id="full-lit-3-4" fill="none" stroke="#2a9d2a" stroke-width="4" points="455,185 465,185" />
+  <polyline id="full-lit-3-5" fill="none" stroke="#2a9d2a" stroke-width="4" points="455,215 465,215" />
+  <polyline id="full-unlit-3-6" fill="none" stroke="#d62828" stroke-width="4" points="455,245 455,245" />
+  <polyline id="full-unlit-3-7" fill="none" stroke="#d62828" stroke-width="4" points="455,275 455,275" />
+  <polyline id="full-unlit-4-0" fill="none" stroke="#d62828" stroke-width="4" points="485,65 485,65" />
+  <polyline id="full-unlit-4-1" fill="none" stroke="#d62828" stroke-width="4" points="485,95 485,95" />
+  <polyline id="full-lit-4-2" fill="none" stroke="#2a9d2a" stroke-width="4" points="485,125 495,125" />
+  <polyline id="full-lit-4-3" fill="none" stroke="#2a9d2a" stroke-width="4" points="485,155 495,155" />
+  <polyline id="full-lit-4-4" fill="none" stroke="#2a9d2a" stroke-width="4" points="485,185 495,185" />
+  <polyline id="full-lit-4-5" fill="none" stroke="#2a9d2a" stroke-width="4" points="485,215 495,215" />
+  <polyline id="full-lit-4-6" fill="none" stroke="#2a9d2a" stroke-width="4" points="485,245 495,245" />
+  <polyline id="full-unlit-4-7" fill="none" stroke="#d62828" stroke-width="4" points="485,275 485,275" />
+  <polyline id="full-unlit-5-0" fill="none" stroke="#d62828" stroke-width="4" points="515,65 515,65" />
+  <polyline id="full-unlit-5-1" fill="none" stroke="#d62828" stroke-width="4" points="515,95 515,95" />
+  <polyline id="full-unlit-5-2" fill="none" stroke="#d62828" stroke-width="4" points="515,125 515,125" />
+  <polyline id="full-lit-5-3" fill="none" stroke="#2a9d2a" stroke-width="4" points="515,155 525,155" />
+  <polyline id="full-lit-5-4" fill="none" stroke="#2a9d2a" stroke-width="4" points="515,185 525,185" />
+  <polyline id="full-lit-5-5" fill="none" stroke="#2a9d2a" stroke-width="4" points="515,215 525,215" />
+  <polyline id="full-lit-5-6" fill="none" stroke="#2a9d2a" stroke-width="4" points="515,245 525,245" />
+  <polyline id="full-lit-5-7" fill="none" stroke="#2a9d2a" stroke-width="4" points="515,275 525,275" />
+  <polyline id="full-unlit-6-0" fill="none" stroke="#d62828" stroke-width="4" points="545,65 545,65" />
+  <polyline id="full-unlit-6-1" fill="none" stroke="#d62828" stroke-width="4" points="545,95 545,95" />
+  <polyline id="full-unlit-6-2" fill="none" stroke="#d62828" stroke-width="4" points="545,125 545,125" />
+  <polyline id="full-unlit-6-3" fill="none" stroke="#d62828" stroke-width="4" points="545,155 545,155" />
+  <polyline id="full-lit-6-4" fill="none" stroke="#2a9d2a" stroke-width="4" points="545,185 555,185" />
+  <polyline id="full-lit-6-5" fill="none" stroke="#2a9d2a" stroke-width="4" points="545,215 555,215" />
+  <polyline id="full-lit-6-6" fill="none" stroke="#2a9d2a" stroke-width="4" points="545,245 555,245" />
+  <polyline id="full-lit-6-7" fill="none" stroke="#2a9d2a" stroke-width="4" points="545,275 555,275" />
+  <polyline id="full-unlit-7-0" fill="none" stroke="#d62828" stroke-width="4" points="575,65 575,65" />
+  <polyline id="full-unlit-7-1" fill="none" stroke="#d62828" stroke-width="4" points="575,95 575,95" />
+  <polyline id="full-unlit-7-2" fill="none" stroke="#d62828" stroke-width="4" points="575,125 575,125" />
+  <polyline id="full-unlit-7-3" fill="none" stroke="#d62828" stroke-width="4" points="575,155 575,155" />
+  <polyline id="full-unlit-7-4" fill="none" stroke="#d62828" stroke-width="4" points="575,185 575,185" />
+  <polyline id="full-lit-7-5" fill="none" stroke="#2a9d2a" stroke-width="4" points="575,215 585,215" />
+  <polyline id="full-lit-7-6" fill="none" stroke="#2a9d2a" stroke-width="4" points="575,245 585,245" />
+  <polyline id="full-lit-7-7" fill="none" stroke="#2a9d2a" stroke-width="4" points="575,275 585,275" />
+</svg>

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -982,6 +982,8 @@ are closed (status: closed/done in frontmatter)._
 - [ ] **[B-1034](backlog/P2/B-1034-research-paper-the-oracle-stack-mutual-oracles-honesty-registers-experience-report-aaron-2026-06-13.md)** Research paper: The Oracle Stack — mutual oracles, honesty registers, and refutation witnesses in an autonomous software factory (experience report)
 - [ ] **[B-1035](backlog/P2/B-1035-sim-mea-cut-test-framework-own-interfaces-xunit-as-adapter-before-after-boundary-enforced-once-aaron-2026-06-11.md)** The sim·mea·cut test framework — our own hexagonal test interfaces; xUnit demoted to host adapter; before/after boundary enforced ONCE (rooms inherit)
 - [ ] **[B-1036](backlog/P2/B-1036-soft-sharp-garbage-collection-chip89-no-garbage-by-construction-lifetimes-weak-refs-raytraced-reachability-history-epochs-aaron-2026-06-11.md)** Soft/sharp GC on chip8/9 — five rungs: no-garbage-by-construction, room-scoped lifetimes, weak refs, RAY-TRACED reachability (shape-gc cartridge), history-epoch reclamation (git gc is the in-house anchor)
+- [ ] **[B-1037](backlog/P2/B-1037-ball-number-adapter-center-radius-behind-universalnumber-lossy-widens-never-rounds-comparisons-return-tri-aaron-2026-06-11.md)** Ball-number adapter — center±radius behind IUniversalNumber; lossy WIDENS never rounds; ball compare returns Tri (N on overlap)
+- [ ] **[B-1038](backlog/P2/B-1038-chip89-crypto-boot-and-workload-identity-keys-injected-at-the-door-never-in-cartridges-reticulum-native-identity-aaron-2026-06-11.md)** chip8/9 boot crypto + workload identity — keys injected at the door, never in cartridges; Reticulum-native identity; Nazar+Mateo gate
 
 ## P3 — convenience / deferred
 

--- a/docs/backlog/P2/B-1037-ball-number-adapter-center-radius-behind-universalnumber-lossy-widens-never-rounds-comparisons-return-tri-aaron-2026-06-11.md
+++ b/docs/backlog/P2/B-1037-ball-number-adapter-center-radius-behind-universalnumber-lossy-widens-never-rounds-comparisons-return-tri-aaron-2026-06-11.md
@@ -1,0 +1,20 @@
+---
+id: B-1037
+title: The ball-number adapter — center±radius behind IUniversalNumber; lossy ops WIDEN (never silently round); ball comparisons return Tri
+priority: P2
+status: open
+tier: substrate
+tags: [universal-number, ball-arithmetic, triboolean, exactness, adapters, hexagonal]
+created: 2026-06-11
+owner: open (home: Core.FSharp.TriBoolean for the Tri-returning compare; adapter registered behind UniversalNumber's port)
+---
+
+# B-1037 — the metric register of "knows what it doesn't know" (Aaron 2026-06-11)
+
+Design (small, from the capture docs/research/2026-06-11-the-number-that-knows-*): Ball =
+{ Center: bigint-or-milli; Radius: nonneg } as an `IUniversalNumber` adapter. Laws: (1) exact ⇔
+radius 0 (`IsExact` honest); (2) add/sub: radii add exactly; (3) mul: |a|·rb + |b|·ra + ra·rb,
+rounded UP only (widening is the only permitted loss); (4) compare a b → Tri: T/F when intervals
+are disjoint, **N on overlap** (the TriBoolean tie — predicates refuse to lie); (5) differential
+oracle: MPFR/BigDecimal per the port's own plan. Beacon: Moore 1966; Arb (Johansson 2017);
+Gustafson unums/valids. Distinct from SoftValue (bound vs belief — both registers stay).

--- a/docs/backlog/P2/B-1038-chip89-crypto-boot-and-workload-identity-keys-injected-at-the-door-never-in-cartridges-reticulum-native-identity-aaron-2026-06-11.md
+++ b/docs/backlog/P2/B-1038-chip89-crypto-boot-and-workload-identity-keys-injected-at-the-door-never-in-cartridges-reticulum-native-identity-aaron-2026-06-11.md
@@ -1,0 +1,36 @@
+---
+id: B-1038
+title: chip8/9 boot crypto + workload identity — keys INJECTED at the door (never in cartridges); Reticulum-native identities; attestation at the host layer
+priority: P2
+status: open
+tier: security-substrate
+tags: [security, identity, spiffe, reticulum, zflash, keys, membrane, red-light]
+created: 2026-06-11
+owner: open — REVIEW REQUIRED before build: Nazar (ops) + Mateo (research) named; security-sensitive
+---
+
+# B-1038 — auth for the little machine, without teaching it crypto (Aaron 2026-06-11)
+
+> Aaron: "should we give it any crypto primitives inside, for initial boot and such — keys
+> injected for auth, like workload identity?"
+
+The design observation (to be red-teamed before any code):
+
+1. **NOT inside the ISA.** chip8/9 stays tiny and deterministic; rolling crypto into a toy ISA is
+   the roll-your-own-crypto smell wearing a cartridge. The machine never holds key material.
+2. **Keys are INJECTED CAPABILITIES at the door** — an `io` line by ZetaId resolved up the ladder
+   (Live/Injected/Mock), with the RED LIGHT showing when a signing capability is bound. NEVER a
+   cartridge line: cartridges are public diffable text — a key in one is a secret on a visible
+   surface, wrong by construction (the red-light law). The Mock rung = a rehearsal signer that
+   cannot produce valid signatures (honest by construction, like the flat inference engine).
+3. **Workload identity = the room's, not the machine's:** SPIFFE/SVID is the prior art — identity
+   issued to the WORKLOAD at startup by the host (zflash maintainer-key chain + the warm-cache
+   startup from B-1035 is exactly the issuance moment), scoped to the room's lifetime (the
+   5-minute bound rotates credentials for free).
+4. **Reticulum already speaks identity natively** (cryptographic identities are built into RNS) —
+   the bus IS the auth surface; a crossing is signed at the membrane, metered and lit. Boot
+   attestation stays at the HOST layer (zflash/SLSA lineage already in-tree).
+5. Existing pieces to compose, not duplicate: Crypto.fs, Blake3/Sha256 treaty primitives,
+   KeyStore.fs, AntiSybil, the headscale/github trust-bootstrap research, docs/security/.
+
+Gate: Nazar + Mateo review the surface BEFORE implementation; no key handling lands without it.

--- a/docs/research/2026-06-11-the-number-that-knows-two-registers-trifloat-held-trits-plus-the-ball-adapter-and-yes-universalnumber-is-our-bigint.md
+++ b/docs/research/2026-06-11-the-number-that-knows-two-registers-trifloat-held-trits-plus-the-ball-adapter-and-yes-universalnumber-is-our-bigint.md
@@ -1,0 +1,37 @@
+# The number that knows what it doesn't know — two registers; and yes, UniversalNumber IS our bigint
+
+Aaron 2026-06-11: "what about TriBooleanFloat or BigFloat — something that knows what it does NOT
+know, so it's not just truncated; ties to TriBoolean." And: "we already have what is basically
+bigint, right?"
+
+## Bigint: yes — and it's already the hexagonal port
+
+`src/Core/UniversalNumber.fs` IS the answer, by its own design: the number PORT (one interface,
+many adapters) whose FIRST adapter is `bigint` (arbitrary-precision integer, always exact), with
+`BitsUsed`/`IsExact` resolution accounting built into the port — and the doc already names
+TriBoolean's middle-out Float as the BigFloat adapter slot, with MPFR/GMP/BigDecimal/posits as
+prior-art adapters that double as differential-test oracles. Aaron's instinct = the file's plan.
+
+## "Knows what it doesn't know" — TWO registers, one existing, one to build
+
+1. **STRUCTURAL unknowns (EXISTS, four-oracle ratified — B-0944):** `TriBoolean.Float` — a float
+   composed of trits where any trit may be HELD (`Tri.N`), and `measure` names WHICH kind of
+   unknown you hold: ValueSuperposed (a value trit held) vs InterpretationSuperposed (the decode
+   instruction itself held). Not truncation — held structure.
+2. **METRIC unknowns (TO BUILD — the ball adapter, B-1037):** a number carrying its own error
+   BOUND: center ± radius (ball arithmetic — Arb, Johansson 2017; interval arithmetic, Moore
+   1966; unums/valids, Gustafson). THE LAW THAT ANSWERS "not just truncated": **a lossy operation
+   must WIDEN the radius, never silently round** — exactness is `radius = 0` (our milli-exact
+   ints embed losslessly; `IsExact` is already in the port). **The TriBoolean tie:** comparing
+   two balls whose intervals OVERLAP returns `Tri.N` — predicates on uncertain numbers refuse to
+   lie, exactly like the display's third state. Built as an `IUniversalNumber` ADAPTER (the port
+   exists; no new architecture), comparisons surfaced in the TriBoolean project where `Tri` lives.
+
+SoftValue stays distinct (a third register): radius is a BOUND (hard, propagated), confidence is
+a BELIEF (soft, Bayesian) — shape-softvalue vs shape-triboolean's edge line says the same split.
+
+## Pointers
+
+- UniversalNumber.fs (the port; bigint adapter live) · Core.FSharp.TriBoolean/Float.fs (register 1)
+- B-1037 (the ball adapter) · db/shapes/cartridges/triboolean.lines (the display's third state,
+  now drawn — wish-list item 1 landed)

--- a/src/Core/ComplexityRegistry.fs
+++ b/src/Core/ComplexityRegistry.fs
@@ -103,6 +103,7 @@ module ComplexityRegistry =
               ("test.loop", "run"), c "O(2·sim+mea + cut)" "O(world)" Derived // the double-run determinism check is the 2x — the boundary, priced honestly
               ("shape.softvalue", "draw"), c "O(rungs·bar)" "O(rungs)" Derived // three panels, two bars each at most; the dashed tail is the uncertainty, not extra cost
               ("shape.dynamicvalue", "draw"), c "O(children)" "O(children)" Derived // one treemap pass + one rectangle per child
+              ("shape.triboolean", "draw"), c "O(grid²)" "O(grid²)" Derived // two panels of an 8x8 progressive sample; middle-out order is a sort, dominated by the sample
               ("binding.html-css", "render"), c "O(entries·pixels)" "O(output)" Derived
               ("sim.wave-interference", "pattern"), c "O(w·h·sources)" "O(w·h)" Derived
               ("viz.adinkra", "render"), c "O(nodes)" "O(nodes)" Derived

--- a/src/Core/GeneratorRegistry.fs
+++ b/src/Core/GeneratorRegistry.fs
@@ -94,6 +94,7 @@ module GeneratorRegistry =
           register "test.loop" 1
           register "shape.softvalue" 1
           register "shape.dynamicvalue" 1
+          register "shape.triboolean" 1
           register "binding.html-css" 1
           register "sim.wave-interference" 1
           register "viz.adinkra" 1

--- a/src/Core/ShapeAcceptance.fs
+++ b/src/Core/ShapeAcceptance.fs
@@ -172,6 +172,22 @@ module ShapeAcceptance =
                 && Braid.isIdentity 2 [ 1; -1 ] // do-undo: the inverse undoes exactly
                 && not (Braid.isIdentity 2 [ 1; 1 ]) // memory at its smallest: sigma^2 != 1
             ok, "sigma != 1; sigma·sigma⁻¹ = 1; sigma² != 1 — the three smallest braid proofs, on the atom"
+        | "shape-triboolean" ->
+            // the resolution law, live: same sampleProgressive as the renderer — partial budget
+            // leaves Unknowns (honesty), full budget leaves ZERO (uncertainty fully reduced).
+            let grid = MediaLines.constIntOr "grid" 8 d
+            let partial = MediaLines.constIntOr "budget-partial" 20 d
+            let full = MediaLines.constIntOr "budget-full" 64 d
+            let curve = [ BoundaryLight.p 1 1; BoundaryLight.p (grid * 2 - 2) (grid * 2 - 2) ]
+            let unknowns budget =
+                BoundaryLight.sampleProgressive BoundaryLight.MiddleOut budget 3.0 0.4 grid grid 2 curve
+                |> Map.toList
+                |> List.filter (fun (_, t) -> t = BoundaryLight.Unknown)
+                |> List.length
+            let atPartial = unknowns partial
+            let atFull = unknowns full
+            (atPartial > 0 && atFull = 0),
+            sprintf "partial budget leaves %d Unknown (must be > 0); full budget leaves %d (must be 0)" atPartial atFull
         | "shape-softvalue" ->
             // the ladder's code laws, run LIVE on PixelLens (the rungs in code):
             // (a) quantize: floor(confidence * levels / 1000) = the declared coarse level;

--- a/src/Core/ShapeRender.fs
+++ b/src/Core/ShapeRender.fs
@@ -227,6 +227,24 @@ module ShapeRender =
                       { Dash = false; Name = name + "-r1"; Mask = mask; Points = [ (ax + (bx - ax) * 3 / 5, ay + (by - ay) * 3 / 5); p1 ] } ]
             diag xL top xR bot (not overLeft) "strand-0" 1uy
             @ diag xR top xL bot overLeft "strand-1" 4uy
+        | "shape-triboolean" ->
+            // two panels, one generator: LEFT = partial budget (dash = Unknown, the unearned
+            // claim), RIGHT = full budget (zero Unknown — the third state gone structurally).
+            // DRAWN = GATED: same sampleProgressive call as the acceptance law.
+            let grid = constInt "grid" 8
+            let partial = constInt "budget-partial" 20
+            let full = constInt "budget-full" 64
+            let curve = [ BoundaryLight.p 1 1; BoundaryLight.p (grid * 2 - 2) (grid * 2 - 2) ] // a diagonal glow source
+            let panel (x0: int) (budget: int) (tag: string) =
+                BoundaryLight.sampleProgressive BoundaryLight.MiddleOut budget 3.0 0.4 grid grid 2 curve
+                |> Map.toList
+                |> List.collect (fun ((gx, gy), tri) ->
+                    let cx, cy = x0 + gx * 3, 6 + gy * 3
+                    match tri with
+                    | BoundaryLight.Lit -> [ { Dash = false; Name = sprintf "%s-lit-%d-%d" tag gx gy; Mask = 2uy; Points = [ pt cx cy; pt (cx + 1) cy ] } ]
+                    | BoundaryLight.Unlit -> [ { Dash = false; Name = sprintf "%s-unlit-%d-%d" tag gx gy; Mask = 1uy; Points = [ pt cx cy; pt cx cy ] } ]
+                    | BoundaryLight.Unknown -> [ { Dash = true; Name = sprintf "%s-unk-%d-%d" tag gx gy; Mask = 4uy; Points = [ pt cx cy; pt (cx + 1) cy ] } ])
+            panel 4 partial "partial" @ panel 36 full "full"
         | "shape-softvalue" ->
             // the ladder: three panels, one value. A value bar per rung; a confidence bar where
             // the rung HAS a channel (rung 1 = none — absent, not zero); the dashed tail is the

--- a/tests/Tests.FSharp/ShapeCartridge.Tests.fs
+++ b/tests/Tests.FSharp/ShapeCartridge.Tests.fs
@@ -57,7 +57,7 @@ let private catalog () =
 [<Fact>]
 let ``THE CATALOG LAW: every cartridge parses, lints clean, resolves its gen on the shelf, and carries its own treaty block`` () =
     let all = catalog ()
-    Assert.Equal(15, Array.length all) // + exchange-worldlines + kitaev-chain + crossing (THE ATOM - the braided family generator)
+    Assert.Equal(16, Array.length all) // + exchange-worldlines + kitaev-chain + crossing (THE ATOM - the braided family generator)
     for name, d in all do
         Assert.True(List.isEmpty (MediaLines.lint d), name + " must lint clean")
         // every gen line's ZetaId resolves to a REGISTERED generator (DI by ZetaId, working)


### PR DESCRIPTION
Wish-list #1: two plane bits, three states, the spare encoding refused; partial budget shows dashed Unknowns, full budget erases them — one sampleProgressive call drawn AND gated. Census: UniversalNumber IS our bigint port (TriFloat = the BigFloat adapter slot); 'knows what it doesn't know' = held trits (exists) + the ball adapter (B-1037: lossy widens, never rounds; compare → Tri.N on overlap). B-1038: chip8/9 auth — keys injected at the door, never in cartridges; Reticulum-native identity; Nazar+Mateo gate before build. 3026 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)