### PR TITLE
fix(setup): skip idle 
Skipping NuGet package signature verification.
Updated advertising manifest microsoft.net.workloads.
No workload update found.
No workloads installed for this feature band. To update workloads installed with earlier SDK versions, include the --from-previous-sdk option.
Garbage collecting for SDK feature band(s) 8.0.100 10.0.200...

Successfully updated workload(s): . — the low-memory CI wedge (my #7839 lane)

### DIFF
--- a/tools/setup/common/dotnet-workloads.sh
+++ b/tools/setup/common/dotnet-workloads.sh
@@ -32,7 +32,23 @@ if [ -f "$MANIFEST" ]; then
   done < "$MANIFEST_LINES"
 fi
 
-# Bring whatever is installed up to the SDK's matching versions (no-op when none).
-echo "↻ dotnet workload update..."
-dotnet workload update >/dev/null 2>&1 || echo "  (workload update skipped: $?)"
+# Bring installed workloads to the SDK's matching versions — ONLY when something is actually
+# installed. `dotnet workload update` is NOT a local no-op on an empty machine: it resolves
+# workload manifests over NuGet, and on a constrained runner that network stall can hang the
+# whole install step (live failure 2026-06-12: the low-memory CI lane wedged twice at 20-65min
+# inside install.sh on this line, with output swallowed so the hang was invisible). Skip-by-
+# default unless we positively see an installed workload or this run just installed one.
+manifest_entries=0
+if [ -f "$MANIFEST" ]; then
+  manifest_entries="$(grep -cvE '^(#|$)' "$MANIFEST" || true)"
+fi
+# installed = any table row between the dashed header and the next blank line ("no installed
+# workloads" sentinel text varies by SDK; the empty table is the stable signal).
+installed_count="$(dotnet workload list 2>/dev/null | awk '/^-+$/{t=1;next} t&&NF{c++} t&&!NF{t=0} END{print c+0}')"
+if [ "$manifest_entries" -gt 0 ] || [ "$installed_count" -gt 0 ]; then
+  echo "↻ dotnet workload update..."
+  dotnet workload update || echo "  (workload update failed: $? — not fatal; manifests stay pinned by global.json)"
+else
+  echo "✓ no workloads installed and manifest empty — skipping workload update (no idle network call)"
+fi
 echo "✓ dotnet workloads in sync"


### PR DESCRIPTION
`dotnet workload update` on an empty machine still downloads every advertising manifest over NuGet — that stall wedged the low-memory lane twice tonight inside install.sh (output was swallowed, so the hang was invisible). Update now runs only when the manifest lists workloads or installed workloads exist (empty-table detection — sentinel text varies by SDK), and its output is visible when it does. Verified live both ways on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)