### PR TITLE
docs(backlog): B-1039 — the ben verb: benchmark as easy as measure; grade the registry's O() predictions

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -984,6 +984,7 @@ are closed (status: closed/done in frontmatter)._
 - [ ] **[B-1036](backlog/P2/B-1036-soft-sharp-garbage-collection-chip89-no-garbage-by-construction-lifetimes-weak-refs-raytraced-reachability-history-epochs-aaron-2026-06-11.md)** Soft/sharp GC on chip8/9 — five rungs: no-garbage-by-construction, room-scoped lifetimes, weak refs, RAY-TRACED reachability (shape-gc cartridge), history-epoch reclamation (git gc is the in-house anchor)
 - [ ] **[B-1037](backlog/P2/B-1037-ball-number-adapter-center-radius-behind-universalnumber-lossy-widens-never-rounds-comparisons-return-tri-aaron-2026-06-11.md)** Ball-number adapter — center±radius behind IUniversalNumber; lossy WIDENS never rounds; ball compare returns Tri (N on overlap)
 - [ ] **[B-1038](backlog/P2/B-1038-chip89-crypto-boot-and-workload-identity-keys-injected-at-the-door-never-in-cartridges-reticulum-native-identity-aaron-2026-06-11.md)** chip8/9 boot crypto + workload identity — keys injected at the door, never in cartridges; Reticulum-native identity; Nazar+Mateo gate
+- [ ] **[B-1039](backlog/P2/B-1039-ben-verb-benchmark-as-easy-as-measure-injected-interfaces-timing-memory-live-with-rooms-grade-the-complexity-predictions-aaron-2026-06-11.md)** The ben verb — benchmark as easy as measure (injected, room-inherited, red-lit); GRADE ComplexityRegistry predictions (n/2n/4n growth vs declared O — VIOLATED = a priced bug); chip8 ticks are the exact DST-clean case
 
 ## P3 — convenience / deferred
 

--- a/docs/backlog/P2/B-1039-ben-verb-benchmark-as-easy-as-measure-injected-interfaces-timing-memory-live-with-rooms-grade-the-complexity-predictions-aaron-2026-06-11.md
+++ b/docs/backlog/P2/B-1039-ben-verb-benchmark-as-easy-as-measure-injected-interfaces-timing-memory-live-with-rooms-grade-the-complexity-predictions-aaron-2026-06-11.md
@@ -1,0 +1,47 @@
+---
+id: B-1039
+title: The ben verb — benchmark as easy as measure; timing/memory injected interfaces living with rooms/cartridges; GRADE the ComplexityRegistry's predictions
+priority: P2
+status: open
+tier: verification-substrate
+tags: [benchmark, ben, sim-mea-cut, testloop, complexity, prediction, rooms, chip8, di-verbs, hexagonal]
+created: 2026-06-11
+owner: open (slice 2 of B-1035's framework; pairs with Naledi's bench lane)
+---
+
+# B-1039 — ben(chmark) joins the verb set (Aaron 2026-06-11, verbatim spine)
+
+> "We should make ben(chmark) work as easy as measure — it's just injected: the extra interfaces
+> or whatever we need. Timing tests and memory use and stuff that LIVE WITH the room/cartridges.
+> We should see how good our PREDICTION is around this. For all our stuff — rooms in dotnet and
+> the chip8 emu we have."
+
+## The shape (the quartet, applied)
+
+1. **`ben` is a VERB beside `sim·mea·cut`** — same static-DI wiring (B-1028 style): a room/test
+   that wants metering declares the interface; the FRAMEWORK injects the meter (B-1035's
+   before/after boundary already owns the rim — ben extends it with timing + allocation capture).
+   Rooms inherit; nobody hand-rolls a stopwatch.
+2. **Ambient honesty:** wall-time and GC counters are ambient entropy — they live ONLY at the
+   boundary (the determinism lint's allowlisted-edge pattern; the double-run check ignores ben
+   output by construction: metering never enters the measurement equality).
+3. **The RED LIGHT on the meter:** a ben-bound room SHOWS it (`[REC ●] ben LIVE …`) — being timed
+   is being observed; consent surface, same law as every io binding.
+4. **THE PREDICTION GRADE (the new jewel):** ComplexityRegistry already DECLARES O(time)/O(space)
+   per (artifact, op) — those are PREDICTIONS. ben runs the artifact at n, 2n, 4n; the growth
+   ratios infer the empirical class; compare to the declared class → a per-artifact verdict:
+   CONFIRMED / TIGHTER-THAN-DECLARED / **VIOLATED** (a violation = a priced bug: the WHY lied,
+   same class as the spiral's court escape). The shelf-wide lint gains a brother: every Derived
+   cost can graduate to MEASURED.
+5. **Hexagonal seniors:** BenchmarkDotNet (.NET's senior bench oracle) as adapter B behind OUR
+   port for the dotnet rooms (theirs calibrates ours' timer); the chip8 emu side needs no wall
+   clock at all — its native meter is TICKS + Frame-map sizes (deterministic benchmarking:
+   instruction counts are exact, replayable, DST-clean — the emu is the EASY case).
+6. **Lives with the cartridge:** a `ben` line kind (budget + the declared class to grade against)
+   so a cartridge ships its own performance expectations — and the gate can refuse a cartridge
+   whose measured class violates its declared one.
+
+Beacon: BenchmarkDotNet; Hoefler & Belli (SC '15, benchmarking rigor); our ComplexityRegistry
+(the predictions) + Naledi's measure-before-proposing register. First slice: tick-count ben for
+the chip8 emu (exact, no ambient) + ONE dotnet room through a BenchmarkDotNet-backed adapter +
+the n/2n/4n grader over three registry rows.


### PR DESCRIPTION
ben joins sim·mea·cut as a DI-injected verb on the B-1035 boundary: rooms inherit timing/memory metering (red-lit — being timed is being observed; ambient only at the rim). The jewel: ComplexityRegistry rows are PREDICTIONS — ben runs n/2n/4n and grades them (VIOLATED = a priced bug). chip8 = the exact case (ticks, no wall clock); BenchmarkDotNet = the dotnet senior adapter. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)