### PR TITLE
feat: port FerryThrottler to TypeScript

### DIFF
--- a/src/Core.TypeScript/ferry-throttler/ferry-throttler.test.ts
+++ b/src/Core.TypeScript/ferry-throttler/ferry-throttler.test.ts
@@ -1,0 +1,333 @@
+/**
+ * ferry-throttler.test.ts — TS reference tests for FerryThrottler port.
+ *
+ * Mirrors the F# test suite at `tests/Tests.FSharp/Runtime/FerryThrottler.Tests.fs`
+ * for byte-locked cross-language parity. Each test name maps to its F# counterpart.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  DETERMINISTIC_CONFIG,
+  FerryThrottler,
+  FerryThrottlerWithResult,
+  withFerries,
+  type FerryThrottlerConfig,
+  type ProcessBatch,
+  type ProcessBatchWithResult,
+} from "./ferry-throttler";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Collect every item processed + boat sizes, drive all items through, complete. */
+async function runCollecting(
+  config: FerryThrottlerConfig,
+  items: number[],
+): Promise<{ processed: number[]; boatSizes: number[] }> {
+  const processed: number[] = [];
+  const boatSizes: number[] = [];
+  const processBatch: ProcessBatch<number> = async (boat) => {
+    boatSizes.push(boat.length);
+    for (const item of boat) processed.push(item);
+  };
+  const throttler = new FerryThrottler(config, processBatch);
+  for (const x of items) {
+    await throttler.enqueue(x);
+  }
+  await throttler.complete();
+  return { processed, boatSizes };
+}
+
+function range(start: number, end: number): number[] {
+  const result: number[] = [];
+  for (let i = start; i <= end; i++) result.push(i);
+  return result;
+}
+
+// ─── Fire-and-forget arity ──────────────────────────────────────────────────
+
+describe("FerryThrottler — fire-and-forget", () => {
+  it("DoP=1 processes every item exactly once, in order", async () => {
+    const items = range(1, 100);
+    const { processed } = await runCollecting(DETERMINISTIC_CONFIG, items);
+    expect(processed).toEqual(items);
+  });
+
+  it("slow traffic ships boats of one — no artificial batching delay", async () => {
+    const processed: number[] = [];
+    const boats: number[] = [];
+    let resolveGate: (() => void) | undefined;
+
+    const processBatch: ProcessBatch<number> = async (boat) => {
+      boats.push(boat.length);
+      for (const item of boat) processed.push(item);
+      resolveGate?.();
+    };
+
+    const throttler = new FerryThrottler(DETERMINISTIC_CONFIG, processBatch);
+
+    for (const x of [10, 20, 30]) {
+      const gate = new Promise<void>((r) => { resolveGate = r; });
+      await throttler.enqueue(x);
+      await gate; // wait for this item's boat to be processed
+    }
+
+    await throttler.complete();
+    expect(processed).toEqual([10, 20, 30]);
+    expect(boats.every((n) => n === 1)).toBe(true);
+  });
+
+  it("bursty traffic coalesces into larger boats up to MaxBatchSize", async () => {
+    const config: FerryThrottlerConfig = { ...DETERMINISTIC_CONFIG, maxBatchSize: 4 };
+    const { processed, boatSizes } = await runCollecting(config, range(1, 50));
+    expect(boatSizes.reduce((a, b) => a + b, 0)).toBe(50);
+    expect(boatSizes.every((n) => n >= 1 && n <= 4)).toBe(true);
+    // All items present
+    expect(new Set(processed)).toEqual(new Set(range(1, 50)));
+  });
+
+  it("DoP=N processes every item exactly once (set-equal; order not guaranteed)", async () => {
+    const items = range(1, 500);
+    const { processed } = await runCollecting(withFerries(4), items);
+    expect(processed.length).toBe(500);
+    expect(new Set(processed)).toEqual(new Set(items));
+  });
+
+  it("bounded queue applies backpressure without dropping work", async () => {
+    const processed: number[] = [];
+    const processBatch: ProcessBatch<number> = async (boat) => {
+      await new Promise((r) => setTimeout(r, 1));
+      for (const item of boat) processed.push(item);
+    };
+    const config: FerryThrottlerConfig = { ...DETERMINISTIC_CONFIG, maxQueueSize: 2 };
+    const throttler = new FerryThrottler(config, processBatch);
+    for (const x of range(1, 30)) {
+      await throttler.enqueue(x);
+    }
+    await throttler.complete();
+    expect(processed.length).toBe(30);
+    expect(new Set(processed)).toEqual(new Set(range(1, 30)));
+  });
+
+  it("byte budget closes boats to match serialization size", async () => {
+    const boats: number[] = [];
+    const processed: number[] = [];
+    const processBatch: ProcessBatch<number> = async (boat) => {
+      boats.push(boat.length);
+      for (const item of boat) processed.push(item);
+    };
+    const config: FerryThrottlerConfig = {
+      ...DETERMINISTIC_CONFIG,
+      maxBatchSize: 100,
+      maxBatchBytes: 25,
+    };
+    const throttler = new FerryThrottler(config, processBatch, () => 10);
+    for (const x of range(1, 10)) await throttler.enqueue(x);
+    await throttler.complete();
+    expect(new Set(processed)).toEqual(new Set(range(1, 10)));
+    // Each item is 10 bytes; budget 25 → boats of at most 2 items
+    expect(boats.every((n) => n >= 1 && n <= 2)).toBe(true);
+  });
+
+  it("a single oversized item still ships alone", async () => {
+    const processed: number[] = [];
+    const processBatch: ProcessBatch<number> = async (boat) => {
+      for (const item of boat) processed.push(item);
+    };
+    const config: FerryThrottlerConfig = { ...DETERMINISTIC_CONFIG, maxBatchBytes: 25 };
+    const throttler = new FerryThrottler(config, processBatch, () => 100);
+    await throttler.enqueue(42);
+    await throttler.complete();
+    expect(processed).toEqual([42]);
+  });
+
+  it("MaxBatchBytes without a sizer is rejected", () => {
+    const noop: ProcessBatch<number> = async () => {};
+    expect(
+      () => new FerryThrottler({ ...DETERMINISTIC_CONFIG, maxBatchBytes: 10 }, noop),
+    ).toThrow();
+  });
+
+  it("invalid configuration is rejected at construction", () => {
+    const noop: ProcessBatch<number> = async () => {};
+    expect(
+      () => new FerryThrottler({ ...DETERMINISTIC_CONFIG, maxDegreeOfParallelism: 0 }, noop),
+    ).toThrow();
+    expect(
+      () => new FerryThrottler({ ...DETERMINISTIC_CONFIG, maxBatchSize: 0 }, noop),
+    ).toThrow();
+  });
+});
+
+// ─── Request/response arity ─────────────────────────────────────────────────
+
+describe("FerryThrottlerWithResult — request/response", () => {
+  it("result arity returns one aligned result per item", async () => {
+    const processBatch: ProcessBatchWithResult<number, number> = async (boat) => {
+      return boat.map((x) => x * 10);
+    };
+    const throttler = new FerryThrottlerWithResult(DETERMINISTIC_CONFIG, processBatch);
+    const tasks = range(1, 20).map((x) => throttler.process(x));
+    const results = await Promise.all(tasks);
+    await throttler.complete();
+    expect(results).toEqual(range(1, 20).map((x) => x * 10));
+  });
+
+  it("result arity faults entire boat on result-length mismatch", async () => {
+    const processBatch: ProcessBatchWithResult<number, number> = async () => {
+      return []; // wrong length
+    };
+    const config: FerryThrottlerConfig = { ...DETERMINISTIC_CONFIG, maxBatchSize: 4 };
+    const throttler = new FerryThrottlerWithResult(config, processBatch);
+    const tasks = range(1, 4).map((x) => throttler.process(x));
+
+    const results = await Promise.allSettled(tasks);
+    await throttler.complete();
+
+    for (const r of results) {
+      expect(r.status).toBe("rejected");
+      if (r.status === "rejected") {
+        expect((r.reason as Error).message).toContain("result count mismatch");
+      }
+    }
+  });
+
+  it("result arity faults every item when processor throws", async () => {
+    const processBatch: ProcessBatchWithResult<number, number> = async () => {
+      throw new Error("boom");
+    };
+    const throttler = new FerryThrottlerWithResult(DETERMINISTIC_CONFIG, processBatch);
+    const tasks = range(1, 3).map((x) => throttler.process(x));
+
+    const results = await Promise.allSettled(tasks);
+    await throttler.complete();
+
+    for (const r of results) {
+      expect(r.status).toBe("rejected");
+      if (r.status === "rejected") {
+        expect((r.reason as Error).message).toBe("boom");
+      }
+    }
+  });
+
+  it("result arity cancels queued item before shipping", async () => {
+    const processed: number[] = [];
+    let resolveGate: (() => void) | undefined;
+    const gate = new Promise<void>((r) => { resolveGate = r; });
+    let entered = false;
+
+    const processBatch: ProcessBatchWithResult<number, number> = async (boat) => {
+      processed.push(boat[0]!);
+      if (!entered) {
+        entered = true;
+        await gate;
+      }
+      return [boat[0]!];
+    };
+
+    const config: FerryThrottlerConfig = { ...DETERMINISTIC_CONFIG, maxBatchSize: 1 };
+    const throttler = new FerryThrottlerWithResult(config, processBatch);
+
+    const first = throttler.process(1);
+
+    // Wait for first to enter the processor
+    await new Promise((r) => setTimeout(r, 10));
+
+    const controller = new AbortController();
+    const second = throttler.process(2, controller.signal);
+    controller.abort();
+
+    resolveGate?.();
+    const firstResult = await first;
+    expect(firstResult).toBe(1);
+
+    const secondResult = await Promise.allSettled([second]);
+    expect(secondResult[0]!.status).toBe("rejected");
+    await throttler.complete();
+    expect(processed).toEqual([1]);
+  });
+
+  it("result arity honors byte budget while preserving aligned results", async () => {
+    const boats: number[] = [];
+    const processBatch: ProcessBatchWithResult<number, number> = async (boat) => {
+      boats.push(boat.length);
+      return boat.map((x) => x + 1);
+    };
+    const config: FerryThrottlerConfig = {
+      ...DETERMINISTIC_CONFIG,
+      maxBatchSize: 100,
+      maxBatchBytes: 25,
+    };
+    const throttler = new FerryThrottlerWithResult(config, processBatch, () => 10);
+    const tasks = range(1, 10).map((x) => throttler.process(x));
+    const results = await Promise.all(tasks);
+    await throttler.complete();
+    expect(results).toEqual(range(1, 10).map((x) => x + 1));
+    expect(boats.every((n) => n >= 1 && n <= 2)).toBe(true);
+  });
+
+  it("result arity faults request when byte sizer throws", async () => {
+    const processed: number[] = [];
+    const processBatch: ProcessBatchWithResult<number, number> = async (boat) => {
+      for (const item of boat) processed.push(item);
+      return boat.map((x) => x);
+    };
+    const config: FerryThrottlerConfig = {
+      ...DETERMINISTIC_CONFIG,
+      maxBatchSize: 4,
+      maxBatchBytes: 100,
+    };
+    const sizer = (item: number): number => {
+      if (item === 2) throw new Error("size failed");
+      return 10;
+    };
+    const throttler = new FerryThrottlerWithResult(config, processBatch, sizer);
+
+    const ok1 = throttler.process(1);
+    const bad = throttler.process(2);
+    const ok3 = throttler.process(3);
+
+    const [r1, rBad, r3] = await Promise.allSettled([ok1, bad, ok3]);
+    await throttler.complete();
+
+    expect(r1!.status).toBe("fulfilled");
+    if (r1!.status === "fulfilled") expect(r1!.value).toBe(1);
+
+    expect(rBad!.status).toBe("rejected");
+    if (rBad!.status === "rejected") {
+      expect((rBad!.reason as Error).message).toBe("size failed");
+    }
+
+    expect(r3!.status).toBe("fulfilled");
+    if (r3!.status === "fulfilled") expect(r3!.value).toBe(3);
+
+    expect(processed).toEqual([1, 3]);
+  });
+
+  it("dispose cancels queued caller tasks", async () => {
+    let resolveEntered: (() => void) | undefined;
+    const entered = new Promise<void>((r) => { resolveEntered = r; });
+    const neverResolve = new Promise<void>(() => {});
+
+    const processBatch: ProcessBatchWithResult<number, number> = async (boat, signal) => {
+      resolveEntered?.();
+      await new Promise<void>((resolve, reject) => {
+        signal.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+        void neverResolve.then(resolve);
+      });
+      return [boat[0]!];
+    };
+
+    const config: FerryThrottlerConfig = { ...DETERMINISTIC_CONFIG, maxBatchSize: 1 };
+    const throttler = new FerryThrottlerWithResult(config, processBatch);
+
+    const first = throttler.process(1);
+    await entered;
+    const second = throttler.process(2);
+
+    throttler.dispose();
+
+    const [r1, r2] = await Promise.allSettled([first, second]);
+    expect(r1!.status).toBe("rejected");
+    expect(r2!.status).toBe("rejected");
+  });
+});

--- a/src/Core.TypeScript/ferry-throttler/ferry-throttler.ts
+++ b/src/Core.TypeScript/ferry-throttler/ferry-throttler.ts
@@ -1,0 +1,588 @@
+/**
+ * ferry-throttler.ts — a degree-of-parallelism-knobbed work queue whose batching
+ * core is the *Flux Capacitor* (Mirror codename): it accumulates queued items and
+ * discharges them as a *boat* (batch) the instant a ferry is free, carrying
+ * whatever is waiting. This is **self-clocked, anti-Nagle** batching — unlike
+ * Nagle's algorithm it adds **no artificial timer/delay**: under slow traffic a
+ * boat of one item sails immediately (zero added latency); under bursts boats
+ * grow up to `maxBatchSize`. Self-clocking is Van Jacobson's ACK-clocking idea
+ * (TCP congestion avoidance, 1988) applied to work batching.
+ *
+ * At `maxDegreeOfParallelism = 1` this is a single deterministic ferry — the
+ * FoundationDB single-thread run-loop shape — and the same type scales to N.
+ *
+ * Prior art / human anchor: the maintainer's Itron `Platform.DotNet`
+ * `Threading.Tasks.Throttling` (`IThrottler`, `MaxDegreeOfParallelism`).
+ *
+ * Port of `src/Core/FerryThrottler.fs` — byte-locked cross-language parity.
+ */
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+/**
+ * Configuration for a FerryThrottler.
+ *
+ * The defaults are the *deterministic* defaults: one ferry. A throttler built
+ * with `DETERMINISTIC_CONFIG` runs as a single cooperative loop — beautiful on
+ * one thread, DST-replayable, the FoundationDB shape — and the SAME code scales
+ * to N ferries by raising `maxDegreeOfParallelism`.
+ */
+export interface FerryThrottlerConfig {
+  /**
+   * Number of ferries (concurrent boat processors). **1 → a single deterministic
+   * cooperative loop** (no cross-ferry interleaving, replays from a seed); **N → N
+   * ferries** draining the same queue for throughput.
+   */
+  readonly maxDegreeOfParallelism: number;
+  /**
+   * Maximum items a single boat carries per `processBatch` call. This is a
+   * *capacity cap, not a delay* — a boat sails with whatever is queued right now,
+   * up to this many. It NEVER waits to fill the boat.
+   */
+  readonly maxBatchSize: number;
+  /**
+   * Optional *byte budget* per boat. `undefined` → count-only batching. When set,
+   * a boat also closes once adding the next item would exceed this many bytes, so
+   * boats stay matched to serialization / buffer / wire sizes. Requires an
+   * `itemSizeBytes` function at construction. A single item larger than the budget
+   * still ships alone — the budget is a target that yields to progress, never a
+   * wall that strands one oversized item.
+   */
+  readonly maxBatchBytes?: number | undefined;
+  /**
+   * Bounded queue size for backpressure. `undefined` → unbounded (enqueue never
+   * blocks). When set, `enqueue` asynchronously waits once N items are in flight
+   * (cooperative backpressure, no dropped work).
+   */
+  readonly maxQueueSize?: number | undefined;
+}
+
+/** Deterministic default: one ferry, 256-item boat cap, unbounded queue. */
+export const DETERMINISTIC_CONFIG: FerryThrottlerConfig = {
+  maxDegreeOfParallelism: 1,
+  maxBatchSize: 256,
+  maxBatchBytes: undefined,
+  maxQueueSize: undefined,
+};
+
+/** Scale-out: `ferries` ferries, otherwise the deterministic defaults. */
+export function withFerries(ferries: number): FerryThrottlerConfig {
+  return { ...DETERMINISTIC_CONFIG, maxDegreeOfParallelism: Math.max(1, ferries) };
+}
+
+/**
+ * Callback that processes one boat (batch) of items. Receives a readonly array
+ * of items and an `AbortSignal` for cooperative cancellation.
+ */
+export type ProcessBatch<T> = (
+  boat: readonly T[],
+  signal: AbortSignal,
+) => Promise<void>;
+
+/**
+ * Callback that processes one boat and returns one result per item (aligned by
+ * index). Receives a readonly array of items and an `AbortSignal`.
+ */
+export type ProcessBatchWithResult<T, R> = (
+  boat: readonly T[],
+  signal: AbortSignal,
+) => Promise<R[]>;
+
+/** Measures the byte size of one item (required when `maxBatchBytes` is set). */
+export type ItemSizeBytes<T> = (item: T) => number;
+
+// ─── Internal: async channel with synchronous tryRead ───────────────────────
+
+/**
+ * Internal channel with synchronous `tryRead` for the ferry drain loop.
+ */
+interface InternalChannel<T> {
+  write(item: T, signal?: AbortSignal): Promise<void>;
+  tryWrite(item: T): boolean;
+  tryRead(): T | undefined;
+  waitToRead(signal: AbortSignal): Promise<boolean>;
+  complete(): void;
+}
+
+function createInternalChannel<T>(capacity?: number): InternalChannel<T> {
+  const buffer: T[] = [];
+  let closed = false;
+
+  let readerWaiters: Array<(hasData: boolean) => void> = [];
+  let writerWaiters: Array<{
+    item: T;
+    resolve: () => void;
+    reject: (err: unknown) => void;
+  }> = [];
+
+  function drainWriters(): void {
+    while (
+      writerWaiters.length > 0 &&
+      (capacity === undefined || buffer.length < capacity)
+    ) {
+      const w = writerWaiters.shift()!;
+      buffer.push(w.item);
+      w.resolve();
+    }
+  }
+
+  function notifyReaders(): void {
+    while (readerWaiters.length > 0 && buffer.length > 0) {
+      const r = readerWaiters.shift()!;
+      r(true);
+    }
+  }
+
+  return {
+    write(item: T, signal?: AbortSignal): Promise<void> {
+      if (closed) return Promise.reject(new Error("Channel closed"));
+      if (signal?.aborted) return Promise.reject(signal.reason);
+
+      if (capacity === undefined || buffer.length < capacity) {
+        buffer.push(item);
+        notifyReaders();
+        return Promise.resolve();
+      }
+
+      // Bounded and full — wait
+      return new Promise<void>((resolve, reject) => {
+        const entry = { item, resolve, reject };
+        writerWaiters.push(entry);
+        if (signal) {
+          signal.addEventListener(
+            "abort",
+            () => {
+              const idx = writerWaiters.indexOf(entry);
+              if (idx >= 0) {
+                writerWaiters.splice(idx, 1);
+                reject(signal.reason);
+              }
+            },
+            { once: true },
+          );
+        }
+      });
+    },
+
+    tryWrite(item: T): boolean {
+      if (closed) return false;
+      if (capacity === undefined || buffer.length < capacity) {
+        buffer.push(item);
+        notifyReaders();
+        return true;
+      }
+      return false;
+    },
+
+    tryRead(): T | undefined {
+      if (buffer.length > 0) {
+        const item = buffer.shift()!;
+        drainWriters();
+        return item;
+      }
+      if (writerWaiters.length > 0) {
+        const w = writerWaiters.shift()!;
+        w.resolve();
+        return w.item;
+      }
+      return undefined;
+    },
+
+    waitToRead(signal: AbortSignal): Promise<boolean> {
+      if (signal.aborted) return Promise.reject(signal.reason);
+      if (buffer.length > 0 || writerWaiters.length > 0) return Promise.resolve(true);
+      if (closed) return Promise.resolve(false);
+
+      return new Promise<boolean>((resolve, reject) => {
+        const handler = (hasData: boolean): void => {
+          signal.removeEventListener("abort", onAbort);
+          resolve(hasData);
+        };
+        const onAbort = (): void => {
+          const idx = readerWaiters.indexOf(handler);
+          if (idx >= 0) readerWaiters.splice(idx, 1);
+          reject(signal.reason);
+        };
+        readerWaiters.push(handler);
+        signal.addEventListener("abort", onAbort, { once: true });
+      });
+    },
+
+    complete(): void {
+      closed = true;
+      for (const r of readerWaiters) r(false);
+      readerWaiters = [];
+      for (const w of writerWaiters) w.reject(new Error("Channel closed"));
+      writerWaiters = [];
+    },
+  };
+}
+
+// ─── FerryThrottler (fire-and-forget) ───────────────────────────────────────
+
+/**
+ * **FerryThrottler** — self-clocked anti-Nagle batching with a DoP knob.
+ *
+ * At `maxDegreeOfParallelism = 1` this is a single deterministic cooperative
+ * loop (DST-replayable). The same code scales to N ferries.
+ *
+ * Ferries are genuine async loops (no thread-per-item; cooperative yielding while
+ * idle). `processBatch` receives each boat.
+ */
+export class FerryThrottler<T> {
+  private readonly _inbox: InternalChannel<T>;
+  private readonly _abortController: AbortController;
+  private readonly _ferryTasks: Promise<void>[];
+  private readonly _sizeOf: ItemSizeBytes<T>;
+  private readonly _config: FerryThrottlerConfig;
+
+  constructor(
+    config: FerryThrottlerConfig,
+    processBatch: ProcessBatch<T>,
+    itemSizeBytes?: ItemSizeBytes<T>,
+  ) {
+    validateConfig(config, itemSizeBytes);
+    this._config = config;
+    this._sizeOf = itemSizeBytes ?? (() => 0);
+    this._inbox = createInternalChannel<T>(config.maxQueueSize);
+    this._abortController = new AbortController();
+
+    this._ferryTasks = Array.from(
+      { length: config.maxDegreeOfParallelism },
+      () => this._runFerry(processBatch),
+    );
+  }
+
+  private async _runFerry(processBatch: ProcessBatch<T>): Promise<void> {
+    const signal = this._abortController.signal;
+    const maxBatch = this._config.maxBatchSize;
+    const byteBudget = this._config.maxBatchBytes;
+    let pending: T | undefined;
+    let hasPending = false;
+
+    try {
+      let running = true;
+      while (running) {
+        let haveWork = hasPending;
+        if (!haveWork) {
+          const more = await this._inbox.waitToRead(signal);
+          haveWork = more;
+          if (!more) running = false;
+        }
+        if (haveWork) {
+          const boat: T[] = [];
+          let bytes = 0;
+
+          if (hasPending) {
+            boat.push(pending as T);
+            bytes = this._sizeOf(pending as T);
+            hasPending = false;
+            pending = undefined;
+          }
+
+          let draining = true;
+          while (draining && boat.length < maxBatch) {
+            const item = this._inbox.tryRead();
+            if (item === undefined) {
+              draining = false;
+            } else {
+              const sz = this._sizeOf(item);
+              if (byteBudget !== undefined && boat.length > 0 && bytes + sz > byteBudget) {
+                pending = item;
+                hasPending = true;
+                draining = false;
+              } else {
+                boat.push(item);
+                bytes += sz;
+              }
+            }
+          }
+
+          if (boat.length > 0) {
+            await processBatch(boat, signal);
+          }
+        }
+      }
+    } catch (e: unknown) {
+      if (!isAbortError(e)) throw e;
+    }
+  }
+
+  /**
+   * Enqueue one item. Returns a promise that resolves when the item is accepted
+   * into the queue — on a bounded throttler this cooperatively waits for room
+   * (backpressure); on an unbounded one it resolves immediately. Does NOT wait
+   * for the item to be *processed*.
+   */
+  async enqueue(item: T, signal?: AbortSignal): Promise<void> {
+    await this._inbox.write(item, signal);
+  }
+
+  /** Try to enqueue without waiting. Returns false if a bounded queue is full. */
+  tryEnqueue(item: T): boolean {
+    return this._inbox.tryWrite(item);
+  }
+
+  /**
+   * Signal that no more items will be enqueued, then await every ferry draining
+   * the queue to completion. After this the throttler is finished.
+   */
+  async complete(): Promise<void> {
+    this._inbox.complete();
+    await Promise.all(this._ferryTasks);
+  }
+
+  /** Dispose: complete the channel, abort ferries, and wait briefly. */
+  dispose(): void {
+    this._inbox.complete();
+    this._abortController.abort();
+    // Fire-and-forget — ferries will catch the abort.
+  }
+}
+
+// ─── FerryRequest (internal for request/response arity) ─────────────────────
+
+interface FerryRequest<T, R> {
+  readonly item: T;
+  resolve: (result: R) => void;
+  reject: (err: unknown) => void;
+  cancelled: boolean;
+}
+
+// ─── FerryThrottlerWithResult (request/response arity) ──────────────────────
+
+/**
+ * Request/response FerryThrottler arity. Producers submit one item and receive
+ * that item's result promise; the ferry still processes boats in batches and fans
+ * aligned results back to the individual callers.
+ *
+ * At `maxDegreeOfParallelism = 1`, completion order is deterministic for
+ * non-cancelled items because one ferry drains boats in FIFO order. With multiple
+ * ferries, every item still receives exactly one result/fault/cancel, but
+ * cross-ferry completion order is intentionally not specified.
+ */
+export class FerryThrottlerWithResult<T, R> {
+  private readonly _inbox: InternalChannel<FerryRequest<T, R>>;
+  private readonly _abortController: AbortController;
+  private readonly _ferryTasks: Promise<void>[];
+  private readonly _sizeOf: ItemSizeBytes<T>;
+  private readonly _config: FerryThrottlerConfig;
+
+  constructor(
+    config: FerryThrottlerConfig,
+    processBatch: ProcessBatchWithResult<T, R>,
+    itemSizeBytes?: ItemSizeBytes<T>,
+  ) {
+    validateConfig(config, itemSizeBytes);
+    this._config = config;
+    this._sizeOf = itemSizeBytes ?? (() => 0);
+    this._inbox = createInternalChannel<FerryRequest<T, R>>(config.maxQueueSize);
+    this._abortController = new AbortController();
+
+    this._ferryTasks = Array.from(
+      { length: config.maxDegreeOfParallelism },
+      () => this._runFerry(processBatch),
+    );
+  }
+
+  private _tryTakeActive(): FerryRequest<T, R> | undefined {
+    for (;;) {
+      const req = this._inbox.tryRead();
+      if (req === undefined) return undefined;
+      if (req.cancelled) continue; // skip cancelled
+      return req;
+    }
+  }
+
+  private _trySizeRequest(req: FerryRequest<T, R>): number | undefined {
+    try {
+      return this._sizeOf(req.item);
+    } catch (e: unknown) {
+      req.reject(e);
+      return undefined;
+    }
+  }
+
+  private async _runFerry(processBatch: ProcessBatchWithResult<T, R>): Promise<void> {
+    const signal = this._abortController.signal;
+    const maxBatch = this._config.maxBatchSize;
+    const byteBudget = this._config.maxBatchBytes;
+    let pending: FerryRequest<T, R> | undefined;
+
+    try {
+      let running = true;
+      while (running) {
+        let haveWork = pending !== undefined;
+        if (!haveWork) {
+          const more = await this._inbox.waitToRead(signal);
+          haveWork = more;
+          if (!more) running = false;
+        }
+        if (haveWork) {
+          const items: T[] = [];
+          const requests: FerryRequest<T, R>[] = [];
+          let bytes = 0;
+
+          // Handle pending (deferred from previous boat)
+          if (pending !== undefined) {
+            if (pending.cancelled) {
+              pending = undefined;
+            } else {
+              const sz = this._trySizeRequest(pending);
+              if (sz !== undefined) {
+                items.push(pending.item);
+                requests.push(pending);
+                bytes = sz;
+              }
+              pending = undefined;
+            }
+          }
+
+          // Drain what's available NOW
+          let draining = true;
+          while (draining && items.length < maxBatch) {
+            const req = this._tryTakeActive();
+            if (req === undefined) {
+              draining = false;
+            } else {
+              const sz = this._trySizeRequest(req);
+              if (sz === undefined) continue; // sizer threw, request already rejected
+              if (byteBudget !== undefined && items.length > 0 && bytes + sz > byteBudget) {
+                pending = req;
+                draining = false;
+              } else {
+                items.push(req.item);
+                requests.push(req);
+                bytes += sz;
+              }
+            }
+          }
+
+          if (items.length > 0) {
+            try {
+              const results = await processBatch(items, signal);
+              if (results.length !== items.length) {
+                const ex = new Error(
+                  `FerryThrottler result count mismatch: processor returned ${results.length} results for ${items.length} items.`,
+                );
+                for (const r of requests) r.reject(ex);
+              } else {
+                for (let i = 0; i < results.length; i++) {
+                  requests[i]!.resolve(results[i]!);
+                }
+              }
+            } catch (e: unknown) {
+              if (isAbortError(e)) {
+                for (const r of requests) r.reject(new AbortError());
+              } else {
+                for (const r of requests) r.reject(e);
+              }
+            }
+          }
+        }
+      }
+    } catch (e: unknown) {
+      // Ferry shutting down — cancel anything remaining
+      if (isAbortError(e)) {
+        this._cancelRemaining(pending);
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  private _cancelRemaining(pending: FerryRequest<T, R> | undefined): void {
+    if (pending !== undefined) {
+      pending.reject(new AbortError());
+    }
+    for (;;) {
+      const req = this._inbox.tryRead();
+      if (req === undefined) break;
+      req.reject(new AbortError());
+    }
+  }
+
+  /**
+   * Submit one item for batch processing. Returns a promise that resolves with
+   * the item's aligned result once the boat containing it is processed.
+   */
+  process(item: T, signal?: AbortSignal): Promise<R> {
+    if (signal?.aborted) {
+      return Promise.reject(signal.reason);
+    }
+
+    return new Promise<R>((resolve, reject) => {
+      const req: FerryRequest<T, R> = { item, resolve, reject, cancelled: false };
+
+      if (signal) {
+        signal.addEventListener(
+          "abort",
+          () => {
+            req.cancelled = true;
+            reject(signal.reason);
+          },
+          { once: true },
+        );
+      }
+
+      this._inbox.write(req, signal).catch((err: unknown) => {
+        req.cancelled = true;
+        reject(err);
+      });
+    });
+  }
+
+  /**
+   * Signal that no more items will be enqueued, then await every ferry draining
+   * the queue to completion.
+   */
+  async complete(): Promise<void> {
+    this._inbox.complete();
+    await Promise.all(this._ferryTasks);
+  }
+
+  /** Dispose: complete the channel, abort ferries. */
+  dispose(): void {
+    this._inbox.complete();
+    this._abortController.abort();
+  }
+}
+
+// ─── Validation ─────────────────────────────────────────────────────────────
+
+function validateConfig<T>(
+  config: FerryThrottlerConfig,
+  itemSizeBytes: ItemSizeBytes<T> | undefined,
+): void {
+  if (config.maxDegreeOfParallelism < 1) {
+    throw new RangeError("maxDegreeOfParallelism must be >= 1");
+  }
+  if (config.maxBatchSize < 1) {
+    throw new RangeError("maxBatchSize must be >= 1");
+  }
+  if (config.maxQueueSize !== undefined && config.maxQueueSize < 1) {
+    throw new RangeError("maxQueueSize, if set, must be >= 1");
+  }
+  if (config.maxBatchBytes !== undefined && config.maxBatchBytes < 1) {
+    throw new RangeError("maxBatchBytes, if set, must be >= 1");
+  }
+  if (config.maxBatchBytes !== undefined && itemSizeBytes === undefined) {
+    throw new RangeError("itemSizeBytes is required when maxBatchBytes is set");
+  }
+}
+
+// ─── Utilities ──────────────────────────────────────────────────────────────
+
+class AbortError extends Error {
+  override readonly name = "AbortError";
+  constructor() {
+    super("The operation was aborted");
+  }
+}
+
+function isAbortError(e: unknown): boolean {
+  if (e instanceof DOMException && e.name === "AbortError") return true;
+  if (e instanceof AbortError) return true;
+  if (e instanceof Error && e.name === "AbortError") return true;
+  return false;
+}

--- a/src/Core.TypeScript/ferry-throttler/index.ts
+++ b/src/Core.TypeScript/ferry-throttler/index.ts
@@ -1,0 +1,1 @@
+export * from "./ferry-throttler";


### PR DESCRIPTION
## Summary

Port `src/Core/FerryThrottler.fs` to `src/Core.TypeScript/ferry-throttler/ferry-throttler.ts`.

## What changed

Both arities preserved with byte-locked cross-language parity:

- **`FerryThrottler<T>`** — fire-and-forget batching
- **`FerryThrottlerWithResult<T, R>`** — request/response with aligned results

All 10 key behaviors from the F# implementation:

1. Self-clocking anti-Nagle (boat sails NOW, never waits to fill)
2. DoP=1 single deterministic cooperative loop (DST-replayable)
3. DoP=N same code scales to N ferries
4. MaxBatchSize capacity cap (not a delay)
5. MaxBatchBytes byte budget (closes boat when exceeded)
6. MaxQueueSize bounded queue for backpressure
7. Request/response arity fans results back to callers
8. One-item pushback when byte budget would be exceeded
9. Cancelled request skipping
10. `complete()` signals no more items, awaits all ferries draining

## What was tested

16 tests mirroring the F# test suite (`tests/Tests.FSharp/Runtime/FerryThrottler.Tests.fs`) — all passing. Pure TypeScript, no runtime-specific APIs.

## Unblocks

- Priority lanes (next step per Rodney's razor)
- Folding `tools/github/poll-pr-gate-batch.ts` through the throttler
- Wiring observe loop priority through FerryThrottler instances

Co-Authored-By: Kiro <noreply@kiro.dev>