### PR TITLE
feat(testloop): THE GLASS-SIDE RULING — no wall clock in the room, enforced by the boundary (B-1039 ruling)

### DIFF
--- a/src/Core/Ben.fs
+++ b/src/Core/Ben.fs
@@ -2,9 +2,14 @@ namespace Zeta.Core
 
 /// Ben — **the ben verb, slice 1: exact meters + the prediction grader** (B-1039; Aaron: "make
 /// ben(chmark) as easy as measure… see how good our PREDICTION is"). This slice carries only
-/// what is EXACT and DST-clean — no wall clock, no GC counters (those are the dotnet-room slice,
-/// behind the boundary with the red light). The chip8 emu is the easy case on purpose: tick
-/// counts and Frame-map sizes are deterministic, replayable, byte-stable.
+/// what is EXACT and DST-clean — no wall clock, no GC counters. THE GLASS-SIDE RULING (Aaron
+/// 2026-06-11, verbatim: "glass-side only no wall clock in the room"): wall-clock time NEVER
+/// enters the sealed room — statistical timing lives entirely in the out-of-process lanes
+/// (BenchmarkDotNet senior adapter; EventPipe/dotnet-trace attach through the glass), and the
+/// double-run boundary mechanically refuses any smuggled clock (see the falsifier in
+/// TestLoop.Host.fs). In-room meters are the exact pair only: ticks + allocBytes. The chip8 emu
+/// is the easy case on purpose: tick counts and Frame-map sizes are deterministic, replayable,
+/// byte-stable.
 ///
 /// THE GRADER closes the loop the ComplexityRegistry opened: every declared O(…) row is a
 /// PREDICTION; feed `infer` cost samples at doubling sizes (n, 2n, 4n, …) and it names the

--- a/tests/Tests.FSharp/TestLoop.Host.fs
+++ b/tests/Tests.FSharp/TestLoop.Host.fs
@@ -93,6 +93,20 @@ let ``THE BOUNDARY REJECTS: an ambient-entropy loop fails the double-run check e
     Assert.Contains("ambient entropy", v.Failure |> Option.defaultValue "")
 
 [<Fact>]
+let ``THE GLASS-SIDE RULING IS MECHANICAL: a loop that smuggles the wall clock into Mea fails the double-run check — no wall clock in the room`` () =
+    // Aaron 2026-06-11: "glass-side only no wall clock in the room." Not a convention — the
+    // boundary itself refuses the clock: two runs from one seed read two different timestamps.
+    let v =
+        TestLoop.run (
+            TestLoop.make "clock smuggler" 4UL
+                (fun _ -> ())
+                (fun () -> System.Diagnostics.Stopwatch.GetTimestamp())
+                (fun _ -> Ok()))
+    Assert.False v.Passed
+    Assert.False v.Deterministic
+    Assert.Contains("ambient entropy", v.Failure |> Option.defaultValue "")
+
+[<Fact>]
 let ``THE BOUNDARY CATCHES THROWS: an exception in Mea becomes a named-phase Failure value, never an escaped throw`` () =
     let v =
         TestLoop.run (

--- a/workitems/081KTWFYCB108QG0R000R6DP13-the-ben-verb-benchmark-as-easy-as-measure-timing-memory-inje.md
+++ b/workitems/081KTWFYCB108QG0R000R6DP13-the-ben-verb-benchmark-as-easy-as-measure-timing-memory-inje.md
@@ -107,3 +107,15 @@ ShapeAcceptance.Tests gates every cartridge the moment it lands (same blade as T
 carry the first three lines. Runtime grading (Confirmed/Tighter/Violated) stays Ben.grade's lane;
 remaining: dotnet wall/alloc-statistical meters behind the boundary + red light; the BenchmarkDotNet
 senior adapter; the pro verb's out-of-process EventPipe lane (Progress 3).
+
+## Progress 5 (2026-06-11) — THE GLASS-SIDE RULING (Aaron, verbatim: "glass-side only no wall clock in the room")
+
+The open design call from Progress 2/3 is decided: wall-clock time NEVER enters the sealed room.
+The "dotnet wall meter behind the boundary + red light" slice is CANCELLED — there is no in-room
+wall meter at any rung. In-room stays the exact pair (chip8Ticks + allocBytes, both replay-equal);
+ALL statistical timing is glass-side: the BenchmarkDotNet senior adapter (its own process, its own
+methodology) and the EventPipe/dotnet-trace attach lane (out-of-process by design). The ruling is
+mechanically enforced, not conventional: the double-run boundary refuses a smuggled clock (two
+runs, one seed, two timestamps — falsifier added to TestLoop.Host.fs alongside the entropy
+smuggler). Noninterference (#13) closes flush: the room's only doors stay Reticulum + the injected
+Source; time is an observable THROUGH the glass, never an input inside it.


### PR DESCRIPTION
Aaron's ruling, verbatim: "glass-side only no wall clock in the room." The in-room wall-meter slice is cancelled; in-room = chip8Ticks + allocBytes only; all statistical timing is glass-side (BenchmarkDotNet / EventPipe attach). New falsifier: a Mea smuggling Stopwatch.GetTimestamp() fails THE DOUBLE-RUN CHECK — the ruling is mechanical, not conventional. Ben.fs header + workitem Progress 5 carry it verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)