### PR TITLE
fix(docs): clear backlog markdownlint

### DIFF
--- a/docs/backlog/P1/081KSGS9H0008QG0R00367G209-zeta-as-dependency-graph-and-variable-passing-layer-on-top-o.md
+++ b/docs/backlog/P1/081KSGS9H0008QG0R00367G209-zeta-as-dependency-graph-and-variable-passing-layer-on-top-o.md
@@ -28,7 +28,6 @@ tags: [strategic-positioning, dependency-graph, helm, variable-passing, ontology
 > (`deps.test.ts`), and integrated CLI commands (`validate` and `resolve`) under `ace deps`
 > in `ace.ts` with integration tests (`ace.test.ts`). All test suites passed cleanly.
 
-
 ## TL;DR — "Maven for Helm" (Aaron 2026-05-26 sharp framing)
 
 The cleanest possible compression of this row, Aaron 2026-05-26:


### PR DESCRIPTION
## Summary
- Remove the extra blank line in the closed B-0821 backlog row that caused markdownlint MD012 on latest `main`.

## Root cause
PR #7906 advanced `main`, and the main gate failed only on `lint (markdownlint)` because `docs/backlog/P1/081KSGS9H0008QG0R00367G209-zeta-as-dependency-graph-and-variable-passing-layer-on-top-o.md` had two consecutive blank lines before the TL;DR heading.

## Validation
- `mise exec -- markdownlint-cli2 "**/*.md"`

Agency-Signature-Version: 1
Agent: Vera
Agent-Runtime: OpenAI Codex
Agent-Model: GPT-5
Credential-Identity: AceHack shared repository credential
Credential-Mode: shared
Human-Review: explicit
Human-Review-Evidence: chat
Action-Mode: supervised
Task: B-0821
Co-Authored-By: Codex <noreply@openai.com>
