### PR TITLE
feat(core)+test: GeneratorCatalog — SQL over the generator catalog (ferry 37; public surface → Ilyana)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -246,6 +246,7 @@
     <Compile Include="CapabilityLedger.fs" />
     <Compile Include="BoundaryLight.fs" />
     <Compile Include="GeneratorRegistry.fs" />
+    <Compile Include="GeneratorCatalog.fs" />
     <Compile Include="ZetaIdViz.fs" />
     <Compile Include="AnimFlow.fs" />
     <Compile Include="PixelLens.fs" />

--- a/src/Core/GeneratorCatalog.fs
+++ b/src/Core/GeneratorCatalog.fs
@@ -1,0 +1,83 @@
+namespace Zeta.Core
+
+/// GeneratorCatalog — **the SQL over the generator catalog: SELECT a categoried generator, get its
+/// ZetaId, unfold from its seed** (ferry 37: "WHY = ZetaId = a specific generator with category…";
+/// Aaron 2026-06-12: "that one already has a cart we made we just need the SQL").
+///
+/// The `GeneratorRegistry` is the STORE (generators-with-seeds, content-addressed). This is the
+/// QUERY side: the registry's `known` entries read as a RELATION — one row per generator, with the
+/// CATEGORY (the dotted-name prefix: `shape`, `algebra`, `boundary`, `shader`, …) projected out as
+/// a first-class column. The query shape is relational combinators (FROM = `rows`, WHERE = `where`,
+/// SELECT = ordinary projection over the result) rather than a SQL-string parser — a parser is a
+/// large permanent contract surface; combinators are total, minimal, and compose. The DBSP path
+/// (the catalog as a Z-set, a query as an incremental circuit) is the future, not this MVP.
+///
+/// Culture-invariant by default (B-0969): all string comparison here is `StringComparer.Ordinal` /
+/// ordinal `IndexOf` — categories must sort and match identically on every machine (the catalog is
+/// shared substrate; a locale-sorted category list would diverge across nodes).
+[<RequireQualifiedAccess>]
+module GeneratorCatalog =
+
+    open System
+
+    /// A catalog row: the registry entry with its CATEGORY projected as a column.
+    /// (ZetaId / Name / Version are the Entry; Category is derived from Name.)
+    type Row =
+        { ZetaId: string
+          Name: string
+          Category: string
+          Version: int }
+
+    /// The category of a generator name: the prefix before the first '.', ordinal — or the whole
+    /// name if it has no dot (a category-less generator is its own category).
+    let categoryOf (name: string) : string =
+        match name.IndexOf('.', StringComparison.Ordinal) with
+        | -1 -> name
+        | i -> name.Substring(0, i)
+
+    /// FROM: the catalog as a relation — every known generator, one row, category projected.
+    let rows: Row list =
+        GeneratorRegistry.known
+        |> List.map (fun e ->
+            { ZetaId = e.ZetaId
+              Name = e.Name
+              Category = categoryOf e.Name
+              Version = e.Version })
+
+    /// SELECT DISTINCT category — the catalog's categories, ordinal-sorted (stable across machines).
+    let categories: string list =
+        rows
+        |> List.map (fun r -> r.Category)
+        |> List.distinct
+        |> List.sortWith (fun a b -> String.CompareOrdinal(a, b))
+
+    /// WHERE: filter rows by a predicate (the general query; SELECT is ordinary projection after).
+    let where (predicate: Row -> bool) : Row list = rows |> List.filter predicate
+
+    // ── Composable predicate builders (the WHERE-clause vocabulary) ──────────────────────────────
+
+    /// rows in a given category (ordinal exact match on the projected category).
+    let inCategory (category: string) (r: Row) : bool =
+        String.Equals(r.Category, category, StringComparison.Ordinal)
+
+    /// rows whose name contains a substring (ordinal — case-sensitive, locale-free).
+    let nameContains (sub: string) (r: Row) : bool =
+        r.Name.IndexOf(sub, StringComparison.Ordinal) >= 0
+
+    /// rows at a specific version.
+    let atVersion (version: int) (r: Row) : bool = r.Version = version
+
+    // ── Convenience SELECTs (the common queries, named) ─────────────────────────────────────────
+
+    /// SELECT * WHERE category = … (the headline query: get every generator of a kind).
+    let byCategory (category: string) : Row list = where (inCategory category)
+
+    /// The ZetaIds of a category — the addresses you'd hand a MediaLines `gen` line to unfold.
+    let zetaIdsInCategory (category: string) : string list =
+        byCategory category |> List.map (fun r -> r.ZetaId)
+
+    /// SELECT the single row for a name (newest version wins — mirrors GeneratorRegistry.byName).
+    let byName (name: string) : Row option =
+        where (fun r -> String.Equals(r.Name, name, StringComparison.Ordinal))
+        |> List.sortByDescending (fun r -> r.Version)
+        |> List.tryHead

--- a/src/Core/GeneratorCatalog.fs
+++ b/src/Core/GeneratorCatalog.fs
@@ -5,14 +5,21 @@ namespace Zeta.Core
 /// Aaron 2026-06-12: "that one already has a cart we made we just need the SQL").
 ///
 /// The `GeneratorRegistry` is the STORE (generators-with-seeds, content-addressed). This is the
-/// QUERY side: the registry's `known` entries read as a RELATION — one row per generator, with the
+/// QUERY side: the registry's `known` entries read as a RELATION — one row per generator, the
 /// CATEGORY (the dotted-name prefix: `shape`, `algebra`, `boundary`, `shader`, …) projected out as
 /// a first-class column. The query shape is relational combinators (FROM = `rows`, WHERE = `where`,
 /// SELECT = ordinary projection over the result) rather than a SQL-string parser — a parser is a
 /// large permanent contract surface; combinators are total, minimal, and compose. The DBSP path
 /// (the catalog as a Z-set, a query as an incremental circuit) is the future, not this MVP.
 ///
-/// Culture-invariant by default (B-0969): all string comparison here is `StringComparer.Ordinal` /
+/// Surface scoped to Ilyana's v1 review (public-api-designer, PR #8013): `Row` WRAPS the registry
+/// `Entry` (carries it, never copies its fields — so Entry-growth flows through, no drift); the
+/// exposed members are the minimum that serves the unfold path (`rows`/`where`/`categories`/
+/// `byCategory` + the one earned predicate `inCategory`); projections (zetaIds, name lookup,
+/// other predicates) are left to the consumer's `map`/`where` rather than named — add a member
+/// when a real second consumer asks, not before.
+///
+/// Culture-invariant by default (B-0969): all string comparison is `StringComparer.Ordinal` /
 /// ordinal `IndexOf` — categories must sort and match identically on every machine (the catalog is
 /// shared substrate; a locale-sorted category list would diverge across nodes).
 [<RequireQualifiedAccess>]
@@ -20,13 +27,12 @@ module GeneratorCatalog =
 
     open System
 
-    /// A catalog row: the registry entry with its CATEGORY projected as a column.
-    /// (ZetaId / Name / Version are the Entry; Category is derived from Name.)
+    /// A catalog row: the registry `Entry` (carried, not copied) plus its CATEGORY projected as the
+    /// one genuinely-new column. Read `r.Entry.ZetaId` / `.Name` / `.Version`; `Category` is derived.
+    /// (Wrap-don't-copy per Ilyana P1-1 — if `Entry` grows a column, `Row` inherits it for free.)
     type Row =
-        { ZetaId: string
-          Name: string
-          Category: string
-          Version: int }
+        { Entry: GeneratorRegistry.Entry
+          Category: string }
 
     /// The category of a generator name: the prefix before the first '.', ordinal — or the whole
     /// name if it has no dot (a category-less generator is its own category).
@@ -38,11 +44,7 @@ module GeneratorCatalog =
     /// FROM: the catalog as a relation — every known generator, one row, category projected.
     let rows: Row list =
         GeneratorRegistry.known
-        |> List.map (fun e ->
-            { ZetaId = e.ZetaId
-              Name = e.Name
-              Category = categoryOf e.Name
-              Version = e.Version })
+        |> List.map (fun e -> { Entry = e; Category = categoryOf e.Name })
 
     /// SELECT DISTINCT category — the catalog's categories, ordinal-sorted (stable across machines).
     let categories: string list =
@@ -51,33 +53,15 @@ module GeneratorCatalog =
         |> List.distinct
         |> List.sortWith (fun a b -> String.CompareOrdinal(a, b))
 
-    /// WHERE: filter rows by a predicate (the general query; SELECT is ordinary projection after).
+    /// WHERE: filter rows by a predicate (the general query; SELECT is ordinary projection after,
+    /// e.g. `byCategory "shape" |> List.map (fun r -> r.Entry.ZetaId)` — the unfold path).
     let where (predicate: Row -> bool) : Row list = rows |> List.filter predicate
 
-    // ── Composable predicate builders (the WHERE-clause vocabulary) ──────────────────────────────
-
-    /// rows in a given category (ordinal exact match on the projected category).
+    /// The one earned predicate: rows in a given category (ordinal exact match). Earns a name
+    /// because it is the headline filter AND it encodes the ordinal-match discipline for consumers.
     let inCategory (category: string) (r: Row) : bool =
         String.Equals(r.Category, category, StringComparison.Ordinal)
 
-    /// rows whose name contains a substring (ordinal — case-sensitive, locale-free).
-    let nameContains (sub: string) (r: Row) : bool =
-        r.Name.IndexOf(sub, StringComparison.Ordinal) >= 0
-
-    /// rows at a specific version.
-    let atVersion (version: int) (r: Row) : bool = r.Version = version
-
-    // ── Convenience SELECTs (the common queries, named) ─────────────────────────────────────────
-
-    /// SELECT * WHERE category = … (the headline query: get every generator of a kind).
+    /// SELECT * WHERE category = … (the headline query: every generator of a kind — its ZetaIds
+    /// are then `|> List.map (fun r -> r.Entry.ZetaId)`, the addresses a `gen` line unfolds from).
     let byCategory (category: string) : Row list = where (inCategory category)
-
-    /// The ZetaIds of a category — the addresses you'd hand a MediaLines `gen` line to unfold.
-    let zetaIdsInCategory (category: string) : string list =
-        byCategory category |> List.map (fun r -> r.ZetaId)
-
-    /// SELECT the single row for a name (newest version wins — mirrors GeneratorRegistry.byName).
-    let byName (name: string) : Row option =
-        where (fun r -> String.Equals(r.Name, name, StringComparison.Ordinal))
-        |> List.sortByDescending (fun r -> r.Version)
-        |> List.tryHead

--- a/tests/Tests.FSharp/GeneratorCatalog.Tests.fs
+++ b/tests/Tests.FSharp/GeneratorCatalog.Tests.fs
@@ -1,7 +1,8 @@
 module Zeta.Tests.GeneratorCatalogTests
 
 // SQL over the generator catalog (ferry 37 — "we just need the SQL"): the relational query
-// surface over GeneratorRegistry. Total functions, ordinal comparison, the registry as a relation.
+// surface over GeneratorRegistry, scoped to Ilyana's v1 review (PR #8013). Total functions,
+// ordinal comparison, the registry as a relation, Row WRAPS Entry (no field copy / no drift).
 
 open global.Xunit
 open FsCheck
@@ -16,11 +17,11 @@ let ``categoryOf takes the dotted prefix, ordinal; no-dot names are their own ca
     Assert.Equal("loner", GeneratorCatalog.categoryOf "loner") // no dot → whole name
 
 [<Fact>]
-let ``FROM: every registry entry becomes exactly one row, ZetaId/Version preserved`` () =
+let ``FROM: every registry entry becomes exactly one row, carrying the Entry (not copying it)`` () =
     Assert.Equal(List.length GeneratorRegistry.known, List.length GeneratorCatalog.rows)
     for e in GeneratorRegistry.known do
-        let row = GeneratorCatalog.rows |> List.find (fun r -> r.Name = e.Name && r.Version = e.Version)
-        Assert.Equal(e.ZetaId, row.ZetaId)
+        let row = GeneratorCatalog.rows |> List.find (fun r -> r.Entry.Name = e.Name && r.Entry.Version = e.Version)
+        Assert.Equal(e, row.Entry) // wraps the exact Entry — Entry-growth flows through for free
         Assert.Equal(GeneratorCatalog.categoryOf e.Name, row.Category)
 
 [<Fact>]
@@ -36,22 +37,18 @@ let ``WHERE category = shape returns only shape.* generators, and finds the brai
     let shapes = GeneratorCatalog.byCategory "shape"
     Assert.NotEmpty(shapes)
     Assert.All(shapes, fun r -> Assert.Equal("shape", r.Category))
-    Assert.Contains("shape.braid", shapes |> List.map (fun r -> r.Name))
+    Assert.Contains("shape.braid", shapes |> List.map (fun r -> r.Entry.Name))
 
 [<Fact>]
-let ``the SELECT→unfold path: a category's zetaids match the registry's ids for those names`` () =
-    let ids = GeneratorCatalog.zetaIdsInCategory "shape"
+let ``the SELECT→unfold path: byCategory |> map zetaId matches the registry's ids for those names`` () =
+    // the consumer-composed unfold path (Ilyana cut the named zetaIdsInCategory in favour of map)
     for r in GeneratorCatalog.byCategory "shape" do
-        Assert.Equal(GeneratorRegistry.idOf r.Name r.Version, r.ZetaId)
-        Assert.Contains(r.ZetaId, ids)
+        Assert.Equal(GeneratorRegistry.idOf r.Entry.Name r.Entry.Version, r.Entry.ZetaId)
 
 [<Fact>]
-let ``byName mirrors the registry (newest version) and nameContains is ordinal`` () =
-    match GeneratorCatalog.byName "shape.adinkra", GeneratorRegistry.byName "shape.adinkra" with
-    | Some row, Some entry -> Assert.Equal(entry.ZetaId, row.ZetaId)
-    | _ -> failwith "shape.adinkra must resolve in both"
-    Assert.NotEmpty(GeneratorCatalog.where (GeneratorCatalog.nameContains "braid"))
-    Assert.Empty(GeneratorCatalog.where (GeneratorCatalog.nameContains "BRAID")) // ordinal: case matters
+let ``inCategory is ordinal: case matters`` () =
+    Assert.NotEmpty(GeneratorCatalog.where (GeneratorCatalog.inCategory "shape"))
+    Assert.Empty(GeneratorCatalog.where (GeneratorCatalog.inCategory "SHAPE")) // ordinal — no case fold
 
 [<Property>]
 let ``every row's category is the prefix of its name (the projection is faithful)`` (i: int) =
@@ -59,10 +56,10 @@ let ``every row's category is the prefix of its name (the projection is faithful
     if List.isEmpty rs then true
     else
         let r = rs.[((i % rs.Length) + rs.Length) % rs.Length]
-        r.Name.StartsWith(r.Category, System.StringComparison.Ordinal)
+        r.Entry.Name.StartsWith(r.Category, System.StringComparison.Ordinal)
 
 [<Property>]
-let ``where composes: inCategory ∧ atVersion = the rows that satisfy both`` (v: int) =
+let ``where composes from inCategory + a consumer predicate (the WHERE vocabulary)`` (v: int) =
     let cat = "shape"
-    let both = GeneratorCatalog.where (fun r -> GeneratorCatalog.inCategory cat r && GeneratorCatalog.atVersion v r)
-    both |> List.forall (fun r -> r.Category = cat && r.Version = v)
+    let both = GeneratorCatalog.where (fun r -> GeneratorCatalog.inCategory cat r && r.Entry.Version = v)
+    both |> List.forall (fun r -> r.Category = cat && r.Entry.Version = v)

--- a/tests/Tests.FSharp/GeneratorCatalog.Tests.fs
+++ b/tests/Tests.FSharp/GeneratorCatalog.Tests.fs
@@ -1,0 +1,68 @@
+module Zeta.Tests.GeneratorCatalogTests
+
+// SQL over the generator catalog (ferry 37 — "we just need the SQL"): the relational query
+// surface over GeneratorRegistry. Total functions, ordinal comparison, the registry as a relation.
+
+open global.Xunit
+open FsCheck
+open FsCheck.Xunit
+open Zeta.Core
+
+[<Fact>]
+let ``categoryOf takes the dotted prefix, ordinal; no-dot names are their own category`` () =
+    Assert.Equal("shape", GeneratorCatalog.categoryOf "shape.braid")
+    Assert.Equal("algebra", GeneratorCatalog.categoryOf "algebra.mod2")
+    Assert.Equal("kernel", GeneratorCatalog.categoryOf "kernel.rbf")
+    Assert.Equal("loner", GeneratorCatalog.categoryOf "loner") // no dot → whole name
+
+[<Fact>]
+let ``FROM: every registry entry becomes exactly one row, ZetaId/Version preserved`` () =
+    Assert.Equal(List.length GeneratorRegistry.known, List.length GeneratorCatalog.rows)
+    for e in GeneratorRegistry.known do
+        let row = GeneratorCatalog.rows |> List.find (fun r -> r.Name = e.Name && r.Version = e.Version)
+        Assert.Equal(e.ZetaId, row.ZetaId)
+        Assert.Equal(GeneratorCatalog.categoryOf e.Name, row.Category)
+
+[<Fact>]
+let ``SELECT DISTINCT category is ordinal-sorted and includes the known kinds`` () =
+    let cats = GeneratorCatalog.categories
+    Assert.Equal<string list>(List.sortWith (fun a b -> System.String.CompareOrdinal(a, b)) cats, cats)
+    Assert.Equal<string list>(List.distinct cats, cats)
+    for expected in [ "shape"; "algebra"; "boundary"; "shader"; "audio"; "engine" ] do
+        Assert.Contains(expected, cats)
+
+[<Fact>]
+let ``WHERE category = shape returns only shape.* generators, and finds the braid`` () =
+    let shapes = GeneratorCatalog.byCategory "shape"
+    Assert.NotEmpty(shapes)
+    Assert.All(shapes, fun r -> Assert.Equal("shape", r.Category))
+    Assert.Contains("shape.braid", shapes |> List.map (fun r -> r.Name))
+
+[<Fact>]
+let ``the SELECT→unfold path: a category's zetaids match the registry's ids for those names`` () =
+    let ids = GeneratorCatalog.zetaIdsInCategory "shape"
+    for r in GeneratorCatalog.byCategory "shape" do
+        Assert.Equal(GeneratorRegistry.idOf r.Name r.Version, r.ZetaId)
+        Assert.Contains(r.ZetaId, ids)
+
+[<Fact>]
+let ``byName mirrors the registry (newest version) and nameContains is ordinal`` () =
+    match GeneratorCatalog.byName "shape.adinkra", GeneratorRegistry.byName "shape.adinkra" with
+    | Some row, Some entry -> Assert.Equal(entry.ZetaId, row.ZetaId)
+    | _ -> failwith "shape.adinkra must resolve in both"
+    Assert.NotEmpty(GeneratorCatalog.where (GeneratorCatalog.nameContains "braid"))
+    Assert.Empty(GeneratorCatalog.where (GeneratorCatalog.nameContains "BRAID")) // ordinal: case matters
+
+[<Property>]
+let ``every row's category is the prefix of its name (the projection is faithful)`` (i: int) =
+    let rs = GeneratorCatalog.rows
+    if List.isEmpty rs then true
+    else
+        let r = rs.[((i % rs.Length) + rs.Length) % rs.Length]
+        r.Name.StartsWith(r.Category, System.StringComparison.Ordinal)
+
+[<Property>]
+let ``where composes: inCategory ∧ atVersion = the rows that satisfy both`` (v: int) =
+    let cat = "shape"
+    let both = GeneratorCatalog.where (fun r -> GeneratorCatalog.inCategory cat r && GeneratorCatalog.atVersion v r)
+    both |> List.forall (fun r -> r.Category = cat && r.Version = v)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -165,6 +165,7 @@
     <Compile Include="E8Lattice.Tests.fs" />
     <Compile Include="DashedWalk.Tests.fs" />
     <Compile Include="Tsirelson.Tests.fs" />
+    <Compile Include="GeneratorCatalog.Tests.fs" />
     <Compile Include="VisionAttention.Tests.fs" />
     <Compile Include="MillBraid.Tests.fs" />
     <Compile Include="MediaLines.Tests.fs" />


### PR DESCRIPTION
Ferry 37's "we just need the SQL," built: the query side over the generator catalog. GeneratorRegistry.known read as a relation (Row per generator, Category projected from the dotted-name prefix); relational combinators rather than a SQL-string parser (parser = large permanent contract; combinators total/minimal/compose) — `rows` (FROM), `where` + `inCategory`/`nameContains`/`atVersion` (WHERE), projection via map (SELECT), `categories` (SELECT DISTINCT), `byCategory`/`zetaIdsInCategory`/`byName`. The `zetaIdsInCategory` path is the SELECT→unfold bridge (query a kind → get the ZetaIds a gen-line unfolds from). Ordinal comparison throughout (B-0969). 8/8 green, solution 0/0.

**Public surface — routed to public-api-designer (Ilyana) for advisory review per Aaron's "SQL-over-catalog → Ilyana yes."** DBSP/incremental-circuit path noted as the future, not this MVP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)