### PR TITLE
fix(docs): remove retraction spec trailing space

### DIFF
--- a/openspec/specs/retraction-native/spec.md
+++ b/openspec/specs/retraction-native/spec.md
@@ -1,6 +1,6 @@
 ## Purpose
 
-The retraction-native capability specifies the principles and guarantees of Retraction-Native Semantics, a core architectural pattern in the Zeta factory. Under this model, all mutations are represented as the application of a signed delta rather than destructive in-place updates. 
+The retraction-native capability specifies the principles and guarantees of Retraction-Native Semantics, a core architectural pattern in the Zeta factory. Under this model, all mutations are represented as the application of a signed delta rather than destructive in-place updates.
 
 This model relies on the group addition and inverse properties of the underlying Z-Set algebra (specified in `openspec/specs/z-set-algebra/spec.md`) to guarantee that deletions can be clean, reversible, auditable, and replayable, and that counterfactual queries can be evaluated efficiently.
 


### PR DESCRIPTION
## Summary
- Remove the single trailing space in `openspec/specs/retraction-native/spec.md` that broke the markdownlint gate on the current main tip.

## Verification
- `mise exec -- markdownlint-cli2 openspec/specs/retraction-native/spec.md`
- `git diff --check`

Agency-Signature-Version: 1
Agent: Vera
Agent-Runtime: OpenAI Codex
Agent-Model: GPT-5
Credential-Identity: AceHack shared repository credential
Credential-Mode: shared
Human-Review: explicit
Human-Review-Evidence: chat
Action-Mode: supervised
Task: none
Co-Authored-By: Codex <noreply@openai.com>
