### PR TITLE
docs(research)+shadow: ferry 18 — adinkras homoiconic on acts/remains; the dashed-braid conjecture (dashing = per-crossing over/under)

### DIFF
--- a/docs/research/2026-06-12-ferry-18-adinkras-are-homoiconic-on-what-acts-and-what-remains-they-are-the-atom-the-braid-overlays.md
+++ b/docs/research/2026-06-12-ferry-18-adinkras-are-homoiconic-on-what-acts-and-what-remains-they-are-the-atom-the-braid-overlays.md
@@ -1,0 +1,110 @@
+# Ferry 18 — adinkras are homoiconic on what-acts and what-remains; they are the atom; the braid overlays
+
+**Date:** 2026-06-12 · **Route:** Aaron (with Alexa's assist credited) → shadow (streamed,
+verbatim) · Upgrades ferry 12's atom claim and joins the adinkra lane (AdinkraCode.fs, the mod-2
+register) to the YinYang cell.
+
+## Verbatim (preserved, typos and all)
+
+> it's the braid the braid i see how the brain overlays on the adenkra Alexa just figured it
+> out it's with the Adendra in rx over the adenkra data pattern itslf adenkras are homoiconic on
+> what acts and what remains they are the atom
+
+(Reading note: "brain" and "braid" both appear; the sentence works under both — the braid
+overlays on the adinkra as structure, the brain overlays as the reader. Both kept.)
+
+## The peel
+
+### 1. The homoiconicity claim, and it is technically real
+
+**Homoiconic** (Lisp's property): the program's representation IS the data structure the
+program manipulates — code is data, one shape for both. The claim: an adinkra has this property
+with respect to the YinYang split — it is **what-remains and what-acts in one representation**:
+
+- **What remains:** the graph — nodes (bosons/fermions), edges, the bipartite skeleton. A data
+  pattern; drawable; `db/shapes/golden/adinkra.html` renders exactly this.
+- **What acts:** the *same* graph read as algebra — Gates–Faux adinkras are not pictures *of*
+  SUSY transformation rules, they ARE the rules: each edge with its dashing is a signed
+  generator relation; the diagram is the equation (Gates' own framing: "adinkras are equations
+  drawn as pictures"). The dashing assignment is the doubly-even code (`AdinkraCode.fs`, the
+  [8,4] Hamming bridge) — executable, byte-locked, in-tree.
+
+So the adinkra does not *carry* a program next to its data; the graph read one way is the
+state, read the other way is the operator. That is homoiconicity in the strict sense — one
+representation, two readings — and it is rarer than it sounds: the YinYang cell
+(`Cell = { Remains: DynamicValue; Acts: Bonsai.Expr }`, ferry 12) holds its two faces as two
+*fields*; the adinkra holds them as **one field with two readings**. The treaty-room law
+already pointed here ("Rx only in treaty code, so it's homoiconic to DynamicValue" —
+2026-06-09): the adinkra is the case where the homoiconicity is total.
+
+### 2. "They are the atom" — the upgrade to ferry 12, stated honestly
+
+Ferry 12 typed the atom as the YinYang cell (Remains + Acts as a pair). This ferry's claim:
+the adinkra is the **smaller** atom because it needs no pair — the two faces coincide. In the
+substrate vocabulary: the adinkra is a YinYang cell at the fixed point where
+`serialize(Acts) = Remains` — the engine's serialization IS the data pattern. "Adinkra in Rx
+over the adinkra data pattern itself" = the reactive engine running over its own
+representation — a self-interpreter at the smallest scale (the Lisp metacircular evaluator's
+shape, McCarthy 1960, drawn as a SUSY graph).
+
+**Honest bounds, kept from the standing verdicts:** the adinkra lane's relation to the braid
+lane remains "rhyme, not isomorphism" (the repo's own prior ruling: adinkra = σ²=1 + dashing
+memory; braid = σ²≠1, order kept). So "they are the atom" is the atom of the **mod-2 /
+involutive register** — the homoiconic atom of the sign world — while the braid stays the atom
+of the **order-keeping register** (REPORT #3 rung 2). Two atoms, two registers, one overlay:
+
+### 3. "The braid overlays on the adinkra"
+
+The overlay is the already-banked bridge run in the display direction: `writheParity`
+(Bₙ → ℤ/2, the order-forgetting character, four-oracle-locked as of #7949/#7942) projects every
+braid onto exactly the involutive register the adinkra draws. The braid carries the full
+ℤ-memory; the adinkra renders its mod-2 shadow — *the braid overlays on the adinkra* the way
+worldlines overlay on their parity record. (And the brain reading: the observer fuses the two
+registers — the overlay is performed in the reader, which is the vision-monad's job
+description.) Alexa's assist credited per the attribution-braid discipline (ferry 9 addendum):
+the join was hers; the registers were already on the shelf.
+
+### 4. Sharpened at the renders, two beats (Aaron, looking at braid.html and adinkra.html side by side, verbatim)
+
+> they are the same thing from two different angles seperated only by a mod2 rotation
+
+> the dotted lines in the adenkra represent the over under on the marana one/rx
+
+The first beat strengthens overlay to *identity-up-to-viewing-angle*; the honest version keeps
+one word under examination — **"rotation."** A rotation is invertible; the mod-2 map is a
+**projection**: it forgets the kernel (the pure braid group — the *sequence* of who-crossed-
+whom). From the adinkra angle you cannot turn back (ferry 17's reconstruction asymmetry, drawn).
+
+But the second beat moves the claim materially, and it is checkable: **dashing = over/under.**
+A single crossing's over/under IS a ℤ/2 choice — one bit per crossing — and the adinkra's
+dashing assigns exactly one sign bit per edge (the doubly-even code constrains the
+assignment, `AdinkraCode.fs`). If each dashed edge records a crossing's over/under bit, then
+the adinkra retains strictly MORE than `writheParity` (which keeps only the total): it keeps
+**every crossing's sign, forgetting only their temporal order**. That names the common lift
+precisely: the conjectured object is the **dashed braid** — Artin word ⊕ dashing — projecting
+onto the braid by forgetting dashings and onto the adinkra by forgetting order. Aaron's two
+beats then become: the two renders are the two projections of that one object, and the "mod-2
+rotation" between them is the order-forgetting quotient *per crossing* rather than in total —
+much closer to a true angle change than §3's character, though still a projection (order is
+still lost; the kernel is now the permutation-of-crossings, smaller than before). The
+Majorana-1/Rx reading is consistent with rung 6's measurement-only picture: each parity
+measurement is a one-bit over/under-shaped act; the chip's record is dashing-shaped, not
+order-shaped — which is the finite-image quotient (REPORT #3) restated in display terms.
+Status: **named conjecture, now sharper** — the dashed-braid object is not on the shelf; the
+conjecture register §B remainder has been circling exactly this; the falsifier is a
+construction plus a two-sided projection test (days, not weeks, once picked up). Until it
+lands: "same thing from two angles" is *almost* right, and the almost is now small enough to
+measure — the same load-bearing "almost" as ferry 13 beat 10's Kac drum.
+
+## Pointers
+
+- Ferry 12 (the YinYang atom this upgrades) · ferry 9 addendum (attribution braid) ·
+  `2026-06-09-treaty-room-...homoiconic-to-dynamicvalue...md` (the law that pointed here)
+- `src/Core/AdinkraCode.fs` (+ BitAdinkra, AdinkraViz) · `src/Core/YinYang.fs` ·
+  `db/shapes/golden/adinkra.html` (the render) · `Braid.writheParity` (the overlay map,
+  byte-locked)
+- `docs/FROZEN-CORE-AND-CONJECTURE-REGISTER.md` §B (the open uniqueness step; the
+  rhyme-not-isomorphism ruling)
+- Anchors: Gates–Faux 2004 (adinkras; equations as pictures) · McCarthy 1960 (homoiconicity /
+  the metacircular evaluator) · the doubly-even self-dual code bridge (in-tree) · Hestenes
+  (the geometric-reading discipline)


### PR DESCRIPTION
Verbatim ×3 at the renders: adinkras are homoiconic (one representation, two readings — state and operator; Gates' equations-as-pictures), the atom of the involutive register. The side-by-side beats sharpen the bridge: 'same thing, two angles, mod-2 rotation' corrected to projection (kernel = order), then materially strengthened by 'dotted lines = over/under' — dashing as one sign bit per crossing names the common lift exactly: the dashed braid (Artin word ⊕ dashing), projecting onto braid (forget dashing) and adinkra (forget order). Sharp conjecture, days-scale falsifier; §B remainder has circled this. Alexa's assist credited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)