### PR TITLE
fix(ace): clear main gate strictness

### DIFF
--- a/docs/ROUND-HISTORY.md
+++ b/docs/ROUND-HISTORY.md
@@ -60,6 +60,7 @@ Anchor: Round 46 is the round where the portable, engine-agnostic Helm dependenc
 ### Arc 1 — Subcommand execution wiring and verification (B-0821)
 
 The CLI subcommands (`ace deps validate` and `ace deps resolve`) are wired into the main entrypoint `src/Core.TypeScript/ace/ace.ts` and evaluated against all verification gates.
+
 - Staged and fast-forward merged the implementation and test suites from branch `riven/b0821-deps-engine` to the `main` branch.
 - Verified TypeScript test suite (`deps.test.ts` and `ace.test.ts`) resulting in all 153 tests passing.
 - Verified `.NET` test suite and Release builds resulting in a warning-free compile and 3,362 passing tests.

--- a/src/Core.TypeScript/ace/ace.ts
+++ b/src/Core.TypeScript/ace/ace.ts
@@ -20,10 +20,19 @@
 import { chmodSync, existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { createPublicKey, createPrivateKey } from "node:crypto";
 import {
-  defaultStorePath, listInstalled, installPackage, contentHash,
-  loadTrustStore, addTrustedKey, listTrustedKeys, validatePackagePaths,
-  addRegistryEntry, listRegistry,
-  writeRegistryRemote, removeRegistryRemote, readRegistriesConfig,
+  defaultStorePath,
+  listInstalled,
+  installPackage,
+  contentHash,
+  loadTrustStore,
+  addTrustedKey,
+  listTrustedKeys,
+  validatePackagePaths,
+  addRegistryEntry,
+  listRegistry,
+  writeRegistryRemote,
+  removeRegistryRemote,
+  readRegistriesConfig,
   type AcePackage,
 } from "./store";
 import { generateKeypair, signManifest, verifySignature, keyId, publicKeyInfoFromPrivatePem } from "./signing";
@@ -33,7 +42,14 @@ import type { IndexSignableContent } from "./index-signature.ts";
 import { applyRevoke, applyQuarantine, applyUnquarantine } from "./registry-revoke.ts";
 import { resolve } from "./resolve.ts";
 import { safePackageHash } from "./package-hash.ts";
-import { buildLockfile, serializeLockfile, parseLockfile, verifyRootMatchesLock, lockfilesEqual, buildLeafLockfile } from "./lockfile.ts";
+import {
+  buildLockfile,
+  serializeLockfile,
+  parseLockfile,
+  verifyRootMatchesLock,
+  lockfilesEqual,
+  buildLeafLockfile,
+} from "./lockfile.ts";
 import { solve } from "./solver.ts";
 
 function isValidDepEdge(e: unknown): boolean {
@@ -115,7 +131,16 @@ interface UpdateArgs {
 
 interface RegistryArgs {
   readonly command: "registry";
-  readonly sub: "list" | "add" | "remote-add" | "remote-list" | "remote-rm" | "publish" | "revoke" | "quarantine" | "unquarantine";
+  readonly sub:
+    | "list"
+    | "add"
+    | "remote-add"
+    | "remote-list"
+    | "remote-rm"
+    | "publish"
+    | "revoke"
+    | "quarantine"
+    | "unquarantine";
   readonly regName?: string;
   readonly regVersion?: string;
   readonly regUrl?: string;
@@ -143,7 +168,17 @@ interface DepsArgs {
   readonly namespace: string;
 }
 
-type ParsedArgs = ListArgs | HelpArgs | InstallArgs | VerifyArgs | KeygenArgs | SignArgs | TrustArgs | RegistryArgs | UpdateArgs | DepsArgs;
+type ParsedArgs =
+  | ListArgs
+  | HelpArgs
+  | InstallArgs
+  | VerifyArgs
+  | KeygenArgs
+  | SignArgs
+  | TrustArgs
+  | RegistryArgs
+  | UpdateArgs
+  | DepsArgs;
 
 interface ArgError {
   readonly error: string;
@@ -163,7 +198,8 @@ function preflightGraph(order: AcePackage[]): string | null {
     if (!phr.ok) return `invalid-package in ${node.manifest.name}: ${phr.reason}`;
     const ph = phr.hash;
     const prior = byStoreKey.get(node.manifest.content_hash);
-    if (prior !== undefined && prior !== ph) return `store-collision — ${node.manifest.name} shares a content_hash store key with a different package`;
+    if (prior !== undefined && prior !== ph)
+      return `store-collision — ${node.manifest.name} shares a content_hash store key with a different package`;
     byStoreKey.set(node.manifest.content_hash, ph);
   }
   return null;
@@ -245,14 +281,18 @@ export function parseArgs(argv: readonly string[]): ParsedArgs | ArgError {
     const sub = argv[1];
     if (sub === "list") return { command: "registry", sub: "list" };
     if (sub === "add") {
-      const name = argv[2], version = argv[3], url = argv[4];
+      const name = argv[2],
+        version = argv[3],
+        url = argv[4];
       if (!name || !version || !url || name.startsWith("-") || version.startsWith("-") || url.startsWith("-")) {
         return { error: "registry add requires <name> <version> <url>" };
       }
       let hash: string | undefined;
       for (let i = 5; i < argv.length; i++) {
-        if (argv[i] === "--hash") { hash = argv[++i]; if (!hash || hash.startsWith("-")) return { error: "--hash requires a value" }; }
-        else return { error: `Unknown option for registry add: ${argv[i]}` };
+        if (argv[i] === "--hash") {
+          hash = argv[++i];
+          if (!hash || hash.startsWith("-")) return { error: "--hash requires a value" };
+        } else return { error: `Unknown option for registry add: ${argv[i]}` };
       }
       const result: RegistryArgs = { command: "registry", sub: "add", regName: name, regVersion: version, regUrl: url };
       if (hash !== undefined) return { ...result, regHash: hash };
@@ -269,11 +309,18 @@ export function parseArgs(argv: readonly string[]): ParsedArgs | ArgError {
       if (action === "add") {
         const url = argv[3];
         if (!url || url.startsWith("-")) return { error: "registry remote add requires <url> --key <keyid>" };
-        let key: string | undefined; let msd: number | undefined;
+        let key: string | undefined;
+        let msd: number | undefined;
         for (let i = 4; i < argv.length; i++) {
-          if (argv[i] === "--key") { key = argv[++i]; if (!key || key.startsWith("-")) return { error: "--key requires a value" }; }
-          else if (argv[i] === "--max-staleness-days") { const v = argv[++i]; if (!v || v.startsWith("-")) return { error: "--max-staleness-days requires a value" }; msd = Number(v); if (!Number.isInteger(msd) || msd <= 0) return { error: "--max-staleness-days must be a positive integer" }; }
-          else return { error: `Unknown option for registry remote add: ${argv[i]}` };
+          if (argv[i] === "--key") {
+            key = argv[++i];
+            if (!key || key.startsWith("-")) return { error: "--key requires a value" };
+          } else if (argv[i] === "--max-staleness-days") {
+            const v = argv[++i];
+            if (!v || v.startsWith("-")) return { error: "--max-staleness-days requires a value" };
+            msd = Number(v);
+            if (!Number.isInteger(msd) || msd <= 0) return { error: "--max-staleness-days must be a positive integer" };
+          } else return { error: `Unknown option for registry remote add: ${argv[i]}` };
         }
         if (!key) return { error: "registry remote add requires --key <keyid>" };
         const r: RegistryArgs = { command: "registry", sub: "remote-add", remoteUrl: url, remoteKey: key };
@@ -285,22 +332,35 @@ export function parseArgs(argv: readonly string[]): ParsedArgs | ArgError {
       let dir: string | undefined, base: string | undefined, key: string | undefined, out: string | undefined;
       let seq: number | undefined;
       for (let i = 2; i < argv.length; i++) {
-        if (argv[i] === "--packages") { dir = argv[++i]; if (!dir || dir.startsWith("-")) return { error: "--packages requires a value" }; }
-        else if (argv[i] === "--base-url") { base = argv[++i]; if (!base || base.startsWith("-")) return { error: "--base-url requires a value" }; }
-        else if (argv[i] === "--key") { key = argv[++i]; if (!key || key.startsWith("-")) return { error: "--key requires a value" }; }
-        else if (argv[i] === "--out") { out = argv[++i]; if (!out || out.startsWith("-")) return { error: "--out requires a value" }; }
-        else if (argv[i] === "--sequence") {
+        if (argv[i] === "--packages") {
+          dir = argv[++i];
+          if (!dir || dir.startsWith("-")) return { error: "--packages requires a value" };
+        } else if (argv[i] === "--base-url") {
+          base = argv[++i];
+          if (!base || base.startsWith("-")) return { error: "--base-url requires a value" };
+        } else if (argv[i] === "--key") {
+          key = argv[++i];
+          if (!key || key.startsWith("-")) return { error: "--key requires a value" };
+        } else if (argv[i] === "--out") {
+          out = argv[++i];
+          if (!out || out.startsWith("-")) return { error: "--out requires a value" };
+        } else if (argv[i] === "--sequence") {
           const sv = argv[++i];
           const n = Number(sv);
           if (!sv || !Number.isInteger(n) || n <= 0) return { error: "--sequence requires a positive integer" };
           seq = n;
-        }
-        else return { error: `Unknown option for registry publish: ${argv[i]}` };
+        } else return { error: `Unknown option for registry publish: ${argv[i]}` };
       }
       if (!dir) return { error: "registry publish requires --packages <dir>" };
       if (!base) return { error: "registry publish requires --base-url <url>" };
       if (!key) return { error: "registry publish requires --key <pem-path>" };
-      let r: RegistryArgs = { command: "registry", sub: "publish", pubPackagesDir: dir, pubBaseUrl: base, pubKeyPath: key };
+      let r: RegistryArgs = {
+        command: "registry",
+        sub: "publish",
+        pubPackagesDir: dir,
+        pubBaseUrl: base,
+        pubKeyPath: key,
+      };
       if (out !== undefined) r = { ...r, pubOut: out };
       if (seq !== undefined) r = { ...r, pubSequence: seq };
       return r;
@@ -310,17 +370,23 @@ export function parseArgs(argv: readonly string[]): ParsedArgs | ArgError {
       if (!spec || spec.startsWith("-")) return { error: `registry ${sub} requires <name>@<version>` };
       // split on the LAST '@' so scoped names (rare) survive; both parts must be non-empty.
       const at = spec.lastIndexOf("@");
-      if (at <= 0 || at === spec.length - 1) return { error: `registry ${sub}: <name>@<version> must have a non-empty name and version` };
-      const name = spec.slice(0, at), version = spec.slice(at + 1);
+      if (at <= 0 || at === spec.length - 1)
+        return { error: `registry ${sub}: <name>@<version> must have a non-empty name and version` };
+      const name = spec.slice(0, at),
+        version = spec.slice(at + 1);
       let key: string | undefined, out: string | undefined, reason: string | undefined;
       for (let i = 3; i < argv.length; i++) {
-        if (argv[i] === "--key") { key = argv[++i]; if (!key || key.startsWith("-")) return { error: "--key requires a value" }; }
-        else if (argv[i] === "--out") { out = argv[++i]; if (!out || out.startsWith("-")) return { error: "--out requires a value" }; }
-        else if (argv[i] === "--reason") {
+        if (argv[i] === "--key") {
+          key = argv[++i];
+          if (!key || key.startsWith("-")) return { error: "--key requires a value" };
+        } else if (argv[i] === "--out") {
+          out = argv[++i];
+          if (!out || out.startsWith("-")) return { error: "--out requires a value" };
+        } else if (argv[i] === "--reason") {
           if (sub === "unquarantine") return { error: "registry unquarantine does not take --reason" };
-          reason = argv[++i]; if (reason === undefined || reason.startsWith("-")) return { error: "--reason requires a value" };
-        }
-        else return { error: `Unknown option for registry ${sub}: ${argv[i]}` };
+          reason = argv[++i];
+          if (reason === undefined || reason.startsWith("-")) return { error: "--reason requires a value" };
+        } else return { error: `Unknown option for registry ${sub}: ${argv[i]}` };
       }
       if (!key) return { error: `registry ${sub} requires --key <pem-path>` };
       let r: RegistryArgs = { command: "registry", sub, revName: name, revVersion: version, pubKeyPath: key };
@@ -392,7 +458,17 @@ export function parseArgs(argv: readonly string[]): ParsedArgs | ArgError {
       }
     }
     if (locked && frozen) return { error: "--locked and --frozen are mutually exclusive" };
-    const baseResult: InstallArgs = { command: "install", source, storePath, allowNoSignature, frozen, locked, lockfile: lockfilePath, ...(allowQuarantined ? { allowQuarantined: true } : {}), ...(offline ? { offline: true } : {}) };
+    const baseResult: InstallArgs = {
+      command: "install",
+      source,
+      storePath,
+      allowNoSignature,
+      frozen,
+      locked,
+      lockfile: lockfilePath,
+      ...(allowQuarantined ? { allowQuarantined: true } : {}),
+      ...(offline ? { offline: true } : {}),
+    };
     if (printResolution) return { ...baseResult, printResolution: true };
     return baseResult;
   }
@@ -476,7 +552,15 @@ export function parseArgs(argv: readonly string[]): ParsedArgs | ArgError {
     if (!graphPath) return { error: "deps requires --graph <path>" };
     if (sub === "resolve" && !outDir) return { error: "deps resolve requires --out-dir <dir>" };
 
-    return { command: "deps", sub, graphPath, outDir, outputEngine, chartsDir, namespace };
+    return {
+      command: "deps",
+      sub,
+      graphPath,
+      outputEngine,
+      namespace,
+      ...(outDir === undefined ? {} : { outDir }),
+      ...(chartsDir === undefined ? {} : { chartsDir }),
+    };
   }
 
   const known = ["remove", "inspect"];
@@ -557,13 +641,18 @@ function writeManifestDir(outDir: string, files: Record<string, unknown>): void 
  *  reachable trusted registry has marked a locked pin). Returns an error string or null. */
 async function checkLockedMarks(
   pins: ReadonlyArray<{ name: string; version: string }>,
-  allowQuarantined: boolean, offline: boolean,
+  allowQuarantined: boolean,
+  offline: boolean,
 ): Promise<string | null> {
-  let revoked: RevocationMap; let quarantined: RevocationMap;
+  let revoked: RevocationMap;
+  let quarantined: RevocationMap;
   try {
     const loaded = await loadRegistries({ trustStore: loadTrustStore(), offline });
-    revoked = loaded.revoked; quarantined = loaded.quarantined;
-  } catch { return null; } // marks unavailable → no veto (preserve frozen registry-independence)
+    revoked = loaded.revoked;
+    quarantined = loaded.quarantined;
+  } catch {
+    return null;
+  } // marks unavailable → no veto (preserve frozen registry-independence)
   for (const pin of pins) {
     if (revoked[pin.name]?.[pin.version] !== undefined) {
       const r = revoked[pin.name]![pin.version]!;
@@ -605,7 +694,9 @@ export async function main(argv: readonly string[]): Promise<number> {
       writeFileSync(keyPath, kp.privatePem, { mode: 0o600, flag: "wx" });
     } catch (e) {
       if ((e as NodeJS.ErrnoException).code === "EEXIST") {
-        console.error(`ace: keygen refused: ${keyPath} already exists — remove it or choose a different --out (refusing to overwrite a private key)`);
+        console.error(
+          `ace: keygen refused: ${keyPath} already exists — remove it or choose a different --out (refusing to overwrite a private key)`,
+        );
         return 1;
       }
       throw e;
@@ -613,24 +704,39 @@ export async function main(argv: readonly string[]): Promise<number> {
     // Belt-and-suspenders: force 0o600 even if the platform ignored mode-on-create.
     chmodSync(keyPath, 0o600);
     // Only write .pub after .key exclusive-create succeeds.
-    writeFileSync(`${parsed.outPrefix}.pub`, JSON.stringify({ algo: "ed25519", key_id: kp.keyId, public_key: kp.publicSpkiB64 }, null, 2));
-    console.log(`ace: wrote ${parsed.outPrefix}.key (0600) + ${parsed.outPrefix}.pub  key_id ${kp.keyId} — share ${parsed.outPrefix}.pub with consumers; keep ${parsed.outPrefix}.key private`);
+    writeFileSync(
+      `${parsed.outPrefix}.pub`,
+      JSON.stringify({ algo: "ed25519", key_id: kp.keyId, public_key: kp.publicSpkiB64 }, null, 2),
+    );
+    console.log(
+      `ace: wrote ${parsed.outPrefix}.key (0600) + ${parsed.outPrefix}.pub  key_id ${kp.keyId} — share ${parsed.outPrefix}.pub with consumers; keep ${parsed.outPrefix}.key private`,
+    );
     return 0;
   }
 
   // sign — recompute content_hash with the SLICE-2 contentHash (never sort files); refuse on mismatch
   if (parsed.command === "sign") {
     let pkg: AcePackage;
-    try { pkg = JSON.parse(readFileSync(parsed.pkgPath, "utf8")) as AcePackage; }
-    catch { console.error("ace: package is not valid JSON"); return 65; }
+    try {
+      pkg = JSON.parse(readFileSync(parsed.pkgPath, "utf8")) as AcePackage;
+    } catch {
+      console.error("ace: package is not valid JSON");
+      return 65;
+    }
     const recomputed = contentHash(new TextEncoder().encode(JSON.stringify(pkg.files)));
     if (recomputed !== pkg.manifest.content_hash) {
-      console.error(`ace: sign refused: package content changed since its content_hash was computed — rebuild the package, then sign`);
+      console.error(
+        `ace: sign refused: package content changed since its content_hash was computed — rebuild the package, then sign`,
+      );
       return 1;
     }
     let priv: string;
-    try { priv = readFileSync(parsed.keyPath, "utf8"); }
-    catch { console.error(`ace: cannot read key ${parsed.keyPath}`); return 1; }
+    try {
+      priv = readFileSync(parsed.keyPath, "utf8");
+    } catch {
+      console.error(`ace: cannot read key ${parsed.keyPath}`);
+      return 1;
+    }
     const signature = signManifest(pkg.manifest, priv);
     const signed = { ...pkg, manifest: { ...pkg.manifest, signature } };
     const out = JSON.stringify(signed, null, 2);
@@ -638,7 +744,9 @@ export async function main(argv: readonly string[]): Promise<number> {
       writeFileSync(parsed.outPath, out);
       console.log(`ace: signed -> ${parsed.outPath} (key_id ${signature.key_id})`);
     } else {
-      process.stderr.write(`ace: signed (key_id ${signature.key_id}) — redirect stdout to a file, or use --out <file>\n`);
+      process.stderr.write(
+        `ace: signed (key_id ${signature.key_id}) — redirect stdout to a file, or use --out <file>\n`,
+      );
       console.log(out);
     }
     return 0;
@@ -648,12 +756,18 @@ export async function main(argv: readonly string[]): Promise<number> {
   if (parsed.command === "trust") {
     if (parsed.sub === "list") {
       const rows = listTrustedKeys();
-      if (rows.length === 0) { console.log("No trusted keys. (add one: ace trust add <pub>)"); return 0; }
+      if (rows.length === 0) {
+        console.log("No trusted keys. (add one: ace trust add <pub>)");
+        return 0;
+      }
       for (const r of rows) console.log(`  ${r.key_id}  [${r.source}]${r.label ? "  " + r.label : ""}`);
       return 0;
     }
     // add: arg is a .pub file path OR a raw base64 SPKI
-    if (!parsed.arg) { console.error("ace: trust add requires a <pubkey-file-or-b64>"); return 64; }
+    if (!parsed.arg) {
+      console.error("ace: trust add requires a <pubkey-file-or-b64>");
+      return 64;
+    }
     let publicB64: string;
     let inputForm: string;
     try {
@@ -674,7 +788,9 @@ export async function main(argv: readonly string[]): Promise<number> {
       if (der.length < 32) throw new Error("too short");
       const pub = createPublicKey({ key: der, format: "der", type: "spki" });
       if (pub.asymmetricKeyType !== "ed25519") {
-        console.error(`ace: trust add: not an Ed25519 public key (got ${pub.asymmetricKeyType ?? "unknown"}) — only Ed25519 keys are accepted`);
+        console.error(
+          `ace: trust add: not an Ed25519 public key (got ${pub.asymmetricKeyType ?? "unknown"}) — only Ed25519 keys are accepted`,
+        );
         return 65;
       }
       // Normalize to the canonical SPKI: createPublicKey accepts an SPKI with trailing
@@ -684,14 +800,20 @@ export async function main(argv: readonly string[]): Promise<number> {
       // key_id no signature ever presents -> that publisher's packages never authenticate.
       canonicalB64 = (pub.export({ type: "spki", format: "der" }) as Buffer).toString("base64");
     } catch {
-      console.error("ace: trust add: invalid Ed25519 public key (not a valid SPKI DER) -- check the .pub file or b64 string");
+      console.error(
+        "ace: trust add: invalid Ed25519 public key (not a valid SPKI DER) -- check the .pub file or b64 string",
+      );
       return 65;
     }
     const kid = keyId(canonicalB64);
     const entry: { key_id: string; public_key: string; label?: string } = { key_id: kid, public_key: canonicalB64 };
     if (parsed.label !== undefined) entry.label = parsed.label;
     const res = addTrustedKey(entry);
-    console.log(res.added ? `ace: trusted ${kid}${parsed.label ? " (" + parsed.label + ")" : ""} [${inputForm}]` : `ace: ${kid} already trusted`);
+    console.log(
+      res.added
+        ? `ace: trusted ${kid}${parsed.label ? " (" + parsed.label + ")" : ""} [${inputForm}]`
+        : `ace: ${kid} already trusted`,
+    );
     return 0;
   }
 
@@ -699,8 +821,14 @@ export async function main(argv: readonly string[]): Promise<number> {
   if (parsed.command === "registry") {
     if (parsed.sub === "remote-list") {
       const remotes = readRegistriesConfig().remotes;
-      if (remotes.length === 0) { console.log("No remote registries. (add: ace registry remote add <url> --key <keyid>)"); return 0; }
-      for (const r of remotes) console.log(`  ${r.url}  key=${r.key_id}${r.max_staleness_days ? `  max-staleness=${r.max_staleness_days}d` : ""}`);
+      if (remotes.length === 0) {
+        console.log("No remote registries. (add: ace registry remote add <url> --key <keyid>)");
+        return 0;
+      }
+      for (const r of remotes)
+        console.log(
+          `  ${r.url}  key=${r.key_id}${r.max_staleness_days ? `  max-staleness=${r.max_staleness_days}d` : ""}`,
+        );
       return 0;
     }
     if (parsed.sub === "remote-rm") {
@@ -709,56 +837,98 @@ export async function main(argv: readonly string[]): Promise<number> {
       return 0;
     }
     if (parsed.sub === "remote-add") {
-      const entry = parsed.remoteMaxStaleness !== undefined
-        ? { url: parsed.remoteUrl!, key_id: parsed.remoteKey!, max_staleness_days: parsed.remoteMaxStaleness }
-        : { url: parsed.remoteUrl!, key_id: parsed.remoteKey! };
+      const entry =
+        parsed.remoteMaxStaleness !== undefined
+          ? { url: parsed.remoteUrl!, key_id: parsed.remoteKey!, max_staleness_days: parsed.remoteMaxStaleness }
+          : { url: parsed.remoteUrl!, key_id: parsed.remoteKey! };
       const { added, updated } = writeRegistryRemote(entry);
       console.log(`ace: ${updated ? "updated" : added ? "added" : "noop"} remote ${parsed.remoteUrl}`);
       return 0;
     }
     if (parsed.sub === "list") {
       const rows = listRegistry();
-      if (rows.length === 0) { console.log("No registry entries. (add one: ace registry add <name> <version> <url>)"); return 0; }
+      if (rows.length === 0) {
+        console.log("No registry entries. (add one: ace registry add <name> <version> <url>)");
+        return 0;
+      }
       for (const r of rows) console.log(`  ${r.name}@${r.version}  ${r.url}  [${r.source}]`);
       return 0;
     }
     if (parsed.sub === "publish") {
       let pem: string;
-      try { pem = readFileSync(parsed.pubKeyPath!, "utf8"); }
-      catch (e) { console.error(`ace: publish: cannot read key ${parsed.pubKeyPath}: ${(e as Error).message}`); return 1; }
+      try {
+        pem = readFileSync(parsed.pubKeyPath!, "utf8");
+      } catch (e) {
+        console.error(`ace: publish: cannot read key ${parsed.pubKeyPath}: ${(e as Error).message}`);
+        return 1;
+      }
       // P2-A: signIndex uses crypto.sign(null, ...) which only supports Ed25519/Ed448 — an RSA/EC key
       // THROWS rather than signing. Pre-check here to fail fast with a clear error before building the index.
       try {
         if (createPrivateKey(pem).asymmetricKeyType !== "ed25519") {
-          console.error("ace: publish refused: --key must be an ed25519 private key"); return 1;
+          console.error("ace: publish refused: --key must be an ed25519 private key");
+          return 1;
         }
-      } catch (e) { console.error(`ace: publish refused: invalid private key: ${(e as Error).message}`); return 1; }
-      const dirs = parsed.pubPackagesDir!.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
-      if (dirs.length === 0) { console.error("ace: publish refused: --packages requires at least one directory"); return 1; }
+      } catch (e) {
+        console.error(`ace: publish refused: invalid private key: ${(e as Error).message}`);
+        return 1;
+      }
+      const dirs = parsed
+        .pubPackagesDir!.split(",")
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+      if (dirs.length === 0) {
+        console.error("ace: publish refused: --packages requires at least one directory");
+        return 1;
+      }
       const packages: { pkg: AcePackage; url?: string }[] = [];
       for (const d of dirs) {
         let entries: string[];
-        try { entries = readdirSync(d).filter((f) => f.endsWith(".json")); }
-        catch (e) { console.error(`ace: publish: cannot read dir ${d}: ${(e as Error).message}`); return 1; }
+        try {
+          entries = readdirSync(d).filter((f) => f.endsWith(".json"));
+        } catch (e) {
+          console.error(`ace: publish: cannot read dir ${d}: ${(e as Error).message}`);
+          return 1;
+        }
         for (const f of entries) {
           const full = join(d, f);
           let raw: string;
-          try { raw = readFileSync(full, "utf8"); } catch { console.error(`ace: publish: skip unreadable ${f}`); continue; }
+          try {
+            raw = readFileSync(full, "utf8");
+          } catch {
+            console.error(`ace: publish: skip unreadable ${f}`);
+            continue;
+          }
           let obj: unknown;
-          try { obj = JSON.parse(raw); } catch { console.error(`ace: publish: skip non-JSON ${f}`); continue; }
-          if (typeof obj !== "object" || obj === null || typeof (obj as AcePackage).manifest !== "object" || (obj as AcePackage).manifest === null
-            || typeof (obj as AcePackage).manifest.name !== "string" || typeof (obj as AcePackage).manifest.version !== "string"
-            || typeof (obj as AcePackage).files !== "object" || (obj as AcePackage).files === null) {
-            console.error(`ace: publish: skip non-package ${f}`); continue;
+          try {
+            obj = JSON.parse(raw);
+          } catch {
+            console.error(`ace: publish: skip non-JSON ${f}`);
+            continue;
+          }
+          if (
+            typeof obj !== "object" ||
+            obj === null ||
+            typeof (obj as AcePackage).manifest !== "object" ||
+            (obj as AcePackage).manifest === null ||
+            typeof (obj as AcePackage).manifest.name !== "string" ||
+            typeof (obj as AcePackage).manifest.version !== "string" ||
+            typeof (obj as AcePackage).files !== "object" ||
+            (obj as AcePackage).files === null
+          ) {
+            console.error(`ace: publish: skip non-package ${f}`);
+            continue;
           }
           // P2-C: a package whose content_hash is missing or does not match its files would be indexed
           // but fail the consumer's content-hash gate. Skip + warn (consistent with the non-package skip).
           if (typeof (obj as AcePackage).manifest.content_hash !== "string") {
-            console.error(`ace: publish: skip ${f} — missing manifest.content_hash`); continue;
+            console.error(`ace: publish: skip ${f} — missing manifest.content_hash`);
+            continue;
           }
           const fh = contentHash(new TextEncoder().encode(JSON.stringify((obj as AcePackage).files)));
           if (fh !== (obj as AcePackage).manifest.content_hash) {
-            console.error(`ace: publish: skip ${f} — content_hash does not match files`); continue;
+            console.error(`ace: publish: skip ${f} — content_hash does not match files`);
+            continue;
           }
           // Optional top-level url override (publish-only, outside the signed manifest). When present
           // it sets the consumer URL directly and relaxes the <name>-<version>.json filename guard for
@@ -766,27 +936,40 @@ export async function main(argv: readonly string[]): Promise<number> {
           let urlOverride: string | undefined;
           const rawUrl = (obj as { url?: unknown }).url;
           if (rawUrl !== undefined) {
-            if (typeof rawUrl !== "string" || rawUrl.length === 0) { console.error(`ace: publish: skip ${f} — url must be a non-empty string`); continue; }
-            try { new URL(rawUrl); } catch { console.error(`ace: publish: skip ${f} — url is not an absolute URL: ${rawUrl}`); continue; }
+            if (typeof rawUrl !== "string" || rawUrl.length === 0) {
+              console.error(`ace: publish: skip ${f} — url must be a non-empty string`);
+              continue;
+            }
+            try {
+              new URL(rawUrl);
+            } catch {
+              console.error(`ace: publish: skip ${f} — url is not an absolute URL: ${rawUrl}`);
+              continue;
+            }
             urlOverride = rawUrl;
           }
           // filename guard applies ONLY when there is no url override (the derived URL depends on the basename)
           if (urlOverride === undefined) {
             const expectedFile = `${(obj as AcePackage).manifest.name}-${(obj as AcePackage).manifest.version}.json`;
             if (f !== expectedFile) {
-              console.error(`ace: publish: skip ${f} — filename must be ${expectedFile} to match its derived consumer URL`); continue;
+              console.error(
+                `ace: publish: skip ${f} — filename must be ${expectedFile} to match its derived consumer URL`,
+              );
+              continue;
             }
           }
           const deps = (obj as AcePackage).manifest.dependencies;
           if (deps !== undefined && !Array.isArray(deps)) {
-            console.error(`ace: publish: skip ${f} — manifest.dependencies must be an array`); continue;
+            console.error(`ace: publish: skip ${f} — manifest.dependencies must be an array`);
+            continue;
           }
           // P2: every files value must be a string — installPackage's writeFileSync(dest, contents)
           // throws on non-string values, so a self-verified index could point at an un-installable
           // package. Skip + warn (consistent with the other scan skips).
           const fileVals = Object.values((obj as AcePackage).files as Record<string, unknown>);
           if (fileVals.some((v) => typeof v !== "string")) {
-            console.error(`ace: publish: skip ${f} — every file value must be a string`); continue;
+            console.error(`ace: publish: skip ${f} — every file value must be a string`);
+            continue;
           }
           // P2: package name/version must be URL-safe — the derived consumer URL is
           // <base>/<name>-<version>.json, so a '#' or '?' (or path sep / control char) would break or
@@ -794,85 +977,173 @@ export async function main(argv: readonly string[]): Promise<number> {
           const nm = (obj as AcePackage).manifest.name;
           const ver = (obj as AcePackage).manifest.version;
           if (/[\x00-\x20#?%/\\]/.test(nm) || /[\x00-\x20#?%/\\]/.test(ver)) {
-            console.error(`ace: publish: skip ${f} — name/version has a URL-unsafe character`); continue;
+            console.error(`ace: publish: skip ${f} — name/version has a URL-unsafe character`);
+            continue;
           }
           // P2: dependency edges must be well-formed (matching the consumer's AceDependency shape),
           // else a consumer resolve would break on a self-verified index.
           const depEdges = (obj as AcePackage).manifest.dependencies;
           if (Array.isArray(depEdges) && !depEdges.every(isValidDepEdge)) {
-            console.error(`ace: publish: skip ${f} — malformed dependency edge`); continue;
+            console.error(`ace: publish: skip ${f} — malformed dependency edge`);
+            continue;
           }
           // P2: reuse the consumer's path guard — a package with an unsafe files key (../ or absolute)
           // would index but be rejected/unsafe at install. Skip + warn.
           const unsafePath = validatePackagePaths(obj as AcePackage);
           if (unsafePath !== null) {
-            console.error(`ace: publish: skip ${f} — unsafe file path: ${unsafePath}`); continue;
+            console.error(`ace: publish: skip ${f} — unsafe file path: ${unsafePath}`);
+            continue;
           }
-          packages.push(urlOverride !== undefined ? { pkg: obj as AcePackage, url: urlOverride } : { pkg: obj as AcePackage });
+          packages.push(
+            urlOverride !== undefined ? { pkg: obj as AcePackage, url: urlOverride } : { pkg: obj as AcePackage },
+          );
         }
       }
-      if (packages.length === 0) { console.error(`ace: publish refused: no valid packages in ${dirs.join(", ")}`); return 1; }
+      if (packages.length === 0) {
+        console.error(`ace: publish refused: no valid packages in ${dirs.join(", ")}`);
+        return 1;
+      }
       const outPath = parsed.pubOut ?? "index.json";
       let prev: IndexDoc | null = null;
       if (existsSync(outPath)) {
         let prevRaw: string;
-        try { prevRaw = readFileSync(outPath, "utf8"); }
-        catch (e) { console.error(`ace: publish refused: cannot read existing ${outPath}: ${(e as Error).message}`); return 1; }
+        try {
+          prevRaw = readFileSync(outPath, "utf8");
+        } catch (e) {
+          console.error(`ace: publish refused: cannot read existing ${outPath}: ${(e as Error).message}`);
+          return 1;
+        }
         const p = parseIndex(prevRaw);
-        if ("error" in p) { console.error(`ace: publish refused: existing ${outPath} is not a valid index (${p.error}) — refusing to reset sequence (would look like a rollback to consumers); remove or fix it`); return 1; }
+        if ("error" in p) {
+          console.error(
+            `ace: publish refused: existing ${outPath} is not a valid index (${p.error}) — refusing to reset sequence (would look like a rollback to consumers); remove or fix it`,
+          );
+          return 1;
+        }
         const prevInfo = publicKeyInfoFromPrivatePem(pem);
         const { signature: prevSig, ...prevContent } = p;
-        const prevVerify = verifyIndexSignature(prevContent, prevSig, new Map([[prevInfo.keyId, { public_key: prevInfo.public_key }]]));
-        if (!prevVerify.ok) { console.error(`ace: publish refused: existing ${outPath} signature does not verify under --key (${prevVerify.reason}) — refusing to auto-bump from an untrusted index; fix or remove it`); return 1; }
+        const prevVerify = verifyIndexSignature(
+          prevContent,
+          prevSig,
+          new Map([[prevInfo.keyId, { public_key: prevInfo.public_key }]]),
+        );
+        if (!prevVerify.ok) {
+          console.error(
+            `ace: publish refused: existing ${outPath} signature does not verify under --key (${prevVerify.reason}) — refusing to auto-bump from an untrusted index; fix or remove it`,
+          );
+          return 1;
+        }
         prev = p;
       }
       const seq = parsed.pubSequence ?? nextSequence(prev);
       // Anti-rollback guard (defense-in-depth): unreachable while sequence is auto-bumped (+1),
       // but protects the deferred explicit --sequence flag from emitting a non-increasing index.
-      if (prev && seq <= prev.sequence) { console.error(`ace: publish refused: sequence ${seq} <= prev ${prev.sequence}`); return 1; }
+      if (prev && seq <= prev.sequence) {
+        console.error(`ace: publish refused: sequence ${seq} <= prev ${prev.sequence}`);
+        return 1;
+      }
       let serialized: string;
       try {
-        const doc = buildIndexDoc({ packages, baseUrl: parsed.pubBaseUrl!, sequence: seq, issuedAt: new Date().toISOString(), privatePem: pem, ...(prev?.revoked ? { revoked: prev.revoked } : {}), ...(prev?.quarantined ? { quarantined: prev.quarantined } : {}) });
-        if ("error" in doc) { console.error(`ace: publish refused: ${doc.error}`); return 1; }
+        const doc = buildIndexDoc({
+          packages,
+          baseUrl: parsed.pubBaseUrl!,
+          sequence: seq,
+          issuedAt: new Date().toISOString(),
+          privatePem: pem,
+          ...(prev?.revoked ? { revoked: prev.revoked } : {}),
+          ...(prev?.quarantined ? { quarantined: prev.quarantined } : {}),
+        });
+        if ("error" in doc) {
+          console.error(`ace: publish refused: ${doc.error}`);
+          return 1;
+        }
         serialized = JSON.stringify(doc, null, 2);
         const reparsed = parseIndex(serialized);
-        if ("error" in reparsed) { console.error(`ace: publish refused: self-verify parse failed: ${reparsed.error}`); return 1; }
+        if ("error" in reparsed) {
+          console.error(`ace: publish refused: self-verify parse failed: ${reparsed.error}`);
+          return 1;
+        }
         const info = publicKeyInfoFromPrivatePem(pem);
         const { signature, ...content } = doc;
         const sv = verifyIndexSignature(content, signature, new Map([[info.keyId, { public_key: info.public_key }]]));
-        if (!sv.ok) { console.error(`ace: publish refused: self-verify signature failed: ${sv.reason}`); return 1; }
-      } catch (e) { console.error(`ace: publish refused: signing failed (check --key is a valid Ed25519 PEM): ${(e as Error).message}`); return 1; }
-      try { writeFileSync(outPath, serialized); }
-      catch (e) { console.error(`ace: publish failed: cannot write ${outPath}: ${(e as Error).message}`); return 1; }
+        if (!sv.ok) {
+          console.error(`ace: publish refused: self-verify signature failed: ${sv.reason}`);
+          return 1;
+        }
+      } catch (e) {
+        console.error(
+          `ace: publish refused: signing failed (check --key is a valid Ed25519 PEM): ${(e as Error).message}`,
+        );
+        return 1;
+      }
+      try {
+        writeFileSync(outPath, serialized);
+      } catch (e) {
+        console.error(`ace: publish failed: cannot write ${outPath}: ${(e as Error).message}`);
+        return 1;
+      }
       console.log(`ace: published ${packages.length} package(s) at sequence ${seq} → ${outPath}`);
       return 0;
     }
     if (parsed.sub === "revoke" || parsed.sub === "quarantine" || parsed.sub === "unquarantine") {
       const verb = parsed.sub;
       let pem: string;
-      try { pem = readFileSync(parsed.pubKeyPath!, "utf8"); }
-      catch (e) { console.error(`ace: ${verb}: cannot read key ${parsed.pubKeyPath}: ${(e as Error).message}`); return 1; }
       try {
-        if (createPrivateKey(pem).asymmetricKeyType !== "ed25519") { console.error(`ace: ${verb} refused: --key must be an ed25519 private key`); return 1; }
-      } catch (e) { console.error(`ace: ${verb} refused: invalid private key: ${(e as Error).message}`); return 1; }
+        pem = readFileSync(parsed.pubKeyPath!, "utf8");
+      } catch (e) {
+        console.error(`ace: ${verb}: cannot read key ${parsed.pubKeyPath}: ${(e as Error).message}`);
+        return 1;
+      }
+      try {
+        if (createPrivateKey(pem).asymmetricKeyType !== "ed25519") {
+          console.error(`ace: ${verb} refused: --key must be an ed25519 private key`);
+          return 1;
+        }
+      } catch (e) {
+        console.error(`ace: ${verb} refused: invalid private key: ${(e as Error).message}`);
+        return 1;
+      }
       const outPath = parsed.pubOut ?? "index.json";
-      if (!existsSync(outPath)) { console.error(`ace: ${verb} refused: ${outPath} does not exist — cannot mark a version in a nonexistent index`); return 1; }
+      if (!existsSync(outPath)) {
+        console.error(`ace: ${verb} refused: ${outPath} does not exist — cannot mark a version in a nonexistent index`);
+        return 1;
+      }
       let prevRaw: string;
-      try { prevRaw = readFileSync(outPath, "utf8"); }
-      catch (e) { console.error(`ace: ${verb} refused: cannot read ${outPath}: ${(e as Error).message}`); return 1; }
+      try {
+        prevRaw = readFileSync(outPath, "utf8");
+      } catch (e) {
+        console.error(`ace: ${verb} refused: cannot read ${outPath}: ${(e as Error).message}`);
+        return 1;
+      }
       const p = parseIndex(prevRaw);
-      if ("error" in p) { console.error(`ace: ${verb} refused: ${outPath} is not a valid index (${p.error}) — no silent reset`); return 1; }
+      if ("error" in p) {
+        console.error(`ace: ${verb} refused: ${outPath} is not a valid index (${p.error}) — no silent reset`);
+        return 1;
+      }
       const prevInfo = publicKeyInfoFromPrivatePem(pem);
       const { signature: prevSig, ...prevContent } = p;
-      const prevVerify = verifyIndexSignature(prevContent, prevSig, new Map([[prevInfo.keyId, { public_key: prevInfo.public_key }]]));
-      if (!prevVerify.ok) { console.error(`ace: ${verb} refused: ${outPath} signature does not verify under --key (${prevVerify.reason}) — not your index`); return 1; }
-      const name = parsed.revName!, version = parsed.revVersion!;
+      const prevVerify = verifyIndexSignature(
+        prevContent,
+        prevSig,
+        new Map([[prevInfo.keyId, { public_key: prevInfo.public_key }]]),
+      );
+      if (!prevVerify.ok) {
+        console.error(
+          `ace: ${verb} refused: ${outPath} signature does not verify under --key (${prevVerify.reason}) — not your index`,
+        );
+        return 1;
+      }
+      const name = parsed.revName!,
+        version = parsed.revVersion!;
       const at = new Date().toISOString();
       let next: IndexSignableContent | { error: string };
       if (verb === "revoke") next = applyRevoke(prevContent, name, version, parsed.revReason, at);
       else if (verb === "quarantine") next = applyQuarantine(prevContent, name, version, parsed.revReason, at);
       else next = applyUnquarantine(prevContent, name, version, at);
-      if ("error" in next) { console.error(`ace: ${verb} refused: ${next.error}`); return 1; }
+      if ("error" in next) {
+        console.error(`ace: ${verb} refused: ${next.error}`);
+        return 1;
+      }
       const seq = p.sequence + 1;
       const content: IndexSignableContent = { ...next, sequence: seq };
       let serialized: string;
@@ -881,12 +1152,25 @@ export async function main(argv: readonly string[]): Promise<number> {
         const doc = { ...content, signature: sig };
         serialized = JSON.stringify(doc, null, 2);
         const reparsed = parseIndex(serialized);
-        if ("error" in reparsed) { console.error(`ace: ${verb} refused: self-verify parse failed: ${reparsed.error}`); return 1; }
+        if ("error" in reparsed) {
+          console.error(`ace: ${verb} refused: self-verify parse failed: ${reparsed.error}`);
+          return 1;
+        }
         const sv = verifyIndexSignature(content, sig, new Map([[prevInfo.keyId, { public_key: prevInfo.public_key }]]));
-        if (!sv.ok) { console.error(`ace: ${verb} refused: self-verify signature failed: ${sv.reason}`); return 1; }
-      } catch (e) { console.error(`ace: ${verb} refused: signing failed: ${(e as Error).message}`); return 1; }
-      try { writeFileSync(outPath, serialized); }
-      catch (e) { console.error(`ace: ${verb} failed: cannot write ${outPath}: ${(e as Error).message}`); return 1; }
+        if (!sv.ok) {
+          console.error(`ace: ${verb} refused: self-verify signature failed: ${sv.reason}`);
+          return 1;
+        }
+      } catch (e) {
+        console.error(`ace: ${verb} refused: signing failed: ${(e as Error).message}`);
+        return 1;
+      }
+      try {
+        writeFileSync(outPath, serialized);
+      } catch (e) {
+        console.error(`ace: ${verb} failed: cannot write ${outPath}: ${(e as Error).message}`);
+        return 1;
+      }
       const verbed = verb === "revoke" ? "revoked" : verb === "quarantine" ? "quarantined" : "unquarantined";
       console.log(`ace: ${verbed} ${name}@${version} → ${outPath} (sequence ${seq})`);
       return 0;
@@ -900,35 +1184,56 @@ export async function main(argv: readonly string[]): Promise<number> {
     if (pkgHash === undefined) {
       let raw: string;
       try {
-        raw = isHttp
-          ? await (await fetch(parsed.regUrl!)).text()
-          : readFileSync(storedUrl, "utf8");
+        raw = isHttp ? await (await fetch(parsed.regUrl!)).text() : readFileSync(storedUrl, "utf8");
       } catch (e) {
         console.error(`ace: registry add: fetch/read failed: ${(e as Error).message}`);
         return 1;
       }
       let pkg: AcePackage;
-      try { pkg = JSON.parse(raw) as AcePackage; } catch { console.error("ace: registry add: package is not valid JSON"); return 65; }
+      try {
+        pkg = JSON.parse(raw) as AcePackage;
+      } catch {
+        console.error("ace: registry add: package is not valid JSON");
+        return 65;
+      }
       // Shape guard before hashing: a parseable-but-malformed package (missing manifest/files)
       // is refused here for SHAPE; a malformed field VALUE (float / lone surrogate) still throws
       // in packageHash, so safePackageHash below maps that to a clean exit. Also verify the
       // package identity matches the CLI name/version so a package cannot be registered under the
       // wrong name (mirrors the resolver declared-identity check, caught here at add-time).
       const pm = pkg as { manifest?: { name?: unknown; version?: unknown }; files?: unknown };
-      if (typeof pkg !== "object" || pkg === null || typeof pm.manifest !== "object" || pm.manifest === null || typeof pm.files !== "object" || pm.files === null) {
+      if (
+        typeof pkg !== "object" ||
+        pkg === null ||
+        typeof pm.manifest !== "object" ||
+        pm.manifest === null ||
+        typeof pm.files !== "object" ||
+        pm.files === null
+      ) {
         console.error("ace: registry add: package is not a well-formed AcePackage (missing manifest/files)");
         return 65;
       }
       if (pm.manifest.name !== parsed.regName || pm.manifest.version !== parsed.regVersion) {
-        console.error(`ace: registry add: package identity ${String(pm.manifest.name)}@${String(pm.manifest.version)} != ${parsed.regName}@${parsed.regVersion}`);
+        console.error(
+          `ace: registry add: package identity ${String(pm.manifest.name)}@${String(pm.manifest.version)} != ${parsed.regName}@${parsed.regVersion}`,
+        );
         return 65;
       }
       const phr = safePackageHash(pkg);
-      if (!phr.ok) { console.error(`ace: registry add: invalid package — ${phr.reason}`); return 65; }
+      if (!phr.ok) {
+        console.error(`ace: registry add: invalid package — ${phr.reason}`);
+        return 65;
+      }
       pkgHash = phr.hash;
     }
     const res = addRegistryEntry(parsed.regName!, parsed.regVersion!, { url: storedUrl, package_hash: pkgHash });
-    console.log(res.added ? `ace: registered ${parsed.regName}@${parsed.regVersion}` : res.updated ? `ace: updated ${parsed.regName}@${parsed.regVersion} (corrected url/hash)` : `ace: ${parsed.regName}@${parsed.regVersion} already registered (identical)`);
+    console.log(
+      res.added
+        ? `ace: registered ${parsed.regName}@${parsed.regVersion}`
+        : res.updated
+          ? `ace: updated ${parsed.regName}@${parsed.regVersion} (corrected url/hash)`
+          : `ace: ${parsed.regName}@${parsed.regVersion} already registered (identical)`,
+    );
     return 0;
   }
 
@@ -957,22 +1262,49 @@ export async function main(argv: readonly string[]): Promise<number> {
   if (parsed.command === "update") {
     let raw: string;
     try {
-      raw = parsed.source.startsWith("http://") || parsed.source.startsWith("https://")
-        ? await (await fetch(parsed.source)).text() : readFileSync(parsed.source, "utf8");
-    } catch (e) { console.error(`ace: download/read failed: ${(e as Error).message}`); return 1; }
+      raw =
+        parsed.source.startsWith("http://") || parsed.source.startsWith("https://")
+          ? await (await fetch(parsed.source)).text()
+          : readFileSync(parsed.source, "utf8");
+    } catch (e) {
+      console.error(`ace: download/read failed: ${(e as Error).message}`);
+      return 1;
+    }
     let pkg: AcePackage;
-    try { pkg = JSON.parse(raw) as AcePackage; } catch { console.error("ace: package is not valid JSON"); return 65; }
-    if (typeof pkg !== "object" || pkg === null || typeof pkg.manifest !== "object" || pkg.manifest === null || typeof pkg.files !== "object" || pkg.files === null) {
-      console.error("ace: update refused: not a well-formed AcePackage"); return 1;
+    try {
+      pkg = JSON.parse(raw) as AcePackage;
+    } catch {
+      console.error("ace: package is not valid JSON");
+      return 65;
+    }
+    if (
+      typeof pkg !== "object" ||
+      pkg === null ||
+      typeof pkg.manifest !== "object" ||
+      pkg.manifest === null ||
+      typeof pkg.files !== "object" ||
+      pkg.files === null
+    ) {
+      console.error("ace: update refused: not a well-formed AcePackage");
+      return 1;
     }
     // Signature gate (same policy as install): hard-refuse a present-but-invalid signature;
     // no-signature is only overridable with --allow-no-signature.
     const v = verifySignature(pkg.manifest, loadTrustStore());
-    if (!v.ok && v.reason !== "no-signature") { console.error(`ace: update refused: ${v.reason}`); return 1; }
-    if (!v.ok && v.reason === "no-signature" && !parsed.allowNoSignature) { console.error("ace: update refused: unsigned package (use --allow-no-signature)"); return 1; }
+    if (!v.ok && v.reason !== "no-signature") {
+      console.error(`ace: update refused: ${v.reason}`);
+      return 1;
+    }
+    if (!v.ok && v.reason === "no-signature" && !parsed.allowNoSignature) {
+      console.error("ace: update refused: unsigned package (use --allow-no-signature)");
+      return 1;
+    }
     // Root content_hash.
     const rootFilesHash = contentHash(new TextEncoder().encode(JSON.stringify(pkg.files)));
-    if (rootFilesHash !== pkg.manifest.content_hash) { console.error(`ace: update refused: bad-content-hash in ${pkg.manifest.name} (root)`); return 1; }
+    if (rootFilesHash !== pkg.manifest.content_hash) {
+      console.error(`ace: update refused: bad-content-hash in ${pkg.manifest.name} (root)`);
+      return 1;
+    }
     // Root is untrusted: guard a packageHash-throw ONCE before any helper (resolve / buildLockfile /
     // buildLeafLockfile) hashes it, so a malformed root refuses as invalid-package, not ace: fatal:.
     const rootHashCheck = safePackageHash(pkg);
@@ -983,23 +1315,47 @@ export async function main(argv: readonly string[]): Promise<number> {
 
     if (Array.isArray(pkg.manifest.dependencies) && pkg.manifest.dependencies.length > 0) {
       const fetchPackage = async (u: string): Promise<string> =>
-        (u.startsWith("http://") || u.startsWith("https://")) ? await (await fetch(u)).text() : readFileSync(u, "utf8");
+        u.startsWith("http://") || u.startsWith("https://") ? await (await fetch(u)).text() : readFileSync(u, "utf8");
       const { registry, warnings, errors } = await loadRegistries({
-        trustStore: loadTrustStore(), offline: parsed.offline === true,
+        trustStore: loadTrustStore(),
+        offline: parsed.offline === true,
       });
       for (const w of warnings) console.error(`ace: ${w}`);
-      if (errors.length > 0) { for (const e of errors) console.error(`ace: update refused: ${e}`); return 1; }
+      if (errors.length > 0) {
+        for (const e of errors) console.error(`ace: update refused: ${e}`);
+        return 1;
+      }
       const solveResult = await solve(pkg, fetchPackage, registry);
-      if (!solveResult.ok) { console.error(`ace: update refused: ${solveResult.reason} — ${solveResult.detail} (path: ${solveResult.path.join(" → ")})`); return 1; }
-      const res = await resolve(pkg, fetchPackage, loadTrustStore(), registry, solveResult.versions, { allowNoSignature: parsed.allowNoSignature });
-      if (!res.ok) { console.error(`ace: update refused: ${res.reason} — ${res.detail} (path: ${res.path.join(" → ")})`); return 1; }
+      if (!solveResult.ok) {
+        console.error(
+          `ace: update refused: ${solveResult.reason} — ${solveResult.detail} (path: ${solveResult.path.join(" → ")})`,
+        );
+        return 1;
+      }
+      const res = await resolve(pkg, fetchPackage, loadTrustStore(), registry, solveResult.versions, {
+        allowNoSignature: parsed.allowNoSignature,
+      });
+      if (!res.ok) {
+        console.error(`ace: update refused: ${res.reason} — ${res.detail} (path: ${res.path.join(" → ")})`);
+        return 1;
+      }
       // Preflight BEFORE writing — never write a lock the graph install would reject (preflight-before-write per spec #6412, fix-forward #6414).
       const pf = preflightGraph(res.order);
-      if (pf !== null) { console.error(`ace: update refused: ${pf}`); return 1; }
+      if (pf !== null) {
+        console.error(`ace: update refused: ${pf}`);
+        return 1;
+      }
       const lf = buildLockfile(pkg, res.order, registry);
-      if ("error" in lf) { console.error(`ace: update refused: could not build lockfile: ${lf.error}`); return 1; }
-      try { writeFileSync(parsed.lockfile, serializeLockfile(lf)); }
-      catch (e) { console.error(`ace: update failed: could not write lockfile ${parsed.lockfile}: ${(e as Error).message}`); return 1; }
+      if ("error" in lf) {
+        console.error(`ace: update refused: could not build lockfile: ${lf.error}`);
+        return 1;
+      }
+      try {
+        writeFileSync(parsed.lockfile, serializeLockfile(lf));
+      } catch (e) {
+        console.error(`ace: update failed: could not write lockfile ${parsed.lockfile}: ${(e as Error).message}`);
+        return 1;
+      }
       console.log(`ace: wrote lockfile ${parsed.lockfile} (${lf.nodes.length} deps)`);
       return 0;
     }
@@ -1007,9 +1363,16 @@ export async function main(argv: readonly string[]): Promise<number> {
     // commits a lock for a package installPackage/--frozen would reject (parity with the
     // graph path's preflightGraph).
     const leafUnsafe = validatePackagePaths(pkg);
-    if (leafUnsafe !== null) { console.error(`ace: update refused: unsafe file path in ${pkg.manifest.name}: ${leafUnsafe}`); return 1; }
-    try { writeFileSync(parsed.lockfile, serializeLockfile(buildLeafLockfile(pkg))); }
-    catch (e) { console.error(`ace: update failed: could not write lockfile ${parsed.lockfile}: ${(e as Error).message}`); return 1; }
+    if (leafUnsafe !== null) {
+      console.error(`ace: update refused: unsafe file path in ${pkg.manifest.name}: ${leafUnsafe}`);
+      return 1;
+    }
+    try {
+      writeFileSync(parsed.lockfile, serializeLockfile(buildLeafLockfile(pkg)));
+    } catch (e) {
+      console.error(`ace: update failed: could not write lockfile ${parsed.lockfile}: ${(e as Error).message}`);
+      return 1;
+    }
     console.log(`ace: wrote lockfile ${parsed.lockfile} (0 deps)`);
     return 0;
   }
@@ -1017,16 +1380,21 @@ export async function main(argv: readonly string[]): Promise<number> {
   if (parsed.command === "install") {
     let raw: string;
     try {
-      raw = parsed.source.startsWith("http://") || parsed.source.startsWith("https://")
-        ? await (await fetch(parsed.source)).text()
-        : readFileSync(parsed.source, "utf8");
+      raw =
+        parsed.source.startsWith("http://") || parsed.source.startsWith("https://")
+          ? await (await fetch(parsed.source)).text()
+          : readFileSync(parsed.source, "utf8");
     } catch (e) {
       console.error(`ace: download/read failed: ${(e as Error).message}`);
       return 1;
     }
     let pkg: AcePackage;
-    try { pkg = JSON.parse(raw) as AcePackage; }
-    catch { console.error("ace: package is not valid JSON"); return 65; }
+    try {
+      pkg = JSON.parse(raw) as AcePackage;
+    } catch {
+      console.error("ace: package is not valid JSON");
+      return 65;
+    }
 
     // AUTHENTICITY GATE (design §6) — before extraction.
     // Only `no-signature` is --allow-no-signature-overridable.
@@ -1044,7 +1412,9 @@ export async function main(argv: readonly string[]): Promise<number> {
       return 1;
     } else if (v.reason === "untrusted-key") {
       const kid = pkg.manifest.signature?.key_id ?? "?";
-      console.error(`ace: install refused: signature from untrusted key ${kid} — unknown publisher. Run 'ace trust list' to see trusted keys, or obtain the publisher's .pub and run 'ace trust add <pub>'.`);
+      console.error(
+        `ace: install refused: signature from untrusted key ${kid} — unknown publisher. Run 'ace trust list' to see trusted keys, or obtain the publisher's .pub and run 'ace trust add <pub>'.`,
+      );
       return 1;
     } else {
       // no-signature
@@ -1076,12 +1446,21 @@ export async function main(argv: readonly string[]): Promise<number> {
       if (parsed.frozen) {
         // SLICE 5.3 frozen replay: install exactly the locked graph; never solve, never touch the registry.
         let lockRaw: string;
-        try { lockRaw = readFileSync(parsed.lockfile, "utf8"); }
-        catch { console.error(`ace: install refused: no lockfile at ${parsed.lockfile} — run install without --frozen first`); return 1; }
+        try {
+          lockRaw = readFileSync(parsed.lockfile, "utf8");
+        } catch {
+          console.error(`ace: install refused: no lockfile at ${parsed.lockfile} — run install without --frozen first`);
+          return 1;
+        }
         const lf = parseLockfile(lockRaw);
-        if ("error" in lf) { console.error(`ace: install refused: malformed lockfile ${parsed.lockfile}: ${lf.error}`); return 1; }
+        if ("error" in lf) {
+          console.error(`ace: install refused: malformed lockfile ${parsed.lockfile}: ${lf.error}`);
+          return 1;
+        }
         if (!verifyRootMatchesLock(pkg, lf)) {
-          console.error(`ace: install refused: lockfile out of date for ${pkg.manifest.name} — re-run without --frozen to regenerate`);
+          console.error(
+            `ace: install refused: lockfile out of date for ${pkg.manifest.name} — re-run without --frozen to regenerate`,
+          );
           return 1;
         }
         // SLICE 7: revocation overrides the lockfile. Best-effort load the registry marks
@@ -1089,7 +1468,10 @@ export async function main(argv: readonly string[]): Promise<number> {
         // every locked pin: a revoked pin hard-refuses; a quarantined pin refuses unless
         // --allow-quarantined (warn when allowed).
         const fr = await checkLockedMarks(lf.nodes, parsed.allowQuarantined === true, parsed.offline === true);
-        if (fr !== null) { console.error(`ace: install refused: ${fr}`); return 1; }
+        if (fr !== null) {
+          console.error(`ace: install refused: ${fr}`);
+          return 1;
+        }
         const trust = loadTrustStore();
         // PASS 1 (verify-all, install NOTHING) — mirrors the default-path preflight: fetch → parse →
         // verify pin + content_hash + signature + path-safety + store-key collision across the WHOLE
@@ -1102,30 +1484,77 @@ export async function main(argv: readonly string[]): Promise<number> {
         const verified: AcePackage[] = []; // locked nodes in lock order; root installed separately
         for (const node of lf.nodes) {
           let nodeRaw: string;
-          try { nodeRaw = (node.url.startsWith("http://") || node.url.startsWith("https://")) ? await (await fetch(node.url)).text() : readFileSync(node.url, "utf8"); }
-          catch (e) { console.error(`ace: install refused: fetch failed for ${node.name}@${node.version} (${node.url}): ${(e as Error).message}`); return 1; }
+          try {
+            nodeRaw =
+              node.url.startsWith("http://") || node.url.startsWith("https://")
+                ? await (await fetch(node.url)).text()
+                : readFileSync(node.url, "utf8");
+          } catch (e) {
+            console.error(
+              `ace: install refused: fetch failed for ${node.name}@${node.version} (${node.url}): ${(e as Error).message}`,
+            );
+            return 1;
+          }
           let np: AcePackage;
-          try { np = JSON.parse(nodeRaw) as AcePackage; } catch { console.error(`ace: install refused: ${node.name}@${node.version} is not valid JSON`); return 1; }
+          try {
+            np = JSON.parse(nodeRaw) as AcePackage;
+          } catch {
+            console.error(`ace: install refused: ${node.name}@${node.version} is not valid JSON`);
+            return 1;
+          }
           // Shape-guard the untrusted fetched bytes (object-ness) before any verify primitive
           // touches them. A malformed field VALUE (float / lone surrogate) still throws in
           // packageHash; safePackageHash below maps that to a clean refusal.
-          const npm = (np as { manifest?: unknown; files?: unknown });
-          if (typeof npm !== "object" || npm === null || typeof npm.manifest !== "object" || npm.manifest === null || typeof npm.files !== "object" || npm.files === null) {
-            console.error(`ace: install refused: ${node.name}@${node.version} is not a well-formed package`); return 1;
+          const npm = np as { manifest?: unknown; files?: unknown };
+          if (
+            typeof npm !== "object" ||
+            npm === null ||
+            typeof npm.manifest !== "object" ||
+            npm.manifest === null ||
+            typeof npm.files !== "object" ||
+            npm.files === null
+          ) {
+            console.error(`ace: install refused: ${node.name}@${node.version} is not a well-formed package`);
+            return 1;
           }
           const nphr = safePackageHash(np);
-          if (!nphr.ok) { console.error(`ace: install refused: invalid-package — ${node.name}@${node.version}: ${nphr.reason}`); return 1; }
+          if (!nphr.ok) {
+            console.error(`ace: install refused: invalid-package — ${node.name}@${node.version}: ${nphr.reason}`);
+            return 1;
+          }
           const nph = nphr.hash;
-          if (nph !== node.package_hash) { console.error(`ace: install refused: package_hash mismatch for ${node.name}@${node.version} (lock pin violated)`); return 1; }
+          if (nph !== node.package_hash) {
+            console.error(
+              `ace: install refused: package_hash mismatch for ${node.name}@${node.version} (lock pin violated)`,
+            );
+            return 1;
+          }
           const fh = contentHash(new TextEncoder().encode(JSON.stringify(np.files)));
-          if (fh !== np.manifest.content_hash) { console.error(`ace: install refused: bad-content-hash in ${node.name}@${node.version}`); return 1; }
+          if (fh !== np.manifest.content_hash) {
+            console.error(`ace: install refused: bad-content-hash in ${node.name}@${node.version}`);
+            return 1;
+          }
           const unsafe = validatePackagePaths(np);
-          if (unsafe !== null) { console.error(`ace: install refused: unsafe file path in ${node.name}@${node.version}: ${unsafe}`); return 1; }
+          if (unsafe !== null) {
+            console.error(`ace: install refused: unsafe file path in ${node.name}@${node.version}: ${unsafe}`);
+            return 1;
+          }
           const nv = verifySignature(np.manifest, trust);
-          if (!nv.ok && nv.reason !== "no-signature") { console.error(`ace: install refused: ${nv.reason} for ${node.name}@${node.version}`); return 1; }
-          if (!nv.ok && nv.reason === "no-signature" && !parsed.allowNoSignature) { console.error(`ace: install refused: unsigned ${node.name}@${node.version} (use --allow-no-signature)`); return 1; }
+          if (!nv.ok && nv.reason !== "no-signature") {
+            console.error(`ace: install refused: ${nv.reason} for ${node.name}@${node.version}`);
+            return 1;
+          }
+          if (!nv.ok && nv.reason === "no-signature" && !parsed.allowNoSignature) {
+            console.error(`ace: install refused: unsigned ${node.name}@${node.version} (use --allow-no-signature)`);
+            return 1;
+          }
           const prior = byStoreKey.get(np.manifest.content_hash);
-          if (prior !== undefined && prior !== nph) { console.error(`ace: install refused: store-collision — ${node.name}@${node.version} shares a content_hash store key with a different package`); return 1; }
+          if (prior !== undefined && prior !== nph) {
+            console.error(
+              `ace: install refused: store-collision — ${node.name}@${node.version} shares a content_hash store key with a different package`,
+            );
+            return 1;
+          }
           byStoreKey.set(np.manifest.content_hash, nph);
           verified.push(np);
         }
@@ -1134,24 +1563,36 @@ export async function main(argv: readonly string[]): Promise<number> {
           const np = verified[i]!;
           const node = lf.nodes[i]!;
           const ir = installPackage(parsed.storePath, np);
-          if (!ir.ok) { console.error(`ace: install refused: ${node.name}@${node.version}: ${ir.error}`); return 1; }
+          if (!ir.ok) {
+            console.error(`ace: install refused: ${node.name}@${node.version}: ${ir.error}`);
+            return 1;
+          }
         }
         // Install the root last (already signature+content_hash verified above).
         const rootIr = installPackage(parsed.storePath, pkg);
-        if (!rootIr.ok) { console.error(`ace: install refused: ${pkg.manifest.name} (root): ${rootIr.error}`); return 1; }
+        if (!rootIr.ok) {
+          console.error(`ace: install refused: ${pkg.manifest.name} (root): ${rootIr.error}`);
+          return 1;
+        }
         console.error(`ace: installed ${lf.nodes.length + 1} from lockfile ${parsed.lockfile} (frozen)`);
         return 0;
       }
       const fetchPackage = async (u: string): Promise<string> =>
-        (u.startsWith("http://") || u.startsWith("https://")) ? await (await fetch(u)).text() : readFileSync(u, "utf8");
+        u.startsWith("http://") || u.startsWith("https://") ? await (await fetch(u)).text() : readFileSync(u, "utf8");
       const { registry, revoked, quarantined, warnings, errors } = await loadRegistries({
-        trustStore: loadTrustStore(), offline: parsed.offline === true,
+        trustStore: loadTrustStore(),
+        offline: parsed.offline === true,
       });
       for (const w of warnings) console.error(`ace: ${w}`);
-      if (errors.length > 0) { for (const e of errors) console.error(`ace: install refused: ${e}`); return 1; }
+      if (errors.length > 0) {
+        for (const e of errors) console.error(`ace: install refused: ${e}`);
+        return 1;
+      }
       const solveResult = await solve(pkg, fetchPackage, registry);
       if (!solveResult.ok) {
-        console.error(`ace: install refused: ${solveResult.reason} — ${solveResult.detail} (path: ${solveResult.path.join(" → ")})`);
+        console.error(
+          `ace: install refused: ${solveResult.reason} — ${solveResult.detail} (path: ${solveResult.path.join(" → ")})`,
+        );
         return 1;
       }
       // Print the solved graph if --print-resolution was requested.
@@ -1160,7 +1601,12 @@ export async function main(argv: readonly string[]): Promise<number> {
           console.log(`  ${n}@${v}`);
         }
       }
-      const res = await resolve(pkg, fetchPackage, loadTrustStore(), registry, solveResult.versions, { allowNoSignature: parsed.allowNoSignature, allowQuarantined: parsed.allowQuarantined === true, revoked, quarantined });
+      const res = await resolve(pkg, fetchPackage, loadTrustStore(), registry, solveResult.versions, {
+        allowNoSignature: parsed.allowNoSignature,
+        allowQuarantined: parsed.allowQuarantined === true,
+        revoked,
+        quarantined,
+      });
       if (!res.ok) {
         console.error(`ace: install refused: ${res.reason} — ${res.detail} (path: ${res.path.join(" → ")})`);
         return 1;
@@ -1169,12 +1615,24 @@ export async function main(argv: readonly string[]): Promise<number> {
       // (CI guard; installs nothing). Falls through to the normal preflight+extract when it matches.
       if (parsed.locked) {
         let lockRaw: string;
-        try { lockRaw = readFileSync(parsed.lockfile, "utf8"); }
-        catch { console.error(`ace: install refused: --locked but no lockfile at ${parsed.lockfile} — run 'ace update' or install without --locked`); return 1; }
+        try {
+          lockRaw = readFileSync(parsed.lockfile, "utf8");
+        } catch {
+          console.error(
+            `ace: install refused: --locked but no lockfile at ${parsed.lockfile} — run 'ace update' or install without --locked`,
+          );
+          return 1;
+        }
         const onDisk = parseLockfile(lockRaw);
-        if ("error" in onDisk) { console.error(`ace: install refused: malformed lockfile ${parsed.lockfile}: ${onDisk.error}`); return 1; }
+        if ("error" in onDisk) {
+          console.error(`ace: install refused: malformed lockfile ${parsed.lockfile}: ${onDisk.error}`);
+          return 1;
+        }
         const fresh = buildLockfile(pkg, res.order, registry);
-        if ("error" in fresh) { console.error(`ace: install refused: could not build lockfile: ${fresh.error}`); return 1; }
+        if ("error" in fresh) {
+          console.error(`ace: install refused: could not build lockfile: ${fresh.error}`);
+          return 1;
+        }
         if (!lockfilesEqual(onDisk, fresh)) {
           console.error(`ace: install refused: lockfile out of date (--locked) — run 'ace update' to regenerate`);
           return 1;
@@ -1183,21 +1641,32 @@ export async function main(argv: readonly string[]): Promise<number> {
       // PREFLIGHT (atomic): integrity + path-safety + store-key collision across the whole
       // graph BEFORE any extract (shared with `update`'s before-write guard via preflightGraph).
       const pf = preflightGraph(res.order);
-      if (pf !== null) { console.error(`ace: install refused: ${pf}`); return 1; }
+      if (pf !== null) {
+        console.error(`ace: install refused: ${pf}`);
+        return 1;
+      }
       // EXTRACT all, leaves first.
       for (const node of res.order) {
         const out = installPackage(parsed.storePath, node);
-        if (!out.ok) { console.error(`ace: install failed mid-graph: ${out.error}`); return 1; }
+        if (!out.ok) {
+          console.error(`ace: install failed mid-graph: ${out.error}`);
+          return 1;
+        }
       }
       // SLICE 5.3: write the lockfile (write failure is a warning, not a failed install).
       const lf = buildLockfile(pkg, res.order, registry);
       if ("error" in lf) {
         console.error(`ace: WARNING: could not build lockfile: ${lf.error}`);
       } else {
-        try { writeFileSync(parsed.lockfile, serializeLockfile(lf)); }
-        catch (e) { console.error(`ace: WARNING: could not write lockfile ${parsed.lockfile}: ${(e as Error).message}`); }
+        try {
+          writeFileSync(parsed.lockfile, serializeLockfile(lf));
+        } catch (e) {
+          console.error(`ace: WARNING: could not write lockfile ${parsed.lockfile}: ${(e as Error).message}`);
+        }
       }
-      console.log(`ace: installed ${res.order.length}: ${res.order.map((p) => `${p.manifest.name}@${p.manifest.version}`).join(", ")}`);
+      console.log(
+        `ace: installed ${res.order.length}: ${res.order.map((p) => `${p.manifest.name}@${p.manifest.version}`).join(", ")}`,
+      );
       return 0;
     }
 
@@ -1207,34 +1676,73 @@ export async function main(argv: readonly string[]): Promise<number> {
     // default: install, then write the trivial leaf lock (empty nodes).
     if (parsed.frozen) {
       let lockRaw: string;
-      try { lockRaw = readFileSync(parsed.lockfile, "utf8"); }
-      catch { console.error(`ace: install refused: no lockfile at ${parsed.lockfile} — run install without --frozen first`); return 1; }
+      try {
+        lockRaw = readFileSync(parsed.lockfile, "utf8");
+      } catch {
+        console.error(`ace: install refused: no lockfile at ${parsed.lockfile} — run install without --frozen first`);
+        return 1;
+      }
       const lf = parseLockfile(lockRaw);
-      if ("error" in lf) { console.error(`ace: install refused: malformed lockfile ${parsed.lockfile}: ${lf.error}`); return 1; }
-      if (!verifyRootMatchesLock(pkg, lf)) { console.error(`ace: install refused: lockfile out of date for ${pkg.manifest.name} — re-run without --frozen to regenerate`); return 1; }
-      const lr = await checkLockedMarks([{ name: pkg.manifest.name, version: pkg.manifest.version }, ...lf.nodes], parsed.allowQuarantined === true, parsed.offline === true);
-      if (lr !== null) { console.error(`ace: install refused: ${lr}`); return 1; }
+      if ("error" in lf) {
+        console.error(`ace: install refused: malformed lockfile ${parsed.lockfile}: ${lf.error}`);
+        return 1;
+      }
+      if (!verifyRootMatchesLock(pkg, lf)) {
+        console.error(
+          `ace: install refused: lockfile out of date for ${pkg.manifest.name} — re-run without --frozen to regenerate`,
+        );
+        return 1;
+      }
+      const lr = await checkLockedMarks(
+        [{ name: pkg.manifest.name, version: pkg.manifest.version }, ...lf.nodes],
+        parsed.allowQuarantined === true,
+        parsed.offline === true,
+      );
+      if (lr !== null) {
+        console.error(`ace: install refused: ${lr}`);
+        return 1;
+      }
     } else if (parsed.locked) {
       let lockRaw: string;
-      try { lockRaw = readFileSync(parsed.lockfile, "utf8"); }
-      catch { console.error(`ace: install refused: --locked but no lockfile at ${parsed.lockfile} — run 'ace update' or install without --locked`); return 1; }
+      try {
+        lockRaw = readFileSync(parsed.lockfile, "utf8");
+      } catch {
+        console.error(
+          `ace: install refused: --locked but no lockfile at ${parsed.lockfile} — run 'ace update' or install without --locked`,
+        );
+        return 1;
+      }
       const onDisk = parseLockfile(lockRaw);
-      if ("error" in onDisk) { console.error(`ace: install refused: malformed lockfile ${parsed.lockfile}: ${onDisk.error}`); return 1; }
-      if (!lockfilesEqual(onDisk, buildLeafLockfile(pkg))) { console.error(`ace: install refused: lockfile out of date (--locked) — run 'ace update' to regenerate`); return 1; }
+      if ("error" in onDisk) {
+        console.error(`ace: install refused: malformed lockfile ${parsed.lockfile}: ${onDisk.error}`);
+        return 1;
+      }
+      if (!lockfilesEqual(onDisk, buildLeafLockfile(pkg))) {
+        console.error(`ace: install refused: lockfile out of date (--locked) — run 'ace update' to regenerate`);
+        return 1;
+      }
     }
     // INTEGRITY + extract (slice 2, unchanged)
     const result = installPackage(parsed.storePath, pkg);
-    if (!result.ok) { console.error(`ace: install refused: ${result.error}`); return 1; }
+    if (!result.ok) {
+      console.error(`ace: install refused: ${result.error}`);
+      return 1;
+    }
     if (signer) {
-      console.log(`ace: integrity + authenticity verified (signed by ${signer.key_id}${signer.label ? " " + signer.label : ""}) -> ${result.dir}`);
+      console.log(
+        `ace: integrity + authenticity verified (signed by ${signer.key_id}${signer.label ? " " + signer.label : ""}) -> ${result.dir}`,
+      );
     } else {
       console.log(`ace: installed ${pkg.manifest.name}@${pkg.manifest.version} -> ${result.dir}`);
       console.log("ace: integrity-verified (content hash). NOT authenticity-verified (--allow-no-signature).");
     }
     // SLICE 5.4: default (non-frozen) path writes the trivial leaf lock; write failure is a warning.
     if (!parsed.frozen) {
-      try { writeFileSync(parsed.lockfile, serializeLockfile(buildLeafLockfile(pkg))); }
-      catch (e) { console.error(`ace: WARNING: could not write lockfile ${parsed.lockfile}: ${(e as Error).message}`); }
+      try {
+        writeFileSync(parsed.lockfile, serializeLockfile(buildLeafLockfile(pkg)));
+      } catch (e) {
+        console.error(`ace: WARNING: could not write lockfile ${parsed.lockfile}: ${(e as Error).message}`);
+      }
     }
     return 0;
   }
@@ -1242,8 +1750,13 @@ export async function main(argv: readonly string[]): Promise<number> {
   if (parsed.command === "verify") {
     const pkgs = listInstalled(parsed.storePath);
     const found = pkgs.find((p) => p.hash === parsed.hash || p.manifest.content_hash === parsed.hash);
-    if (!found) { console.error(`ace: no installed package with hash ${parsed.hash}`); return 1; }
-    console.log(`ace: ${found.manifest.name}@${found.manifest.version} present (manifest hash ${found.manifest.content_hash})`);
+    if (!found) {
+      console.error(`ace: no installed package with hash ${parsed.hash}`);
+      return 1;
+    }
+    console.log(
+      `ace: ${found.manifest.name}@${found.manifest.version} present (manifest hash ${found.manifest.content_hash})`,
+    );
     return 0;
   }
 

--- a/src/Core.TypeScript/ace/deps.ts
+++ b/src/Core.TypeScript/ace/deps.ts
@@ -56,12 +56,18 @@ export interface ChartOutputsSpec {
 
 export function toJs(v: YamlValue): any {
   switch (v.t) {
-    case "Null": return null;
-    case "Bool": return v.value;
-    case "Int": return Number(v.value);
-    case "Float": return v.value;
-    case "Str": return v.value;
-    case "Seq": return v.items.map(toJs);
+    case "Null":
+      return null;
+    case "Bool":
+      return v.value;
+    case "Int":
+      return Number(v.value);
+    case "Float":
+      return v.value;
+    case "Str":
+      return v.value;
+    case "Seq":
+      return v.items.map(toJs);
     case "Map": {
       const obj: Record<string, any> = {};
       for (const [k, val] of v.entries) {
@@ -135,15 +141,18 @@ export function getTargetPath(target: string): string {
 
 export function setNestedProperty(obj: any, path: string, value: any): void {
   const parts = path.split(".");
+  if (parts.length === 0 || parts[0] === "") {
+    throw new Error("nested path must be non-empty");
+  }
   let current = obj;
   for (let i = 0; i < parts.length - 1; i++) {
-    const part = parts[i];
+    const part = parts[i]!;
     if (!(part in current)) {
       current[part] = {};
     }
     current = current[part];
   }
-  current[parts[parts.length - 1]] = value;
+  current[parts[parts.length - 1]!] = value;
 }
 
 export function resolveGraph(graph: AppDependencyGraphSpec, chartsDir?: string): ResolvedGraph {
@@ -189,11 +198,20 @@ export function resolveGraph(graph: AppDependencyGraphSpec, chartsDir?: string):
           for (const cons of out.consumes) {
             const parts = cons.target.split(".");
             if (parts.length < 2) {
-              throw new Error(`Validation error: target '${cons.target}' is malformed (must be '<chart>.values.<path>')`);
+              throw new Error(
+                `Validation error: target '${cons.target}' is malformed (must be '<chart>.values.<path>')`,
+              );
             }
             const consumer = parts[0];
+            if (consumer === undefined || consumer.length === 0) {
+              throw new Error(
+                `Validation error: target '${cons.target}' is malformed (must be '<chart>.values.<path>')`,
+              );
+            }
             if (!nodes.has(consumer)) {
-              throw new Error(`Validation error: consumer target '${cons.target}' references unknown chart '${consumer}'`);
+              throw new Error(
+                `Validation error: consumer target '${cons.target}' references unknown chart '${consumer}'`,
+              );
             }
             // If consumer uses producer's output, consumer depends on producer
             adj.get(consumer)!.add(producer);
@@ -217,7 +235,9 @@ export function resolveGraph(graph: AppDependencyGraphSpec, chartsDir?: string):
         if (entry.outputs) {
           for (const out of entry.outputs) {
             if (!declaredOutputs.has(out.name)) {
-              throw new Error(`Validation error: chart '${chart}' references output '${out.name}' which is not declared in its outputs contract`);
+              throw new Error(
+                `Validation error: chart '${chart}' references output '${out.name}' which is not declared in its outputs contract`,
+              );
             }
           }
         }
@@ -366,7 +386,6 @@ export function generateArgoCD(resolved: ResolvedGraph, namespace: string = "def
 
   for (const chart of resolved.order) {
     const wave = resolved.waves.get(chart) ?? 0;
-    const node = resolved.nodes.get(chart)!;
 
     const app: any = {
       apiVersion: "argoproj.io/v1alpha1",


### PR DESCRIPTION
## Summary
- Fix the `ace deps` TypeScript strictness failures on current `main` by omitting undefined optional fields under `exactOptionalPropertyTypes`.
- Narrow dependency target path segments before using them as map keys and remove the unused ArgoCD node local.
- Add the missing blank line before the Round 46 list so markdownlint passes.

## Root cause
`riven/b0821-deps-engine` landed with code that was runtime-correct but not strict-TypeScript clean under CI's `exactOptionalPropertyTypes` and indexed-access checks. The same main gate also caught one MD032 list-spacing issue in `docs/ROUND-HISTORY.md`.

## Validation
- `mise exec -- bun --bun tsc --noEmit -p tsconfig.json`
- `mise exec -- markdownlint-cli2 "**/*.md"`
- `mise exec -- bun test src/Core.TypeScript/ace/deps.test.ts src/Core.TypeScript/ace/ace.test.ts`
- `dotnet build src/Core/Core.fsproj -c Release` after an initial SDK/F# compiler process exited 139
- `dotnet build -c Release`
- `dotnet test Zeta.sln -c Release --no-build -m:1`
- `dotnet format --verify-no-changes`

Agency-Signature-Version: 1
Agent: Vera
Agent-Runtime: OpenAI Codex
Agent-Model: GPT-5
Credential-Identity: AceHack shared repository credential
Credential-Mode: shared
Human-Review: explicit
Human-Review-Evidence: chat
Action-Mode: supervised
Task: B-0821
Co-Authored-By: Codex <noreply@openai.com>
