### PR TITLE
docs(linguistic-seed): land v1 formal terms — implication/equality/set/function/retraction + DAG

### DIFF
--- a/docs/linguistic-seed/README.md
+++ b/docs/linguistic-seed/README.md
@@ -130,26 +130,32 @@ surface-contact surfaces the gaps.
 
 ## Initial term candidates (to land in v1)
 
-Zero terms landed yet. First candidates (not prescriptive,
-agent-pick; Aaron + formal-verification-expert nudge):
+**v1 landed (6 terms; the DAG is in `prereq-graph.json`):**
 
-- **truth** (Tarski's predicate; metalanguage-scoped)
-- **implication** (material conditional; Meredith-derivable)
-- **equality** (structural identity; reflexive /
-  symmetric / transitive)
-- **set** (extensional; Zermelo-Fraenkel-subset-minimal)
-- **function** (set-theoretic: set of ordered pairs with
-  uniqueness)
-- **axiom** (self-referential in the seed itself: a
-  seed-term whose `defined-by: axiomatic`)
-- **definition** (self-referential: a seed-term that
-  makes another term precise)
-- **retraction** (Zeta-adjacent; negative-weight
-  inverse; grounds into signed-integer weights)
+- **truth** (Tarski's predicate; metalanguage-scoped) — `terms/truth.md`
+- **implication** (material conditional; Meredith-derivable) —
+  `terms/implication.md`, deps `[truth]`
+- **equality** (Leibniz indiscernibility; reflexive / symmetric /
+  transitive) — `terms/equality.md`, deps `[implication]`
+- **set** (extensional; Zermelo-Fraenkel) — `terms/set.md`,
+  deps `[equality, implication]`
+- **function** (set-theoretic: single-valued total relation) —
+  `terms/function.md`, deps `[set, equality]`
+- **retraction** (Zeta-adjacent; Z-set negative-weight inverse;
+  the formal twin of the five-year-old walk's "honest take-back") —
+  `terms/retraction.md`, deps `[function]`
 
-Adding a ninth term requires the previous eight to be
-landed first (per backwards-chain discipline — each term
-can only depend on already-landed terms).
+**Candidates next** (backwards-chained as downstream need surfaces):
+
+- **membership** (the `∈` primitive set.md currently leaves untermed —
+  the one honest dangling edge in the graph)
+- **axiom** (self-referential: a seed-term whose `defined-by: axiomatic`)
+- **definition** (self-referential: a seed-term that makes another precise)
+- **relation** / **order** / **number** (as Craft / soulfile need them)
+
+Per the backwards-chain discipline, each new term may depend only on
+already-landed terms (no dangling references; `prereq-graph.json` enforces
+the constraint).
 
 ## Composition with other substrate
 
@@ -217,16 +223,18 @@ commitment is adopter-pluggable.
 
 ## Follow-up work (tracked via gap #2 closure)
 
-- Land the prereq-graph.json skeleton with empty DAG
-- Land first 3-5 terms (`truth` / `implication` / `equality`
-  / `set` / `function`) as v1
+- [x] Land the `prereq-graph.json` (landed **populated**, not empty — six
+  terms with real edges; one honest dangling primitive recorded)
+- [x] Land first 3-5 terms (`truth` / `implication` / `equality` / `set` /
+  `function`) as v1 — landed, plus `retraction` as the Zeta-adjacent capstone
 - Route formal-verification-expert (Soraya) for Lean4
-  sketch-and-formalise pattern
+  sketch-and-formalise pattern (the term Lean blocks are **draft sketches**,
+  not proven — Soraya's lane to harden)
 - Route applied-mathematics-expert + formal-verification-
   expert for initial term-review cadence
 - Update cross-references from other factory memories
   (soulfile DSL, Craft memory, prompt-injection-bootstrap
-  memory) to point at live seed files once v1 lands
+  memory) to point at live seed files now that v1 has landed
 
 ## Gap #2 closure status
 

--- a/docs/linguistic-seed/prereq-graph.json
+++ b/docs/linguistic-seed/prereq-graph.json
@@ -1,0 +1,22 @@
+{
+  "version": 1,
+  "description": "Linguistic-seed term dependency DAG. Each term's dependencies are the seed terms directly invoked in its mathematical definition. Constraints: no cycles; root terms have empty dependencies (axiomatic); every dependency names a landed term. Grows by backwards-chaining from downstream need (README S growth-discipline).",
+  "constraints": {
+    "acyclic": true,
+    "roots-have-empty-deps": true,
+    "no-dangling-refs": true
+  },
+  "terms": {
+    "truth": [],
+    "implication": ["truth"],
+    "equality": ["implication"],
+    "set": ["equality", "implication"],
+    "function": ["set", "equality"],
+    "retraction": ["function"]
+  },
+  "primitives-not-yet-termed": {
+    "membership": "The set-membership relation (x is-in A) is taken primitive in set.md but has no seed term yet; an honest dangling edge to be backwards-chained when a downstream term forces it."
+  },
+  "landed": ["truth", "implication", "equality", "set", "function", "retraction"],
+  "candidates-next": ["axiom", "definition", "membership", "relation", "order", "number"]
+}

--- a/docs/linguistic-seed/terms/equality.md
+++ b/docs/linguistic-seed/terms/equality.md
@@ -1,0 +1,94 @@
+---
+name: equality
+defined-by: Leibniz's law (indiscernibility of identicals); first-order logic with equality
+formalised: draft
+dependencies: [implication]
+---
+
+# equality
+
+## Plain English
+
+Two names are **equal** when they point at the very same thing. *"The
+morning star"* and *"the evening star"* are two names for one planet
+(Venus) — so they are equal. The test: if `x` equals `y`, then anything
+true of `x` is true of `y`, because there is only one thing there wearing
+two names.
+
+Equality is not "looks alike" and not "is similar to." Two identical-
+looking toys are still two toys. Equality means *one and the same thing*.
+
+## Mathematical definition
+
+Equality `=` is the relation that is:
+
+- **reflexive** — `x = x`
+- **symmetric** — `x = y → y = x`
+- **transitive** — `(x = y) ∧ (y = z) → x = z`
+
+and satisfies **Leibniz's law** (indiscernibility of identicals): for
+every property `P`,
+
+```
+x = y  →  (P(x) ↔ P(y))
+```
+
+The arrows and the biconditional `↔` are [`implication`](implication.md)
+(`↔` is two implications), which is why equality depends on it. Leibniz's
+law is what makes equality *usable*: it licenses substituting equals for
+equals everywhere.
+
+## Lean4 formalisation
+
+```lean4
+-- Lean's `Eq` is the inductive equality; `rfl` is reflexivity, and the
+-- other properties are derived (real Mathlib/core declarations):
+example (x : α) : x = x := rfl
+example (x y : α) (h : x = y) : y = x := h.symm
+example (x y z : α) (h₁ : x = y) (h₂ : y = z) : x = z := h₁.trans h₂
+
+-- Leibniz substitution (indiscernibility of identicals) is `Eq.subst`:
+example (x y : α) (P : α → Prop) (h : x = y) (px : P x) : P y := h ▸ px
+```
+
+Lean takes equality as a single-constructor inductive type whose only
+proof is `rfl`; symmetry, transitivity, and substitution are theorems
+about it, not separate axioms.
+
+## Grounding point (per Otto-21 Craft discipline)
+
+**A secret identity.** *Clark Kent = Superman.* Two names, one person.
+Anything true of Clark (he is in this room) is true of Superman (he is in
+this room) — because there is exactly one individual. The moment a story
+needs them to be in two different places at once, it is denying the
+equality. That is Leibniz's law doing detective work.
+
+## What this term DOES NOT mean
+
+- **Not similarity / equivalence.** Equal things are *one* thing; similar
+  things are several things that share features. Equivalence relations
+  (same-remainder, same-colour) group many distinct things; equality does
+  not.
+- **Not assignment.** The `=` that binds a value to a name in some
+  programming languages is a command, not the equality relation.
+- **Not culture-sensitive string match.** When equality is decided on text,
+  the seed sense is **ordinal / structural** identity, never locale-aware
+  collation. (See the factory's *culture-invariant-by-default* rule:
+  `Comparer<string>.Default` is the wrong test; `StringComparer.Ordinal`
+  is the right one. Equality must be bit-honest for 4-language byte-lock.)
+
+## Citations
+
+- **Leibniz, G. W.** *Discourse on Metaphysics* (1686) — the identity of
+  indiscernibles and indiscernibility of identicals.
+- **Frege, Gottlob.** *Über Sinn und Bedeutung* (1892) — sense vs.
+  reference; the morning-star / evening-star example.
+- **Martin-Löf, Per.** *Intuitionistic Type Theory* (1984) — definitional
+  vs. propositional equality, the distinction Lean's `Eq` makes precise.
+
+## What this term IS (summary)
+
+The relation that holds when two names denote one and the same thing —
+reflexive, symmetric, transitive, and substitution-licensing (Leibniz).
+On text, the seed sense is ordinal/structural identity, not linguistic
+collation.

--- a/docs/linguistic-seed/terms/function.md
+++ b/docs/linguistic-seed/terms/function.md
@@ -1,0 +1,89 @@
+---
+name: function
+defined-by: Set-theoretic function (single-valued, total relation); Dirichlet–Bourbaki; Kuratowski ordered pair
+formalised: draft
+dependencies: [set, equality]
+---
+
+# function
+
+## Plain English
+
+A **function** is a rule that gives each input *exactly one* output. A
+vending machine: each button gives one snack, and the *same* button always
+gives the *same* snack. Two things are required — every button does
+something (no dead buttons), and no button gives two different snacks on
+two different presses.
+
+That "same input ⇒ same output, always" is the heart of it. It is also the
+seed of *determinism*: if the world is a function of its starting state,
+the same start replays to the same ending.
+
+## Mathematical definition
+
+A function `f` from `A` to `B` is a [`set`](set.md) of ordered pairs
+`f ⊆ A × B` that is
+
+- **total** — `∀a ∈ A. ∃b ∈ B. (a, b) ∈ f`  (every input has an output), and
+- **single-valued** — `∀a, b₁, b₂. (a, b₁) ∈ f ∧ (a, b₂) ∈ f → b₁ = b₂`
+  (the output is unique).
+
+Together these say `∀a ∈ A. ∃! b ∈ B. (a, b) ∈ f`. The uniqueness clause
+is [`equality`](equality.md) (`b₁ = b₂`); the pairs live in a
+[`set`](set.md). An **ordered pair** is itself reducible to sets via
+Kuratowski's encoding `(a, b) := {{a}, {a, b}}`, so a function bottoms out
+entirely in sets and equality.
+
+## Lean4 formalisation
+
+```lean4
+-- Lean takes the function space `A → B` as primitive (type theory),
+-- rather than building it from ordered pairs. Single-valuedness is then
+-- automatic and shows up as congruence — equal inputs give equal outputs:
+example (f : A → B) (x y : A) (h : x = y) : f x = f y := congrArg f h
+
+-- The set-theoretic reading (a function AS its graph) is also available:
+--   `Set.graphOn` / `Function.graph` relate `f` to `{(a, f a) | a}`.
+```
+
+The two readings agree: type theory's primitive arrow and set theory's
+single-valued total relation describe the same object; `congrArg` is the
+single-valuedness law made into a theorem.
+
+## Grounding point (per Otto-21 Craft discipline)
+
+**A light switch.** Each position of the switch maps to exactly one state
+of the bulb: up → on, down → off. You never get "up → sometimes on,
+sometimes off" — if you did, it wouldn't be a switch, it'd be a gremlin.
+The vending machine is the same lesson with more buttons. Determinism is
+just this promise scaled up to a whole machine: the factory's DST
+(deterministic simulation testing) is the demand that a run be a *function*
+of its seed.
+
+## What this term DOES NOT mean
+
+- **Not a general relation.** A relation may send one input to many outputs
+  (one person → many phone numbers). A function may not; that's the
+  single-valued clause.
+- **Not a procedure with side effects.** The seed sense is a pure mapping
+  input→output, not a block of code that also writes to the world. (The
+  factory keeps effects behind a metered membrane — noninterference §13 —
+  precisely to keep the mathematical-function reading honest.)
+- **Not partiality by default.** The seed function is *total* over its
+  stated domain; a "partial function" is a total function on a smaller
+  domain, named honestly.
+
+## Citations
+
+- **Dirichlet, P. G. L.** (1837) — the modern "arbitrary rule" notion of a
+  function, freed from formula.
+- **Kuratowski, Kazimierz.** (1921) — the ordered-pair-as-set encoding
+  `(a,b) = {{a},{a,b}}` used above.
+- **Bourbaki, Nicolas.** *Théorie des ensembles* (1954) — the function-as-
+  graph (set of ordered pairs) standardisation.
+
+## What this term IS (summary)
+
+A total, single-valued mapping from inputs to outputs — same input always
+the same output. Built from sets and equality (graph of ordered pairs); in
+type theory, the primitive arrow. The seed-root of determinism (DST).

--- a/docs/linguistic-seed/terms/implication.md
+++ b/docs/linguistic-seed/terms/implication.md
@@ -1,0 +1,101 @@
+---
+name: implication
+defined-by: The material conditional (classical propositional logic); Meredith's single-axiom basis
+formalised: draft
+dependencies: [truth]
+---
+
+# implication
+
+## Plain English
+
+**Implication** is the "if … then …" link between two claims. *"If it
+rains, the ground gets wet."* It makes one promise, and the promise is
+broken in exactly one situation: the first part is true but the second
+part is false. If the first part is false, the promise was never tested —
+it simply didn't apply, so it counts as kept.
+
+That last bit is the surprising part to a beginner: *"if the moon is made
+of cheese, then 2 + 2 = 4"* is a true implication, because the "if" never
+happened. Implication is a promise about what follows *when* the first
+thing holds — not a claim that the first thing holds.
+
+## Mathematical definition
+
+Written `φ → ψ`. Its truth (grounds through [`truth`](truth.md)) is given
+by the truth table:
+
+```
+φ      ψ      φ → ψ
+true   true   true
+true   false  false        ← the only false row
+false  true   true
+false  false  true
+```
+
+Equivalently, `φ → ψ  ≡  ¬φ ∨ ψ` (material conditional). In classical
+propositional calculus, implication together with negation generates every
+connective, and **Meredith's single 21-symbol axiom** generates the whole
+of classical propositional logic from this base via *modus ponens*
+(`φ` and `φ → ψ` yield `ψ`). This is why implication is a seed term: it is
+the smallest connective from which the rest of propositional reasoning
+unfolds.
+
+## Lean4 formalisation
+
+```lean4
+-- In Lean, implication is the function arrow itself: `φ → ψ`.
+-- A proof of `φ → ψ` IS a function taking a proof of `φ` to a proof
+-- of `ψ` (the Brouwer–Heyting–Kolmogorov / Curry–Howard reading).
+-- Modus ponens is therefore just function application:
+example (φ ψ : Prop) (hφ : φ) (himp : φ → ψ) : ψ := himp hφ
+
+-- Classical material-conditional equivalence (¬φ ∨ ψ) needs classical
+-- logic; it is NOT constructively provable in the → direction:
+open Classical in
+example (φ ψ : Prop) : (φ → ψ) ↔ (¬φ ∨ ψ) := by
+  constructor
+  · intro h; exact (em φ).elim (fun hφ => Or.inr (h hφ)) Or.inl
+  · intro h hφ; exact h.elim (fun hnφ => absurd hφ hnφ) id
+```
+
+The constructive arrow and the classical material conditional differ only
+on the law of excluded middle — a distinction the seed records rather than
+hides.
+
+## Grounding point (per Otto-21 Craft discipline)
+
+**A vending machine.** *"If you put in a dollar, you get the snack."* The
+promise is broken only by the one bad case: you put in your dollar and no
+snack comes out (`φ` true, `ψ` false). If you never put in a dollar, the
+machine broke no promise — it just sat there. That "never tested ⇒ promise
+kept" rule is exactly why `false → anything` is true.
+
+## What this term DOES NOT mean
+
+- **Not causation.** `φ → ψ` does not say `φ` *makes* `ψ` happen; it only
+  forbids the true→false case. Correlation/causation is a separate matter.
+- **Not biconditional.** Implication runs one way. `φ → ψ` does not give
+  you `ψ → φ`. (Two implications together make `↔`; see
+  [`equality`](equality.md), which uses the biconditional.)
+- **Not relevance.** The material conditional is true whenever the
+  antecedent is false, *even if the two parts are unrelated*. Relevance
+  logics reject this; the seed uses the classical material conditional.
+
+## Citations
+
+- **Frege, Gottlob.** *Begriffsschrift* (1879). The conditional stroke —
+  the first rigorous treatment of "if…then" in a formal logic.
+- **Whitehead & Russell.** *Principia Mathematica* (1910). Material
+  implication `⊃`.
+- **Meredith, C. A.** Single-axiom bases for the propositional calculus
+  (1950s). Demonstrates implication-based minimal axiomatisation — the
+  README's Meredith-minimalism anchor.
+- **Howard, W. A.** *The formulae-as-types notion of construction* (1969).
+  The Curry–Howard reading used in the Lean section.
+
+## What this term IS (summary)
+
+The "if…then" connective, false only when a true antecedent meets a false
+consequent. The minimal connective from which propositional logic is
+generated (Meredith); in type theory, the function arrow itself.

--- a/docs/linguistic-seed/terms/retraction.md
+++ b/docs/linguistic-seed/terms/retraction.md
@@ -1,0 +1,98 @@
+---
+name: retraction
+defined-by: Z-set negative weight (DBSP signed multiplicity); the additive-group inverse
+formalised: draft
+dependencies: [function]
+---
+
+# retraction
+
+## Plain English
+
+A **retraction** is an honest "I take that back." When you add a thing, it
+gets weight **+1**. When you retract it, you add weight **−1**, and the two
+cancel to zero. The point: you do **not erase** the fact that you once
+added it. The undo is its own real, recorded event sitting next to the
+original — like an accountant who never scribbles out a wrong entry but
+posts an equal-and-opposite one beneath it.
+
+This is step 4 of the five-year-old walk: *saying sorry is a move you're
+allowed to make, and it's written down honestly, not deleted.* Adding is
+mixing light to make a colour; retracting is mixing paint to take one
+away (emit / retract — the RGB / CMYK duality).
+
+## Mathematical definition
+
+Over a domain `D`, a **Z-set** is a [`function`](function.md)
+`w : D → ℤ` with finite support (only finitely many elements have nonzero
+weight). Two operations:
+
+```
+emit(x)     :  w(x) ← w(x) + 1
+retract(x)  :  w(x) ← w(x) − 1
+```
+
+Because `(ℤ, +)` is an additive group, `+1` followed by `−1` is the group
+inverse and sums to `0`:
+
+```
+emit(x) then retract(x)   ⟹   net weight 0   (the element cancels)
+```
+
+Crucially this is **correction, not deduplication**. Two `emit(x)` give
+weight `+2`, not `+1` — retraction does not make the operation idempotent;
+it provides a signed inverse. Deletion would *remove the key* `x` from the
+map and lose the history; retraction *adds an inverse element*, so the
+event log still records that `x` was emitted and then taken back.
+
+## Lean4 formalisation
+
+```lean4
+-- ℤ is an additive group; retraction is adding the additive inverse,
+-- and emit-then-retract cancels by `neg_add_cancel` / `add_neg_cancel`
+-- (real Mathlib lemmas):
+example (n : ℤ) : n + 1 + (-1) = n := by ring
+
+-- A Z-set as a finitely-supported function to ℤ is `Finsupp D ℤ`
+-- (Mathlib `D →₀ ℤ`); emit/retract are `+ single x 1` / `- single x 1`,
+-- and the group structure gives the cancellation for free.
+```
+
+## Grounding point (per Otto-21 Craft discipline)
+
+**The accountant's reversing entry.** When a bookkeeper posts a mistake,
+they do not erase it — erasing destroys the audit trail and looks like
+fraud. They post a second, equal-and-opposite entry. The books now net to
+the right number *and* tell the whole truth about what happened. A
+retraction is that reversing entry, made a first-class primitive. It is
+also the externalised "−1": the honest correction written into the ledger
+rather than felt as private regret (the forgiveness-gravity ferry, #43).
+
+## What this term DOES NOT mean
+
+- **Not deletion / erasure.** Deletion drops the key and forgets;
+  retraction adds an inverse and remembers. The event history is preserved
+  (manifesto §5, memory-preservation).
+- **Not idempotent dedup.** Retraction is a *signed inverse*, not a
+  duplicate guard. `+1` twice is `+2`; guarding against double-apply needs
+  an idempotency key, a different mechanism (manifesto §12).
+- **Not logical negation.** `¬φ` flips a truth value; retraction flips the
+  *weight* of an element in a multiset-with-signs. Different operators on
+  different objects.
+
+## Citations
+
+- **Budiu, McSherry, Ryzhyk, Tannen.** *DBSP: Automatic Incremental View
+  Maintenance for Rich Query Languages* (VLDB 2023). Z-sets / signed
+  multiplicities — the factory's streaming substrate (`src/Core/ZSet.fs`).
+- **Group theory** — the additive inverse in `(ℤ, +)`; the cancellation
+  law that makes emit/retract net to zero.
+- **Green, Karvounarakis, Tannen.** *Provenance semirings* (PODS 2007) —
+  weighted collections, the lineage Z-sets specialise.
+
+## What this term IS (summary)
+
+The signed inverse of an emit: adding weight `−1` so the element nets to
+zero, while the event log keeps both the add and the take-back. Correction,
+not deletion; not idempotent. The formal twin of the walk's "honest
+take-back" and the externalised "−1".

--- a/docs/linguistic-seed/terms/set.md
+++ b/docs/linguistic-seed/terms/set.md
@@ -1,0 +1,85 @@
+---
+name: set
+defined-by: The axiom of extensionality (Zermelo–Fraenkel); Cantor's collection
+formalised: draft
+dependencies: [equality, implication]
+---
+
+# set
+
+## Plain English
+
+A **set** is a collection of things where the *only* thing that matters is
+**which** things are in it — not what order you list them, not how many
+times you say them. Your toy box is the same toy box whether you list the
+blocks first or the cars first, and saying "blocks, blocks" doesn't give
+you more blocks.
+
+The whole identity of a set is its members. So two sets are the same set
+exactly when they have the same members — nothing else about them counts.
+
+## Mathematical definition
+
+Take membership `∈` as primitive (`x ∈ A` means "`x` is in `A`"). The
+defining law is the **axiom of extensionality**:
+
+```
+A = B   ↔   ∀x. (x ∈ A  ↔  x ∈ B)
+```
+
+Two sets are [`equal`](equality.md) iff they have exactly the same
+elements. The biconditionals are [`implication`](implication.md). This one
+axiom is what makes order and repetition invisible: `{1, 2}`, `{2, 1}`, and
+`{1, 1, 2}` all have the same members, so by extensionality they are the
+same set.
+
+(Membership `∈` is itself a primitive not yet given its own seed term —
+an honest dangling edge recorded in the prereq graph, to be backwards-
+chained when a downstream term needs it.)
+
+## Lean4 formalisation
+
+```lean4
+-- In Mathlib a set over `α` is its membership predicate:
+--   `Set α := α → Prop`,  with  `x ∈ A` meaning `A x`.
+-- Extensionality is `Set.ext` (a real Mathlib lemma):
+example (A B : Set α) (h : ∀ x, x ∈ A ↔ x ∈ B) : A = B := Set.ext h
+```
+
+Modelling a set as its membership predicate makes extensionality almost
+definitional: two predicates that agree on every input are the same set.
+
+## Grounding point (per Otto-21 Craft discipline)
+
+**A guest list.** The party's guest list is defined by *who is invited* —
+not the order names were written, not whether someone got written twice by
+mistake. Two lists with the same guests are the same guest list. If you
+want order to matter (who arrives first) or repeats to matter (how many
+slices each person ate), you need a different tool — a sequence or a bag —
+not a set.
+
+## What this term DOES NOT mean
+
+- **Not a list / sequence.** A list cares about order and position;
+  `[1, 2] ≠ [2, 1]`. A set does not.
+- **Not a multiset / bag.** A bag counts repeats; `{|1, 1|}` differs from
+  `{|1|}`. A set collapses repeats. (The factory's **Bag** primitive is
+  the multiset — deliberately *not* a set — and it carries the
+  ordinal-parity requirement; see `docs/PRIMITIVE-REGISTRY.md`.)
+- **Not a type.** Types and sets are related but distinct foundations; the
+  seed stays foundation-agnostic (see README §What-this-skeleton-does-NOT-do).
+
+## Citations
+
+- **Cantor, Georg.** *Beiträge zur Begründung der transfiniten
+  Mengenlehre* (1895) — the founding notion of a set as a collection.
+- **Zermelo, Ernst.** *Untersuchungen über die Grundlagen der Mengenlehre*
+  (1908) — the axiomatisation including extensionality.
+- **Fraenkel, Abraham.** (1922) — the F in ZF; replacement and the modern
+  axiom set.
+
+## What this term IS (summary)
+
+A collection identified entirely by its members (extensionality): order
+and repetition do not count. Distinct from list (order matters) and bag
+(repeats matter).


### PR DESCRIPTION
## What

Lands the **v1 formal terms** of the linguistic seed — the bottom-up mathematical twins of the [five-year-old walk](docs/linguistic-seed/FIVE-YEAR-OLD-WALK.md)'s child-words (merged #8029). The walk gave the top-down vernacular side; this gives the formal side. They meet in the middle.

## The chain (rooted at the already-landed `truth`)

```
truth → implication → equality → set → function → retraction
```

| Term | Anchor | Deps |
|------|--------|------|
| `implication` | material conditional; Frege / Meredith single-axiom | `[truth]` |
| `equality` | Leibniz indiscernibility; Frege sense/reference | `[implication]` |
| `set` | extensionality; Cantor / Zermelo–Fraenkel | `[equality, implication]` |
| `function` | single-valued total relation; Dirichlet / Kuratowski | `[set, equality]` |
| `retraction` | Z-set negative-weight inverse; **Budiu et al. DBSP** | `[function]` |

`retraction` is the Zeta-adjacent capstone — the formal twin of walk step 4 (the **honest take-back**, the externalised −1): correction not deletion, *not* idempotent dedup, history preserved.

## Discipline followed

- **Per-term schema** (README): plain English / mathematical / Lean4 / grounding point / DOES-NOT-mean / citations.
- **Lean blocks are honest DRAFT sketches** using real Mathlib declarations (`rfl`, `Eq.subst`, `Set.ext`, `congrArg`, `neg_add_cancel`) — *not* proven theorems, mirroring `truth.md`'s discipline of never checking in incorrect Lean. Soraya's lane to harden.
- **`prereq-graph.json` landed populated** (not the deferred empty skeleton): six terms with real edges, the `∈` membership primitive recorded as the one honest dangling edge, constraints documented.
- **Validated**: acyclic / no dangling refs / roots-empty / every term has a file and vice-versa.
- README's two stale spots ("Zero terms landed yet"; follow-up checklist) updated.

## Authorization

Aaron directed it: *"take #1 — land the formal terms (shadow*)"* / *"I like that otto"* — fork-1 of the offered next-steps. Docs-only, no gated class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)