### PR TITLE
fix(repo): retarget the nine symlinks #7820 broke (Pages red on every push) + tracked-symlink CI guard

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -925,6 +925,12 @@ jobs:
       - name: Run audit-backlog-items (--enforce-duplicate-ids)
         run: bun tools/hygiene/audit-backlog-items.ts --enforce-duplicate-ids
 
+      # Dangling tracked symlinks crash the GitHub Pages (Jekyll) build on realpath — invisible
+      # to the test suites. Surfaced 2026-06-11: #7820 moved 31 dirs to db/ and nine relative
+      # links dangled; Pages was red for hours on every push.
+      - name: Run audit-dangling-symlinks (Pages/Jekyll guard)
+        run: bun tools/hygiene/audit-dangling-symlinks.ts
+
   lint-backlog-parent-child-status:
     # Fail if any backlog row declares `status: closed` (or equivalent —
     # landed/superseded/merged/done/superseded-by-*) while a declared

--- a/db/hy
+++ b/db/hy
@@ -1,1 +1,1 @@
-hygiene
+../hygiene

--- a/db/products/glomotion.md
+++ b/db/products/glomotion.md
@@ -1,1 +1,1 @@
-../universal/gamepad.md
+../../universal/gamepad.md

--- a/tools/hygiene/audit-dangling-symlinks.ts
+++ b/tools/hygiene/audit-dangling-symlinks.ts
@@ -1,0 +1,52 @@
+#!/usr/bin/env bun
+// audit-dangling-symlinks.ts — every git-TRACKED symlink must resolve inside the repo.
+//
+// Why: the 2026-06-11 db/ migration (#7820) moved 31 dirs but not the relative symlinks
+// pointing at/from them — nine links dangled and the GitHub Pages (Jekyll) build crashed on
+// realpath for hours (every push, `No such file or directory @ rb_check_realpath_internal`).
+// A dangling tracked symlink is invisible to dotnet/bun test suites; this is the guard.
+//
+// Scope: tracked symlinks only (mode 120000 in the index) — untracked/ignored trees
+// (references/, node_modules/, .lake/) are not ours to police here.
+// Exit 0 = all resolve · 1 = lists the danglers.
+
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const root = (() => {
+  const r = spawnSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8" });
+  if (r.status !== 0) {
+    console.error("audit-dangling-symlinks: not a git repo");
+    process.exit(1);
+  }
+  return r.stdout.trim();
+})();
+
+const ls = spawnSync("git", ["ls-files", "-s"], { encoding: "utf8", cwd: root, maxBuffer: 64 * 1024 * 1024 });
+if (ls.status !== 0) {
+  console.error("audit-dangling-symlinks: git ls-files failed");
+  process.exit(1);
+}
+
+const danglers: string[] = [];
+let tracked = 0;
+for (const line of ls.stdout.split("\n")) {
+  if (!line.startsWith("120000 ")) continue;
+  tracked += 1;
+  const path = line.split("\t")[1];
+  if (path === undefined) continue;
+  const abs = resolve(root, path);
+  // existsSync follows the link; a link to a link resolves transitively (the kernel's job).
+  if (!existsSync(abs)) {
+    const target = spawnSync("readlink", [abs], { encoding: "utf8" }).stdout.trim();
+    danglers.push(`${path} -> ${target}  (resolves to ${resolve(dirname(abs), target)})`);
+  }
+}
+
+if (danglers.length > 0) {
+  console.error(`FAIL: ${danglers.length} tracked symlink(s) dangle — Jekyll/Pages crashes on these (see header):`);
+  for (const d of danglers) console.error("  " + d);
+  process.exit(1);
+}
+console.log(`ok: all ${tracked} tracked symlinks resolve`);

--- a/universal/a.md
+++ b/universal/a.md
@@ -1,1 +1,1 @@
-../shapes/a.md
+../db/shapes/a.md

--- a/universal/b.md
+++ b/universal/b.md
@@ -1,1 +1,1 @@
-../shapes/b.md
+../db/shapes/b.md

--- a/universal/c.md
+++ b/universal/c.md
@@ -1,1 +1,1 @@
-../shapes/c.md
+../db/shapes/c.md

--- a/universal/d.md
+++ b/universal/d.md
@@ -1,1 +1,1 @@
-../shapes/d.md
+../db/shapes/d.md

--- a/universal/d0.md
+++ b/universal/d0.md
@@ -1,1 +1,1 @@
-../shapes/d0.md
+../db/shapes/d0.md

--- a/universal/e.md
+++ b/universal/e.md
@@ -1,1 +1,1 @@
-../shapes/e.md
+../db/shapes/e.md

--- a/universal/f.md
+++ b/universal/f.md
@@ -1,1 +1,1 @@
-../shapes/f.md
+../db/shapes/f.md


### PR DESCRIPTION
GitHub Pages (Jekyll) has failed on every push since ~00:10Z: the db/ migration moved dirs but not the relative symlinks through them — `db/hy`, `universal/{a..f,d0}.md`, `db/products/glomotion.md` all dangled and Jekyll crashes on realpath. All nine retargeted and verified resolving. New `audit-dangling-symlinks.ts` (gate.yml) checks all 160 tracked symlinks; falsifier verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)