### PR TITLE
feat(braid)+test: REPORT #3 Round-1 kernel laws + ferry-12 braid-density measures

### DIFF
--- a/src/Core/Braid.fs
+++ b/src/Core/Braid.fs
@@ -98,6 +98,43 @@ module Braid =
     /// underlying permutation's sign character. A projection (order forgotten, parity kept).
     let writheParity (b: int list) : int = List.length b % 2
 
+    /// The writhe: the exponent sum of the braid word (+1 per positive crossing, −1 per negative).
+    /// The unique homomorphism Bₙ → ℤ; `writheParity` is this, mod 2. Ferry-12 density axis, ℤ side.
+    let writhe (b: int list) : int =
+        b |> List.sumBy (fun c -> if c > 0 then 1 else -1)
+
+    /// Per-pair crossing load: how many crossings (either sign) act on each adjacent strand-pair
+    /// (generator index i = the pair (i, i+1), 0-based). The ferry-12 dense-vs-sparse measure:
+    /// dense braiding = high load concentrated on pairs; sparse = load near zero. Sums to word length.
+    let pairLoad (n: int) (b: int list) : Map<int, int> =
+        let counts =
+            b |> List.countBy (fun c -> abs c - 1) |> Map.ofList
+        [ 0 .. n - 2 ] |> List.map (fun i -> i, defaultArg (counts.TryFind i) 0) |> Map.ofList
+
+    /// The underlying permutation (position → strand id): forget over/under, keep WHERE strands end.
+    /// This is the quotient Bₙ ↠ Sₙ that `writheParity` factors through — the order-forgetting map
+    /// whose kernel (the pure braid group) is exactly what the braid remembers beyond shuffling.
+    let permutation (n: int) (b: int list) : int list =
+        let arr = Array.init n id
+        for c in b do
+            let i = abs c - 1
+            if i + 1 < n then
+                let t = arr.[i]
+                arr.[i] <- arr.[i + 1]
+                arr.[i + 1] <- t
+        List.ofArray arr
+
+    /// The sign of a permutation via inversion count — independent of how the permutation was made,
+    /// so it can CHECK (not assume) that writheParity equals the sign character (the commuting square
+    /// from math REPORT #3 §2: χ = sign ∘ (Bₙ ↠ Sₙ)).
+    let permutationSign (p: int list) : int =
+        let a = List.toArray p
+        let mutable inv = 0
+        for i in 0 .. a.Length - 2 do
+            for j in i + 1 .. a.Length - 1 do
+                if a.[i] > a.[j] then inv <- inv + 1
+        inv % 2
+
     /// DELETE one strand from a braid word (n strands, 0-based strand index by STARTING position):
     /// the surviving (n−1)-braid. Position-tracked: a crossing involving the deleted strand's
     /// current position vanishes from the word (the survivor passes straight) but still swaps the

--- a/tests/Tests.FSharp/Braid.Tests.fs
+++ b/tests/Tests.FSharp/Braid.Tests.fs
@@ -49,3 +49,44 @@ let ``property: every braid word composed with its inverse is the identity (rand
 [<Property(Arbitrary = [| typeof<BraidArbs> |])>]
 let ``property: the Artin relation holds INSIDE any context — u·(s1 s2 s1)·v = u·(s2 s1 s2)·v`` (u: int list) (v: int list) =
     Braid.equal N (u @ [ 1; 2; 1 ] @ v) (u @ [ 2; 1; 2 ] @ v)
+
+// ── Math REPORT #3 Round-1 kernel laws + ferry-12 density measures (2026-06-12) ──────────────────
+
+[<Property(Arbitrary = [| typeof<BraidArbs> |])>]
+let ``REPRESENTATION LAW: act of a concatenation = composition of the actions (the functor law)`` (b1: int list) (b2: int list) =
+    [ 0 .. N - 1 ]
+    |> List.forall (fun i -> Braid.act (b1 @ b2) (Braid.gen i) = Braid.act b2 (Braid.act b1 (Braid.gen i)))
+
+[<Property(Arbitrary = [| typeof<BraidArbs> |])>]
+let ``THE COMMUTING SQUARE: writheParity = sign ∘ permutation — the χ : Bₙ → ℤ/2 character factors through Sₙ`` (b: int list) =
+    Braid.writheParity b = Braid.permutationSign (Braid.permutation N b)
+
+[<Property(Arbitrary = [| typeof<BraidArbs> |])>]
+let ``writheParity is a homomorphism: parity of a concatenation = sum of parities mod 2`` (b1: int list) (b2: int list) =
+    Braid.writheParity (b1 @ b2) = (Braid.writheParity b1 + Braid.writheParity b2) % 2
+
+[<Property(Arbitrary = [| typeof<BraidArbs> |])>]
+let ``writhe is a homomorphism to ℤ and writhe ≡ length mod 2`` (b1: int list) (b2: int list) =
+    Braid.writhe (b1 @ b2) = Braid.writhe b1 + Braid.writhe b2
+    && (abs (Braid.writhe b1) % 2 = List.length b1 % 2)
+
+[<Property(Arbitrary = [| typeof<BraidArbs> |])>]
+let ``DENSITY: pairLoad sums to word length and covers exactly the adjacent pairs`` (b: int list) =
+    let load = Braid.pairLoad N b
+    (load |> Map.toList |> List.sumBy snd) = List.length b
+    && (load |> Map.toList |> List.map fst) = [ 0 .. N - 2 ]
+
+[<Fact>]
+let ``DENSITY: dense vs sparse braiding are distinguishable by pairLoad (ferry 12's axis, measured)`` () =
+    // dense: all load on one pair, repeatedly (σ₁⁶ — six crossings, one pair)
+    let dense = Braid.pairLoad N [ 1; 1; 1; 1; 1; 1 ]
+    // sparse: the same six crossings spread across three far pairs
+    let sparse = Braid.pairLoad N [ 1; 3; 1; 3; 1; 3 ]
+    Assert.Equal(6, dense.[0])
+    Assert.Equal(3, sparse.[0])
+    Assert.Equal(3, sparse.[2])
+
+[<Fact>]
+let ``the permutation is the order-forgetting quotient: σ₁² has trivial permutation but is NOT the identity braid`` () =
+    Assert.Equal<int list>([ 0 .. N - 1 ], Braid.permutation N [ 1; 1 ])
+    Assert.False(Braid.isIdentity N [ 1; 1 ]) // the kernel (pure braid group) is the memory


### PR DESCRIPTION
Starts Round 1 of math dispatch #3 (Aaron: "any of those are good to do" → picked 1+2): the representation/functor law as FsCheck property, the writhe/sign commuting square (REPORT #3 §2's named one-day test — permutationSign computed independently via inversion count so the square is checked, not assumed), homomorphism laws for writhe (ℤ) and writheParity (ℤ/2), and ferry 12's dense-vs-sparse braiding made measurable (pairLoad per adjacent strand-pair; kernel witness: σ₁² has trivial permutation but is not the identity — the pure braid group is the memory). 16/16 tests green, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)