### PR TITLE
docs(research)+shadow: ferry 44 §6 — Dune the video game (the lived origin of the council/three-faction model)

### DIFF
--- a/docs/research/2026-06-13-ferry-44-the-council-a-bft-faction-body-the-institution-that-runs-the-correction-term.md
+++ b/docs/research/2026-06-13-ferry-44-the-council-a-bft-faction-body-the-institution-that-runs-the-correction-term.md
@@ -85,6 +85,38 @@ captures); Lamport named the bound (`3f+1`); the Multi-Oracle Principle named th
 ferry 43 named the correction term — the council is where all four become one body that can
 actually sit and decide.
 
+### 6. Origin (Aaron, verbatim): Dune the video game
+
+> dune the video game is where i learned it
+
+The lived source of the model — and it composes with the gaming-pedagogy thread (wolf3d/goonies
+as "god mode," ferry 41 §addendum: the game is the container that transmits the shape before the
+citation exists, ferry 20 §3). Dune's political structure *is* a faction-balance system at two
+layers:
+
+- **Three houses.** The genre-founding real-time-strategy game (Westwood's *Dune II*, 1992)
+  fights three factions — Houses Atreides, Harkonnen, and Ordos — in a balance-of-power war over
+  the spice. Three factions, **exactly B-0652's count, for exactly §1's reason**: two factions
+  give no tie-break, four-plus add needless modeling complexity, three (a cooperative pair + a
+  rogue) is the minimum coherent majority model. Aaron learned the three-faction shape by *playing
+  it*.
+- **The Landsraad.** In Frank Herbert's *Dune* (1965), the **Landsraad is the council of the Great
+  Houses** — the assembly of factions that checks the Emperor, balanced against the Spacing Guild
+  (transport monopoly), CHOAM (economic power), and the Bene Gesserit. It is a Byzantine-tolerant
+  faction body in fiction: no single house may capture the whole, and the *balance is the safety
+  property.* **Madison's Federalist 10 (§2) wearing a stillsuit** — the same "design for inevitable
+  factions so none dominates," dramatized.
+
+The pedagogy point: the council/three-faction-tolerance model was *taught by the game* — the shape
+arrived through play, the formal anchors (Lamport, Madison) came later. The game was the shaped
+container; the citation is the Beacon compression of what it transmitted.
+
+Honest bound: "the video game" is not pinned to one title here — *Dune II* is the canonical
+three-house RTS (and *Emperor: Battle for Dune*, 2001, is also three houses), while the Landsraad
+council is franchise lore across Herbert's novels. The load-bearing thing is the
+three-faction-balance shape he learned, not the exact SKU (anti-Mandela, ferry 41: don't
+confabulate the specific title beyond what he said).
+
 ## Bounds
 
 - **The council is the *institutional reading* of B-0652; the formal model is B-0652's, not
@@ -121,3 +153,6 @@ actually sit and decide.
   (`3f+1`) · Castro & Liskov 1999 (PBFT) · Douceur 2002 (Sybil — council-packing) · Ostrom
   (polycentric governance) · modern BFT faction bodies: Tendermint/Cosmos validator+governance,
   Polkadot Council (the contemporary instances of exactly this organ)
+- Origin / pedagogy (§6): Frank Herbert, *Dune* (1965 — the Landsraad, the faction balance) ·
+  Westwood, *Dune II* (1992 — the three-house RTS, genre origin) · the gaming-pedagogy thread
+  (ferry 41 addendum: games as the container that transmits the shape before the citation)


### PR DESCRIPTION
Aaron: 'dune the video game is where i learned it.' The lived source: Dune's faction-balance at two layers — the three houses (Dune II, 1992 = B-0652's three-faction count) and the Landsraad (Herbert 1965 = council of Great Houses; balance is the safety property; Madison's Federalist 10 in a stillsuit). The model was taught by the game; the formal anchors came later (the gaming-pedagogy thread). Honest bound: not pinned to one title; the load-bearing thing is the three-faction shape.

Generated with Claude Code