### PR TITLE
fix(ace,docs): unbreak tsc + markdownlint on main (B-0821 deps-engine fast-forward bypassed gates)

### DIFF
--- a/docs/ROUND-HISTORY.md
+++ b/docs/ROUND-HISTORY.md
@@ -60,6 +60,7 @@ Anchor: Round 46 is the round where the portable, engine-agnostic Helm dependenc
 ### Arc 1 — Subcommand execution wiring and verification (B-0821)
 
 The CLI subcommands (`ace deps validate` and `ace deps resolve`) are wired into the main entrypoint `src/Core.TypeScript/ace/ace.ts` and evaluated against all verification gates.
+
 - Staged and fast-forward merged the implementation and test suites from branch `riven/b0821-deps-engine` to the `main` branch.
 - Verified TypeScript test suite (`deps.test.ts` and `ace.test.ts`) resulting in all 153 tests passing.
 - Verified `.NET` test suite and Release builds resulting in a warning-free compile and 3,362 passing tests.

--- a/src/Core.TypeScript/ace/ace.ts
+++ b/src/Core.TypeScript/ace/ace.ts
@@ -137,9 +137,9 @@ interface DepsArgs {
   readonly command: "deps";
   readonly sub: "validate" | "resolve";
   readonly graphPath: string;
-  readonly outDir?: string;
+  readonly outDir?: string | undefined;
   readonly outputEngine: "flux" | "argocd" | "both";
-  readonly chartsDir?: string;
+  readonly chartsDir?: string | undefined;
   readonly namespace: string;
 }
 

--- a/src/Core.TypeScript/ace/deps.ts
+++ b/src/Core.TypeScript/ace/deps.ts
@@ -138,12 +138,16 @@ export function setNestedProperty(obj: any, path: string, value: any): void {
   let current = obj;
   for (let i = 0; i < parts.length - 1; i++) {
     const part = parts[i];
+    if (part === undefined) continue; // split() never yields undefined entries; satisfies the checker honestly
     if (!(part in current)) {
       current[part] = {};
     }
     current = current[part];
   }
-  current[parts[parts.length - 1]] = value;
+  const last = parts[parts.length - 1];
+  if (last !== undefined) {
+    current[last] = value;
+  }
 }
 
 export function resolveGraph(graph: AppDependencyGraphSpec, chartsDir?: string): ResolvedGraph {
@@ -192,7 +196,7 @@ export function resolveGraph(graph: AppDependencyGraphSpec, chartsDir?: string):
               throw new Error(`Validation error: target '${cons.target}' is malformed (must be '<chart>.values.<path>')`);
             }
             const consumer = parts[0];
-            if (!nodes.has(consumer)) {
+            if (consumer === undefined || !nodes.has(consumer)) {
               throw new Error(`Validation error: consumer target '${cons.target}' references unknown chart '${consumer}'`);
             }
             // If consumer uses producer's output, consumer depends on producer
@@ -281,7 +285,6 @@ export function generateFlux(resolved: ResolvedGraph, namespace: string = "defau
   const manifests: Record<string, any> = {};
 
   for (const chart of resolved.order) {
-    const node = resolved.nodes.get(chart)!;
     const deps = Array.from(resolved.nodes.keys()).filter((n) => {
       // Find what this node directly depends on
       if (node.dependsOn?.includes(n)) return true;

--- a/src/Core.TypeScript/ace/deps.ts
+++ b/src/Core.TypeScript/ace/deps.ts
@@ -285,6 +285,7 @@ export function generateFlux(resolved: ResolvedGraph, namespace: string = "defau
   const manifests: Record<string, any> = {};
 
   for (const chart of resolved.order) {
+    const node = resolved.nodes.get(chart)!;
     const deps = Array.from(resolved.nodes.keys()).filter((n) => {
       // Find what this node directly depends on
       if (node.dependsOn?.includes(n)) return true;
@@ -369,7 +370,6 @@ export function generateArgoCD(resolved: ResolvedGraph, namespace: string = "def
 
   for (const chart of resolved.order) {
     const wave = resolved.waves.get(chart) ?? 0;
-    const node = resolved.nodes.get(chart)!;
 
     const app: any = {
       apiVersion: "argoproj.io/v1alpha1",


### PR DESCRIPTION
Five tsc errors (exactOptionalPropertyTypes on DepsArgs optionals, possibly-undefined index parts, an unused binding) + one MD032 in ROUND-HISTORY — all from the fast-forward deps-engine merge that bypassed the gates. tsc 0 errors; full ace suite green (153+ tests). Includes a self-caught fixup: my first pass removed the wrong of two identical `node` bindings; tests caught it before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)