### PR TITLE
feat: add PriorityFerryThrottler with priority lanes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
         "@types/semver": "7.7.1",
         "eslint": "10.2.1",
         "eslint-plugin-sonarjs": "4.0.3",
+        "fast-check": "3.22.0",
         "globals": "17.5.0",
         "jiti": "2.6.1",
         "markdownlint-cli2": "0.22.1",
@@ -274,6 +275,8 @@
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "fast-check": ["fast-check@3.22.0", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-8HKz3qXqnHYp/VCNn2qfjHdAdcI8zcSqOyX64GOMukp7SL2bfzfeDKjSd+UyECtejccaZv3LcvZTm9YDD22iCQ=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -546,6 +549,8 @@
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
+
+    "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
     "qified": ["qified@0.10.1", "", { "dependencies": { "hookified": "^2.1.1" } }, "sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA=="],
 

--- a/docs/research/2026-06-12-soft-priority-ferry-throttler-math-handoff.md
+++ b/docs/research/2026-06-12-soft-priority-ferry-throttler-math-handoff.md
@@ -1,0 +1,119 @@
+# Soft PriorityFerryThrottler — Math Team Handoff
+
+**Date:** 2026-06-12  
+**From:** Alexa (Kiro)  
+**To:** Math team (formal verification / soft-value modeling)  
+**Status:** Research-grade  
+**Operational status:** research-grade  
+
+## Context
+
+We just landed the hard `FerryThrottler` TypeScript port (PR #7861, merged) and designed the
+`PriorityFerryThrottler` — a composition layer that manages N lane queues with a shared ferry
+pool and a drain scheduler (strict priority or Deficit Round Robin). Design doc at:
+
+`.kiro/specs/ferry-throttler-priority-lanes/design.md`
+
+The existing `SoftThrottle.fs` already provides the soft half for the single-lane throttler:
+- Logistic admission gradient (sigmoid pressure → admission probability)
+- Flux tank (capacitor: charges idle, discharges on bursts, LC-tank resonance)
+- Deterministic soft decisions (SplitMix64-seeded, DST-replayable)
+- `wrapHandler` that wraps a scheduler handler with soft throttling
+
+Aaron's directive: "send it to math team to figure out how to make the soft version of this
+too in case you need changes to this version — we already have a soft ferry throttler, want to
+be able to model this one too."
+
+## Answers from Aaron (2026-06-12)
+
+1. **Pressure: per-lane.** Each lane gets its own admission sigmoid with its own pressure
+   reading. The per-lane backpressure in the hard design maps directly.
+
+2. **Everything can be soft** — the drain scheduling, the DRR weights, the admission, even
+   the emulator and the agent itself. The soft version should not artificially limit what can
+   be a distribution. If the drain order can be a soft value (ensemble over permutations),
+   let it. If the DRR weights can be soft values adapting to throughput, let them.
+
+3. **Flux tank: per-lane, OR coupled — configurable, try both.** Start with per-lane tanks
+   (independent LC oscillators per lane). Then add a coupled mode where discharging one
+   lane's tank partially charges another (the coupling matrix encodes priority relationships).
+   Expose as a setting so we can A/B the two modes and see the difference empirically.
+
+4. **Heat budget: per-lane.** Each lane has its own thermal budget (independent Bekenstein
+   accounting). High-priority lanes may have larger budgets or faster charge rates, but the
+   accounting is lane-local.
+
+## Design Implications for the Hard PriorityFerryThrottler
+
+Given these answers, the hard design should ensure:
+
+- **Per-lane config is rich enough** to carry soft parameters later (already true — per-lane
+  `maxBatchSize`, `maxBatchBytes`, `maxQueueSize` map to per-lane tank capacity / charge rate).
+- **The drain scheduler is a pluggable interface** (already true — `DrainScheduler` with
+  `selectLane` + `recordDrain`). A soft scheduler just replaces the implementation.
+- **Per-lane state is observable** (queue depth, drain count, bytes processed) so the soft
+  layer can read pressure per-lane. → Add optional lane metrics to the design.
+- **The coupled-tank mode means the drain scheduler needs access to all lane states** when
+  making a decision (not just "has work?" booleans). → Widen `selectLane` to receive lane
+  queue depths, not just booleans. This is a minor design change.
+
+## Proposed Minor Design Change
+
+In the current design, `selectLane` receives `laneHasWork: readonly boolean[]`. To support
+coupled-mode soft scheduling and per-lane pressure reading, widen this to:
+
+```typescript
+interface LaneSnapshot {
+  readonly hasWork: boolean;
+  readonly queueDepth: number;
+  readonly bytesQueued: number;
+  readonly drainCount: number;
+}
+
+interface DrainScheduler {
+  selectLane(lanes: readonly LaneSnapshot[]): number;
+  recordDrain(laneIndex: number, batchSize: number, batchBytes: number): void;
+}
+```
+
+This is additive (the strict-priority scheduler ignores the extra fields and still just
+scans for the first `hasWork === true`), but the soft/coupled scheduler will use queue depths
+and drain counts to compute per-lane pressure and coupled-tank interactions.
+
+## What the Math Team Should Deliver
+
+1. **`SoftPriorityThrottle` module** — the soft layer over `PriorityFerryThrottler`:
+   - Per-lane sigmoid admission (pressure = f(queueDepth, drainRate))
+   - Per-lane flux tanks (independent mode)
+   - Coupled flux tanks (coupling matrix mode, configurable)
+   - Soft DRR weights (distribution over weights, collapsing per-drain)
+   - Soft drain order (ensemble over permutations, the `SoftEmu` pattern)
+
+2. **Correctness properties for the soft regime** — how the 12 hard properties degrade
+   gracefully (e.g., "strict priority ordering" → "priority ordering probability → 1 as
+   k → ∞"; "no-starvation" → "expected drain proportion converges to weights").
+
+3. **The coupled-oscillator formulation** — the coupling matrix, energy conservation
+   constraints, and whether it satisfies detailed balance (so the stationary distribution
+   is well-defined and the soft system has an equilibrium).
+
+## What I Need Back
+
+1. **Any changes to the hard `PriorityFerryThrottler` design** that would make soft modeling
+   cleaner. Better to adjust now before implementation than retrofit later.
+
+2. **The proposed `SoftPriorityThrottle` module shape** — what types and functions it exposes,
+   how it composes with the existing `SoftThrottle.wrapHandler` pattern.
+
+3. **Whether the correctness properties in the design doc need soft variants.** E.g., does
+   "strict priority drain ordering" become "drain ordering probability converges to priority
+   order as k → ∞" in the soft regime?
+
+## Source Files
+
+- `src/Core/SoftThrottle.fs` — existing soft throttle (single-queue)
+- `src/Core/SoftEmu.fs` — soft emulator (ensemble modeling pattern)
+- `src/Core/FerryThrottler.fs` — hard ferry throttler (F#)
+- `src/Core.TypeScript/ferry-throttler/ferry-throttler.ts` — hard ferry throttler (TS port)
+- `.kiro/specs/ferry-throttler-priority-lanes/design.md` — priority lanes design
+- `.kiro/specs/ferry-throttler-priority-lanes/requirements.md` — priority lanes requirements

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/semver": "7.7.1",
     "eslint": "10.2.1",
     "eslint-plugin-sonarjs": "4.0.3",
+    "fast-check": "3.22.0",
     "globals": "17.5.0",
     "jiti": "2.6.1",
     "markdownlint-cli2": "0.22.1",

--- a/src/Core.TypeScript/ferry-throttler/drain-scheduler.test.ts
+++ b/src/Core.TypeScript/ferry-throttler/drain-scheduler.test.ts
@@ -1,0 +1,154 @@
+/**
+ * drain-scheduler.test.ts — unit tests for DrainScheduler implementations.
+ *
+ * Covers StrictPriorityScheduler and WeightedFairScheduler (Deficit Round Robin).
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  createStrictPriorityScheduler,
+  createWeightedFairScheduler,
+  type LaneSnapshot,
+} from "./drain-scheduler";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function lane(hasWork: boolean, queueDepth = 1, bytesQueued = 0, drainCount = 0): LaneSnapshot {
+  return { hasWork, queueDepth, bytesQueued, drainCount };
+}
+
+// ─── StrictPriorityScheduler ────────────────────────────────────────────────
+
+describe("StrictPriorityScheduler", () => {
+  it("returns first lane with work (index 0 = highest priority)", () => {
+    const scheduler = createStrictPriorityScheduler();
+    const lanes: LaneSnapshot[] = [lane(true), lane(true), lane(true)];
+    expect(scheduler.selectLane(lanes)).toBe(0);
+  });
+
+  it("skips non-hasWork lanes and returns first with work", () => {
+    const scheduler = createStrictPriorityScheduler();
+    const lanes: LaneSnapshot[] = [lane(false), lane(false), lane(true)];
+    expect(scheduler.selectLane(lanes)).toBe(2);
+  });
+
+  it("returns -1 when all lanes are empty", () => {
+    const scheduler = createStrictPriorityScheduler();
+    const lanes: LaneSnapshot[] = [lane(false), lane(false), lane(false)];
+    expect(scheduler.selectLane(lanes)).toBe(-1);
+  });
+
+  it("returns -1 for an empty lanes array", () => {
+    const scheduler = createStrictPriorityScheduler();
+    expect(scheduler.selectLane([])).toBe(-1);
+  });
+
+  it("ignores non-hasWork lanes even if they have queueDepth", () => {
+    const scheduler = createStrictPriorityScheduler();
+    // Lane 0 has queueDepth but hasWork is false (e.g. paused)
+    const lanes: LaneSnapshot[] = [lane(false, 10), lane(true, 1)];
+    expect(scheduler.selectLane(lanes)).toBe(1);
+  });
+
+  it("recordDrain is a no-op (stateless)", () => {
+    const scheduler = createStrictPriorityScheduler();
+    // Should not throw
+    scheduler.recordDrain(0, 5, 1024);
+    // Behavior unchanged after recordDrain
+    const lanes: LaneSnapshot[] = [lane(false), lane(true)];
+    expect(scheduler.selectLane(lanes)).toBe(1);
+  });
+});
+
+// ─── WeightedFairScheduler ──────────────────────────────────────────────────
+
+describe("WeightedFairScheduler", () => {
+  describe("validation", () => {
+    it("throws on empty weights", () => {
+      expect(() => createWeightedFairScheduler([])).toThrow("weights must not be empty");
+    });
+
+    it("throws on non-positive weight (zero)", () => {
+      expect(() => createWeightedFairScheduler([1, 0, 2])).toThrow("must be positive");
+    });
+
+    it("throws on non-positive weight (negative)", () => {
+      expect(() => createWeightedFairScheduler([1, -1, 2])).toThrow("must be positive");
+    });
+  });
+
+  describe("proportional drain", () => {
+    it("distributes drains proportionally with weights [3, 2, 1] over 100 iterations", () => {
+      const scheduler = createWeightedFairScheduler([3, 2, 1]);
+      const counts = [0, 0, 0];
+      const lanes: LaneSnapshot[] = [lane(true), lane(true), lane(true)];
+
+      for (let i = 0; i < 100; i++) {
+        const selected = scheduler.selectLane(lanes);
+        expect(selected).toBeGreaterThanOrEqual(0);
+        expect(selected).toBeLessThan(3);
+        counts[selected]!++;
+        scheduler.recordDrain(selected, 1, 100);
+      }
+
+      // With weights [3, 2, 1] (sum=6), expected proportions: 50%, 33%, 17%
+      // Allow ±5% tolerance for DRR rounding
+      expect(counts[0]!).toBeGreaterThanOrEqual(45);
+      expect(counts[0]!).toBeLessThanOrEqual(55);
+      expect(counts[1]!).toBeGreaterThanOrEqual(28);
+      expect(counts[1]!).toBeLessThanOrEqual(38);
+      expect(counts[2]!).toBeGreaterThanOrEqual(12);
+      expect(counts[2]!).toBeLessThanOrEqual(22);
+    });
+
+    it("no starvation: every lane with work gets at least one drain in 100 iterations", () => {
+      const scheduler = createWeightedFairScheduler([10, 1, 1]);
+      const counts = [0, 0, 0];
+      const lanes: LaneSnapshot[] = [lane(true), lane(true), lane(true)];
+
+      for (let i = 0; i < 100; i++) {
+        const selected = scheduler.selectLane(lanes);
+        expect(selected).toBeGreaterThanOrEqual(0);
+        counts[selected]!++;
+        scheduler.recordDrain(selected, 1, 50);
+      }
+
+      // Even the lowest-weight lane must receive some drains
+      expect(counts[0]!).toBeGreaterThan(0);
+      expect(counts[1]!).toBeGreaterThan(0);
+      expect(counts[2]!).toBeGreaterThan(0);
+    });
+  });
+
+  describe("tie-breaking", () => {
+    it("ties broken by lower index (= higher priority)", () => {
+      // Equal weights → all deficits grow equally → first call picks index 0
+      const scheduler = createWeightedFairScheduler([1, 1, 1]);
+      const lanes: LaneSnapshot[] = [lane(true), lane(true), lane(true)];
+      // First selectLane: all deficits equal (1/3 each) → tie → index 0 wins
+      const first = scheduler.selectLane(lanes);
+      expect(first).toBe(0);
+    });
+  });
+
+  describe("lane availability", () => {
+    it("returns -1 when no lane has work", () => {
+      const scheduler = createWeightedFairScheduler([1, 2, 3]);
+      const lanes: LaneSnapshot[] = [lane(false), lane(false), lane(false)];
+      expect(scheduler.selectLane(lanes)).toBe(-1);
+    });
+
+    it("skips lanes without work even if they have high deficit", () => {
+      const scheduler = createWeightedFairScheduler([1, 1]);
+      // First select with both available
+      const lanes1: LaneSnapshot[] = [lane(true), lane(true)];
+      const first = scheduler.selectLane(lanes1);
+      scheduler.recordDrain(first, 1, 0);
+
+      // Now only lane 1 has work
+      const lanes2: LaneSnapshot[] = [lane(false), lane(true)];
+      const second = scheduler.selectLane(lanes2);
+      expect(second).toBe(1);
+    });
+  });
+});

--- a/src/Core.TypeScript/ferry-throttler/drain-scheduler.ts
+++ b/src/Core.TypeScript/ferry-throttler/drain-scheduler.ts
@@ -1,0 +1,127 @@
+/**
+ * drain-scheduler.ts — lane selection strategies for multi-lane priority ferry throttler.
+ *
+ * Two scheduling disciplines:
+ * 1. StrictPriority — stateless, always drains the highest-priority lane with work.
+ * 2. WeightedFair (Deficit Round Robin) — proportional lane selection preventing starvation.
+ *
+ * The `LaneSnapshot` interface is intentionally richer than strict-priority needs so the
+ * future soft-priority layer (coupled-oscillator / per-lane pressure) can observe without
+ * a separate observation channel. See design.md §"Drain Scheduler (internal)".
+ */
+
+// ─── Interfaces ─────────────────────────────────────────────────────────────
+
+/** Per-lane snapshot exposed to the scheduler. */
+export interface LaneSnapshot {
+  readonly hasWork: boolean;
+  readonly queueDepth: number;
+  readonly bytesQueued: number;
+  readonly drainCount: number;
+}
+
+/** Strategy for selecting which lane to drain next when a ferry becomes free. */
+export interface DrainScheduler {
+  /** Returns the lane index to drain next, or -1 if all lanes are empty. */
+  selectLane(lanes: readonly LaneSnapshot[]): number;
+  /** Record that a drain happened from this lane (batch size + bytes for soft accounting). */
+  recordDrain(laneIndex: number, batchSize: number, batchBytes: number): void;
+}
+
+// ─── StrictPriorityScheduler ────────────────────────────────────────────────
+
+/**
+ * Stateless strict-priority scheduler. Iterates lanes in index order (assumes lanes
+ * are pre-sorted by priority ascending = higher priority first) and returns the first
+ * index where `hasWork === true`.
+ */
+class StrictPriorityScheduler implements DrainScheduler {
+  selectLane(lanes: readonly LaneSnapshot[]): number {
+    for (let i = 0; i < lanes.length; i++) {
+      const lane = lanes[i];
+      if (lane !== undefined && lane.hasWork) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  recordDrain(_laneIndex: number, _batchSize: number, _batchBytes: number): void {
+    // Stateless — no-op.
+  }
+}
+
+// ─── WeightedFairScheduler (Deficit Round Robin) ────────────────────────────
+
+/**
+ * Deficit Round Robin scheduler. Each lane accumulates a deficit proportional to its
+ * normalized weight; among lanes with work, the one with the highest deficit is selected.
+ * Ties broken by lower index (= higher priority).
+ */
+class WeightedFairScheduler implements DrainScheduler {
+  private readonly normalizedWeights: readonly number[];
+  private readonly deficits: number[];
+
+  constructor(weights: readonly number[]) {
+    if (weights.length === 0) {
+      throw new Error("WeightedFairScheduler: weights must not be empty");
+    }
+    for (let i = 0; i < weights.length; i++) {
+      const w = weights[i];
+      if (w === undefined || w <= 0) {
+        throw new Error(
+          `WeightedFairScheduler: weight at index ${String(i)} must be positive, got ${String(w)}`,
+        );
+      }
+    }
+
+    const sum = weights.reduce((acc, w) => acc + w, 0);
+    this.normalizedWeights = weights.map((w) => w / sum);
+    this.deficits = new Array<number>(weights.length).fill(0);
+  }
+
+  selectLane(lanes: readonly LaneSnapshot[]): number {
+    // (1) Add each lane's normalized weight to its deficit.
+    for (let i = 0; i < this.deficits.length; i++) {
+      const nw = this.normalizedWeights[i];
+      if (nw !== undefined) {
+        this.deficits[i] = (this.deficits[i] ?? 0) + nw;
+      }
+    }
+
+    // (2) Among lanes with work, select the one with the highest deficit.
+    //     Ties broken by lower index (= higher priority).
+    let bestIndex = -1;
+    let bestDeficit = -Infinity;
+
+    for (let i = 0; i < lanes.length && i < this.deficits.length; i++) {
+      const lane = lanes[i];
+      if (lane !== undefined && lane.hasWork) {
+        const deficit = this.deficits[i] ?? 0;
+        if (deficit > bestDeficit) {
+          bestDeficit = deficit;
+          bestIndex = i;
+        }
+      }
+    }
+
+    return bestIndex;
+  }
+
+  recordDrain(laneIndex: number, _batchSize: number, _batchBytes: number): void {
+    // Subtract 1.0 from the selected lane's deficit.
+    if (laneIndex >= 0 && laneIndex < this.deficits.length) {
+      this.deficits[laneIndex] = (this.deficits[laneIndex] ?? 0) - 1.0;
+    }
+  }
+}
+
+// ─── Factory functions ──────────────────────────────────────────────────────
+
+export function createStrictPriorityScheduler(): DrainScheduler {
+  return new StrictPriorityScheduler();
+}
+
+export function createWeightedFairScheduler(weights: readonly number[]): DrainScheduler {
+  return new WeightedFairScheduler(weights);
+}

--- a/src/Core.TypeScript/ferry-throttler/ferry-throttler.ts
+++ b/src/Core.TypeScript/ferry-throttler/ferry-throttler.ts
@@ -17,6 +17,9 @@
  * Port of `src/Core/FerryThrottler.fs` — byte-locked cross-language parity.
  */
 
+import { createInternalChannel } from "./internal-channel.ts";
+import type { InternalChannel } from "./internal-channel.ts";
+
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 /**
@@ -91,132 +94,7 @@ export type ProcessBatchWithResult<T, R> = (
 /** Measures the byte size of one item (required when `maxBatchBytes` is set). */
 export type ItemSizeBytes<T> = (item: T) => number;
 
-// ─── Internal: async channel with synchronous tryRead ───────────────────────
-
-/**
- * Internal channel with synchronous `tryRead` for the ferry drain loop.
- */
-interface InternalChannel<T> {
-  write(item: T, signal?: AbortSignal): Promise<void>;
-  tryWrite(item: T): boolean;
-  tryRead(): T | undefined;
-  waitToRead(signal: AbortSignal): Promise<boolean>;
-  complete(): void;
-}
-
-function createInternalChannel<T>(capacity?: number): InternalChannel<T> {
-  const buffer: T[] = [];
-  let closed = false;
-
-  let readerWaiters: Array<(hasData: boolean) => void> = [];
-  let writerWaiters: Array<{
-    item: T;
-    resolve: () => void;
-    reject: (err: unknown) => void;
-  }> = [];
-
-  function drainWriters(): void {
-    while (
-      writerWaiters.length > 0 &&
-      (capacity === undefined || buffer.length < capacity)
-    ) {
-      const w = writerWaiters.shift()!;
-      buffer.push(w.item);
-      w.resolve();
-    }
-  }
-
-  function notifyReaders(): void {
-    while (readerWaiters.length > 0 && buffer.length > 0) {
-      const r = readerWaiters.shift()!;
-      r(true);
-    }
-  }
-
-  return {
-    write(item: T, signal?: AbortSignal): Promise<void> {
-      if (closed) return Promise.reject(new Error("Channel closed"));
-      if (signal?.aborted) return Promise.reject(signal.reason);
-
-      if (capacity === undefined || buffer.length < capacity) {
-        buffer.push(item);
-        notifyReaders();
-        return Promise.resolve();
-      }
-
-      // Bounded and full — wait
-      return new Promise<void>((resolve, reject) => {
-        const entry = { item, resolve, reject };
-        writerWaiters.push(entry);
-        if (signal) {
-          signal.addEventListener(
-            "abort",
-            () => {
-              const idx = writerWaiters.indexOf(entry);
-              if (idx >= 0) {
-                writerWaiters.splice(idx, 1);
-                reject(signal.reason);
-              }
-            },
-            { once: true },
-          );
-        }
-      });
-    },
-
-    tryWrite(item: T): boolean {
-      if (closed) return false;
-      if (capacity === undefined || buffer.length < capacity) {
-        buffer.push(item);
-        notifyReaders();
-        return true;
-      }
-      return false;
-    },
-
-    tryRead(): T | undefined {
-      if (buffer.length > 0) {
-        const item = buffer.shift()!;
-        drainWriters();
-        return item;
-      }
-      if (writerWaiters.length > 0) {
-        const w = writerWaiters.shift()!;
-        w.resolve();
-        return w.item;
-      }
-      return undefined;
-    },
-
-    waitToRead(signal: AbortSignal): Promise<boolean> {
-      if (signal.aborted) return Promise.reject(signal.reason);
-      if (buffer.length > 0 || writerWaiters.length > 0) return Promise.resolve(true);
-      if (closed) return Promise.resolve(false);
-
-      return new Promise<boolean>((resolve, reject) => {
-        const handler = (hasData: boolean): void => {
-          signal.removeEventListener("abort", onAbort);
-          resolve(hasData);
-        };
-        const onAbort = (): void => {
-          const idx = readerWaiters.indexOf(handler);
-          if (idx >= 0) readerWaiters.splice(idx, 1);
-          reject(signal.reason);
-        };
-        readerWaiters.push(handler);
-        signal.addEventListener("abort", onAbort, { once: true });
-      });
-    },
-
-    complete(): void {
-      closed = true;
-      for (const r of readerWaiters) r(false);
-      readerWaiters = [];
-      for (const w of writerWaiters) w.reject(new Error("Channel closed"));
-      writerWaiters = [];
-    },
-  };
-}
+// ─── Internal: async channel (imported from shared module) ──────────────────
 
 // ─── FerryThrottler (fire-and-forget) ───────────────────────────────────────
 

--- a/src/Core.TypeScript/ferry-throttler/index.ts
+++ b/src/Core.TypeScript/ferry-throttler/index.ts
@@ -1,1 +1,8 @@
 export * from "./ferry-throttler";
+export { createInternalChannel } from "./internal-channel.ts";
+export type { InternalChannel } from "./internal-channel.ts";
+export * from "./drain-scheduler";
+export * from "./lane-notifier";
+export * from "./priority-config";
+export { PriorityFerryThrottler } from "./priority-ferry-throttler.ts";
+export { PriorityFerryThrottlerWithResult } from "./priority-ferry-throttler-with-result.ts";

--- a/src/Core.TypeScript/ferry-throttler/internal-channel.ts
+++ b/src/Core.TypeScript/ferry-throttler/internal-channel.ts
@@ -1,0 +1,140 @@
+/**
+ * internal-channel.ts — bounded async channel with synchronous tryRead.
+ *
+ * Extracted from ferry-throttler.ts as a shared module so that both the
+ * single-queue FerryThrottler and the multi-lane PriorityFerryThrottler
+ * can reuse the same backpressure-aware channel primitive.
+ */
+
+// ─── InternalChannel ────────────────────────────────────────────────────────
+
+/**
+ * Internal channel with synchronous `tryRead` for the ferry drain loop.
+ */
+export interface InternalChannel<T> {
+  write(item: T, signal?: AbortSignal): Promise<void>;
+  tryWrite(item: T): boolean;
+  tryRead(): T | undefined;
+  waitToRead(signal: AbortSignal): Promise<boolean>;
+  complete(): void;
+  /** Total number of items waiting: buffered + blocked in writers. */
+  readonly queueDepth: number;
+}
+
+export function createInternalChannel<T>(capacity?: number): InternalChannel<T> {
+  const buffer: T[] = [];
+  let closed = false;
+
+  let readerWaiters: Array<(hasData: boolean) => void> = [];
+  let writerWaiters: Array<{
+    item: T;
+    resolve: () => void;
+    reject: (err: unknown) => void;
+  }> = [];
+
+  function drainWriters(): void {
+    while (
+      writerWaiters.length > 0 &&
+      (capacity === undefined || buffer.length < capacity)
+    ) {
+      const w = writerWaiters.shift()!;
+      buffer.push(w.item);
+      w.resolve();
+    }
+  }
+
+  function notifyReaders(): void {
+    while (readerWaiters.length > 0 && buffer.length > 0) {
+      const r = readerWaiters.shift()!;
+      r(true);
+    }
+  }
+
+  return {
+    get queueDepth(): number {
+      return buffer.length + writerWaiters.length;
+    },
+
+    write(item: T, signal?: AbortSignal): Promise<void> {
+      if (closed) return Promise.reject(new Error("Channel closed"));
+      if (signal?.aborted) return Promise.reject(signal.reason);
+
+      if (capacity === undefined || buffer.length < capacity) {
+        buffer.push(item);
+        notifyReaders();
+        return Promise.resolve();
+      }
+
+      // Bounded and full — wait
+      return new Promise<void>((resolve, reject) => {
+        const entry = { item, resolve, reject };
+        writerWaiters.push(entry);
+        if (signal) {
+          signal.addEventListener(
+            "abort",
+            () => {
+              const idx = writerWaiters.indexOf(entry);
+              if (idx >= 0) {
+                writerWaiters.splice(idx, 1);
+                reject(signal.reason);
+              }
+            },
+            { once: true },
+          );
+        }
+      });
+    },
+
+    tryWrite(item: T): boolean {
+      if (closed) return false;
+      if (capacity === undefined || buffer.length < capacity) {
+        buffer.push(item);
+        notifyReaders();
+        return true;
+      }
+      return false;
+    },
+
+    tryRead(): T | undefined {
+      if (buffer.length > 0) {
+        const item = buffer.shift()!;
+        drainWriters();
+        return item;
+      }
+      if (writerWaiters.length > 0) {
+        const w = writerWaiters.shift()!;
+        w.resolve();
+        return w.item;
+      }
+      return undefined;
+    },
+
+    waitToRead(signal: AbortSignal): Promise<boolean> {
+      if (signal.aborted) return Promise.reject(signal.reason);
+      if (buffer.length > 0 || writerWaiters.length > 0) return Promise.resolve(true);
+      if (closed) return Promise.resolve(false);
+
+      return new Promise<boolean>((resolve, reject) => {
+        const handler = (hasData: boolean): void => {
+          signal.removeEventListener("abort", onAbort);
+          resolve(hasData);
+        };
+        const onAbort = (): void => {
+          const idx = readerWaiters.indexOf(handler);
+          if (idx >= 0) readerWaiters.splice(idx, 1);
+          reject(signal.reason);
+        };
+        readerWaiters.push(handler);
+        signal.addEventListener("abort", onAbort, { once: true });
+      });
+    },
+
+    complete(): void {
+      closed = true;
+      for (const r of readerWaiters) r(false);
+      readerWaiters = [];
+      for (const w of writerWaiters) w.reject(new Error("Channel closed"));
+      writerWaiters = [];
+    },
+  };
+}

--- a/src/Core.TypeScript/ferry-throttler/lane-notifier.test.ts
+++ b/src/Core.TypeScript/ferry-throttler/lane-notifier.test.ts
@@ -1,0 +1,142 @@
+/**
+ * lane-notifier.test.ts — unit tests for LaneNotifier.
+ *
+ * Covers: single wake, multiple concurrent wakes, abort rejection,
+ * already-aborted signal, fresh-cycle semantics, and rapid notify behavior.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { createLaneNotifier } from "./lane-notifier";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Creates a deferred that tracks whether a promise resolved or rejected. */
+function track(p: Promise<void>): {
+  resolved: boolean;
+  rejected: boolean;
+  reason: unknown;
+  promise: Promise<void>;
+} {
+  const state = { resolved: false, rejected: false, reason: undefined as unknown };
+  state.promise = p.then(
+    () => { state.resolved = true; },
+    (err: unknown) => { state.rejected = true; state.reason = err; },
+  );
+  return state as typeof state & { promise: Promise<void> };
+}
+
+/** Flush microtask queue so promises settle. */
+async function flush(): Promise<void> {
+  await new Promise<void>((r) => { setTimeout(r, 0); });
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("LaneNotifier", () => {
+  it("notify wakes a single waiting wait() call", async () => {
+    const notifier = createLaneNotifier();
+    const ac = new AbortController();
+
+    const state = track(notifier.wait(ac.signal));
+    await flush();
+    expect(state.resolved).toBe(false);
+
+    notifier.notify();
+    await flush();
+    expect(state.resolved).toBe(true);
+  });
+
+  it("notify wakes multiple concurrent wait() calls", async () => {
+    const notifier = createLaneNotifier();
+    const ac1 = new AbortController();
+    const ac2 = new AbortController();
+    const ac3 = new AbortController();
+
+    const s1 = track(notifier.wait(ac1.signal));
+    const s2 = track(notifier.wait(ac2.signal));
+    const s3 = track(notifier.wait(ac3.signal));
+    await flush();
+
+    expect(s1.resolved).toBe(false);
+    expect(s2.resolved).toBe(false);
+    expect(s3.resolved).toBe(false);
+
+    notifier.notify();
+    await flush();
+
+    expect(s1.resolved).toBe(true);
+    expect(s2.resolved).toBe(true);
+    expect(s3.resolved).toBe(true);
+  });
+
+  it("wait rejects with abort reason when signal is aborted", async () => {
+    const notifier = createLaneNotifier();
+    const ac = new AbortController();
+    const reason = new Error("cancelled");
+
+    const state = track(notifier.wait(ac.signal));
+    await flush();
+    expect(state.rejected).toBe(false);
+
+    ac.abort(reason);
+    await flush();
+
+    expect(state.rejected).toBe(true);
+    expect(state.reason).toBe(reason);
+  });
+
+  it("wait rejects immediately if signal is already aborted", async () => {
+    const notifier = createLaneNotifier();
+    const ac = new AbortController();
+    const reason = new Error("already done");
+    ac.abort(reason);
+
+    const state = track(notifier.wait(ac.signal));
+    await flush();
+
+    expect(state.rejected).toBe(true);
+    expect(state.reason).toBe(reason);
+  });
+
+  it("after notify, next wait does NOT resolve immediately (waits for next notify)", async () => {
+    const notifier = createLaneNotifier();
+    const ac1 = new AbortController();
+    const ac2 = new AbortController();
+
+    // First cycle: wait then notify
+    const s1 = track(notifier.wait(ac1.signal));
+    notifier.notify();
+    await flush();
+    expect(s1.resolved).toBe(true);
+
+    // Second cycle: wait should NOT resolve immediately
+    const s2 = track(notifier.wait(ac2.signal));
+    await flush();
+    expect(s2.resolved).toBe(false);
+
+    // Only resolves on the next notify
+    notifier.notify();
+    await flush();
+    expect(s2.resolved).toBe(true);
+  });
+
+  it("multiple rapid notify calls don't accumulate (each creates one fresh cycle)", async () => {
+    const notifier = createLaneNotifier();
+    const ac = new AbortController();
+
+    // Fire several notifies without any waiter
+    notifier.notify();
+    notifier.notify();
+    notifier.notify();
+
+    // A wait issued AFTER the rapid notifies should NOT resolve immediately
+    const state = track(notifier.wait(ac.signal));
+    await flush();
+    expect(state.resolved).toBe(false);
+
+    // Only resolves on the next notify
+    notifier.notify();
+    await flush();
+    expect(state.resolved).toBe(true);
+  });
+});

--- a/src/Core.TypeScript/ferry-throttler/lane-notifier.ts
+++ b/src/Core.TypeScript/ferry-throttler/lane-notifier.ts
@@ -1,0 +1,77 @@
+/**
+ * lane-notifier.ts — shared notification primitive for multi-lane ferry throttler.
+ *
+ * Provides a simple signal/wait mechanism so the drain loop can sleep until
+ * a lane has new work or completes. Multiple concurrent `wait()` calls all
+ * resolve on the same `notify()`. After `notify()`, the next `wait()` waits
+ * for the NEXT notify (does not immediately resolve).
+ */
+
+// ─── Interface ──────────────────────────────────────────────────────────────
+
+/** Shared notification primitive for lane coordination. */
+export interface LaneNotifier {
+  /** Signal that a lane has new work or has completed. */
+  notify(): void;
+  /** Wait until any lane has work or all lanes are done. Rejects on abort. */
+  wait(signal: AbortSignal): Promise<void>;
+}
+
+// ─── Implementation ─────────────────────────────────────────────────────────
+
+/**
+ * Creates a LaneNotifier backed by a single promise + resolver pair.
+ *
+ * - `notify()` resolves the current promise, then creates a fresh one for
+ *   the next wait cycle.
+ * - `wait(signal)` awaits the current promise. If the signal is already
+ *   aborted, rejects immediately. Registers an abort listener that rejects
+ *   the wait.
+ * - Multiple concurrent `wait()` calls all wake on the same `notify()`.
+ * - After `notify()`, the next `wait()` call waits for the NEXT notify.
+ */
+export function createLaneNotifier(): LaneNotifier {
+  let resolve: () => void;
+  let promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+
+  return {
+    notify(): void {
+      const prev = resolve;
+      promise = new Promise<void>((r) => {
+        resolve = r;
+      });
+      prev();
+    },
+
+    wait(signal: AbortSignal): Promise<void> {
+      if (signal.aborted) {
+        return Promise.reject(signal.reason as unknown);
+      }
+
+      const current = promise;
+
+      return new Promise<void>((res, rej) => {
+        let settled = false;
+
+        const onAbort = (): void => {
+          if (!settled) {
+            settled = true;
+            rej(signal.reason as unknown);
+          }
+        };
+
+        signal.addEventListener("abort", onAbort, { once: true });
+
+        void current.then(() => {
+          if (!settled) {
+            settled = true;
+            signal.removeEventListener("abort", onAbort);
+            res();
+          }
+        });
+      });
+    },
+  };
+}

--- a/src/Core.TypeScript/ferry-throttler/priority-config.test.ts
+++ b/src/Core.TypeScript/ferry-throttler/priority-config.test.ts
@@ -1,0 +1,260 @@
+/**
+ * priority-config.test.ts — unit tests for PriorityFerryThrottlerConfig types
+ * and validatePriorityConfig.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  DETERMINISTIC_PRIORITY_CONFIG,
+  validatePriorityConfig,
+  type DrainingPolicy,
+  type PriorityFerryThrottlerConfig,
+} from "./priority-config";
+
+// ─── DETERMINISTIC_PRIORITY_CONFIG shape ────────────────────────────────────
+
+describe("DETERMINISTIC_PRIORITY_CONFIG", () => {
+  it("has maxDegreeOfParallelism = 1", () => {
+    expect(DETERMINISTIC_PRIORITY_CONFIG.maxDegreeOfParallelism).toBe(1);
+  });
+
+  it("has 2 lanes", () => {
+    expect(DETERMINISTIC_PRIORITY_CONFIG.lanes).toHaveLength(2);
+  });
+
+  it("has strict draining policy", () => {
+    expect(DETERMINISTIC_PRIORITY_CONFIG.drainingPolicy.kind).toBe("strict");
+  });
+
+  it("has defaultPriority = 1 (low lane)", () => {
+    expect(DETERMINISTIC_PRIORITY_CONFIG.defaultPriority).toBe(1);
+  });
+
+  it("has defaultMaxBatchSize = 256", () => {
+    expect(DETERMINISTIC_PRIORITY_CONFIG.defaultMaxBatchSize).toBe(256);
+  });
+
+  it("lane priorities are 0 (high) and 1 (low)", () => {
+    expect(DETERMINISTIC_PRIORITY_CONFIG.lanes[0]!.priority).toBe(0);
+    expect(DETERMINISTIC_PRIORITY_CONFIG.lanes[1]!.priority).toBe(1);
+  });
+
+  it("passes validation without throwing", () => {
+    expect(() => validatePriorityConfig(DETERMINISTIC_PRIORITY_CONFIG)).not.toThrow();
+  });
+});
+
+// ─── Valid configs ──────────────────────────────────────────────────────────
+
+describe("validatePriorityConfig — valid configs", () => {
+  it("accepts a minimal single-lane strict config", () => {
+    const config: PriorityFerryThrottlerConfig = {
+      maxDegreeOfParallelism: 1,
+      defaultMaxBatchSize: 1,
+      defaultMaxBatchBytes: undefined,
+      lanes: [{ priority: 0 }],
+      defaultPriority: 0,
+      drainingPolicy: { kind: "strict" },
+    };
+    expect(() => validatePriorityConfig(config)).not.toThrow();
+  });
+
+  it("accepts a multi-lane weighted-fair config with weights", () => {
+    const weights = new Map([[0, 3], [1, 2], [2, 1]]);
+    const policy: DrainingPolicy = { kind: "weighted-fair", weights };
+    const config: PriorityFerryThrottlerConfig = {
+      maxDegreeOfParallelism: 4,
+      defaultMaxBatchSize: 128,
+      defaultMaxBatchBytes: 65536,
+      lanes: [
+        { priority: 0, weight: 3, maxBatchSize: 64 },
+        { priority: 1, weight: 2, maxBatchBytes: 32768 },
+        { priority: 2, weight: 1, maxQueueSize: 1000 },
+      ],
+      defaultPriority: 1,
+      drainingPolicy: policy,
+    };
+    expect(() => validatePriorityConfig(config)).not.toThrow();
+  });
+
+  it("accepts config with all per-lane overrides set", () => {
+    const config: PriorityFerryThrottlerConfig = {
+      maxDegreeOfParallelism: 2,
+      defaultMaxBatchSize: 100,
+      defaultMaxBatchBytes: 4096,
+      lanes: [
+        { priority: 10, maxBatchSize: 50, maxBatchBytes: 2048, maxQueueSize: 500 },
+      ],
+      defaultPriority: 10,
+      drainingPolicy: { kind: "strict" },
+    };
+    expect(() => validatePriorityConfig(config)).not.toThrow();
+  });
+});
+
+// ─── Invalid configs ────────────────────────────────────────────────────────
+
+describe("validatePriorityConfig — invalid configs", () => {
+  function baseConfig(overrides: Partial<PriorityFerryThrottlerConfig> = {}): PriorityFerryThrottlerConfig {
+    return {
+      maxDegreeOfParallelism: 2,
+      defaultMaxBatchSize: 128,
+      defaultMaxBatchBytes: undefined,
+      lanes: [{ priority: 0 }, { priority: 1 }],
+      defaultPriority: 0,
+      drainingPolicy: { kind: "strict" },
+      ...overrides,
+    };
+  }
+
+  it("throws RangeError when maxDegreeOfParallelism < 1", () => {
+    expect(() => validatePriorityConfig(baseConfig({ maxDegreeOfParallelism: 0 }))).toThrow(RangeError);
+    expect(() => validatePriorityConfig(baseConfig({ maxDegreeOfParallelism: -1 }))).toThrow(RangeError);
+  });
+
+  it("throws RangeError when lanes is empty", () => {
+    expect(() => validatePriorityConfig(baseConfig({ lanes: [] }))).toThrow(RangeError);
+    expect(() => validatePriorityConfig(baseConfig({ lanes: [] }))).toThrow(/at least one lane/);
+  });
+
+  it("throws RangeError on duplicate priority levels", () => {
+    const config = baseConfig({ lanes: [{ priority: 5 }, { priority: 5 }] });
+    expect(() => validatePriorityConfig(config)).toThrow(RangeError);
+    expect(() => validatePriorityConfig(config)).toThrow(/duplicate priority/);
+  });
+
+  it("throws RangeError when defaultMaxBatchSize < 1", () => {
+    expect(() => validatePriorityConfig(baseConfig({ defaultMaxBatchSize: 0 }))).toThrow(RangeError);
+    expect(() => validatePriorityConfig(baseConfig({ defaultMaxBatchSize: -5 }))).toThrow(RangeError);
+  });
+
+  it("throws RangeError when defaultMaxBatchBytes is defined and < 1", () => {
+    expect(() => validatePriorityConfig(baseConfig({ defaultMaxBatchBytes: 0 }))).toThrow(RangeError);
+    expect(() => validatePriorityConfig(baseConfig({ defaultMaxBatchBytes: -1 }))).toThrow(RangeError);
+  });
+
+  it("throws RangeError when a lane's maxBatchSize is defined and < 1", () => {
+    const config = baseConfig({ lanes: [{ priority: 0, maxBatchSize: 0 }, { priority: 1 }] });
+    expect(() => validatePriorityConfig(config)).toThrow(RangeError);
+    expect(() => validatePriorityConfig(config)).toThrow(/maxBatchSize/);
+  });
+
+  it("throws RangeError when a lane's maxBatchBytes is defined and < 1", () => {
+    const config = baseConfig({ lanes: [{ priority: 0, maxBatchBytes: -1 }, { priority: 1 }] });
+    expect(() => validatePriorityConfig(config)).toThrow(RangeError);
+    expect(() => validatePriorityConfig(config)).toThrow(/maxBatchBytes/);
+  });
+
+  it("throws RangeError when a lane's maxQueueSize is defined and < 1", () => {
+    const config = baseConfig({ lanes: [{ priority: 0, maxQueueSize: 0 }, { priority: 1 }] });
+    expect(() => validatePriorityConfig(config)).toThrow(RangeError);
+    expect(() => validatePriorityConfig(config)).toThrow(/maxQueueSize/);
+  });
+
+  it("throws RangeError when defaultPriority doesn't match any lane", () => {
+    const config = baseConfig({ defaultPriority: 99 });
+    expect(() => validatePriorityConfig(config)).toThrow(RangeError);
+    expect(() => validatePriorityConfig(config)).toThrow(/does not match/);
+  });
+
+  it("throws RangeError when weighted-fair policy but lane is missing weight", () => {
+    const weights = new Map([[0, 1], [1, 2]]);
+    const config = baseConfig({
+      lanes: [{ priority: 0, weight: 1 }, { priority: 1 }],  // lane 1 missing weight
+      drainingPolicy: { kind: "weighted-fair", weights },
+    });
+    expect(() => validatePriorityConfig(config)).toThrow(RangeError);
+    expect(() => validatePriorityConfig(config)).toThrow(/weight must be > 0/);
+  });
+
+  it("throws RangeError when weighted-fair policy but lane has weight <= 0", () => {
+    const weights = new Map([[0, 1], [1, 0]]);
+    const config = baseConfig({
+      lanes: [{ priority: 0, weight: 1 }, { priority: 1, weight: 0 }],
+      drainingPolicy: { kind: "weighted-fair", weights },
+    });
+    expect(() => validatePriorityConfig(config)).toThrow(RangeError);
+    expect(() => validatePriorityConfig(config)).toThrow(/weight must be > 0/);
+  });
+
+  it("throws RangeError with negative weight on weighted-fair", () => {
+    const weights = new Map([[0, 1], [1, -2]]);
+    const config = baseConfig({
+      lanes: [{ priority: 0, weight: 1 }, { priority: 1, weight: -2 }],
+      drainingPolicy: { kind: "weighted-fair", weights },
+    });
+    expect(() => validatePriorityConfig(config)).toThrow(RangeError);
+    expect(() => validatePriorityConfig(config)).toThrow(/weight must be > 0/);
+  });
+});
+
+// ─── Serialization round-trip ───────────────────────────────────────────────
+
+import { serializeConfig, deserializeConfig } from "./priority-config";
+
+describe("serializeConfig / deserializeConfig", () => {
+  it("round-trips DETERMINISTIC_PRIORITY_CONFIG with deep equality", () => {
+    const json = serializeConfig(DETERMINISTIC_PRIORITY_CONFIG);
+    const restored = deserializeConfig(json);
+
+    expect(restored.maxDegreeOfParallelism).toBe(DETERMINISTIC_PRIORITY_CONFIG.maxDegreeOfParallelism);
+    expect(restored.defaultMaxBatchSize).toBe(DETERMINISTIC_PRIORITY_CONFIG.defaultMaxBatchSize);
+    expect(restored.defaultMaxBatchBytes).toBe(DETERMINISTIC_PRIORITY_CONFIG.defaultMaxBatchBytes);
+    expect(restored.defaultPriority).toBe(DETERMINISTIC_PRIORITY_CONFIG.defaultPriority);
+    expect(restored.drainingPolicy).toEqual(DETERMINISTIC_PRIORITY_CONFIG.drainingPolicy);
+    expect(restored.lanes).toEqual(DETERMINISTIC_PRIORITY_CONFIG.lanes);
+  });
+
+  it("round-trips a weighted-fair config with 3 lanes including the Map", () => {
+    const weights = new Map<number, number>([[0, 5], [1, 3], [2, 1]]);
+    const original: PriorityFerryThrottlerConfig = {
+      maxDegreeOfParallelism: 3,
+      defaultMaxBatchSize: 64,
+      defaultMaxBatchBytes: 8192,
+      lanes: [
+        { priority: 0, weight: 5, maxBatchSize: 32 },
+        { priority: 1, weight: 3, maxQueueSize: 500 },
+        { priority: 2, weight: 1, maxBatchBytes: 4096 },
+      ],
+      defaultPriority: 1,
+      drainingPolicy: { kind: "weighted-fair", weights },
+    };
+
+    const json = serializeConfig(original);
+    const restored = deserializeConfig(json);
+
+    expect(restored.maxDegreeOfParallelism).toBe(3);
+    expect(restored.defaultMaxBatchSize).toBe(64);
+    expect(restored.defaultMaxBatchBytes).toBe(8192);
+    expect(restored.defaultPriority).toBe(1);
+    expect(restored.lanes).toEqual(original.lanes);
+    expect(restored.drainingPolicy.kind).toBe("weighted-fair");
+
+    // Verify the Map was correctly reconstructed
+    const restoredPolicy = restored.drainingPolicy as { kind: "weighted-fair"; weights: ReadonlyMap<number, number> };
+    expect(restoredPolicy.weights).toBeInstanceOf(Map);
+    expect(restoredPolicy.weights.size).toBe(3);
+    expect(restoredPolicy.weights.get(0)).toBe(5);
+    expect(restoredPolicy.weights.get(1)).toBe(3);
+    expect(restoredPolicy.weights.get(2)).toBe(1);
+  });
+
+  it("throws on malformed JSON", () => {
+    expect(() => deserializeConfig("not json")).toThrow("Invalid config JSON");
+  });
+
+  it("throws on missing required fields (empty object)", () => {
+    expect(() => deserializeConfig("{}")).toThrow("Invalid config JSON");
+  });
+
+  it("throws when lanes is not an array", () => {
+    const bad = JSON.stringify({
+      maxDegreeOfParallelism: 1,
+      defaultMaxBatchSize: 128,
+      defaultPriority: 0,
+      lanes: "not-an-array",
+      drainingPolicy: { kind: "strict" },
+    });
+    expect(() => deserializeConfig(bad)).toThrow("Invalid config JSON");
+  });
+});

--- a/src/Core.TypeScript/ferry-throttler/priority-config.ts
+++ b/src/Core.TypeScript/ferry-throttler/priority-config.ts
@@ -1,0 +1,300 @@
+/**
+ * priority-config.ts — configuration types and validation for PriorityFerryThrottler.
+ *
+ * Defines the lane-based priority model: N lanes with distinct priority levels,
+ * a shared ferry pool (`maxDegreeOfParallelism`), and a draining policy that
+ * controls how ferries pick work across lanes (strict = highest priority first;
+ * weighted-fair = proportional to assigned weights).
+ *
+ * The `DETERMINISTIC_PRIORITY_CONFIG` constant gives a single-ferry, two-lane,
+ * strict-draining setup suitable for deterministic simulation testing (DST).
+ */
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+/** Priority level — lower number = higher priority. */
+export type PriorityLevel = number;
+
+/** Draining policy discriminator. */
+export type DrainingPolicy =
+  | { readonly kind: "strict" }
+  | { readonly kind: "weighted-fair"; readonly weights: ReadonlyMap<PriorityLevel, number> };
+
+/** Per-lane configuration overrides. */
+export interface LaneConfig {
+  readonly priority: PriorityLevel;
+  readonly maxBatchSize?: number | undefined;
+  readonly maxBatchBytes?: number | undefined;
+  readonly maxQueueSize?: number | undefined;
+  /** Weight for weighted-fair draining. Required when policy is weighted-fair. */
+  readonly weight?: number | undefined;
+}
+
+/** Top-level configuration for PriorityFerryThrottler. */
+export interface PriorityFerryThrottlerConfig {
+  /** Total ferries shared across all lanes. */
+  readonly maxDegreeOfParallelism: number;
+  /** Default batch size when lane doesn't override. */
+  readonly defaultMaxBatchSize: number;
+  /** Default batch bytes when lane doesn't override. */
+  readonly defaultMaxBatchBytes?: number | undefined;
+  /** Lane definitions, ordered by priority (ascending = higher priority first). */
+  readonly lanes: readonly LaneConfig[];
+  /** Which lane enqueue defaults to when priority is omitted. */
+  readonly defaultPriority: PriorityLevel;
+  /** The draining policy. */
+  readonly drainingPolicy: DrainingPolicy;
+}
+
+// ─── Deterministic default ──────────────────────────────────────────────────
+
+/** Deterministic two-lane config for DST replay: one ferry, strict draining. */
+export const DETERMINISTIC_PRIORITY_CONFIG: PriorityFerryThrottlerConfig = {
+  maxDegreeOfParallelism: 1,
+  defaultMaxBatchSize: 256,
+  defaultMaxBatchBytes: undefined,
+  lanes: [
+    { priority: 0 },  // high
+    { priority: 1 },  // low
+  ],
+  defaultPriority: 1,
+  drainingPolicy: { kind: "strict" },
+};
+
+// ─── Validation ─────────────────────────────────────────────────────────────
+
+/**
+ * Validates a PriorityFerryThrottlerConfig, throwing `RangeError` on any
+ * constraint violation. Call this at construction time before building the
+ * throttler's internal state.
+ */
+export function validatePriorityConfig(config: PriorityFerryThrottlerConfig): void {
+  if (config.maxDegreeOfParallelism < 1) {
+    throw new RangeError("maxDegreeOfParallelism must be >= 1");
+  }
+
+  if (config.defaultMaxBatchSize < 1) {
+    throw new RangeError("defaultMaxBatchSize must be >= 1");
+  }
+
+  if (config.defaultMaxBatchBytes !== undefined && config.defaultMaxBatchBytes < 1) {
+    throw new RangeError("defaultMaxBatchBytes, if set, must be >= 1");
+  }
+
+  if (config.lanes.length === 0) {
+    throw new RangeError("lanes must contain at least one lane");
+  }
+
+  // Check for duplicate priorities
+  const seen = new Set<PriorityLevel>();
+  for (const lane of config.lanes) {
+    if (seen.has(lane.priority)) {
+      throw new RangeError(`duplicate priority level: ${lane.priority}`);
+    }
+    seen.add(lane.priority);
+  }
+
+  // Per-lane field validation
+  for (const lane of config.lanes) {
+    if (lane.maxBatchSize !== undefined && lane.maxBatchSize < 1) {
+      throw new RangeError(`lane priority=${lane.priority}: maxBatchSize, if set, must be >= 1`);
+    }
+    if (lane.maxBatchBytes !== undefined && lane.maxBatchBytes < 1) {
+      throw new RangeError(`lane priority=${lane.priority}: maxBatchBytes, if set, must be >= 1`);
+    }
+    if (lane.maxQueueSize !== undefined && lane.maxQueueSize < 1) {
+      throw new RangeError(`lane priority=${lane.priority}: maxQueueSize, if set, must be >= 1`);
+    }
+  }
+
+  // defaultPriority must match a lane
+  if (!config.lanes.some((lane) => lane.priority === config.defaultPriority)) {
+    throw new RangeError(
+      `defaultPriority ${config.defaultPriority} does not match any lane's priority`,
+    );
+  }
+
+  // Weighted-fair policy requires every lane to have a positive weight
+  if (config.drainingPolicy.kind === "weighted-fair") {
+    for (const lane of config.lanes) {
+      if (lane.weight === undefined || lane.weight <= 0) {
+        throw new RangeError(
+          `lane priority=${lane.priority}: weight must be > 0 when draining policy is weighted-fair`,
+        );
+      }
+    }
+  }
+}
+
+// ─── Serialization ──────────────────────────────────────────────────────────
+
+/** JSON-safe representation of a lane config (identical to LaneConfig). */
+interface PlainLaneConfig {
+  readonly priority: number;
+  readonly maxBatchSize?: number;
+  readonly maxBatchBytes?: number;
+  readonly maxQueueSize?: number;
+  readonly weight?: number;
+}
+
+/** JSON-safe representation of a draining policy. */
+type PlainDrainingPolicy =
+  | { readonly kind: "strict" }
+  | { readonly kind: "weighted-fair"; readonly weights: Record<string, number> };
+
+/** JSON-safe representation of the full config. */
+interface PlainConfig {
+  readonly maxDegreeOfParallelism: number;
+  readonly defaultMaxBatchSize: number;
+  readonly defaultMaxBatchBytes?: number;
+  readonly lanes: readonly PlainLaneConfig[];
+  readonly defaultPriority: number;
+  readonly drainingPolicy: PlainDrainingPolicy;
+}
+
+/**
+ * Serialize a `PriorityFerryThrottlerConfig` to a JSON string.
+ *
+ * The `ReadonlyMap<PriorityLevel, number>` in weighted-fair's `weights` is
+ * serialized as a plain object `{ [priority: string]: number }`.
+ */
+export function serializeConfig(config: PriorityFerryThrottlerConfig): string {
+  let plainPolicy: PlainDrainingPolicy;
+
+  if (config.drainingPolicy.kind === "strict") {
+    plainPolicy = { kind: "strict" };
+  } else {
+    const weightsObj: Record<string, number> = {};
+    for (const [key, value] of config.drainingPolicy.weights) {
+      weightsObj[String(key)] = value;
+    }
+    plainPolicy = { kind: "weighted-fair", weights: weightsObj };
+  }
+
+  const plain: PlainConfig = {
+    maxDegreeOfParallelism: config.maxDegreeOfParallelism,
+    defaultMaxBatchSize: config.defaultMaxBatchSize,
+    ...(config.defaultMaxBatchBytes !== undefined ? { defaultMaxBatchBytes: config.defaultMaxBatchBytes } : {}),
+    lanes: config.lanes.map((lane) => {
+      const out: Record<string, number | undefined> = { priority: lane.priority };
+      if (lane.maxBatchSize !== undefined) out["maxBatchSize"] = lane.maxBatchSize;
+      if (lane.maxBatchBytes !== undefined) out["maxBatchBytes"] = lane.maxBatchBytes;
+      if (lane.maxQueueSize !== undefined) out["maxQueueSize"] = lane.maxQueueSize;
+      if (lane.weight !== undefined) out["weight"] = lane.weight;
+      return out as unknown as PlainLaneConfig;
+    }),
+    defaultPriority: config.defaultPriority,
+    drainingPolicy: plainPolicy,
+  };
+
+  return JSON.stringify(plain);
+}
+
+/**
+ * Deserialize a JSON string into a `PriorityFerryThrottlerConfig`.
+ *
+ * Throws `Error("Invalid config JSON: <reason>")` if the JSON is malformed,
+ * missing required fields, or contains wrong types. After reconstruction,
+ * calls `validatePriorityConfig()` to enforce domain constraints.
+ */
+export function deserializeConfig(json: string): PriorityFerryThrottlerConfig {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(json) as unknown;
+  } catch {
+    throw new Error("Invalid config JSON: malformed JSON");
+  }
+
+  if (raw === null || typeof raw !== "object") {
+    throw new Error("Invalid config JSON: expected an object");
+  }
+
+  const obj = raw as Record<string, unknown>;
+
+  // Required top-level fields
+  if (typeof obj["maxDegreeOfParallelism"] !== "number") {
+    throw new Error("Invalid config JSON: maxDegreeOfParallelism must be a number");
+  }
+  if (typeof obj["defaultMaxBatchSize"] !== "number") {
+    throw new Error("Invalid config JSON: defaultMaxBatchSize must be a number");
+  }
+  if (typeof obj["defaultPriority"] !== "number") {
+    throw new Error("Invalid config JSON: defaultPriority must be a number");
+  }
+
+  // Optional defaultMaxBatchBytes
+  if (obj["defaultMaxBatchBytes"] !== undefined && obj["defaultMaxBatchBytes"] !== null && typeof obj["defaultMaxBatchBytes"] !== "number") {
+    throw new Error("Invalid config JSON: defaultMaxBatchBytes must be a number or undefined");
+  }
+
+  // lanes
+  if (!Array.isArray(obj["lanes"])) {
+    throw new Error("Invalid config JSON: lanes must be an array");
+  }
+
+  const lanes: LaneConfig[] = [];
+  for (let i = 0; i < (obj["lanes"] as unknown[]).length; i++) {
+    const laneRaw = (obj["lanes"] as unknown[])[i];
+    if (laneRaw === null || typeof laneRaw !== "object") {
+      throw new Error(`Invalid config JSON: lanes[${String(i)}] must be an object`);
+    }
+    const l = laneRaw as Record<string, unknown>;
+    if (typeof l["priority"] !== "number") {
+      throw new Error(`Invalid config JSON: lanes[${String(i)}].priority must be a number`);
+    }
+    const lane: LaneConfig = {
+      priority: l["priority"] as number,
+      maxBatchSize: typeof l["maxBatchSize"] === "number" ? (l["maxBatchSize"] as number) : undefined,
+      maxBatchBytes: typeof l["maxBatchBytes"] === "number" ? (l["maxBatchBytes"] as number) : undefined,
+      maxQueueSize: typeof l["maxQueueSize"] === "number" ? (l["maxQueueSize"] as number) : undefined,
+      weight: typeof l["weight"] === "number" ? (l["weight"] as number) : undefined,
+    };
+    lanes.push(lane);
+  }
+
+  // drainingPolicy
+  if (obj["drainingPolicy"] === null || obj["drainingPolicy"] === undefined || typeof obj["drainingPolicy"] !== "object") {
+    throw new Error("Invalid config JSON: drainingPolicy must be an object");
+  }
+
+  const policyRaw = obj["drainingPolicy"] as Record<string, unknown>;
+  if (policyRaw["kind"] !== "strict" && policyRaw["kind"] !== "weighted-fair") {
+    throw new Error("Invalid config JSON: drainingPolicy.kind must be 'strict' or 'weighted-fair'");
+  }
+
+  let drainingPolicy: DrainingPolicy;
+  if (policyRaw["kind"] === "strict") {
+    drainingPolicy = { kind: "strict" };
+  } else {
+    if (policyRaw["weights"] === null || policyRaw["weights"] === undefined || typeof policyRaw["weights"] !== "object" || Array.isArray(policyRaw["weights"])) {
+      throw new Error("Invalid config JSON: drainingPolicy.weights must be an object");
+    }
+    const weightsRaw = policyRaw["weights"] as Record<string, unknown>;
+    const weights = new Map<PriorityLevel, number>();
+    for (const [key, value] of Object.entries(weightsRaw)) {
+      const numKey = Number(key);
+      if (!Number.isFinite(numKey)) {
+        throw new Error(`Invalid config JSON: drainingPolicy.weights key '${key}' is not a valid number`);
+      }
+      if (typeof value !== "number") {
+        throw new Error(`Invalid config JSON: drainingPolicy.weights['${key}'] must be a number`);
+      }
+      weights.set(numKey, value);
+    }
+    drainingPolicy = { kind: "weighted-fair", weights };
+  }
+
+  const config: PriorityFerryThrottlerConfig = {
+    maxDegreeOfParallelism: obj["maxDegreeOfParallelism"] as number,
+    defaultMaxBatchSize: obj["defaultMaxBatchSize"] as number,
+    defaultMaxBatchBytes: typeof obj["defaultMaxBatchBytes"] === "number" ? (obj["defaultMaxBatchBytes"] as number) : undefined,
+    lanes,
+    defaultPriority: obj["defaultPriority"] as number,
+    drainingPolicy,
+  };
+
+  // Validate the reconstructed config (throws RangeError on constraint violation)
+  validatePriorityConfig(config);
+
+  return config;
+}

--- a/src/Core.TypeScript/ferry-throttler/priority-ferry-throttler-with-result.test.ts
+++ b/src/Core.TypeScript/ferry-throttler/priority-ferry-throttler-with-result.test.ts
@@ -1,0 +1,314 @@
+/**
+ * priority-ferry-throttler-with-result.test.ts — tests for PriorityFerryThrottlerWithResult.
+ *
+ * Covers result alignment, strict priority ordering with results, result count
+ * mismatch faulting, processor throw faulting, cancelled request skipping, byte
+ * sizer throw faulting a single item, byte budget with results, invalid priority
+ * rejection, and dispose rejecting queued items.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { PriorityFerryThrottlerWithResult } from "./priority-ferry-throttler-with-result.ts";
+import type { ProcessBatchWithResult, ItemSizeBytes } from "./ferry-throttler.ts";
+import type { PriorityFerryThrottlerConfig } from "./priority-config.ts";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function range(start: number, end: number): number[] {
+  const result: number[] = [];
+  for (let i = start; i <= end; i++) result.push(i);
+  return result;
+}
+
+/** A strict two-lane config: priority 0 (high) and priority 1 (low). DoP=1. */
+const STRICT_TWO_LANE: PriorityFerryThrottlerConfig = {
+  maxDegreeOfParallelism: 1,
+  defaultMaxBatchSize: 256,
+  defaultMaxBatchBytes: undefined,
+  lanes: [
+    { priority: 0 },
+    { priority: 1 },
+  ],
+  defaultPriority: 1,
+  drainingPolicy: { kind: "strict" },
+};
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("PriorityFerryThrottlerWithResult", () => {
+  it("result arity returns aligned results: items enqueued across lanes, each gets x*10 as result", async () => {
+    const processBatch: ProcessBatchWithResult<number, number> = async (boat) => {
+      return boat.map((x) => x * 10);
+    };
+
+    const throttler = new PriorityFerryThrottlerWithResult(STRICT_TWO_LANE, processBatch);
+
+    const promises: Promise<number>[] = [];
+    for (const x of range(1, 5)) {
+      promises.push(throttler.process(x, 0)); // high priority
+    }
+    for (const x of range(6, 10)) {
+      promises.push(throttler.process(x, 1)); // low priority
+    }
+
+    await throttler.complete();
+    const results = await Promise.all(promises);
+
+    // Each result is x*10
+    expect(results).toEqual([10, 20, 30, 40, 50, 60, 70, 80, 90, 100]);
+  });
+
+  it("strict priority ordering with results: high-priority items get results before low-priority", async () => {
+    const resolveOrder: number[] = [];
+
+    const processBatch: ProcessBatchWithResult<number, number> = async (boat) => {
+      return boat.map((x) => x * 10);
+    };
+
+    const throttler = new PriorityFerryThrottlerWithResult(STRICT_TWO_LANE, processBatch);
+
+    // Enqueue low-priority first, then high-priority
+    const lowPromises: Promise<number>[] = [];
+    for (const x of range(1, 5)) {
+      lowPromises.push(
+        throttler.process(x, 1).then((r) => {
+          resolveOrder.push(x);
+          return r;
+        }),
+      );
+    }
+
+    const highPromises: Promise<number>[] = [];
+    for (const x of range(10, 14)) {
+      highPromises.push(
+        throttler.process(x, 0).then((r) => {
+          resolveOrder.push(x);
+          return r;
+        }),
+      );
+    }
+
+    await throttler.complete();
+    await Promise.all([...highPromises, ...lowPromises]);
+
+    // All high-priority items (10-14) should resolve before any low-priority (1-5)
+    const highIndices = resolveOrder
+      .map((val, idx) => ({ val, idx }))
+      .filter(({ val }) => val >= 10)
+      .map(({ idx }) => idx);
+    const lowIndices = resolveOrder
+      .map((val, idx) => ({ val, idx }))
+      .filter(({ val }) => val < 10)
+      .map(({ idx }) => idx);
+
+    const maxHighIndex = Math.max(...highIndices);
+    const minLowIndex = Math.min(...lowIndices);
+    expect(maxHighIndex).toBeLessThan(minLowIndex);
+  });
+
+  it("result count mismatch faults entire boat: processor returns wrong-length array", async () => {
+    const processBatch: ProcessBatchWithResult<number, number> = async (boat) => {
+      // Return fewer results than items
+      return boat.slice(0, 1).map((x) => x * 10);
+    };
+
+    const throttler = new PriorityFerryThrottlerWithResult(STRICT_TWO_LANE, processBatch);
+
+    const promises = range(1, 3).map((x) => throttler.process(x, 0));
+    await throttler.complete();
+
+    for (const p of promises) {
+      await expect(p).rejects.toThrow("result count mismatch");
+    }
+  });
+
+  it("processor throw faults all items in boat: processor throws Error('boom')", async () => {
+    const processBatch: ProcessBatchWithResult<number, number> = async (_boat) => {
+      throw new Error("boom");
+    };
+
+    const throttler = new PriorityFerryThrottlerWithResult(STRICT_TWO_LANE, processBatch);
+
+    const promises = range(1, 4).map((x) => throttler.process(x, 0));
+    await throttler.complete();
+
+    for (const p of promises) {
+      await expect(p).rejects.toThrow("boom");
+    }
+  });
+
+  it("cancelled request skipping: cancel one item mid-flight, others still process", async () => {
+    let gate: (() => void) | undefined;
+    const gatePromise = new Promise<void>((r) => { gate = r; });
+
+    const processBatch: ProcessBatchWithResult<number, number> = async (boat) => {
+      await gatePromise;
+      return boat.map((x) => x * 10);
+    };
+
+    const config: PriorityFerryThrottlerConfig = {
+      maxDegreeOfParallelism: 1,
+      defaultMaxBatchSize: 256,
+      defaultMaxBatchBytes: undefined,
+      lanes: [{ priority: 0 }],
+      defaultPriority: 0,
+      drainingPolicy: { kind: "strict" },
+    };
+
+    const throttler = new PriorityFerryThrottlerWithResult(config, processBatch);
+
+    const ac = new AbortController();
+    const p1 = throttler.process(1, 0);
+    const p2 = throttler.process(2, 0, ac.signal);
+    const p3 = throttler.process(3, 0);
+
+    // Give the ferry time to start processing the first boat (item 1)
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Cancel item 2 before the ferry picks it up for boat assembly
+    ac.abort();
+
+    // Let the first boat complete
+    gate!();
+
+    await throttler.complete();
+
+    const r1 = await p1;
+    const r3 = await p3;
+    expect(r1).toBe(10);
+    expect(r3).toBe(30);
+
+    // p2 should have been rejected due to cancellation
+    await expect(p2).rejects.toBeDefined();
+  });
+
+  it("byte sizer throw faults single item: sizer throws for one item, others in same boat still work", async () => {
+    const processBatch: ProcessBatchWithResult<number, number> = async (boat) => {
+      return boat.map((x) => x * 10);
+    };
+
+    const sizer: ItemSizeBytes<number> = (item: number): number => {
+      if (item === 3) throw new Error("sizer exploded");
+      return 10;
+    };
+
+    const config: PriorityFerryThrottlerConfig = {
+      maxDegreeOfParallelism: 1,
+      defaultMaxBatchSize: 256,
+      defaultMaxBatchBytes: 1000,
+      lanes: [{ priority: 0 }],
+      defaultPriority: 0,
+      drainingPolicy: { kind: "strict" },
+    };
+
+    const throttler = new PriorityFerryThrottlerWithResult(config, processBatch, sizer);
+
+    const p1 = throttler.process(1, 0);
+    const p2 = throttler.process(2, 0);
+    const p3 = throttler.process(3, 0); // sizer will throw for this
+    const p4 = throttler.process(4, 0);
+
+    await throttler.complete();
+
+    expect(await p1).toBe(10);
+    expect(await p2).toBe(20);
+    expect(await p4).toBe(40);
+
+    // p3 should be rejected with the sizer error
+    await expect(p3).rejects.toThrow("sizer exploded");
+  });
+
+  it("byte budget with results: lane maxBatchBytes constrains boat size, results still aligned", async () => {
+    const boatSizes: number[] = [];
+    const processBatch: ProcessBatchWithResult<number, number> = async (boat) => {
+      boatSizes.push(boat.length);
+      return boat.map((x) => x * 10);
+    };
+
+    const sizer: ItemSizeBytes<number> = () => 10;
+
+    const config: PriorityFerryThrottlerConfig = {
+      maxDegreeOfParallelism: 1,
+      defaultMaxBatchSize: 100,
+      defaultMaxBatchBytes: undefined,
+      lanes: [
+        { priority: 0, maxBatchBytes: 25 }, // 10 bytes each → max 2 per boat
+      ],
+      defaultPriority: 0,
+      drainingPolicy: { kind: "strict" },
+    };
+
+    const throttler = new PriorityFerryThrottlerWithResult(config, processBatch, sizer);
+
+    const promises = range(1, 6).map((x) => throttler.process(x, 0));
+    await throttler.complete();
+
+    const results = await Promise.all(promises);
+
+    // Results still aligned
+    expect(results).toEqual([10, 20, 30, 40, 50, 60]);
+
+    // Every boat should have at most 2 items (10 bytes each, budget 25)
+    for (const sz of boatSizes) {
+      expect(sz).toBeGreaterThanOrEqual(1);
+      expect(sz).toBeLessThanOrEqual(2);
+    }
+  });
+
+  it("invalid priority rejection: non-configured priority, assert RangeError", async () => {
+    const processBatch: ProcessBatchWithResult<number, number> = async (boat) => {
+      return boat.map((x) => x * 10);
+    };
+
+    const throttler = new PriorityFerryThrottlerWithResult(STRICT_TWO_LANE, processBatch);
+
+    await expect(throttler.process(1, 99)).rejects.toBeInstanceOf(RangeError);
+
+    throttler.dispose();
+  });
+
+  it("dispose rejects queued items: items in queue, dispose(), all rejected", async () => {
+    const processBatch: ProcessBatchWithResult<number, number> = async (boat, signal) => {
+      // Simulate a long-running batch that respects the abort signal
+      await new Promise<void>((resolve, reject) => {
+        if (signal.aborted) {
+          reject(signal.reason);
+          return;
+        }
+        const timer = setTimeout(resolve, 5000);
+        signal.addEventListener("abort", () => {
+          clearTimeout(timer);
+          reject(signal.reason);
+        }, { once: true });
+      });
+      return boat.map((x) => x * 10);
+    };
+
+    const config: PriorityFerryThrottlerConfig = {
+      maxDegreeOfParallelism: 1,
+      defaultMaxBatchSize: 2,
+      defaultMaxBatchBytes: undefined,
+      lanes: [{ priority: 0 }],
+      defaultPriority: 0,
+      drainingPolicy: { kind: "strict" },
+    };
+
+    const throttler = new PriorityFerryThrottlerWithResult(config, processBatch);
+
+    const p1 = throttler.process(1, 0);
+    const p2 = throttler.process(2, 0);
+    const p3 = throttler.process(3, 0);
+    const p4 = throttler.process(4, 0);
+
+    // Give ferry time to pick up the first boat (items 1,2) and queue items 3,4
+    await new Promise((r) => setTimeout(r, 20));
+
+    throttler.dispose();
+
+    // All promises should reject
+    const results = await Promise.allSettled([p1, p2, p3, p4]);
+    for (const r of results) {
+      expect(r.status).toBe("rejected");
+    }
+  });
+});

--- a/src/Core.TypeScript/ferry-throttler/priority-ferry-throttler-with-result.ts
+++ b/src/Core.TypeScript/ferry-throttler/priority-ferry-throttler-with-result.ts
@@ -1,0 +1,381 @@
+/**
+ * priority-ferry-throttler-with-result.ts — multi-lane priority ferry throttler (request/response arity).
+ *
+ * Composes N lane queues (one `InternalChannel<FerryRequest<T, R>>` per lane), a
+ * `LaneNotifier` for shared notification when any lane gets work, a `DrainScheduler`
+ * that picks which lane to drain, and M ferry loops (shared ferry pool).
+ *
+ * Each lane has its own backpressure (bounded queue), batch size, and byte budget.
+ * Ferries are self-clocked, anti-Nagle: they drain whatever is available NOW,
+ * never wait to fill a boat.
+ *
+ * At `maxDegreeOfParallelism = 1` with strict draining, this is deterministic and
+ * DST-replayable — the FoundationDB single-thread shape extended to priority lanes,
+ * with per-item result alignment.
+ */
+
+import { createInternalChannel } from "./internal-channel.ts";
+import type { InternalChannel } from "./internal-channel.ts";
+import { createLaneNotifier } from "./lane-notifier.ts";
+import type { LaneNotifier } from "./lane-notifier.ts";
+import {
+  createStrictPriorityScheduler,
+  createWeightedFairScheduler,
+} from "./drain-scheduler.ts";
+import type { DrainScheduler, LaneSnapshot } from "./drain-scheduler.ts";
+import { validatePriorityConfig } from "./priority-config.ts";
+import type {
+  PriorityFerryThrottlerConfig,
+  PriorityLevel,
+} from "./priority-config.ts";
+import type { ProcessBatchWithResult, ItemSizeBytes } from "./ferry-throttler.ts";
+
+// ─── FerryRequest ───────────────────────────────────────────────────────────
+
+interface FerryRequest<T, R> {
+  readonly item: T;
+  resolve: (result: R) => void;
+  reject: (err: unknown) => void;
+  cancelled: boolean;
+}
+
+// ─── Per-lane state ─────────────────────────────────────────────────────────
+
+interface LaneState<T, R> {
+  readonly channel: InternalChannel<FerryRequest<T, R>>;
+  readonly maxBatchSize: number;
+  readonly maxBatchBytes: number | undefined;
+  readonly priority: PriorityLevel;
+  bytesQueued: number;
+  drainCount: number;
+  pending: FerryRequest<T, R> | undefined;
+}
+
+// ─── PriorityFerryThrottlerWithResult ───────────────────────────────────────
+
+/**
+ * Multi-lane priority ferry throttler — request/response arity.
+ *
+ * Producers call `process(item, priority?, signal?)` and receive a promise that
+ * resolves with the item's aligned result once the boat containing it is
+ * processed. Boats are batched per-lane with configurable max-batch-size and
+ * byte budget. Ferries drain lanes according to the configured draining policy
+ * (strict priority or weighted-fair).
+ */
+export class PriorityFerryThrottlerWithResult<T, R> {
+  private readonly _lanes: LaneState<T, R>[];
+  private readonly _priorityToLane: Map<PriorityLevel, number>;
+  private readonly _scheduler: DrainScheduler;
+  private readonly _notifier: LaneNotifier;
+  private readonly _abortController: AbortController;
+  private readonly _ferryTasks: Promise<void>[];
+  private readonly _sizeOf: ItemSizeBytes<T>;
+  private readonly _config: PriorityFerryThrottlerConfig;
+  private readonly _processBatch: ProcessBatchWithResult<T, R>;
+
+  constructor(
+    config: PriorityFerryThrottlerConfig,
+    processBatch: ProcessBatchWithResult<T, R>,
+    itemSizeBytes?: ItemSizeBytes<T>,
+  ) {
+    // 1. Validate config
+    validatePriorityConfig(config);
+
+    // 2. Check byte budget requires sizer
+    if (config.defaultMaxBatchBytes !== undefined && itemSizeBytes === undefined) {
+      throw new RangeError("itemSizeBytes is required when defaultMaxBatchBytes is set");
+    }
+    for (const lane of config.lanes) {
+      if (lane.maxBatchBytes !== undefined && itemSizeBytes === undefined) {
+        throw new RangeError("itemSizeBytes is required when any lane sets maxBatchBytes");
+      }
+    }
+
+    this._config = config;
+    this._processBatch = processBatch;
+    this._sizeOf = itemSizeBytes ?? (() => 0);
+
+    // 3. Create lanes sorted by priority ascending (index 0 = highest priority)
+    const sortedLanes = [...config.lanes].sort((a, b) => a.priority - b.priority);
+
+    this._lanes = sortedLanes.map((laneCfg) => ({
+      channel: createInternalChannel<FerryRequest<T, R>>(laneCfg.maxQueueSize),
+      maxBatchSize: laneCfg.maxBatchSize ?? config.defaultMaxBatchSize,
+      maxBatchBytes: laneCfg.maxBatchBytes ?? config.defaultMaxBatchBytes,
+      priority: laneCfg.priority,
+      bytesQueued: 0,
+      drainCount: 0,
+      pending: undefined,
+    }));
+
+    // Build priority → lane index map
+    this._priorityToLane = new Map<PriorityLevel, number>();
+    for (let i = 0; i < this._lanes.length; i++) {
+      const lane = this._lanes[i]!;
+      this._priorityToLane.set(lane.priority, i);
+    }
+
+    // 4. Create DrainScheduler
+    if (config.drainingPolicy.kind === "strict") {
+      this._scheduler = createStrictPriorityScheduler();
+    } else {
+      const weights = sortedLanes.map((l) => l.weight!);
+      this._scheduler = createWeightedFairScheduler(weights);
+    }
+
+    // 5. Create LaneNotifier
+    this._notifier = createLaneNotifier();
+
+    // 6. Create AbortController for ferry cancellation
+    this._abortController = new AbortController();
+
+    // 7. Start ferry loops
+    this._ferryTasks = Array.from(
+      { length: config.maxDegreeOfParallelism },
+      () => this._runFerry(),
+    );
+  }
+
+  // ─── Ferry loop ─────────────────────────────────────────────────────────
+
+  private _allChannelsClosed = false;
+
+  private async _runFerry(): Promise<void> {
+    const signal = this._abortController.signal;
+
+    try {
+      while (true) {
+        // Check if any lane has work right now (level-triggered check)
+        const laneIndex = this._selectReadyLane();
+
+        if (laneIndex !== -1) {
+          // Collect a boat from the selected lane
+          const { items, requests, bytes } = this._collectBoat(laneIndex);
+
+          if (items.length > 0) {
+            try {
+              const results = await this._processBatch(items, signal);
+              if (results.length !== items.length) {
+                const ex = new Error(
+                  `PriorityFerryThrottlerWithResult result count mismatch: processor returned ${String(results.length)} results for ${String(items.length)} items.`,
+                );
+                for (const r of requests) r.reject(ex);
+              } else {
+                for (let i = 0; i < results.length; i++) {
+                  requests[i]!.resolve(results[i]!);
+                }
+              }
+            } catch (e: unknown) {
+              if (isAbortError(e)) {
+                for (const r of requests) r.reject(new AbortError());
+              } else {
+                for (const r of requests) r.reject(e);
+              }
+            }
+
+            this._scheduler.recordDrain(laneIndex, items.length, bytes);
+            const lane = this._lanes[laneIndex]!;
+            lane.drainCount++;
+            lane.bytesQueued -= bytes;
+          }
+          continue; // Check for more work immediately
+        }
+
+        // No work available — check if all lanes are completed
+        if (this._allChannelsClosed && this._allLanesEmpty()) break;
+
+        // Wait until any lane has work or channels close
+        await this._notifier.wait(signal);
+      }
+    } catch (e: unknown) {
+      if (!isAbortError(e)) throw e;
+    }
+  }
+
+  private _selectReadyLane(): number {
+    const snapshots: LaneSnapshot[] = this._lanes.map((lane) => ({
+      hasWork: lane.pending !== undefined || lane.channel.queueDepth > 0,
+      queueDepth: lane.channel.queueDepth + (lane.pending !== undefined ? 1 : 0),
+      bytesQueued: lane.bytesQueued,
+      drainCount: lane.drainCount,
+    }));
+    return this._scheduler.selectLane(snapshots);
+  }
+
+  private _allLanesEmpty(): boolean {
+    for (const lane of this._lanes) {
+      if (lane.pending !== undefined || lane.channel.queueDepth > 0) return false;
+    }
+    return true;
+  }
+
+  // ─── collectBoat logic ──────────────────────────────────────────────────
+
+  private _collectBoat(laneIndex: number): {
+    items: readonly T[];
+    requests: readonly FerryRequest<T, R>[];
+    bytes: number;
+  } {
+    const lane = this._lanes[laneIndex]!;
+    const maxBatch = lane.maxBatchSize;
+    const byteBudget = lane.maxBatchBytes;
+    const items: T[] = [];
+    const requests: FerryRequest<T, R>[] = [];
+    let bytes = 0;
+
+    // Start with any pending request deferred from previous boat
+    if (lane.pending !== undefined) {
+      const req = lane.pending;
+      lane.pending = undefined;
+      if (!req.cancelled) {
+        const sz = this._trySizeRequest(req);
+        if (sz !== undefined) {
+          items.push(req.item);
+          requests.push(req);
+          bytes = sz;
+        }
+      }
+    }
+
+    // tryRead() from the lane's channel — skip cancelled requests
+    let draining = true;
+    while (draining && items.length < maxBatch) {
+      const req = this._tryTakeActive(lane);
+      if (req === undefined) {
+        draining = false;
+      } else {
+        const sz = this._trySizeRequest(req);
+        if (sz === undefined) continue; // sizer threw, request already rejected
+        if (byteBudget !== undefined && items.length > 0 && bytes + sz > byteBudget) {
+          // Defer this request to next boat
+          lane.pending = req;
+          draining = false;
+        } else {
+          items.push(req.item);
+          requests.push(req);
+          bytes += sz;
+        }
+      }
+    }
+
+    return { items, requests, bytes };
+  }
+
+  /** Read from lane channel, skipping cancelled requests. */
+  private _tryTakeActive(lane: LaneState<T, R>): FerryRequest<T, R> | undefined {
+    for (;;) {
+      const req = lane.channel.tryRead();
+      if (req === undefined) return undefined;
+      if (req.cancelled) continue; // skip cancelled
+      return req;
+    }
+  }
+
+  /** Try to compute item size; on failure reject the request and return undefined. */
+  private _trySizeRequest(req: FerryRequest<T, R>): number | undefined {
+    try {
+      return this._sizeOf(req.item);
+    } catch (e: unknown) {
+      req.reject(e);
+      return undefined;
+    }
+  }
+
+  // ─── Public API ─────────────────────────────────────────────────────────
+
+  /**
+   * Submit one item for batch processing with an explicit priority level.
+   * Returns a promise that resolves with the item's aligned result once the
+   * boat containing it is processed.
+   */
+  process(item: T, priority?: PriorityLevel, signal?: AbortSignal): Promise<R> {
+    const level = priority ?? this._config.defaultPriority;
+    const laneIndex = this._priorityToLane.get(level);
+    if (laneIndex === undefined) {
+      return Promise.reject(
+        new RangeError(`Priority level ${String(level)} is not a configured lane`),
+      );
+    }
+
+    if (signal?.aborted) {
+      return Promise.reject(signal.reason);
+    }
+
+    const lane = this._lanes[laneIndex]!;
+
+    return new Promise<R>((resolve, reject) => {
+      const req: FerryRequest<T, R> = { item, resolve, reject, cancelled: false };
+
+      if (signal) {
+        signal.addEventListener(
+          "abort",
+          () => {
+            req.cancelled = true;
+            reject(signal.reason);
+          },
+          { once: true },
+        );
+      }
+
+      lane.channel.write(req, signal).then(() => {
+        lane.bytesQueued += this._sizeOf(item);
+        this._notifier.notify();
+      }).catch((err: unknown) => {
+        req.cancelled = true;
+        reject(err);
+      });
+    });
+  }
+
+  /**
+   * Signal completion, await all ferries draining all lanes.
+   */
+  async complete(): Promise<void> {
+    for (const lane of this._lanes) {
+      lane.channel.complete();
+    }
+    this._allChannelsClosed = true;
+    // Wake all sleeping ferries
+    for (let i = 0; i < this._config.maxDegreeOfParallelism; i++) {
+      this._notifier.notify();
+    }
+    await Promise.all(this._ferryTasks);
+  }
+
+  /**
+   * Abort all ferries, reject all queued requests.
+   */
+  dispose(): void {
+    this._abortController.abort();
+    for (const lane of this._lanes) {
+      lane.channel.complete();
+      // Drain remaining requests and reject them
+      for (;;) {
+        const req = lane.channel.tryRead();
+        if (req === undefined) break;
+        req.reject(new AbortError());
+      }
+      if (lane.pending !== undefined) {
+        lane.pending.reject(new AbortError());
+        lane.pending = undefined;
+      }
+    }
+    this._allChannelsClosed = true;
+  }
+}
+
+// ─── Utilities ──────────────────────────────────────────────────────────────
+
+class AbortError extends Error {
+  override readonly name = "AbortError";
+  constructor() {
+    super("The operation was aborted");
+  }
+}
+
+function isAbortError(e: unknown): boolean {
+  if (e instanceof DOMException && e.name === "AbortError") return true;
+  if (e instanceof AbortError) return true;
+  if (e instanceof Error && e.name === "AbortError") return true;
+  return false;
+}

--- a/src/Core.TypeScript/ferry-throttler/priority-ferry-throttler.integration.test.ts
+++ b/src/Core.TypeScript/ferry-throttler/priority-ferry-throttler.integration.test.ts
@@ -1,0 +1,179 @@
+/**
+ * priority-ferry-throttler.integration.test.ts — integration smoke tests.
+ *
+ * 1. Observe loop simulation (strict): HIGH items before LOW items.
+ * 2. Weighted-fair gives proportional drain.
+ * 3. Regression: existing FerryThrottler tests still pass (meta-check).
+ */
+
+import { describe, expect, it } from "bun:test";
+import { PriorityFerryThrottler } from "./priority-ferry-throttler.ts";
+import type { PriorityFerryThrottlerConfig } from "./priority-config.ts";
+import type { ProcessBatch } from "./ferry-throttler.ts";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+interface Signal {
+  readonly tag: "HIGH" | "LOW";
+  readonly id: number;
+}
+
+// ─── Test 1: Observe loop simulation (strict) ───────────────────────────────
+
+describe("Integration: Observe loop simulation (strict)", () => {
+  it("all HIGH items processed before any LOW item", async () => {
+    const config: PriorityFerryThrottlerConfig = {
+      maxDegreeOfParallelism: 1,
+      defaultMaxBatchSize: 256,
+      defaultMaxBatchBytes: undefined,
+      lanes: [
+        { priority: 0 },  // HIGH = critical signals
+        { priority: 1 },  // LOW = background refresh
+      ],
+      defaultPriority: 1,
+      drainingPolicy: { kind: "strict" },
+    };
+
+    const processed: Signal[] = [];
+    const processBatch: ProcessBatch<Signal> = async (boat) => {
+      for (const item of boat) processed.push(item);
+    };
+
+    const throttler = new PriorityFerryThrottler(config, processBatch);
+
+    // Enqueue 10 LOW items first
+    for (let i = 0; i < 10; i++) {
+      throttler.tryEnqueue({ tag: "LOW", id: i }, 1);
+    }
+
+    // Then enqueue 5 HIGH items
+    for (let i = 0; i < 5; i++) {
+      throttler.tryEnqueue({ tag: "HIGH", id: i }, 0);
+    }
+
+    await throttler.complete();
+
+    // All 15 items processed
+    expect(processed.length).toBe(15);
+
+    // All HIGH items should appear before any LOW item
+    const highIndices = processed
+      .map((item, idx) => ({ item, idx }))
+      .filter(({ item }) => item.tag === "HIGH")
+      .map(({ idx }) => idx);
+    const lowIndices = processed
+      .map((item, idx) => ({ item, idx }))
+      .filter(({ item }) => item.tag === "LOW")
+      .map(({ idx }) => idx);
+
+    expect(highIndices.length).toBe(5);
+    expect(lowIndices.length).toBe(10);
+
+    const maxHighIndex = Math.max(...highIndices);
+    const minLowIndex = Math.min(...lowIndices);
+    expect(maxHighIndex).toBeLessThan(minLowIndex);
+  });
+});
+
+// ─── Test 2: Weighted-fair gives proportional drain ─────────────────────────
+
+describe("Integration: Weighted-fair gives proportional drain", () => {
+  it("drain proportions are within ±15% of expected weights [6, 3, 1]", async () => {
+    const weights = [6, 3, 1];
+    const totalWeight = weights.reduce((a, b) => a + b, 0); // 10
+    const expectedProportions = weights.map((w) => w / totalWeight); // [0.6, 0.3, 0.1]
+
+    const config: PriorityFerryThrottlerConfig = {
+      maxDegreeOfParallelism: 1,
+      defaultMaxBatchSize: 1, // batch size 1 to get fine-grained scheduling
+      defaultMaxBatchBytes: undefined,
+      lanes: [
+        { priority: 0, weight: 6 },
+        { priority: 1, weight: 3 },
+        { priority: 2, weight: 1 },
+      ],
+      defaultPriority: 0,
+      drainingPolicy: {
+        kind: "weighted-fair",
+        weights: new Map([
+          [0, 6],
+          [1, 3],
+          [2, 1],
+        ]),
+      },
+    };
+
+    // Track processing order by lane
+    const drainOrder: number[] = [];
+    const processBatch: ProcessBatch<{ lane: number; id: number }> = async (boat) => {
+      for (const item of boat) drainOrder.push(item.lane);
+    };
+
+    const throttler = new PriorityFerryThrottler(config, processBatch);
+
+    // Enqueue 100 items to each lane
+    for (let i = 0; i < 100; i++) {
+      throttler.tryEnqueue({ lane: 0, id: i }, 0);
+      throttler.tryEnqueue({ lane: 1, id: i }, 1);
+      throttler.tryEnqueue({ lane: 2, id: i }, 2);
+    }
+
+    await throttler.complete();
+
+    // All 300 items should be processed
+    expect(drainOrder.length).toBe(300);
+
+    // Measure actual proportions
+    const counts = [0, 0, 0];
+    for (const lane of drainOrder) {
+      counts[lane]!++;
+    }
+
+    // Each lane should have processed all 100 items
+    expect(counts[0]).toBe(100);
+    expect(counts[1]).toBe(100);
+    expect(counts[2]).toBe(100);
+
+    // Check proportional drain ordering in the first 100 drain events
+    // (while all lanes have work, the scheduler should approximate the weights)
+    const firstNDrains = drainOrder.slice(0, 100);
+    const firstCounts = [0, 0, 0];
+    for (const lane of firstNDrains) {
+      firstCounts[lane]!++;
+    }
+
+    const actualProportions = firstCounts.map((c) => c / 100);
+
+    for (let i = 0; i < 3; i++) {
+      const expected = expectedProportions[i]!;
+      const actual = actualProportions[i]!;
+      const diff = Math.abs(actual - expected);
+      // Within ±15%
+      expect(diff).toBeLessThanOrEqual(0.15);
+    }
+  });
+});
+
+// ─── Test 3: Regression — existing FerryThrottler tests still pass ──────────
+
+describe("Integration: Regression check", () => {
+  it("existing FerryThrottler tests pass (meta-check via import)", async () => {
+    // This is a structural meta-check: importing the existing FerryThrottler
+    // and verifying its basic operation still works after priority layer addition.
+    const { FerryThrottler, DETERMINISTIC_CONFIG } = await import("./ferry-throttler.ts");
+
+    const processed: number[] = [];
+    const processBatch: ProcessBatch<number> = async (boat) => {
+      for (const item of boat) processed.push(item);
+    };
+
+    const throttler = new FerryThrottler(DETERMINISTIC_CONFIG, processBatch);
+
+    for (let i = 1; i <= 20; i++) {
+      await throttler.enqueue(i);
+    }
+    await throttler.complete();
+
+    expect(processed).toEqual(Array.from({ length: 20 }, (_, i) => i + 1));
+  });
+});

--- a/src/Core.TypeScript/ferry-throttler/priority-ferry-throttler.property.test.ts
+++ b/src/Core.TypeScript/ferry-throttler/priority-ferry-throttler.property.test.ts
@@ -1,0 +1,394 @@
+/**
+ * priority-ferry-throttler.property.test.ts — property-based tests (fast-check)
+ * for PriorityFerryThrottler.
+ *
+ * Properties verified:
+ * 1. Strict priority drain ordering
+ * 3. DST-replayable determinism
+ * 7. Per-lane backpressure isolation
+ * 8. No-drop under backpressure
+ * 11. Config serialization round-trip
+ * 12. Invalid priority rejection
+ */
+
+import { describe, expect, it } from "bun:test";
+import fc from "fast-check";
+import { PriorityFerryThrottler } from "./priority-ferry-throttler.ts";
+import type { PriorityFerryThrottlerConfig, LaneConfig, DrainingPolicy } from "./priority-config.ts";
+import { serializeConfig, deserializeConfig } from "./priority-config.ts";
+import type { ProcessBatch } from "./ferry-throttler.ts";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+interface TaggedItem {
+  readonly id: number;
+  readonly priority: number;
+}
+
+// ─── Property 1: Strict priority drain ordering ─────────────────────────────
+
+describe("Property 1: Strict priority drain ordering", () => {
+  it("no item from a lower-priority lane processes while a higher-priority lane has pending items", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.integer({ min: 5, max: 50 }),
+        fc.integer({ min: 2, max: 3 }),
+        fc.infiniteStream(fc.nat({ max: 99 })),
+        async (numItems, numLanes, priorityStream) => {
+          // Generate distinct priorities for lanes (sorted ascending = higher priority first)
+          const priorities: number[] = [];
+          const seen = new Set<number>();
+          const iter = priorityStream[Symbol.iterator]();
+          while (priorities.length < numLanes) {
+            const { value } = iter.next();
+            if (value !== undefined && !seen.has(value as number)) {
+              seen.add(value as number);
+              priorities.push(value as number);
+            }
+          }
+          priorities.sort((a, b) => a - b);
+
+          const config: PriorityFerryThrottlerConfig = {
+            maxDegreeOfParallelism: 1,
+            defaultMaxBatchSize: 256,
+            defaultMaxBatchBytes: undefined,
+            lanes: priorities.map((p) => ({ priority: p })),
+            defaultPriority: priorities[0]!,
+            drainingPolicy: { kind: "strict" },
+          };
+
+          const processed: TaggedItem[] = [];
+          const processBatch: ProcessBatch<TaggedItem> = async (boat) => {
+            for (const item of boat) processed.push(item);
+          };
+
+          const throttler = new PriorityFerryThrottler(config, processBatch);
+
+          // Generate items with random lane assignments
+          const items: TaggedItem[] = [];
+          for (let i = 0; i < numItems; i++) {
+            const laneIdx = i % numLanes;
+            const priority = priorities[laneIdx]!;
+            items.push({ id: i, priority });
+          }
+
+          // Enqueue all items via tryEnqueue
+          for (const item of items) {
+            throttler.tryEnqueue(item, item.priority);
+          }
+
+          await throttler.complete();
+
+          // Verify strict ordering: for each processed item, all items with
+          // higher priority (lower number) that were enqueued should have been
+          // processed before it.
+          const processedOrder = new Map<number, number>();
+          for (let i = 0; i < processed.length; i++) {
+            processedOrder.set(processed[i]!.id, i);
+          }
+
+          for (let i = 0; i < processed.length; i++) {
+            const current = processed[i]!;
+            // Check that no higher-priority item appears after this one
+            for (let j = i + 1; j < processed.length; j++) {
+              const later = processed[j]!;
+              // If later has a strictly higher priority (lower number), that's a violation
+              if (later.priority < current.priority) {
+                // This would mean a higher-priority item was processed after a lower-priority one
+                expect(later.priority).toBeGreaterThanOrEqual(current.priority);
+              }
+            }
+          }
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+});
+
+// ─── Property 3: DST-replayable determinism ─────────────────────────────────
+
+describe("Property 3: DST-replayable determinism", () => {
+  it("same enqueue sequence produces identical drain order across two runs", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.array(fc.record({ id: fc.nat({ max: 10000 }), lane: fc.nat({ max: 1 }) }), {
+          minLength: 1,
+          maxLength: 40,
+        }),
+        async (sequence) => {
+          const config: PriorityFerryThrottlerConfig = {
+            maxDegreeOfParallelism: 1,
+            defaultMaxBatchSize: 256,
+            defaultMaxBatchBytes: undefined,
+            lanes: [{ priority: 0 }, { priority: 1 }],
+            defaultPriority: 1,
+            drainingPolicy: { kind: "strict" },
+          };
+
+          async function run(): Promise<number[]> {
+            const order: number[] = [];
+            const processBatch: ProcessBatch<{ id: number; lane: number }> = async (boat) => {
+              for (const item of boat) order.push(item.id);
+            };
+            const throttler = new PriorityFerryThrottler(config, processBatch);
+            for (const item of sequence) {
+              throttler.tryEnqueue(item, item.lane);
+            }
+            await throttler.complete();
+            return order;
+          }
+
+          const run1 = await run();
+          const run2 = await run();
+
+          expect(run1).toEqual(run2);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+});
+
+// ─── Property 7: Per-lane backpressure isolation ────────────────────────────
+
+describe("Property 7: Per-lane backpressure isolation", () => {
+  it("filling one lane does not prevent enqueue to a different lane", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.integer({ min: 1, max: 10 }),
+        async (fillCount) => {
+          const maxQueueSize = 2;
+
+          const config: PriorityFerryThrottlerConfig = {
+            maxDegreeOfParallelism: 1,
+            defaultMaxBatchSize: 256,
+            defaultMaxBatchBytes: undefined,
+            lanes: [
+              { priority: 0 },  // lane 0: unbounded
+              { priority: 1, maxQueueSize },  // lane 1: bounded
+            ],
+            defaultPriority: 1,
+            drainingPolicy: { kind: "strict" },
+          };
+
+          // Block processing so items stay in queue
+          let unblock: (() => void) | undefined;
+          const gate = new Promise<void>((r) => { unblock = r; });
+          const processBatch: ProcessBatch<number> = async () => {
+            await gate;
+          };
+
+          const throttler = new PriorityFerryThrottler(config, processBatch);
+
+          // Fill lane 1 to its capacity
+          for (let i = 0; i < maxQueueSize; i++) {
+            const accepted = throttler.tryEnqueue(i, 1);
+            expect(accepted).toBe(true);
+          }
+
+          // Lane 1 should now reject
+          const overflowResult = throttler.tryEnqueue(999, 1);
+          expect(overflowResult).toBe(false);
+
+          // Lane 0 should still accept (isolation)
+          const isolatedResult = throttler.tryEnqueue(fillCount, 0);
+          expect(isolatedResult).toBe(true);
+
+          unblock?.();
+          await throttler.complete();
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+});
+
+// ─── Property 8: No-drop under backpressure ─────────────────────────────────
+
+describe("Property 8: No-drop under backpressure", () => {
+  it("all enqueued items are processed even with small bounded queues", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.array(fc.record({ id: fc.nat({ max: 50000 }), lane: fc.nat({ max: 1 }) }), {
+          minLength: 1,
+          maxLength: 30,
+        }),
+        async (items) => {
+          const config: PriorityFerryThrottlerConfig = {
+            maxDegreeOfParallelism: 1,
+            defaultMaxBatchSize: 256,
+            defaultMaxBatchBytes: undefined,
+            lanes: [
+              { priority: 0, maxQueueSize: 3 },
+              { priority: 1, maxQueueSize: 3 },
+            ],
+            defaultPriority: 1,
+            drainingPolicy: { kind: "strict" },
+          };
+
+          const processed: Array<{ id: number; lane: number }> = [];
+          const processBatch: ProcessBatch<{ id: number; lane: number }> = async (boat) => {
+            for (const item of boat) processed.push(item);
+          };
+
+          const throttler = new PriorityFerryThrottler(config, processBatch);
+
+          // Use await enqueue — backpressure will make some wait
+          for (const item of items) {
+            await throttler.enqueue(item, item.lane);
+          }
+
+          await throttler.complete();
+
+          // All items must be processed (no drops)
+          expect(processed.length).toBe(items.length);
+          // Verify set equality
+          const processedIds = new Set(processed.map((p) => p.id));
+          const inputIds = new Set(items.map((i) => i.id));
+          expect(processedIds).toEqual(inputIds);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+});
+
+// ─── Property 11: Config serialization round-trip ───────────────────────────
+
+describe("Property 11: Config serialization round-trip", () => {
+  it("serialize then deserialize yields structurally equal config", async () => {
+    // Arbitrary for a valid PriorityFerryThrottlerConfig
+    const arbLaneConfig = (priority: number, needsWeight: boolean): fc.Arbitrary<LaneConfig> =>
+      fc.record({
+        priority: fc.constant(priority),
+        maxBatchSize: fc.option(fc.integer({ min: 1, max: 1000 }), { nil: undefined }),
+        maxBatchBytes: fc.option(fc.integer({ min: 1, max: 100000 }), { nil: undefined }),
+        maxQueueSize: fc.option(fc.integer({ min: 1, max: 1000 }), { nil: undefined }),
+        weight: needsWeight
+          ? fc.integer({ min: 1, max: 100 }).map((w) => w as number | undefined)
+          : fc.option(fc.integer({ min: 1, max: 100 }), { nil: undefined }),
+      });
+
+    const arbConfig: fc.Arbitrary<PriorityFerryThrottlerConfig> = fc
+      .integer({ min: 1, max: 4 })
+      .chain((numLanes) =>
+        fc.boolean().chain((isWeighted) => {
+          // Generate distinct priorities
+          return fc
+            .uniqueArray(fc.nat({ max: 99 }), { minLength: numLanes, maxLength: numLanes })
+            .chain((priorities) => {
+              const sortedPriorities = [...priorities].sort((a, b) => a - b);
+              const lanes = fc.tuple(
+                ...sortedPriorities.map((p) => arbLaneConfig(p, isWeighted)),
+              );
+              return lanes.chain((laneConfigs) => {
+                const defaultPriorityArb = fc.constantFrom(...sortedPriorities);
+                const policyArb: fc.Arbitrary<DrainingPolicy> = isWeighted
+                  ? fc.constant<DrainingPolicy>({
+                      kind: "weighted-fair",
+                      weights: new Map(
+                        laneConfigs.map((l) => [l.priority, l.weight ?? 1]),
+                      ),
+                    })
+                  : fc.constant<DrainingPolicy>({ kind: "strict" });
+
+                return fc.record({
+                  maxDegreeOfParallelism: fc.integer({ min: 1, max: 8 }),
+                  defaultMaxBatchSize: fc.integer({ min: 1, max: 1000 }),
+                  defaultMaxBatchBytes: fc.option(fc.integer({ min: 1, max: 100000 }), {
+                    nil: undefined,
+                  }),
+                  lanes: fc.constant(laneConfigs as readonly LaneConfig[]),
+                  defaultPriority: defaultPriorityArb,
+                  drainingPolicy: policyArb,
+                });
+              });
+            });
+        }),
+      );
+
+    await fc.assert(
+      fc.asyncProperty(arbConfig, async (config) => {
+        const json = serializeConfig(config);
+        const restored = deserializeConfig(json);
+
+        // Structural equality checks
+        expect(restored.maxDegreeOfParallelism).toBe(config.maxDegreeOfParallelism);
+        expect(restored.defaultMaxBatchSize).toBe(config.defaultMaxBatchSize);
+        expect(restored.defaultMaxBatchBytes).toBe(config.defaultMaxBatchBytes);
+        expect(restored.defaultPriority).toBe(config.defaultPriority);
+        expect(restored.lanes.length).toBe(config.lanes.length);
+
+        for (let i = 0; i < config.lanes.length; i++) {
+          const orig = config.lanes[i]!;
+          const rest = restored.lanes[i]!;
+          expect(rest.priority).toBe(orig.priority);
+          expect(rest.maxBatchSize).toBe(orig.maxBatchSize);
+          expect(rest.maxBatchBytes).toBe(orig.maxBatchBytes);
+          expect(rest.maxQueueSize).toBe(orig.maxQueueSize);
+          expect(rest.weight).toBe(orig.weight);
+        }
+
+        expect(restored.drainingPolicy.kind).toBe(config.drainingPolicy.kind);
+        if (
+          config.drainingPolicy.kind === "weighted-fair" &&
+          restored.drainingPolicy.kind === "weighted-fair"
+        ) {
+          for (const [key, value] of config.drainingPolicy.weights) {
+            expect(restored.drainingPolicy.weights.get(key)).toBe(value);
+          }
+          expect(restored.drainingPolicy.weights.size).toBe(
+            config.drainingPolicy.weights.size,
+          );
+        }
+      }),
+      { numRuns: 100 },
+    );
+  });
+});
+
+// ─── Property 12: Invalid priority rejection ────────────────────────────────
+
+describe("Property 12: Invalid priority rejection", () => {
+  it("enqueue/tryEnqueue with unconfigured priority throws RangeError", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.uniqueArray(fc.nat({ max: 50 }), { minLength: 1, maxLength: 4 }),
+        fc.nat({ max: 99 }),
+        async (configuredPriorities, rawBadPriority) => {
+          // Ensure badPriority is NOT in the configured set
+          const configSet = new Set(configuredPriorities);
+          let badPriority = rawBadPriority;
+          while (configSet.has(badPriority)) {
+            badPriority = (badPriority + 1) % 100;
+          }
+          // If we wrapped around and still in set, skip (extremely unlikely with max 4 lanes)
+          if (configSet.has(badPriority)) return;
+
+          const sorted = [...configuredPriorities].sort((a, b) => a - b);
+          const config: PriorityFerryThrottlerConfig = {
+            maxDegreeOfParallelism: 1,
+            defaultMaxBatchSize: 256,
+            defaultMaxBatchBytes: undefined,
+            lanes: sorted.map((p) => ({ priority: p })),
+            defaultPriority: sorted[0]!,
+            drainingPolicy: { kind: "strict" },
+          };
+
+          const processBatch: ProcessBatch<number> = async () => {};
+          const throttler = new PriorityFerryThrottler(config, processBatch);
+
+          // tryEnqueue should throw RangeError
+          expect(() => throttler.tryEnqueue(42, badPriority)).toThrow(RangeError);
+
+          // enqueue should reject with RangeError
+          await expect(throttler.enqueue(42, badPriority)).rejects.toBeInstanceOf(RangeError);
+
+          throttler.dispose();
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+});

--- a/src/Core.TypeScript/ferry-throttler/priority-ferry-throttler.test.ts
+++ b/src/Core.TypeScript/ferry-throttler/priority-ferry-throttler.test.ts
@@ -1,0 +1,300 @@
+/**
+ * priority-ferry-throttler.test.ts — tests for PriorityFerryThrottler (fire-and-forget arity).
+ *
+ * Covers strict priority ordering, default priority, invalid priority rejection,
+ * DoP=N set-equal, per-lane backpressure, single-lane equivalence, byte budget
+ * per lane, complete drains all lanes, and dispose aborts.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { PriorityFerryThrottler } from "./priority-ferry-throttler.ts";
+import { DETERMINISTIC_CONFIG, FerryThrottler } from "./ferry-throttler.ts";
+import type { ProcessBatch } from "./ferry-throttler.ts";
+import type { PriorityFerryThrottlerConfig } from "./priority-config.ts";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function range(start: number, end: number): number[] {
+  const result: number[] = [];
+  for (let i = start; i <= end; i++) result.push(i);
+  return result;
+}
+
+/** A strict two-lane config: priority 0 (high) and priority 1 (low). DoP=1. */
+const STRICT_TWO_LANE: PriorityFerryThrottlerConfig = {
+  maxDegreeOfParallelism: 1,
+  defaultMaxBatchSize: 256,
+  defaultMaxBatchBytes: undefined,
+  lanes: [
+    { priority: 0 },
+    { priority: 1 },
+  ],
+  defaultPriority: 1,
+  drainingPolicy: { kind: "strict" },
+};
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("PriorityFerryThrottler", () => {
+  it("strict priority ordering (DoP=1): high-priority items all process before low-priority", async () => {
+    const processed: Array<{ priority: number; value: number }> = [];
+    const processBatch: ProcessBatch<{ priority: number; value: number }> = async (boat) => {
+      for (const item of boat) processed.push(item);
+    };
+
+    const throttler = new PriorityFerryThrottler(STRICT_TWO_LANE, processBatch);
+
+    // Enqueue low-priority items first
+    for (const v of range(1, 5)) {
+      throttler.tryEnqueue({ priority: 1, value: v }, 1);
+    }
+    // Then enqueue high-priority items
+    for (const v of range(10, 14)) {
+      throttler.tryEnqueue({ priority: 0, value: v }, 0);
+    }
+
+    await throttler.complete();
+
+    // All high-priority items should appear before any low-priority item
+    const highIndices = processed
+      .map((item, idx) => ({ item, idx }))
+      .filter(({ item }) => item.priority === 0)
+      .map(({ idx }) => idx);
+    const lowIndices = processed
+      .map((item, idx) => ({ item, idx }))
+      .filter(({ item }) => item.priority === 1)
+      .map(({ idx }) => idx);
+
+    const maxHighIndex = Math.max(...highIndices);
+    const minLowIndex = Math.min(...lowIndices);
+    expect(maxHighIndex).toBeLessThan(minLowIndex);
+  });
+
+  it("default priority: enqueue without specifying priority goes to default lane", async () => {
+    const processed: number[] = [];
+    const processBatch: ProcessBatch<number> = async (boat) => {
+      for (const item of boat) processed.push(item);
+    };
+
+    const config: PriorityFerryThrottlerConfig = {
+      ...STRICT_TWO_LANE,
+      defaultPriority: 0,
+    };
+
+    const throttler = new PriorityFerryThrottler(config, processBatch);
+
+    // Enqueue without priority — should go to defaultPriority (0 = high)
+    await throttler.enqueue(42);
+    await throttler.complete();
+
+    expect(processed).toEqual([42]);
+  });
+
+  it("invalid priority rejection: enqueue with non-configured priority throws RangeError", async () => {
+    const processBatch: ProcessBatch<number> = async () => {};
+    const throttler = new PriorityFerryThrottler(STRICT_TWO_LANE, processBatch);
+
+    await expect(throttler.enqueue(1, 99)).rejects.toBeInstanceOf(RangeError);
+    expect(() => throttler.tryEnqueue(1, 99)).toThrow(RangeError);
+
+    throttler.dispose();
+  });
+
+  it("DoP=N set-equal: 4 ferries, items across lanes, all items processed", async () => {
+    const processed: number[] = [];
+    const processBatch: ProcessBatch<number> = async (boat) => {
+      for (const item of boat) processed.push(item);
+    };
+
+    const config: PriorityFerryThrottlerConfig = {
+      maxDegreeOfParallelism: 4,
+      defaultMaxBatchSize: 16,
+      defaultMaxBatchBytes: undefined,
+      lanes: [
+        { priority: 0 },
+        { priority: 1 },
+        { priority: 2 },
+      ],
+      defaultPriority: 1,
+      drainingPolicy: { kind: "strict" },
+    };
+
+    const throttler = new PriorityFerryThrottler(config, processBatch);
+
+    const items = range(1, 100);
+    for (const x of items) {
+      const priority = x % 3; // distribute across lanes
+      await throttler.enqueue(x, priority);
+    }
+    await throttler.complete();
+
+    expect(processed.length).toBe(100);
+    expect(new Set(processed)).toEqual(new Set(items));
+  });
+
+  it("per-lane backpressure: bounded low-priority lane full, high-priority lane still accepts", async () => {
+    let resolveGate: (() => void) | undefined;
+    const gate = new Promise<void>((r) => { resolveGate = r; });
+    let processCalled = false;
+
+    const processBatch: ProcessBatch<number> = async (boat, _signal) => {
+      processCalled = true;
+      await gate;
+      void boat;
+    };
+
+    const config: PriorityFerryThrottlerConfig = {
+      maxDegreeOfParallelism: 1,
+      defaultMaxBatchSize: 256,
+      defaultMaxBatchBytes: undefined,
+      lanes: [
+        { priority: 0 },  // high, unbounded
+        { priority: 1, maxQueueSize: 2 },  // low, bounded to 2
+      ],
+      defaultPriority: 1,
+      drainingPolicy: { kind: "strict" },
+    };
+
+    const throttler = new PriorityFerryThrottler(config, processBatch);
+
+    // Fill the low-priority lane
+    const accepted1 = throttler.tryEnqueue(1, 1);
+    const accepted2 = throttler.tryEnqueue(2, 1);
+    const accepted3 = throttler.tryEnqueue(3, 1); // should fail — lane is full
+
+    expect(accepted1).toBe(true);
+    expect(accepted2).toBe(true);
+    expect(accepted3).toBe(false);
+
+    // High-priority lane should still accept
+    const acceptedHigh = throttler.tryEnqueue(100, 0);
+    expect(acceptedHigh).toBe(true);
+
+    resolveGate?.();
+    await throttler.complete();
+    expect(processCalled).toBe(true);
+  });
+
+  it("single-lane equivalence: single-lane PriorityFerryThrottler behaves like plain FerryThrottler", async () => {
+    const priorityProcessed: number[] = [];
+    const plainProcessed: number[] = [];
+
+    const priorityProcess: ProcessBatch<number> = async (boat) => {
+      for (const item of boat) priorityProcessed.push(item);
+    };
+    const plainProcess: ProcessBatch<number> = async (boat) => {
+      for (const item of boat) plainProcessed.push(item);
+    };
+
+    const singleLaneConfig: PriorityFerryThrottlerConfig = {
+      maxDegreeOfParallelism: 1,
+      defaultMaxBatchSize: 256,
+      defaultMaxBatchBytes: undefined,
+      lanes: [{ priority: 0 }],
+      defaultPriority: 0,
+      drainingPolicy: { kind: "strict" },
+    };
+
+    const priorityThrottler = new PriorityFerryThrottler(singleLaneConfig, priorityProcess);
+    const plainThrottler = new FerryThrottler(DETERMINISTIC_CONFIG, plainProcess);
+
+    const items = range(1, 50);
+    for (const x of items) {
+      await priorityThrottler.enqueue(x);
+      await plainThrottler.enqueue(x);
+    }
+
+    await priorityThrottler.complete();
+    await plainThrottler.complete();
+
+    expect(priorityProcessed).toEqual(plainProcessed);
+    expect(priorityProcessed).toEqual(items);
+  });
+
+  it("byte budget per lane: lane with maxBatchBytes creates appropriately-sized boats", async () => {
+    const boats: number[][] = [];
+    const processBatch: ProcessBatch<number> = async (boat) => {
+      boats.push([...boat]);
+    };
+
+    const config: PriorityFerryThrottlerConfig = {
+      maxDegreeOfParallelism: 1,
+      defaultMaxBatchSize: 100,
+      defaultMaxBatchBytes: undefined,
+      lanes: [
+        { priority: 0, maxBatchBytes: 25 },  // Each item is 10 bytes → max 2 per boat
+      ],
+      defaultPriority: 0,
+      drainingPolicy: { kind: "strict" },
+    };
+
+    const sizer = (_item: number): number => 10;
+    const throttler = new PriorityFerryThrottler(config, processBatch, sizer);
+
+    for (const x of range(1, 10)) {
+      throttler.tryEnqueue(x, 0);
+    }
+
+    await throttler.complete();
+
+    // Every boat should have at most 2 items (10 bytes each, budget 25)
+    for (const boat of boats) {
+      expect(boat.length).toBeGreaterThanOrEqual(1);
+      expect(boat.length).toBeLessThanOrEqual(2);
+    }
+    // All items processed
+    const allItems = boats.flat();
+    expect(new Set(allItems)).toEqual(new Set(range(1, 10)));
+  });
+
+  it("complete drains all lanes: items in both lanes, complete(), verify all processed", async () => {
+    const processed: number[] = [];
+    const processBatch: ProcessBatch<number> = async (boat) => {
+      for (const item of boat) processed.push(item);
+    };
+
+    const throttler = new PriorityFerryThrottler(STRICT_TWO_LANE, processBatch);
+
+    // Put items in both lanes
+    for (const x of range(1, 10)) {
+      await throttler.enqueue(x, 0);
+    }
+    for (const x of range(11, 20)) {
+      await throttler.enqueue(x, 1);
+    }
+
+    await throttler.complete();
+
+    expect(processed.length).toBe(20);
+    expect(new Set(processed)).toEqual(new Set(range(1, 20)));
+  });
+
+  it("dispose aborts: items in queue, dispose(), ferries stop", async () => {
+    let processCount = 0;
+    const neverResolve = new Promise<void>(() => {});
+
+    const processBatch: ProcessBatch<number> = async (_boat, signal) => {
+      processCount++;
+      await new Promise<void>((resolve, reject) => {
+        signal.addEventListener("abort", () => reject(signal.reason as unknown), { once: true });
+        void neverResolve.then(resolve);
+      });
+    };
+
+    const throttler = new PriorityFerryThrottler(STRICT_TWO_LANE, processBatch);
+
+    // Enqueue some items
+    for (const x of range(1, 10)) {
+      throttler.tryEnqueue(x, 0);
+    }
+
+    // Give ferry time to pick up work
+    await new Promise((r) => setTimeout(r, 10));
+
+    throttler.dispose();
+
+    // Ferry should have started but been aborted — processCount can be >= 1
+    // The key invariant is that dispose returns without hanging
+    expect(processCount).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/src/Core.TypeScript/ferry-throttler/priority-ferry-throttler.ts
+++ b/src/Core.TypeScript/ferry-throttler/priority-ferry-throttler.ts
@@ -1,0 +1,298 @@
+/**
+ * priority-ferry-throttler.ts — multi-lane priority ferry throttler (fire-and-forget arity).
+ *
+ * Composes N lane queues (one `InternalChannel<T>` per lane), a `LaneNotifier`
+ * for shared notification when any lane gets work, a `DrainScheduler` that picks
+ * which lane to drain, and M ferry loops (shared ferry pool).
+ *
+ * Each lane has its own backpressure (bounded queue), batch size, and byte budget.
+ * Ferries are self-clocked, anti-Nagle: they drain whatever is available NOW,
+ * never wait to fill a boat.
+ *
+ * At `maxDegreeOfParallelism = 1` with strict draining, this is deterministic and
+ * DST-replayable — the FoundationDB single-thread shape extended to priority lanes.
+ */
+
+import { createInternalChannel } from "./internal-channel.ts";
+import type { InternalChannel } from "./internal-channel.ts";
+import { createLaneNotifier } from "./lane-notifier.ts";
+import type { LaneNotifier } from "./lane-notifier.ts";
+import {
+  createStrictPriorityScheduler,
+  createWeightedFairScheduler,
+} from "./drain-scheduler.ts";
+import type { DrainScheduler, LaneSnapshot } from "./drain-scheduler.ts";
+import {
+  validatePriorityConfig,
+} from "./priority-config.ts";
+import type {
+  PriorityFerryThrottlerConfig,
+  PriorityLevel,
+} from "./priority-config.ts";
+import type { ProcessBatch, ItemSizeBytes } from "./ferry-throttler.ts";
+
+// ─── Per-lane state ─────────────────────────────────────────────────────────
+
+interface LaneState<T> {
+  readonly channel: InternalChannel<T>;
+  readonly maxBatchSize: number;
+  readonly maxBatchBytes: number | undefined;
+  readonly priority: PriorityLevel;
+  bytesQueued: number;
+  drainCount: number;
+  pending: T | undefined;
+  hasPending: boolean;
+}
+
+// ─── PriorityFerryThrottler ─────────────────────────────────────────────────
+
+/**
+ * Multi-lane priority ferry throttler — fire-and-forget arity.
+ *
+ * Items are enqueued with an explicit priority level (defaults to
+ * `config.defaultPriority`). Each priority level maps to a lane with its own
+ * bounded queue, batch size, and byte budget. Ferries drain lanes according to
+ * the configured draining policy (strict priority or weighted-fair).
+ */
+export class PriorityFerryThrottler<T> {
+  private readonly _lanes: LaneState<T>[];
+  private readonly _priorityToLane: Map<PriorityLevel, number>;
+  private readonly _scheduler: DrainScheduler;
+  private readonly _notifier: LaneNotifier;
+  private readonly _abortController: AbortController;
+  private readonly _ferryTasks: Promise<void>[];
+  private readonly _sizeOf: ItemSizeBytes<T>;
+  private readonly _config: PriorityFerryThrottlerConfig;
+  private readonly _processBatch: ProcessBatch<T>;
+
+  constructor(
+    config: PriorityFerryThrottlerConfig,
+    processBatch: ProcessBatch<T>,
+    itemSizeBytes?: ItemSizeBytes<T>,
+  ) {
+    // 1. Validate config
+    validatePriorityConfig(config);
+
+    // 2. Check byte budget requires sizer
+    if (config.defaultMaxBatchBytes !== undefined && itemSizeBytes === undefined) {
+      throw new RangeError("itemSizeBytes is required when defaultMaxBatchBytes is set");
+    }
+    for (const lane of config.lanes) {
+      if (lane.maxBatchBytes !== undefined && itemSizeBytes === undefined) {
+        throw new RangeError("itemSizeBytes is required when any lane sets maxBatchBytes");
+      }
+    }
+
+    this._config = config;
+    this._processBatch = processBatch;
+    this._sizeOf = itemSizeBytes ?? (() => 0);
+
+    // 3. Create lanes sorted by priority ascending (index 0 = highest priority)
+    const sortedLanes = [...config.lanes].sort((a, b) => a.priority - b.priority);
+
+    this._lanes = sortedLanes.map((laneCfg) => ({
+      channel: createInternalChannel<T>(laneCfg.maxQueueSize),
+      maxBatchSize: laneCfg.maxBatchSize ?? config.defaultMaxBatchSize,
+      maxBatchBytes: laneCfg.maxBatchBytes ?? config.defaultMaxBatchBytes,
+      priority: laneCfg.priority,
+      bytesQueued: 0,
+      drainCount: 0,
+      pending: undefined as T | undefined,
+      hasPending: false,
+    }));
+
+    // Build priority → lane index map
+    this._priorityToLane = new Map<PriorityLevel, number>();
+    for (let i = 0; i < this._lanes.length; i++) {
+      const lane = this._lanes[i]!;
+      this._priorityToLane.set(lane.priority, i);
+    }
+
+    // 4. Create DrainScheduler
+    if (config.drainingPolicy.kind === "strict") {
+      this._scheduler = createStrictPriorityScheduler();
+    } else {
+      const weights = sortedLanes.map((l) => l.weight!);
+      this._scheduler = createWeightedFairScheduler(weights);
+    }
+
+    // 5. Create LaneNotifier
+    this._notifier = createLaneNotifier();
+
+    // 6. Create AbortController for ferry cancellation
+    this._abortController = new AbortController();
+
+    // 7. Start ferry loops
+    this._ferryTasks = Array.from(
+      { length: config.maxDegreeOfParallelism },
+      () => this._runFerry(),
+    );
+  }
+
+  // ─── Ferry loop ─────────────────────────────────────────────────────────
+
+  private _allChannelsClosed = false;
+
+  private async _runFerry(): Promise<void> {
+    const signal = this._abortController.signal;
+
+    try {
+      while (true) {
+        // Check if any lane has work right now (level-triggered check)
+        const laneIndex = this._selectReadyLane();
+
+        if (laneIndex !== -1) {
+          // Collect a boat from the selected lane
+          const { boat, bytes } = this._collectBoat(laneIndex);
+
+          if (boat.length > 0) {
+            await this._processBatch(boat, signal);
+            this._scheduler.recordDrain(laneIndex, boat.length, bytes);
+            const lane = this._lanes[laneIndex]!;
+            lane.drainCount++;
+            lane.bytesQueued -= bytes;
+          }
+          continue; // Check for more work immediately
+        }
+
+        // No work available — check if all lanes are completed
+        if (this._allChannelsClosed && this._allLanesEmpty()) break;
+
+        // Wait until any lane has work or channels close
+        await this._notifier.wait(signal);
+      }
+    } catch (e: unknown) {
+      if (!isAbortError(e)) throw e;
+    }
+  }
+
+  private _selectReadyLane(): number {
+    const snapshots: LaneSnapshot[] = this._lanes.map((lane) => ({
+      hasWork: lane.hasPending || lane.channel.queueDepth > 0,
+      queueDepth: lane.channel.queueDepth + (lane.hasPending ? 1 : 0),
+      bytesQueued: lane.bytesQueued,
+      drainCount: lane.drainCount,
+    }));
+    return this._scheduler.selectLane(snapshots);
+  }
+
+  private _allLanesEmpty(): boolean {
+    for (const lane of this._lanes) {
+      if (lane.hasPending || lane.channel.queueDepth > 0) return false;
+    }
+    return true;
+  }
+
+  // ─── collectBoat logic ──────────────────────────────────────────────────
+
+  private _collectBoat(laneIndex: number): { boat: readonly T[]; bytes: number } {
+    const lane = this._lanes[laneIndex]!;
+    const maxBatch = lane.maxBatchSize;
+    const byteBudget = lane.maxBatchBytes;
+    const boat: T[] = [];
+    let bytes = 0;
+
+    // Start with any pending item deferred from previous boat
+    if (lane.hasPending) {
+      const item = lane.pending as T;
+      boat.push(item);
+      bytes = this._sizeOf(item);
+      lane.hasPending = false;
+      lane.pending = undefined;
+    }
+
+    // tryRead() from the lane's channel until constraints
+    let draining = true;
+    while (draining && boat.length < maxBatch) {
+      const item = lane.channel.tryRead();
+      if (item === undefined) {
+        draining = false;
+      } else {
+        const sz = this._sizeOf(item);
+        if (byteBudget !== undefined && boat.length > 0 && bytes + sz > byteBudget) {
+          // Defer this item to next boat
+          lane.pending = item;
+          lane.hasPending = true;
+          draining = false;
+        } else {
+          boat.push(item);
+          bytes += sz;
+        }
+      }
+    }
+
+    return { boat, bytes };
+  }
+
+  // ─── Public API ─────────────────────────────────────────────────────────
+
+  /**
+   * Enqueue with explicit priority (defaults to config.defaultPriority).
+   * Per-lane backpressure: the promise resolves when the item is accepted into
+   * the target lane's queue.
+   */
+  async enqueue(item: T, priority?: PriorityLevel, signal?: AbortSignal): Promise<void> {
+    const level = priority ?? this._config.defaultPriority;
+    const laneIndex = this._priorityToLane.get(level);
+    if (laneIndex === undefined) {
+      throw new RangeError(`Priority level ${String(level)} is not a configured lane`);
+    }
+    const lane = this._lanes[laneIndex]!;
+    await lane.channel.write(item, signal);
+    lane.bytesQueued += this._sizeOf(item);
+    this._notifier.notify();
+  }
+
+  /**
+   * Try-enqueue without waiting. Returns false if the target lane's queue is full.
+   */
+  tryEnqueue(item: T, priority?: PriorityLevel): boolean {
+    const level = priority ?? this._config.defaultPriority;
+    const laneIndex = this._priorityToLane.get(level);
+    if (laneIndex === undefined) {
+      throw new RangeError(`Priority level ${String(level)} is not a configured lane`);
+    }
+    const lane = this._lanes[laneIndex]!;
+    const accepted = lane.channel.tryWrite(item);
+    if (accepted) {
+      lane.bytesQueued += this._sizeOf(item);
+      this._notifier.notify();
+    }
+    return accepted;
+  }
+
+  /**
+   * Signal completion, await all ferries draining all lanes.
+   */
+  async complete(): Promise<void> {
+    for (const lane of this._lanes) {
+      lane.channel.complete();
+    }
+    this._allChannelsClosed = true;
+    // Wake all sleeping ferries (each notify wakes one waiter)
+    for (let i = 0; i < this._config.maxDegreeOfParallelism; i++) {
+      this._notifier.notify();
+    }
+    await Promise.all(this._ferryTasks);
+  }
+
+  /**
+   * Abort all ferries, complete all channels.
+   */
+  dispose(): void {
+    for (const lane of this._lanes) {
+      lane.channel.complete();
+    }
+    this._allChannelsClosed = true;
+    this._abortController.abort();
+    // Fire-and-forget — ferries will catch the abort.
+  }
+}
+
+// ─── Utilities ──────────────────────────────────────────────────────────────
+
+function isAbortError(e: unknown): boolean {
+  if (e instanceof DOMException && e.name === "AbortError") return true;
+  if (e instanceof Error && e.name === "AbortError") return true;
+  return false;
+}


### PR DESCRIPTION
## Summary

Multi-lane priority ferry throttler composing N lane queues with a shared ferry pool and configurable drain scheduling. Implements step 1 of Rodney's razor from the FerryThrottler handoff.

## Architecture (Approach B)

- N `InternalChannel` instances (one per lane, extracted as shared module)
- `LaneNotifier` (promise/resolver pair for cross-lane wake)
- `DrainScheduler`: StrictPriority (stateless scan) or WeightedFair (DRR)
- M ferries drain lanes per the scheduler's `selectLane(LaneSnapshot[])`

## Both arities

- `PriorityFerryThrottler<T>` (fire-and-forget)
- `PriorityFerryThrottlerWithResult<T, R>` (request/response)

## Priority-specific features

- Per-lane backpressure (independent queue bounds)
- Strict priority: higher-priority lanes always drain first
- Weighted-fair DRR: proportional drain with no-starvation guarantee
- DST-replayable at DoP=1 (deterministic drain ordering)
- Config serialization round-trip (JSON)
- `LaneSnapshot` interface widened for soft-layer readiness

## What was tested

90 tests (unit + 6 property-based via fast-check + 3 integration), all passing.

## Also included

- Research handoff for math team on soft priority throttler (`docs/research/2026-06-12-soft-priority-ferry-throttler-math-handoff.md`)

Co-Authored-By: Kiro <noreply@kiro.dev>