### PR TITLE
fix(installer): skip nmtui when no wifi hardware — QEMU install path

### DIFF
--- a/full-ai-cluster/usb-nixos-installer/zeta-first-boot.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-first-boot.sh
@@ -53,6 +53,8 @@ ROLE_PROMPT_SECS="${ROLE_PROMPT_SECS:-10}"
 # the ROLE_PROMPT_SECS env-override pattern so the timeout is tunable
 # without source edits.
 NMTUI_RETRY_PROMPT_SECS="${NMTUI_RETRY_PROMPT_SECS:-10}"
+# B-0891: QEMU/ethernet-only hosts have no wl* iface — nmtui cannot help on serial.
+NO_WIFI_EXTRA_WAIT_SECS="${NO_WIFI_EXTRA_WAIT_SECS:-90}"
 
 # ── Role pick: 10-sec single-keystroke prompt ─────────────────────────
 # Defaults to whatever the ISO's /etc/zeta-firstboot.conf shipped with
@@ -94,9 +96,21 @@ drop_to_shell() {
 }
 
 has_internet() {
-  # Use 2-second timeout per ping; rely on DNS to also be working since
-  # nixos-install needs it later anyway.
+  # IP first (QEMU NAT often has DNS lag); github.com proves DNS for nixos-install.
+  ping -c 1 -W 2 -q 1.1.1.1 >/dev/null 2>&1 && return 0
   ping -c 1 -W 2 -q github.com >/dev/null 2>&1
+}
+
+has_wifi_hardware() {
+  local _iface _name
+  for _iface in /sys/class/net/*; do
+    _name=$(basename "$_iface")
+    [[ "$_name" == lo ]] && continue
+    if [[ -d "$_iface/wireless" ]] || [[ "$_name" == wl* ]]; then
+      return 0
+    fi
+  done
+  return 1
 }
 
 # ANSI 'reset terminal' escape — no external `clear` dependency,
@@ -128,6 +142,24 @@ done
 if has_internet; then
   echo "  ethernet ok (DHCP)"
 else
+  if ! has_wifi_hardware; then
+    echo
+    echo "[2/3] No wifi hardware — waiting up to ${NO_WIFI_EXTRA_WAIT_SECS}s for ethernet (B-0891 headless/QEMU)."
+    WAITED=0
+    while ! has_internet; do
+      if [[ "$WAITED" -ge "$NO_WIFI_EXTRA_WAIT_SECS" ]]; then
+        break
+      fi
+      sleep 5
+      WAITED=$((WAITED + 5))
+      echo "  ... ${WAITED}s"
+    done
+    if has_internet; then
+      echo "  ethernet ok (after extra wait)"
+    else
+      echo "[zeta-first-boot] Still offline; proceeding to zeta-install (will fail loudly if unreachable)."
+    fi
+  else
   echo
   echo "[2/3] No ethernet internet detected. Launching wifi setup (nmtui)."
   echo "      After connecting, quit nmtui to continue install."
@@ -191,6 +223,7 @@ else
         ;;
     esac
   done
+  fi
 fi
 
 echo

--- a/tools/ci/audit-installer-substrate.ts
+++ b/tools/ci/audit-installer-substrate.ts
@@ -129,6 +129,8 @@ const REQUIRED_SENTINELS: readonly SentinelAssertion[] = [
       "zeta-install", // calls into zeta-install.sh after network up
       "/dev/ttyS0", // B-0891 serial mirror target (x86 QEMU / CI)
       "tee -a", // preserves tty1 + mirrors to serial UART
+      "has_wifi_hardware", // B-0891 skip nmtui on ethernet-only/QEMU
+      "1.1.1.1", // IP-first internet probe (DNS lag on NAT)
     ],
     rationale: "first-boot script must include eth-wait + nmtui + zeta-install call",
   },


### PR DESCRIPTION
## Summary

Serial logs from the post-#7874 proof dispatch show first-boot reaches ttyS0 but **stalls in nmtui** for 30min — QEMU has virtio-net only, no `wl*`.

- `has_internet`: probe `1.1.1.1` before DNS
- `has_wifi_hardware`: skip nmtui on ethernet-only; extra 90s DHCP wait then proceed to `zeta-install`

`081KSNY2Z0008QG0R0008PN7RQ`

## Test plan

- [x] `bun tools/ci/audit-installer-substrate.ts`
- [ ] Merge + `workflow_dispatch` — serial must show `[3/3] Running zeta-install` and `[iter-5.1]`


Made with [Cursor](https://cursor.com)