### PR TITLE
feat(core): ledger rung 2 — CapabilityLedger.partition drives the inference ladder

### DIFF
--- a/db/capabilities/README.md
+++ b/db/capabilities/README.md
@@ -10,5 +10,8 @@ MediaLines (our own dogfood): `cap` rows declare, `support` rows place. Per-emu 
 `db/emus/<machine>/capabilities.lines` (the chip8 one is first). The promised lint + resolver landed 2026-06-12: `Zeta.Core.CapabilityLedger` (parse / `resolve`
 with re-planning refusals / `systemsAtLeast` / `lint`) — pure over MediaLines, no IO in the
 module; CI sweeps BOTH real ledgers through the lint via tests/Tests.FSharp/CapabilityLedger
-.Tests.fs (dangling support rows, alien statuses, and dark caps all fail the gate). Next: feed
-`systemsAtLeast` into the inference/host ladders as the hostLive/granted input.
+.Tests.fs (dangling support rows, alien statuses, and dark caps all fail the gate). Rung 2 landed
+2026-06-12: `CapabilityLedger.partition` — generic over the factory type — splits a host's
+candidates by the ledger's word (Live → hostLive, Injected → granted, everything else dropped to
+the honest Mock rung); the inference ladder consumes it end-to-end in CI (data decides, code
+obeys). Next: the setup-side tier vocabulary folding into this same cap/support shape.

--- a/src/Core/CapabilityLedger.fs
+++ b/src/Core/CapabilityLedger.fs
@@ -109,3 +109,23 @@ module CapabilityLedger =
           for KeyValue(cap, _) in ledger.Caps do
               if not (supportRaw |> List.exists (fun e -> e.Name = cap)) then
                   yield sprintf "cap '%s' has zero support rows — place it (absent is a valid placement)" cap ]
+
+    /// THE LADDER WIRING (the README's named next, rung 2): partition a host's candidate
+    /// factories by what the LEDGER says this system actually holds. Live placements feed the
+    /// ladder's `hostLive` slot; Injected placements feed `granted`; Mock/Absent/unplaced are
+    /// DROPPED — so a downstream `resolve` falls to its honest Mock rung instead of binding a
+    /// capability the ledger never placed. Generic over the factory type: the same wiring serves
+    /// the inference port today and every port after it (data decides, code obeys).
+    let partition
+        (ledger: Ledger)
+        (system: string)
+        (factories: Map<string, 'T>)
+        : Map<string, 'T> * Map<string, 'T> =
+        factories
+        |> Map.fold
+            (fun (live, granted) name factory ->
+                match resolve name system ledger with
+                | Ok s when s.Status = Live -> Map.add name factory live, granted
+                | Ok s when s.Status = Injected -> live, Map.add name factory granted
+                | _ -> live, granted)
+            (Map.empty, Map.empty)

--- a/tests/Tests.FSharp/CapabilityLedger.Tests.fs
+++ b/tests/Tests.FSharp/CapabilityLedger.Tests.fs
@@ -68,3 +68,47 @@ let ``LINT FALSIFIERS: dangling support, alien status, and a dark cap are each n
     Assert.Contains(findings, fun f -> f.Contains "undeclared cap 'x.ghost'")
     Assert.Contains(findings, fun f -> f.Contains "unknown status 'shiny'")
     Assert.Contains(findings, fun f -> f.Contains "cap 'x.dark' has zero support rows")
+
+// ── RUNG 2: the ledger DRIVES the inference ladder (data decides, code obeys) ──
+open Zeta.Core.Abstractions
+
+let private fakeEngine (name: string) : unit -> IInferenceEngine =
+    fun () ->
+        { new IInferenceEngine with
+            member _.Name = name
+            member _.RunGaussian(model, _, _) =
+                InferenceResult(true, 1, [| for v in 0 .. model.VariableCount - 1 -> GaussianMarginal(v, 0.0, 1.0) |]) }
+
+let private candidates =
+    Map.ofList
+        [ "engine.zeta-bayesian", fakeEngine "zeta-bayesian"
+          "engine.infer-net", fakeEngine "infer-net"
+          "engine.never-registered", fakeEngine "ghost" ]
+
+[<Fact>]
+let ``RUNG 2 — partition by the REAL ledger: Live feeds hostLive, Injected feeds granted, unknown is dropped to the Mock rung`` () =
+    let ledger = CapabilityLedger.ofDoc (generic ())
+    let hostLive, granted = CapabilityLedger.partition ledger "dotnet" candidates
+    Assert.True(Map.containsKey "engine.zeta-bayesian" hostLive) // ledger: live
+    Assert.True(Map.containsKey "engine.infer-net" granted) // ledger: injected BY DESIGN
+    Assert.False(Map.containsKey "engine.never-registered" hostLive)
+    Assert.False(Map.containsKey "engine.never-registered" granted)
+    // end-to-end through the ladder: the ledger's word becomes the binding's light
+    match InferenceLadder.resolve hostLive granted "engine.zeta-bayesian" with
+    | InferenceLadder.EngineBinding.Live _ -> ()
+    | b -> failwith (InferenceLadder.light b)
+    match InferenceLadder.resolve hostLive granted "engine.infer-net" with
+    | InferenceLadder.EngineBinding.Injected _ -> ()
+    | b -> failwith (InferenceLadder.light b)
+    match InferenceLadder.resolve hostLive granted "engine.never-registered" with
+    | InferenceLadder.EngineBinding.Mock _ -> () // honest rehearsal, never a masquerade
+    | b -> failwith (InferenceLadder.light b)
+
+[<Fact>]
+let ``RUNG 2 — an unplaced SYSTEM binds nothing: every request falls to the honest Mock rung`` () =
+    let ledger = CapabilityLedger.ofDoc (generic ())
+    let hostLive, granted = CapabilityLedger.partition ledger "cobol" candidates
+    Assert.True(Map.isEmpty hostLive && Map.isEmpty granted)
+    match InferenceLadder.resolve hostLive granted "engine.zeta-bayesian" with
+    | InferenceLadder.EngineBinding.Mock(_, e) -> Assert.Equal("mock-flat", e.Name)
+    | b -> failwith (InferenceLadder.light b)


### PR DESCRIPTION
The README's named next: `partition` splits candidate factories by the ledger's word (Live→hostLive, Injected→granted, else dropped to the honest Mock rung), generic over the factory type so every port after inference gets the same wiring free. End-to-end against the real ledger: zeta-bayesian Live, infer-net Injected-by-design, ghost engine + unplaced system both fall to mock-flat with the off-light. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)