### PR TITLE
feat(setup): host tiers × package requirements — `tier=` in manifests, ZETA_HOST_TIER on hosts (workitem 081KTWQZY7F)

### DIFF
--- a/.github/workflows/low-memory.yml
+++ b/.github/workflows/low-memory.yml
@@ -140,6 +140,11 @@ jobs:
           key: nuget-${{ runner.os }}-${{ hashFiles('Directory.Packages.props') }}
 
       - name: Install toolchain via three-way-parity script (GOVERNANCE Section 24)
+        # slim host declaration: this lane builds+tests only — standard/full-tier manifest
+        # entries (stryker, analyzers, the diagnostics suite) are skipped LOUDLY by
+        # dotnet-tools.sh. Workitem 081KTWQZY7F08QG0R0034KN17T (host tiers x package requires).
+        env:
+          ZETA_HOST_TIER: slim
         run: ./tools/setup/install.sh
 
       - name: Build (0 Warning(s) / 0 Error(s) required)

--- a/tools/setup/common/dotnet-tools.sh
+++ b/tools/setup/common/dotnet-tools.sh
@@ -28,6 +28,22 @@ fi
 # sharing a name prefix (dotnet-ef vs dotnet-ef-tools) don't collide.
 INSTALLED="$(dotnet tool list -g 2>/dev/null | awk 'NR>2 {print tolower($1)}' || echo '')"
 
+# HOST TIERS (Aaron 2026-06-12: "packages declare their requirements and os declare their
+# capabilities — that's how we know not to install on small/slow runners"): a manifest entry may
+# carry `tier=<slim|standard|full>`; the host declares ZETA_HOST_TIER (default full — dev
+# machines get everything; constrained CI lanes declare slim). Untagged entries are slim
+# (required everywhere). Install when host >= requirement; skips are LOUD, never silent.
+HOST_TIER="${ZETA_HOST_TIER:-full}"
+tier_rank() {
+  case "$1" in
+    slim) echo 0 ;;
+    standard) echo 1 ;;
+    full) echo 2 ;;
+    *) echo "error: unknown tier '$1' (slim|standard|full)" >&2; return 1 ;;
+  esac
+}
+HOST_RANK="$(tier_rank "$HOST_TIER")"
+
 MANIFEST_LINES="$(mktemp)"
 trap 'rm -f "$MANIFEST_LINES"' EXIT
 awk '
@@ -36,8 +52,17 @@ awk '
 ' "$MANIFEST" > "$MANIFEST_LINES"
 
 while IFS= read -r line || [ -n "$line" ]; do
-  # Manifest lines are "<tool> <version>" or just "<tool>".
+  # Manifest lines are "<tool> [<version>] [tier=<t>]".
+  required_tier="slim"
+  for token in $line; do
+    case "$token" in tier=*) required_tier="${token#tier=}" ;; esac
+  done
+  line="${line// tier=$required_tier/}"
   tool="$(echo "$line" | awk '{print $1}')"
+  if [ "$(tier_rank "$required_tier")" -gt "$HOST_RANK" ]; then
+    echo "→ $tool skipped: requires tier=$required_tier, host declares $HOST_TIER (ZETA_HOST_TIER)"
+    continue
+  fi
   version="$(echo "$line" | awk '{print $2}')"
   tool_lc="$(echo "$tool" | tr '[:upper:]' '[:lower:]')"
   if echo "$INSTALLED" | grep -Fxq "$tool_lc"; then

--- a/tools/setup/manifests/dotnet-tools
+++ b/tools/setup/manifests/dotnet-tools
@@ -2,8 +2,12 @@
 # Format: <tool-id> [<version>]    (version optional; comments start with `#`)
 #
 # Pin only when we have a reason to pin; unpinned tools track latest.
+#
+# `tier=<slim|standard|full>` declares an entry's host requirement (untagged = slim = required
+# everywhere). Hosts declare ZETA_HOST_TIER (default full; the low-memory CI lane declares slim).
+# Workitem 081KTWQZY7F08QG0R0034KN17T — the cap/support pattern applied to setup.
 
-dotnet-stryker
+dotnet-stryker tier=standard
 # F# analyzers pack — G-Research rules + FSharp.Analyzers.Build
 # MSBuild integration. README.md references `dotnet tool install
 # --global fsharp-analyzers` directly; this manifest makes that
@@ -11,15 +15,15 @@ dotnet-stryker
 # `dotnet msbuild /t:AnalyzeFSharpProject` works for every
 # contributor without a separate install step. Bodhi round-34
 # DX audit flagged the tooling-gap.
-fsharp-analyzers
+fsharp-analyzers tier=standard
 # The cross-platform diagnostics suite (Aaron 2026-06-11: "the dotnet CLI perf commands are
 # cross-platform and pretty good — we should use those; it's dotnet tools you install").
 # EventPipe-based, works on macOS/Linux/Windows — the statistical/offline lane beside Ben's
 # deterministic meters (B-1039/B-1040): trace = CPU/event capture (opens in PerfView or
 # SpeedScope), counters = live metrics, gcdump = heap snapshots, dump = post-mortem,
 # stack = quick stack prints.
-dotnet-trace
-dotnet-counters
-dotnet-gcdump
-dotnet-dump
-dotnet-stack
+dotnet-trace tier=standard
+dotnet-counters tier=standard
+dotnet-gcdump tier=standard
+dotnet-dump tier=standard
+dotnet-stack tier=standard

--- a/workitems/081KTWQZY7F08QG0R0034KN17T-host-tiers-x-package-requirements-manifests-declare-requires.md
+++ b/workitems/081KTWQZY7F08QG0R0034KN17T-host-tiers-x-package-requirements-manifests-declare-requires.md
@@ -1,0 +1,44 @@
+---
+id: 081KTWQZY7F08QG0R0034KN17T
+type: task
+state: backlog
+priority: P2
+slug: host-tiers-x-package-requirements-manifests-declare-requires
+title: "Host tiers x package requirements — manifests declare requires, hosts declare capabilities, the installer matches (the cap/support pattern applied to setup)"
+created: 2026-06-12T01:43:52.303Z
+depends_on: []
+composes_with: []
+---
+
+# Host tiers x package requirements — manifests declare requires, hosts declare capabilities, the installer matches (the cap/support pattern applied to setup)
+
+<!-- Work-item body. ZetaId-keyed (conflict-free, time-sortable). "Backlog" is a
+     STATE = this folder; completion moves the file to workitems/done/YYYY/MM/.
+     Identity is the zetaid prefix — resolve cross-refs by `081KTWQZY7F08QG0R0034KN17T-*.md` glob. -->
+
+## Origin (Aaron 2026-06-12, verbatim)
+
+> "maybe we should start having category or tier or something when we add a tier or packages can
+> declare their requirements and os declare their capablities and that's how wo know not to
+> install on small/slow runner"
+
+Triggered by the low-memory wedge (#7865): `dotnet workload update` downloading every advertising
+manifest on a constrained runner. The shape is EXACTLY the capability-ledger pattern
+(db/capabilities: cap rows declare, support rows place) applied to setup — packages = cap rows
+(declare requirements), hosts = support rows (declare capabilities), the installer is the
+resolver. Prior art in-repo: one-liner-tools.sh ZETA_INSTALL_FULL opt-in (a 2-tier special case).
+
+## Slice 1 (landed with this workitem)
+
+- Manifest token `tier=<slim|standard|full>` (untagged = slim = required everywhere);
+  `ZETA_HOST_TIER` declares the host (default full — dev machines get everything; the low-memory
+  workflow declares slim). slim < standard < full; install when host ≥ requirement; skips are
+  LOUD (named tool + both tiers).
+- Applied in dotnet-tools.sh; the diagnostics suite + stryker + fsharp-analyzers tagged standard
+  (build/test on slim lanes need none of them; gate lanes default to full).
+
+## Remaining
+
+- Auto-detect host capabilities (mem/cores) instead of/alongside the env declaration.
+- Extend to brew/mise/one-liner manifests (fold ZETA_INSTALL_FULL into the same tiers).
+- Unify with db/capabilities resolver wiring (one cap/support vocabulary across setup + runtime).


### PR DESCRIPTION
Aaron's observation built: packages declare requirements (`tier=slim|standard|full` manifest token), hosts declare capabilities (`ZETA_HOST_TIER`, default full), the installer matches — skips loud, never silent. Diagnostics suite + stryker + analyzers tagged standard; the low-memory lane declares slim (seven NuGet installs gone from the wedge-prone path). Verified live both tiers. Same cap/support shape as db/capabilities; unification named in the workitem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)