### PR TITLE
feat(core): CapabilityLedger resolver — know what to inject before asking; refusals re-plan; lint sweeps both ledgers in CI

### DIFF
--- a/db/capabilities/README.md
+++ b/db/capabilities/README.md
@@ -7,6 +7,8 @@ The data half of `universal/port`: capabilities named by ZetaId (the registry mi
 support rows per (system, language) carrying the LADDER status — live / injected / mock /
 absent — so a resolver (or a human) reads what a host can bind before asking. Format =
 MediaLines (our own dogfood): `cap` rows declare, `support` rows place. Per-emu ledgers live at
-`db/emus/<machine>/capabilities.lines` (the chip8 one is first). Follow-ups: a lint (support
-rows must reference declared caps; cap ZetaIds must resolve on the shelf) and resolver wiring —
-this ledger becomes the hostLive/granted input the ladders read.
+`db/emus/<machine>/capabilities.lines` (the chip8 one is first). The promised lint + resolver landed 2026-06-12: `Zeta.Core.CapabilityLedger` (parse / `resolve`
+with re-planning refusals / `systemsAtLeast` / `lint`) — pure over MediaLines, no IO in the
+module; CI sweeps BOTH real ledgers through the lint via tests/Tests.FSharp/CapabilityLedger
+.Tests.fs (dangling support rows, alien statuses, and dark caps all fail the gate). Next: feed
+`systemsAtLeast` into the inference/host ladders as the hostLive/granted input.

--- a/src/Core/CapabilityLedger.fs
+++ b/src/Core/CapabilityLedger.fs
@@ -1,0 +1,111 @@
+namespace Zeta.Core
+
+/// CapabilityLedger — **the resolver over the capability ledgers** (Aaron 2026-06-11: "keep a
+/// list of capabilities generically — which ones are supported on which systems and languages —
+/// so we know what to INJECT"; ratified 2026-06-12: "sounds good to me" on resolver wiring).
+///
+/// The ledgers (`db/capabilities/capabilities.lines`, `db/emus/<machine>/capabilities.lines`)
+/// are MediaLines docs: `cap <name> <desc>` declares, `support <cap> <system> <status> <note>`
+/// places. THIS module is pure over parsed text — the caller reads files (sealed-room friendly:
+/// no IO here); `resolve` answers what a host can bind BEFORE asking, and refusals are USEFUL
+/// (an unknown cap or system names what IS known, so the caller re-plans instead of guessing).
+/// `lint` is the ledger's own honesty sweep: support rows must reference declared caps, statuses
+/// come from the closed ladder set, and a declared cap with zero support rows is dark data.
+[<RequireQualifiedAccess>]
+module CapabilityLedger =
+
+    /// The ladder (universal/port's Light, as data): how a (cap, system) pair is held.
+    type Status =
+        | Live // implemented here, first-class
+        | Injected // bound from outside by design (e.g. tests-side engines)
+        | Mock // the honest rehearsal rung
+        | Absent // declared missing — a wish, visibly
+
+    let parseStatus (s: string) : Status option =
+        match s with
+        | "live" -> Some Live
+        | "injected" -> Some Injected
+        | "mock" -> Some Mock
+        | "absent" -> Some Absent
+        | _ -> None
+
+    type Support =
+        { Cap: string
+          System: string
+          Status: Status
+          Note: string }
+
+    type Ledger =
+        { Caps: Map<string, string> // name -> description
+          Support: Support list }
+
+    /// Parse a ledger from MediaLines entries (caller parses the text; we read the kinds).
+    let ofDoc (d: MediaLines.Doc) : Ledger =
+        let caps =
+            MediaLines.ofKind "cap" d
+            |> List.map (fun e -> e.Name, (e.Fields |> List.tryHead |> Option.defaultValue ""))
+            |> Map.ofList
+        let support =
+            MediaLines.ofKind "support" d
+            |> List.choose (fun e ->
+                match e.Fields with
+                | system :: status :: rest ->
+                    parseStatus status
+                    |> Option.map (fun st ->
+                        { Cap = e.Name
+                          System = system
+                          Status = st
+                          Note = rest |> List.tryHead |> Option.defaultValue "" })
+                | _ -> None)
+        { Caps = caps; Support = support }
+
+    /// What can THIS system bind for THIS capability? Absent is an OK answer (declared missing);
+    /// an unknown cap or unplaced system is an Error that names the known options (re-plan fuel).
+    let resolve (cap: string) (system: string) (ledger: Ledger) : Result<Support, string> =
+        if not (Map.containsKey cap ledger.Caps) then
+            let known = ledger.Caps |> Map.toList |> List.map fst |> String.concat ", "
+            Error(sprintf "unknown capability '%s' — the ledger declares: %s" cap known)
+        else
+            match ledger.Support |> List.tryFind (fun s -> s.Cap = cap && s.System = system) with
+            | Some s -> Ok s
+            | None ->
+                let placed =
+                    ledger.Support
+                    |> List.filter (fun s -> s.Cap = cap)
+                    |> List.map (fun s -> sprintf "%s=%s" s.System (string s.Status))
+                    |> String.concat ", "
+                Error(sprintf "capability '%s' has no support row for system '%s' — placed: %s" cap system placed)
+
+    /// Every system that holds the capability at a given rung or better (Live > Injected > Mock > Absent).
+    let private rank =
+        function
+        | Live -> 3
+        | Injected -> 2
+        | Mock -> 1
+        | Absent -> 0
+
+    let systemsAtLeast (cap: string) (floor: Status) (ledger: Ledger) : string list =
+        ledger.Support
+        |> List.filter (fun s -> s.Cap = cap && rank s.Status >= rank floor)
+        |> List.map (fun s -> s.System)
+
+    /// The ledger's own honesty sweep (the README's promised lint, as pure findings).
+    let lint (d: MediaLines.Doc) : string list =
+        let ledger = ofDoc d
+        let declaredCaps = ledger.Caps |> Map.toList |> List.map fst |> Set.ofList
+        let supportRaw = MediaLines.ofKind "support" d
+        [ // a support row referencing an undeclared cap is a dangling pointer
+          for e in supportRaw do
+              if not (Set.contains e.Name declaredCaps) then
+                  yield sprintf "support row references undeclared cap '%s'" e.Name
+          // a status outside the closed ladder set is a typo wearing a vest
+          for e in supportRaw do
+              match e.Fields with
+              | _ :: status :: _ when parseStatus status |> Option.isNone ->
+                  yield sprintf "support row for '%s' carries unknown status '%s' (live|injected|mock|absent)" e.Name status
+              | f when List.length f < 2 -> yield sprintf "support row for '%s' needs system and status" e.Name
+              | _ -> ()
+          // a declared cap with no support row is dark data — declare its absence honestly
+          for KeyValue(cap, _) in ledger.Caps do
+              if not (supportRaw |> List.exists (fun e -> e.Name = cap)) then
+                  yield sprintf "cap '%s' has zero support rows — place it (absent is a valid placement)" cap ]

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -236,6 +236,7 @@
     <Compile Include="Braid.fs" />
     <Compile Include="MediaLines.fs" />
     <Compile Include="CartridgeLaw.fs" />
+    <Compile Include="CapabilityLedger.fs" />
     <Compile Include="BoundaryLight.fs" />
     <Compile Include="GeneratorRegistry.fs" />
     <Compile Include="ZetaIdViz.fs" />

--- a/tests/Tests.FSharp/CapabilityLedger.Tests.fs
+++ b/tests/Tests.FSharp/CapabilityLedger.Tests.fs
@@ -1,0 +1,70 @@
+module Zeta.Tests.CapabilityLedgerTests
+
+// The capability resolver over the REAL ledgers (db/capabilities + db/emus/chip8): know what to
+// inject BEFORE asking; refusals re-plan; the lint keeps the data honest in CI.
+
+open System.IO
+open global.Xunit
+open Zeta.Core
+
+let private repoRoot () =
+    let mutable dir = DirectoryInfo(System.AppContext.BaseDirectory)
+    while not (isNull dir) && not (File.Exists(Path.Combine(dir.FullName, "Zeta.sln"))) do
+        dir <- dir.Parent
+    dir.FullName
+
+let private docOf (relative: string) =
+    match MediaLines.parse (File.ReadAllText(Path.Combine(repoRoot (), relative))) with
+    | Ok d -> d
+    | Error e -> failwith e
+
+let private generic () = docOf "db/capabilities/capabilities.lines"
+let private chip8 () = docOf "db/emus/chip8/capabilities.lines"
+
+[<Fact>]
+let ``BOTH REAL LEDGERS LINT CLEAN: every support row references a declared cap, statuses are the closed ladder set, no dark caps`` () =
+    Assert.Empty(CapabilityLedger.lint (generic ()))
+    Assert.Empty(CapabilityLedger.lint (chip8 ()))
+
+[<Fact>]
+let ``RESOLVE: the fault-parity treaty reads back — fault.register is LIVE on all four oracles`` () =
+    let ledger = CapabilityLedger.ofDoc (chip8 ())
+    for system in [ "fsharp"; "csharp"; "typescript"; "rust" ] do
+        match CapabilityLedger.resolve "fault.register" system ledger with
+        | Ok s -> Assert.Equal(CapabilityLedger.Live, s.Status)
+        | Error e -> failwith e
+    Assert.Equal<string list>(
+        [ "fsharp"; "csharp"; "typescript"; "rust" ],
+        CapabilityLedger.systemsAtLeast "fault.register" CapabilityLedger.Live ledger)
+
+[<Fact>]
+let ``REFUSALS RE-PLAN: an unknown cap names the declared set; an unplaced system names the placements`` () =
+    let ledger = CapabilityLedger.ofDoc (generic ())
+    match CapabilityLedger.resolve "engine.vibes" "dotnet" ledger with
+    | Ok _ -> failwith "unknown cap must refuse"
+    | Error e -> Assert.Contains("the ledger declares:", e)
+    match CapabilityLedger.resolve "sketch.iblt" "cobol" ledger with
+    | Ok _ -> failwith "unplaced system must refuse"
+    | Error e ->
+        Assert.Contains("placed:", e)
+        Assert.Contains("fsharp=Live", e)
+
+[<Fact>]
+let ``THE LADDER READS AS DATA: injected and absent are honest answers, not errors`` () =
+    let ledger = CapabilityLedger.ofDoc (generic ())
+    match CapabilityLedger.resolve "engine.infer-net" "dotnet" ledger with
+    | Ok s -> Assert.Equal(CapabilityLedger.Injected, s.Status) // tests-side only BY DESIGN
+    | Error e -> failwith e
+    match CapabilityLedger.resolve "sketch.iblt" "rust" ledger with
+    | Ok s -> Assert.Equal(CapabilityLedger.Absent, s.Status) // the wish, visibly
+    | Error e -> failwith e
+
+[<Fact>]
+let ``LINT FALSIFIERS: dangling support, alien status, and a dark cap are each named`` () =
+    let bad =
+        "cap\tx.real\tdesc\nsupport\tx.ghost\tdotnet\tlive\tnote\nsupport\tx.real\tdotnet\tshiny\tnote\ncap\tx.dark\tdesc\n"
+    let d = MediaLines.parse bad |> Result.toOption |> Option.get
+    let findings = CapabilityLedger.lint d
+    Assert.Contains(findings, fun f -> f.Contains "undeclared cap 'x.ghost'")
+    Assert.Contains(findings, fun f -> f.Contains "unknown status 'shiny'")
+    Assert.Contains(findings, fun f -> f.Contains "cap 'x.dark' has zero support rows")

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -185,6 +185,7 @@
     <Compile Include="TestLoop.Host.fs" />
     <Compile Include="Ben.Tests.fs" />
     <Compile Include="BenPort.Tests.fs" />
+    <Compile Include="CapabilityLedger.Tests.fs" />
     <Compile Include="WaveSim.Tests.fs" />
     <Compile Include="AdinkraViz.Tests.fs" />
     <Compile Include="SpectralPivot.Tests.fs" />


### PR DESCRIPTION
Aaron's ratified pick: the resolver over db/capabilities + db/emus/chip8. `resolve` answers the ladder rung (absent is honest, not an error) and refuses unknowns usefully (names the declared set / the placements); `systemsAtLeast` reads the ladder as data — the fault-parity treaty reads back as four-oracle Live; `lint` (the README's promise) sweeps both real ledgers in CI with falsifiers for dangling rows, alien statuses, dark caps. Pure over MediaLines, no IO in the module. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)