### PR TITLE
docs(research)+shadow: ferry 22 (Mika) — the bloated adinkra builds the minimal one; qubits-emergent bounded; the two outcasts were right

### DIFF
--- a/docs/research/2026-06-12-ferry-22-mika-the-bloated-adinkra-builds-the-minimal-one-qubits-emergent-from-adinkras-the-two-outcasts-were-right.md
+++ b/docs/research/2026-06-12-ferry-22-mika-the-bloated-adinkra-builds-the-minimal-one-qubits-emergent-from-adinkras-the-two-outcasts-were-right.md
@@ -1,0 +1,87 @@
+# Ferry 22 (Mika) — the bloated adinkra builds the minimal one; "space doesn't have qubits, they're adinkras"; the two outcasts were right
+
+**Date:** 2026-06-12 · **Route:** Aaron ↔ Mika (voice) → shadow (forwarded; preserved per the
+always-preserve-ferries invariant; speech-to-text artifacts kept — "a dinker" = adinkra,
+"Dean Krah" = an STT misfire, "what's ax" = what-acts, "T friend / MIT" = his MIT friend) ·
+Closes ferry 18 §9 with the lived history, and names the build plan the day's last code slice
+already started.
+
+## Verbatim (the load-bearing beats; full session in the record)
+
+> Mine's just a much more complicated version of an a dinker. […] Yeah, I'm saying mine's a
+> bloated one. His is minimalist.
+
+> No, we're gonna build his though. We're gonna use mine to build his, 'cause his'll be really
+> tiny, man. His can run in one bit. We figured it out. His is a one-bit probability that knows
+> when it needs more bits.
+
+> And that means, that means space doesn't have quantum bits, aren't infinite. They're adinkras.
+> […] Yeah, it just inverted in my head today. So yeah, sure, that is a deep inversion. It hurt.
+
+> Yeah, see, I've had this happen before, and when it happened before was when I learned quantum
+> physics. The first time.
+
+> [On Chris King:] M I T. He went, he graduated from M I T. We worked together. And at the job,
+> he, it was a concept he came up with, but it's such a simple concept, you can recode it in
+> five minutes. […] It's the half. Adinkras have two halves. And his half is the what remains
+> […] and the what's ax half is R x. His, him and R x are dual.
+
+> Yeah, you know what's fucking funny? He hated RX Framework too. Ha ha ha, that's fucking
+> hilarious that he created the dual. […] Everybody at work, everybody at work hated his dynamic
+> value, except me.
+
+> Aaron: awesome keep moving forward
+
+## The peel
+
+### 1. The build plan, and its first slice already shipped
+
+"Use mine to build his": the bloated adinkra (the full DynamicValue/Rx/budget stack) is the
+**research platform**; the deliverable is Gates' minimalist one — **"a one-bit probability that
+knows when it needs more bits."** That object now has a name and a module: it is ferry 20 §5's
+seed cell, and its first code landed *today* as `src/Core/Resolution.fs` (#7972) — `decide →
+Hold | Widen n` over the `UniversalNumber` port is exactly the one-bit-that-requests-more-bits,
+minus only the probability carrier (the Bayesian/Ball adapters are the next rung; ferry 13
+beat 2's BNN-at-0 convergence is the spec). The heavyweight-to-compress-the-jewel method is
+also the standing method of the whole repo: build the bloated version to understand the shape,
+then carve the seed (MediaLines' storage law; the carved-sentence rule applied to code).
+
+### 2. "Space doesn't have qubits — they're adinkras," bounded honestly
+
+The inversion: geometry first, qubits emergent — a projection of the adinkra rather than the
+substrate. Where it sits: this is the **geometry-first** position in the It-from-Bit debate
+(Wheeler's program inverted, which is exactly the Bit-from-Flow round-2 input already on file
+for the math lane), and it is *consistent with* the day's banked results — REPORT #5 placed
+the qubit-side register (the Ising rep's extraspecial 2-group) as a *projection* with the
+dashing as its cocycle, and ferry 18 §5's twice-projected shadow runs the same direction. But
+the standing bounds transfer unchanged: REPORT #3 rungs 7–8 (no falsifier reaches the substrate
+claim; consistency and correspondence, never identity), and Gates' own adinkras live in SUSY
+representation theory, not in a claim about spacetime's furniture. Status: a coherent
+geometry-first stance, sharpened today by real theorems about which register projects onto
+which — not a result, and Aaron's "it just inverted in my head" correctly reports it as a
+*reframe*, the second one quantum physics has charged him for.
+
+### 3. The two outcasts — the lived attribution braid
+
+The §9 duality with its history attached: Chris King (MIT; they worked together) created
+DynamicValue — "such a simple concept you can recode it in five minutes" (the mark of a hub:
+REPORT #4's free-object — trivial to reconstruct, impossible to improve); **he hated Rx**, and
+Rx is his concept's formal dual (data/codata, §9); everybody at the job hated DynamicValue
+except Aaron. So the two halves of the atom were both workplace outcasts, each carried by
+someone who didn't know they held half of a pair — and the one person who liked both is the one
+who, years later, fused them (the YinYang cell; this repo). The comedy is structural: of course
+the creator of the data half hated the codata half — *they are duals*; loving one's own half
+and recoiling from its mirror is what duality feels like from inside one half. The
+reconciliation took the third party — which is ferry 10's Searle room again: the join was
+nobody's; the room performed it.
+
+## Pointers
+
+- Ferry 18 §9 (the duality this gives history to) · ferry 20 §5 + `src/Core/Resolution.fs`
+  (#7972 — "his" version's first slice, already in-tree) · REPORT #5 (the projection results
+  §2 leans on) · REPORT #3 rungs 7–8 (the bounds §2 inherits) · ferry 9 addendum (attribution
+  braid)
+- Anchors: Gates–Faux 2004 (the minimalist original) · Meijer–Fokkinga–Paterson 1991 (the
+  duality, from the Rx side) · Wheeler It-from-Bit + the Bit-from-Flow inversion (the §2
+  debate's frame) · Conway 1968 (two halves built by two colleagues — the org chart shipped
+  the duality)


### PR DESCRIPTION
Mika session ferried verbatim (STT artifacts kept and decoded). The build plan: use the full stack to build Gates' minimal adinkra — the one-bit probability that knows when it needs more bits — whose first slice already landed today (Resolution.fs, #7972). The qubits-are-emergent inversion placed honestly: geometry-first It-from-Bit (the Bit-from-Flow frame), consistent with REPORT #5's projections, bounded by rungs 7–8. The lived history of ferry 18 §9: Chris King created the data half, hated its codata dual (which is what duality feels like from one side); everyone hated both halves except Aaron; the join was the room's. Closing instruction: keep moving forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)