### PR TITLE
[codex] feat(core): connect flow-bit oracle to vision attention

### DIFF
--- a/src/Core.QSharp.ReferenceOracle/ZetaReferenceOracle.qs
+++ b/src/Core.QSharp.ReferenceOracle/ZetaReferenceOracle.qs
@@ -149,4 +149,28 @@ namespace Zeta.ReferenceOracle {
         Rz(2.0 * 3.141592653589793 / 3.0, qs[0]);
         H(qs[0]);
     }
+
+    operation ApplyExternalBitDifferentiator(externalBit : Bool, qs : Qubit[]) : Unit is Adj + Ctl {
+        H(qs[0]);
+        if externalBit {
+            Z(qs[0]);
+        }
+        H(qs[0]);
+    }
+
+    operation ApplyExternalBitDistinguishZero(qs : Qubit[]) : Unit is Adj + Ctl {
+        ApplyExternalBitDifferentiator(false, qs);
+    }
+
+    operation ApplyExternalBitDistinguishOne(qs : Qubit[]) : Unit is Adj + Ctl {
+        ApplyExternalBitDifferentiator(true, qs);
+    }
+
+    operation MeasureExternalBitDifferentiator(externalBit : Bool) : Result {
+        use q = Qubit();
+        ApplyExternalBitDifferentiator(externalBit, [q]);
+        let measured = M(q);
+        Reset(q);
+        return measured;
+    }
 }

--- a/src/Core.QSharp.ReferenceOracle/generate-qsharp-golden.py
+++ b/src/Core.QSharp.ReferenceOracle/generate-qsharp-golden.py
@@ -336,6 +336,24 @@ def build_vectors() -> dict[str, Any]:
                 ),
                 interference_case("mach-zehnder-closed-pi-phase", "ApplyMachZehnderClosedPiPhase", math.pi, 1.0),
             ],
+            "flowBitDistinction": [
+                {
+                    "id": "external-bit-zero",
+                    "operation": "Zeta.ReferenceOracle.ApplyExternalBitDistinguishZero",
+                    "externalBit": False,
+                    "probabilities": single_qubit_probs_from_operation("ApplyExternalBitDistinguishZero"),
+                    "formula": "H; optional Z(externalBit); H maps phase distinction into the measured Z basis",
+                    "checks": ["BitFromFlow", "external entropy bit", "identity/distinction"],
+                },
+                {
+                    "id": "external-bit-one",
+                    "operation": "Zeta.ReferenceOracle.ApplyExternalBitDistinguishOne",
+                    "externalBit": True,
+                    "probabilities": single_qubit_probs_from_operation("ApplyExternalBitDistinguishOne"),
+                    "formula": "H; optional Z(externalBit); H maps phase distinction into the measured Z basis",
+                    "checks": ["BitFromFlow", "external entropy bit", "identity/distinction"],
+                },
+            ],
             "pauliAnticommutation": [
                 pauli_anticommutation_case("X after Z = -(Z after X)", "ApplyPauliXAfterZ", "ApplyPauliZAfterX"),
                 pauli_anticommutation_case("X after Y = -(Y after X)", "ApplyPauliXAfterY", "ApplyPauliYAfterX"),

--- a/src/Core.QSharp.ReferenceOracle/qsharp-golden.json
+++ b/src/Core.QSharp.ReferenceOracle/qsharp-golden.json
@@ -217,6 +217,38 @@
         "state": "PhiPlus"
       }
     ],
+    "flowBitDistinction": [
+      {
+        "checks": [
+          "BitFromFlow",
+          "external entropy bit",
+          "identity/distinction"
+        ],
+        "externalBit": false,
+        "formula": "H; optional Z(externalBit); H maps phase distinction into the measured Z basis",
+        "id": "external-bit-zero",
+        "operation": "Zeta.ReferenceOracle.ApplyExternalBitDistinguishZero",
+        "probabilities": {
+          "One": 0.0,
+          "Zero": 1.0
+        }
+      },
+      {
+        "checks": [
+          "BitFromFlow",
+          "external entropy bit",
+          "identity/distinction"
+        ],
+        "externalBit": true,
+        "formula": "H; optional Z(externalBit); H maps phase distinction into the measured Z basis",
+        "id": "external-bit-one",
+        "operation": "Zeta.ReferenceOracle.ApplyExternalBitDistinguishOne",
+        "probabilities": {
+          "One": 1.0,
+          "Zero": 0.0
+        }
+      }
+    ],
     "gateUnitaries": {
       "BellPhiPlusPrep": [
         [

--- a/src/Core.QSharp.ReferenceOracle/qsharp-golden.test.ts
+++ b/src/Core.QSharp.ReferenceOracle/qsharp-golden.test.ts
@@ -148,6 +148,22 @@ test("interference observables distinguish open, reinforce, and cancel cases", (
   closeTo(cancelled.One, 1);
 });
 
+test("flow-bit distinction turns one external entropy bit into a measured identity bit", () => {
+  const cases = new Map(golden.vectors.flowBitDistinction.map((v) => [v.id, v]));
+
+  const zero = expectDefined(cases.get("external-bit-zero"), "external-bit-zero");
+  expect(zero.operation).toBe("Zeta.ReferenceOracle.ApplyExternalBitDistinguishZero");
+  expect(zero.externalBit).toBe(false);
+  closeTo(zero.probabilities.Zero, 1);
+  closeTo(zero.probabilities.One, 0);
+
+  const one = expectDefined(cases.get("external-bit-one"), "external-bit-one");
+  expect(one.operation).toBe("Zeta.ReferenceOracle.ApplyExternalBitDistinguishOne");
+  expect(one.externalBit).toBe(true);
+  closeTo(one.probabilities.Zero, 0);
+  closeTo(one.probabilities.One, 1);
+});
+
 test("Q# Pauli products pin the hardware-side anticommutation signs", () => {
   for (const item of golden.vectors.pauliAnticommutation) {
     expect(item.relation).toBe("lhsMatrix = -rhsMatrix");

--- a/src/Core.QSharp.ReferenceOracle/quantum-circuit.test.ts
+++ b/src/Core.QSharp.ReferenceOracle/quantum-circuit.test.ts
@@ -82,6 +82,24 @@ const machZehnderActions = new Map<string, CircuitAction>([
   ],
 ]);
 
+const flowBitActions = new Map<string, CircuitAction>([
+  [
+    "Zeta.ReferenceOracle.ApplyExternalBitDistinguishZero",
+    (circuit) => {
+      append(circuit, "h", 0);
+      append(circuit, "h", 0);
+    },
+  ],
+  [
+    "Zeta.ReferenceOracle.ApplyExternalBitDistinguishOne",
+    (circuit) => {
+      append(circuit, "h", 0);
+      append(circuit, "z", 0);
+      append(circuit, "h", 0);
+    },
+  ],
+]);
+
 const singleQubitGateActions = new Map<string, CircuitAction>([
   [
     "H",
@@ -407,6 +425,21 @@ describe("quantum-circuit simulator (second observable oracle)", () => {
 
       closeTo(probZero, v.probabilities.Zero, qsharpDumpTolerance);
       closeTo(probOne, v.probabilities.One, qsharpDumpTolerance);
+    }
+  });
+
+  test("flow-bit distinction maps external entropy bits into measured identity bits", () => {
+    for (const v of golden.vectors.flowBitDistinction) {
+      const circuit = new QuantumCircuit(1);
+      applyKnownOperation(circuit, v.operation, flowBitActions);
+      circuit.run();
+
+      const probOne = probabilityOne(circuit);
+      const probZero = 1 - probOne;
+
+      closeTo(probZero, v.probabilities.Zero, qsharpDumpTolerance);
+      closeTo(probOne, v.probabilities.One, qsharpDumpTolerance);
+      closeTo(probOne, v.externalBit ? 1 : 0, qsharpDumpTolerance);
     }
   });
 

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -237,6 +237,7 @@
     <Compile Include="InferenceLadder.fs" />
     <Compile Include="TimeGen.fs" />
     <Compile Include="Braid.fs" />
+    <Compile Include="VisionAttention.fs" />
     <Compile Include="MediaLines.fs" />
     <Compile Include="CartridgeLaw.fs" />
     <Compile Include="CapabilityLedger.fs" />

--- a/src/Core/QuantumObservableDbsp.Tests.fs
+++ b/src/Core/QuantumObservableDbsp.Tests.fs
@@ -166,3 +166,18 @@ let ``F# parses quantum Z-set transcript and verifies parity under DBSP updates`
         | QuantumObservableRow.InterferenceVisibility expectedVisibility -> assertInterferenceNear v expectedVisibility
         | _ -> Assert.Fail("Expected InterferenceVisibility row")
     | _ -> Assert.Fail("Expected InterferenceVisibility row")
+
+[<Fact>]
+let ``Q# oracle observable rows live on the signed Z-set ledger`` () =
+    let row =
+        QuantumObservableDbsp.machZehnderClosedRow
+            "mach-zehnder-closed-pi-phase"
+            "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiPhase"
+            Math.PI
+
+    let signed =
+        [ QuantumObservableDbsp.delta row 1L
+          QuantumObservableDbsp.delta row -1L ]
+        |> QuantumObservableDbsp.zsetOfDeltas
+
+    Assert.True(ZSet.isEmpty signed)

--- a/src/Core/VisionAttention.fs
+++ b/src/Core/VisionAttention.fs
@@ -1,0 +1,179 @@
+namespace Zeta.Core
+
+open System
+open System.Numerics
+
+/// Finite treaty for "memory braids as gravity" plus attention-weighted
+/// self-budgeting. This does not make Q# or Bayesian inference the DBSP
+/// runtime. It gives both oracles a small, typed shape to agree on:
+/// memory braid load prices durable path history, attention ranks which
+/// futures the Vision budget should inspect first, and normal budget pressure
+/// remains a Vision report.
+[<RequireQualifiedAccess>]
+module VisionAttention =
+
+    type Attention =
+        { Weight: float
+          ResolutionBits: int }
+
+    type MemoryBraid =
+        { Strands: int
+          Word: int list
+          BytesPerCrossing: int64
+          PureKernelBytes: int64 }
+
+    type Proposal<'S> =
+        { Label: string
+          State: 'S
+          BaseSpaceBytes: int64
+          TimeTicks: int
+          BytesPerTick: int64
+          BaseUncertaintyResolutionBits: int
+          Attention: Attention
+          Memory: MemoryBraid option }
+
+    type RankedBranch<'S> =
+        { Proposal: Proposal<'S>
+          Branch: Vision.FutureBranch<'S>
+          GravityBytes: int64
+          Rank: float }
+
+    type Feedback =
+        | InvalidStrandCount of strands: int
+        | InvalidBraidWord of strands: int * word: int list
+        | NegativeBytesPerCrossing of bytes: int64
+        | NegativePureKernelBytes of bytes: int64
+        | NegativeBaseSpaceBytes of bytes: int64
+        | NegativeTimeTicks of ticks: int
+        | NegativeBytesPerTick of bytes: int64
+        | NegativeBaseUncertaintyResolutionBits of bits: int
+        | InvalidAttentionWeight of weight: float
+        | NegativeAttentionResolutionBits of bits: int
+        | ByteCostOverflow of bytes: BigInteger
+        | VisionFeedback of Vision.GrowthFeedback
+
+    let private addCapped (a: BigInteger) (b: BigInteger) : Result<BigInteger, Feedback> =
+        let total = a + b
+        if total > BigInteger Int64.MaxValue then Error(ByteCostOverflow total) else Ok total
+
+    let private toInt64 (value: BigInteger) : int64 = int64 value
+
+    let memoryGravityBytes (memory: MemoryBraid) : Result<int64, Feedback> =
+        result {
+            if memory.Strands < 2 then
+                return! Error(InvalidStrandCount memory.Strands)
+            elif memory.BytesPerCrossing < 0L then
+                return! Error(NegativeBytesPerCrossing memory.BytesPerCrossing)
+            elif memory.PureKernelBytes < 0L then
+                return! Error(NegativePureKernelBytes memory.PureKernelBytes)
+            elif not (Braid.validWord memory.Strands memory.Word) then
+                return! Error(InvalidBraidWord(memory.Strands, memory.Word))
+            else
+                let loadBytes =
+                    Braid.pairLoad memory.Strands memory.Word
+                    |> Map.toSeq
+                    |> Seq.map (fun (_, load) ->
+                        BigInteger load * BigInteger load * BigInteger memory.BytesPerCrossing)
+                    |> Seq.fold (+) BigInteger.Zero
+
+                let permutationIsTrivial =
+                    Braid.permutation memory.Strands memory.Word = [ 0 .. memory.Strands - 1 ]
+
+                let pureKernelMemory =
+                    permutationIsTrivial
+                    && not (Braid.isIdentity memory.Strands memory.Word)
+
+                let kernelBytes =
+                    if pureKernelMemory then BigInteger memory.PureKernelBytes else BigInteger.Zero
+
+                let! total = addCapped loadBytes kernelBytes
+                return toInt64 total
+        }
+
+    let private validateProposal (proposal: Proposal<'S>) : Result<unit, Feedback> =
+        if proposal.BaseSpaceBytes < 0L then
+            Error(NegativeBaseSpaceBytes proposal.BaseSpaceBytes)
+        elif proposal.TimeTicks < 0 then
+            Error(NegativeTimeTicks proposal.TimeTicks)
+        elif proposal.BytesPerTick < 0L then
+            Error(NegativeBytesPerTick proposal.BytesPerTick)
+        elif proposal.BaseUncertaintyResolutionBits < 0 then
+            Error(NegativeBaseUncertaintyResolutionBits proposal.BaseUncertaintyResolutionBits)
+        elif proposal.Attention.ResolutionBits < 0 then
+            Error(NegativeAttentionResolutionBits proposal.Attention.ResolutionBits)
+        elif not (Double.IsFinite proposal.Attention.Weight) || proposal.Attention.Weight < 0.0 then
+            Error(InvalidAttentionWeight proposal.Attention.Weight)
+        else
+            Ok()
+
+    let toRankedBranch (proposal: Proposal<'S>) : Result<RankedBranch<'S>, Feedback> =
+        result {
+            do! validateProposal proposal
+
+            let! gravityBytes =
+                match proposal.Memory with
+                | Some memory -> memoryGravityBytes memory
+                | None -> Ok 0L
+
+            let! spaceBytes =
+                addCapped (BigInteger proposal.BaseSpaceBytes) (BigInteger gravityBytes)
+                |> Result.map toInt64
+
+            let uncertaintyBits =
+                BigInteger proposal.BaseUncertaintyResolutionBits
+                + BigInteger proposal.Attention.ResolutionBits
+
+            if uncertaintyBits > BigInteger Int32.MaxValue then
+                return! Error(ByteCostOverflow uncertaintyBits)
+            else
+                let rank =
+                    proposal.Attention.Weight
+                    * Math.Log(2.0 + float gravityBytes, 2.0)
+
+                let branch : Vision.FutureBranch<'S> =
+                    { Label = proposal.Label
+                      State = proposal.State
+                      Cost =
+                        { SpaceBytes = spaceBytes
+                          TimeTicks = proposal.TimeTicks
+                          BytesPerTick = proposal.BytesPerTick
+                          UncertaintyResolutionBits = int uncertaintyBits } }
+
+                return
+                    { Proposal = proposal
+                      Branch = branch
+                      GravityBytes = gravityBytes
+                      Rank = rank }
+        }
+
+    let rankProposals (proposals: Proposal<'S> list) : Result<RankedBranch<'S> list, Feedback> =
+        let rec loop acc rest =
+            result {
+                match rest with
+                | [] ->
+                    return
+                        acc
+                        |> List.sortWith (fun left right ->
+                            let rankOrder = compare right.Rank left.Rank
+                            if rankOrder <> 0 then
+                                rankOrder
+                            else
+                                StringComparer.Ordinal.Compare(left.Branch.Label, right.Branch.Label))
+                | proposal :: tail ->
+                    let! branch = toRankedBranch proposal
+                    return! loop (branch :: acc) tail
+            }
+
+        loop [] proposals
+
+    let predict
+        (proposals: Proposal<'S> list)
+        (tank: SoftThrottle.Tank)
+        : Result<Vision.PredictionReport<'S>, Feedback> =
+        result {
+            let! ranked = rankProposals proposals
+            let branches = ranked |> List.map _.Branch
+            return!
+                Vision.predictBranches branches tank
+                |> Result.mapError VisionFeedback
+        }

--- a/tests/Bayesian.Tests/Bayesian.Tests.fsproj
+++ b/tests/Bayesian.Tests/Bayesian.Tests.fsproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <Compile Include="Message.Tests.fs" />
+    <Compile Include="VisionAttentionBudget.Tests.fs" />
     <Compile Include="FactorGraph.Tests.fs" />
     <Compile Include="MessageBatch.Tests.fs" />
     <Compile Include="Bp.Tests.fs" />

--- a/tests/Bayesian.Tests/VisionAttentionBudget.Tests.fs
+++ b/tests/Bayesian.Tests/VisionAttentionBudget.Tests.fs
@@ -1,0 +1,38 @@
+module Zeta.Bayesian.Tests.VisionAttentionBudgetTests
+
+open global.Xunit
+open Zeta.Bayesian
+open Zeta.Core
+
+let private mustOk =
+    function
+    | Ok value -> value
+    | Error feedback -> failwithf "expected Ok, got %A" feedback
+
+let private proposal label weight : VisionAttention.Proposal<string> =
+    { Label = label
+      State = label
+      BaseSpaceBytes = 9L
+      TimeTicks = 0
+      BytesPerTick = 0L
+      BaseUncertaintyResolutionBits = 0
+      Attention =
+        { Weight = weight
+          ResolutionBits = 8 }
+      Memory = None }
+
+[<Fact>]
+let ``Bayesian evidence weights Vision self-budget ordering`` () =
+    let prior = Beta.create 1.0 1.0
+    let posterior = Beta.product prior (Beta.likelihood 9.0 1.0)
+
+    let priorBranch = proposal "prior-flat" (Beta.mean prior)
+    let posteriorBranch = proposal "posterior-evidence" (Beta.mean posterior)
+
+    let report =
+        VisionAttention.predict [ priorBranch; posteriorBranch ] (SoftThrottle.tank 10.0 0.0)
+        |> mustOk
+
+    Assert.True(Beta.mean posterior > Beta.mean prior)
+    Assert.Equal<string list>([ "posterior-evidence" ], report.Boarded |> List.map _.Label)
+    Assert.Equal<string list>([ "prior-flat" ], report.Deferred |> List.map _.Label)

--- a/tests/Tests.FSharp/QSharpOracle.Tests.fs
+++ b/tests/Tests.FSharp/QSharpOracle.Tests.fs
@@ -110,6 +110,10 @@ let private interferenceCase (id: string) =
     vectors.GetProperty("interferenceVisibility").EnumerateArray()
     |> Seq.find (fun item -> item.GetProperty("id").GetString() = id)
 
+let private flowBitCase (id: string) =
+    vectors.GetProperty("flowBitDistinction").EnumerateArray()
+    |> Seq.find (fun item -> item.GetProperty("id").GetString() = id)
+
 let private bellCoincidenceCase (id: string) =
     vectors.GetProperty("bellCoincidence").EnumerateArray()
     |> Seq.find (fun item -> item.GetProperty("id").GetString() = id)
@@ -224,6 +228,22 @@ let ``QubitIso raw kernels match Q# gate matrices on computational basis states`
     assertRaw "Ry(pi/3)" (QubitIso.Raw.ry (Math.PI / 3.0))
     assertRaw "Ry(pi/2)" (QubitIso.Raw.ry (Math.PI / 2.0))
     assertRaw "Rz(pi/3)" (QubitIso.Raw.rz (Math.PI / 3.0))
+
+[<Fact>]
+let ``Q# flow-bit oracle turns external entropy into deterministic distinction`` () =
+    let zero = flowBitCase "external-bit-zero"
+    let zeroProb = zero.GetProperty("probabilities")
+    Assert.False(zero.GetProperty("externalBit").GetBoolean())
+    Assert.Equal("Zeta.ReferenceOracle.ApplyExternalBitDistinguishZero", zero.GetProperty("operation").GetString())
+    closeTo 1.0 (zeroProb.GetProperty("Zero").GetDouble())
+    closeTo 0.0 (zeroProb.GetProperty("One").GetDouble())
+
+    let one = flowBitCase "external-bit-one"
+    let oneProb = one.GetProperty("probabilities")
+    Assert.True(one.GetProperty("externalBit").GetBoolean())
+    Assert.Equal("Zeta.ReferenceOracle.ApplyExternalBitDistinguishOne", one.GetProperty("operation").GetString())
+    closeTo 0.0 (oneProb.GetProperty("Zero").GetDouble())
+    closeTo 1.0 (oneProb.GetProperty("One").GetDouble())
 
 [<Fact>]
 let ``BellTest canonical CHSH observables match the Q# golden vector`` () =

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -161,6 +161,7 @@
     <Compile Include="TimeGen.Tests.fs" />
     <Compile Include="Braid.Tests.fs" />
     <Compile Include="Braid.GoldenVectors.Tests.fs" />
+    <Compile Include="VisionAttention.Tests.fs" />
     <Compile Include="MillBraid.Tests.fs" />
     <Compile Include="MediaLines.Tests.fs" />
     <Compile Include="BoundaryLight.Tests.fs" />

--- a/tests/Tests.FSharp/VisionAttention.Tests.fs
+++ b/tests/Tests.FSharp/VisionAttention.Tests.fs
@@ -1,0 +1,57 @@
+module Zeta.Tests.VisionAttentionTests
+
+open global.Xunit
+open Zeta.Core
+
+let private mustOk =
+    function
+    | Ok value -> value
+    | Error feedback -> failwithf "expected Ok, got %A" feedback
+
+let private attention weight bits : VisionAttention.Attention =
+    { Weight = weight
+      ResolutionBits = bits }
+
+let private memory strands word bytes pureBytes : VisionAttention.MemoryBraid =
+    { Strands = strands
+      Word = word
+      BytesPerCrossing = bytes
+      PureKernelBytes = pureBytes }
+
+let private proposal label state baseBytes attention memory : VisionAttention.Proposal<int> =
+    { Label = label
+      State = state
+      BaseSpaceBytes = baseBytes
+      TimeTicks = 0
+      BytesPerTick = 0L
+      BaseUncertaintyResolutionBits = 0
+      Attention = attention
+      Memory = memory }
+
+[<Fact>]
+let ``memory braid gravity prices dense pure-kernel memory`` () =
+    let densePure = memory 2 [ 1; 1 ] 3L 11L
+    let sparseVisible = memory 5 [ 1; 3 ] 3L 11L
+
+    let denseBytes = VisionAttention.memoryGravityBytes densePure |> mustOk
+    let sparseBytes = VisionAttention.memoryGravityBytes sparseVisible |> mustOk
+
+    Assert.Equal(23L, denseBytes)
+    Assert.Equal(6L, sparseBytes)
+    Assert.True(denseBytes > sparseBytes)
+
+[<Fact>]
+let ``attention rank decides which self-future boards first while byte cost stays honest`` () =
+    let highGravity = Some(memory 2 [ 1; 1 ] 2L 4L)
+    let highAttention = proposal "high-attention-memory" 1 4L (attention 10.0 8) highGravity
+    let lowAttention = proposal "low-attention-flat" 2 5L (attention 1.0 8) None
+
+    let report =
+        VisionAttention.predict [ lowAttention; highAttention ] (SoftThrottle.tank 18.0 0.0)
+        |> mustOk
+
+    Assert.Equal(Vision.PartiallyAdmitted, report.Outcome)
+    Assert.Equal<string list>([ "high-attention-memory" ], report.Boarded |> List.map _.Label)
+    Assert.Equal<string list>([ "low-attention-flat" ], report.Deferred |> List.map _.Label)
+    Assert.Equal(17L, report.BoardedBytes)
+    Assert.Equal(6L, report.DeferredBytes)


### PR DESCRIPTION
## What changed

- Added `VisionAttention` in `src/Core` to price memory-braid load as a byte-denominated gravity term and rank proposed futures by attention before handing them to the existing Vision tank.
- Added a self-contained Q# flow-bit PoC: `H; optional Z(externalBit); H`, where one external entropy bit becomes deterministic measured distinction.
- Locked the new flow-bit oracle rows in `qsharp-golden.json` and covered them from TS and F#.
- Added Bayesian evidence -> attention ordering coverage, plus a signed Z-set retraction check for Q# observable rows.

## Why

This keeps both requested shapes: Q# can run the finite proof-of-concept as an oracle/reference, while the repo-owned F#/Bayesian path keeps DBSP and Vision as the runtime abstractions. Attention changes ordering; the byte tank still enforces arithmetic truth and backpressure.

## Validation

- `dotnet build Zeta.sln -c Release -m:1`
- `dotnet test Zeta.sln -c Release --no-build`
- `dotnet format --verify-no-changes`
- `bun test src/Core.QSharp.ReferenceOracle/qsharp-golden.test.ts src/Core.QSharp.ReferenceOracle/quantum-circuit.test.ts`

Note: local Microsoft QDK/qsharp is not installed in this foreground clone, so I did not rerun `generate-qsharp-golden.py`; the generator and committed deterministic golden rows were updated together and verified by the TS/F# oracle consumers.

Agency-Signature-Version: 1
Agent: Vera
Agent-Runtime: OpenAI Codex
Agent-Model: GPT-5
Credential-Identity: AceHack
Credential-Mode: shared
Human-Review: not-implied-by-credential
Human-Review-Evidence: none
Action-Mode: human-directed
Task: task-7948
Co-authored-by: Codex <noreply@openai.com>


