### PR TITLE
feat(chip9): THE FAULT-PARITY TREATY — fault.register goes four-language-live

### DIFF
--- a/db/emus/chip8/capabilities.lines
+++ b/db/emus/chip8/capabilities.lines
@@ -12,7 +12,10 @@ support	isa.chip9	fsharp	live	treaty-locking oracle
 support	isa.chip9	csharp	live	golden conformer
 support	isa.chip9	typescript	live	golden conformer
 support	isa.chip9	rust	live	golden conformer
-support	fault.register	fsharp	live	Frame.Fault (chip9 dialect; conformers: wish — fault parity is a treaty change)
+support	fault.register	fsharp	live	Frame.Fault — the locking oracle (chip9 dialect)
+support	fault.register	csharp	live	fault-parity treaty 2026-06-12 (Chip9Machine.Fault/CallStack)
+support	fault.register	typescript	live	fault-parity treaty 2026-06-12 (Frame.fault/stack)
+support	fault.register	rust	live	fault-parity treaty 2026-06-12 (Chip9.fault/stack)
 support	rng.seeded	fsharp	live	all four conformers share the golden's determinism
 support	meter.ticks	fsharp	live	Ben slice 1
 support	trace.self	fsharp	live	the reflection channels (G/cyan/B; mono stays the program's)

--- a/src/Core.CSharp/Chip9Machine.cs
+++ b/src/Core.CSharp/Chip9Machine.cs
@@ -41,6 +41,12 @@ public sealed class Chip9Machine
     /// <summary>The higher planes' per-pixel bitmask (bits 1-2; zero ⇒ absent).</summary>
     public IDictionary<int, byte> Extra { get; } = new Dictionary<int, byte>();
 
+    /// <summary>The call stack (FAULT TREATY 2026-06-12: classic 16-frame cap).</summary>
+    public IList<int> CallStack { get; } = new List<int>();
+
+    /// <summary>The fault register — recorded, never fatal; the first fault wins.</summary>
+    public string? Fault { get; private set; }
+
     /// <summary>Load a ROM at 0x200.</summary>
     public void LoadRom(IReadOnlyList<byte> rom)
     {
@@ -58,7 +64,7 @@ public sealed class Chip9Machine
         return (byte)(mono | (Extra.TryGetValue(idx, out var hi) ? hi : (byte)0));
     }
 
-    /// <summary>Execute one instruction (treaty subset: 00E0, 6XNN, ANNN, DXYN, Fn01).</summary>
+    /// <summary>Execute one instruction (treaty subset: 00E0, 00EE, 2NNN, 6XNN, ANNN, DXYN, Fn01).</summary>
     public void Step()
     {
         var op = ((Mem.TryGetValue(Pc, out var hiB) ? hiB : 0) << 8)
@@ -73,6 +79,32 @@ public sealed class Chip9Machine
         {
             case 0x0000 when op == 0x00E0:
                 ClearSelected();
+                break;
+            case 0x0000 when op == 0x00EE:
+                // FAULT TREATY: RET — pop, or record underflow (never fatal; first fault wins)
+                if (CallStack.Count > 0)
+                {
+                    Pc = CallStack[^1];
+                    CallStack.RemoveAt(CallStack.Count - 1);
+                }
+                else
+                {
+                    Fault ??= "stack underflow: 00EE (RET) on empty stack";
+                }
+
+                break;
+            case 0x2000:
+                // FAULT TREATY: CALL — at depth 16 the CALL is REFUSED (fall through)
+                if (CallStack.Count >= 16)
+                {
+                    Fault ??= "stack overflow: CALL (2NNN) at depth 16 refused";
+                }
+                else
+                {
+                    CallStack.Add(Pc);
+                    Pc = nnn;
+                }
+
                 break;
             case 0x6000:
                 V[x] = nn;

--- a/src/Core.Rust.Chip9/src/lib.rs
+++ b/src/Core.Rust.Chip9/src/lib.rs
@@ -18,6 +18,10 @@ pub struct Chip9 {
     pub plane: u8,
     pub display: HashSet<usize>,
     pub extra: HashMap<usize, u8>,
+    /// The call stack (FAULT TREATY 2026-06-12: classic 16-frame cap).
+    pub stack: Vec<usize>,
+    /// The fault register — recorded, never fatal; the first fault wins.
+    pub fault: Option<String>,
 }
 
 impl Default for Chip9 {
@@ -37,6 +41,8 @@ impl Chip9 {
             plane: 1,
             display: HashSet::new(),
             extra: HashMap::new(),
+            stack: Vec::new(),
+            fault: None,
         }
     }
 
@@ -54,7 +60,7 @@ impl Chip9 {
         mono | self.extra.get(&idx).copied().unwrap_or(0)
     }
 
-    /// Execute one instruction (treaty subset: 00E0, 6XNN, ANNN, DXYN, Fn01).
+    /// Execute one instruction (treaty subset: 00E0, 00EE, 2NNN, 6XNN, ANNN, DXYN, Fn01).
     pub fn step(&mut self) {
         let op = ((self.mem.get(&self.pc).copied().unwrap_or(0) as usize) << 8)
             | self.mem.get(&(self.pc + 1)).copied().unwrap_or(0) as usize;
@@ -65,6 +71,30 @@ impl Chip9 {
         self.pc += 2;
 
         match op & 0xf000 {
+            0x0000 if op == 0x00ee => {
+                // FAULT TREATY: RET — pop, or record underflow (never fatal; first fault wins)
+                match self.stack.pop() {
+                    Some(top) => self.pc = top,
+                    None => {
+                        if self.fault.is_none() {
+                            self.fault =
+                                Some("stack underflow: 00EE (RET) on empty stack".to_string());
+                        }
+                    }
+                }
+            }
+            0x2000 => {
+                // FAULT TREATY: CALL — at depth 16 the CALL is REFUSED (fall through)
+                if self.stack.len() >= 16 {
+                    if self.fault.is_none() {
+                        self.fault =
+                            Some("stack overflow: CALL (2NNN) at depth 16 refused".to_string());
+                    }
+                } else {
+                    self.stack.push(self.pc);
+                    self.pc = nnn;
+                }
+            }
             0x0000 if op == 0x00e0 => self.clear_selected(),
             0x6000 => self.v[x] = nn,
             0xa000 => self.i = nnn,

--- a/src/Core.Rust.Chip9/tests/golden_vectors.rs
+++ b/src/Core.Rust.Chip9/tests/golden_vectors.rs
@@ -26,7 +26,7 @@ fn byte_lock_replaying_the_treaty_rom_reproduces_the_golden_color_grid_exactly()
         .map(|i| u8::from_str_radix(&rom_hex[i * 2..i * 2 + 2], 16).unwrap())
         .collect();
     let golden_plane: u8 = lines[1].split('\t').nth(1).unwrap().parse().unwrap();
-    let golden_rows = &lines[2..];
+    let golden_rows = &lines[2..2 + H]; // the fault-treaty keys follow the grid
     assert_eq!(golden_rows.len(), H);
 
     let mut m = Chip9::create();
@@ -40,5 +40,58 @@ fn byte_lock_replaying_the_treaty_rom_reproduces_the_golden_color_grid_exactly()
     for (y, golden_row) in golden_rows.iter().enumerate() {
         let row: String = (0..W).map(|x| format!("{:x}", m.color_at(x, y))).collect();
         assert_eq!(&row, golden_row, "row {y} diverged");
+    }
+}
+
+fn keyed<'a>(lines: &'a [&'a str], key: &str) -> &'a str {
+    lines
+        .iter()
+        .find(|l| l.starts_with(&format!("{key}\t")))
+        .unwrap_or_else(|| panic!("golden key missing: {key}"))
+        .split('\t')
+        .nth(1)
+        .unwrap()
+}
+
+#[test]
+fn fault_treaty_recorded_never_fatal_refused_call_falls_through_text_pc_depth_byte_locked() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    let path = root.join("src/Core.TypeScript/chip9/golden-vectors.lines");
+    let text = fs::read_to_string(&path).unwrap();
+    let lines: Vec<&str> = text
+        .lines()
+        .filter(|l| !l.starts_with('#') && !l.is_empty())
+        .collect();
+
+    for which in ["underflow", "overflow"] {
+        let rom_hex = keyed(&lines, &format!("fault-rom-{which}"));
+        let rom: Vec<u8> = (0..rom_hex.len() / 2)
+            .map(|i| u8::from_str_radix(&rom_hex[i * 2..i * 2 + 2], 16).unwrap())
+            .collect();
+        let steps: usize = keyed(&lines, &format!("fault-steps-{which}")).parse().unwrap();
+
+        let mut m = Chip9::create();
+        m.load_rom(&rom);
+        for _ in 0..steps {
+            m.step();
+        }
+
+        assert_eq!(
+            m.fault.as_deref(),
+            Some(keyed(&lines, &format!("fault-text-{which}"))),
+            "{which}: fault text"
+        );
+        assert_eq!(
+            format!("{:04x}", m.pc),
+            keyed(&lines, &format!("fault-pc-{which}")),
+            "{which}: pc"
+        );
+        let depth: usize = keyed(&lines, &format!("fault-depth-{which}")).parse().unwrap();
+        assert_eq!(m.stack.len(), depth, "{which}: depth");
     }
 }

--- a/src/Core.TypeScript/chip9/chip9.test.ts
+++ b/src/Core.TypeScript/chip9/chip9.test.ts
@@ -28,7 +28,7 @@ describe("CHIP-9 — the color-plane treaty (TS oracle)", () => {
 
     const rom = new Uint8Array((romHex.match(/.{2}/g) ?? []).map((h) => parseInt(h, 16)));
     const goldenPlane = parseInt(planeText, 10);
-    const goldenRows = lines.slice(2);
+    const goldenRows = lines.slice(2, 2 + H); // the fault-treaty keys follow the grid
     expect(goldenRows.length).toBe(H);
 
     let f = create();
@@ -46,4 +46,22 @@ describe("CHIP-9 — the color-plane treaty (TS oracle)", () => {
       expect(row).toBe(expected);
     }
   });
+
+  const keyed = (key: string): string => {
+    const line = lines.find((l) => l.startsWith(key + "\t"));
+    expect(line).toBeDefined();
+    return line?.split("\t")[1] ?? "";
+  };
+
+  for (const which of ["underflow", "overflow"] as const) {
+    it(`FAULT TREATY (${which}): recorded never fatal; refused CALL falls through; text/pc/depth byte-locked`, () => {
+      const rom = new Uint8Array((keyed(`fault-rom-${which}`).match(/.{2}/g) ?? []).map((h) => parseInt(h, 16)));
+      const steps = parseInt(keyed(`fault-steps-${which}`), 10);
+      let f = loadRom(rom, create());
+      for (let s = 0; s < steps; s++) f = step(f);
+      expect(f.fault).toBe(keyed(`fault-text-${which}`));
+      expect(f.pc.toString(16).padStart(4, "0")).toBe(keyed(`fault-pc-${which}`));
+      expect(f.stack.length).toBe(parseInt(keyed(`fault-depth-${which}`), 10));
+    });
+  }
 });

--- a/src/Core.TypeScript/chip9/chip9.ts
+++ b/src/Core.TypeScript/chip9/chip9.ts
@@ -3,7 +3,8 @@
  * Mirrors src/Core/Chip8Cow.fs (the F# oracle that LOCKED the treaty): Fn01 plane select (3 bits =
  * RGB), per-selected-plane XOR draw with VF collision, selective CLS. Zero case structural: plane 0
  * (mono) lives in `display`; higher planes in `extra` (zero ⇒ absent). Subset sufficient for the
- * treaty ROM: 00E0, 1NNN-equivalents not needed, ANNN, 6XNN, DXYN, Fn01.
+ * treaty ROM: 00E0, ANNN, 6XNN, DXYN, Fn01 — plus the FAULT TREATY (2026-06-12): 2NNN/00EE with
+ * the fault register (recorded never fatal; first fault wins; refused CALL falls through).
  * TREATY: replaying ./golden-vectors.lines' rom must reproduce its 32×64 hex color grid exactly.
  */
 
@@ -19,6 +20,8 @@ export interface Frame {
   plane: number;
   display: Map<number, boolean>;
   extra: Map<number, number>;
+  stack: number[];
+  fault: string | null;
 }
 
 export function create(): Frame {
@@ -30,6 +33,8 @@ export function create(): Frame {
     plane: 1,
     display: new Map(),
     extra: new Map(),
+    stack: [],
+    fault: null,
   };
 }
 
@@ -54,7 +59,12 @@ export function step(f: Frame): Frame {
 
   switch (op & 0xf000) {
     case 0x0000:
-      if (op === 0x00e0) {
+      if (op === 0x00ee) {
+        // FAULT TREATY: RET — pop, or record underflow (never fatal; first fault wins)
+        const top = f.stack.pop();
+        if (top !== undefined) f.pc = top;
+        else if (f.fault === null) f.fault = "stack underflow: 00EE (RET) on empty stack";
+      } else if (op === 0x00e0) {
         // selective CLS: clear only the SELECTED planes; canonical extra (zero ⇒ delete)
         if (f.plane & 1) f.display.clear();
         const keep = ~f.plane & 0b110;
@@ -65,6 +75,15 @@ export function step(f: Frame): Frame {
             else f.extra.set(k, m2);
           }
         }
+      }
+      break;
+    case 0x2000:
+      // FAULT TREATY: CALL — classic 16-frame cap; at depth 16 the CALL is REFUSED (fall through)
+      if (f.stack.length >= 16) {
+        if (f.fault === null) f.fault = "stack overflow: CALL (2NNN) at depth 16 refused";
+      } else {
+        f.stack.push(f.pc);
+        f.pc = nnn;
       }
       break;
     case 0x6000:

--- a/src/Core.TypeScript/chip9/golden-vectors.lines
+++ b/src/Core.TypeScript/chip9/golden-vectors.lines
@@ -43,3 +43,18 @@ plane	1
 0011111111000000000000000000000000000000000000000000000000001111
 0011111111000000000000000000000000000000000000000000000000001111
 0011111111000000000000000000000000000000000000000000000000001111
+
+# FAULT TREATY (2026-06-12, fault-parity): the fault REGISTER is part of the treaty — faults are
+# RECORDED, never fatal; the first fault wins; a refused CALL falls through (PC advances). Two
+# vectors: 00EE on an empty stack (underflow), and a 17-deep CALL chain (the 17th refused at the
+# classic 16-frame cap). All four oracles replay these and must match text/pc/depth exactly.
+fault-rom-underflow	00ee
+fault-steps-underflow	1
+fault-text-underflow	stack underflow: 00EE (RET) on empty stack
+fault-pc-underflow	0202
+fault-depth-underflow	0
+fault-rom-overflow	2202220422062208220a220c220e22102212221422162218221a221c221e22202222
+fault-steps-overflow	17
+fault-text-overflow	stack overflow: CALL (2NNN) at depth 16 refused
+fault-pc-overflow	0222
+fault-depth-overflow	16

--- a/tests/Tests.CSharp/Chip9CrossVerifyTests.cs
+++ b/tests/Tests.CSharp/Chip9CrossVerifyTests.cs
@@ -35,7 +35,7 @@ public sealed class Chip9CrossVerifyTests
             .Select(i => byte.Parse(romHex.AsSpan(i * 2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture))
             .ToArray();
         var goldenPlane = byte.Parse(lines[1].Split('\t')[1], CultureInfo.InvariantCulture);
-        var goldenRows = lines.Skip(2).ToList();
+        var goldenRows = lines.Skip(2).Take(Chip9Machine.Height).ToList(); // fault-treaty keys follow the grid
         Assert.Equal(Chip9Machine.Height, goldenRows.Count);
 
         var m = new Chip9Machine();
@@ -53,5 +53,32 @@ public sealed class Chip9CrossVerifyTests
                 .Select(x => m.ColorAt(x, y).ToString("x", CultureInfo.InvariantCulture)));
             Assert.Equal(goldenRows[y], row);
         }
+    }
+
+    [Theory]
+    [InlineData("underflow")]
+    [InlineData("overflow")]
+    public void FaultTreatyRecordedNeverFatalRefusedCallFallsThroughTextPcDepthByteLocked(string which)
+    {
+        var path = Path.Join(RepoRoot(), "src", "Core.TypeScript", "chip9", "golden-vectors.lines");
+        var lines = File.ReadAllLines(path).Where(l => !l.StartsWith('#') && l.Length > 0).ToList();
+        string Keyed(string key) => lines.First(l => l.StartsWith(key + "\t", StringComparison.Ordinal)).Split('\t')[1];
+
+        var romHex = Keyed($"fault-rom-{which}");
+        var rom = Enumerable.Range(0, romHex.Length / 2)
+            .Select(i => byte.Parse(romHex.AsSpan(i * 2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture))
+            .ToArray();
+        var steps = int.Parse(Keyed($"fault-steps-{which}"), CultureInfo.InvariantCulture);
+
+        var m = new Chip9Machine();
+        m.LoadRom(rom);
+        for (var s = 0; s < steps; s++)
+        {
+            m.Step();
+        }
+
+        Assert.Equal(Keyed($"fault-text-{which}"), m.Fault);
+        Assert.Equal(Keyed($"fault-pc-{which}"), m.Pc.ToString("x4", CultureInfo.InvariantCulture));
+        Assert.Equal(int.Parse(Keyed($"fault-depth-{which}"), CultureInfo.InvariantCulture), m.CallStack.Count);
     }
 }

--- a/tests/Tests.FSharp/Chip9Treaty.Tests.fs
+++ b/tests/Tests.FSharp/Chip9Treaty.Tests.fs
@@ -71,7 +71,26 @@ let ``BYTE-LOCK: the CHIP-9 treaty ROM's final color grid matches the golden vec
     if not (File.Exists goldenPath) then
         File.WriteAllLines("/tmp/chip9-golden-actual.lines", actual)
         failwith "golden file missing — actual dumped to /tmp/chip9-golden-actual.lines"
-    Assert.Equal<string list>(goldenLines (), actual)
+    // the fault-treaty keys follow the grid: the grid lock is the first 2 + 32 lines
+    Assert.Equal<string list>(goldenLines () |> List.truncate (2 + Chip8.DisplayH), actual)
+
+let private keyed (key: string) =
+    goldenLines ()
+    |> List.pick (fun l -> if l.StartsWith(key + "\t") then Some(l.Split('\t').[1]) else None)
+
+[<Theory>]
+[<InlineData("underflow")>]
+[<InlineData("overflow")>]
+let ``FAULT TREATY: the ORACLE locks text + pc + depth — recorded never fatal, refused CALL falls through`` (which: string) =
+    let romHex = keyed (sprintf "fault-rom-%s" which)
+    let rom = [| for i in 0 .. romHex.Length / 2 - 1 -> System.Convert.ToByte(romHex.Substring(i * 2, 2), 16) |]
+    let steps = int (keyed (sprintf "fault-steps-%s" which))
+    let final =
+        [ 1..steps ]
+        |> List.fold (fun f _ -> Chip8Cow.step f) (Chip8Cow.create 7UL |> Chip8Cow.loadRom rom)
+    Assert.Equal(Some(keyed (sprintf "fault-text-%s" which)), final.Fault)
+    Assert.Equal(keyed (sprintf "fault-pc-%s" which), sprintf "%04x" final.PC)
+    Assert.Equal(int (keyed (sprintf "fault-depth-%s" which)), List.length final.Stack)
 
 [<Fact>]
 let ``the treaty ROM's semantics sanity-check (independent of the golden bytes)`` () =


### PR DESCRIPTION
The cap ledger's named treaty wish: the golden file gains a FAULT TREATY section (underflow + 17-deep CALL-chain overflow) locking fault text/pc/depth byte-for-byte; C#/TS/Rust conformers gain CALL/RET + the fault register with the oracle's exact semantics (recorded never fatal, first fault wins, refused CALL falls through); all four checkers updated; F# oracle locks the section. fault.register becomes the second four-language-live capability after isa.chip9. F#/C#/TS/Rust all green, clippy 0, existing grid bytes untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)