### PR TITLE
chore(backlog): backfill zetaid on 13 rows (B-1022..B-1036)

### DIFF
--- a/docs/backlog/P2/B-1022-fuse-four-corner-harmonic-kleisli-arrow-plus-fourcornerownership-tools-to-src-port-aaron-2026-06-10.md
+++ b/docs/backlog/P2/B-1022-fuse-four-corner-harmonic-kleisli-arrow-plus-fourcornerownership-tools-to-src-port-aaron-2026-06-10.md
@@ -1,5 +1,6 @@
 ---
 id: B-1022
+zetaid: 081KTQD8A0008QG0R0005EFYPV
 title: Fuse the arrow/four-corner/feedback/scheduler fragments into one four-corner harmonic Kleisli arrow; graduate FourCornerOwnership tools→src + port TS→F#/C#/Rust
 priority: P2
 status: executed-per-rodney-razor (2026-06-10; residual items deferred-with-reasons below)

--- a/docs/backlog/P2/B-1023-root-declutter-for-dx-max-db-folder-grouping-plus-max-adopts-interfaces-rx-verbs-2026-06-10.md
+++ b/docs/backlog/P2/B-1023-root-declutter-for-dx-max-db-folder-grouping-plus-max-adopts-interfaces-rx-verbs-2026-06-10.md
@@ -1,5 +1,6 @@
 ---
 id: B-1023
+zetaid: 081KTQD8A0008QG0R0030HWMZV
 title: Root declutter for DX — Max finds the repo root intimidating; group into folders (e.g. db/) without breaking load-bearing paths
 priority: P2
 status: open

--- a/docs/backlog/P2/B-1024-speak-to-tv-plus-own-microkernel-iso-boot-qemu-tested-raspberry-pi-self-contained-hardware-capability-matrix-friction-heat-visible-aaron-2026-06-11.md
+++ b/docs/backlog/P2/B-1024-speak-to-tv-plus-own-microkernel-iso-boot-qemu-tested-raspberry-pi-self-contained-hardware-capability-matrix-friction-heat-visible-aaron-2026-06-11.md
@@ -1,5 +1,6 @@
 ---
 id: B-1024
+zetaid: 081KTSZN10008QG0R00349SM6P
 title: Speak-to-the-TV + own microkernel/ISO boot, QEMU-tested, Raspberry Pi self-contained, hardware capability matrix with visible friction/heat
 priority: P2
 status: open

--- a/docs/backlog/P2/B-1025-universal-action-grammar-plus-reversible-risc-isa-generate-microkernel-to-mips-riscv-fpga-verilog-shaders-pi-first-artisanal-then-room-aaron-2026-06-11.md
+++ b/docs/backlog/P2/B-1025-universal-action-grammar-plus-reversible-risc-isa-generate-microkernel-to-mips-riscv-fpga-verilog-shaders-pi-first-artisanal-then-room-aaron-2026-06-11.md
@@ -1,5 +1,6 @@
 ---
 id: B-1025
+zetaid: 081KTSZN10008QG0R000VZHRQ4
 title: Universal action grammar + reversible RISC-like ISA — generate the microkernel to any hardware (Pi first artisanal, then automate into a room)
 priority: P2
 status: open

--- a/docs/backlog/P2/B-1026-the-swarm-board-see-swarm-friction-heat-heatmap-zork-navigate-join-conference-remotely-citizenship-right-even-chip8s-aaron-2026-06-11.md
+++ b/docs/backlog/P2/B-1026-the-swarm-board-see-swarm-friction-heat-heatmap-zork-navigate-join-conference-remotely-citizenship-right-even-chip8s-aaron-2026-06-11.md
@@ -1,5 +1,6 @@
 ---
 id: B-1026
+zetaid: 081KTSZN10008QG0R0003SDRWD
 title: The swarm board — sit down, see the swarm + friction/heat heatmap, Zork-navigate, join/conference rooms remotely; a citizenship right (even CHIP-8s)
 priority: P2
 status: open

--- a/docs/backlog/P2/B-1027-craft-verb-precision-bob-weave-tie-twist-braid-textile-warp-weft-jacquard-braid-relations-test-salon-textile-craft-schools-aaron-2026-06-11.md
+++ b/docs/backlog/P2/B-1027-craft-verb-precision-bob-weave-tie-twist-braid-textile-warp-weft-jacquard-braid-relations-test-salon-textile-craft-schools-aaron-2026-06-11.md
@@ -1,5 +1,6 @@
 ---
 id: B-1027
+zetaid: 081KTSZN10008QG0R001BW91GT
 title: Craft-verb precision (bob/weave/tie/twist/braid) + the textile frame (warp/weft/loom/selvage) — ratify the registry, test the braid relations
 priority: P2
 status: open

--- a/docs/backlog/P2/B-1028-mips-emulator-treaty-room-like-chip8-maxs-machine-hennessy-lineage-aaron-2026-06-11.md
+++ b/docs/backlog/P2/B-1028-mips-emulator-treaty-room-like-chip8-maxs-machine-hennessy-lineage-aaron-2026-06-11.md
@@ -1,5 +1,6 @@
 ---
 id: B-1028
+zetaid: 081KTSZN10008QG0R001BCCTXT
 title: MIPS emulator as a treaty room — like our CHIP-8, for Max (Hennessy lineage; the B-1025 fan-out's second machine)
 priority: P2
 status: open

--- a/docs/backlog/P2/B-1029-quirk-craft-school-toy-layer-and-quantum-circuit-ts-second-oracle-with-qsharp-export-lior-owner-aaron-2026-06-12.md
+++ b/docs/backlog/P2/B-1029-quirk-craft-school-toy-layer-and-quantum-circuit-ts-second-oracle-with-qsharp-export-lior-owner-aaron-2026-06-12.md
@@ -1,5 +1,6 @@
 ---
 id: B-1029
+zetaid: 081KTWJ1R0008QG0R001ZBWKTR
 title: The TS quantum lane — quantum-circuit as second oracle (Q# export, the three Vera jobs) + Quirk as the craft-school toy layer
 priority: P2
 status: open

--- a/docs/backlog/P2/B-1031-drw-clip-vs-wrap-cosmac-vip-correct-edge-semantics-four-oracle-coordinated-golden-regen-aaron-2026-06-13.md
+++ b/docs/backlog/P2/B-1031-drw-clip-vs-wrap-cosmac-vip-correct-edge-semantics-four-oracle-coordinated-golden-regen-aaron-2026-06-13.md
@@ -1,5 +1,6 @@
 ---
 id: B-1031
+zetaid: 081KTZ4EF0008QG0R002WVTMMJ
 title: DRW edge semantics — clip (COSMAC VIP correct) not wrap; a coordinated four-oracle golden change
 priority: P2
 status: done

--- a/docs/backlog/P2/B-1032-wset-ring-generic-circuit-three-rings-one-calculus-dbsp-quantum-inference-gdl-anchor-aaron-2026-06-13.md
+++ b/docs/backlog/P2/B-1032-wset-ring-generic-circuit-three-rings-one-calculus-dbsp-quantum-inference-gdl-anchor-aaron-2026-06-13.md
@@ -1,5 +1,6 @@
 ---
 id: B-1032
+zetaid: 081KTZ4EF0008QG0R001R3XPYV
 title: WSet<'K,'W> — the ring-generic circuit; three rings, one calculus (DBSP ℤ · quantum ℂ · inference ℝ≥0), GDL-anchored
 priority: P2
 status: done

--- a/docs/backlog/P2/B-1033-hexagonal-inference-port-own-the-interface-zeta-bayesian-and-infer-net-as-adapters-plugin-system-convergence-aaron-2026-06-13.md
+++ b/docs/backlog/P2/B-1033-hexagonal-inference-port-own-the-interface-zeta-bayesian-and-infer-net-as-adapters-plugin-system-convergence-aaron-2026-06-13.md
@@ -1,5 +1,6 @@
 ---
 id: B-1033
+zetaid: 081KTZ4EF0008QG0R000WJGSWX
 title: Hexagonal inference port — own the interface; Zeta.Bayesian + Infer.NET as the two adapters (theirs tests ours); plugin-system convergence audit
 priority: P2
 status: done

--- a/docs/backlog/P2/B-1034-research-paper-the-oracle-stack-mutual-oracles-honesty-registers-experience-report-aaron-2026-06-13.md
+++ b/docs/backlog/P2/B-1034-research-paper-the-oracle-stack-mutual-oracles-honesty-registers-experience-report-aaron-2026-06-13.md
@@ -1,5 +1,6 @@
 ---
 id: B-1034
+zetaid: 081KTZ4EF0008QG0R0035FW7HY
 title: "Research paper: The Oracle Stack — mutual oracles, honesty registers, and refutation witnesses in an autonomous software factory (experience report)"
 priority: P2
 status: open

--- a/docs/backlog/P2/B-1035-sim-mea-cut-test-framework-own-interfaces-xunit-as-adapter-before-after-boundary-enforced-once-aaron-2026-06-11.md
+++ b/docs/backlog/P2/B-1035-sim-mea-cut-test-framework-own-interfaces-xunit-as-adapter-before-after-boundary-enforced-once-aaron-2026-06-11.md
@@ -1,5 +1,6 @@
 ---
 id: B-1035
+zetaid: 081KTSZN10008QG0R002J0GE0Z
 title: The sim·mea·cut test framework — our own hexagonal test interfaces; xUnit demoted to host adapter; before/after boundary enforced ONCE (rooms inherit)
 priority: P2
 status: open


### PR DESCRIPTION
Adds deterministic 128-bit ZetaId to the last 13 rows missing it. All 1130 backlog rows now have zetaid (100% coverage). Agents can address work-items by ZetaId uniformly.