### PR TITLE
docs(research)+shadow: ferry 13 beat 8 confirmation — the identity principle falls out (derived, not designed)

### DIFF
--- a/docs/research/2026-06-12-ferry-13-the-destination-stack-bnn-qnn-transformer-on-qsharp-starts-at-0-training-equals-running-the-sim-mea-cut-braid.md
+++ b/docs/research/2026-06-12-ferry-13-the-destination-stack-bnn-qnn-transformer-on-qsharp-starts-at-0-training-equals-running-the-sim-mea-cut-braid.md
@@ -189,6 +189,13 @@ measure of distinction); Maxwell's demon / Landauer (ferry 8 — distinction has
 price, so identity is not free); the every-bug-has-economic-value ledger (entropy reduction is
 the earned, banked act).
 
+**Confirmed by Aaron, same day, replying to the no-ambient-selfhood reading (verbatim):** *"yes
+exactly this is what falls out"* — noting the verb: the identity principle **falls out** of the
+noninterference discipline; it is derived, not designed. §13 was adopted as an engineering
+constraint (metered channels for DST and entropy budgets) and identity-as-captured-entropy is a
+*consequence*, the same way the soft-max width law fell out of the fusion algebra. Theorems you
+didn't aim at are the strongest evidence the axioms are right.
+
 ## Pointers
 
 - Welch Labs MLA + GGUF + active-inference transcripts (2026-06-12, ip-questionable — the three


### PR DESCRIPTION
Aaron's confirmation appended verbatim: "yes exactly this is what falls out." The verb is the content: identity-as-captured-entropy is a consequence of the noninterference discipline, not an added axiom — theorems you didn't aim at are the strongest evidence the axioms are right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)