### PR TITLE
feat(ben): cartridge `ben` line + gate refusal — rooms state their own cost predictions (B-1039)

### DIFF
--- a/db/shapes/cartridges/dynamicvalue.lines
+++ b/db/shapes/cartridges/dynamicvalue.lines
@@ -31,6 +31,7 @@ edge	court-form-of	shape-buckyball	rooms-with-areas vs rooms-with-doors: two way
 edge	soft-overlay	shape-softvalue	any node may carry (value, confidence) — brightness over the tile is the same colorize law, lifted from pixels to tiles (the named follow-up)
 issue	area-read	otto	open	Iris review 2026-06-11: outlined-only tiles read as empty cards; weight numerals / faint fill need the strict-dialect extension (same issue as softvalue in-svg-labels) — one decision for both
 anim	draw	treemap
+ben	draw	shape.dynamicvalue	O(children)
 # treaties — written only by each oracle's own choice (consent first); dissent is a verdict.
 treaty	aaron	meaning	ratified	"I saw both — nice, they look good to me" — render-loop ratification of the treemap (5:3:2 tiles read at a glance), 2026-06-11
 treaty	fsharp	bytes	ratified	five in-file integer laws hold; the engine law runs the SAME treemap call the renderer draws — tests green

--- a/db/shapes/cartridges/softvalue.lines
+++ b/db/shapes/cartridges/softvalue.lines
@@ -29,6 +29,7 @@ prereq	the-zero-case	rung 1 first: see what mono CANNOT say before admiring what
 edge	projection-of	shape-adinkra	both draw a register the base display cannot carry (signs there, confidence here) — capability upgrades as visible channels
 issue	in-svg-labels	otto	open	Iris+Rune review 2026-06-11: rung labels ("value"/"+ coarse"/"+ fine") and per-stroke <title> tooltips need a deliberate STRICT-DIALECT extension (fromSvg refuses foreign elements today) — extend emitter+parser together or not at all
 anim	draw	ladder
+ben	draw	shape.softvalue	O(rungs·bar)
 # treaties — written only by each oracle's own choice (consent first); dissent is a verdict.
 treaty	aaron	meaning	ratified	"I saw both — nice, they look good to me" — render-loop ratification of the ladder (value bars equal, coarse visibly shorter than fine, dashed tails read), 2026-06-11
 treaty	fsharp	bytes	ratified	both in-file bar laws are exact integer identities; quantize + colorize run live in the gate — tests green

--- a/db/shapes/cartridges/triboolean.lines
+++ b/db/shapes/cartridges/triboolean.lines
@@ -22,6 +22,7 @@ prereq	boundary-light	src/Core/BoundaryLight.fs — Tri and sampleProgressive (m
 prereq	the-float	src/Core.FSharp.TriBoolean/Float.fs — the same third state at NUMBER scope (held trits; four-oracle ratified)
 edge	soft-sibling	shape-softvalue	confidence is a DEGREE of knowing; Unknown is the REFUSAL to claim — two different honesty registers, both drawn
 anim	draw	progressive
+ben	draw	shape.triboolean	O(grid²)
 # treaties — written only by each oracle's own choice (consent first); dissent is a verdict.
 treaty	fsharp	bytes	ratified	both in-file laws are integer identities; the resolution law runs sampleProgressive live at both budgets — tests green
 treaty	otto	meaning	ratified	the spare encoding refused, the Unknown dashed, the full budget erasing it — my own frame, my own choice

--- a/src/Core/ComplexityRegistry.fs
+++ b/src/Core/ComplexityRegistry.fs
@@ -205,3 +205,65 @@ module ComplexityRegistry =
         Map.ofList
             [ "saves", [ "save-state recordings (the campaign notebook)" ]
               "rooms.persona", [ "identity (the persona's own; clause 2 — theirs)" ] ]
+
+    /// THE BEN LINE (B-1039: the prediction lives WITH the room). A cartridge declares its own
+    /// cost prediction in-file:
+    ///
+    ///     ben	draw	shape.dynamicvalue	O(children)
+    ///
+    /// (kind=ben, name=the operation, fields=[artifact; predicted time O]). benCheck cross-checks
+    /// the in-file claim against THIS registry: an unparseable O, a row the registry does not
+    /// carry, or a shape that disagrees with the registry's declared time all REFUSE — and the
+    /// shelf sweep in ShapeAcceptance.Tests enforces it for every cartridge the moment it lands
+    /// (same blade as THE GOLDEN LOCK: an in-file claim is checked in CI, never taken on faith).
+    /// Runtime grading of the prediction (Confirmed/Tighter/Violated) stays Ben.grade's lane.
+    type BenVerdict =
+        { Op: string
+          Artifact: string
+          Ok: bool
+          Evidence: string }
+
+    let benCheck (d: MediaLines.Doc) : BenVerdict list =
+        MediaLines.ofKind "ben" d
+        |> List.map (fun e ->
+            match e.Fields with
+            | artifact :: predicted :: _ ->
+                match parseO predicted with
+                | None ->
+                    { Op = e.Name
+                      Artifact = artifact
+                      Ok = false
+                      Evidence = sprintf "unparseable prediction '%s' — refusal, never a guess" predicted }
+                | Some shape ->
+                    match Map.tryFind (artifact, e.Name) declared with
+                    | None ->
+                        { Op = e.Name
+                          Artifact = artifact
+                          Ok = false
+                          Evidence = "no registry row — a prediction must point at a stated shelf cost (add the row or fix the name)" }
+                    | Some cost ->
+                        match parseO cost.Time with
+                        | Some reg when reg = shape ->
+                            { Op = e.Name
+                              Artifact = artifact
+                              Ok = true
+                              Evidence = sprintf "prediction %s agrees with the registry's %s (degree %d, logs %d)" predicted cost.Time shape.Degree shape.Logs }
+                        | Some _ ->
+                            { Op = e.Name
+                              Artifact = artifact
+                              Ok = false
+                              Evidence = sprintf "prediction %s DISAGREES with the registry's %s — one of them is lying; reconcile before the gate opens" predicted cost.Time }
+                        | None ->
+                            { Op = e.Name
+                              Artifact = artifact
+                              Ok = false
+                              Evidence = sprintf "the registry's own '%s' is unsearchable — fix the registry row first" cost.Time }
+            | _ ->
+                { Op = e.Name
+                  Artifact = "?"
+                  Ok = false
+                  Evidence = "a ben line must carry artifact and predicted O" })
+
+    /// Does every in-file ben prediction agree with the registry? (No ben lines = vacuously true:
+    /// the prediction is OPTIONAL in-file — the registry row is the required half; see unstated.)
+    let benHolds (d: MediaLines.Doc) : bool = benCheck d |> List.forall (fun b -> b.Ok)

--- a/src/Core/MediaLines.fs
+++ b/src/Core/MediaLines.fs
@@ -103,7 +103,7 @@ module MediaLines =
     let knownKinds: Set<string> =
         Set.ofList
             [ "meta"; "frame"; "sprite"; "anim"; "rom"; "glyph"; "palette"; "gen"; "sim"; "mea"; "cut"
-              "io"; "button"; "constant"; "dimension"; "treaty"; "law"; "prereq"; "edge"; "issue" ]
+              "io"; "button"; "constant"; "dimension"; "treaty"; "law"; "prereq"; "edge"; "issue"; "ben" ]
 
     /// The entries a reader carries without understanding — future media types in transit.
     let carried (d: Doc) : Entry list =
@@ -224,6 +224,8 @@ module MediaLines =
                     [ { Kind = e.Kind; Name = e.Name; Problem = "a treaty line must declare register (bytes|meaning) and verdict" } ]
                 | "law" when List.length e.Fields < 1 ->
                     [ { Kind = e.Kind; Name = e.Name; Problem = "a law must carry its equation (the file states its own check)" } ]
+                | "ben" when List.length e.Fields < 2 ->
+                    [ { Kind = e.Kind; Name = e.Name; Problem = "a ben line must declare artifact and predicted O (the room states its own cost)" } ]
                 | "prereq" when List.length e.Fields < 1 ->
                     [ { Kind = e.Kind; Name = e.Name; Problem = "a prereq must point somewhere (what to learn first, and where)" } ]
                 | "edge" when List.length e.Fields < 2 ->

--- a/tests/Tests.FSharp/ShapeAcceptance.Tests.fs
+++ b/tests/Tests.FSharp/ShapeAcceptance.Tests.fs
@@ -241,3 +241,36 @@ let ``HTMLCSSBINDING INJECTION FALSIFIER: a hostile motto cannot smuggle script 
 [<Fact>]
 let ``the generator shelf has ZERO ZetaId collisions (distinct names never share an id — byId shadowing surfaced, not silent)`` () =
     Assert.Equal<(string * string list) list>([], GeneratorRegistry.collisions ())
+
+[<Fact>]
+let ``THE BEN LINE: every cartridge's in-file cost prediction agrees with the registry — the shelf sweep is the gate`` () =
+    for s in shapes do
+        let d = docOf s
+        for b in ComplexityRegistry.benCheck d do
+            Assert.True(b.Ok, sprintf "%s ben %s/%s: %s" s b.Artifact b.Op b.Evidence)
+    // the three new rooms actually CARRY the line (the sweep must not be vacuous shelf-wide)
+    for named in [ "softvalue"; "dynamicvalue"; "triboolean" ] do
+        Assert.NotEmpty(ComplexityRegistry.benCheck (docOf named))
+
+[<Fact>]
+let ``BEN FALSIFIERS: garbage O, a missing registry row, and a lying prediction all REFUSE — and a bare ben line is a lint finding`` () =
+    let docFrom (benLine: string) =
+        MediaLines.parse ("meta\tname\tshape-test\n" + benLine + "\n") |> Result.toOption |> Option.get
+    // garbage O: refusal, never a guess
+    let garbage = ComplexityRegistry.benCheck (docFrom "ben\tdraw\tshape.dynamicvalue\tO(vibes^^)")
+    Assert.False((List.exactlyOne garbage).Ok)
+    // no registry row: a prediction must point at a stated shelf cost
+    let missing = ComplexityRegistry.benCheck (docFrom "ben\tdraw\tshape.never-registered\tO(n)")
+    Assert.False((List.exactlyOne missing).Ok)
+    Assert.Contains("no registry row", (List.exactlyOne missing).Evidence)
+    // the lie: registry says O(children) (degree 1); the cartridge claims O(children²)
+    let lying = ComplexityRegistry.benCheck (docFrom "ben\tdraw\tshape.dynamicvalue\tO(children²)")
+    Assert.False((List.exactlyOne lying).Ok)
+    Assert.Contains("DISAGREES", (List.exactlyOne lying).Evidence)
+    // agreement passes (same shape, written differently is NOT required — exact parse equality is)
+    let honest = ComplexityRegistry.benCheck (docFrom "ben\tdraw\tshape.dynamicvalue\tO(children)")
+    Assert.True((List.exactlyOne honest).Ok)
+    Assert.True(ComplexityRegistry.benHolds (docFrom "ben\tdraw\tshape.dynamicvalue\tO(children)"))
+    // structural honesty: a ben line without its two fields is a lint finding, not a silent pass
+    let bare = docFrom "ben\tdraw\tshape.only-artifact"
+    Assert.NotEmpty(MediaLines.lint bare)

--- a/workitems/081KTWFYCB108QG0R000R6DP13-the-ben-verb-benchmark-as-easy-as-measure-timing-memory-inje.md
+++ b/workitems/081KTWFYCB108QG0R000R6DP13-the-ben-verb-benchmark-as-easy-as-measure-timing-memory-inje.md
@@ -94,3 +94,16 @@ Beacon: MUMPS/M (Octo Barnett & Neil Pappalardo, Massachusetts General Hospital,
 X11.1-1977) — the memory-mapped hierarchical-global lineage; .NET EventPipe (out-of-process
 tracing, the diagnostics-IPC design) — observation that never enters the observed process's
 code path.
+
+## Progress 4 (2026-06-11) — the cartridge `ben` line + gate refusal SHIP
+
+A room now states its own cost prediction in-file: `ben	draw	shape.dynamicvalue	O(children)`
+(kind=ben, name=operation, fields=[artifact; predicted time O]). `ComplexityRegistry.benCheck`
+cross-checks the in-file claim against the registry — an unparseable O, a missing registry row, or
+a prediction that DISAGREES with the registry's declared time all REFUSE; the shelf sweep in
+ShapeAcceptance.Tests gates every cartridge the moment it lands (same blade as THE GOLDEN LOCK).
+`ben` joined MediaLines knownKinds (the near-miss lint had rightly flagged it as one letter from
+`gen`) + a structural lint (artifact + predicted O required). softvalue/dynamicvalue/triboolean
+carry the first three lines. Runtime grading (Confirmed/Tighter/Violated) stays Ben.grade's lane;
+remaining: dotnet wall/alloc-statistical meters behind the boundary + red light; the BenchmarkDotNet
+senior adapter; the pro verb's out-of-process EventPipe lane (Progress 3).


### PR DESCRIPTION
The next named B-1039 slice: a cartridge declares its complexity prediction in-file and the gate cross-checks it against ComplexityRegistry — garbage O, missing row, or a lying prediction refuses the cartridge at the shelf sweep (same blade as THE GOLDEN LOCK). `ben` joined knownKinds (the near-miss lint had correctly flagged it one letter from `gen`) + structural lint. First three lines on softvalue/dynamicvalue/triboolean; falsifiers prove every refusal reachable. 1396/1396.

🤖 Generated with [Claude Code](https://claude.com/claude-code)