### PR TITLE
feat(ben): B-1039 slice 1 — exact chip8 tick meter + the prediction grader (two registry rows graded CONFIRMED)

### DIFF
--- a/docs/backlog/P2/B-1039-ben-verb-benchmark-as-easy-as-measure-injected-interfaces-timing-memory-live-with-rooms-grade-the-complexity-predictions-aaron-2026-06-11.md
+++ b/docs/backlog/P2/B-1039-ben-verb-benchmark-as-easy-as-measure-injected-interfaces-timing-memory-live-with-rooms-grade-the-complexity-predictions-aaron-2026-06-11.md
@@ -2,7 +2,7 @@
 id: B-1039
 title: The ben verb — benchmark as easy as measure; timing/memory injected interfaces living with rooms/cartridges; GRADE the ComplexityRegistry's predictions
 priority: P2
-status: open
+status: in-progress
 tier: verification-substrate
 tags: [benchmark, ben, sim-mea-cut, testloop, complexity, prediction, rooms, chip8, di-verbs, hexagonal]
 created: 2026-06-11
@@ -45,3 +45,5 @@ Beacon: BenchmarkDotNet; Hoefler & Belli (SC '15, benchmarking rigor); our Compl
 (the predictions) + Naledi's measure-before-proposing register. First slice: tick-count ben for
 the chip8 emu (exact, no ambient) + ONE dotnet room through a BenchmarkDotNet-backed adapter +
 the n/2n/4n grader over three registry rows.
+
+## Progress (slice 1, 2026-06-11): Ben.fs SHIPS — the exact chip8 tick meter (Steps/MemEntries/DisplayLit/Extra/StackDepth/Faulted, deterministic) + the GRADER (infer doubling-ratio growth class; grade = Confirmed/Tighter/Violated). Two REAL predictions graded CONFIRMED with exact cost proxies (treemap tiles = O(children); IBLT build work = n·k via the table's own count sum); falsifiers prove Violated/Tighter/refusal. Dogfooded through ITestLoop. Remaining: dotnet wall/alloc meters behind the boundary + red light; BenchmarkDotNet senior adapter; the cartridge `ben` line kind + gate refusal.

--- a/src/Core/Ben.fs
+++ b/src/Core/Ben.fs
@@ -1,0 +1,78 @@
+namespace Zeta.Core
+
+/// Ben — **the ben verb, slice 1: exact meters + the prediction grader** (B-1039; Aaron: "make
+/// ben(chmark) as easy as measure… see how good our PREDICTION is"). This slice carries only
+/// what is EXACT and DST-clean — no wall clock, no GC counters (those are the dotnet-room slice,
+/// behind the boundary with the red light). The chip8 emu is the easy case on purpose: tick
+/// counts and Frame-map sizes are deterministic, replayable, byte-stable.
+///
+/// THE GRADER closes the loop the ComplexityRegistry opened: every declared O(…) row is a
+/// PREDICTION; feed `infer` cost samples at doubling sizes (n, 2n, 4n, …) and it names the
+/// empirical growth class; `grade` compares prediction to measurement:
+///   CONFIRMED (measured = declared) · TIGHTER (measured grows slower — the WHY undersold) ·
+///   VIOLATED (measured grows faster — the WHY lied: a priced bug, the spiral-escape class).
+[<RequireQualifiedAccess>]
+module Ben =
+
+    /// The exact chip8 meter — every field deterministic from (seed, rom, steps).
+    type Chip8Meter =
+        { Steps: int
+          MemEntries: int
+          DisplayLit: int
+          ExtraEntries: int
+          StackDepth: int
+          Faulted: bool }
+
+    /// Run `steps` ticks and meter the result — the emu's native benchmark (ticks, not seconds).
+    let chip8Ticks (steps: int) (f0: Chip8Cow.Frame) : Chip8Meter =
+        let final = [ 1 .. max 0 steps ] |> List.fold (fun f _ -> Chip8Cow.step f) f0
+        { Steps = max 0 steps
+          MemEntries = Map.count final.Mem
+          DisplayLit = final.Display |> Map.filter (fun _ v -> v) |> Map.count
+          ExtraEntries = Map.count final.Extra
+          StackDepth = List.length final.Stack
+          Faulted = final.Fault.IsSome }
+
+    /// The growth classes the grader can name (slice 1: the doubling-ratio set).
+    type Growth =
+        | Constant
+        | Linear
+        | Quadratic
+        | Superquadratic
+
+    /// Infer the growth class from cost samples at DOUBLING sizes [(n,c); (2n,c'); (4n,c'')…]:
+    /// classify the mean doubling ratio against 1 / 2 / 4 (nearest wins; >6 ⇒ Superquadratic).
+    /// Needs ≥ 2 samples; degenerate inputs return None (refusal, not a guess).
+    let infer (samples: (int * int64) list) : Growth option =
+        match samples with
+        | (_, c0) :: _ when c0 > 0L && List.length samples >= 2 ->
+            let ratios =
+                samples
+                |> List.pairwise
+                |> List.map (fun ((_, a), (_, b)) -> float b / float a)
+            let mean = List.average ratios
+            if mean > 6.0 then Some Superquadratic
+            elif abs (mean - 4.0) < 1.0 then Some Quadratic
+            elif abs (mean - 2.0) < 0.7 then Some Linear
+            elif abs (mean - 1.0) < 0.35 then Some Constant
+            else Some Superquadratic
+        | _ -> None
+
+    /// The verdict on one prediction.
+    type Grade =
+        | Confirmed
+        | Tighter // measured grows SLOWER than declared — the WHY undersold; update it
+        | Violated // measured grows FASTER than declared — the WHY lied; a priced bug
+
+    let private rank =
+        function
+        | Constant -> 0
+        | Linear -> 1
+        | Quadratic -> 2
+        | Superquadratic -> 3
+
+    /// Compare the declared class (the ComplexityRegistry's prediction) to the measured one.
+    let grade (declared: Growth) (measured: Growth) : Grade =
+        if rank measured = rank declared then Confirmed
+        elif rank measured < rank declared then Tighter
+        else Violated

--- a/src/Core/ComplexityRegistry.fs
+++ b/src/Core/ComplexityRegistry.fs
@@ -101,6 +101,8 @@ module ComplexityRegistry =
               ("sketch.iblt", "build"), c "O(n·k)" "O(cells)" Derived // n keys, k buckets each; cells sized to the DIFFERENCE, not the set
               ("sketch.iblt", "reconcile"), c "O(|Δ|·k)" "O(cells)" Derived // subtract is O(cells); peeling touches each difference key k times — the whole point
               ("test.loop", "run"), c "O(2·sim+mea + cut)" "O(world)" Derived // the double-run determinism check is the 2x — the boundary, priced honestly
+              ("test.ben", "chip8Ticks"), c "O(steps)" "O(frame)" Derived // the exact meter: one fold over ticks
+              ("test.ben", "grade"), c "O(samples)" "O(1)" Derived // ratio classification — the grader itself is cheap; the RUNS dominate
               ("shape.softvalue", "draw"), c "O(rungs·bar)" "O(rungs)" Derived // three panels, two bars each at most; the dashed tail is the uncertainty, not extra cost
               ("shape.dynamicvalue", "draw"), c "O(children)" "O(children)" Derived // one treemap pass + one rectangle per child
               ("shape.triboolean", "draw"), c "O(grid²)" "O(grid²)" Derived // two panels of an 8x8 progressive sample; middle-out order is a sort, dominated by the sample

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -227,6 +227,7 @@
     <Compile Include="ZetaMax.fs" />
     <Compile Include="Chip9Phys.fs" />
     <Compile Include="TestLoop.fs" />
+    <Compile Include="Ben.fs" />
     <Compile Include="WSet.fs" />
     <Compile Include="IbltReconcile.fs" />
     <Compile Include="InferenceLadder.fs" />

--- a/src/Core/GeneratorRegistry.fs
+++ b/src/Core/GeneratorRegistry.fs
@@ -95,6 +95,7 @@ module GeneratorRegistry =
           register "shape.softvalue" 1
           register "shape.dynamicvalue" 1
           register "shape.triboolean" 1
+          register "test.ben" 1
           register "binding.html-css" 1
           register "sim.wave-interference" 1
           register "viz.adinkra" 1

--- a/tests/Tests.FSharp/Ben.Tests.fs
+++ b/tests/Tests.FSharp/Ben.Tests.fs
@@ -1,0 +1,57 @@
+module Zeta.Tests.BenTests
+
+// B-1039 slice 1: the exact meters + THE PREDICTION GRADER — dogfooded through ITestLoop (the
+// double-run check proves every meter deterministic for free; ben output never enters mea
+// equality because here ben output IS the measurement, exactly and replayably).
+
+open global.Xunit
+open Zeta.Core
+
+let private host (loop: ITestLoop<'w, 'm>) =
+    let v = TestLoop.run loop
+    Assert.True(v.Passed, sprintf "%s — %s [%s]" v.Name (defaultArg v.Failure "?") v.Replay)
+
+[<Fact>]
+let ``BEN METER (chip8 ticks): exact, replayable, fault-aware — through the TestLoop boundary`` () =
+    host (
+        TestLoop.make "ben: chip8 tick meter is exact" 7UL
+            (fun seed ->
+                Chip8Cow.create seed
+                |> Chip8Cow.loadRom [| 0x60uy; 0x05uy; 0x61uy; 0x03uy; 0xA3uy; 0x00uy; 0xD0uy; 0x11uy; 0x12uy; 0x08uy |]
+                |> fun f -> { f with Mem = Map.add 0x300 0xF0uy f.Mem })
+            (fun f0 -> Ben.chip8Ticks 20 f0)
+            (fun m ->
+                if m.Steps <> 20 then Error "step count drifted"
+                elif m.DisplayLit <> 4 then Error(sprintf "expected the 4-pixel sprite row lit; got %d" m.DisplayLit)
+                elif m.Faulted then Error "healthy rom reported a fault"
+                else Ok()))
+
+[<Fact>]
+let ``THE GRADER confirms a TRUE prediction: treemap tile count is O(children) — measured linear, declared linear`` () =
+    // the registry's ("shape.dynamicvalue","draw") O(children) prediction, graded with EXACT costs
+    let cost n =
+        LayoutEngine.treemap 0 0 6000 10 true [ for i in 1 .. n -> string i, 1 ]
+        |> List.length |> int64
+    let samples = [ 8, cost 8; 16, cost 16; 32, cost 32 ]
+    Assert.Equal(Some Ben.Linear, Ben.infer samples)
+    Assert.Equal(Ben.Confirmed, Ben.grade Ben.Linear (Ben.infer samples).Value)
+
+[<Fact>]
+let ``THE GRADER confirms IBLT build work is O(n·k): the table's total count IS the exact work done`` () =
+    // ("sketch.iblt","build") O(n·k): sum of |Count| after build = n·k bucket updates, exactly
+    let work n =
+        let t = IbltReconcile.build 4096 3 (Seq.map uint64 (seq { 1 .. n }))
+        t.Cells |> Array.sumBy (fun c -> int64 (abs c.Count))
+    let samples = [ 100, work 100; 200, work 200; 400, work 400 ]
+    Assert.Equal(300L, work 100) // n·k exactly — the proxy is the work, not an estimate
+    Assert.Equal(Some Ben.Linear, Ben.infer samples)
+    Assert.Equal(Ben.Confirmed, Ben.grade Ben.Linear (Ben.infer samples).Value)
+
+[<Fact>]
+let ``THE GRADER'S FALSIFIERS: quadratic growth against a linear claim is VIOLATED; slower growth is TIGHTER; garbage refuses`` () =
+    let quadratic = [ 10, 100L; 20, 400L; 40, 1600L ]
+    Assert.Equal(Some Ben.Quadratic, Ben.infer quadratic)
+    Assert.Equal(Ben.Violated, Ben.grade Ben.Linear Ben.Quadratic) // the WHY lied — a priced bug
+    Assert.Equal(Ben.Tighter, Ben.grade Ben.Quadratic Ben.Linear) // undersold — update the WHY
+    Assert.Equal(Some Ben.Constant, Ben.infer [ 10, 50L; 20, 50L; 40, 50L ])
+    Assert.Equal(None, Ben.infer [ 10, 0L ]) // degenerate input: refusal, never a guess

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -183,6 +183,7 @@
     <Compile Include="WSet.MachZehnder.Tests.fs" />
     <Compile Include="IbltReconcile.Tests.fs" />
     <Compile Include="TestLoop.Host.fs" />
+    <Compile Include="Ben.Tests.fs" />
     <Compile Include="WaveSim.Tests.fs" />
     <Compile Include="AdinkraViz.Tests.fs" />
     <Compile Include="SpectralPivot.Tests.fs" />


### PR DESCRIPTION
Ben.chip8Ticks: the emu's native benchmark — ticks not seconds, every field deterministic. The grader: doubling-ratio growth inference + Confirmed/Tighter/Violated against the registry's declared O() predictions. First real grades both CONFIRMED with exact work proxies (treemap tiles = O(children); IBLT build work = n·k exactly via the table's own count sum). Falsifiers included; dogfooded through ITestLoop. Suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)