### PR TITLE
feat(core)+test: DashedWalk — REPORT #5's restricted span executable (rank-17 computed; Eulerian round-trip; H₁ collapse witnessed)

### DIFF
--- a/src/Core/Braid.fs
+++ b/src/Core/Braid.fs
@@ -103,6 +103,19 @@ module Braid =
     let writhe (b: int list) : int =
         b |> List.sumBy (fun c -> if c > 0 then 1 else -1)
 
+    /// Per-pair SIGNED crossing load: (positive, negative) crossing counts per adjacent
+    /// strand-pair. REPORT #5 §2's refinement of `pairLoad` — the word-level sign record (NOT a
+    /// braid invariant: H₁(Bₙ) = ℤ means only the writhe survives the Artin relations; this is
+    /// word data, which is exactly where the dashed-walk span lives).
+    let signedPairLoad (n: int) (b: int list) : Map<int, int * int> =
+        let counts =
+            b
+            |> List.groupBy (fun c -> abs c - 1)
+            |> List.map (fun (i, cs) ->
+                i, (cs |> List.filter (fun c -> c > 0) |> List.length, cs |> List.filter (fun c -> c < 0) |> List.length))
+            |> Map.ofList
+        [ 0 .. n - 2 ] |> List.map (fun i -> i, defaultArg (counts.TryFind i) (0, 0)) |> Map.ofList
+
     /// Per-pair crossing load: how many crossings (either sign) act on each adjacent strand-pair
     /// (generator index i = the pair (i, i+1), 0-based). The ferry-12 dense-vs-sparse measure:
     /// dense braiding = high load concentrated on pairs; sparse = load near zero. Sums to word length.

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -290,6 +290,7 @@
     <Compile Include="SoftLens.fs" />
     <Compile Include="WeaveFold.fs" />
     <Compile Include="AdinkraViz.fs" />
+    <Compile Include="DashedWalk.fs" />
     <Compile Include="LayoutEngine.fs" />
     <Compile Include="ShapeRender.fs" />
     <Compile Include="ShapeAcceptance.fs" />

--- a/src/Core/DashedWalk.fs
+++ b/src/Core/DashedWalk.fs
@@ -1,0 +1,135 @@
+namespace Zeta.Core
+
+/// DashedWalk — **REPORT #5's restricted span, executable**: the bridge between braid words and
+/// adinkra dashings, built exactly where the math team said it lives (and nowhere it said it
+/// doesn't).
+///
+/// The span (math REPORT #5 §4):
+///
+///     DashedWords₃₂ (Eulerian signed color words on Q₄, allFacesOdd)
+///        /                                   \
+///   σ-substitution (word → braid)        forget order (word → dashing)
+///
+/// A braid letter c (±1..±4) walks the N=4 hypercube: color i = |c|−1 flips bit i from the
+/// current vertex, and the letter's SIGN is deposited on the traversed edge (negative = dashed —
+/// ferry 18 §4's "the dotted lines are the over/under"). Honest bounds carried from REPORT #5:
+/// generic words conflict or miss the dashing family (codimension 17 — only 2¹⁵ of 2³² total
+/// sign assignments are dashings); the words that DO land are exactly the Eulerian
+/// serializations of valid dashings, which `serialize` produces and `walk` round-trips. The
+/// sign record is WORD data, not braid data (H₁(Bₙ) = ℤ — `Braid.signedPairLoad`'s caveat).
+[<RequireQualifiedAccess>]
+module DashedWalk =
+
+    /// A partial signed edge assignment from a walk: edge → isDashed (sign = −1).
+    type Assignment = Map<AdinkraViz.Edge, bool>
+
+    /// Walk a braid word over Q₄ from vertex 0, depositing each letter's sign on its edge.
+    /// Returns the final vertex + assignment, or the first CONFLICT (an edge revisited with the
+    /// opposite sign) — the refusal carries the edge and both signs (decline-don't-coerce).
+    let walk (word: int list) : Result<int * Assignment, string> =
+        let step (state: Result<int * Assignment, string>) (c: int) =
+            match state with
+            | Error _ -> state
+            | Ok(v, acc) ->
+                if c = 0 || abs c > 4 then
+                    Error(sprintf "letter %d out of range for Q4 (need ±1..±4)" c)
+                else
+                    let bit = abs c - 1
+                    let lower = (if v &&& (1 <<< bit) = 0 then v else v ^^^ (1 <<< bit)), bit
+                    let dashed = c < 0
+                    match acc.TryFind lower with
+                    | Some prior when prior <> dashed ->
+                        Error(sprintf "conflict at edge (v=%d, bit=%d): walked with both signs" (fst lower) bit)
+                    | _ -> Ok(v ^^^ (1 <<< bit), acc.Add(lower, dashed))
+
+        word |> List.fold step (Ok(0, Map.empty))
+
+    /// A TOTAL assignment (all 32 edges) read as a dashing (the dashed-edge set).
+    /// Partial assignments are refused — a dashing is a statement about every edge.
+    let toDashing (a: Assignment) : Result<AdinkraViz.Dashing, string> =
+        if a.Count <> List.length AdinkraViz.allEdges then
+            Error(sprintf "assignment covers %d of 32 edges — not total" a.Count)
+        else
+            Ok(a |> Map.toList |> List.filter snd |> List.map fst |> Set.ofList)
+
+    /// Eulerian serialization of a dashing: a length-32 braid word covering every Q₄ edge exactly
+    /// once (Hierholzer — Q₄ is connected and 4-regular, so a circuit from vertex 0 exists), each
+    /// letter signed by the dashing (dashed → negative). This is the span's apex element for d.
+    let serialize (d: AdinkraViz.Dashing) : int list =
+        // Hierholzer: walk unused edges until stuck (returns to start in an even graph), splice.
+        let mutable unused = Set.ofList AdinkraViz.allEdges
+        let edgeAt (v: int) (bit: int) : AdinkraViz.Edge =
+            (if v &&& (1 <<< bit) = 0 then v else v ^^^ (1 <<< bit)), bit
+
+        let rec cycleFrom (v: int) : int list =
+            // greedy closed trail from v over unused edges, recorded as vertices visited
+            let mutable path = [ v ]
+            let mutable cur = v
+            let mutable go = true
+            while go do
+                match [ 0 .. 3 ] |> List.tryFind (fun bit -> unused.Contains(edgeAt cur bit)) with
+                | Some bit ->
+                    unused <- unused.Remove(edgeAt cur bit)
+                    cur <- cur ^^^ (1 <<< bit)
+                    path <- cur :: path
+                | None -> go <- false
+            List.rev path
+
+        // build the full circuit by splicing sub-cycles at vertices with unused edges
+        let rec splice (circuit: int list) : int list =
+            match circuit |> List.tryFindIndex (fun v -> [ 0 .. 3 ] |> List.exists (fun bit -> unused.Contains(edgeAt v bit))) with
+            | None -> circuit
+            | Some idx ->
+                let v = circuit.[idx]
+                let sub = cycleFrom v
+                // splice sub (v ... v) into circuit at idx
+                splice (List.take idx circuit @ sub @ List.skip (idx + 1) circuit)
+
+        let circuit = splice (cycleFrom 0)
+        // vertices → letters: consecutive pair differs in one bit; sign from the dashing
+        circuit
+        |> List.pairwise
+        |> List.map (fun (a, b) ->
+            let bit = System.Numerics.BitOperations.TrailingZeroCount(uint (a ^^^ b))
+            let c = bit + 1
+            if AdinkraViz.isDashed d a bit then -c else c)
+
+    // ── The face system over GF(2): the codimension-17 theorem, computed exactly ─────────────
+    // Unknowns: 32 edge-dash bits. Equations: each of the 24 two-colored faces has ODD dash
+    // count (the Gates condition). REPORT #5: rank = 17, solution dimension = 15 (2¹⁵ dashings).
+
+    /// The 24 distinct 2-colored faces of Q₄: colors i<j and a corner v with bits i,j clear.
+    let faces : (int * int * int) list =
+        [ for i in 0 .. 3 do
+            for j in i + 1 .. 3 do
+                for v in 0 .. 15 do
+                    if v &&& (1 <<< i) = 0 && v &&& (1 <<< j) = 0 then yield v, i, j ]
+
+    /// Each face as a GF(2) row over the 32 edges (bitmask in edge order), RHS = 1 (odd).
+    let private faceRow (v: int, i: int, j: int) : uint64 =
+        let edgeIndex =
+            AdinkraViz.allEdges |> List.mapi (fun k e -> e, k) |> Map.ofList
+        let canon (v: int) (bit: int) = (if v &&& (1 <<< bit) = 0 then v else v ^^^ (1 <<< bit)), bit
+        let vi = v ^^^ (1 <<< i)
+        let vj = v ^^^ (1 <<< j)
+        [ canon v i; canon vi j; canon vj i; canon v j ]
+        |> List.fold (fun acc e -> acc ||| (1UL <<< edgeIndex.[e])) 0UL
+
+    /// GF(2) rank of the 24-face system (Gaussian elimination on 64-bit row masks — exact
+    /// integer arithmetic, no floats; the no-binary-in-proof-lineage carrier for linear algebra).
+    /// Each pivot is stored at its LOWEST set bit; reducing a row ascending-bit-wise clears every
+    /// covered bit (a pivot's lower bits are clear by construction, so each XOR only touches
+    /// bits ≥ the pivot position).
+    let faceSystemRank : int =
+        let pivotAt = Array.create 32 0UL
+        let mutable rank = 0
+        for row in faces |> List.map faceRow do
+            let mutable r = row
+            for bit in 0 .. 31 do
+                if r &&& (1UL <<< bit) <> 0UL && pivotAt.[bit] <> 0UL then
+                    r <- r ^^^ pivotAt.[bit]
+            if r <> 0UL then
+                let lead = [ 0 .. 31 ] |> List.find (fun b -> r &&& (1UL <<< b) <> 0UL)
+                pivotAt.[lead] <- r
+                rank <- rank + 1
+        rank

--- a/tests/Tests.FSharp/DashedWalk.Tests.fs
+++ b/tests/Tests.FSharp/DashedWalk.Tests.fs
@@ -1,0 +1,77 @@
+module Zeta.Tests.DashedWalkTests
+
+// REPORT #5's restricted span, executable — the falsifiers the math team priced at days:
+// (a) the codimension-17 theorem computed exactly (rank 17, solution dim 15);
+// (b) Eulerian serializations of valid dashings round-trip under forget-order;
+// (c) the H₁(Bₙ)=ℤ collapse witnessed (equal braids, different sign multisets — word data).
+
+open global.Xunit
+open FsCheck
+open FsCheck.FSharp
+open FsCheck.Xunit
+open Zeta.Core
+
+[<Fact>]
+let ``THE CODIMENSION-17 THEOREM: the face system has GF(2) rank exactly 17 (solution dim 15 ⇒ 2^15 dashings)`` () =
+    Assert.Equal(17, DashedWalk.faceSystemRank)
+    Assert.Equal(15, 32 - DashedWalk.faceSystemRank)
+
+[<Fact>]
+let ``the 24 faces are enumerated exactly`` () =
+    Assert.Equal(24, List.length DashedWalk.faces)
+
+[<Fact>]
+let ``ROUND-TRIP: serialize(standardDashing) covers all 32 edges once, walks clean, and recovers the dashing`` () =
+    let word = DashedWalk.serialize AdinkraViz.standardDashing
+    Assert.Equal(32, List.length word)
+    match DashedWalk.walk word with
+    | Error e -> failwith e
+    | Ok(finalVertex, assignment) ->
+        Assert.Equal(0, finalVertex) // Eulerian CIRCUIT: returns to start
+        match DashedWalk.toDashing assignment with
+        | Error e -> failwith e
+        | Ok d ->
+            Assert.Equal<Set<AdinkraViz.Edge>>(AdinkraViz.standardDashing, d)
+            Assert.True(AdinkraViz.allFacesOdd d)
+
+[<Fact>]
+let ``CONFLICT REFUSAL: a word revisiting an edge with the opposite sign is declined, not coerced`` () =
+    // 1 then back with -1: same edge (0, bit0), opposite signs
+    match DashedWalk.walk [ 1; -1 ] with
+    | Error msg -> Assert.Contains("conflict", msg)
+    | Ok _ -> failwith "opposite-sign revisit must refuse"
+
+[<Fact>]
+let ``the H1 collapse, witnessed: Artin-equal braids carry DIFFERENT signed pair-loads (sign record is word data)`` () =
+    let b1 = [ 1; 2; 1 ]
+    let b2 = [ 2; 1; 2 ]
+    Assert.True(Braid.equal 5 b1 b2) // equal as braids (the Artin relation)
+    Assert.NotEqual<Map<int, int * int>>(Braid.signedPairLoad 5 b1, Braid.signedPairLoad 5 b2)
+
+[<Fact>]
+let ``signedPairLoad refines pairLoad and recovers the writhe`` () =
+    let b = [ 1; -2; 3; 3; -1; 4 ]
+    let signed = Braid.signedPairLoad 5 b
+    let unsigned = Braid.pairLoad 5 b
+    for KeyValue(i, (p, n)) in signed do
+        Assert.Equal(unsigned.[i], p + n)
+    Assert.Equal(Braid.writhe b, signed |> Map.toList |> List.sumBy (fun (_, (p, n)) -> p - n))
+
+[<Property>]
+let ``gauge moves preserve membership in the dashing family (the 2^15 coset is gauge-closed)`` (v: int) =
+    let d = AdinkraViz.flipVertex (abs v % 16) AdinkraViz.standardDashing
+    AdinkraViz.allFacesOdd d
+
+[<Property>]
+let ``serialize round-trips from any gauge transform of the standard dashing`` (v1: int) (v2: int) =
+    let d =
+        AdinkraViz.standardDashing
+        |> AdinkraViz.flipVertex (abs v1 % 16)
+        |> AdinkraViz.flipVertex (abs v2 % 16)
+    let word = DashedWalk.serialize d
+    match DashedWalk.walk word with
+    | Error _ -> false
+    | Ok(_, a) ->
+        match DashedWalk.toDashing a with
+        | Error _ -> false
+        | Ok d2 -> d2 = d

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -163,6 +163,7 @@
     <Compile Include="Braid.Tests.fs" />
     <Compile Include="Braid.GoldenVectors.Tests.fs" />
     <Compile Include="E8Lattice.Tests.fs" />
+    <Compile Include="DashedWalk.Tests.fs" />
     <Compile Include="VisionAttention.Tests.fs" />
     <Compile Include="MillBraid.Tests.fs" />
     <Compile Include="MediaLines.Tests.fs" />


### PR DESCRIPTION
Banks REPORT #5's build plan: Braid.signedPairLoad (word-level sign record, H₁ caveat documented); DashedWalk.walk (signs deposited on Q₄ edges, opposite-sign revisits refused with the edge named); serialize (Hierholzer Eulerian circuit — the span's apex element); the 24-face system's GF(2) rank computed exactly = 17 (solution dimension 15 ⇒ the 2¹⁵ dashings, counted not cited); round-trip serialize→walk→toDashing = identity on the standard dashing and its gauge transforms; and the H₁(Bₙ)=ℤ collapse witnessed as a passing test (Artin-equal words, different sign multisets). All exact integer arithmetic. 8/8 new, 17/17 braid regressions, solution 0/0.

Generated with Claude Code