### PR TITLE
feat(setup): mise k8s split — .mise.full.toml on full hosts; clusters declare full; CI tests full (workitem 081KTWQZY7F slice 3)

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -354,7 +354,7 @@ jobs:
           path: |
             ~/.local/share/mise
             ~/.cache/mise
-          key: mise-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.mise.toml') }}
+          key: mise-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.mise.toml', '.mise.full.toml') }}
 
       - name: Cache elan (Lean 4 toolchain)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -500,6 +500,9 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install toolchain via three-way-parity script (GOVERNANCE §24)
+        env:
+          # kubeconform lives in .mise.full.toml — declare full explicitly (workitem 081KTWQZY7F)
+          ZETA_HOST_TIER: full
         run: ./tools/setup/install.sh
 
       - name: yamllint (k8s manifests)

--- a/.github/workflows/k8s-argocd-health-test.yml
+++ b/.github/workflows/k8s-argocd-health-test.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Install toolchain via three-way-parity script
         env:
           MISE_GITHUB_TOKEN: ${{ github.token }}
+          # k8s lane NEEDS the .mise.full.toml set (k3d/kubectl/helm) — declare full
+          # explicitly, never rely on runner-size auto-detect (workitem 081KTWQZY7F).
+          ZETA_HOST_TIER: full
         run: ./tools/setup/install.sh
 
       - name: Install bun dependencies
@@ -97,6 +100,9 @@ jobs:
       - name: Install toolchain via three-way-parity script
         env:
           MISE_GITHUB_TOKEN: ${{ github.token }}
+          # k8s lane NEEDS the .mise.full.toml set (k3d/kubectl/helm) — declare full
+          # explicitly, never rely on runner-size auto-detect (workitem 081KTWQZY7F).
+          ZETA_HOST_TIER: full
         run: ./tools/setup/install.sh
 
       - name: Install bun dependencies

--- a/.github/workflows/low-memory.yml
+++ b/.github/workflows/low-memory.yml
@@ -111,7 +111,7 @@ jobs:
           path: |
             ~/.local/share/mise
             ~/.cache/mise
-          key: mise-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.mise.toml') }}
+          key: mise-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.mise.toml', '.mise.full.toml') }}
 
       - name: Cache elan (Lean 4 toolchain)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.mise.full.toml
+++ b/.mise.full.toml
@@ -1,0 +1,16 @@
+# Full-tier runtime pins — merged into .mise.toml ONLY when the host is tier=full
+# (MISE_ENV=full, set by tools/setup/common/mise.sh via the host-tier helper).
+# Workitem 081KTWQZY7F08QG0R0034KN17T; Aaron 2026-06-12: "addison and max and every cluster
+# [node gets] full" — cluster nodes declare full at the zeta-install.sh call site regardless of
+# hardware auto-detect; CI k8s lanes declare full explicitly; slim/standard hosts skip these.
+#
+# Cluster integration + GitOps health tooling (operator 2026-05-31): B-0967 proves
+# Kubernetes + ArgoCD health through k3d/kind; kubeconform validates the k8s manifests in
+# the `lint (yaml/k8s)` gate job. Same pins as before the split — one tool graph, tiered.
+
+[tools]
+k3d = "5.8.3"
+kind = "0.31.0"
+kubectl = "1.36.1"
+helm = "4.2.0"
+"ubi:yannh/kubeconform" = "0.7.0"

--- a/.mise.toml
+++ b/.mise.toml
@@ -60,16 +60,10 @@ actionlint = "1.7.12"
 # slim + ubuntu-24.04-arm runners don't ship shellcheck pre-
 # installed, so declarative pin here ensures dev/CI parity.
 shellcheck = "0.11.0"
-# Cluster integration + GitOps health tooling (operator 2026-05-31):
-# B-0891 keeps USB/ISO tests focused on zflash/boot/retention, while
-# B-0967 proves Kubernetes + ArgoCD health separately through k3d/kind.
-# Pin these here so dev laptops, CI runners, devcontainers, Windows
-# install.ps1, and NixOS-installed nodes running install.sh converge on
-# one tool graph instead of ad hoc `brew install ...` instructions.
-k3d = "5.8.3"
-kind = "0.31.0"
-kubectl = "1.36.1"
-helm = "4.2.0"
+# Cluster integration + GitOps tooling (k3d/kind/kubectl/helm/kubeconform) moved to
+# .mise.full.toml (host-tier split, workitem 081KTWQZY7F08QG0R0034KN17T): full-tier hosts
+# (dev laptops, cluster nodes, CI k8s lanes) still converge on the one pinned tool graph
+# via MISE_ENV=full; slim/standard hosts skip the k8s set.
 # Node + npm: required for the npm-backed mise tools below.
 # Mise's `npm:` backend installs via `npm install -g`, so the
 # Node runtime must be installed first. Pinned here so dev
@@ -113,14 +107,6 @@ node = "24"
 # pip (the uv-canonical ADR; identical to `pipx:semgrep` above). No pip anywhere.
 # Pin per dep-pin-search-first (PyPI 2026-06-10: 1.38.0).
 "pipx:yamllint" = "1.38.0"
-# kubeconform: FAST offline Kubernetes-manifest schema validator (the other half
-# of the `lint (yaml/k8s)` gate — validates ArgoCD Application CRs + k8s manifests
-# against API schemas; --ignore-missing-schemas so CRDs don't false-fail). A Go
-# binary, installed cross-platform via mise's `ubi:` backend (GitHub-release
-# universal binary installer) — one pin covers mac/linux/windows, install.sh +
-# install.ps1 in sync. Pin per dep-pin-search-first (GitHub releases 2026-06-10:
-# v0.7.0; ubi strips the leading v).
-"ubi:yannh/kubeconform" = "0.7.0"
 
 [settings]
 # `python-build-standalone` (upstream for mise's python plugin)

--- a/full-ai-cluster/usb-nixos-installer/zeta-install.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-install.sh
@@ -1426,7 +1426,7 @@ if [ -d "$ZETA_HOME" ]; then
       BUN_INSTALL="$ZETA_HOME/.bun" \
       ZETA_INSTALL_NIXOS_MODE=installed \
       ZETA_INSTALL_FULL=1 \
-      bash -c "cd $ZETA_HOME/Zeta && tools/setup/install.sh" 2>&1 | tail -10 || \
+      bash -c "cd $ZETA_HOME/Zeta && ZETA_HOST_TIER=full tools/setup/install.sh" 2>&1 | tail -10 || \
         echo "[iter-5.5.0]   WARN: install.sh FAILED — runtimes/agent CLIs may be partial; can retry post-reboot via 'cd ~/Zeta && tools/setup/install.sh'"
   fi
 

--- a/tools/ci/manifest-symmetry.test.ts
+++ b/tools/ci/manifest-symmetry.test.ts
@@ -26,7 +26,12 @@ function parseManifest(name: string): string[] {
 }
 
 function expectMiseTool(name: string, version: string): void {
-  const raw = readFileSync(join(repoRoot, ".mise.toml"), "utf8");
+  // the host-tier split (workitem 081KTWQZY7F): full-tier pins live in .mise.full.toml,
+  // merged via MISE_ENV=full — symmetry holds across the PAIR, not one file.
+  const raw =
+    readFileSync(join(repoRoot, ".mise.toml"), "utf8") +
+    "\n" +
+    readFileSync(join(repoRoot, ".mise.full.toml"), "utf8");
   expect(raw).toMatch(miseToolPattern(name, version));
 }
 
@@ -72,6 +77,8 @@ const WINDOWS_EXCEPTIONS: Record<string, string> = {
   "fuse-overlayfs": "Linux rootless overlay storage driver; Windows podman uses WSL2's VM storage",
   opam: "OCaml package manager; only needed on Unix to build tlapm from source. Windows tlapm installs via prebuilt MSI/zip.",
   z3: "SMT solver; on Windows, Z3 is either scoop-installed or used via JS z3-solver npm package.",
+  "headscale-cli":
+    "headscale SERVER-side CLI — mesh coordination ops run on Linux/macOS hosts; Windows dev boxes join the mesh as tailscale clients (manifests/windows tailscale line).",
   "r-base":
     "R statistical runtime (charting/grammar-of-graphics lens-finder); covered on Windows by the `r` manifest line (scoop r / winget RProject.R / choco R.Project). apt names the package r-base; brew + scoop name it r.",
 };

--- a/tools/setup/common/mise.sh
+++ b/tools/setup/common/mise.sh
@@ -20,7 +20,21 @@ fi
 # a project-local .mise.toml. Silent on repeat runs.
 mise trust "$REPO_ROOT/.mise.toml" >/dev/null
 
-echo "↓ mise install (reading $REPO_ROOT/.mise.toml)..."
+# HOST TIERS (workitem 081KTWQZY7F08QG0R0034KN17T): full-tier hosts also merge
+# .mise.full.toml (the k8s set: k3d/kind/kubectl/helm/kubeconform) via MISE_ENV=full.
+# Cluster nodes declare full at the zeta-install.sh call site (Aaron 2026-06-12:
+# "addison and max and every cluster [node gets] full"); CI k8s lanes declare full
+# explicitly; slim/standard hosts skip the set LOUDLY here.
+# shellcheck source=tools/setup/common/host-tier.sh disable=SC1091
+. "$(cd "$(dirname "$0")" && pwd)/host-tier.sh"
+if zeta_tier_allows full; then
+  export MISE_ENV=full
+  mise trust "$REPO_ROOT/.mise.full.toml" >/dev/null
+  echo "↓ mise install (reading .mise.toml + .mise.full.toml — host is full/$ZETA_HOST_TIER_SOURCE)..."
+else
+  echo "→ .mise.full.toml (k8s set) skipped: requires tier=full, host is $ZETA_HOST_TIER ($ZETA_HOST_TIER_SOURCE)"
+  echo "↓ mise install (reading $REPO_ROOT/.mise.toml)..."
+fi
 if [ "${GITHUB_ACTIONS:-}" = "true" ] &&
    [ -n "${GITHUB_TOKEN:-}" ] &&
    [ -z "${MISE_GITHUB_TOKEN:-}" ] &&

--- a/tools/setup/install.ps1
+++ b/tools/setup/install.ps1
@@ -212,6 +212,12 @@ Write-Host "mise: $(Get-ToolVersion { mise --version })"
 Push-Location $RepoRoot
 try {
   Invoke-Tool { mise trust } 'mise trust'
+  # HOST TIERS (workitem 081KTWQZY7F): Windows boxes are dev machines — full tier unless
+  # explicitly declared otherwise; full merges .mise.full.toml (the k8s set) via MISE_ENV.
+  if (-not $env:ZETA_HOST_TIER -or $env:ZETA_HOST_TIER -eq 'full') {
+    $env:MISE_ENV = 'full'
+    Invoke-Tool { mise trust "$RepoRoot\.mise.full.toml" } 'mise trust (.mise.full.toml)'
+  }
   Invoke-Tool { mise install } 'mise install'
 } finally { Pop-Location }
 

--- a/tools/setup/manifests/windows
+++ b/tools/setup/manifests/windows
@@ -61,3 +61,8 @@ r         winget=RProject.R    choco=R.Project
 # scoop, the resolver-primary). MIT. `optional` (best-effort): network-bundle fetch on first run.
 tectonic    optional
 gnupg     winget=GnuPG.GnuPG    choco=gnupg    # GPG — commit/artifact signing
+
+# Mesh networking client (symmetry with manifests/brew tailscale, PR #7477's network-dep
+# precedent). headscale-cli is the SERVER-side CLI (Linux/macOS ops) — allowlisted exception
+# in manifest-symmetry.test.ts, not installed on Windows dev boxes.
+tailscale    winget=Tailscale.Tailscale    choco=tailscale    optional

--- a/workitems/081KTWQZY7F08QG0R0034KN17T-host-tiers-x-package-requirements-manifests-declare-requires.md
+++ b/workitems/081KTWQZY7F08QG0R0034KN17T-host-tiers-x-package-requirements-manifests-declare-requires.md
@@ -52,9 +52,22 @@ resolver. Prior art in-repo: one-liner-tools.sh ZETA_INSTALL_FULL opt-in (a 2-ti
 
 - apt manifest: all current entries are dotnet-required (slim) — tier the loop when a heavy
   entry first appears.
-- mise: `.mise.toml` installs wholesale; tiering means splitting the k8s set (k3d/kind/kubectl/
-  helm/kubeconform) out — a real change, decide deliberately.
 - Fold the legacy full-tier gates (ZETA_INSTALL_FULL in one-liner-tools/tlaps, ZETA_INSTALL_QUANTUM)
   into the same vocabulary.
 - verifiers.sh jars: tests may invoke TLC/Alloy — audit before tiering.
 - Unify with db/capabilities resolver wiring (one cap/support vocabulary across setup + runtime).
+
+## Slice 3 (Aaron: "do the mise k8s split too… addison and max and every cluster to have full…
+we want to test full")
+
+- `.mise.full.toml` — the k8s set (k3d/kind/kubectl/helm/kubeconform) at the SAME pins, merged
+  only on full hosts via MISE_ENV=full (mise.sh sources host-tier.sh; slim/standard skip LOUDLY).
+- Cluster nodes are full BY DECLARATION (Aaron verbatim): zeta-install.sh pins ZETA_HOST_TIER=full
+  at its install.sh call — hardware auto-detect never decides for a cluster node.
+- "Test full" honored: the gate `lint (yaml/k8s)` job + both k8s-argocd-health install steps
+  declare ZETA_HOST_TIER=full explicitly (never rely on runner-size auto-detect).
+- Cache keys (gate + low-memory) hash BOTH mise files; manifest-symmetry reads the PAIR;
+  install.ps1 defaults Windows to full (merges .mise.full.toml) unless declared otherwise.
+- Drive-by main fix: #7477's headscale-cli/tailscale brew entries had no Windows symmetry —
+  tailscale joins manifests/windows (winget client, optional), headscale-cli allowlisted
+  (server-side ops CLI).


### PR DESCRIPTION
Per Aaron: k8s set (k3d/kind/kubectl/helm/kubeconform, same pins) → `.mise.full.toml`, merged via MISE_ENV=full on full hosts; slim/standard skip loudly. Cluster nodes declare full at the zeta-install.sh call site (never auto-detect); gate lint(yaml/k8s) + k8s-argocd lanes declare full explicitly (the test-full ask). Cache keys hash both files; symmetry test reads the pair; install.ps1 defaults Windows to full. Drive-by: fixes the pre-existing main-red symmetry test (#7477's headscale/tailscale had no Windows row). Verified live both tiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)