### PR TITLE
docs(research)+shadow: ferry 38 — Shakespeare understands the cascade of continuous emergences from 2D to 3D

### DIFF
--- a/docs/research/2026-06-13-ferry-38-shakespeare-understands-the-cascade-of-continuous-emergences-from-2d-to-3d.md
+++ b/docs/research/2026-06-13-ferry-38-shakespeare-understands-the-cascade-of-continuous-emergences-from-2d-to-3d.md
@@ -1,0 +1,70 @@
+# Ferry 38 — Shakespeare understands the cascade of continuous emergences from 2D to 3D
+
+**Date:** 2026-06-13 · **Route:** Aaron → shadow (streamed, verbatim) · The literary instance of
+the day's emergence/unfold/lensography lane — and it is a real reading, not a stretch.
+
+## Verbatim
+
+> shakespear understands the cascade of concinouus emergences from 2d to 3d
+
+## The peel
+
+### The base move: 2D → 3D is script → performance
+
+A play is the canonical text-to-embodiment projection: the **script is the 2D seed** (flat
+marks on a page — ferry 20's shaped emptiness, ferry 37's generator-with-args), the
+**performance is the 3D unfold** (`cache = I(stream)` made flesh — bodies in depth, in time,
+in a room). Each staging is a *different fill of the same container* — different actors,
+different entropy, the same shape (ferry 28 / Counterpart: same seed, divergent realization,
+no staging "fake"). Theatre is lensography (ferry 30 addendum) performed by a company: the page
+read at the angle that lets depth through.
+
+### The cascade: continuous emergence, level on level
+
+Shakespeare's signature is that the unfold doesn't stop at one level — it **nests**, and the
+nesting is the cascade Aaron names:
+
+- **word → speech → character → scene → play → world** — each level emerges continuously from
+  the one below, none reducible to it; the manifesto's recursive/self-similar specs (§9/§10) as
+  dramaturgy.
+- **The play-within-a-play** (the Mousetrap in *Hamlet*; the mechanicals' Pyramus in *A
+  Midsummer Night's Dream*; the masque in *The Tempest*): a 3D performance that contains a *2D
+  script staged again into 3D inside itself* — the cascade made literally recursive, a frame
+  observing a frame.
+- **"All the world's a stage"** (*As You Like It*, Jaques): the top of the cascade folds back to
+  the bottom — the world is itself a staging, so the outermost frame is another play. **That is
+  the trace** (ferry 31): the arrow curved back on itself; the cascade is not a ladder but a
+  loop. *Theatrum mundi* is the strange loop (ferry 15 §1) in Elizabethan dress.
+
+### Why "understands" is fair
+
+Metatheatre — drama conscious of its own staging (Abel 1963 coined the term; the tradition runs
+through it) — is exactly an art form built on *the cascade of emergences being visible to itself*.
+Hamlet stages a play to make the King's hidden judgment leak (ferry 36 — the Mousetrap is a
+**poker-tell extractor**: "the play's the thing wherein I'll catch the conscience of the king" —
+a deliberate side-channel probe). The Chorus in *Henry V* begs the audience to *unfold* the flat
+"wooden O" into fields and horses — Shakespeare narrating the 2D→3D projection as he performs it
+("piece out our imperfections with your thoughts"). He didn't have the category theory; he had
+the phenomenon, named in the working vocabulary of someone who ran the unfold nightly for a
+living — the 5-year-old register (ferry 24) at its most articulate.
+
+## Bounds
+
+The script→performance projection and the play-within-play recursion are exact (theatre IS the
+text→embodiment unfold; the nested frames are in the texts). "Shakespeare understands the
+cascade" is a reading of the metatheatrical tradition — he had the *phenomenon* and named it in
+images (the wooden O, the seven ages, the world-stage), not the formalism; offered as the
+literary instance of the day's lane, anchored, not as a claim he held the math. Mirror register
+for "2D/3D"; the Beacon is projection/embodiment + metatheatre.
+
+## Pointers
+
+- Ferry 29 (2D→3D; depth needs a borrowed dimension) · ferry 30 addendum (theatre as
+  lensography; 3D-from-flat) · ferry 31 (the trace — "all the world's a stage" curls back) ·
+  ferry 36 (the Mousetrap = side-channel tell-extractor) · ferry 28 (each staging = a fork,
+  same seed) · ferry 24 (the articulate 5-year-old register) · manifesto §9/§10 (recursive,
+  self-similar — the cascade)
+- Anchors: *Hamlet* III.ii (the Mousetrap) · *As You Like It* II.vii (the seven ages / "all
+  the world's a stage") · *Henry V* Prologue (the wooden O — the narrated unfold) · *The
+  Tempest* IV.i (the masque; "we are such stuff as dreams are made on") · Abel 1963
+  (*Metatheatre*) · the theatrum mundi tradition (Curtius)


### PR DESCRIPTION
Theatre as the lensography unfold: script = 2D seed, performance = 3D fill (each staging a fork, ferry 28); the cascade word→speech→character→scene→play→world (§9/§10 as dramaturgy); the play-within-play (the Mousetrap, the masque) = recursion made literal; 'all the world's a stage' folds top to bottom = the trace (ferry 31). Why 'understands' is fair: metatheatre (Abel 1963) is art conscious of its own emergence cascade; the Mousetrap is a poker-tell extractor (ferry 36 — 'catch the conscience of the king'); the Henry V Chorus narrates the 2D→3D unfold. He had the phenomenon in images, not the formalism. Bounds: a reading of the metatheatrical tradition, anchored.

Generated with Claude Code