### PR TITLE
fix(docs): MD037 — escape underscores in GGUF transcript heading

### DIFF
--- a/docs/research/ip-questionable/2026-06-12-gguf-llamacpp-quantization-legacy-k-i-quants-superblocks-importance-matrix-mixed-precision-verbatim-transcript-aaron-forwarded.md
+++ b/docs/research/ip-questionable/2026-06-12-gguf-llamacpp-quantization-legacy-k-i-quants-superblocks-importance-matrix-mixed-precision-verbatim-transcript-aaron-forwarded.md
@@ -435,7 +435,7 @@ It's simply a way to select better scales.
 
 There's one more aspect that I wanted to touch on.
 
-### Mixed precision (_S, _M, _L, _XL)
+### Mixed precision (\_S, \_M, \_L, \_XL)
 
 Some of the K-quants variants have a size modifier, be it S for small, M for medium, L for large, and so on.
 


### PR DESCRIPTION
Local lint flagged MD037 (spaces inside emphasis markers) on the "Mixed precision (_S, _M, _L, _XL)" heading after #7928 merged. Escaped the underscores; file now lints clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)