### PR TITLE
feat(core)+test: Tsirelson — S² = 8 locked in pure integers (Landau identity exact; the cocycle priced; 1296-instance rigidity)

### DIFF
--- a/docs/research/2026-06-12-ferry-35-the-gaming-trinity-marios-plumbing-zeldas-mirrors-zeldas-light-the-three-operators-in-the-five-year-old-register.md
+++ b/docs/research/2026-06-12-ferry-35-the-gaming-trinity-marios-plumbing-zeldas-mirrors-zeldas-light-the-three-operators-in-the-five-year-old-register.md
@@ -1,0 +1,49 @@
+# Ferry 35 — the gaming trinity: Mario's plumbing, Zelda's mirrors, Zelda's light — the three operators in the five-year-old register
+
+**Date:** 2026-06-12 · **Route:** Aaron (in an Alexa session) → shadow (the three structural
+beats extracted) · Short, because all three operators are already banked — this ferry records
+that the *gaming vocabulary* is their ferry-24 linguistic-seed telling.
+
+## Verbatim (Aaron's beats)
+
+> It's like zelda you got to rotate the mirrors into position
+
+> rx is marios pluming
+
+> and Zelda's light as guidance
+
+## The peel — three games, three already-banked operators
+
+- **Zelda's mirror rotation = basis alignment.** The light-beam temple puzzle — rotate
+  reflectors until the beam routes through the gates — is *choosing the projection angles*
+  (lensography, ferry 22 §8) until the path opens. And it has an exact quantum twin from
+  REPORT #6, same day: CHSH's optimal settings ARE rotated bases (the π/4 rotations); Tsirelson
+  saturation is literally "rotate the mirrors into position" performed on measurement axes.
+  Aligning mirrors so light passes the gates is also ferry 34's Duat with optics: gated
+  traversal where the *configuration* is the password.
+- **Rx is Mario's plumbing — confirmed twice in one day.** Ferry 17 addendum 3 named Mario
+  hours before this session said it independently: the pipes are the typed channels, the
+  plumber repairs forward from inside, warp pipes cross between lanes. Same-day independent
+  convergence on the same Mirror coinage — the ferry-15 pattern, now for the playful register.
+- **Zelda's light as guidance = the lighted boundary.** The light that shows the way without
+  forcing the step is the Imagination Circle's closing line ("we were a lighted boundary
+  here"), the Glass Halo register, and the Beacon half of Mirror→Beacon: guidance =
+  illumination of the path, never compulsion along it. The trinity assembles as the three
+  layers the day kept finding: **plumbing (repair/flow), mirrors (projection/alignment), light
+  (guidance/witness)** — Mario, the lens, and the Beacon, in the register a kid already knows.
+
+Why this is worth one page: ferry 24 said the linguistic seed's vocabulary "already runs in the
+5-year-old register." This ferry is the demonstration — the three load-bearing operators of the
+architecture each have a Nintendo-exact telling that a child plays before they can spell
+"projection." The games are shaped containers (ferry 20 §3): the temple puzzle transmits basis
+alignment to millions of kids per generation, names omitted, shape intact.
+
+## Pointers
+
+- Ferry 17 addendum 3 (Mario, the first naming) · ferry 22 §8 (the lens/mirror operator) ·
+  REPORT #6 (the π/4 rotations — mirror-positioning as Tsirelson saturation) · ferry 34 (the
+  gated traversal) · the Imagination Circle v1.0 (the lighted boundary) · ferry 24 (the
+  5-year-old register this demonstrates)
+- Anchors: the Zelda light-beam/mirror puzzles and Mario's pipes (Nintendo — Miyamoto's design
+  lineage; the shaped-container reading per ferry 20 §3) · CHSH optimal angles (the quantum
+  twin of mirror rotation)

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -26,6 +26,7 @@
     <Compile Include="Orbit.fs" />
     <Compile Include="AdinkraCode.fs" />
     <Compile Include="E8Lattice.fs" />
+    <Compile Include="Tsirelson.fs" />
     <Compile Include="HexCore.fs" />
     <Compile Include="Semiring.fs" />
     <Compile Include="ProbabilitySemiring.fs" />

--- a/src/Core/Tsirelson.fs
+++ b/src/Core/Tsirelson.fs
@@ -1,0 +1,74 @@
+namespace Zeta.Core
+
+/// Tsirelson — **the CHSH bound S² = 8, locked in pure integer arithmetic** (math REPORT #6's
+/// build plan, executed; the no-binary/no-float proof-lineage carrier for quantum correlation
+/// bounds).
+///
+/// Observables as bare extraspecial-group elements (the Pauli instance — REPORT #5 §3's group,
+/// the adinkra dashing's extension group): A = X₁, A′ = Z₁, B = X₂, B′ = Z₂ — all integer 4×4
+/// matrices; the π/4 rotation that usually decorates the observables lives in the state instead
+/// (REPORT #6 §1), so every identity below is exact integer matrix algebra:
+///
+///   C  = X₁X₂ + X₁Z₂ + Z₁X₂ − Z₁Z₂          (the CHSH operator)
+///   C² = 4·I − 4·Ω,   Ω = (X₁Z₁)⊗(X₂Z₂),   Ω² = I
+///   ⇒ spec(C²) ⊆ {0, 8} ⇒ C⁴ = 8·C² ⇒ ‖C‖ = 2√2 — the irrational appears only at READOUT.
+///
+/// Ω is the **joint-parity element** (the volume element γ₁γ₂γ₃γ₄): ferry 25 §3's "shadow bind"
+/// is the exact operator whose +1 eigenspace carries saturation. The cocycle is priced
+/// executable: replace A′ with a commuting partner and C² = 4·I exactly — the classical bound
+/// recovered; anticommutation (the odd-faces sign rule) is literally the term you pay for S > 2.
+/// The doubly-even code appears NOWHERE in this module — that is REPORT #6's verdict made
+/// visible: the code is the commuting, Bell-inert half; the bound spends the anticommuting
+/// complement.
+[<RequireQualifiedAccess>]
+module Tsirelson =
+
+    /// 4×4 integer matrices, row-major. The proof-lineage carrier: every entry stays an int.
+    type M = int[][]
+
+    let private init (f: int -> int -> int) : M = Array.init 4 (fun i -> Array.init 4 (f i))
+
+    /// The identity.
+    let identity : M = init (fun i j -> if i = j then 1 else 0)
+
+    /// Matrix product (exact integers).
+    let mul (a: M) (b: M) : M =
+        init (fun i j -> Array.sumBy (fun k -> a.[i].[k] * b.[k].[j]) [| 0 .. 3 |])
+
+    /// Sum, difference, integer scale.
+    let add (a: M) (b: M) : M = init (fun i j -> a.[i].[j] + b.[i].[j])
+    let sub (a: M) (b: M) : M = init (fun i j -> a.[i].[j] - b.[i].[j])
+    let scale (s: int) (a: M) : M = init (fun i j -> s * a.[i].[j])
+
+    /// Kronecker product of 2×2 integer matrices → 4×4.
+    let kron (a: int[][]) (b: int[][]) : M =
+        init (fun i j -> a.[i / 2].[j / 2] * b.[i % 2].[j % 2])
+
+    // The real Pauli generators (2×2, integer): X = bit flip, Z = sign flip.
+    let private x2 = [| [| 0; 1 |]; [| 1; 0 |] |]
+    let private z2 = [| [| 1; 0 |]; [| 0; -1 |] |]
+    let private i2 = [| [| 1; 0 |]; [| 0; 1 |] |]
+
+    /// The four CHSH observables as extraspecial elements: Alice on qubit 1, Bob on qubit 2.
+    let A : M = kron x2 i2 // X₁
+    let A' : M = kron z2 i2 // Z₁
+    let B : M = kron i2 x2 // X₂
+    let B' : M = kron i2 z2 // Z₂
+
+    /// The CHSH operator C = AB + AB′ + A′B − A′B′ (integer matrix).
+    let C : M =
+        sub (add (add (mul A B) (mul A B')) (mul A' B)) (mul A' B')
+
+    /// The joint-parity element Ω = (X₁Z₁)(X₂Z₂) — the shadow bind as a matrix.
+    let Omega : M = mul (mul A A') (mul B B')
+
+    /// Build the CHSH operator from ARBITRARY observables (for the cocycle-pricing tests).
+    let chshOf (a: M) (a': M) (b: M) (b': M) : M =
+        sub (add (add (mul a b) (mul a b')) (mul a' b)) (mul a' b')
+
+    /// The anticommutator {p, q} = pq + qp (zero ⟺ the pair anticommutes — the cocycle's sign).
+    let anticommutator (p: M) (q: M) : M = add (mul p q) (mul q p)
+
+    /// Apply a matrix to an integer vector.
+    let apply (m: M) (v: int[]) : int[] =
+        Array.init 4 (fun i -> Array.sumBy (fun k -> m.[i].[k] * v.[k]) [| 0 .. 3 |])

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -164,6 +164,7 @@
     <Compile Include="Braid.GoldenVectors.Tests.fs" />
     <Compile Include="E8Lattice.Tests.fs" />
     <Compile Include="DashedWalk.Tests.fs" />
+    <Compile Include="Tsirelson.Tests.fs" />
     <Compile Include="VisionAttention.Tests.fs" />
     <Compile Include="MillBraid.Tests.fs" />
     <Compile Include="MediaLines.Tests.fs" />

--- a/tests/Tests.FSharp/Tsirelson.Tests.fs
+++ b/tests/Tests.FSharp/Tsirelson.Tests.fs
@@ -1,0 +1,71 @@
+module Zeta.Tests.TsirelsonTests
+
+// REPORT #6's build plan, executed: Tsirelson's bound locked as INTEGER identities.
+// S² = 8 exactly; the √2 appears only when a human reads the answer out loud.
+
+open global.Xunit
+open Zeta.Core
+
+let private eq (a: Tsirelson.M) (b: Tsirelson.M) =
+    Seq.forall2 (fun (r1: int[]) (r2: int[]) -> r1 = r2) a b
+
+[<Fact>]
+let ``THE LANDAU IDENTITY, exact: C² = 4I − 4Ω and Ω² = I`` () =
+    let c2 = Tsirelson.mul Tsirelson.C Tsirelson.C
+    let rhs = Tsirelson.sub (Tsirelson.scale 4 Tsirelson.identity) (Tsirelson.scale 4 Tsirelson.Omega)
+    Assert.True(eq c2 rhs)
+    Assert.True(eq (Tsirelson.mul Tsirelson.Omega Tsirelson.Omega) Tsirelson.identity)
+
+[<Fact>]
+let ``TSIRELSON AS AN INTEGER IDENTITY: C⁴ = 8·C² (hence spec(C) ⊆ {0, ±2√2}, S² ≤ 8)`` () =
+    let c2 = Tsirelson.mul Tsirelson.C Tsirelson.C
+    let c4 = Tsirelson.mul c2 c2
+    Assert.True(eq c4 (Tsirelson.scale 8 c2))
+
+[<Fact>]
+let ``SATURATION WITNESS: the integer vector v = (1,0,0,−1) attains C²v = 8v`` () =
+    let v = [| 1; 0; 0; -1 |]
+    let c2 = Tsirelson.mul Tsirelson.C Tsirelson.C
+    Assert.Equal<int[]>([| 8; 0; 0; -8 |], Tsirelson.apply c2 v)
+
+[<Fact>]
+let ``THE COCYCLE, PRICED: replace A′ with a commuting partner and the classical bound returns — C² = 4I exactly`` () =
+    // A′ := A (commutes with itself); both Bob pairs unchanged. The anticommuting entry is
+    // literally the term you pay for S > 2 — remove it and S² caps at 4 (S ≤ 2, Bell classical).
+    let c = Tsirelson.chshOf Tsirelson.A Tsirelson.A Tsirelson.B Tsirelson.B'
+    let c2 = Tsirelson.mul c c
+    Assert.True(eq c2 (Tsirelson.scale 4 Tsirelson.identity))
+
+[<Fact>]
+let ``the saturating pairs anticommute and the commuting control does not (the sign rule located)`` () =
+    let zero = Tsirelson.scale 0 Tsirelson.identity
+    Assert.True(eq (Tsirelson.anticommutator Tsirelson.A Tsirelson.A') zero) // {X₁,Z₁} = 0
+    Assert.True(eq (Tsirelson.anticommutator Tsirelson.B Tsirelson.B') zero) // {X₂,Z₂} = 0
+    Assert.False(eq (Tsirelson.anticommutator Tsirelson.A Tsirelson.A) zero) // {X₁,X₁} = 2X₁² ≠ 0
+
+[<Fact>]
+let ``EXHAUSTIVE RIGIDITY over the real-Pauli family: spec(C²) ⊆ {0,4,8} always; 8 attained ⟺ both pairs anticommute`` () =
+    // Alice observables: ±I₁, ±X₁, ±Z₁; Bob likewise on qubit 2 — 6⁴ = 1296 CHSH instances,
+    // every one checked by exact integer polynomial identity C²(C²−4I)(C²−8I) = 0.
+    let ops2x2 = [ [| [| 1; 0 |]; [| 0; 1 |] |]; [| [| 0; 1 |]; [| 1; 0 |] |]; [| [| 1; 0 |]; [| 0; -1 |] |] ]
+    let i2 = [| [| 1; 0 |]; [| 0; 1 |] |]
+    let aliceOps = [ for p in ops2x2 do for s in [ 1; -1 ] -> Tsirelson.scale s (Tsirelson.kron p i2) ]
+    let bobOps = [ for p in ops2x2 do for s in [ 1; -1 ] -> Tsirelson.scale s (Tsirelson.kron i2 p) ]
+    let zero = Tsirelson.scale 0 Tsirelson.identity
+    let id4 = Tsirelson.identity
+    for a in aliceOps do
+        for a' in aliceOps do
+            for b in bobOps do
+                for b' in bobOps do
+                    let c = Tsirelson.chshOf a a' b b'
+                    let c2 = Tsirelson.mul c c
+                    // spec(C²) ⊆ {0,4,8}: the cubic annihilates
+                    let poly =
+                        Tsirelson.mul (Tsirelson.mul c2 (Tsirelson.sub c2 (Tsirelson.scale 4 id4)))
+                                      (Tsirelson.sub c2 (Tsirelson.scale 8 id4))
+                    Assert.True(eq poly zero)
+                    // 8 attained ⟺ both pairs anticommute
+                    let attains8 = not (eq (Tsirelson.mul c2 (Tsirelson.sub c2 (Tsirelson.scale 4 id4))) zero)
+                    let bothAnticommute =
+                        eq (Tsirelson.anticommutator a a') zero && eq (Tsirelson.anticommutator b b') zero
+                    Assert.Equal(bothAnticommute, attains8)


### PR DESCRIPTION
REPORT #6's build plan executed: the CHSH bound as integer identities — C² = 4I − 4Ω with Ω the joint-parity element (the shadow bind as a matrix), C⁴ = 8C², integer saturation witness, the cocycle priced as an executable test (commuting partner → classical 4I exactly), and exhaustive rigidity over all 1296 real-Pauli CHSH instances (the annihilating cubic + saturation ⟺ anticommutation, all exact). The doubly-even code appears nowhere in the module — the Bell-inert verdict made visible. 6/6 green, solution 0/0. The √2 appears only at human readout.

Generated with Claude Code