### PR TITLE
fix(tsc): drop unused mkdirSync import — unbreak the tsc gate

### DIFF
--- a/tools/substrate-claim-checker/check-semantic-equivalence.test.ts
+++ b/tools/substrate-claim-checker/check-semantic-equivalence.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { checkFile } from "./check-semantic-equivalence.ts";


### PR DESCRIPTION
Main's tsc lint went red on TS6133 (unused import) from the B-0170.1 merge; one-line removal, tsc clean, test file still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)