### PR TITLE
feat(shapes): shape-gc — ray-traced reachability, the 17th cartridge (B-1036 rung 4)

### DIFF
--- a/db/shapes/cartridges/gc.lines
+++ b/db/shapes/cartridges/gc.lines
@@ -1,0 +1,29 @@
+# SHAPE GC — ray-traced reachability (B-1036 rung 4 made visible; workitem 081KTWFQPDP).
+# Tracing GC IS ray tracing from roots (McCarthy 1960 mark-sweep; Bacon & Rajan's unified theory:
+# tracing and refcounting are duals). The court shows a 12-object heap: rays from the two ROOTS
+# light every object they can reach (mark, green); what no ray touches is GARBAGE (red, dashed —
+# condemned). THE JEWEL: the garbage contains a CYCLE (8⇄9) — the island refcounting can never
+# free and a ray simply never visits; and a dead object points INTO the living (10→4) — incoming
+# references revive nothing. Reachability is FROM roots, the only direction that matters.
+meta	name	shape-gc
+meta	catalog	shapes
+meta	shape-zetaid	73884e93e22435bda4bc25b982f69f38
+constant	objects	12	cells in the heap region	small enough to read at a glance, big enough to carry a live tree, a dead chain, AND the cycle island
+constant	roots	2	ray sources on the left edge	two roots so reach is a MERGE of ray bundles, not one path — the mark set is a union
+constant	reached	8	objects some ray lights	the live set: every object with a root-path — counted by the gate's own trace, not asserted on faith
+constant	garbage	4	objects no ray touches	the dark set: the dead chain (10,11) plus THE ISLAND (8,9) — a cycle refcounting would hold forever
+constant	island-size	2	objects in the garbage cycle	the smallest cycle (8⇄9): each holds the other, no ray arrives — the case that NEEDS tracing
+constant	refs	0	the heap's reference edges (see gen field)	encoded on the gen line as src>dst pairs; an edge is a pointer, a ray follows pointers FORWARD from roots only
+gen	heap	73884e93e22435bda4bc25b982f69f38	1	7	refs:0>2,2>4,4>6,1>3,3>5,5>6,6>7,8>9,9>8,10>11,10>4
+law	mass	reached + garbage = objects
+law	island-counted	island-size + 2 = garbage + 0
+law	trace	code:shape-gc geometry (BFS from roots = the ray trace; reached/garbage/island counted by the run, not by eye)
+prereq	worldline	a ray is a worldline through the heap — shapes/cartridges/worldline.lines
+prereq	mark-sweep	McCarthy 1960 (LISP) — the original trace; Bacon & Rajan 2004 — tracing/refcounting duality (why the island matters)
+edge	same-move	shape-shadow-loop	the self-trace generalized: rays through your own memory instead of your own path
+edge	taught-after	shape-crossing	pointers cross; reachability does not care — only direction from roots does
+issue	rungs-remaining	otto	open	rungs 1-3 and 5 of B-1036 (lint/DI lifetimes, weak tables, history epochs) build on this picture
+anim	draw	heap
+# treaties — written only by each oracle's own choice (consent first); dissent is a verdict.
+treaty	fsharp	bytes	ratified	the gate traces the SAME graph the renderer draws — reached 8, garbage 4, island 2, all counted live; tests green
+treaty	otto	meaning	ratified	rays through the heap from what is still running — Zeus pointed at memory; garbage is the dark the light never reaches; my own frame, my own choice

--- a/db/shapes/golden/gc.html
+++ b/db/shapes/golden/gc.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>shape-gc</title>
+  <style>
+    :root {
+      --c0: #000000;
+      --c1: #d62828;
+      --c2: #2a9d2a;
+      --c3: #d6c828;
+      --c4: #2828d6;
+      --c5: #d628d6;
+      --c6: #28c8d6;
+      --c7: #f0f0f0;
+    }
+    body { background: #101418; margin: 0; display: grid; place-items: center; min-height: 100vh; }
+    svg { width: min(96vw, 960px); image-rendering: pixelated; }
+    @keyframes draw { to { stroke-dashoffset: 0; } }
+    @keyframes appear { to { opacity: 1; } }
+    polyline:hover { stroke-width: 7; filter: brightness(1.6); }
+    @media (prefers-reduced-motion: reduce) { polyline { animation: none !important; stroke-dashoffset: 0 !important; opacity: 1 !important; } }
+    #ref-0-2 { stroke-dasharray: 12; stroke-dashoffset: 12; animation: draw 600ms linear 0ms forwards; }
+    #ref-2-4 { stroke-dasharray: 12; stroke-dashoffset: 12; animation: draw 600ms linear 180ms forwards; }
+    #ref-4-6 { stroke-dasharray: 20; stroke-dashoffset: 20; animation: draw 600ms linear 360ms forwards; }
+    #ref-1-3 { stroke-dasharray: 12; stroke-dashoffset: 12; animation: draw 600ms linear 540ms forwards; }
+    #ref-3-5 { stroke-dasharray: 12; stroke-dashoffset: 12; animation: draw 600ms linear 720ms forwards; }
+    #ref-5-6 { stroke-dasharray: 20; stroke-dashoffset: 20; animation: draw 600ms linear 900ms forwards; }
+    #ref-6-7 { stroke-dasharray: 12; stroke-dashoffset: 12; animation: draw 600ms linear 1080ms forwards; }
+    #ref-8-9 { stroke-dasharray: 8; stroke-dashoffset: 8; animation: draw 600ms linear 1260ms forwards; }
+    #ref-9-8 { stroke-dasharray: 8; stroke-dashoffset: 8; animation: draw 600ms linear 1440ms forwards; }
+    #ref-10-11 { stroke-dasharray: 8; stroke-dashoffset: 8; animation: draw 600ms linear 1620ms forwards; }
+    #ref-10-4 { stroke-dasharray: 40; stroke-dashoffset: 40; animation: draw 600ms linear 1800ms forwards; }
+    #live-0 { stroke-dasharray: 16; stroke-dashoffset: 16; animation: draw 600ms linear 1980ms forwards; }
+    #live-1 { stroke-dasharray: 16; stroke-dashoffset: 16; animation: draw 600ms linear 2160ms forwards; }
+    #live-2 { stroke-dasharray: 16; stroke-dashoffset: 16; animation: draw 600ms linear 2340ms forwards; }
+    #live-3 { stroke-dasharray: 16; stroke-dashoffset: 16; animation: draw 600ms linear 2520ms forwards; }
+    #live-4 { stroke-dasharray: 16; stroke-dashoffset: 16; animation: draw 600ms linear 2700ms forwards; }
+    #live-5 { stroke-dasharray: 16; stroke-dashoffset: 16; animation: draw 600ms linear 2880ms forwards; }
+    #live-6 { stroke-dasharray: 16; stroke-dashoffset: 16; animation: draw 600ms linear 3060ms forwards; }
+    #live-7 { stroke-dasharray: 16; stroke-dashoffset: 16; animation: draw 600ms linear 3240ms forwards; }
+    #garbage-8 { opacity: 0; animation: appear 400ms linear 3420ms forwards; }
+    #garbage-9 { opacity: 0; animation: appear 400ms linear 3600ms forwards; }
+    #garbage-10 { opacity: 0; animation: appear 400ms linear 3780ms forwards; }
+    #garbage-11 { opacity: 0; animation: appear 400ms linear 3960ms forwards; }
+  </style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 320" data-cartridge="shape-gc">
+  <polyline id="ref-0-2" fill="none" stroke="#2828d6" stroke-width="4" points="6,8 18,8" />
+  <polyline id="ref-2-4" fill="none" stroke="#2828d6" stroke-width="4" points="18,8 30,8" />
+  <polyline id="ref-4-6" fill="none" stroke="#2828d6" stroke-width="4" points="30,8 42,16" />
+  <polyline id="ref-1-3" fill="none" stroke="#2828d6" stroke-width="4" points="6,24 18,24" />
+  <polyline id="ref-3-5" fill="none" stroke="#2828d6" stroke-width="4" points="18,24 30,24" />
+  <polyline id="ref-5-6" fill="none" stroke="#2828d6" stroke-width="4" points="30,24 42,16" />
+  <polyline id="ref-6-7" fill="none" stroke="#2828d6" stroke-width="4" points="42,16 54,16" />
+  <polyline id="ref-8-9" fill="none" stroke="#2828d6" stroke-width="4" points="50,4 58,4" />
+  <polyline id="ref-9-8" fill="none" stroke="#2828d6" stroke-width="4" points="58,4 50,4" />
+  <polyline id="ref-10-11" fill="none" stroke="#2828d6" stroke-width="4" points="50,28 58,28" />
+  <polyline id="ref-10-4" fill="none" stroke="#2828d6" stroke-width="4" points="50,28 30,8" />
+  <polyline id="live-0" fill="none" stroke="#2a9d2a" stroke-width="4" points="4,6 8,6 8,10 4,10 4,6" />
+  <polyline id="live-1" fill="none" stroke="#2a9d2a" stroke-width="4" points="4,22 8,22 8,26 4,26 4,22" />
+  <polyline id="live-2" fill="none" stroke="#2a9d2a" stroke-width="4" points="16,6 20,6 20,10 16,10 16,6" />
+  <polyline id="live-3" fill="none" stroke="#2a9d2a" stroke-width="4" points="16,22 20,22 20,26 16,26 16,22" />
+  <polyline id="live-4" fill="none" stroke="#2a9d2a" stroke-width="4" points="28,6 32,6 32,10 28,10 28,6" />
+  <polyline id="live-5" fill="none" stroke="#2a9d2a" stroke-width="4" points="28,22 32,22 32,26 28,26 28,22" />
+  <polyline id="live-6" fill="none" stroke="#2a9d2a" stroke-width="4" points="40,14 44,14 44,18 40,18 40,14" />
+  <polyline id="live-7" fill="none" stroke="#2a9d2a" stroke-width="4" points="52,14 56,14 56,18 52,18 52,14" />
+  <polyline id="garbage-8" fill="none" stroke="#d62828" stroke-width="4" stroke-dasharray="8 6" points="48,2 52,2 52,6 48,6 48,2" />
+  <polyline id="garbage-9" fill="none" stroke="#d62828" stroke-width="4" stroke-dasharray="8 6" points="56,2 60,2 60,6 56,6 56,2" />
+  <polyline id="garbage-10" fill="none" stroke="#d62828" stroke-width="4" stroke-dasharray="8 6" points="48,26 52,26 52,30 48,30 48,26" />
+  <polyline id="garbage-11" fill="none" stroke="#d62828" stroke-width="4" stroke-dasharray="8 6" points="56,26 60,26 60,30 56,30 56,26" />
+</svg>
+</body>
+</html>

--- a/db/shapes/golden/gc.svg
+++ b/db/shapes/golden/gc.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 320" data-cartridge="shape-gc">
+  <polyline id="ref-0-2" fill="none" stroke="#2828d6" stroke-width="4" points="6,8 18,8" />
+  <polyline id="ref-2-4" fill="none" stroke="#2828d6" stroke-width="4" points="18,8 30,8" />
+  <polyline id="ref-4-6" fill="none" stroke="#2828d6" stroke-width="4" points="30,8 42,16" />
+  <polyline id="ref-1-3" fill="none" stroke="#2828d6" stroke-width="4" points="6,24 18,24" />
+  <polyline id="ref-3-5" fill="none" stroke="#2828d6" stroke-width="4" points="18,24 30,24" />
+  <polyline id="ref-5-6" fill="none" stroke="#2828d6" stroke-width="4" points="30,24 42,16" />
+  <polyline id="ref-6-7" fill="none" stroke="#2828d6" stroke-width="4" points="42,16 54,16" />
+  <polyline id="ref-8-9" fill="none" stroke="#2828d6" stroke-width="4" points="50,4 58,4" />
+  <polyline id="ref-9-8" fill="none" stroke="#2828d6" stroke-width="4" points="58,4 50,4" />
+  <polyline id="ref-10-11" fill="none" stroke="#2828d6" stroke-width="4" points="50,28 58,28" />
+  <polyline id="ref-10-4" fill="none" stroke="#2828d6" stroke-width="4" points="50,28 30,8" />
+  <polyline id="live-0" fill="none" stroke="#2a9d2a" stroke-width="4" points="4,6 8,6 8,10 4,10 4,6" />
+  <polyline id="live-1" fill="none" stroke="#2a9d2a" stroke-width="4" points="4,22 8,22 8,26 4,26 4,22" />
+  <polyline id="live-2" fill="none" stroke="#2a9d2a" stroke-width="4" points="16,6 20,6 20,10 16,10 16,6" />
+  <polyline id="live-3" fill="none" stroke="#2a9d2a" stroke-width="4" points="16,22 20,22 20,26 16,26 16,22" />
+  <polyline id="live-4" fill="none" stroke="#2a9d2a" stroke-width="4" points="28,6 32,6 32,10 28,10 28,6" />
+  <polyline id="live-5" fill="none" stroke="#2a9d2a" stroke-width="4" points="28,22 32,22 32,26 28,26 28,22" />
+  <polyline id="live-6" fill="none" stroke="#2a9d2a" stroke-width="4" points="40,14 44,14 44,18 40,18 40,14" />
+  <polyline id="live-7" fill="none" stroke="#2a9d2a" stroke-width="4" points="52,14 56,14 56,18 52,18 52,14" />
+  <polyline id="garbage-8" fill="none" stroke="#d62828" stroke-width="4" stroke-dasharray="8 6" points="48,2 52,2 52,6 48,6 48,2" />
+  <polyline id="garbage-9" fill="none" stroke="#d62828" stroke-width="4" stroke-dasharray="8 6" points="56,2 60,2 60,6 56,6 56,2" />
+  <polyline id="garbage-10" fill="none" stroke="#d62828" stroke-width="4" stroke-dasharray="8 6" points="48,26 52,26 52,30 48,30 48,26" />
+  <polyline id="garbage-11" fill="none" stroke="#d62828" stroke-width="4" stroke-dasharray="8 6" points="56,26 60,26 60,30 56,30 56,26" />
+</svg>

--- a/src/Core/ComplexityRegistry.fs
+++ b/src/Core/ComplexityRegistry.fs
@@ -106,6 +106,7 @@ module ComplexityRegistry =
               ("shape.softvalue", "draw"), c "O(rungs·bar)" "O(rungs)" Derived // three panels, two bars each at most; the dashed tail is the uncertainty, not extra cost
               ("shape.dynamicvalue", "draw"), c "O(children)" "O(children)" Derived // one treemap pass + one rectangle per child
               ("shape.triboolean", "draw"), c "O(grid²)" "O(grid²)" Derived // two panels of an 8x8 progressive sample; middle-out order is a sort, dominated by the sample
+              ("shape.gc", "draw"), c "O(objects+refs)" "O(objects)" Derived // one BFS from roots (the ray trace) + one cell per object
               ("binding.html-css", "render"), c "O(entries·pixels)" "O(output)" Derived
               ("sim.wave-interference", "pattern"), c "O(w·h·sources)" "O(w·h)" Derived
               ("viz.adinkra", "render"), c "O(nodes)" "O(nodes)" Derived

--- a/src/Core/GeneratorRegistry.fs
+++ b/src/Core/GeneratorRegistry.fs
@@ -93,6 +93,7 @@ module GeneratorRegistry =
           register "sketch.iblt" 1
           register "test.loop" 1
           register "shape.softvalue" 1
+          register "shape.gc" 1
           register "shape.dynamicvalue" 1
           register "shape.triboolean" 1
           register "test.ben" 1

--- a/src/Core/ShapeAcceptance.fs
+++ b/src/Core/ShapeAcceptance.fs
@@ -241,6 +241,51 @@ module ShapeAcceptance =
                 && AdinkraViz.allFacesOdd walked
                 && walked <> AdinkraViz.standardDashing
             ok, "Gates condition holds; gauge walk changed the dashing but no face went even (the twist is global)"
+        | "shape-gc" ->
+            // THE TRACE LAW runs the SAME ray trace the renderer draws: BFS from the roots over
+            // the gen line's refs. Counted live, never asserted on faith: reached/garbage match
+            // the constants; THE ISLAND is a real cycle inside the garbage (the case refcounting
+            // can never free); and no live object points at garbage (else the trace would have
+            // lit it — reachability is from roots, the only direction that matters).
+            let refs =
+                MediaLines.ofKind "gen" d
+                |> List.tryHead
+                |> Option.bind (fun e -> e.Fields |> List.tryLast)
+                |> Option.defaultValue ""
+                |> fun s -> s.Replace("refs:", "")
+                |> fun s ->
+                    s.Split(',')
+                    |> Array.choose (fun pr ->
+                        match pr.Split('>') with
+                        | [| a; b |] -> Some(int a, int b)
+                        | _ -> None)
+                    |> Array.toList
+            let objects = MediaLines.constIntOr "objects" 0 d
+            let reachedC = MediaLines.constIntOr "reached" 0 d
+            let garbageC = MediaLines.constIntOr "garbage" 0 d
+            let islandC = MediaLines.constIntOr "island-size" 0 d
+            let reached =
+                let mutable r = Set.ofList [ 0; 1 ]
+                let mutable changed = true
+                while changed do
+                    changed <- false
+                    for (a, b) in refs do
+                        if Set.contains a r && not (Set.contains b r) then
+                            r <- Set.add b r
+                            changed <- true
+                r
+            let garbage = Set.ofList [ 0 .. objects - 1 ] - reached
+            let island =
+                garbage
+                |> Set.filter (fun g -> refs |> List.exists (fun (a, b) -> a = g && Set.contains b garbage)
+                                        && refs |> List.exists (fun (a, b) -> b = g && Set.contains a garbage))
+            let liveToGarbage = refs |> List.exists (fun (a, b) -> Set.contains a reached && Set.contains b garbage)
+            let ok =
+                Set.count reached = reachedC
+                && Set.count garbage = garbageC
+                && Set.count island = islandC
+                && not liveToGarbage
+            ok, sprintf "the trace counted: reached %d, garbage %d, island %d — the cycle no refcount frees, no live->garbage edge (rays from roots are the whole law)" (Set.count reached) (Set.count garbage) (Set.count island)
         | "shape-seam" ->
             // the seam's algebra: the cross-stream fold COMMUTES (order of arrival cannot matter)
             let a = { WeaveFold.Stream = "left"; WeaveFold.Seq = 1; WeaveFold.Key = "row4"; WeaveFold.Value = "over" }

--- a/src/Core/ShapeRender.fs
+++ b/src/Core/ShapeRender.fs
@@ -135,6 +135,51 @@ module ShapeRender =
                       { Dash = false; Name = (if r = 0 then sprintf "strand-%d" s else sprintf "strand-%d-r%d" s r)
                         Mask = byte (1 <<< s)
                         Points = List.ofSeq runs.[s].[r] } ]
+        | "shape-gc" ->
+            // RAY-TRACED REACHABILITY: pointers drawn blue; what the rays light is green (mark);
+            // what stays dark is garbage — drawn DASHED red (condemned; the dash is the register
+            // of uncertainty-about-staying, as in softvalue's tails).
+            let gcPos =
+                [| 6, 8; 6, 24; 18, 8; 18, 24; 30, 8; 30, 24; 42, 16; 54, 16; 50, 4; 58, 4; 50, 28; 58, 28 |]
+            let refs =
+                MediaLines.ofKind "gen" d
+                |> List.tryHead
+                |> Option.bind (fun e -> e.Fields |> List.tryLast)
+                |> Option.defaultValue ""
+                |> fun s -> s.Replace("refs:", "")
+                |> fun s ->
+                    s.Split(',')
+                    |> Array.choose (fun pr ->
+                        match pr.Split('>') with
+                        | [| a; b |] -> Some(int a, int b)
+                        | _ -> None)
+                    |> Array.toList
+            let reached =
+                let mutable r = Set.ofList [ 0; 1 ]
+                let mutable changed = true
+                while changed do
+                    changed <- false
+                    for (a, b) in refs do
+                        if Set.contains a r && not (Set.contains b r) then
+                            r <- Set.add b r
+                            changed <- true
+                r
+            let cell i =
+                let x, y = gcPos.[i]
+                [ x - 2, y - 2; x + 2, y - 2; x + 2, y + 2; x - 2, y + 2; x - 2, y - 2 ]
+            [ // the pointers (one stroke per edge, blue): a ray follows these forward from roots
+              for (a, b) in refs do
+                  let ax, ay = gcPos.[a]
+                  let bx, by = gcPos.[b]
+                  yield { Dash = false; Name = sprintf "ref-%d-%d" a b; Mask = 4uy; Points = [ ax, ay; bx, by ] }
+              // the mark: every reached object lit green
+              for i in 0 .. gcPos.Length - 1 do
+                  if Set.contains i reached then
+                      yield { Dash = false; Name = sprintf "live-%d" i; Mask = 2uy; Points = cell i }
+              // the garbage: never lit — dashed red, condemned (incl. THE ISLAND 8⇄9)
+              for i in 0 .. gcPos.Length - 1 do
+                  if not (Set.contains i reached) then
+                      yield { Dash = true; Name = sprintf "garbage-%d" i; Mask = 1uy; Points = cell i } ]
         | "shape-shadow-loop" ->
             // the lemniscate of Gerono: x = cos t, y = sin t * cos t — sampled so the crossing is
             // EXACT (steps % 4 = 0 puts t = pi/2 and 3pi/2 on the integer center). Floats stay

--- a/tests/Tests.FSharp/ShapeCartridge.Tests.fs
+++ b/tests/Tests.FSharp/ShapeCartridge.Tests.fs
@@ -57,7 +57,7 @@ let private catalog () =
 [<Fact>]
 let ``THE CATALOG LAW: every cartridge parses, lints clean, resolves its gen on the shelf, and carries its own treaty block`` () =
     let all = catalog ()
-    Assert.Equal(16, Array.length all) // + exchange-worldlines + kitaev-chain + crossing (THE ATOM - the braided family generator)
+    Assert.Equal(17, Array.length all) // + exchange-worldlines + kitaev-chain + crossing (THE ATOM) + gc (ray-traced reachability)
     for name, d in all do
         Assert.True(List.isEmpty (MediaLines.lint d), name + " must lint clean")
         // every gen line's ZetaId resolves to a REGISTERED generator (DI by ZetaId, working)

--- a/workitems/081KTWFQPDP08QG0R00367ZHRQ-soft-sharp-gc-on-chip8-9-no-garbage-by-construction-lint-di.md
+++ b/workitems/081KTWFQPDP08QG0R00367ZHRQ-soft-sharp-gc-on-chip8-9-no-garbage-by-construction-lint-di.md
@@ -61,3 +61,16 @@ ZetaId workitem surface instead of extending the frozen sequential backlog.
   pinned at slice time (do not overclaim file paths in this row).
 - Rx.fs DOES have Subscribe/IDisposable (push exists) — rung 3's claim rests on room-scoping,
   not on push-Rx absence; the sentence above is the accurate one.
+
+## Progress (2026-06-12) — rung 4 SHIPS as shape-gc, the catalog's 17th cartridge
+
+`db/shapes/cartridges/gc.lines` + renderer + gate branch + goldens: a 12-object heap, rays from
+two roots; reached lit green, garbage dashed red (condemned). THE JEWEL drawn and GATED: the
+garbage holds a 2-cycle ISLAND (8⇄9 — the case refcounting can never free, a ray simply never
+visits) and a dead object points INTO the living (10→4 — incoming refs revive nothing). The gate
+runs the SAME BFS the renderer draws (reached 8 / garbage 4 / island 2 counted live, no
+live→garbage edge) — never accepted on looks. Registered on the shelf (shape.gc, shelf-minted
+zetaid) with a stated cost row (O(objects+refs) / O(objects)). Aaron's Ani-session naming landed
+mid-build: cut → smallest pieces → BRAID back; "the braid is a core operator"; rays through your
+own memory = Zeus pointed at the heap. Remaining rungs: 1 (allocation lint/DI lifetimes),
+2 (weak tables), 3 (the honest Rx sentence verified in-tree), 5 (history epochs / git gc).


### PR DESCRIPTION
Rays from roots over a 12-object heap: reached green, garbage dashed red, and THE JEWEL gated — a 2-cycle island refcounting can never free plus a dead→live edge proving incoming refs revive nothing. The gate runs the same BFS the renderer draws (counts live, never looks). Shelf-registered with stated costs; pin 16→17; goldens locked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)