### PR TITLE
feat(setup): the dotnet WORKLOADS lane (recovered — raced #7838's squash)

### DIFF
--- a/tools/setup/common/dotnet-workloads.sh
+++ b/tools/setup/common/dotnet-workloads.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# tools/setup/common/dotnet-workloads.sh — installs dotnet WORKLOADS from
+# manifests/dotnet-workloads and brings installed ones to latest. Sibling of
+# dotnet-tools.sh; same idempotent shape. SDK selection itself stays declarative
+# in global.json (rollForward: latestFeature).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+MANIFEST="$REPO_ROOT/tools/setup/manifests/dotnet-workloads"
+
+if ! command -v dotnet >/dev/null 2>&1; then
+  echo "error: dotnet not on PATH (mise should have put it there)"
+  exit 1
+fi
+
+if [ -f "$MANIFEST" ]; then
+  grep -vE '^(#|$)' "$MANIFEST" | while IFS= read -r workload; do
+    workload="$(echo "$workload" | awk '{print $1}')"
+    [ -z "$workload" ] && continue
+    echo "↓ dotnet workload install $workload..."
+    dotnet workload install "$workload" --skip-sign-check 2>/dev/null \
+      || dotnet workload install "$workload"
+  done
+fi
+
+# Bring whatever is installed up to the SDK's matching versions (no-op when none).
+echo "↻ dotnet workload update..."
+dotnet workload update >/dev/null 2>&1 || echo "  (workload update skipped: $?)"
+echo "✓ dotnet workloads in sync"

--- a/tools/setup/linux.sh
+++ b/tools/setup/linux.sh
@@ -220,6 +220,7 @@ export PATH="$HOME/.dotnet/tools:$PATH"
 
 "$SETUP_DIR/common/elan.sh"
 "$SETUP_DIR/common/dotnet-tools.sh"
+"$SETUP_DIR/common/dotnet-workloads.sh"
 "$SETUP_DIR/common/verifiers.sh"
 # TLAPS (tlapm, TLA+ proof manager) — opam source-build (no arm64 upstream
 # binary; Aaron path-A). Heavy OCaml build → gated behind ZETA_INSTALL_FULL

--- a/tools/setup/macos.sh
+++ b/tools/setup/macos.sh
@@ -152,6 +152,7 @@ export PATH="$HOME/.dotnet/tools:$PATH"
 
 "$SETUP_DIR/common/elan.sh"
 "$SETUP_DIR/common/dotnet-tools.sh"
+"$SETUP_DIR/common/dotnet-workloads.sh"
 "$SETUP_DIR/common/verifiers.sh"
 # TLAPS (tlapm, TLA+ proof manager) — opam source-build (no arm64 upstream
 # binary; Aaron path-A). Heavy OCaml build → gated behind ZETA_INSTALL_FULL

--- a/tools/setup/manifests/dotnet-workloads
+++ b/tools/setup/manifests/dotnet-workloads
@@ -1,0 +1,7 @@
+# dotnet WORKLOADS — installed/updated by tools/setup/common/dotnet-workloads.sh (Aaron
+# 2026-06-11: "we might have to install workloads — make sure install.sh and our declarative
+# stuff has that"). Format: one workload id per line; comments start with `#`.
+#
+# Deliberately EMPTY today: no project in-tree needs a workload yet (wasm-tools / aspire /
+# maui land here the day one does — declare, don't speculate). The installer still runs
+# `dotnet workload update` so anything already installed tracks the SDK.


### PR DESCRIPTION
The workloads commit raced #7838's auto-merge and missed the squash; cherry-picked clean onto main. manifests/dotnet-workloads (deliberately empty — declare, don't speculate) + dotnet-workloads.sh (install listed + workload update), wired after dotnet-tools in macos/linux. Dejan's surface, additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)