### PR TITLE
feat(perf): pro.ts — the pro verb's glass-side EventPipe attach lane (B-1039)

### DIFF
--- a/src/Core/Ben.fs
+++ b/src/Core/Ben.fs
@@ -2,9 +2,14 @@ namespace Zeta.Core
 
 /// Ben — **the ben verb, slice 1: exact meters + the prediction grader** (B-1039; Aaron: "make
 /// ben(chmark) as easy as measure… see how good our PREDICTION is"). This slice carries only
-/// what is EXACT and DST-clean — no wall clock, no GC counters (those are the dotnet-room slice,
-/// behind the boundary with the red light). The chip8 emu is the easy case on purpose: tick
-/// counts and Frame-map sizes are deterministic, replayable, byte-stable.
+/// what is EXACT and DST-clean — no wall clock, no GC counters. THE GLASS-SIDE RULING (Aaron
+/// 2026-06-11, verbatim: "glass-side only no wall clock in the room"): wall-clock time NEVER
+/// enters the sealed room — statistical timing lives entirely in the out-of-process lanes
+/// (BenchmarkDotNet senior adapter; EventPipe/dotnet-trace attach through the glass), and the
+/// double-run boundary mechanically refuses any smuggled clock (see the falsifier in
+/// TestLoop.Host.fs). In-room meters are the exact pair only: ticks + allocBytes. The chip8 emu
+/// is the easy case on purpose: tick counts and Frame-map sizes are deterministic, replayable,
+/// byte-stable.
 ///
 /// THE GRADER closes the loop the ComplexityRegistry opened: every declared O(…) row is a
 /// PREDICTION; feed `infer` cost samples at doubling sizes (n, 2n, 4n, …) and it names the

--- a/tests/Tests.FSharp/TestLoop.Host.fs
+++ b/tests/Tests.FSharp/TestLoop.Host.fs
@@ -93,6 +93,20 @@ let ``THE BOUNDARY REJECTS: an ambient-entropy loop fails the double-run check e
     Assert.Contains("ambient entropy", v.Failure |> Option.defaultValue "")
 
 [<Fact>]
+let ``THE GLASS-SIDE RULING IS MECHANICAL: a loop that smuggles the wall clock into Mea fails the double-run check — no wall clock in the room`` () =
+    // Aaron 2026-06-11: "glass-side only no wall clock in the room." Not a convention — the
+    // boundary itself refuses the clock: two runs from one seed read two different timestamps.
+    let v =
+        TestLoop.run (
+            TestLoop.make "clock smuggler" 4UL
+                (fun _ -> ())
+                (fun () -> System.Diagnostics.Stopwatch.GetTimestamp())
+                (fun _ -> Ok()))
+    Assert.False v.Passed
+    Assert.False v.Deterministic
+    Assert.Contains("ambient entropy", v.Failure |> Option.defaultValue "")
+
+[<Fact>]
 let ``THE BOUNDARY CATCHES THROWS: an exception in Mea becomes a named-phase Failure value, never an escaped throw`` () =
     let v =
         TestLoop.run (

--- a/tools/perf/pro.ts
+++ b/tools/perf/pro.ts
@@ -1,0 +1,67 @@
+#!/usr/bin/env bun
+// pro.ts — the pro(file) verb's GLASS-SIDE attach lane (B-1039 Progress 3/5; Aaron 2026-06-11:
+// "now lets have ben and pro(file) and all in our framework air tight vacuum tight" + the ruling
+// "glass-side only no wall clock in the room").
+//
+// THE DISCIPLINE: this tool NEVER enters the room. It attaches dotnet-trace (EventPipe — the
+// out-of-process diagnostics IPC) to a running .NET process and observes THROUGH THE GLASS: zero
+// syscalls injected into the observed loop, the Reticulum-only seal intact, the red light on (the
+// observed process can see the diagnostics session — observation is never covert). In-room
+// measurement stays the exact pair (Ben.chip8Ticks + Ben.allocBytes); everything statistical —
+// wall time, CPU stacks, GC events — lives HERE, outside the membrane.
+//
+// Usage:
+//   bun tools/perf/pro.ts --pid <pid> [--seconds <s>] [--out <file.nettrace>]
+//   bun tools/perf/pro.ts [--out <file.nettrace>] -- <command> [args...]
+//
+// In `--` mode the command is spawned and the trace attaches to THAT pid. Caveat (honest): for
+// `dotnet test`, the interesting work runs in a CHILD testhost process — attach to its pid with
+// --pid instead (find it via `dotnet-trace ps`). Analysis lanes: PerfView (Windows, the senior
+// session — Aaron owns), TraceEvent / `dotnet-trace report` (cross-platform).
+
+import { spawn, spawnSync } from "node:child_process";
+
+function fail(msg: string): never {
+  console.error("pro: " + msg);
+  process.exit(1);
+}
+
+const argv = process.argv.slice(2);
+const sep = argv.indexOf("--");
+const flags = sep >= 0 ? argv.slice(0, sep) : argv;
+const cmd = sep >= 0 ? argv.slice(sep + 1) : [];
+
+function flagOf(name: string): string | undefined {
+  const i = flags.indexOf("--" + name);
+  return i >= 0 ? flags[i + 1] : undefined;
+}
+
+const pidFlag = flagOf("pid");
+const seconds = flagOf("seconds");
+const out = flagOf("out") ?? `pro-${pidFlag ?? "spawn"}-${process.pid}.nettrace`;
+
+if ((pidFlag === undefined) === (cmd.length === 0)) {
+  fail("exactly one of --pid <pid> or `-- <command...>` is required (see header for usage)");
+}
+
+let pid: number;
+let child: ReturnType<typeof spawn> | undefined;
+if (pidFlag !== undefined) {
+  pid = Number(pidFlag);
+  if (!Number.isInteger(pid) || pid <= 0) fail(`--pid must be a positive integer, got '${pidFlag}'`);
+} else {
+  child = spawn(cmd[0]!, cmd.slice(1), { stdio: "inherit" });
+  if (child.pid === undefined) fail(`could not spawn: ${cmd.join(" ")}`);
+  pid = child.pid;
+  console.error(`pro: spawned pid ${pid}: ${cmd.join(" ")}`);
+}
+
+const traceArgs = ["collect", "-p", String(pid), "-o", out];
+if (seconds !== undefined) traceArgs.push("--duration", `00:00:00:${seconds.padStart(2, "0")}`);
+
+console.error(`pro: attaching through the glass — dotnet-trace ${traceArgs.join(" ")}`);
+const trace = spawnSync("dotnet-trace", traceArgs, { stdio: "inherit" });
+
+if (child !== undefined && child.exitCode === null) child.kill("SIGTERM");
+if (trace.status !== 0) fail(`dotnet-trace exited ${trace.status} (is pid ${pid} a .NET process with diagnostics IPC? try \`dotnet-trace ps\`)`);
+console.error(`pro: trace written to ${out} — analyze with \`dotnet-trace report ${out} topN\` or PerfView/TraceEvent`);

--- a/workitems/081KTWFYCB108QG0R000R6DP13-the-ben-verb-benchmark-as-easy-as-measure-timing-memory-inje.md
+++ b/workitems/081KTWFYCB108QG0R000R6DP13-the-ben-verb-benchmark-as-easy-as-measure-timing-memory-inje.md
@@ -107,3 +107,15 @@ ShapeAcceptance.Tests gates every cartridge the moment it lands (same blade as T
 carry the first three lines. Runtime grading (Confirmed/Tighter/Violated) stays Ben.grade's lane;
 remaining: dotnet wall/alloc-statistical meters behind the boundary + red light; the BenchmarkDotNet
 senior adapter; the pro verb's out-of-process EventPipe lane (Progress 3).
+
+## Progress 5 (2026-06-11) — THE GLASS-SIDE RULING (Aaron, verbatim: "glass-side only no wall clock in the room")
+
+The open design call from Progress 2/3 is decided: wall-clock time NEVER enters the sealed room.
+The "dotnet wall meter behind the boundary + red light" slice is CANCELLED — there is no in-room
+wall meter at any rung. In-room stays the exact pair (chip8Ticks + allocBytes, both replay-equal);
+ALL statistical timing is glass-side: the BenchmarkDotNet senior adapter (its own process, its own
+methodology) and the EventPipe/dotnet-trace attach lane (out-of-process by design). The ruling is
+mechanically enforced, not conventional: the double-run boundary refuses a smuggled clock (two
+runs, one seed, two timestamps — falsifier added to TestLoop.Host.fs alongside the entropy
+smuggler). Noninterference (#13) closes flush: the room's only doors stay Reticulum + the injected
+Source; time is an observable THROUGH the glass, never an input inside it.

--- a/workitems/081KTWFYCB108QG0R000R6DP13-the-ben-verb-benchmark-as-easy-as-measure-timing-memory-inje.md
+++ b/workitems/081KTWFYCB108QG0R000R6DP13-the-ben-verb-benchmark-as-easy-as-measure-timing-memory-inje.md
@@ -119,3 +119,11 @@ mechanically enforced, not conventional: the double-run boundary refuses a smugg
 runs, one seed, two timestamps — falsifier added to TestLoop.Host.fs alongside the entropy
 smuggler). Noninterference (#13) closes flush: the room's only doors stay Reticulum + the injected
 Source; time is an observable THROUGH the glass, never an input inside it.
+
+## Progress 6 (2026-06-11) — pro's attach lane SHIPS (tools/perf/pro.ts)
+
+The glass-side wrapper, ruling-compliant by construction: spawns (or takes --pid) and attaches
+dotnet-trace/EventPipe from OUTSIDE — zero syscalls in the room, red light on, seal intact.
+Smoke-verified live (1.7MB .nettrace off a spawned fsi). Honest caveat in-header: `dotnet test`
+work runs in a child testhost — attach by --pid via `dotnet-trace ps`. Remaining: BenchmarkDotNet
+senior adapter.


### PR DESCRIPTION
The glass-side ruling made code: `bun tools/perf/pro.ts [--pid N | -- <cmd>]` attaches dotnet-trace from outside the room — zero syscalls injected, seal intact, red light on. Smoke-verified live (1.7MB .nettrace off a spawned fsi). In-room stays chip8Ticks + allocBytes; remaining slice = BenchmarkDotNet senior adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)