### PR TITLE
feat(setup): cross-platform dotnet diagnostics suite in the install manifest (trace/counters/gcdump/dump/stack)

### DIFF
--- a/tools/setup/manifests/dotnet-tools
+++ b/tools/setup/manifests/dotnet-tools
@@ -12,3 +12,14 @@ dotnet-stryker
 # contributor without a separate install step. Bodhi round-34
 # DX audit flagged the tooling-gap.
 fsharp-analyzers
+# The cross-platform diagnostics suite (Aaron 2026-06-11: "the dotnet CLI perf commands are
+# cross-platform and pretty good — we should use those; it's dotnet tools you install").
+# EventPipe-based, works on macOS/Linux/Windows — the statistical/offline lane beside Ben's
+# deterministic meters (B-1039/B-1040): trace = CPU/event capture (opens in PerfView or
+# SpeedScope), counters = live metrics, gcdump = heap snapshots, dump = post-mortem,
+# stack = quick stack prints.
+dotnet-trace
+dotnet-counters
+dotnet-gcdump
+dotnet-dump
+dotnet-stack


### PR DESCRIPTION
Aaron's call, landed in the lane that already existed: tools/setup/manifests/dotnet-tools + the idempotent installer. EventPipe-based, macOS/Linux/Windows — the statistical/offline profiling lane beside Ben's deterministic meters. Dejan's review welcome (his surface, additive change). Docs+manifest only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)