### PR TITLE
chore(backlog): rename last 2 stragglers to zetaid-slug

### DIFF
--- a/docs/backlog/P3/081KTSZN10008QG0R002NMN8P7-perfview-windows-session-etw-deep-profiles-vs-crossplatform-.md
+++ b/docs/backlog/P3/081KTSZN10008QG0R002NMN8P7-perfview-windows-session-etw-deep-profiles-vs-crossplatform-.md
@@ -1,5 +1,6 @@
 ---
 id: B-1040
+zetaid: 081KTSZN10008QG0R002NMN8P7
 title: PerfView session on Windows (Aaron) — ETW deep profiles for the dotnet rooms; cross-platform lane = dotnet-trace/EventPipe + TraceEvent
 priority: P3
 status: open

--- a/docs/backlog/P3/081KTWJ1R0008QG0R000JJDPFZ-evaluate-microsoft-quantum-viz-js-circuit-diagram-rendering-.md
+++ b/docs/backlog/P3/081KTWJ1R0008QG0R000JJDPFZ-evaluate-microsoft-quantum-viz-js-circuit-diagram-rendering-.md
@@ -1,5 +1,6 @@
 ---
 id: B-1030
+zetaid: 081KTWJ1R0008QG0R000JJDPFZ
 title: Evaluate @microsoft/quantum-viz.js for circuit-diagram rendering in our TS apps
 priority: P3
 status: open


### PR DESCRIPTION
B-1030 and B-1040 were created after the batch run. Now all 1131 files use zetaid naming. Zero B-NNNN filenames remain.