### PR TITLE
fix(B-0248.2): macOS compat + tested — 4 cells provisioned on Mac Studio

### DIFF
--- a/tools/setup/host-loop-bootstrap.sh
+++ b/tools/setup/host-loop-bootstrap.sh
@@ -182,10 +182,10 @@ else
 
     # Parse: cell-id harness=X agent=Y interval=N forward=0|1
     CELL_ID=$(echo "$line" | awk '{print $1}')
-    HARNESS=$(echo "$line" | grep -oP 'harness=\K[^ ]+')
-    AGENT=$(echo "$line" | grep -oP 'agent=\K[^ ]+')
-    INTERVAL=$(echo "$line" | grep -oP 'interval=\K[^ ]+')
-    FORWARD=$(echo "$line" | grep -oP 'forward=\K[^ ]+')
+    HARNESS=$(echo "$line" | sed -n 's/.*harness=\([^ ]*\).*/\1/p')
+    AGENT=$(echo "$line" | sed -n 's/.*agent=\([^ ]*\).*/\1/p')
+    INTERVAL=$(echo "$line" | sed -n 's/.*interval=\([^ ]*\).*/\1/p')
+    FORWARD=$(echo "$line" | sed -n 's/.*forward=\([^ ]*\).*/\1/p')
 
     if [[ -n "$CELL_ID" && -n "$AGENT" ]]; then
       provision_cell "$CELL_ID" "${HARNESS:-auto}" "$AGENT" "${INTERVAL:-60}" "${FORWARD:-1}"

--- a/tools/setup/install.sh
+++ b/tools/setup/install.sh
@@ -243,6 +243,23 @@ WINEOF
 esac
 
 echo
+
+# --- Provision agent loop cells (B-0248.2) ---
+# After deps are installed, provision the 4 system cells from the
+# cluster-cells manifest. Runs on every install/update — idempotent
+# (cells that already exist get updated, new cells get created).
+# Skip on CI (no launchd) and skip if ZETA_SKIP_CELLS=1.
+if [ "${CI:-}" != "true" ] && [ "${ZETA_SKIP_CELLS:-0}" != "1" ]; then
+  if [ -f "$SETUP_DIR/host-loop-bootstrap.sh" ]; then
+    echo ""
+    echo "=== Provisioning agent loop cells (B-0248.2) ==="
+    bash "$SETUP_DIR/host-loop-bootstrap.sh" --skip-health-check || {
+      echo "Warning: cell provisioning failed (non-fatal). Cells can be"
+      echo "provisioned manually: bash tools/setup/host-loop-bootstrap.sh"
+    }
+  fi
+fi
+
 echo "=== Install complete ==="
 echo "If this is your first run, open a new shell or source"
 echo "\$HOME/.config/zeta/shellenv.sh to pick up PATH changes."


### PR DESCRIPTION
Fixes grep -P (Linux-only) with sed for macOS. Tested end-to-end: install.sh -> host-loop-bootstrap.sh -> reads cluster-cells manifest -> 4 cells (otto/vera/lior/alexa) provisioned and running via launchctl.