### PR TITLE
fix(zflash): B-0891 acceptance proof — boot zflash USB + retention markers

### DIFF
--- a/tools/ci/qemu-boot-test.ts
+++ b/tools/ci/qemu-boot-test.ts
@@ -17,6 +17,7 @@
  *
  * Usage:
  *   bun tools/ci/qemu-boot-test.ts <iso-path>
+ *   bun tools/ci/qemu-boot-test.ts --usb-image <zflash-raw.img>
  *
  * Exit codes:
  *   0 — boot succeeded (login prompt observed within timeout)
@@ -49,8 +50,14 @@ interface BootResult {
 
 type Arch = "x86_64" | "aarch64";
 
+interface BootMedia {
+  readonly kind: "iso" | "usb-image";
+  readonly path: string;
+}
+
 function usage(): never {
   console.error("usage: bun tools/ci/qemu-boot-test.ts <iso-path> [--arch x86_64|aarch64]");
+  console.error("       bun tools/ci/qemu-boot-test.ts --usb-image <zflash-raw.img> [--arch x86_64|aarch64]");
   process.exit(2);
 }
 
@@ -82,10 +89,13 @@ function checkDependencies(arch: Arch): string | null {
   return null;
 }
 
-function buildQemuArgs(arch: Arch, isoPath: string, serialLogPath: string): string[] {
+function buildQemuArgs(arch: Arch, bootMedia: BootMedia, serialLogPath: string): string[] {
   const kvm = existsSync(KVM_PATH);
 
   if (arch === "aarch64") {
+    if (bootMedia.kind === "usb-image") {
+      throw new Error("aarch64 --usb-image boot is not supported yet");
+    }
     // -machine virt + EDK2 UEFI; the PL011 serial (ttyAMA0 — matched by
     // the installer's console= kernel param) lands in the serial log.
     const efi = AARCH64_EFI_CANDIDATES.find((f) => existsSync(f))!;
@@ -94,7 +104,7 @@ function buildQemuArgs(arch: Arch, isoPath: string, serialLogPath: string): stri
       "-m", String(MEMORY_MB),
       "-smp", "2",
       "-bios", efi,
-      "-cdrom", isoPath,
+      "-cdrom", bootMedia.path,
       "-boot", "d",
       "-serial", `file:${serialLogPath}`,
       "-display", "none",
@@ -121,14 +131,25 @@ function buildQemuArgs(arch: Arch, isoPath: string, serialLogPath: string): stri
     "-machine", "q35",
     "-m", String(MEMORY_MB),
     "-smp", "2",
-    "-cdrom", isoPath,
-    "-boot", "d",
     "-serial", `file:${serialLogPath}`,
     "-display", "none",
     "-no-reboot",
     // BIOS instead of UEFI — simpler boot path; ISO supports both but
     // BIOS requires no extra firmware package.
   ];
+
+  if (bootMedia.kind === "usb-image") {
+    args.push(
+      "-drive",
+      `file=${bootMedia.path},if=none,format=raw,readonly=on,id=zflashboot`,
+      "-device",
+      "qemu-xhci,id=xhci",
+      "-device",
+      "usb-storage,bus=xhci.0,drive=zflashboot,bootindex=1",
+    );
+  } else {
+    args.push("-cdrom", bootMedia.path, "-boot", "d");
+  }
 
   // KVM acceleration when /dev/kvm is available (GitHub Actions
   // ubuntu-24.04 supports nested KVM). Falls back to TCG (slow but
@@ -197,6 +218,20 @@ async function waitForLoginPrompt(
   };
 }
 
+function parseBootMedia(argv: string[]): BootMedia | null {
+  const usbFlag = argv.indexOf("--usb-image");
+  if (usbFlag >= 0) {
+    const path = argv[usbFlag + 1];
+    if (!path) return null;
+    argv.splice(usbFlag, 2);
+    return { kind: "usb-image", path };
+  }
+  const [isoPath] = argv;
+  if (!isoPath) return null;
+  argv.shift();
+  return { kind: "iso", path: isoPath };
+}
+
 async function main(): Promise<never> {
   const argv = process.argv.slice(2);
   const archFlag = argv.indexOf("--arch");
@@ -207,11 +242,11 @@ async function main(): Promise<never> {
     arch = v;
     argv.splice(archFlag, 2);
   }
-  const [isoPath] = argv;
-  if (!isoPath) usage();
+  const bootMedia = parseBootMedia(argv);
+  if (!bootMedia) usage();
 
-  if (!existsSync(isoPath)) {
-    console.error(`[qemu-boot-test] ISO not found: ${isoPath}`);
+  if (!existsSync(bootMedia.path)) {
+    console.error(`[qemu-boot-test] boot media not found: ${bootMedia.path}`);
     process.exit(2);
   }
 
@@ -226,13 +261,19 @@ async function main(): Promise<never> {
 
   const timeoutSeconds = timeoutSecondsFor(arch);
 
-  console.log(`[qemu-boot-test] ISO: ${isoPath}`);
+  console.log(`[qemu-boot-test] Boot media: ${bootMedia.kind} ${bootMedia.path}`);
   console.log(`[qemu-boot-test] Serial log: ${serialLogPath}`);
   console.log(`[qemu-boot-test] Memory: ${MEMORY_MB}MB; timeout: ${timeoutSeconds}s`);
   console.log(`[qemu-boot-test] Expecting login prompt: "${EXPECTED_LOGIN_PROMPT}"`);
 
   console.log(`[qemu-boot-test] Arch: ${arch}`);
-  const qemuArgs = buildQemuArgs(arch, isoPath, serialLogPath);
+  let qemuArgs: string[];
+  try {
+    qemuArgs = buildQemuArgs(arch, bootMedia, serialLogPath);
+  } catch (error) {
+    console.error(`[qemu-boot-test] ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(2);
+  }
   console.log(`[qemu-boot-test] Launching: ${qemuBinary(arch)} ${qemuArgs.join(" ")}`);
 
   const qemu = spawn(qemuBinary(arch), qemuArgs, {

--- a/tools/zflash/test-harness/README.md
+++ b/tools/zflash/test-harness/README.md
@@ -169,7 +169,7 @@ When a scenario transitions to composes-with-existing:
 
 | Scenario | Where it runs | Notes |
 |---|---|---|
-| 1 initial-format | every `build-ai-cluster-iso` PR | `audit-installer-iso-content` + `zflash-file-backed --test` + `qemu-boot-test` |
+| 1 initial-format | every `build-ai-cluster-iso` PR | `audit-installer-iso-content` + `zflash-file-backed --test` + `qemu-boot-test --usb-image` |
 | 2 boot-cluster-up | push / `workflow_dispatch` on ISO workflow | delegates to `qemu-full-install-test.ts` |
 | 3 retention | `workflow_dispatch` on ISO workflow | `ZFLASH_QEMU_RETENTION_EXECUTE=1`; auto-bakes boot image when ISO exists |
 | 4 path-fork | `workflow_dispatch` on ISO workflow | `ZFLASH_QEMU_PATH_FORK_EXECUTE=1` + bootstrap; fork boots stop on B-0891 markers only (one full install in bootstrap) |

--- a/tools/zflash/test-harness/prepare-boot-image.test.ts
+++ b/tools/zflash/test-harness/prepare-boot-image.test.ts
@@ -6,7 +6,6 @@ import {
   DEFAULT_QEMU_USB_UUID,
   writeTestCredentialBlob,
 } from "./prepare-boot-image";
-import { B0891_RETENTION_USB_SERIAL_MARKERS } from "./serial-markers";
 import { planQcow2SnapshotRetention } from "./qemu-state";
 
 describe("prepare-boot-image", () => {
@@ -22,7 +21,7 @@ describe("prepare-boot-image", () => {
     }
   });
 
-  test("retention plan uses B-0891 USB markers when boot image is supplied", () => {
+  test("retention restart requires installed-OS restore markers even with zflash boot image", () => {
     const planned = planQcow2SnapshotRetention({
       isoPath: "/tmp/installer.iso",
       bootImagePath: "/tmp/zflash-boot.img",
@@ -32,7 +31,7 @@ describe("prepare-boot-image", () => {
     });
     expect("ok" in planned).toBe(true);
     if (!("ok" in planned)) throw new Error("expected plan");
-    for (const marker of B0891_RETENTION_USB_SERIAL_MARKERS) {
+    for (const marker of ["zeta-creds-restore:", "already-present"]) {
       expect(planned.ok.requiredSerialMarkers).toContain(marker);
       expect(planned.ok.restartStopCondition.successMarkers).toContain(marker);
     }

--- a/tools/zflash/test-harness/prepare-boot-image.ts
+++ b/tools/zflash/test-harness/prepare-boot-image.ts
@@ -62,12 +62,12 @@ export function resolveEspOffsetBytesForIso(isoPath: string): number {
 }
 
 export function checkZflashToolchain(): string | null {
-  for (const [bin, installHint] of [
-    ["qemu-img", "qemu-utils"],
-    ["mcopy", "mtools"],
+  for (const [bin, installHint, probeArgs] of [
+    ["qemu-img", "qemu-utils", ["--version"] as const],
+    ["mcopy", "mtools", ["-V"] as const],
   ] as const) {
     try {
-      const result = spawnSync(bin, ["--version"], { encoding: "utf8" });
+      const result = spawnSync(bin, [...probeArgs], { encoding: "utf8" });
       if (result.status !== 0) {
         return `${bin} not usable (exit ${String(result.status)}); install via apt/brew (${installHint})`;
       }

--- a/tools/zflash/test-harness/qemu-state.test.ts
+++ b/tools/zflash/test-harness/qemu-state.test.ts
@@ -134,10 +134,7 @@ describe("B-0891 QEMU state-preservation planner", () => {
       "usb-storage,bus=xhci.0,drive=zflashboot,bootindex=1",
     );
     expect(result.ok.restartFromIsoWithDisk.args).toContain("file=/tmp/zeta.qcow2,if=virtio,format=qcow2");
-    for (const marker of [
-      "[B-0891-retention]   found pre-baked zeta-creds.enc on boot USB ESP",
-      "[B-0891-retention]   Step 6.95-picker will skip account re-entry",
-    ]) {
+    for (const marker of ["zeta-creds-restore:", "already-present"]) {
       expect(result.ok.requiredSerialMarkers).toContain(marker);
       expect(result.ok.restartStopCondition.successMarkers).toContain(marker);
     }

--- a/tools/zflash/test-harness/qemu-state.ts
+++ b/tools/zflash/test-harness/qemu-state.ts
@@ -218,12 +218,9 @@ export {
   RETENTION_FAILURE_SERIAL_MARKERS,
 } from "./serial-markers";
 
-function restartRetentionSerialMarkers(
-  bootImagePath: string | undefined,
-): readonly string[] {
-  return bootImagePath === undefined
-    ? INSTALLED_OS_RETENTION_SERIAL_MARKERS
-    : B0891_RETENTION_USB_SERIAL_MARKERS;
+function restartRetentionSerialMarkers(): readonly string[] {
+  // Restart proves installed-OS cred restore idempotency, not early USB ESP copy.
+  return INSTALLED_OS_RETENTION_SERIAL_MARKERS;
 }
 
 function nonEmpty(value: string): boolean {
@@ -379,11 +376,11 @@ export function planQcow2SnapshotRetention(input: Qcow2SnapshotRetentionInput): 
       },
       restartStopCondition: {
         serialLogPath: normalized.serialLogPath,
-        successMarkers: restartRetentionSerialMarkers(normalized.bootImagePath),
+        successMarkers: restartRetentionSerialMarkers(),
         failureMarkers: RETENTION_FAILURE_SERIAL_MARKERS,
         terminalFailureMarkers: RETENTION_ABSENT_TERMINAL_MARKERS,
       },
-      requiredSerialMarkers: restartRetentionSerialMarkers(normalized.bootImagePath),
+      requiredSerialMarkers: restartRetentionSerialMarkers(),
     },
   };
 }

--- a/tools/zflash/test-harness/run.ts
+++ b/tools/zflash/test-harness/run.ts
@@ -226,7 +226,7 @@ function emitDryRun(scenarioId?: ScenarioId): number {
 
 function dryRunPlanMessage(scenario: Scenario): string {
   if (scenario.id === "initial-format") {
-    return "would run audit-installer-iso-content.ts + zflash-file-backed --test bake + qemu-boot-test.ts";
+    return "would run audit-installer-iso-content.ts + zflash-file-backed --test bake + qemu-boot-test.ts --usb-image <zflash-boot.img>";
   }
   if (scenario.status === "composes-with-existing") {
     return `would delegate to existing tools/ci/ substrate: ${scenario.composesWith[0]}`;
@@ -290,7 +290,7 @@ function runInitialFormatScenario(isoPath: string): ScenarioResult {
     };
   }
 
-  const boot = runHarnessScript("tools/ci/qemu-boot-test.ts", [absIso]);
+  const boot = runHarnessScript("tools/ci/qemu-boot-test.ts", ["--usb-image", prepared.outputImagePath]);
   steps.push("qemu-boot-test");
   const durationMs = Date.now() - start;
   if (!boot.ok) {


### PR DESCRIPTION
## Summary
- Scenario 1 now QEMU-boots the zflash-prepared raw USB image (`qemu-boot-test --usb-image`) instead of the plain ISO, so CI proves the baked image is bootable.
- Scenario 3 restart success requires installed-OS `zeta-creds-restore:` / `already-present` markers (not early USB ESP copy lines).
- `mcopy` toolchain probe uses `-V` for GNU mtools compatibility.

## Test plan
- [x] `bun test tools/zflash/test-harness/` (82 pass)
- [ ] `build-ai-cluster-iso` scenario 1 on PR
- [ ] `workflow_dispatch` scenarios 3–4 after merge


Made with [Cursor](https://cursor.com)