### PR TITLE
feat(setup): host-tier slice 2 — shared helper + memory auto-detect; brew/workloads/dotnet-tools tier-aware

### DIFF
--- a/tools/setup/common/dotnet-tools.sh
+++ b/tools/setup/common/dotnet-tools.sh
@@ -28,21 +28,9 @@ fi
 # sharing a name prefix (dotnet-ef vs dotnet-ef-tools) don't collide.
 INSTALLED="$(dotnet tool list -g 2>/dev/null | awk 'NR>2 {print tolower($1)}' || echo '')"
 
-# HOST TIERS (Aaron 2026-06-12: "packages declare their requirements and os declare their
-# capabilities — that's how we know not to install on small/slow runners"): a manifest entry may
-# carry `tier=<slim|standard|full>`; the host declares ZETA_HOST_TIER (default full — dev
-# machines get everything; constrained CI lanes declare slim). Untagged entries are slim
-# (required everywhere). Install when host >= requirement; skips are LOUD, never silent.
-HOST_TIER="${ZETA_HOST_TIER:-full}"
-tier_rank() {
-  case "$1" in
-    slim) echo 0 ;;
-    standard) echo 1 ;;
-    full) echo 2 ;;
-    *) echo "error: unknown tier '$1' (slim|standard|full)" >&2; return 1 ;;
-  esac
-}
-HOST_RANK="$(tier_rank "$HOST_TIER")"
+# HOST TIERS — shared helper (workitem 081KTWQZY7F08QG0R0034KN17T).
+# shellcheck source=tools/setup/common/host-tier.sh disable=SC1091
+. "$(cd "$(dirname "$0")" && pwd)/host-tier.sh"
 
 MANIFEST_LINES="$(mktemp)"
 trap 'rm -f "$MANIFEST_LINES"' EXIT
@@ -53,14 +41,11 @@ awk '
 
 while IFS= read -r line || [ -n "$line" ]; do
   # Manifest lines are "<tool> [<version>] [tier=<t>]".
-  required_tier="slim"
-  for token in $line; do
-    case "$token" in tier=*) required_tier="${token#tier=}" ;; esac
-  done
-  line="${line// tier=$required_tier/}"
+  required_tier="$(zeta_tier_of_line "$line")"
+  line="$(zeta_strip_tier "$line")"
   tool="$(echo "$line" | awk '{print $1}')"
-  if [ "$(tier_rank "$required_tier")" -gt "$HOST_RANK" ]; then
-    echo "→ $tool skipped: requires tier=$required_tier, host declares $HOST_TIER (ZETA_HOST_TIER)"
+  if ! zeta_tier_allows "$required_tier"; then
+    echo "→ $tool skipped: requires tier=$required_tier, host is $ZETA_HOST_TIER ($ZETA_HOST_TIER_SOURCE)"
     continue
   fi
   version="$(echo "$line" | awk '{print $2}')"

--- a/tools/setup/common/host-tier.sh
+++ b/tools/setup/common/host-tier.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# tools/setup/common/host-tier.sh — THE HOST-TIER HELPER, sourced by installers.
+# Workitem 081KTWQZY7F08QG0R0034KN17T (Aaron 2026-06-12: "packages can declare their
+# requirements and os declare their capabilities and that's how we know not to install on
+# small/slow runners") — the cap/support pattern applied to setup: manifest entries declare
+# `tier=<slim|standard|full>` (untagged = slim = required everywhere); the host declares
+# ZETA_HOST_TIER, or we AUTO-DETECT from memory when undeclared (>=16GB full; >=8GB standard;
+# else slim). Skips must be LOUD — every caller prints the named entry + both tiers.
+#
+# Usage (in a sourced installer):
+#   . "$(dirname "$0")/host-tier.sh"
+#   req="$(zeta_tier_of_line "$line")"; line="$(zeta_strip_tier "$line")"
+#   if ! zeta_tier_allows "$req"; then echo "→ $name skipped: requires tier=$req, host is $ZETA_HOST_TIER"; continue; fi
+
+zeta_tier_rank() {
+  case "$1" in
+    slim) echo 0 ;;
+    standard) echo 1 ;;
+    full) echo 2 ;;
+    *) echo "error: unknown tier '$1' (slim|standard|full)" >&2; return 1 ;;
+  esac
+}
+
+zeta_detect_host_tier() {
+  local mem_bytes=""
+  if [ "$(uname -s)" = "Darwin" ]; then
+    mem_bytes="$(sysctl -n hw.memsize 2>/dev/null || echo 0)"
+  elif [ -r /proc/meminfo ]; then
+    mem_bytes="$(( $(awk '/^MemTotal:/{print $2}' /proc/meminfo) * 1024 ))"
+  fi
+  if [ -z "$mem_bytes" ] || [ "$mem_bytes" -eq 0 ] 2>/dev/null; then
+    echo full # unknown hardware: degrade to the permissive default, never silently slim
+  elif [ "$mem_bytes" -ge $((16 * 1024 * 1024 * 1024)) ]; then
+    echo full
+  elif [ "$mem_bytes" -ge $((8 * 1024 * 1024 * 1024)) ]; then
+    echo standard
+  else
+    echo slim
+  fi
+}
+
+# Resolve once: explicit declaration wins; otherwise detect (and say which path was taken).
+if [ -n "${ZETA_HOST_TIER:-}" ]; then
+  zeta_tier_rank "$ZETA_HOST_TIER" >/dev/null # validate or die loudly
+  ZETA_HOST_TIER_SOURCE="declared"
+else
+  ZETA_HOST_TIER="$(zeta_detect_host_tier)"
+  ZETA_HOST_TIER_SOURCE="detected"
+fi
+ZETA_HOST_RANK="$(zeta_tier_rank "$ZETA_HOST_TIER")"
+export ZETA_HOST_TIER ZETA_HOST_RANK ZETA_HOST_TIER_SOURCE
+
+# tier of a manifest line (default slim).
+zeta_tier_of_line() {
+  local token tier="slim"
+  for token in $1; do
+    case "$token" in tier=*) tier="${token#tier=}" ;; esac
+  done
+  echo "$tier"
+}
+
+# the line with its tier= token removed.
+zeta_strip_tier() {
+  local token out=""
+  for token in $1; do
+    case "$token" in tier=*) ;; *) out="$out $token" ;; esac
+  done
+  echo "${out# }"
+}
+
+# does the host allow an entry requiring $1?
+zeta_tier_allows() {
+  [ "$(zeta_tier_rank "$1")" -le "$ZETA_HOST_RANK" ]
+}

--- a/tools/setup/macos.sh
+++ b/tools/setup/macos.sh
@@ -96,10 +96,21 @@ if [ -f "$BREW_MANIFEST" ]; then
     { sub(/#.*$/, ""); gsub(/^[[:space:]]+|[[:space:]]+$/, "") }
     NF > 0 { print }
   ' "$BREW_MANIFEST")"
+  # HOST TIERS — entries may carry tier=<slim|standard|full>; host declares or auto-detects
+  # (workitem 081KTWQZY7F08QG0R0034KN17T).
+  # shellcheck disable=SC1091
+  . "$SETUP_DIR/common/host-tier.sh"
   if [ -n "$PKGS" ]; then
     echo "↓ installing brew packages from $(basename "$BREW_MANIFEST")..."
     # `brew install` is idempotent on already-installed formulae.
-    printf '%s\n' "$PKGS" | while IFS= read -r pkg; do
+    printf '%s\n' "$PKGS" | while IFS= read -r pkg_line; do
+      required_tier="$(zeta_tier_of_line "$pkg_line")"
+      pkg="$(zeta_strip_tier "$pkg_line" | awk '{print $1}')"
+      [ -z "$pkg" ] && continue
+      if ! zeta_tier_allows "$required_tier"; then
+        echo "→ $pkg skipped: requires tier=$required_tier, host is $ZETA_HOST_TIER ($ZETA_HOST_TIER_SOURCE)"
+        continue
+      fi
       if brew list --formula "$pkg" >/dev/null 2>&1; then
         brew upgrade "$pkg" >/dev/null 2>&1 || true
       else

--- a/tools/setup/manifests/brew
+++ b/tools/setup/manifests/brew
@@ -36,7 +36,7 @@ ollama  # CPU-served tiny model for the move-next selector + observe.ts
 # for qcow2 snapshot/restart state preservation. The file-backed zflash
 # image builder uses mtools' mcopy to write ESP payloads into raw images
 # without mounting physical USB devices.
-qemu
+qemu tier=standard
 mtools
 
 # Formal-verification rung 3 — TLAPS (tlapm, TLA+ proof manager) toolchain
@@ -46,7 +46,7 @@ mtools
 # opam = the OCaml package manager that builds tlapm from a pinned source
 # commit (see common/tlaps.sh). The SMT backend (z3) is declared below.
 # Bottled; idempotent (brew install skips if present).
-opam  # OCaml package manager — builds tlapm from source per common/tlaps.sh
+opam tier=standard  # OCaml package manager — builds tlapm from source per common/tlaps.sh
 
 # Container runtime for the effectful do_item executor (rationale: B-0964 §2). podman
 # is the default OCI runtime: Apache-2.0, rootless, daemonless. Coexists with an
@@ -54,7 +54,7 @@ opam  # OCaml package manager — builds tlapm from source per common/tlaps.sh
 # /`podman-docker` (they shadow the real docker CLI). macOS one-time bootstrap:
 # `podman machine init && podman machine start`. Version unpinned (fast-mover CLI;
 # brew default) per dep-pin-search-first-authority. Idempotent: brew skips if present.
-podman
+podman tier=standard
 
 # Z3 SMT solver — the formal-verification portfolio's SMT prover (tools/Z3Verify +
 # Formal/Z3.Laws.Tests shell `z3 -in`). Was UNDECLARED (the test self-skips when absent =
@@ -68,7 +68,7 @@ z3
 # "the patterns in R are timeless… scatter plots… to find solid ground over memory space").
 # Pin per dep-pin-search-first (WebSearch 2026-06-08): brew formula `r`, GPL-2; brew default
 # version; idempotent (brew skips if present). Symmetric with apt `r-base` + windows `r`.
-r
+r tier=standard
 
 # tectonic — lean single-binary LaTeX engine (Leslie Lamport's LaTeX on a self-contained XeTeX;
 # Aaron 2026-06-08 "pull in Lamport's LaTeX"). COST-AWARE: a few-MB binary that fetches packages
@@ -76,7 +76,7 @@ r
 # rendering + LaTeX-source as an LLM-readable math representation. Pin per dep-pin-search-first
 # (WebSearch 2026-06-08): brew formula `tectonic`, MIT; idempotent. Symmetric with windows
 # `tectonic` (scoop main). Linux: best-effort gap — see the NOTE in manifests/apt.
-tectonic
+tectonic tier=standard
 gnupg  # GPG — commit/artifact signing (close-over GPG, Aaron 2026-06-09)
 
 # Network plane — Reticulum + Headscale (Aaron 2026-06-10: "we are using Reticulum and

--- a/workitems/081KTWQZY7F08QG0R0034KN17T-host-tiers-x-package-requirements-manifests-declare-requires.md
+++ b/workitems/081KTWQZY7F08QG0R0034KN17T-host-tiers-x-package-requirements-manifests-declare-requires.md
@@ -37,8 +37,24 @@ resolver. Prior art in-repo: one-liner-tools.sh ZETA_INSTALL_FULL opt-in (a 2-ti
 - Applied in dotnet-tools.sh; the diagnostics suite + stryker + fsharp-analyzers tagged standard
   (build/test on slim lanes need none of them; gate lanes default to full).
 
+## Slice 2 (Aaron: "what else we got — do that too")
+
+- `common/host-tier.sh` — THE shared helper: explicit `ZETA_HOST_TIER` wins, else AUTO-DETECT
+  from memory (>=16GB full / >=8GB standard / else slim; unknown hardware degrades to full —
+  permissive, never silently slim); skip messages name declared-vs-detected.
+- Consumers: dotnet-tools.sh (refactored onto the helper), dotnet-workloads.sh (entries may
+  carry tier=), macos.sh brew loop (tier-aware parse — a tier= token no longer reaches
+  `brew install`).
+- brew manifest: qemu/podman/opam/r/tectonic tagged standard (z3 stays slim — tests use it;
+  ollama/hermes stay slim — operator-declared core).
+
 ## Remaining
 
-- Auto-detect host capabilities (mem/cores) instead of/alongside the env declaration.
-- Extend to brew/mise/one-liner manifests (fold ZETA_INSTALL_FULL into the same tiers).
+- apt manifest: all current entries are dotnet-required (slim) — tier the loop when a heavy
+  entry first appears.
+- mise: `.mise.toml` installs wholesale; tiering means splitting the k8s set (k3d/kind/kubectl/
+  helm/kubeconform) out — a real change, decide deliberately.
+- Fold the legacy full-tier gates (ZETA_INSTALL_FULL in one-liner-tools/tlaps, ZETA_INSTALL_QUANTUM)
+  into the same vocabulary.
+- verifiers.sh jars: tests may invoke TLC/Alloy — audit before tiering.
 - Unify with db/capabilities resolver wiring (one cap/support vocabulary across setup + runtime).


### PR DESCRIPTION
Slice 2 of workitem 081KTWQZY7F per Aaron's go-ahead: one shared helper (explicit ZETA_HOST_TIER wins, else memory auto-detect ≥16GB full / ≥8GB standard / else slim; unknown degrades permissive-to-full), wired into dotnet-tools, dotnet-workloads, and the macos brew loop (tier tokens no longer reach `brew install`). Brew heavies (qemu/podman/opam/r/tectonic) tagged standard; z3 and ollama/hermes deliberately stay slim. Verified live on both tiers + falsifier. Remaining slices named in the workitem (apt, mise split, legacy-flag folding, verifiers audit, db/capabilities unification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)