### PR TITLE
[codex] feat(core): add typed io boundary over fusion

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -37,6 +37,7 @@
     <Compile Include="Bag.fs" />
     <Compile Include="ZSet.fs" />
     <Compile Include="FusionReconstruction.fs" />
+    <Compile Include="IoBoundary.fs" />
     <Compile Include="WeightedSet.fs" />
     <Compile Include="RayTensor.fs" />
     <Compile Include="ToffoliGate.fs" />

--- a/src/Core/IoBoundary.fs
+++ b/src/Core/IoBoundary.fs
@@ -1,0 +1,77 @@
+namespace Zeta.Core
+
+open System.Runtime.CompilerServices
+
+/// Typed inside/outside boundary for the signed-ledger-to-grow-only transition.
+///
+/// `Inside` may hold a signed Z-set ledger: emits and retracts can cancel before
+/// observation. `Outside` holds only the fused G-set view: monotone presence,
+/// with multiplicity, negative evidence, and the path that produced the result
+/// kept behind the boundary.
+[<RequireQualifiedAccess>]
+module IoBoundary =
+
+    [<Struct; IsReadOnly>]
+    type Inside<'K when 'K : comparison> =
+        val internal Ledger: ZSet<'K>
+        internal new(ledger: ZSet<'K>) = { Ledger = ledger }
+
+    [<Struct; IsReadOnly>]
+    type Outside<'K when 'K : comparison> =
+        val internal View: GSet<'K>
+        internal new(view: GSet<'K>) = { View = view }
+
+    let emptyInside<'K when 'K : comparison> : Inside<'K> =
+        Inside ZSet.empty
+
+    let emptyOutside<'K when 'K : comparison> : Outside<'K> =
+        Outside GSet.empty
+
+    /// Enter the boundary with an already-composed signed ledger.
+    let input (z: ZSet<'K>) : Inside<'K> =
+        Inside z
+
+    /// Enter the boundary with add-only genesis facts.
+    let genesis (keys: 'K seq) : Inside<'K> =
+        keys |> ZSet.ofKeys |> Inside
+
+    /// One positive internal event.
+    let emit (key: 'K) : Inside<'K> =
+        ZSet.singleton key 1L |> Inside
+
+    /// One negative internal event.
+    let retract (key: 'K) : Inside<'K> =
+        ZSet.singleton key -1L |> Inside
+
+    /// Compose signed interiors before any exterior observation occurs.
+    let compose (left: Inside<'K>) (right: Inside<'K>) : Inside<'K> =
+        ZSet.add left.Ledger right.Ledger |> Inside
+
+    let composeAll (insides: Inside<'K> seq) : Inside<'K> =
+        let mutable acc = ZSet.empty
+        for inside in insides do
+            acc <- ZSet.add acc inside.Ledger
+        Inside acc
+
+    /// Cross the I/O boundary: only positive support becomes exterior identity.
+    let fuse (inside: Inside<'K>) : Outside<'K> =
+        inside.Ledger |> FusionReconstruction.fuse |> Outside
+
+    /// Leave the boundary with the public grow-only view.
+    let output (outside: Outside<'K>) : GSet<'K> =
+        outside.View
+
+    let toArray (outside: Outside<'K>) : 'K[] =
+        GSet.toArray outside.View
+
+    let toList (outside: Outside<'K>) : 'K list =
+        GSet.toList outside.View
+
+    let contains (key: 'K) (outside: Outside<'K>) : bool =
+        GSet.contains key outside.View
+
+    let count (outside: Outside<'K>) : int =
+        GSet.count outside.View
+
+    let isEmpty (outside: Outside<'K>) : bool =
+        GSet.isEmpty outside.View

--- a/tests/Tests.FSharp/Algebra/IoBoundary.Tests.fs
+++ b/tests/Tests.FSharp/Algebra/IoBoundary.Tests.fs
@@ -1,0 +1,75 @@
+module Zeta.Tests.Algebra.IoBoundaryTests
+
+open global.Xunit
+open Zeta.Core
+
+[<Fact>]
+let ``I/O boundary fuses composed signed interior into exterior G-set`` () =
+    let interior =
+        IoBoundary.composeAll [
+            IoBoundary.emit "life"
+            IoBoundary.emit "life"
+            IoBoundary.emit "identity"
+            IoBoundary.retract "identity"
+            IoBoundary.retract "void"
+        ]
+
+    let exterior = IoBoundary.fuse interior
+
+    Assert.Equal<string list>([ "life" ], IoBoundary.toList exterior)
+    Assert.Equal(1, IoBoundary.count exterior)
+
+[<Fact>]
+let ``I/O boundary composes before output so internal ledgers do not leak`` () =
+    let insert = IoBoundary.emit "boundary"
+    let retract = IoBoundary.retract "boundary"
+
+    let composedOutput =
+        IoBoundary.compose insert retract
+        |> IoBoundary.fuse
+
+    let leakedIfObservedTooEarly =
+        GSet.union
+            (insert |> IoBoundary.fuse |> IoBoundary.output)
+            (retract |> IoBoundary.fuse |> IoBoundary.output)
+
+    Assert.True(IoBoundary.isEmpty composedOutput)
+    Assert.Equal<string list>([ "boundary" ], GSet.toList leakedIfObservedTooEarly)
+
+[<Fact>]
+let ``input and output name the I/O passage without exposing signed history`` () =
+    let exterior =
+        ZSet.ofSeq [
+            "inside", 3L
+            "outside", 1L
+            "inside", -3L
+        ]
+        |> IoBoundary.input
+        |> IoBoundary.fuse
+        |> IoBoundary.output
+
+    Assert.Equal<string list>([ "outside" ], GSet.toList exterior)
+
+[<Fact>]
+let ``genesis enters as add-only facts and exits sorted unique`` () =
+    let exterior =
+        IoBoundary.genesis [ "zeta"; "genesis"; "zeta"; "boundary" ]
+        |> IoBoundary.fuse
+
+    Assert.Equal<string list>([ "boundary"; "genesis"; "zeta" ], IoBoundary.toList exterior)
+
+[<Fact>]
+let ``outside stays monotone after the boundary`` () =
+    let first =
+        IoBoundary.emit "mark"
+        |> IoBoundary.fuse
+        |> IoBoundary.output
+
+    let absent =
+        IoBoundary.retract "mark"
+        |> IoBoundary.fuse
+        |> IoBoundary.output
+
+    GSet.union first absent
+    |> GSet.toList
+    |> fun actual -> Assert.Equal<string list>([ "mark" ], actual)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -25,6 +25,7 @@
     <Compile Include="Algebra/Bag.Tests.fs" />
     <Compile Include="Algebra/ZSet.Tests.fs" />
     <Compile Include="Algebra/FusionReconstruction.Tests.fs" />
+    <Compile Include="Algebra/IoBoundary.Tests.fs" />
     <Compile Include="Algebra/ZSet.Overflow.Tests.fs" />
     <Compile Include="Algebra/Residuated.Tests.fs" />
     <Compile Include="Algebra/IndexedZSet.Tests.fs" />


### PR DESCRIPTION
## Summary

- Add `IoBoundary.Inside` and `IoBoundary.Outside` as typed source vocabulary for the inside/outside boundary over fusion.
- Keep signed `ZSet` evidence private to the inside wrapper; only fused positive-support `GSet` leaves through `IoBoundary.output`.
- Add algebra tests proving compose-before-output, monotone outside behavior, genesis input, and input/output naming.

## Verification

- `dotnet build tests/Tests.FSharp/Tests.FSharp.fsproj -c Release -m:1`
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --no-build --filter "FullyQualifiedName~IoBoundaryTests|FullyQualifiedName~FusionReconstructionTests|FullyQualifiedName~GSetTests|FullyQualifiedName~ZSetTests"`
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --no-build`
- `dotnet format --verify-no-changes`
- `dotnet build Zeta.sln -c Release -m:1`
- `dotnet test Zeta.sln -c Release --no-build`

Agency-Signature-Version: 1
Agent: Vera (Codex)
Agent-Runtime: OpenAI Codex
Agent-Model: GPT-5
Credential-Identity: AceHack
Credential-Mode: shared
Human-Review: not-implied-by-credential
Human-Review-Evidence: none
Action-Mode: human-directed
Task: task-io-monad-boundary
