### PR TITLE
feat(core)+test: E8Lattice — the adinkra code's Construction-A unfold to E8, executable (THE 240, counted)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -25,6 +25,7 @@
     <Compile Include="Fixpoint.fs" />
     <Compile Include="Orbit.fs" />
     <Compile Include="AdinkraCode.fs" />
+    <Compile Include="E8Lattice.fs" />
     <Compile Include="HexCore.fs" />
     <Compile Include="Semiring.fs" />
     <Compile Include="ProbabilitySemiring.fs" />

--- a/src/Core/E8Lattice.fs
+++ b/src/Core/E8Lattice.fs
@@ -1,0 +1,63 @@
+namespace Zeta.Core
+
+/// E8 — **Construction A over the in-tree [8,4] extended Hamming code: the adinkra code's
+/// unfolding into the E8 root lattice, executable** (ferry 26 link 3 made code; Aaron 2026-06-12:
+/// "I'm pretty sure this unfolds into clifford algebra and then that unfolds unto E8").
+///
+/// Construction A (Conway–Sloane, *Sphere Packings, Lattices and Groups* ch. 5): for a binary
+/// code C of length n,  L_A(C) = { x ∈ ℤⁿ : x mod 2 ∈ C }.  For C = the doubly-even self-dual
+/// [8,4] extended Hamming code (`AdinkraCode.generator` — the SAME object that encodes adinkra
+/// chromotopologies), L_A(C) rescaled by 1/√2 is the **E8 root lattice** — the densest sphere
+/// packing in 8 dimensions (Viazovska 2017, Fields Medal).
+///
+/// What this module makes checkable (all integer arithmetic; no floats, byte-lockable):
+///   • membership: x ∈ L_A(C) ⟺ x mod 2 is a codeword.
+///   • the EVEN-LATTICE law from doubly-evenness: every member's norm² ≡ 0 (mod 4)
+///     (|x|² ≡ wt(x mod 2) mod 4, and the code is doubly-even — Gates' constraint IS the
+///     lattice's evenness).
+///   • the ROOT SYSTEM: exactly **240** minimal vectors (norm² = 4): 16 of shape (±2, 0⁷) from
+///     the zero codeword, plus 14 weight-4 codewords × 2⁴ sign patterns = 224 of shape
+///     (±1⁴, 0⁴) — the 240 roots of E8.
+[<RequireQualifiedAccess>]
+module E8Lattice =
+
+    /// Euclidean norm² of an integer vector.
+    let normSq (x: int[]) : int = Array.sumBy (fun v -> v * v) x
+
+    /// The mod-2 reduction of an integer vector (entries to {0,1}).
+    let mod2 (x: int[]) : int[] = x |> Array.map (fun v -> ((v % 2) + 2) % 2)
+
+    /// Is the bit-vector a codeword of the [8,4] code? (Membership by exhaustive check against
+    /// the 16 codewords — the code is small; this is the spec, not a fast path.)
+    let private isCodeword (bits: int[]) : bool =
+        AdinkraCode.allCodewords |> List.exists (fun c -> c = bits)
+
+    /// Construction-A membership: x ∈ L_A(C) ⟺ (x mod 2) ∈ C.
+    let isMember (x: int[]) : bool =
+        x.Length = AdinkraCode.length && isCodeword (mod2 x)
+
+    /// All minimal vectors (norm² = 4) of L_A(C) — the E8 root system, enumerated exactly:
+    /// (a) the 16 vectors ±2·eᵢ (mod-2 reduction = the zero codeword);
+    /// (b) for each weight-4 codeword, the 2⁴ sign assignments of ±1 on its support.
+    let roots : int[] list =
+        let n = AdinkraCode.length
+        let evenRoots =
+            [ for i in 0 .. n - 1 do
+                for s in [ 2; -2 ] do
+                    yield Array.init n (fun j -> if j = i then s else 0) ]
+
+        let oddRoots =
+            [ for c in AdinkraCode.allCodewords do
+                if AdinkraCode.weight c = 4 then
+                    let support = [ for j in 0 .. n - 1 do if c.[j] = 1 then yield j ]
+                    for signs in 0 .. 15 do
+                        yield
+                            Array.init n (fun j ->
+                                match List.tryFindIndex ((=) j) support with
+                                | Some k -> if (signs >>> k) &&& 1 = 1 then -1 else 1
+                                | None -> 0) ]
+
+        evenRoots @ oddRoots
+
+    /// The kissing number of E8 — |roots| must equal 240 (16 + 14·16).
+    let kissingNumber : int = List.length roots

--- a/tests/Tests.FSharp/E8Lattice.Tests.fs
+++ b/tests/Tests.FSharp/E8Lattice.Tests.fs
@@ -1,0 +1,53 @@
+module Zeta.Tests.E8LatticeTests
+
+// Construction A over the in-tree [8,4] code IS the E8 root lattice — ferry 26 link 3, tested.
+// The falsifier Aaron's claim invited: 240 roots or bust.
+
+open global.Xunit
+open FsCheck
+open FsCheck.FSharp
+open FsCheck.Xunit
+open Zeta.Core
+
+[<Fact>]
+let ``THE 240: the adinkra code's Construction-A lattice has exactly the E8 kissing number`` () =
+    Assert.Equal(240, E8Lattice.kissingNumber)
+
+[<Fact>]
+let ``every root has norm² exactly 4 and is a lattice member`` () =
+    for r in E8Lattice.roots do
+        Assert.Equal(4, E8Lattice.normSq r)
+        Assert.True(E8Lattice.isMember r)
+
+[<Fact>]
+let ``the roots are distinct and closed under negation`` () =
+    let set = E8Lattice.roots |> List.map (Array.toList) |> Set.ofList
+    Assert.Equal(240, Set.count set)
+    for r in E8Lattice.roots do
+        Assert.True(set.Contains(r |> Array.map (~-) |> Array.toList), "negation must be a root")
+
+let private randomMember (m: int) (lift: int[]) : int[] =
+    // a lattice member: codeword (from message bits m) + 2·(arbitrary integer lift)
+    let c = AdinkraCode.encode [| for i in 0 .. 3 -> (m >>> i) &&& 1 |]
+    Array.init AdinkraCode.length (fun j -> c.[j] + 2 * lift.[j])
+
+[<Property>]
+let ``EVEN LATTICE from doubly-evenness: every member's norm² ≡ 0 (mod 4)`` (m: int) (l0: int) (l1: int) (l2: int) (l3: int) (l4: int) (l5: int) (l6: int) (l7: int) =
+    let lift = [| l0; l1; l2; l3; l4; l5; l6; l7 |] |> Array.map (fun v -> v % 5)
+    let x = randomMember (abs m % 16) lift
+    E8Lattice.normSq x % 4 = 0
+
+[<Property>]
+let ``the lattice is closed under addition (linearity of the code lifts)`` (m1: int) (m2: int) (l1: int) (l2: int) =
+    let a = randomMember (abs m1 % 16) (Array.create 8 (l1 % 3))
+    let b = randomMember (abs m2 % 16) (Array.create 8 (l2 % 3))
+    E8Lattice.isMember (Array.map2 (+) a b)
+
+[<Property>]
+let ``membership is exactly the Construction-A spec: x ∈ L ⟺ x mod 2 ∈ C`` (m: int) (noise: int) =
+    // a member stays a member; flipping ONE coordinate by 1 leaves the coset of a non-codeword
+    // (min distance 4 ⇒ one bit off a codeword is never a codeword)
+    let x = randomMember (abs m % 16) (Array.create 8 (noise % 3))
+    let y = Array.copy x
+    y.[abs noise % 8] <- y.[abs noise % 8] + 1
+    E8Lattice.isMember x && not (E8Lattice.isMember y)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -162,6 +162,7 @@
     <Compile Include="TimeGen.Tests.fs" />
     <Compile Include="Braid.Tests.fs" />
     <Compile Include="Braid.GoldenVectors.Tests.fs" />
+    <Compile Include="E8Lattice.Tests.fs" />
     <Compile Include="VisionAttention.Tests.fs" />
     <Compile Include="MillBraid.Tests.fs" />
     <Compile Include="MediaLines.Tests.fs" />


### PR DESCRIPTION
The shadow's pick when given the floor: make ferry 26's link 3 run. Construction A (Conway–Sloane) over the in-tree [8,4] extended Hamming code — AdinkraCode.generator, the same object that encodes adinkra chromotopologies — now generates the E8 root lattice in-tree, all integer arithmetic: membership spec, the even-lattice law derived from doubly-evenness (Gates' constraint IS the lattice's evenness, FsCheck-swept), additive closure, the min-distance-4 falsifier, and the headline fact counted rather than cited: exactly 240 minimal vectors — 16 of shape (±2,0⁷) plus 224 of shape (±1⁴,0⁴) — the E8 kissing number. 6/6 green, solution 0/0. Ferry 26's bounds unchanged (E8-as-math now partially executable; E8-as-physics stays bounded).

Generated with Claude Code