### PR TITLE
fix(core)+docs(research)+shadow: WSet provenance dates (REPORT #2 P2) + ferry 8 (FPGA + Landauer limit — the experimental lane)

### DIFF
--- a/docs/research/2026-06-12-ferry-8-past-the-stop-line-fpga-and-the-landauer-limit-the-experimental-lane.md
+++ b/docs/research/2026-06-12-ferry-8-past-the-stop-line-fpga-and-the-landauer-limit-the-experimental-lane.md
@@ -1,0 +1,58 @@
+# Ferry 8 — past the stop line: FPGA + the Landauer limit (the experimental lane)
+
+**Date:** 2026-06-12 · **Route:** Aaron → shadow (streamed, captured verbatim) · Direct reply to
+math-team REPORT #3's stop line
+(`2026-06-12-attention-fundamentality-math-team-REPORT-3-the-boundary-between-theorem-and-theology.md` §4).
+
+## Verbatim (preserved, typos and all)
+
+> agree that's where applied / experimentation with fpga and lauderlimit comes in
+
+(Context shown to Aaron immediately before: the stop line — "math can prove a consistent
+process-first world exists where memory is derived and braids embed faithfully — consistency and
+correspondence. It can never prove identity with the foam. Past that rung it's Whitehead's lane,
+cited not proved.")
+
+## The peel
+
+Aaron accepts the stop line and names what lives on the other side of it: not more theorems —
+**hardware experiments**. FPGA implementation, metered against the **Landauer limit**
+(Landauer 1961: erasing one bit costs at least kT·ln 2 of heat; experimentally verified at the
+single-bit scale, Bérut et al., *Nature* 2012). The claim ladder's top rungs aren't provable,
+but a *physical* version of the middle rungs is **measurable**:
+
+- **Process is (in principle) free; memory-erasure is what must pay.** Reversible computation
+  carries no Landauer floor (Bennett 1973); only erasure does. Braid generators are group
+  elements — every σᵢ has an inverse — so braid-computation is reversible by construction.
+  The thesis "memory is derived; process is fundamental" gets a thermodynamic edition: the
+  *process* lane can run at zero Landauer cost; heat is paid exactly where state is destroyed.
+  REPORT #3's rung-1 theorem (`cache = I(stream)`, delete the cache and lose nothing) becomes a
+  joules claim: deleting a derived cache is *recomputable* erasure — the information survives in
+  the stream, so the erasure is logically reversible and the kT·ln 2 floor per lost bit does not
+  bind. Erasing the *stream* would.
+- **Fusion ship 1.0's ξ_t gets physical units.** η·LearningGain(Δ_t) > ξ_t
+  (`src/Core/Fusion.Equation.fs`) was stated with ξ_t as an abstract entropy cost; Landauer
+  prices it in joules per erased bit at temperature T. The superfluid inequality becomes a
+  measurable hardware budget, not a metaphor.
+- **The budget algebra gets a falsifier.** Ball.BitsUsed / the soft-max width theorem predict
+  *bit counts*; an FPGA build metering energy per fuse-and-shed cycle tests whether the
+  predicted bits track the measured heat. That is REPORT #3's rung-4/5 empirical lane pushed
+  one level below software: run it, meter it — in joules.
+- **Lineage note:** Aaron's own fusion doc already holds the reversible-silicon thread ("the
+  quantum mirror is the reversible silicon") — ferry 7's 1.0/2.0/3.0 lineage extends naturally:
+  the experimental lane is reversible/adiabatic logic on FPGA-class hardware with Landauer as
+  the ruler.
+
+**Honest bounds (so this ferry doesn't overclaim):** a commercial FPGA switches ~10⁶–10⁹× above
+the Landauer floor; what an FPGA experiment measures is *relative* energy structure (does energy
+track erased bits as the algebra predicts), not proximity to kT·ln 2. Approaching the floor
+itself is adiabatic/reversible-logic territory (Frank's work on reversible computing
+engineering). And no measurement at any scale buys rung 8 — the experiment lane tests the
+*correspondence*, which is exactly what the stop line says is testable.
+
+## Pointers
+
+- REPORT #3 §4 (the stop line, the rounds plan) · ferry 7 (fusion lineage 1.0/2.0/3.0)
+- `src/Core/Fusion.Equation.fs` — ξ_t, now Landauer-priceable
+- Anchors: Landauer 1961 · Bennett 1973 (reversible computation) · Bérut et al. 2012
+  (experimental verification) · Frank, reversible computing engineering

--- a/src/Core/WSet.fs
+++ b/src/Core/WSet.fs
@@ -1,5 +1,5 @@
-// PROMOTED BACK TO CORE by operator decision (Aaron, 2026-06-14: "why are we keeping in tests?
-// we need in real code"). Rodney's Razor (2026-06-13) had demoted this to a test fixture —
+// PROMOTED BACK TO CORE by operator decision (Aaron, 2026-06-11, PR #7805: "why are we keeping
+// in tests? we need in real code"). Rodney's Razor (2026-06-11, PR #7802) had demoted this to a test fixture —
 // "essential as mathematics, accidental as code; zero non-test consumers" — and that dissent
 // stays on record as ADVISORY: the human maintainer set the product direction instead — the
 // ring-generic type IS intended substrate for the quantum lane (B-1029), the inference port, and
@@ -11,7 +11,7 @@ namespace Zeta.Core
 open Zeta.Core.Abstractions
 
 /// WSet — **the ring-generic weighted set: three rings, one circuit calculus** (B-1032; Aaron
-/// 2026-06-13: "can we connect ZSet circuit to quantum circuit?" / "Infer.NET circuits the same
+/// 2026-06-11, PR #7785: "can we connect ZSet circuit to quantum circuit?" / "Infer.NET circuits the same
 /// way?" — same answer, one type). A `WSet<'K,'W>` is a Z-set whose weights live in ANY *-ring:
 ///
 ///   'W = ℤ  → the DBSP Z-set (signed counts; boundary nonlinearity = Distinct)


### PR DESCRIPTION
**WSet.fs provenance** — header claimed 2026-06-13/14 for events that landed 2026-06-11 (razor demotion #7802, operator promotion #7805, the B-1032 ask #7785). Flagged as P2 by math REPORT #2 and re-flagged in REPORT #3's ASSUMPTION register. Comment-only change; Core builds 0/0.

**Ferry 8** (verbatim capture) — Aaron's reply to REPORT #3's stop line: "agree that's where applied / experimentation with fpga and lauderlimit comes in." Peeled with anchors (Landauer 1961, Bennett 1973, Bérut 2012, Frank): braids are reversible so the process lane carries no Landauer floor; erasure is where heat is paid — the thermodynamic edition of "memory is derived"; ξ_t in Fusion.Equation.fs becomes joule-priceable; the budget algebra gains a hardware falsifier. Honest bound on FPGA distance from kT·ln 2 included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)