### PR TITLE
fix(installer): mirror zeta-first-boot to ttyS0 for B-0891 serial harness

### DIFF
--- a/full-ai-cluster/usb-nixos-installer/nixos/installer/configuration.nix
+++ b/full-ai-cluster/usb-nixos-installer/nixos/installer/configuration.nix
@@ -296,7 +296,8 @@
       ExecStart = "/run/current-system/sw/bin/zeta-first-boot";
       StandardInput = "tty";
       # tty1 for the operator; zeta-first-boot.sh tees the same stream to
-      # /dev/console so QEMU serial (B-0891) sees [iter-5.1] + retention markers.
+      # /dev/ttyS0 (x86) or /dev/ttyAMA0 (aarch64) so QEMU serial (B-0891)
+      # sees [iter-5.1] + retention markers (/dev/console is tty1 here).
       StandardOutput = "tty";
       StandardError = "tty";
       TTYPath = "/dev/tty1";

--- a/full-ai-cluster/usb-nixos-installer/zeta-first-boot.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-first-boot.sh
@@ -25,14 +25,21 @@
 
 set -uo pipefail
 
-# B-0891: mirror first-boot + zeta-install progress to the kernel console.
-# zeta-first-boot.service binds stdout to tty1 for the operator; QEMU and
-# CI harnesses capture serial (console=ttyS0 → /dev/console). Without this
-# tee, [iter-5.1] and retention markers never appear in serial logs even
-# when install succeeds on tty1.
-if [[ -w /dev/console ]]; then
+# B-0891: mirror first-boot + zeta-install progress to the serial UART.
+# zeta-first-boot.service binds stdout to tty1 for the operator; QEMU/CI
+# harnesses poll ttyS0 (x86) or ttyAMA0 (aarch64). Kernel cmdline lists
+# console=tty1 last, so /dev/console is tty1 — tee there is a no-op for
+# serial. Mirror to the hardware UART instead.
+_b0891_serial_dev=""
+for _dev in /dev/ttyS0 /dev/ttyAMA0; do
+  if [[ -w "$_dev" ]]; then
+    _b0891_serial_dev="$_dev"
+    break
+  fi
+done
+if [[ -n "$_b0891_serial_dev" ]]; then
   exec 3>&1
-  exec > >(/run/current-system/sw/bin/tee -a /dev/console >&3) 2>&1
+  exec > >(/run/current-system/sw/bin/tee -a "$_b0891_serial_dev" >&3) 2>&1
 fi
 
 CONF=/etc/zeta-firstboot.conf

--- a/tools/ci/audit-installer-substrate.ts
+++ b/tools/ci/audit-installer-substrate.ts
@@ -127,8 +127,8 @@ const REQUIRED_SENTINELS: readonly SentinelAssertion[] = [
       "ETHERNET_WAIT_SECS", // eth-30s wait
       "nmtui", // wifi setup TUI launch
       "zeta-install", // calls into zeta-install.sh after network up
-      "/dev/console", // B-0891 serial mirror for QEMU harness
-      "tee -a /dev/console", // preserves tty1 + mirrors to kernel console
+      "/dev/ttyS0", // B-0891 serial mirror target (x86 QEMU / CI)
+      "tee -a", // preserves tty1 + mirrors to serial UART
     ],
     rationale: "first-boot script must include eth-wait + nmtui + zeta-install call",
   },

--- a/tools/ci/qemu-full-install-test.ts
+++ b/tools/ci/qemu-full-install-test.ts
@@ -100,7 +100,7 @@ const IDLE_INSTALLER_SHELL_MARKER = "nixos@zeta-installer:~";
 
 const CONSOLE_MIRROR_HINT =
   "serial log shows idle installer shell without install progress — " +
-  "zeta-first-boot may be running on tty1 only; mirror output to /dev/console " +
+  "zeta-first-boot may be running on tty1 only; mirror output to /dev/ttyS0 " +
   "(see full-ai-cluster/usb-nixos-installer/zeta-first-boot.sh)";
 
 const TIMEOUT_SECONDS = 1800; // 30 min — generous for TCG fallback;

--- a/tools/zflash/test-harness/qemu-state.ts
+++ b/tools/zflash/test-harness/qemu-state.ts
@@ -632,7 +632,7 @@ function runManagedCommandUntilSerialMarkers(
         stderr:
           `terminal marker observed before required serial markers: ${terminalFailureMarker}; ` +
           `still waiting for ${stopCondition.successMarkers.join(", ")}. ` +
-          `If install is progressing on tty1 only, ensure zeta-first-boot mirrors to /dev/console (B-0891).`,
+          `If install is progressing on tty1 only, ensure zeta-first-boot mirrors to /dev/ttyS0 (B-0891).`,
       };
     }
 


### PR DESCRIPTION
## Summary

- **Root cause:** `#7863` teed to `/dev/console`, but installer kernel cmdline sets `console=tty1` last — so `/dev/console` **is tty1**, same as `zeta-first-boot.service`. Serial (ttyS0) never saw install output.
- **Fix:** Mirror to `/dev/ttyS0` (x86) or `/dev/ttyAMA0` (aarch64); preserve tty1 via fd 3.
- Updates audit sentinel + harness fail-fast hints to match.

Work item: `081KSNY2Z0008QG0R0008PN7RQ` (B-0891).

## Evidence from last proof dispatch

Serial logs showed only `nixos@zeta-installer:~$` — harness failed at 2 min idle-shell fail-fast. GitHub steps were green due to `continue-on-error: true`.

## Test plan

- [x] `bun tools/ci/audit-installer-substrate.ts`
- [x] `bun test tools/zflash/test-harness/`
- [ ] Merge + `workflow_dispatch` on `build-ai-cluster-iso.yml` — scenarios 2–4 serial logs must contain `[iter-5.1]` / `B-0891-retention`


Made with [Cursor](https://cursor.com)