### PR TITLE
fix(zflash): serial-getty race — don't fail harness on idle shell during first-boot

### DIFF
--- a/src/Core.TypeScript/zflash/test-harness/qemu-state.ts
+++ b/src/Core.TypeScript/zflash/test-harness/qemu-state.ts
@@ -5,6 +5,7 @@ import {
   INSTALLED_OS_RETENTION_SERIAL_MARKERS,
   RETENTION_ABSENT_TERMINAL_MARKERS,
   RETENTION_FAILURE_SERIAL_MARKERS,
+  serialFirstBootInProgress,
 } from "./serial-markers";
 
 /**
@@ -622,7 +623,13 @@ function runManagedCommandUntilSerialMarkers(
     }
 
     const terminalFailureMarker = firstMatchedMarker(phaseSerialOutput, stopCondition.terminalFailureMarkers ?? []);
-    if (terminalFailureMarker !== undefined) {
+    if (
+      terminalFailureMarker !== undefined &&
+      !(
+        terminalFailureMarker === "nixos@zeta-installer:~" &&
+        serialFirstBootInProgress(phaseSerialOutput)
+      )
+    ) {
       stopManagedProcess(managed, "SIGTERM", pollIntervalMs);
       return {
         step,

--- a/src/Core.TypeScript/zflash/test-harness/serial-markers.test.ts
+++ b/src/Core.TypeScript/zflash/test-harness/serial-markers.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { serialFirstBootInProgress } from "./serial-markers";
+
+describe("serialFirstBootInProgress", () => {
+  test("idle serial-getty shell alone is not first-boot progress", () => {
+    expect(serialFirstBootInProgress("nixos@zeta-installer:~$")).toBe(false);
+  });
+
+  test("mirrored first-boot banner suppresses getty-race false positive", () => {
+    const serial = "nixos@zeta-installer:~$\n  Zeta cluster installer\nRole selected: control-plane";
+    expect(serialFirstBootInProgress(serial)).toBe(true);
+  });
+});

--- a/src/Core.TypeScript/zflash/test-harness/serial-markers.ts
+++ b/src/Core.TypeScript/zflash/test-harness/serial-markers.ts
@@ -31,3 +31,16 @@ export const RETENTION_FAILURE_SERIAL_MARKERS: readonly string[] = [
 ];
 
 export const RETENTION_ABSENT_TERMINAL_MARKERS: readonly string[] = ["nixos@zeta-installer:~"];
+
+/** Emitted on tty1 and mirrored to ttyS0 while zeta-first-boot.service runs. */
+export const FIRST_BOOT_PROGRESS_SERIAL_MARKERS: readonly string[] = [
+  "Zeta cluster installer",
+  "Role selected:",
+  "[3/3] Running zeta-install",
+  "[zeta-first-boot]",
+];
+
+/** serial-getty autologin on ttyS0 can appear before mirrored first-boot output. */
+export function serialFirstBootInProgress(serialOutput: string): boolean {
+  return FIRST_BOOT_PROGRESS_SERIAL_MARKERS.some((marker) => serialOutput.includes(marker));
+}

--- a/tools/ci/qemu-full-install-test.ts
+++ b/tools/ci/qemu-full-install-test.ts
@@ -63,6 +63,7 @@ import { execFileSync, spawn } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { serialFirstBootInProgress } from "../../src/Core.TypeScript/zflash/test-harness/serial-markers";
 
 // Success marker: the `[iter-5.1]` prefix appears at the wifi-persistence
 // step in zeta-install.sh (Step 6.7; line 527). This is the correct
@@ -235,7 +236,8 @@ async function waitForInstallProgress(serialLogPath: string): Promise<InstallRes
           content.includes(IDLE_INSTALLER_SHELL_MARKER) &&
           !content.includes(SUCCESS_MARKER) &&
           !content.includes("[zeta-first-boot]") &&
-          !content.includes("[iter-")
+          !content.includes("[iter-") &&
+          !serialFirstBootInProgress(content)
         ) {
           const tail = content.slice(-2000);
           return {


### PR DESCRIPTION
## Summary

Proof dispatch after #7870 showed first-boot **is** mirrored to ttyS0 (`Zeta cluster installer`, `Role selected:` in serial), but harness still failed at 2 min because `serial-getty@ttyS0` autologin prints `nixos@zeta-installer:~` **before** install markers.

- Add `serialFirstBootInProgress()` marker guard in harness + `qemu-full-install-test` fail-fast
- Retention/path-fork terminal marker ignored when first-boot output is already on serial

Work item: `081KSNY2Z0008QG0R0008PN7RQ`

## Test plan

- [x] `bun test src/Core.TypeScript/zflash/test-harness/`
- [ ] Merge + `workflow_dispatch` — scenarios 2–4 must reach `[iter-5.1]` in serial (install ~5–10 min on KVM)


Made with [Cursor](https://cursor.com)