### PR TITLE
feat(core)+test: Resolution — the self-budgeting cell (the first bit that knows when it needs more bits)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -51,6 +51,7 @@
     <Compile Include="CliVerb.fs" />
     <Compile Include="Optics.fs" />
     <Compile Include="UniversalNumber.fs" />
+    <Compile Include="Resolution.fs" />
     <Compile Include="TravelerFrame.fs" />
     <Compile Include="FrameDelta.fs" />
     <Compile Include="UncertainClock.fs" />

--- a/src/Core/Resolution.fs
+++ b/src/Core/Resolution.fs
@@ -1,0 +1,61 @@
+namespace Zeta.Core
+
+/// Resolution — **the self-budgeting cell: the first bit that knows when it needs more bits.**
+///
+/// Aaron 2026-06-12 (ferry 20 §5): "the first bit that knows when it needs more bits to contain
+/// the uncertainty." This is the seed at minimum scale (ferry 20: shape kept, entropy ready) and
+/// the base case of the recursive budget (ferry 16: budget = flow control = stability of self;
+/// the contraction's floor). It reads the resolution accounting already on the `UniversalNumber`
+/// port (`BitsUsed` = signal above noise; `IsExact`) and adds the one decision that makes a value
+/// *self*-budgeting: **does my current width carry the bits this uncertainty demands, and if not,
+/// how many more?**
+///
+/// Pure module over the port interface — no class, no captured state (the interfaces-free /
+/// classes-earned meta-rule): the cell is a *reading* of a value through its port, not a new
+/// stateful object. `widen` is supplied by the caller's carrier (Ball.shed, BigFloat precision
+/// raise, …) because growing precision is the carrier's business; this module decides *whether*
+/// and *by how much*, never *how* — the separation Vera named (fuse/Vision policy preserves
+/// "shape without history" outside; the carrier keeps the history inside).
+[<RequireQualifiedAccess>]
+module Resolution =
+
+    /// A resolution reading: signal bits currently carried, and whether the value is exact.
+    /// The Beacon register's "physics of floats" made a value: bits = signal above the noise.
+    type Reading = { SignalBits: int; IsExact: bool }
+
+    /// Read a value's resolution through its port.
+    let read (port: UniversalNumber.IUniversalNumber<'T>) (v: 'T) : Reading =
+        { SignalBits = port.BitsUsed v; IsExact = port.IsExact v }
+
+    /// Does the value carry at least `required` signal bits? (The "am I wide enough?" question —
+    /// the whole interpretation a width-1 seed keeps, ferry 20 §5.)
+    let sufficientFor (required: int) (port: UniversalNumber.IUniversalNumber<'T>) (v: 'T) : bool =
+        port.BitsUsed v >= required
+
+    /// How many MORE signal bits are needed to reach `required` (0 if already sufficient).
+    /// This is the cell's demand signal — the bit that knows it needs more bits, quantified.
+    /// Never negative: surplus is not a deficit (uncertainty has no sign — Ball's law 1 echoed).
+    let deficit (required: int) (port: UniversalNumber.IUniversalNumber<'T>) (v: 'T) : int =
+        max 0 (required - port.BitsUsed v)
+
+    /// The self-budgeting decision over one incoming demand: hold if the current width suffices,
+    /// otherwise report the deficit so the carrier can widen. Returns a typed verdict, never an
+    /// exception (Result/decline discipline) — the refusal-to-overflow is a first-class value
+    /// (composes with Vera's tryFuse, ferry 17: a decline that carries information).
+    type Verdict =
+        /// Width suffices for the demand; nothing to do (the contraction held — ferry 16).
+        | Hold
+        /// Width is short by `Bits`; the carrier must widen by at least this to contain the demand.
+        | Widen of Bits: int
+
+    /// Decide whether a value's resolution contains a demand of `required` signal bits.
+    let decide (required: int) (port: UniversalNumber.IUniversalNumber<'T>) (v: 'T) : Verdict =
+        match deficit required port v with
+        | 0 -> Hold
+        | n -> Widen n
+
+    /// Fold a stream of bit-demands into the running maximum width required to contain them all —
+    /// the budget accumulating its own ceiling (the recursive-budget base case, ferry 16; a max-
+    /// monoid, so it is idempotent and order-free — apply-N == apply-once, manifesto §12).
+    let ceiling (demands: int seq) : int =
+        Seq.fold max 0 demands

--- a/tests/Tests.FSharp/Resolution.Tests.fs
+++ b/tests/Tests.FSharp/Resolution.Tests.fs
@@ -1,0 +1,74 @@
+module Zeta.Tests.ResolutionTests
+
+// Resolution — the self-budgeting cell ("the first bit that knows when it needs more bits",
+// ferry 20 §5). Exercised over BOTH UniversalNumber adapters (bigInt: always exact; Ball: the
+// inexact bound carrier) so the seed cell is port-generic, not bigint-specific.
+
+open System.Numerics
+open global.Xunit
+open FsCheck
+open FsCheck.Xunit
+open Zeta.Core
+open Zeta.Core.FSharp.TriBoolean
+
+let private big (n: int) = BigInteger(n)
+let private ball c r = match Ball.create (big c) (big r) with Ok b -> b | Error e -> failwith e
+
+[<Fact>]
+let ``read reports signal bits and exactness through the bigInt port`` () =
+    let r = Resolution.read UniversalNumber.bigInt (big 0)
+    Assert.Equal(0, r.SignalBits)
+    Assert.True(r.IsExact)
+    let r2 = Resolution.read UniversalNumber.bigInt (big 255) // 8 bits
+    Assert.Equal(8, r2.SignalBits)
+    Assert.True(r2.IsExact)
+
+[<Fact>]
+let ``sufficientFor is the "am I wide enough" question`` () =
+    Assert.True(Resolution.sufficientFor 8 UniversalNumber.bigInt (big 255)) // 8 bits >= 8
+    Assert.False(Resolution.sufficientFor 9 UniversalNumber.bigInt (big 255)) // 8 bits < 9
+
+[<Fact>]
+let ``deficit quantifies the demand for more bits and is never negative`` () =
+    Assert.Equal(0, Resolution.deficit 4 UniversalNumber.bigInt (big 255)) // surplus -> 0, not -4
+    Assert.Equal(2, Resolution.deficit 10 UniversalNumber.bigInt (big 255)) // short by 2
+
+[<Fact>]
+let ``decide returns Hold when sufficient and Widen by the deficit when short`` () =
+    Assert.Equal(Resolution.Hold, Resolution.decide 8 UniversalNumber.bigInt (big 255))
+    Assert.Equal(Resolution.Widen 2, Resolution.decide 10 UniversalNumber.bigInt (big 255))
+
+[<Fact>]
+let ``the cell is port-generic: Ball (inexact carrier) reads fewer signal bits as the radius grows`` () =
+    // exact ball: full signal; widened ball: signal shrinks (radius eats low bits) -> needs more.
+    let exact = Ball.exact (big 255)
+    let fuzzy = ball 255 15 // radius 15 ~ 4 noise bits
+    let sExact = Resolution.read Ball.universal exact
+    let sFuzzy = Resolution.read Ball.universal fuzzy
+    Assert.True(sExact.IsExact)
+    Assert.False(sFuzzy.IsExact)
+    Assert.True(sFuzzy.SignalBits < sExact.SignalBits, "noise must lower the signal-bit count")
+
+[<Property>]
+let ``deficit is exactly the shortfall: deficit r + min(bits, r) = r`` (required: int) =
+    let req = abs required % 64
+    let v = big 255 // 8 signal bits on the bigInt port
+    let bits = UniversalNumber.bigInt.BitsUsed v
+    Resolution.deficit req UniversalNumber.bigInt v + min bits req = req
+
+[<Property>]
+let ``decide agrees with sufficientFor`` (required: int) =
+    let req = abs required % 64
+    let v = big 1000
+    match Resolution.decide req UniversalNumber.bigInt v with
+    | Resolution.Hold -> Resolution.sufficientFor req UniversalNumber.bigInt v
+    | Resolution.Widen n -> n > 0 && not (Resolution.sufficientFor req UniversalNumber.bigInt v)
+
+[<Property>]
+let ``ceiling is the max-monoid: idempotent and order-free`` (xs: int list) =
+    let demands = xs |> List.map (fun x -> abs x % 1000)
+    let c = Resolution.ceiling demands
+    // idempotent: folding the result back in changes nothing
+    Resolution.ceiling (c :: demands) = c
+    // order-free: reversal agrees
+    && Resolution.ceiling (List.rev demands) = c

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -190,6 +190,7 @@
     <Compile Include="BenPort.Tests.fs" />
     <Compile Include="CapabilityLedger.Tests.fs" />
     <Compile Include="Ball.Tests.fs" />
+    <Compile Include="Resolution.Tests.fs" />
     <Compile Include="RxAdapter.Tests.fs" />
     <Compile Include="WaveSim.Tests.fs" />
     <Compile Include="AdinkraViz.Tests.fs" />


### PR DESCRIPTION
Builds ferry 21's most load-bearing gap (the seed's interface) and ferry 20 §5's "first bit that knows when it needs more bits." Pure F# module over the existing `IUniversalNumber` port — interfaces-free (reads the port, mints no class), so no public-API gate needed yet:

- `read` → (signal bits, exact?) · `sufficientFor` → the "am I wide enough?" question · `deficit` → the demand for more bits (never negative) · `decide` → `Hold | Widen n` (Result/decline discipline — the refusal-to-overflow is a first-class value, composes with Vera's `tryFuse`) · `ceiling` → the max-monoid (idempotent + order-free, §12 — the recursive budget's base case, ferry 16).
- The carrier supplies widen (`Ball.shed` / BigFloat); this module decides *whether* and *how much*, never *how* — exactly Vera's shape-without-history-outside / history-inside split.

Port-generic by test: bigInt (always exact) AND Ball (radius eats low bits → fewer signal bits → needs more). 8/8 green incl. 3 FsCheck properties; solution builds 0 warnings 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)