### PR TITLE
[codex] ci(stryker): bound core csharp mutation target

### DIFF
--- a/stryker-config.json
+++ b/stryker-config.json
@@ -6,9 +6,8 @@
       "tests/Core.CSharp.Tests/Core.CSharp.Tests.csproj"
     ],
     "mutate": [
-      "!**/AssemblyInfo.cs",
-      "!**/bin/**",
-      "!**/obj/**"
+      "Variance.cs",
+      "ZetaCircuitBuilder.cs"
     ],
     "thresholds": {
       "high": 80,


### PR DESCRIPTION
## Summary

Bounds the observational Stryker.NET lane to the C# files that the workflow and `tests/Core.CSharp.Tests` actually cover: `Variance.cs` and `ZetaCircuitBuilder.cs`.

## Why

Core-touching PRs were timing out in Stryker. The failed run on PR #7948 generated 1,746 mutants, coverage capture failed, Stryker fell back to testing 1,264 mutants, and the job hit the 60-minute workflow timeout. The workflow comments already describe this lane as the direct C# Core surface currently backed by `Core.CSharp.Tests`; the config had drifted broader than that actual test substrate.

With project-relative mutate globs, the root `dotnet stryker` command now completes locally in about 77 seconds. It still records the current debt honestly: 3 mutants survive and the score is 0%, with the existing `break: 0` observational stance unchanged.

## Validation

- `dotnet stryker` (completed locally in 00:01:16.965, 3 surviving mutants observed, exit 0 due existing break-at-0 telemetry stance)
- `dotnet build Zeta.sln -c Release -m:1`

Agency-Signature-Version: 1
Agent: Vera
Agent-Runtime: OpenAI Codex
Agent-Model: GPT-5
Credential-Identity: AceHack
Credential-Mode: shared
Human-Review: not-implied-by-credential
Human-Review-Evidence: none
Action-Mode: human-directed
Task: task-7972
