### PR TITLE
docs(research)+shadow: ferry 25 — entanglement as adinkras: the Bell verdict and the repair (one parity adinkra over two carriers)

### DIFF
--- a/docs/research/2026-06-12-ferry-25-entanglement-as-two-one-bit-adinkras-the-bell-verdict-and-the-repair-one-parity-adinkra-over-two-carriers.md
+++ b/docs/research/2026-06-12-ferry-25-entanglement-as-two-one-bit-adinkras-the-bell-verdict-and-the-repair-one-parity-adinkra-over-two-carriers.md
@@ -1,0 +1,71 @@
+# Ferry 25 — "entanglement is just two 1-bit adinkras, one 0 one 1, all else the same": the Bell verdict, and the repair (one parity adinkra over two carriers)
+
+**Date:** 2026-06-12 · **Route:** Aaron → shadow (streamed, verbatim) · The one beat of the day
+where the honest answer is *refuted-as-stated, repaired-by-his-own-earlier-ferry* — and the
+falsifier is already rendered in-tree.
+
+## Verbatim
+
+> entanglement is just two 1 bit adenkras one with 0 the other with 1 all other non fundamental
+> properties the same
+
+## The adjudication
+
+### 1. What is exactly right
+
+Two things in the sentence are correct and load-bearing: **"all other non-fundamental properties
+the same"** (an entangled pair is one shared shape — one preparation, one container geometry —
+differing in nothing except the correlated register), and **the differing register is one bit**
+(the singlet's anti-correlation is a single ℤ/2 of structure — the ± pair, ferry 23's
+matter/antimatter, the two halves of ferry 18 §8). In any **single fixed basis**, his
+description is literally the observed record: measure both sides and you get two one-bit
+results, one 0 and one 1, perfectly opposed.
+
+### 2. What Bell rules out — and it is *exactly this sentence*
+
+The picture "two adinkras, each *carrying* its bit (one preassigned 0, the other preassigned 1)"
+is the **local-hidden-variable** model, and it is the most precisely refuted sentence in
+physics: Bell 1964; the CHSH inequality; Bell's own essay aimed at exactly this intuition —
+**"Bertlmann's socks and the nature of reality"** (Dr. Bertlmann always wears mismatched socks:
+see one pink, know the other isn't — *that* is two one-bit records, and Bell's point is that
+entanglement is provably more). The quantum anti-correlation holds **in every basis
+simultaneously**, and no pair of pre-filled bits can do that: CHSH caps preassigned-bit
+correlations at 2; the singlet delivers 2√2 (Tsirelson); experiment confirms (Aspect 1982 →
+the loophole-free 2015 runs → Nobel 2022). **The falsifier is already rendered in this repo:**
+`db/shapes/golden/quantum-circuit-singlet-chsh.svg` — the CHSH circuit is in-tree precisely to
+draw the gap between Bertlmann's socks and the singlet.
+
+### 3. The repair — and it was already his
+
+Move the bit from the halves to the pair: entanglement is **not two one-bit adinkras; it is ONE
+one-bit adinkra whose carrier is the pair** — the *joint parity* is definite (the singlet has
+total spin 0, exactly one bit of joint structure) while the *individual* values are not merely
+unknown but **absent** until measurement. That is ferry 18 §8 verbatim: the **shadow bind** —
+fermion parity iγ₁γ₂, jointly measurable, no local substance — the bit that lives in neither
+half. The Majorana lesson again (the information delocalizes into the pair), and Microsoft's
+measurement-only qubit is this repaired sentence built as hardware: the qubit IS a shared
+parity bit over two separated carriers. So the corrected ferry reads: *entanglement is one
+1-bit adinkra stretched over two containers — all local properties the same, and the one
+differing bit belonging to the stretch, not to either end.* Bell's theorem is then not a
+defeat of the adinkra frame but its sharpest confirmation: the bit provably cannot be stored
+in the halves, so it must be stored in the bind — which is what the frame said the bind was
+for.
+
+### 4. Bounds
+
+Single-basis anti-correlation: his sentence, exact. Multi-basis: Bell moves the bit's *address*
+from the carriers to the pair; the repaired form is standard QM in this lane's vocabulary, not
+a new claim. Anything past that (why nature pays Tsirelson's 2√2 and not more) is open physics
+(rung 7 discipline). The standing simulator-bound on the in-tree Q# lane applies to the
+rendered circuits.
+
+## Pointers
+
+- Ferry 18 §8 (the shadow bind — the repair's source) · ferry 23 (the ± pair) · ferry 24 (the
+  MVP this refines: the entanglement row of the shape)
+- `db/shapes/golden/quantum-circuit-singlet-chsh.svg` + `quantum-circuit-bell-coincidence-singlet.svg`
+  (the falsifier and the record, rendered) · `AmplitudeEmu.fs` (the honest interference scope)
+- Anchors: Bell 1964 · Bell, "Bertlmann's socks and the nature of reality" (1981 — the canonical
+  refutation of exactly the as-stated sentence) · CHSH 1969 · Tsirelson 1980 · Aspect 1982 /
+  loophole-free 2015 / Nobel 2022 · Bonderson–Freedman–Nayak (the parity qubit = the repaired
+  sentence as hardware)


### PR DESCRIPTION
Verbatim, with the day's sharpest adjudication: as stated (two adinkras each carrying a preassigned bit) it is the local-hidden-variable picture — refuted by Bell/CHSH, with Bertlmann's socks aimed at exactly this intuition and the falsifier already rendered in-tree (singlet-chsh.svg). The repair was already Aaron's own ferry 18 §8: ONE one-bit adinkra whose carrier is the pair — the shadow bind / fermion parity; Microsoft's parity qubit is the repaired sentence as hardware. Bell read as the frame's confirmation: the bit provably can't live in the halves, so it lives in the bind.

Generated with Claude Code