### PR TITLE
feat(perf): pro family moves to src — Core.TypeScript/perf glass-side lanes (trace, counters, gcdump)

### DIFF
--- a/src/Core.TypeScript/perf/counters.ts
+++ b/src/Core.TypeScript/perf/counters.ts
@@ -1,0 +1,21 @@
+// counters — the pro(file) verb's LIVE-METRICS lane (dotnet-counters), glass-side only.
+// Usage: bun src/Core.TypeScript/perf/counters.ts [--pid N | -- <cmd...>] [--seconds S] [--out F]
+// With --out: collects to csv. Without: live monitor in the terminal.
+
+import { acquire, observe, durationOf, parseLaneFlags, type LaneFlags } from "./glass";
+
+/** Pure: the dotnet-counters argv — monitor (no out) or collect-to-csv (out). */
+export function countersArgsOf(pid: number, flags: Pick<LaneFlags, "seconds" | "out">): string[] {
+  const args = [flags.out !== undefined ? "collect" : "monitor", "-p", String(pid)];
+  if (flags.out !== undefined) args.push("-o", flags.out, "--format", "csv");
+  if (flags.seconds !== undefined) args.push("--duration", durationOf(flags.seconds));
+  return args;
+}
+
+if (import.meta.main) {
+  const flags = parseLaneFlags(process.argv.slice(2));
+  const t = acquire({ pid: flags.pid, command: flags.command });
+  const args = countersArgsOf(t.pid, flags);
+  console.error(`counters: watching through the glass — dotnet-counters ${args.join(" ")}`);
+  process.exit(observe("dotnet-counters", args, t));
+}

--- a/src/Core.TypeScript/perf/gcdump.ts
+++ b/src/Core.TypeScript/perf/gcdump.ts
@@ -1,0 +1,20 @@
+// gcdump — the pro(file) verb's HEAP-SNAPSHOT lane (dotnet-gcdump), glass-side only.
+// Usage: bun src/Core.TypeScript/perf/gcdump.ts --pid N [--out F]
+// (Snapshot of a live heap — no spawn mode: a heap worth dumping already exists.)
+
+import { acquire, observe, parseLaneFlags, type LaneFlags } from "./glass";
+
+/** Pure: the dotnet-gcdump argv for one snapshot. */
+export function gcdumpArgsOf(pid: number, flags: Pick<LaneFlags, "out">): string[] {
+  const args = ["collect", "-p", String(pid)];
+  if (flags.out !== undefined) args.push("-o", flags.out);
+  return args;
+}
+
+if (import.meta.main) {
+  const flags = parseLaneFlags(process.argv.slice(2));
+  const t = acquire({ pid: flags.pid, command: flags.command });
+  const args = gcdumpArgsOf(t.pid, flags);
+  console.error(`gcdump: snapshotting through the glass — dotnet-gcdump ${args.join(" ")}`);
+  process.exit(observe("dotnet-gcdump", args, t));
+}

--- a/src/Core.TypeScript/perf/glass.test.ts
+++ b/src/Core.TypeScript/perf/glass.test.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "bun:test";
+import { durationOf, parseLaneFlags } from "./glass";
+import { traceArgsOf } from "./pro";
+import { countersArgsOf } from "./counters";
+import { gcdumpArgsOf } from "./gcdump";
+
+// the pure halves are the tested halves — no process is spawned here (the spawn is the one
+// side-effecting door, exercised by the live smoke in the PR, not the test suite).
+
+test("durationOf renders dd:hh:mm:ss and refuses non-positive", () => {
+  expect(durationOf(4)).toBe("00:00:00:04");
+  expect(durationOf(3661)).toBe("00:01:01:01");
+  expect(() => durationOf(0)).toThrow();
+  expect(() => durationOf(1.5)).toThrow();
+});
+
+test("parseLaneFlags: pid mode, spawn mode, and the refusals", () => {
+  expect(parseLaneFlags(["--pid", "42", "--seconds", "9"])).toMatchObject({ pid: 42, seconds: 9 });
+  expect(parseLaneFlags(["--out", "x.nettrace", "--", "dotnet", "fsi", "s.fsx"])).toMatchObject({ out: "x.nettrace", command: ["dotnet", "fsi", "s.fsx"] });
+  expect(() => parseLaneFlags(["--pid", "zero"])).toThrow();
+  expect(() => parseLaneFlags(["--seconds"])).toThrow();
+});
+
+test("traceArgsOf: default out is keyed to the pid; duration only when asked", () => {
+  expect(traceArgsOf(7, {})).toEqual(["collect", "-p", "7", "-o", "pro-7.nettrace"]);
+  expect(traceArgsOf(7, { seconds: 4, out: "t.nettrace" })).toEqual(["collect", "-p", "7", "-o", "t.nettrace", "--duration", "00:00:00:04"]);
+});
+
+test("countersArgsOf: monitor without out, collect-to-csv with out", () => {
+  expect(countersArgsOf(7, {})).toEqual(["monitor", "-p", "7"]);
+  expect(countersArgsOf(7, { out: "c.csv", seconds: 9 })).toEqual(["collect", "-p", "7", "-o", "c.csv", "--format", "csv", "--duration", "00:00:00:09"]);
+});
+
+test("gcdumpArgsOf: one snapshot, optional out", () => {
+  expect(gcdumpArgsOf(7, {})).toEqual(["collect", "-p", "7"]);
+  expect(gcdumpArgsOf(7, { out: "h.gcdump" })).toEqual(["collect", "-p", "7", "-o", "h.gcdump"]);
+});

--- a/src/Core.TypeScript/perf/glass.ts
+++ b/src/Core.TypeScript/perf/glass.ts
@@ -1,0 +1,78 @@
+// glass — the shared GLASS-SIDE discipline for every pro(file) lane (B-1039; Aaron 2026-06-11:
+// "glass-side only no wall clock in the room" + "lets move to src"). A lane NEVER enters the
+// room: it attaches a dotnet diagnostics tool (EventPipe IPC) to a pid from OUTSIDE — zero
+// syscalls injected into the observed loop, the Reticulum-only seal intact, the red light on
+// (diagnostics sessions are visible to the observed process; observation is never covert).
+//
+// Library shape (Core.TypeScript convention): the ARG BUILDERS are pure and tested; the spawn
+// is the one thin side-effecting door. In-room measurement stays the exact pair
+// (Ben.chip8Ticks + Ben.allocBytes) — everything statistical lives here, through the glass.
+
+import { spawn, spawnSync } from "node:child_process";
+
+export interface GlassTarget {
+  /** Attach to an already-running .NET process. */
+  readonly pid?: number | undefined;
+  /** Or spawn this command and attach to its root pid (testhost caveat: `dotnet test` does its
+   * work in a CHILD process — find it with `dotnet-trace ps` and use pid instead). */
+  readonly command?: readonly string[] | undefined;
+}
+
+/** Resolve the target to a pid, spawning if asked. Returns the pid and the child (if spawned). */
+export function acquire(target: GlassTarget): { pid: number; child?: ReturnType<typeof spawn> } {
+  if ((target.pid === undefined) === (target.command === undefined || target.command.length === 0)) {
+    throw new Error("exactly one of pid or command is required");
+  }
+  if (target.pid !== undefined) {
+    if (!Number.isInteger(target.pid) || target.pid <= 0) throw new Error(`pid must be a positive integer, got ${target.pid}`);
+    return { pid: target.pid };
+  }
+  const cmd = target.command!;
+  const child = spawn(cmd[0]!, cmd.slice(1), { stdio: "inherit" });
+  if (child.pid === undefined) throw new Error(`could not spawn: ${cmd.join(" ")}`);
+  return { pid: child.pid, child };
+}
+
+/** Run one diagnostics tool to completion, glass-side, inheriting stdio. */
+export function observe(tool: string, args: readonly string[], target: { child?: ReturnType<typeof spawn> }): number {
+  const r = spawnSync(tool, args as string[], { stdio: "inherit" });
+  if (target.child !== undefined && target.child.exitCode === null) target.child.kill("SIGTERM");
+  return r.status ?? 1;
+}
+
+/** `--duration` form dotnet diagnostics tools expect (dd:hh:mm:ss) from plain seconds. */
+export function durationOf(seconds: number): string {
+  if (!Number.isInteger(seconds) || seconds <= 0) throw new Error(`seconds must be a positive integer, got ${seconds}`);
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `00:${pad(h)}:${pad(m)}:${pad(s)}`;
+}
+
+/** Shared CLI flag parsing for every lane: [--pid N] [--seconds S] [--out F] [-- cmd...]. */
+export interface LaneFlags {
+  readonly pid?: number | undefined;
+  readonly seconds?: number | undefined;
+  readonly out?: string | undefined;
+  readonly command?: readonly string[] | undefined;
+}
+
+export function parseLaneFlags(argv: readonly string[]): LaneFlags {
+  const sep = argv.indexOf("--");
+  const flags = sep >= 0 ? argv.slice(0, sep) : argv;
+  const command = sep >= 0 ? argv.slice(sep + 1) : undefined;
+  const valueOf = (name: string): string | undefined => {
+    const i = flags.indexOf("--" + name);
+    if (i >= 0 && i + 1 >= flags.length) throw new Error(`--${name} needs a value`);
+    return i >= 0 ? flags[i + 1] : undefined;
+  };
+  const num = (name: string): number | undefined => {
+    const v = valueOf(name);
+    if (v === undefined) return undefined;
+    const n = Number(v);
+    if (!Number.isInteger(n) || n <= 0) throw new Error(`--${name} must be a positive integer, got '${v}'`);
+    return n;
+  };
+  return { pid: num("pid"), seconds: num("seconds"), out: valueOf("out"), command };
+}

--- a/src/Core.TypeScript/perf/pro.ts
+++ b/src/Core.TypeScript/perf/pro.ts
@@ -1,0 +1,26 @@
+// pro — the pro(file) verb's TRACE lane (dotnet-trace / EventPipe), glass-side only.
+// Usage: bun src/Core.TypeScript/perf/pro.ts [--pid N | -- <cmd...>] [--seconds S] [--out F]
+// Analysis lanes: PerfView (Windows, the senior session), TraceEvent, `dotnet-trace report`.
+
+import { acquire, observe, durationOf, parseLaneFlags, type LaneFlags } from "./glass";
+
+/** Pure: the dotnet-trace argv for a collection — tested without spawning anything. */
+export function traceArgsOf(pid: number, flags: Pick<LaneFlags, "seconds" | "out">): string[] {
+  const out = flags.out ?? `pro-${pid}.nettrace`;
+  const args = ["collect", "-p", String(pid), "-o", out];
+  if (flags.seconds !== undefined) args.push("--duration", durationOf(flags.seconds));
+  return args;
+}
+
+if (import.meta.main) {
+  const flags = parseLaneFlags(process.argv.slice(2));
+  const t = acquire({ pid: flags.pid, command: flags.command });
+  const args = traceArgsOf(t.pid, flags);
+  console.error(`pro: attaching through the glass — dotnet-trace ${args.join(" ")}`);
+  const status = observe("dotnet-trace", args, t);
+  if (status !== 0) {
+    console.error(`pro: dotnet-trace exited ${status} (is pid ${t.pid} a .NET process? try \`dotnet-trace ps\`)`);
+    process.exit(status);
+  }
+  console.error(`pro: trace written — analyze with \`dotnet-trace report <file> topN\` or PerfView/TraceEvent`);
+}

--- a/workitems/081KTWFYCB108QG0R000R6DP13-the-ben-verb-benchmark-as-easy-as-measure-timing-memory-inje.md
+++ b/workitems/081KTWFYCB108QG0R000R6DP13-the-ben-verb-benchmark-as-easy-as-measure-timing-memory-inje.md
@@ -119,3 +119,13 @@ mechanically enforced, not conventional: the double-run boundary refuses a smugg
 runs, one seed, two timestamps — falsifier added to TestLoop.Host.fs alongside the entropy
 smuggler). Noninterference (#13) closes flush: the room's only doors stay Reticulum + the injected
 Source; time is an observable THROUGH the glass, never an input inside it.
+
+## Progress 7 (2026-06-11) — pro moves to src and brings the family (Aaron: "lets move to src and pick some other ones too")
+
+`src/Core.TypeScript/perf/` — the glass-side lanes as REAL CODE, Core.TypeScript convention (pure
+arg builders tested without spawning; the spawn is the one side-effecting door): `glass.ts` (the
+shared discipline: acquire/observe/durationOf/flags), `pro.ts` (trace lane, dotnet-trace),
+`counters.ts` (live-metrics lane, monitor or collect-to-csv), `gcdump.ts` (heap-snapshot lane).
+tools/perf/pro.ts (PR #7855) closed unmerged in favor of this. Live smoke re-verified from the
+src path (2.0MB .nettrace). tools/profile.ts noted as the older installer/launcher predecessor —
+the manifest owns install now; these lanes own launch.


### PR DESCRIPTION
Per Aaron: move pro to src and pick siblings. `src/Core.TypeScript/perf/`: glass.ts (shared glass-side discipline), pro.ts (trace), counters.ts (live metrics), gcdump.ts (heap snapshot) — pure arg builders tested (5/5, no spawns in suite), live smoke re-verified from src path. Supersedes #7855 (closed unmerged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)