### PR TITLE
feat(testloop): B-1035 COMPLETE — golden lock + light + chip9-board host (the treaty replays through the framework)

### DIFF
--- a/src/Core/Chip9Board.fs
+++ b/src/Core/Chip9Board.fs
@@ -1,0 +1,42 @@
+namespace Zeta.Core
+
+/// Chip9Board — **the chip9-board HOST for sim·mea·cut loops** (B-1035's last named slice): a
+/// test loop hosted ON the machine that already has exact ticks, color planes, and the fault
+/// register. Sim loads the ROM into a fresh frame (the rom bytes are CONSTANTS — solid ground;
+/// the seed remains the replay tag the boundary requires); Mea runs the program and banks the
+/// FULL observable state (color grid rows + plane + fault + pc — the same canonical text form
+/// the four-oracle treaty locks); Cut is whatever the room asserts — `TestLoop.cutGolden` makes
+/// a board loop a treaty replay for free. Everything in here is deterministic by construction:
+/// the board host is sealed-room eligible with zero waivers.
+[<RequireQualifiedAccess>]
+module Chip9Board =
+
+    /// The banked measurement: the machine's observable state as canonical text rows —
+    /// plane line, 32 color-grid rows, then the fault and pc lines (everything the treaty sees).
+    let render (f: Chip8Cow.Frame) : string list =
+        [ yield sprintf "plane\t%d" f.Plane
+          for y in 0 .. Chip8.DisplayH - 1 do
+              yield
+                  [| for x in 0 .. Chip8.DisplayW - 1 -> sprintf "%x" (Chip8Cow.colorAt x y f) |]
+                  |> String.concat ""
+          yield sprintf "fault\t%s" (f.Fault |> Option.defaultValue "none")
+          yield sprintf "pc\t%04x" (int f.PC) ]
+
+    /// Host a loop on the board: ROM in, `steps` instructions, the rendered state out.
+    /// `extraMem` seeds fixed data (sprites) outside the ROM window — constants, like the ROM.
+    let loop
+        (name: string)
+        (seed: uint64)
+        (rom: byte[])
+        (extraMem: (int * byte) list)
+        (steps: int)
+        (cut: string list -> Result<unit, string>)
+        : ITestLoop<Chip8Cow.Frame, string list> =
+        TestLoop.make
+            name
+            seed
+            (fun s ->
+                let f0 = Chip8Cow.create s |> Chip8Cow.loadRom rom
+                { f0 with Mem = extraMem |> List.fold (fun m (k, v) -> Map.add k v m) f0.Mem })
+            (fun f0 -> [ 1..steps ] |> List.fold (fun f _ -> Chip8Cow.step f) f0 |> render)
+            cut

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -227,6 +227,7 @@
     <Compile Include="ZetaMax.fs" />
     <Compile Include="Chip9Phys.fs" />
     <Compile Include="TestLoop.fs" />
+    <Compile Include="Chip9Board.fs" />
     <Compile Include="Ben.fs" />
     <Compile Include="BenPort.fs" />
     <Compile Include="WSet.fs" />

--- a/src/Core/TestLoop.fs
+++ b/src/Core/TestLoop.fs
@@ -90,6 +90,33 @@ module TestLoop =
                   Replay = replay
                   Deterministic = deterministic }
 
+    /// THE GOLDEN LOCK, boundary-blessed (B-1035 final slice): a canned Cut that byte-locks a
+    /// rendering against golden rows — rooms inherit the treaty discipline the cartridges have.
+    /// Honest on divergence: the FIRST diverging row is named with both byte sequences' heads.
+    let cutGolden (golden: string list) (render: 'm -> string list) : 'm -> Result<unit, string> =
+        fun mea ->
+            let actual = render mea
+            if List.length actual <> List.length golden then
+                Error(sprintf "GOLDEN LOCK: row count diverged — golden %d rows, actual %d" (List.length golden) (List.length actual))
+            else
+                match List.zip golden actual |> List.tryFindIndex (fun (g, a) -> g <> a) with
+                | None -> Ok()
+                | Some i ->
+                    let g, a = List.item i golden, List.item i actual
+                    Error(sprintf "GOLDEN LOCK: row %d diverged — golden '%s' vs actual '%s'" i (g.Substring(0, min 48 g.Length)) (a.Substring(0, min 48 a.Length)))
+
+    /// THE LIGHT (universal/port Light, B-1035 final slice): the verdict's truth in one glance.
+    /// [REC ●] = something real was verified AND it replayed byte-equal; [off ○] = the cut
+    /// failed (rehearsal until fixed); [!! ●] = AMBIENT — the loop passed or failed but did NOT
+    /// replay byte-equal, which outranks everything (a nondeterministic pass proves nothing).
+    let light (v: Verdict) : string =
+        if not v.Deterministic then
+            sprintf "[!! ●] AMBIENT %s — Sim+Mea did not replay byte-equal (%s)" v.Name v.Replay
+        elif v.Passed then
+            sprintf "[REC ●] LOCKED %s (%s)" v.Name v.Replay
+        else
+            sprintf "[off ○] FAILED %s — %s (%s)" v.Name (v.Failure |> Option.defaultValue "?") v.Replay
+
     /// Inline constructor — most loops are three lambdas and a seed (keep migration cheap).
     let make (name: string) (seed: uint64) (sim: uint64 -> 'w) (mea: 'w -> 'm) (cut: 'm -> Result<unit, string>) : ITestLoop<'w, 'm> =
         { new ITestLoop<'w, 'm> with

--- a/tests/Tests.FSharp/TestLoop.Host.fs
+++ b/tests/Tests.FSharp/TestLoop.Host.fs
@@ -118,3 +118,67 @@ let ``THE BOUNDARY CATCHES THROWS: an exception in Mea becomes a named-phase Fai
     Assert.False v.Passed
     Assert.Contains("Mea threw", v.Failure |> Option.defaultValue "")
     Assert.Contains("seed 0x4", v.Replay)
+
+// ── B-1035 FINAL SLICES: the golden lock + the light, boundary-blessed; the chip9-board host ──
+[<Fact>]
+let ``THE GOLDEN LOCK IS BOUNDARY-BLESSED: cutGolden locks byte-for-byte and names the first diverging row honestly`` () =
+    let cut = TestLoop.cutGolden [ "row-a"; "row-b" ] id
+    Assert.Equal(Ok(), cut [ "row-a"; "row-b" ])
+    match cut [ "row-a"; "row-X" ] with
+    | Ok() -> failwith "divergence must refuse"
+    | Error e ->
+        Assert.Contains("row 1 diverged", e)
+        Assert.Contains("row-X", e)
+    match cut [ "row-a" ] with
+    | Ok() -> failwith "row-count divergence must refuse"
+    | Error e -> Assert.Contains("row count diverged", e)
+
+[<Fact>]
+let ``THE LIGHT: one glance — LOCKED on a deterministic pass, FAILED on a cut, and AMBIENT OUTRANKS EVERYTHING`` () =
+    let locked = TestLoop.run (TestLoop.make "locked" 4UL (fun _ -> 1) (fun w -> w + 1) (fun _ -> Ok()))
+    Assert.StartsWith("[REC ●] LOCKED", TestLoop.light locked)
+    let failed = TestLoop.run (TestLoop.make "failed" 4UL (fun _ -> 1) (fun w -> w) (fun _ -> Error "the cut says no"))
+    Assert.StartsWith("[off ○] FAILED", TestLoop.light failed)
+    let ambient =
+        TestLoop.run (
+            TestLoop.make "ambient" 4UL
+                (fun _ -> ())
+                (fun () -> System.Guid.NewGuid().ToString()) // SEAL-WAIVER: falsifier — the light must show AMBIENT
+                (fun _ -> Ok()))
+    Assert.StartsWith("[!! ●] AMBIENT", TestLoop.light ambient)
+
+[<Fact>]
+let ``THE CHIP9-BOARD HOST: the four-oracle treaty golden replays through the framework — rooms inherit the lock`` () =
+    // the REAL treaty golden (rom + plane + 32 rows) read HOST-SIDE; the loop itself runs sealed
+    let repoRoot =
+        let mutable dir = System.IO.DirectoryInfo(System.AppContext.BaseDirectory)
+        while not (isNull dir) && not (System.IO.File.Exists(System.IO.Path.Combine(dir.FullName, "Zeta.sln"))) do
+            dir <- dir.Parent
+        dir.FullName
+    let lines =
+        System.IO.File.ReadAllLines(System.IO.Path.Combine(repoRoot, "src", "Core.TypeScript", "chip9", "golden-vectors.lines"))
+        |> Array.filter (fun l -> not (l.StartsWith "#") && l.Length > 0)
+        |> Array.toList
+    let romHex = (List.item 0 lines).Split('\t').[1]
+    let rom = [| for i in 0 .. romHex.Length / 2 - 1 -> System.Convert.ToByte(romHex.Substring(i * 2, 2), 16) |]
+    let goldenGrid = List.item 1 lines :: (lines |> List.skip 2 |> List.truncate Chip8.DisplayH)
+    // board render adds fault+pc lines after the grid; the treaty grid is the locked prefix
+    let cut = TestLoop.cutGolden goldenGrid (fun (rows: string list) -> rows |> List.truncate (1 + Chip8.DisplayH))
+    let verdict =
+        TestLoop.run (Chip9Board.loop "chip9 treaty via the board host" 7UL rom [ for k in 0..7 -> 0x300 + k, 0xFFuy ] 30 cut)
+    Assert.True(verdict.Passed, TestLoop.light verdict)
+    Assert.True(verdict.Deterministic)
+    Assert.StartsWith("[REC ●] LOCKED", TestLoop.light verdict)
+
+[<Fact>]
+let ``THE BOARD HOST CARRIES THE FAULT REGISTER: the overflow treaty vector replays as a sealed loop`` () =
+    let overflowRom = [| for k in 0..16 do
+                           let op = 0x2202 + 2 * k
+                           yield byte (op >>> 8)
+                           yield byte (op &&& 0xFF) |]
+    let cut (rows: string list) =
+        let has (s: string) = rows |> List.exists (fun r -> r = s)
+        if has "fault\tstack overflow: CALL (2NNN) at depth 16 refused" && has "pc\t0222" then Ok()
+        else Error(sprintf "fault/pc lines wrong: %A" (rows |> List.skip (1 + Chip8.DisplayH)))
+    let verdict = TestLoop.run (Chip9Board.loop "overflow fault via the board host" 7UL overflowRom [] 17 cut)
+    Assert.True(verdict.Passed, TestLoop.light verdict)


### PR DESCRIPTION
The last two named slices, ratified by Aaron: `cutGolden` (rooms inherit the byte-lock; honest first-divergence naming), `light` (one-glance verdicts where AMBIENT outranks everything), and `Chip9Board.loop` (sim·mea·cut hosted on the emu — full observable state banked as canonical text, sealed-room eligible with zero waivers). Dogfood: the four-oracle treaty golden and the overflow fault vector both replay through the framework as sealed loops, LOCKED lights on. B-1035 → done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)