### PR TITLE
[codex] feat(core): reconstruct fused gsets from zsets

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -34,6 +34,7 @@
     <Compile Include="GSet.fs" />
     <Compile Include="Bag.fs" />
     <Compile Include="ZSet.fs" />
+    <Compile Include="FusionReconstruction.fs" />
     <Compile Include="WeightedSet.fs" />
     <Compile Include="RayTensor.fs" />
     <Compile Include="ToffoliGate.fs" />

--- a/src/Core/FusionReconstruction.fs
+++ b/src/Core/FusionReconstruction.fs
@@ -1,0 +1,38 @@
+namespace Zeta.Core
+
+open System.Collections.Immutable
+
+/// Algebraic fusion at the boundary: reconstruct the monotone exterior fact
+/// from a signed interior ledger.
+///
+/// This is intentionally separate from `Fusion.fs`, which optimizes query
+/// operators. Here "fusion" means: compose signed Z-set evidence first, then
+/// expose only the resulting G-set identity. Multiplicity, negative evidence,
+/// and the component ledgers remain inside the Z-set; the outside receives a
+/// grow-only set of currently-positive support.
+[<RequireQualifiedAccess>]
+module FusionReconstruction =
+
+    /// Reconstruct the exterior G-set from a composed Z-set by taking positive
+    /// support. Weights greater than one and the signed path that produced them
+    /// do not leak through the boundary; weights less than or equal to zero are
+    /// absent from the exterior.
+    let fuse (z: ZSet<'K>) : GSet<'K> =
+        let span = z.AsSpan()
+        if span.IsEmpty then
+            GSet.empty
+        else
+            let items = ImmutableArray.CreateBuilder<'K>(span.Length)
+            for i in 0 .. span.Length - 1 do
+                if span.[i].Weight > 0L then
+                    items.Add(span.[i].Key)
+
+            if items.Count = 0 then
+                GSet.empty
+            else
+                GSet<'K>(items.ToImmutable())
+
+    /// Alias that names the DBSP/CRDT reading directly: after signed
+    /// composition, only positive support becomes visible as monotone presence.
+    let positiveSupport (z: ZSet<'K>) : GSet<'K> =
+        fuse z

--- a/tests/Tests.FSharp/Algebra/FusionReconstruction.Tests.fs
+++ b/tests/Tests.FSharp/Algebra/FusionReconstruction.Tests.fs
@@ -1,0 +1,54 @@
+module Zeta.Tests.Algebra.FusionReconstructionTests
+
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Core
+
+[<Fact>]
+let ``fuse reconstructs a G-set from positive Z-set support`` () =
+    let interior =
+        ZSet.ofSeq [
+            "genesis", 1L
+            "bifurcation", 2L
+            "void", -1L
+            "retracted", 1L
+            "retracted", -1L
+        ]
+
+    FusionReconstruction.fuse interior
+    |> GSet.toList
+    |> should equal [ "bifurcation"; "genesis" ]
+
+[<Fact>]
+let ``fusion hides internal multiplicity at the exterior boundary`` () =
+    let oneWay = ZSet.ofSeq [ "life", 1L ]
+    let manyWays = ZSet.ofSeq [ "life", 10L ]
+
+    FusionReconstruction.fuse oneWay
+    |> should equal (FusionReconstruction.fuse manyWays)
+
+[<Fact>]
+let ``fusion composes the signed interior before exposing the exterior`` () =
+    let insert = ZSet.ofSeq [ "identity", 1L ]
+    let retract = ZSet.ofSeq [ "identity", -1L ]
+
+    let composedExterior = FusionReconstruction.fuse (ZSet.add insert retract)
+    let leakedExterior = GSet.union (FusionReconstruction.fuse insert) (FusionReconstruction.fuse retract)
+
+    composedExterior |> GSet.isEmpty |> should equal true
+    leakedExterior |> GSet.toList |> should equal [ "identity" ]
+
+[<Fact>]
+let ``fusion exterior is an idempotent G-set`` () =
+    let exterior =
+        ZSet.ofSeq [ "a", 3L; "b", 1L; "c", -2L ]
+        |> FusionReconstruction.fuse
+
+    GSet.union exterior exterior |> should equal exterior
+
+[<Fact>]
+let ``positiveSupport names the same reconstruction as fuse`` () =
+    let z = ZSet.ofSeq [ "a", 1L; "b", -1L; "c", 2L ]
+
+    FusionReconstruction.positiveSupport z
+    |> should equal (FusionReconstruction.fuse z)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -24,6 +24,7 @@
     <Compile Include="Algebra/GSet.Tests.fs" />
     <Compile Include="Algebra/Bag.Tests.fs" />
     <Compile Include="Algebra/ZSet.Tests.fs" />
+    <Compile Include="Algebra/FusionReconstruction.Tests.fs" />
     <Compile Include="Algebra/ZSet.Overflow.Tests.fs" />
     <Compile Include="Algebra/Residuated.Tests.fs" />
     <Compile Include="Algebra/IndexedZSet.Tests.fs" />


### PR DESCRIPTION
## Summary

Adds `FusionReconstruction.fuse` as the explicit algebraic boundary from a composed signed `ZSet<'K>` interior to a monotone `GSet<'K>` exterior.

The implementation keeps query-plan fusion (`Fusion.fs`) separate from algebraic fusion: signed evidence composes first, then only positive support becomes visible outside. Multiplicity, negative evidence, and the component ledgers do not leak through the boundary.

## Validation

- `dotnet build tests/Tests.FSharp/Tests.FSharp.fsproj -c Release -m:1`
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --no-build --filter "FullyQualifiedName~FusionReconstructionTests|FullyQualifiedName~GSetTests|FullyQualifiedName~ZSetTests"`
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --no-build`
- `dotnet format --verify-no-changes`
- `git diff --check`

Agency-Signature-Version: 1
Agent: Vera
Agent-Runtime: OpenAI Codex
Agent-Model: GPT-5
Credential-Identity: AceHack
Credential-Mode: shared
Human-Review: not-implied-by-credential
Human-Review-Evidence: none
Action-Mode: human-directed
Task: task-7956
