### PR TITLE
fix(installer): mirror zeta-first-boot to serial console for B-0891 QEMU

### DIFF
--- a/full-ai-cluster/usb-nixos-installer/nixos/installer/configuration.nix
+++ b/full-ai-cluster/usb-nixos-installer/nixos/installer/configuration.nix
@@ -295,6 +295,8 @@
       Type = "idle";
       ExecStart = "/run/current-system/sw/bin/zeta-first-boot";
       StandardInput = "tty";
+      # tty1 for the operator; zeta-first-boot.sh tees the same stream to
+      # /dev/console so QEMU serial (B-0891) sees [iter-5.1] + retention markers.
       StandardOutput = "tty";
       StandardError = "tty";
       TTYPath = "/dev/tty1";

--- a/full-ai-cluster/usb-nixos-installer/zeta-first-boot.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-first-boot.sh
@@ -25,6 +25,16 @@
 
 set -uo pipefail
 
+# B-0891: mirror first-boot + zeta-install progress to the kernel console.
+# zeta-first-boot.service binds stdout to tty1 for the operator; QEMU and
+# CI harnesses capture serial (console=ttyS0 → /dev/console). Without this
+# tee, [iter-5.1] and retention markers never appear in serial logs even
+# when install succeeds on tty1.
+if [[ -w /dev/console ]]; then
+  exec 3>&1
+  exec > >(/run/current-system/sw/bin/tee -a /dev/console >&3) 2>&1
+fi
+
 CONF=/etc/zeta-firstboot.conf
 [[ -f "$CONF" ]] && . "$CONF"
 HOST="${HOST:-control-plane}"

--- a/tools/ci/audit-installer-substrate.ts
+++ b/tools/ci/audit-installer-substrate.ts
@@ -127,6 +127,8 @@ const REQUIRED_SENTINELS: readonly SentinelAssertion[] = [
       "ETHERNET_WAIT_SECS", // eth-30s wait
       "nmtui", // wifi setup TUI launch
       "zeta-install", // calls into zeta-install.sh after network up
+      "/dev/console", // B-0891 serial mirror for QEMU harness
+      "tee -a /dev/console", // preserves tty1 + mirrors to kernel console
     ],
     rationale: "first-boot script must include eth-wait + nmtui + zeta-install call",
   },

--- a/tools/ci/qemu-full-install-test.ts
+++ b/tools/ci/qemu-full-install-test.ts
@@ -95,6 +95,14 @@ const FAILURE_MARKERS: readonly string[] = [
   "bail", // generic flash-usb / zeta-install bail
 ];
 
+/** Idle live-ISO shell on serial while install markers are absent (B-0891). */
+const IDLE_INSTALLER_SHELL_MARKER = "nixos@zeta-installer:~";
+
+const CONSOLE_MIRROR_HINT =
+  "serial log shows idle installer shell without install progress — " +
+  "zeta-first-boot may be running on tty1 only; mirror output to /dev/console " +
+  "(see full-ai-cluster/usb-nixos-installer/zeta-first-boot.sh)";
+
 const TIMEOUT_SECONDS = 1800; // 30 min — generous for TCG fallback;
 // KVM should finish in 5-10 min
 const POLL_INTERVAL_MS = 2000;
@@ -221,6 +229,21 @@ async function waitForInstallProgress(serialLogPath: string): Promise<InstallRes
               elapsedSeconds: elapsedSec,
             };
           }
+        }
+        if (
+          elapsedSec >= 120 &&
+          content.includes(IDLE_INSTALLER_SHELL_MARKER) &&
+          !content.includes(SUCCESS_MARKER) &&
+          !content.includes("[zeta-first-boot]") &&
+          !content.includes("[iter-")
+        ) {
+          const tail = content.slice(-2000);
+          return {
+            exitCode: 1,
+            reason: `FAILURE — ${CONSOLE_MIRROR_HINT}`,
+            serialLogTail: tail,
+            elapsedSeconds: elapsedSec,
+          };
         }
       } catch {
         // Log file in transit; retry on next poll

--- a/tools/zflash/test-harness/qemu-state.ts
+++ b/tools/zflash/test-harness/qemu-state.ts
@@ -631,7 +631,8 @@ function runManagedCommandUntilSerialMarkers(
         stdout: "",
         stderr:
           `terminal marker observed before required serial markers: ${terminalFailureMarker}; ` +
-          `still waiting for ${stopCondition.successMarkers.join(", ")}`,
+          `still waiting for ${stopCondition.successMarkers.join(", ")}. ` +
+          `If install is progressing on tty1 only, ensure zeta-first-boot mirrors to /dev/console (B-0891).`,
       };
     }
 


### PR DESCRIPTION
## Summary
- **`zeta-first-boot.sh`** tees stdout/stderr to `/dev/console` while preserving tty1 for the operator — QEMU serial now sees `[iter-5.1]` and retention markers when install runs on tty1.
- **`configuration.nix`** documents the tty1 + serial dual-sink contract.
- **`qemu-full-install-test.ts`** fail-fast after 2 min when serial shows idle `nixos@zeta-installer:~` without install progress (points at console mirror).
- **`audit-installer-substrate.ts`** sentinel guards the tee pattern.

Per Rodney's Razor: the install.sh / zeta-install.sh split stays; this fixes the accidental console-capture gap blocking B-0891 scenarios 2–4.

## Test plan
- [ ] `bash -n full-ai-cluster/usb-nixos-installer/zeta-first-boot.sh`
- [ ] `bun test tools/zflash/test-harness/qemu-state.test.ts`
- [ ] `build-ai-cluster-iso` scenario 2 + workflow_dispatch scenarios 3–4 after merge


Made with [Cursor](https://cursor.com)