### PR TITLE
feat(yaml/markdown): rescue Lior's YAML + Markdown Treaty (orphaned commit a45172a0a)

### DIFF
--- a/src/Core.CSharp.DynamicValue/DynamicValues.cs
+++ b/src/Core.CSharp.DynamicValue/DynamicValues.cs
@@ -4,7 +4,9 @@
 
 using System.Collections.Immutable;
 using System.Globalization;
+using System.Linq;
 using System.Text;
+using Zeta.Core.CSharp.Yaml;
 
 namespace Zeta.Core.CSharp;
 
@@ -217,6 +219,112 @@ public static class DynamicValues
         var sb = new StringBuilder();
         WriteCanonical(sb, value);
         return new Result<string, EncodeError>.Ok(sb.ToString());
+    }
+
+    public static Result<string, EncodeError> ToYaml(DynamicValue value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        if (FirstDeferred(value, 0) is EncodeError deferred)
+        {
+            return new Result<string, EncodeError>.Err(deferred);
+        }
+
+        YamlValue yv = ToYamlValue(value);
+        string encoded = YamlEncoder.Encode(yv);
+        return new Result<string, EncodeError>.Ok(encoded);
+    }
+
+    private static YamlValue ToYamlValue(DynamicValue value)
+    {
+        return value switch
+        {
+            DynamicValue.Null => YamlValue.YNull.Instance,
+            DynamicValue.Bool b => new YamlValue.YBool(b.Value),
+            DynamicValue.Int i => new YamlValue.YInt(i.Value),
+            DynamicValue.Float f => new YamlValue.YFloat(f.Value),
+            DynamicValue.String s => new YamlValue.YStr(s.Value),
+            DynamicValue.Array a => new YamlValue.YSeq(a.Items.Select(ToYamlValue).ToList()),
+            DynamicValue.Object o => new YamlValue.YMap(o.Pairs.Select(p => new KeyValuePair<string, YamlValue>(p.Key, ToYamlValue(p.Value))).ToList()),
+            _ => throw new InvalidOperationException("Unreachable: Bytes checked by FirstDeferred")
+        };
+    }
+
+    public static Result<DynamicValue, DecodeError> FromYaml(string yaml)
+    {
+        if (yaml == null)
+        {
+            return new Result<DynamicValue, DecodeError>.Err(DecodeError.NonCanonical);
+        }
+
+        ParseResult parseResult = YamlDom.Parse(yaml);
+        if (!parseResult.Ok)
+        {
+            return new Result<DynamicValue, DecodeError>.Err(DecodeError.NonCanonical);
+        }
+
+        var decodeResult = FromYamlValue(parseResult.Value!, 0);
+        if (decodeResult is not Result<DynamicValue, DecodeError>.Ok okDec)
+        {
+            var errDec = (Result<DynamicValue, DecodeError>.Err)decodeResult;
+            return new Result<DynamicValue, DecodeError>.Err(errDec.Error);
+        }
+
+        var reEncodeResult = ToYaml(okDec.Value);
+        if (reEncodeResult is not Result<string, EncodeError>.Ok okEnc || !string.Equals(okEnc.Value, yaml, StringComparison.Ordinal))
+        {
+            return new Result<DynamicValue, DecodeError>.Err(DecodeError.NonCanonical);
+        }
+
+        return new Result<DynamicValue, DecodeError>.Ok(okDec.Value);
+    }
+
+    private static Result<DynamicValue, DecodeError> FromYamlValue(YamlValue yv, int depth)
+    {
+        if (depth > MaxNestingDepth)
+        {
+            return new Result<DynamicValue, DecodeError>.Err(DecodeError.NestingTooDeep);
+        }
+
+        switch (yv)
+        {
+            case YamlValue.YNull:
+                return new Result<DynamicValue, DecodeError>.Ok(new DynamicValue.Null());
+            case YamlValue.YBool b:
+                return new Result<DynamicValue, DecodeError>.Ok(new DynamicValue.Bool(b.Value));
+            case YamlValue.YInt i:
+                return new Result<DynamicValue, DecodeError>.Ok(new DynamicValue.Int(i.Value));
+            case YamlValue.YFloat f:
+                return new Result<DynamicValue, DecodeError>.Ok(new DynamicValue.Float(f.Value));
+            case YamlValue.YStr s:
+                return new Result<DynamicValue, DecodeError>.Ok(new DynamicValue.String(s.Value));
+            case YamlValue.YSeq seq:
+                var items = ImmutableArray.CreateBuilder<DynamicValue>(seq.Items.Count);
+                foreach (var item in seq.Items)
+                {
+                    var res = FromYamlValue(item, depth + 1);
+                    if (res is not Result<DynamicValue, DecodeError>.Ok okRes)
+                    {
+                        return res;
+                    }
+                    items.Add(okRes.Value);
+                }
+                return new Result<DynamicValue, DecodeError>.Ok(new DynamicValue.Array(items.ToImmutable()));
+            case YamlValue.YMap map:
+                var pairs = ImmutableArray.CreateBuilder<KeyValuePair<string, DynamicValue>>(map.Entries.Count);
+                foreach (var kv in map.Entries)
+                {
+                    var res = FromYamlValue(kv.Value, depth + 1);
+                    if (res is not Result<DynamicValue, DecodeError>.Ok okRes)
+                    {
+                        return res;
+                    }
+                    pairs.Add(new KeyValuePair<string, DynamicValue>(kv.Key, okRes.Value));
+                }
+                return new Result<DynamicValue, DecodeError>.Ok(new DynamicValue.Object(pairs.ToImmutable()));
+            default:
+                return new Result<DynamicValue, DecodeError>.Err(DecodeError.Unsupported);
+        }
     }
 
     // The first deferred variant (Float/Bytes) or NestingTooDeep anywhere in the tree, or null if

--- a/src/Core.CSharp.DynamicValue/MarkdownTreaty.cs
+++ b/src/Core.CSharp.DynamicValue/MarkdownTreaty.cs
@@ -1,0 +1,108 @@
+namespace Zeta.Core.CSharp;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+/// <summary>
+/// Markdown + Frontmatter Treaty (Priority 1) for C#.
+/// Parses and serializes markdown files with frontmatter.
+/// </summary>
+public static class MarkdownTreaty
+{
+    public static Result<(DynamicValue Metadata, string Body), string> Parse(string text)
+    {
+        text ??= "";
+        if (text.StartsWith("---", StringComparison.Ordinal) && (text.Length == 3 || text[3] == '\n' || (text[3] == '\r' && text.Length > 4 && text[4] == '\n')))
+        {
+            int headerLen = text[3] == '\r' ? 5 : 4;
+
+            if (!TryFindClosingDelimiter(text, headerLen, out int closeStart, out int newlineLen, out int closeEnd))
+            {
+                return new Result<(DynamicValue, string), string>.Err("Unclosed frontmatter delimiter");
+            }
+
+            string yamlPart = text.Substring(headerLen, closeStart + newlineLen - headerLen);
+            string bodyPart = text.Substring(closeEnd);
+
+            var fromYamlRes = DynamicValues.FromYaml(yamlPart);
+            if (fromYamlRes is not Result<DynamicValue, DecodeError>.Ok okYaml)
+            {
+                var errRes = (Result<DynamicValue, DecodeError>.Err)fromYamlRes;
+                return new Result<(DynamicValue, string), string>.Err($"Failed to parse frontmatter YAML: {errRes.Error}");
+            }
+
+            if (okYaml.Value is not DynamicValue.Object metadata)
+            {
+                return new Result<(DynamicValue, string), string>.Err("Frontmatter must be a YAML map (Object)");
+            }
+
+            return new Result<(DynamicValue, string), string>.Ok((metadata, bodyPart));
+        }
+        else
+        {
+            var emptyObj = new DynamicValue.Object(ImmutableArray<KeyValuePair<string, DynamicValue>>.Empty);
+            return new Result<(DynamicValue, string), string>.Ok((emptyObj, text));
+        }
+    }
+
+    private static bool TryFindClosingDelimiter(
+        string text, int startIdx, out int closeStart, out int newlineLen, out int closeEnd)
+    {
+        closeStart = -1; newlineLen = -1; closeEnd = -1;
+        int index = startIdx;
+        while (index < text.Length)
+        {
+            bool isNewline = false; int curNewlineLen = 0; int nextIdx = index;
+            if (text[index] == '\n')
+            {
+                isNewline = true; curNewlineLen = 1; nextIdx = index + 1;
+            }
+            else if (text[index] == '\r' && index + 1 < text.Length && text[index + 1] == '\n')
+            {
+                isNewline = true; curNewlineLen = 2; nextIdx = index + 2;
+            }
+
+            if (isNewline)
+            {
+                if (nextIdx + 3 <= text.Length && string.Equals(text.Substring(nextIdx, 3), "---", StringComparison.Ordinal))
+                {
+                    int tailIdx = nextIdx + 3;
+                    if (tailIdx == text.Length || text[tailIdx] == '\n' || (text[tailIdx] == '\r' && tailIdx + 1 < text.Length && text[tailIdx + 1] == '\n'))
+                    {
+                        closeStart = index;
+                        newlineLen = curNewlineLen;
+                        closeEnd = tailIdx == text.Length ? tailIdx : (text[tailIdx] == '\n' ? tailIdx + 1 : tailIdx + 2);
+                        return true;
+                    }
+                }
+                index = nextIdx;
+            }
+            else index++;
+        }
+        return false;
+    }
+
+    public static Result<string, EncodeError> Serialize(DynamicValue metadata, string body)
+    {
+        if (metadata is not DynamicValue.Object obj)
+        {
+            return new Result<string, EncodeError>.Err(EncodeError.NotXmlRepresentable);
+        }
+
+        if (obj.Pairs.Length == 0)
+        {
+            return new Result<string, EncodeError>.Ok(body ?? "");
+        }
+
+        var toYamlRes = DynamicValues.ToYaml(obj);
+        if (toYamlRes is not Result<string, EncodeError>.Ok okYaml)
+        {
+            var errRes = (Result<string, EncodeError>.Err)toYamlRes;
+            return new Result<string, EncodeError>.Err(errRes.Error);
+        }
+
+        string result = $"---\n{okYaml.Value}---\n{body ?? ""}";
+        return new Result<string, EncodeError>.Ok(result);
+    }
+}

--- a/src/Core.CSharp.DynamicValue/Zeta.Core.CSharp.DynamicValue.csproj
+++ b/src/Core.CSharp.DynamicValue/Zeta.Core.CSharp.DynamicValue.csproj
@@ -28,4 +28,7 @@
        (supply-chain doctrine). namespace is Zeta.Core.CSharp (assembly is …DynamicValue) so the
        namespace doesn't collide with the DynamicValue type. -->
 
+  <ItemGroup>
+    <ProjectReference Include="..\Core.CSharp.Yaml\Zeta.Core.CSharp.Yaml.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Core.FSharp.Git/CliParse.fs
+++ b/src/Core.FSharp.Git/CliParse.fs
@@ -1,33 +1,99 @@
 namespace Zeta.Core.FSharp.Git
 
+open System
+open Zeta.Core
+
+/// Unified command type wrapping either a git-ref or a database-stream command.
+[<RequireQualifiedAccess>]
+type ZetaCliCommand =
+    | Git of GitCommand
+    | Db of Zeta.Core.DbCommand<Zeta.Core.DvKey>
+
 /// CLI argument parser for the git-ref command verbs (roadmap #1, no-git-CLI; core-library-first). PURE:
-/// `argv -> GitCommand` (or a usage error). Kept a library function so it's CI-tested; the runnable
-/// `zeta` exe stays a trivial shell (open repo → `parse argv` → `GitCommand.run` → print). The MCP
-/// wrapper maps tool-calls → GitCommand the same way. Mirrors a developer's git muscle-memory so the
+/// `argv -> ZetaCliCommand` (or a usage error). Kept a library function so it's CI-tested; the runnable
+/// `zeta` exe stays a trivial shell (open repo → parse argv → GitCommand/DbCommand run → print). The MCP
+/// wrapper maps tool-calls → ZetaCliCommand the same way. Mirrors a developer's git muscle-memory so the
 /// done-test (a full work-cycle with zero `git` CLI) reads naturally: `zeta commit "msg"`, `zeta log`, …
 module CliParse =
 
     let usage =
         "usage: zeta <commit <msg> | log [n] | branch <name> | checkout <ref> | status | "
-        + "push [remote] [branch] | fetch [remote]>"
+        + "push [remote] [branch] | fetch [remote] | "
+        + "db append <zset-json> [captured-json] | db history [fromSeq] | db get <seq> | db status>"
 
-    let parse (argv: string[]) : Result<GitCommand, string> =
+    let private parseCaptured (capturedJson: string) : Result<Map<string, string>, string> =
+        if String.IsNullOrEmpty capturedJson then
+            Ok Map.empty
+        else
+            match DynamicValue.fromCanonicalJson capturedJson with
+            | Ok (DynamicValue.Object kvs) ->
+                let mutable err = None
+                let map =
+                    kvs |> List.choose (fun (k, v) ->
+                        match v with
+                        | DynamicValue.String s -> Some (k, s)
+                        | _ ->
+                            err <- Some (sprintf "captured field '%s' must be a string" k)
+                            None)
+                    |> Map.ofList
+                match err with
+                | Some msg -> Error msg
+                | None -> Ok map
+            | Ok _ -> Error "captured-json must be a JSON object"
+            | Error e -> Error (sprintf "failed to parse captured JSON: %A" e)
+
+    let parse (argv: string[]) : Result<ZetaCliCommand, string> =
         match List.ofArray argv with
-        | [ "commit"; msg ] -> Ok(GitCommand.Commit msg)
-        | [ "log" ] -> Ok(GitCommand.Log 20)
+        | [ "commit"; msg ] -> Ok(ZetaCliCommand.Git(GitCommand.Commit msg))
+        | [ "log" ] -> Ok(ZetaCliCommand.Git(GitCommand.Log 20))
         | [ "log"; n ] ->
             match System.Int32.TryParse n with
-            | true, v when v > 0 -> Ok(GitCommand.Log v)
+            | true, v when v > 0 -> Ok(ZetaCliCommand.Git(GitCommand.Log v))
             | _ -> Error(sprintf "log: expected a positive count, got '%s'" n)
-        | [ "branch"; name ] -> Ok(GitCommand.Branch name)
-        | [ "checkout"; refName ] -> Ok(GitCommand.Checkout refName)
-        | [ "status" ] -> Ok GitCommand.Status
+        | [ "branch"; name ] -> Ok(ZetaCliCommand.Git(GitCommand.Branch name))
+        | [ "checkout"; refName ] -> Ok(ZetaCliCommand.Git(GitCommand.Checkout refName))
+        | [ "status" ] -> Ok(ZetaCliCommand.Git GitCommand.Status)
         // push: remote defaults to origin, branch to current HEAD (None).
-        | [ "push" ] -> Ok(GitCommand.Push("origin", None))
-        | [ "push"; remote ] -> Ok(GitCommand.Push(remote, None))
-        | [ "push"; remote; branch ] -> Ok(GitCommand.Push(remote, Some branch))
+        | [ "push" ] -> Ok(ZetaCliCommand.Git(GitCommand.Push("origin", None)))
+        | [ "push"; remote ] -> Ok(ZetaCliCommand.Git(GitCommand.Push(remote, None)))
+        | [ "push"; remote; branch ] -> Ok(ZetaCliCommand.Git(GitCommand.Push(remote, Some branch)))
         // fetch: remote defaults to origin.
-        | [ "fetch" ] -> Ok(GitCommand.Fetch "origin")
-        | [ "fetch"; remote ] -> Ok(GitCommand.Fetch remote)
+        | [ "fetch" ] -> Ok(ZetaCliCommand.Git(GitCommand.Fetch "origin"))
+        | [ "fetch"; remote ] -> Ok(ZetaCliCommand.Git(GitCommand.Fetch remote))
+
+        // db commands
+        | [ "db"; "status" ] -> Ok(ZetaCliCommand.Db Zeta.Core.DbCommand.Status)
+        | [ "db"; "history" ] -> Ok(ZetaCliCommand.Db(Zeta.Core.DbCommand.History -1L))
+        | [ "db"; "history"; fromSeqStr ] ->
+            match System.Int64.TryParse fromSeqStr with
+            | true, v -> Ok(ZetaCliCommand.Db(Zeta.Core.DbCommand.History v))
+            | false, _ -> Error(sprintf "db history: expected an integer sequence, got '%s'" fromSeqStr)
+        | [ "db"; "get"; seqStr ] ->
+            match System.Int64.TryParse seqStr with
+            | true, v -> Ok(ZetaCliCommand.Db(Zeta.Core.DbCommand.Get v))
+            | false, _ -> Error(sprintf "db get: expected an integer sequence, got '%s'" seqStr)
+        | "db" :: "append" :: zsetJson :: rest ->
+            let capturedJson =
+                match rest with
+                | [ cap ] -> cap
+                | [] -> ""
+                | _ -> null
+            if isNull capturedJson then
+                Error "db append: too many arguments. usage: db append <zset-json> [captured-json]"
+            else
+                match DynamicValue.fromCanonicalJson zsetJson with
+                | Ok dv ->
+                    try
+                        let zset = ZSetDynamic.ofDynamicValue DvKey.ofValue dv
+                        match parseCaptured capturedJson with
+                        | Ok captured ->
+                            Ok(ZetaCliCommand.Db(Zeta.Core.DbCommand.Append(zset, captured)))
+                        | Error msg ->
+                            Error (sprintf "db append: invalid captured JSON: %s" msg)
+                    with ex ->
+                        Error (sprintf "db append: invalid zset dynamic value representation: %s" ex.Message)
+                | Error e ->
+                    Error (sprintf "db append: failed to parse zset JSON: %A" e)
         | [] -> Error usage
         | other -> Error(sprintf "unknown command: '%s'\n%s" (String.concat " " other) usage)
+

--- a/src/Core.Rust.DynamicValue/Cargo.lock
+++ b/src/Core.Rust.DynamicValue/Cargo.lock
@@ -96,7 +96,12 @@ name = "zeta-core-dynamic-value"
 version = "0.1.0"
 dependencies = [
  "serde_json",
+ "zeta-core-yaml",
 ]
+
+[[package]]
+name = "zeta-core-yaml"
+version = "0.1.0"
 
 [[package]]
 name = "zmij"

--- a/src/Core.Rust.DynamicValue/Cargo.toml
+++ b/src/Core.Rust.DynamicValue/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 # Production default = ZERO external dependencies (supply-chain doctrine).
 [dependencies]
+zeta-core-yaml = { path = "../Core.Rust.Yaml" }
 
 # serde_json is DEV-ONLY: the cross-verify test reads the shared nested-JSON
 # golden-vectors.json fixture, for which a real parser is warranted; we match the

--- a/src/Core.Rust.DynamicValue/src/lib.rs
+++ b/src/Core.Rust.DynamicValue/src/lib.rs
@@ -15,6 +15,9 @@
 //! oracle replays the shared seed and must value-match every locked vector.
 //! "The compilers don't lie."
 
+/// Markdown + Frontmatter Treaty (Priority 1)
+pub mod markdown;
+
 /// The runtime type tag -- QueryInterface ("what shape are you?") for a value
 /// with no compile-time type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -373,6 +376,86 @@ impl DynamicValue {
         match value.to_canonical_xml() {
             Ok(s) if s == xml => Ok(value),
             _ => Err(DecodeError::NonCanonical),
+        }
+    }
+
+    /// Canonical YAML encoding -- the text-lock target for six shapes (Float + Bytes are DEFERRED).
+    /// Object keys in INSERTION order.
+    ///
+    /// # Errors
+    /// Returns [`EncodeError`] for `Bytes` or if nesting depth is exceeded.
+    pub fn to_canonical_yaml(&self) -> Result<String, EncodeError> {
+        let yv = self.to_yaml_value(0)?;
+        Ok(zeta_core_yaml::encoder::encode(&yv))
+    }
+
+    fn to_yaml_value(&self, depth: usize) -> Result<zeta_core_yaml::dom::YamlValue, EncodeError> {
+        if depth > MAX_NESTING_DEPTH {
+            return Err(EncodeError::NestingTooDeep);
+        }
+        match self {
+            DynamicValue::Null => Ok(zeta_core_yaml::dom::YamlValue::Null),
+            DynamicValue::Bool(b) => Ok(zeta_core_yaml::dom::YamlValue::Bool(*b)),
+            DynamicValue::Int(i) => Ok(zeta_core_yaml::dom::YamlValue::Int(*i)),
+            DynamicValue::Float(f) => Ok(zeta_core_yaml::dom::YamlValue::Float(*f)),
+            DynamicValue::String(s) => Ok(zeta_core_yaml::dom::YamlValue::Str(s.clone())),
+            DynamicValue::Bytes(_) => Err(EncodeError::BytesDeferred),
+            DynamicValue::Array(items) => {
+                let mut y_items = Vec::with_capacity(items.len());
+                for item in items {
+                    y_items.push(item.to_yaml_value(depth + 1)?);
+                }
+                Ok(zeta_core_yaml::dom::YamlValue::Seq(y_items))
+            }
+            DynamicValue::Object(pairs) => {
+                let mut y_pairs = Vec::with_capacity(pairs.len());
+                for (k, v) in pairs {
+                    y_pairs.push((k.clone(), v.to_yaml_value(depth + 1)?));
+                }
+                Ok(zeta_core_yaml::dom::YamlValue::Map(y_pairs))
+            }
+        }
+    }
+
+    /// Decode canonical YAML back into a DynamicValue. Strict canonical check requires
+    /// to_canonical_yaml() == yaml.
+    ///
+    /// # Errors
+    /// Returns [`DecodeError`] if parsing fails or YAML is non-canonical.
+    pub fn from_canonical_yaml(yaml: &str) -> Result<DynamicValue, DecodeError> {
+        let y_val = zeta_core_yaml::dom::parse(yaml).map_err(|_| DecodeError::NonCanonical)?;
+        let decoded = Self::from_yaml_value(&y_val, 0)?;
+        // Strict canonical check
+        match decoded.to_canonical_yaml() {
+            Ok(s) if s == yaml => Ok(decoded),
+            _ => Err(DecodeError::NonCanonical),
+        }
+    }
+
+    fn from_yaml_value(yv: &zeta_core_yaml::dom::YamlValue, depth: usize) -> Result<DynamicValue, DecodeError> {
+        if depth > MAX_NESTING_DEPTH {
+            return Err(DecodeError::NestingTooDeep);
+        }
+        match yv {
+            zeta_core_yaml::dom::YamlValue::Null => Ok(DynamicValue::Null),
+            zeta_core_yaml::dom::YamlValue::Bool(b) => Ok(DynamicValue::Bool(*b)),
+            zeta_core_yaml::dom::YamlValue::Int(i) => Ok(DynamicValue::Int(*i)),
+            zeta_core_yaml::dom::YamlValue::Float(f) => Ok(DynamicValue::Float(*f)),
+            zeta_core_yaml::dom::YamlValue::Str(s) => Ok(DynamicValue::String(s.clone())),
+            zeta_core_yaml::dom::YamlValue::Seq(items) => {
+                let mut dv_items = Vec::with_capacity(items.len());
+                for item in items {
+                    dv_items.push(Self::from_yaml_value(item, depth + 1)?);
+                }
+                Ok(DynamicValue::Array(dv_items))
+            }
+            zeta_core_yaml::dom::YamlValue::Map(pairs) => {
+                let mut dv_pairs = Vec::with_capacity(pairs.len());
+                for (k, v) in pairs {
+                    dv_pairs.push((k.clone(), Self::from_yaml_value(v, depth + 1)?));
+                }
+                Ok(DynamicValue::Object(dv_pairs))
+            }
         }
     }
 }

--- a/src/Core.Rust.DynamicValue/src/markdown.rs
+++ b/src/Core.Rust.DynamicValue/src/markdown.rs
@@ -1,0 +1,90 @@
+use crate::{DynamicValue, EncodeError};
+
+/// Parse a Markdown string into metadata (DynamicValue::Object) and the remaining body string.
+/// Asserts strict canonical check on the frontmatter YAML.
+pub fn parse_markdown(text: &str) -> Result<(DynamicValue, String), String> {
+    if text.starts_with("---") && (text.len() == 3 || text.as_bytes()[3] == b'\n' || (text.as_bytes()[3] == b'\r' && text.len() > 4 && text.as_bytes()[4] == b'\n')) {
+        let header_len = if text.as_bytes()[3] == b'\r' { 5 } else { 4 };
+
+        let mut index = header_len;
+        let mut close_start = None;
+        let mut newline_len = 0;
+        let mut close_end = 0;
+
+        let bytes = text.as_bytes();
+        while index < bytes.len() {
+            let mut is_newline = false;
+            let mut cur_newline_len = 0;
+            let mut next_idx = index;
+
+            if bytes[index] == b'\n' {
+                is_newline = true;
+                cur_newline_len = 1;
+                next_idx = index + 1;
+            } else if bytes[index] == b'\r' && index + 1 < bytes.len() && bytes[index + 1] == b'\n' {
+                is_newline = true;
+                cur_newline_len = 2;
+                next_idx = index + 2;
+            }
+
+            if is_newline {
+                if next_idx + 3 <= bytes.len() && &bytes[next_idx..next_idx + 3] == b"---" {
+                    let tail_idx = next_idx + 3;
+                    if tail_idx == bytes.len() {
+                        close_start = Some(index);
+                        newline_len = cur_newline_len;
+                        close_end = tail_idx;
+                        break;
+                    } else if bytes[tail_idx] == b'\n' {
+                        close_start = Some(index);
+                        newline_len = cur_newline_len;
+                        close_end = tail_idx + 1;
+                        break;
+                    } else if bytes[tail_idx] == b'\r' && tail_idx + 1 < bytes.len() && bytes[tail_idx + 1] == b'\n' {
+                        close_start = Some(index);
+                        newline_len = cur_newline_len;
+                        close_end = tail_idx + 2;
+                        break;
+                    }
+                }
+                index = next_idx;
+            } else {
+                index += 1;
+            }
+        }
+
+        let close_start = match close_start {
+            Some(idx) => idx,
+            None => return Err("Unclosed frontmatter delimiter".to_string()),
+        };
+
+        let yaml_part = &text[header_len..close_start + newline_len];
+        let body_part = &text[close_end..];
+
+        let decoded = DynamicValue::from_canonical_yaml(yaml_part)
+            .map_err(|e| format!("Failed to parse frontmatter YAML: {e:?}"))?;
+
+        match decoded {
+            DynamicValue::Object(pairs) => Ok((DynamicValue::Object(pairs), body_part.to_string())),
+            _ => Err("Frontmatter must be a YAML map (Object)".to_string()),
+        }
+    } else {
+        Ok((DynamicValue::Object(Vec::new()), text.to_string()))
+    }
+}
+
+/// Serialize metadata (DynamicValue::Object) and a body string into a Markdown string with frontmatter.
+/// If metadata is empty (Object(vec![])), frontmatter section is omitted entirely.
+pub fn serialize_markdown(metadata: &DynamicValue, body: &str) -> Result<String, EncodeError> {
+    match metadata {
+        DynamicValue::Object(pairs) => {
+            if pairs.is_empty() {
+                Ok(body.to_string())
+            } else {
+                let yaml = metadata.to_canonical_yaml()?;
+                Ok(format!("---\n{yaml}---\n{body}"))
+            }
+        }
+        _ => Err(EncodeError::NotXmlRepresentable),
+    }
+}

--- a/src/Core.Rust.DynamicValue/tests/yaml_tests.rs
+++ b/src/Core.Rust.DynamicValue/tests/yaml_tests.rs
@@ -1,0 +1,57 @@
+//! YAML and MarkdownTreaty tests.
+
+use zeta_core_dynamic_value::markdown::{parse_markdown, serialize_markdown};
+use zeta_core_dynamic_value::{DecodeError, DynamicValue};
+
+#[test]
+fn test_yaml_round_trip() {
+    let sample = DynamicValue::Object(vec![
+        ("a".to_string(), DynamicValue::Int(10)),
+        ("b".to_string(), DynamicValue::String("hello".to_string())),
+        ("n".to_string(), DynamicValue::Null),
+        (
+            "nested".to_string(),
+            DynamicValue::Array(vec![DynamicValue::Int(1), DynamicValue::Bool(true)]),
+        ),
+    ]);
+
+    let yaml = sample.to_canonical_yaml().unwrap();
+    let decoded = DynamicValue::from_canonical_yaml(&yaml).unwrap();
+    assert_eq!(sample, decoded);
+}
+
+#[test]
+fn test_yaml_rejects_non_canonical() {
+    let non_canonical = "a: 10\n";
+    let res = DynamicValue::from_canonical_yaml(non_canonical);
+    assert_eq!(res, Err(DecodeError::NonCanonical));
+}
+
+#[test]
+fn test_markdown_treaty_round_trip() {
+    let metadata = DynamicValue::Object(vec![
+        ("title".to_string(), DynamicValue::String("Zeta Rust Treaty".to_string())),
+        ("version".to_string(), DynamicValue::Int(1)),
+    ]);
+    let body = "This is the document body.\nLine 2.\n";
+
+    let serialized = serialize_markdown(&metadata, body).unwrap();
+    assert!(serialized.starts_with("---"));
+
+    let (parsed_meta, parsed_body) = parse_markdown(&serialized).unwrap();
+    assert_eq!(metadata, parsed_meta);
+    assert_eq!(body, parsed_body);
+}
+
+#[test]
+fn test_markdown_treaty_empty_metadata() {
+    let metadata = DynamicValue::Object(vec![]);
+    let body = "Pure markdown document with no frontmatter.\n";
+
+    let serialized = serialize_markdown(&metadata, body).unwrap();
+    assert_eq!(body, serialized);
+
+    let (parsed_meta, parsed_body) = parse_markdown(&serialized).unwrap();
+    assert_eq!(metadata, parsed_meta);
+    assert_eq!(body, parsed_body);
+}

--- a/src/Core.TypeScript/dynamic-value/markdown.ts
+++ b/src/Core.TypeScript/dynamic-value/markdown.ts
@@ -1,0 +1,96 @@
+import { Tagged } from "./cbor";
+import { canonicalYaml, fromCanonicalYaml } from "./yaml";
+
+export type MarkdownParseResult = { ok: true; metadata: Tagged; body: string } | { ok: false; error: string };
+export type MarkdownSerializeResult = { ok: true; value: string } | { ok: false; error: string };
+
+export function parseMarkdown(text: string): MarkdownParseResult {
+  text = text ?? "";
+  if (text.startsWith("---") && (text.length === 3 || text[3] === "\n" || (text[3] === "\r" && text.length > 4 && text[4] === "\n"))) {
+    const headerLen = text[3] === "\r" ? 5 : 4;
+
+    let index = headerLen;
+    let closeStart = -1;
+    let newlineLen = -1;
+    let closeEnd = -1;
+
+    while (index < text.length) {
+      let isNewline = false;
+      let curNewlineLen = 0;
+      let nextIdx = index;
+
+      if (text[index] === "\n") {
+        isNewline = true;
+        curNewlineLen = 1;
+        nextIdx = index + 1;
+      } else if (text[index] === "\r" && index + 1 < text.length && text[index + 1] === "\n") {
+        isNewline = true;
+        curNewlineLen = 2;
+        nextIdx = index + 2;
+      }
+
+      if (isNewline) {
+        if (nextIdx + 3 <= text.length && text.substring(nextIdx, nextIdx + 3) === "---") {
+          const tailIdx = nextIdx + 3;
+          if (tailIdx === text.length) {
+            closeStart = index;
+            newlineLen = curNewlineLen;
+            closeEnd = tailIdx;
+            break;
+          } else if (text[tailIdx] === "\n") {
+            closeStart = index;
+            newlineLen = curNewlineLen;
+            closeEnd = tailIdx + 1;
+            break;
+          } else if (text[tailIdx] === "\r" && tailIdx + 1 < text.length && text[tailIdx + 1] === "\n") {
+            closeStart = index;
+            newlineLen = curNewlineLen;
+            closeEnd = tailIdx + 2;
+            break;
+          }
+        }
+        index = nextIdx;
+      } else {
+        index++;
+      }
+    }
+
+    if (closeStart === -1) {
+      return { ok: false, error: "Unclosed frontmatter delimiter" };
+    }
+
+    const yamlPart = text.substring(headerLen, closeStart + newlineLen);
+    const bodyPart = text.substring(closeEnd);
+
+    const fromYamlRes = fromCanonicalYaml(yamlPart);
+    if (!fromYamlRes.ok) {
+      return { ok: false, error: `Failed to parse frontmatter YAML: ${fromYamlRes.error}` };
+    }
+
+    if (fromYamlRes.value.t !== "obj") {
+      return { ok: false, error: "Frontmatter must be a YAML map (Object)" };
+    }
+
+    return { ok: true, metadata: fromYamlRes.value, body: bodyPart };
+  } else {
+    return { ok: true, metadata: { t: "obj", v: [] }, body: text };
+  }
+}
+
+export function serializeMarkdown(metadata: Tagged, body: string): MarkdownSerializeResult {
+  if (metadata.t !== "obj") {
+    return { ok: false, error: "Metadata must be a Object" };
+  }
+
+  if (metadata.v.length === 0) {
+    return { ok: true, value: body ?? "" };
+  }
+
+  const toYamlRes = canonicalYaml(metadata);
+  if (!toYamlRes.ok) {
+    return { ok: false, error: toYamlRes.error };
+  }
+
+  const result = `---\n${toYamlRes.value}---\n${body ?? ""}`;
+  return { ok: true, value: result };
+}

--- a/src/Core.TypeScript/dynamic-value/yaml.test.ts
+++ b/src/Core.TypeScript/dynamic-value/yaml.test.ts
@@ -1,0 +1,79 @@
+import { expect, test, describe } from "bun:test";
+import { Tagged } from "./cbor";
+import { canonicalYaml, fromCanonicalYaml } from "./yaml";
+import { parseMarkdown, serializeMarkdown } from "./markdown";
+
+describe("TS YAML dynamic value serialization", () => {
+  test("canonicalYaml and fromCanonicalYaml round-trip", () => {
+    const sample: Tagged = {
+      t: "obj",
+      v: [
+        ["a", { t: "int", v: "10" }],
+        ["b", { t: "str", v: "hello" }],
+        ["n", { t: "null" }],
+        ["nested", { t: "arr", v: [{ t: "int", v: "1" }, { t: "bool", v: true }] }],
+      ],
+    };
+
+    const toRes = canonicalYaml(sample);
+    expect(toRes.ok).toBe(true);
+    if (toRes.ok) {
+      const fromRes = fromCanonicalYaml(toRes.value);
+      expect(fromRes.ok).toBe(true);
+      if (fromRes.ok) {
+        expect(fromRes.value).toEqual(sample);
+      }
+    }
+  });
+
+  test("fromCanonicalYaml rejects non-canonical formatting", () => {
+    const nonCanonical = 'a: 10\n';
+    const res = fromCanonicalYaml(nonCanonical);
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error).toBe("NonCanonical");
+    }
+  });
+});
+
+describe("TS MarkdownTreaty", () => {
+  test("parseMarkdown and serializeMarkdown round-trip", () => {
+    const metadata: Tagged = {
+      t: "obj",
+      v: [
+        ["title", { t: "str", v: "Zeta TS Treaty" }],
+        ["version", { t: "int", v: "1" }],
+      ],
+    };
+    const body = "This is the document body.\nLine 2.\n";
+
+    const serRes = serializeMarkdown(metadata, body);
+    expect(serRes.ok).toBe(true);
+    if (serRes.ok) {
+      expect(serRes.value.startsWith("---")).toBe(true);
+      const parseRes = parseMarkdown(serRes.value);
+      expect(parseRes.ok).toBe(true);
+      if (parseRes.ok) {
+        expect(parseRes.metadata).toEqual(metadata);
+        expect(parseRes.body).toBe(body);
+      }
+    }
+  });
+
+  test("serializeMarkdown handles empty metadata by omitting frontmatter", () => {
+    const metadata: Tagged = { t: "obj", v: [] };
+    const body = "Pure markdown document with no frontmatter.\n";
+
+    const serRes = serializeMarkdown(metadata, body);
+    expect(serRes.ok).toBe(true);
+    if (serRes.ok) {
+      expect(serRes.value).toBe(body);
+      const parseRes = parseMarkdown(serRes.value);
+      expect(parseRes.ok).toBe(true);
+      if (parseRes.ok) {
+        expect(parseRes.metadata).toEqual(metadata);
+        expect(parseRes.body).toBe(body);
+      }
+    }
+  });
+});

--- a/src/Core.TypeScript/dynamic-value/yaml.ts
+++ b/src/Core.TypeScript/dynamic-value/yaml.ts
@@ -1,0 +1,143 @@
+import { Tagged } from "./cbor";
+import { parse as parseYaml } from "../yaml/dom";
+import type { YamlValue } from "../yaml/dom";
+import { encode as encodeYaml } from "../yaml/encoder";
+
+export type EncodeError = "BytesDeferred" | "NestingTooDeep";
+export type DecodeError = "UnexpectedEnd" | "TrailingData" | "Unsupported" | "IntegerOverflow" | "NonCanonical" | "NestingTooDeep";
+
+export type EncodeResult = { ok: true; value: string } | { ok: false; error: EncodeError };
+export type DecodeResult = { ok: true; value: Tagged } | { ok: false; error: DecodeError };
+
+const MAX_NESTING_DEPTH = 256;
+
+function firstDeferred(n: Tagged, depth: number): EncodeError | null {
+  if (depth > MAX_NESTING_DEPTH) {
+    return "NestingTooDeep";
+  }
+  switch (n.t) {
+    case "bytes":
+      return "BytesDeferred";
+    case "arr": {
+      for (const item of n.v) {
+        const err = firstDeferred(item, depth + 1);
+        if (err !== null) return err;
+      }
+      return null;
+    }
+    case "obj": {
+      for (const [_, val] of n.v) {
+        const err = firstDeferred(val, depth + 1);
+        if (err !== null) return err;
+      }
+      return null;
+    }
+    default:
+      return null;
+  }
+}
+
+function toYamlValue(n: Tagged): YamlValue {
+  switch (n.t) {
+    case "null":
+      return { t: "Null" };
+    case "bool":
+      return { t: "Bool", value: n.v };
+    case "int":
+      return { t: "Int", value: BigInt(n.v) };
+    case "float":
+      return { t: "Float", value: Number(f64FromBitsHex(n.v)) };
+    case "str":
+      return { t: "Str", value: n.v };
+    case "arr":
+      return { t: "Seq", items: n.v.map(toYamlValue) };
+    case "obj":
+      return { t: "Map", entries: n.v.map(([k, val]) => [k, toYamlValue(val)]) };
+    default:
+      throw new Error(`Unreachable: bytes checked by firstDeferred`);
+  }
+}
+
+function f64FromBitsHex(hex: string): number {
+  const dv = new DataView(new ArrayBuffer(8));
+  dv.setBigUint64(0, BigInt("0x" + hex), false);
+  return dv.getFloat64(0, false);
+}
+
+function f64BitsHex(v: number): string {
+  const dv = new DataView(new ArrayBuffer(8));
+  dv.setFloat64(0, v, false);
+  return dv.getBigUint64(0, false).toString(16).padStart(16, "0");
+}
+
+export function canonicalYaml(n: Tagged): EncodeResult {
+  const err = firstDeferred(n, 0);
+  if (err !== null) {
+    return { ok: false, error: err };
+  }
+  try {
+    const yv = toYamlValue(n);
+    const yaml = encodeYaml(yv);
+    return { ok: true, value: yaml };
+  } catch (ex) {
+    return { ok: false, error: "BytesDeferred" };
+  }
+}
+
+export function fromCanonicalYaml(yaml: string): DecodeResult {
+  if (yaml === null || yaml === undefined) {
+    return { ok: false, error: "NonCanonical" };
+  }
+  const parseResult = parseYaml(yaml);
+  if (!parseResult.ok) {
+    return { ok: false, error: "NonCanonical" };
+  }
+  const decodeResult = fromYamlValue(parseResult.value, 0);
+  if (!decodeResult.ok) {
+    return decodeResult;
+  }
+  // Strict canonical check: canonicalYaml(decoded) == yaml
+  const reEncode = canonicalYaml(decodeResult.value);
+  if (!reEncode.ok || reEncode.value !== yaml) {
+    return { ok: false, error: "NonCanonical" };
+  }
+  return { ok: true, value: decodeResult.value };
+}
+
+function fromYamlValue(yv: YamlValue, depth: number): DecodeResult {
+  if (depth > MAX_NESTING_DEPTH) {
+    return { ok: false, error: "NestingTooDeep" };
+  }
+  switch (yv.t) {
+    case "Null":
+      return { ok: true, value: { t: "null" } };
+    case "Bool":
+      return { ok: true, value: { t: "bool", v: yv.value } };
+    case "Int":
+      return { ok: true, value: { t: "int", v: yv.value.toString() } };
+    case "Float":
+      return { ok: true, value: { t: "float", v: f64BitsHex(yv.value) } };
+    case "Str":
+      return { ok: true, value: { t: "str", v: yv.value } };
+    case "Seq": {
+      const items: Tagged[] = [];
+      for (const item of yv.items) {
+        const res = fromYamlValue(item, depth + 1);
+        if (!res.ok) return res;
+        items.push(res.value);
+      }
+      return { ok: true, value: { t: "arr", v: items } };
+    }
+    case "Map": {
+      const entries: [string, Tagged][] = [];
+      for (const [k, val] of yv.entries) {
+        const res = fromYamlValue(val, depth + 1);
+        if (!res.ok) return res;
+        entries.push([k, res.value]);
+      }
+      return { ok: true, value: { t: "obj", v: entries } };
+    }
+    default:
+      return { ok: false, error: "Unsupported" };
+  }
+}

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -62,6 +62,7 @@
     <Compile Include="BeliefConvergence.fs" />
     <Compile Include="Evolution.fs" />
     <Compile Include="DynamicValue.fs" />
+    <Compile Include="MarkdownTreaty.fs" />
     <Compile Include="YinYang.fs" />
     <Compile Include="Diplomacy.fs" />
     <Compile Include="DurableDiplomacy.fs" />
@@ -340,6 +341,7 @@
     <!-- Language-neutral contract lib (ITensor); WeightedSet implements it -->
     <ProjectReference Include="..\Core.Abstractions\Zeta.Core.Abstractions.csproj" />
     <ProjectReference Include="..\Core.FSharp.ZetaId\Zeta.Core.FSharp.ZetaId.fsproj" />
+    <ProjectReference Include="..\Core.FSharp.Yaml\Zeta.Core.FSharp.Yaml.fsproj" />
   </ItemGroup>
 
   <!-- F# static analyzers. Run via `dotnet msbuild -t:AnalyzeFSharpProject`. -->

--- a/src/Core/DynamicValue.fs
+++ b/src/Core/DynamicValue.fs
@@ -1431,3 +1431,74 @@ module DynamicValue =
                 match toCanonicalXml value with
                 | Ok s when System.String.Equals(s, xml, System.StringComparison.Ordinal) -> Ok value
                 | _ -> Error DecodeError.NonCanonical
+
+    /// Canonical YAML encoding — the text-lock target for six shapes (Float + Bytes are DEFERRED
+    /// in YAML). Object keys in INSERTION order.
+    let toYaml (value: DynamicValue) : Result<string, EncodeError> =
+        let rec go (depth: int) (v: DynamicValue) : Result<Zeta.Core.FSharp.Yaml.Dom.YamlValue, EncodeError> =
+            if depth > maxNestingDepth then
+                Error EncodeError.NestingTooDeep
+            else
+                match v with
+                | DynamicValue.Null -> Ok Zeta.Core.FSharp.Yaml.Dom.YamlValue.VNull
+                | DynamicValue.Bool b -> Ok (Zeta.Core.FSharp.Yaml.Dom.YamlValue.VBool b)
+                | DynamicValue.Int i -> Ok (Zeta.Core.FSharp.Yaml.Dom.YamlValue.VInt i)
+                | DynamicValue.Float f -> Ok (Zeta.Core.FSharp.Yaml.Dom.YamlValue.VFloat f)
+                | DynamicValue.String s -> Ok (Zeta.Core.FSharp.Yaml.Dom.YamlValue.VStr s)
+                | DynamicValue.Bytes _ -> Error EncodeError.BytesDeferred
+                | DynamicValue.Array items ->
+                    items
+                    |> List.fold
+                        (fun acc item -> acc |> Result.bind (fun parsed -> go (depth + 1) item |> Result.map (fun y -> y :: parsed)))
+                        (Ok [])
+                    |> Result.map (fun parsed -> Zeta.Core.FSharp.Yaml.Dom.YamlValue.VSeq (List.rev parsed))
+                | DynamicValue.Object pairs ->
+                    pairs
+                    |> List.fold
+                        (fun acc (k, v) ->
+                            acc |> Result.bind (fun parsed -> go (depth + 1) v |> Result.map (fun y -> (k, y) :: parsed)))
+                        (Ok [])
+                    |> Result.map (fun parsed -> Zeta.Core.FSharp.Yaml.Dom.YamlValue.VMap (List.rev parsed))
+
+        go 0 value |> Result.map Zeta.Core.FSharp.Yaml.Encoder.encode
+
+    /// Decode canonical YAML back into a DynamicValue. Strict canonical check requires
+    /// toYaml(decoded) = yaml.
+    let fromYaml (yaml: string) : Result<DynamicValue, DecodeError> =
+        let yaml = if System.Object.ReferenceEquals(yaml, null) then "" else yaml
+        let rec go (depth: int) (y: Zeta.Core.FSharp.Yaml.Dom.YamlValue) : Result<DynamicValue, DecodeError> =
+            if depth > maxNestingDepth then
+                Error DecodeError.NestingTooDeep
+            else
+                match y with
+                | Zeta.Core.FSharp.Yaml.Dom.YamlValue.VNull -> Ok DynamicValue.Null
+                | Zeta.Core.FSharp.Yaml.Dom.YamlValue.VBool b -> Ok (DynamicValue.Bool b)
+                | Zeta.Core.FSharp.Yaml.Dom.YamlValue.VInt i -> Ok (DynamicValue.Int i)
+                | Zeta.Core.FSharp.Yaml.Dom.YamlValue.VFloat f -> Ok (DynamicValue.Float f)
+                | Zeta.Core.FSharp.Yaml.Dom.YamlValue.VStr s -> Ok (DynamicValue.String s)
+                | Zeta.Core.FSharp.Yaml.Dom.YamlValue.VSeq items ->
+                    items
+                    |> List.fold
+                        (fun acc item -> acc |> Result.bind (fun parsed -> go (depth + 1) item |> Result.map (fun d -> d :: parsed)))
+                        (Ok [])
+                    |> Result.map (fun parsed -> DynamicValue.Array (List.rev parsed))
+                | Zeta.Core.FSharp.Yaml.Dom.YamlValue.VMap pairs ->
+                    pairs
+                    |> List.fold
+                        (fun acc (k, v) ->
+                            acc |> Result.bind (fun parsed -> go (depth + 1) v |> Result.map (fun d -> (k, d) :: parsed)))
+                        (Ok [])
+                    |> Result.map (fun parsed -> DynamicValue.Object (List.rev parsed))
+
+        let parsedResult =
+            match Zeta.Core.FSharp.Yaml.Dom.parse yaml with
+            | Ok y -> Ok y
+            | Error _ -> Error DecodeError.NonCanonical
+
+        parsedResult
+        |> Result.bind (go 0)
+        |> Result.bind (fun decoded ->
+            match toYaml decoded with
+            | Ok canonicalYaml when canonicalYaml = yaml -> Ok decoded
+            | _ -> Error DecodeError.NonCanonical)
+

--- a/src/Core/MarkdownTreaty.fs
+++ b/src/Core/MarkdownTreaty.fs
@@ -1,0 +1,71 @@
+namespace Zeta.Core
+
+open System.Collections.Immutable
+
+/// **Markdown + Frontmatter Treaty (Priority 1)**
+///
+/// Implements a 4-language read/write treaty for parsing .md files.
+/// Delimited by "---" at the start of the file, containing frontmatter
+/// serialized as canonical YAML, mapping to a DynamicValue.Object.
+/// If there is no frontmatter, it parses metadata as an empty Object [].
+module MarkdownTreaty =
+
+    /// Parse a Markdown string into metadata (DynamicValue.Object) and the remaining body string.
+    /// Asserts strict canonical check on the frontmatter YAML.
+    let parse (text: string) : Result<DynamicValue * string, string> =
+        let text = if System.Object.ReferenceEquals(text, null) then "" else text
+        if text.StartsWith("---") && (text.Length = 3 || text.[3] = '\n' || (text.[3] = '\r' && text.Length > 4 && text.[4] = '\n')) then
+            let headerLen = if text.[3] = '\r' then 5 else 4
+            
+            let rec findClosing (index: int) =
+                if index >= text.Length then
+                    None
+                else
+                    let isNewline, newlineLen, nextIdx =
+                        if text.[index] = '\n' then true, 1, index + 1
+                        elif text.[index] = '\r' && index + 1 < text.Length && text.[index + 1] = '\n' then true, 2, index + 2
+                        else false, 0, index + 1
+                    if isNewline then
+                        if nextIdx + 3 <= text.Length && text.Substring(nextIdx, 3) = "---" then
+                            let tailIdx = nextIdx + 3
+                            if tailIdx = text.Length then
+                                Some (index, newlineLen, tailIdx)
+                            elif text.[tailIdx] = '\n' then
+                                Some (index, newlineLen, tailIdx + 1)
+                            elif text.[tailIdx] = '\r' && tailIdx + 1 < text.Length && text.[tailIdx + 1] = '\n' then
+                                Some (index, newlineLen, tailIdx + 2)
+                            else
+                                findClosing nextIdx
+                        else
+                            findClosing nextIdx
+                    else
+                        findClosing nextIdx
+
+            match findClosing headerLen with
+            | None ->
+                Error "Unclosed frontmatter delimiter"
+            | Some (closeStart, newlineLen, closeEnd) ->
+                let yamlPart = text.Substring(headerLen, closeStart + newlineLen - headerLen)
+                let bodyPart = text.Substring(closeEnd)
+                match DynamicValue.fromYaml yamlPart with
+                | Error err -> Error (sprintf "Failed to parse frontmatter YAML: %A" err)
+                | Ok (DynamicValue.Object pairs as metadata) ->
+                    Ok (metadata, bodyPart)
+                | Ok _ ->
+                    Error "Frontmatter must be a YAML map (Object)"
+        else
+            Ok (DynamicValue.Object [], text)
+
+    /// Serialize metadata (DynamicValue.Object) and a body string into a Markdown string with frontmatter.
+    /// If metadata is empty (Object []), frontmatter section is omitted entirely.
+    let serialize (metadata: DynamicValue) (body: string) : Result<string, EncodeError> =
+        match metadata with
+        | DynamicValue.Object [] ->
+            Ok body
+        | DynamicValue.Object _ ->
+            match DynamicValue.toYaml metadata with
+            | Error err -> Error err
+            | Ok yaml ->
+                Ok (sprintf "---\n%s---\n%s" yaml body)
+        | _ ->
+            Error EncodeError.NonRepresentable

--- a/tests/Tests.CSharp/Yaml/DynamicValueYamlTests.cs
+++ b/tests/Tests.CSharp/Yaml/DynamicValueYamlTests.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Xunit;
+using Zeta.Core.CSharp;
+
+namespace Zeta.Tests.CSharp.Yaml;
+
+public class DynamicValueYamlTests
+{
+    private static DynamicValue.Bytes Bytes(params byte[] xs) => new(ImmutableArray.Create(xs));
+    private static DynamicValue.Array Arr(params DynamicValue[] xs) => new(ImmutableArray.Create(xs));
+    private static DynamicValue.Object Obj(params (string Key, DynamicValue Value)[] kvs) =>
+        new(kvs.Select(kv => new KeyValuePair<string, DynamicValue>(kv.Key, kv.Value)).ToImmutableArray());
+
+    [Fact]
+    public void DynamicValueToYamlAndFromYamlRoundTrips()
+    {
+        var sample = Obj(
+            ("a", new DynamicValue.Int(10L)),
+            ("b", new DynamicValue.String("hello")),
+            ("n", new DynamicValue.Null()),
+            ("nested", Arr(new DynamicValue.Int(1L), new DynamicValue.Bool(true)))
+        );
+
+        var toRes = DynamicValues.ToYaml(sample);
+        Assert.True(toRes is Result<string, EncodeError>.Ok);
+        var yaml = ((Result<string, EncodeError>.Ok)toRes).Value;
+
+        var fromRes = DynamicValues.FromYaml(yaml);
+        Assert.True(fromRes is Result<DynamicValue, DecodeError>.Ok);
+        var decoded = ((Result<DynamicValue, DecodeError>.Ok)fromRes).Value;
+
+        Assert.Equal(sample, decoded);
+    }
+
+    [Fact]
+    public void FromYamlRejectsNonCanonical()
+    {
+        var nonCanonical = "a: 10\n";
+        var res = DynamicValues.FromYaml(nonCanonical);
+        Assert.True(res is Result<DynamicValue, DecodeError>.Err);
+        Assert.Equal(DecodeError.NonCanonical, ((Result<DynamicValue, DecodeError>.Err)res).Error);
+    }
+
+    [Fact]
+    public void MarkdownTreatyParsesAndSerializes()
+    {
+        var metadata = Obj(
+            ("title", new DynamicValue.String("Zeta C# Treaty")),
+            ("version", new DynamicValue.Int(1L))
+        );
+        var body = "This is the document body.\nLine 2.\n";
+
+        var serRes = MarkdownTreaty.Serialize(metadata, body);
+        var serialized = ((Result<string, EncodeError>.Ok)serRes).Value;
+        Assert.StartsWith("---", serialized, System.StringComparison.Ordinal);
+
+        var parseRes = MarkdownTreaty.Parse(serialized);
+        Assert.True(parseRes is Result<(DynamicValue Metadata, string Body), string>.Ok);
+        var parsed = ((Result<(DynamicValue Metadata, string Body), string>.Ok)parseRes).Value;
+
+        Assert.Equal(metadata, parsed.Metadata);
+        Assert.Equal(body, parsed.Body);
+    }
+
+    [Fact]
+    public void MarkdownTreatyHandlesEmptyMetadata()
+    {
+        var metadata = Obj();
+        var body = "Pure markdown document with no frontmatter.\n";
+
+        var serRes = MarkdownTreaty.Serialize(metadata, body);
+        Assert.True(serRes is Result<string, EncodeError>.Ok);
+        var serialized = ((Result<string, EncodeError>.Ok)serRes).Value;
+
+        Assert.Equal(body, serialized);
+
+        var parseRes = MarkdownTreaty.Parse(serialized);
+        Assert.True(parseRes is Result<(DynamicValue Metadata, string Body), string>.Ok);
+        var parsed = ((Result<(DynamicValue Metadata, string Body), string>.Ok)parseRes).Value;
+
+        Assert.Equal(metadata, parsed.Metadata);
+        Assert.Equal(body, parsed.Body);
+    }
+}

--- a/tests/Tests.FSharp.Git/CliParse.Tests.fs
+++ b/tests/Tests.FSharp.Git/CliParse.Tests.fs
@@ -8,23 +8,23 @@ open Zeta.Core.FSharp.Git
 
 [<Fact>]
 let ``parse maps the git-ref verbs`` () =
-    Assert.Equal<Result<GitCommand, string>>(Ok(GitCommand.Commit "msg"), CliParse.parse [| "commit"; "msg" |])
-    Assert.Equal<Result<GitCommand, string>>(Ok(GitCommand.Log 20), CliParse.parse [| "log" |])
-    Assert.Equal<Result<GitCommand, string>>(Ok(GitCommand.Log 5), CliParse.parse [| "log"; "5" |])
-    Assert.Equal<Result<GitCommand, string>>(Ok(GitCommand.Branch "feature"), CliParse.parse [| "branch"; "feature" |])
-    Assert.Equal<Result<GitCommand, string>>(Ok(GitCommand.Checkout "main"), CliParse.parse [| "checkout"; "main" |])
-    Assert.Equal<Result<GitCommand, string>>(Ok GitCommand.Status, CliParse.parse [| "status" |])
+    Assert.Equal<Result<ZetaCliCommand, string>>(Ok(ZetaCliCommand.Git(GitCommand.Commit "msg")), CliParse.parse [| "commit"; "msg" |])
+    Assert.Equal<Result<ZetaCliCommand, string>>(Ok(ZetaCliCommand.Git(GitCommand.Log 20)), CliParse.parse [| "log" |])
+    Assert.Equal<Result<ZetaCliCommand, string>>(Ok(ZetaCliCommand.Git(GitCommand.Log 5)), CliParse.parse [| "log"; "5" |])
+    Assert.Equal<Result<ZetaCliCommand, string>>(Ok(ZetaCliCommand.Git(GitCommand.Branch "feature")), CliParse.parse [| "branch"; "feature" |])
+    Assert.Equal<Result<ZetaCliCommand, string>>(Ok(ZetaCliCommand.Git(GitCommand.Checkout "main")), CliParse.parse [| "checkout"; "main" |])
+    Assert.Equal<Result<ZetaCliCommand, string>>(Ok(ZetaCliCommand.Git GitCommand.Status), CliParse.parse [| "status" |])
 
 [<Fact>]
 let ``parse maps the network verbs with remote/branch defaults`` () =
-    Assert.Equal<Result<GitCommand, string>>(Ok(GitCommand.Push("origin", None)), CliParse.parse [| "push" |])
-    Assert.Equal<Result<GitCommand, string>>(Ok(GitCommand.Push("upstream", None)), CliParse.parse [| "push"; "upstream" |])
-    Assert.Equal<Result<GitCommand, string>>(
-        Ok(GitCommand.Push("origin", Some "main")),
+    Assert.Equal<Result<ZetaCliCommand, string>>(Ok(ZetaCliCommand.Git(GitCommand.Push("origin", None))), CliParse.parse [| "push" |])
+    Assert.Equal<Result<ZetaCliCommand, string>>(Ok(ZetaCliCommand.Git(GitCommand.Push("upstream", None))), CliParse.parse [| "push"; "upstream" |])
+    Assert.Equal<Result<ZetaCliCommand, string>>(
+        Ok(ZetaCliCommand.Git(GitCommand.Push("origin", Some "main"))),
         CliParse.parse [| "push"; "origin"; "main" |]
     )
-    Assert.Equal<Result<GitCommand, string>>(Ok(GitCommand.Fetch "origin"), CliParse.parse [| "fetch" |])
-    Assert.Equal<Result<GitCommand, string>>(Ok(GitCommand.Fetch "upstream"), CliParse.parse [| "fetch"; "upstream" |])
+    Assert.Equal<Result<ZetaCliCommand, string>>(Ok(ZetaCliCommand.Git(GitCommand.Fetch "origin")), CliParse.parse [| "fetch" |])
+    Assert.Equal<Result<ZetaCliCommand, string>>(Ok(ZetaCliCommand.Git(GitCommand.Fetch "upstream")), CliParse.parse [| "fetch"; "upstream" |])
 
 [<Fact>]
 let ``parse errors on empty, bad count, and unknown verbs`` () =

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -448,6 +448,7 @@
     <Compile Include="Yaml/CrossVerifyTests.fs" />
     <Compile Include="Yaml/EncoderRoundTripTests.fs" />
     <Compile Include="Yaml/DynamicValueYamlBridgeTests.fs" />
+    <Compile Include="Yaml/DynamicValueYamlTests.fs" />
     <Compile Include="Sha256/Sha256Tests.fs" />
     <Compile Include="Sha256/CrossVerifyTests.fs" />
     <Compile Include="CanonicalJson/CrossVerifyTests.fs" />

--- a/tests/Tests.FSharp/Yaml/DynamicValueYamlTests.fs
+++ b/tests/Tests.FSharp/Yaml/DynamicValueYamlTests.fs
@@ -1,0 +1,69 @@
+module Zeta.Tests.FSharp.Yaml.DynamicValueYamlTests
+
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Core
+
+[<Fact>]
+let ``DynamicValue toYaml and fromYaml round-trips correctly`` () =
+    let sample =
+        DynamicValue.Object [
+            "a", DynamicValue.Int 10L
+            "b", DynamicValue.String "hello"
+            "n", DynamicValue.Null
+            "nested", DynamicValue.Array [ DynamicValue.Int 1L; DynamicValue.Bool true ]
+        ]
+    match DynamicValue.toYaml sample with
+    | Error err -> failwithf "Failed to serialize: %A" err
+    | Ok yaml ->
+        match DynamicValue.fromYaml yaml with
+        | Error err -> failwithf "Failed to deserialize: %A\nYAML:\n%s" err yaml
+        | Ok decoded ->
+            decoded |> should equal sample
+
+[<Fact>]
+let ``DynamicValue fromYaml rejects non-canonical formatting`` () =
+    // Canonical YAML always quotes keys and strings, uses block indentation, and terminates with newline.
+    // Non-canonical input (e.g. unquoted key, raw float without .0, trailing whitespace)
+    // should fail the strict fixed-point check.
+    let nonCanonical = "a: 10\n" // unquoted key 'a'
+    match DynamicValue.fromYaml nonCanonical with
+    | Error DecodeError.NonCanonical -> ()
+    | Ok value -> failwithf "Expected NonCanonical decode error, got Ok: %A" value
+    | Error err -> failwithf "Expected DecodeError.NonCanonical, got %A" err
+
+[<Fact>]
+let ``MarkdownTreaty parses and serializes correctly`` () =
+    let metadata = DynamicValue.Object [ "title", DynamicValue.String "Zeta Treaty"; "version", DynamicValue.Int 1L ]
+    let body = "This is the document body.\nLine 2.\n"
+    
+    // Test serialize
+    match MarkdownTreaty.serialize metadata body with
+    | Error err -> failwithf "Failed to serialize markdown: %A" err
+    | Ok serialized ->
+        // Assert delimiters exist
+        serialized.StartsWith("---") |> should equal true
+        
+        // Test parse
+        match MarkdownTreaty.parse serialized with
+        | Error err -> failwithf "Failed to parse markdown: %s" err
+        | Ok (parsedMeta, parsedBody) ->
+            parsedMeta |> should equal metadata
+            parsedBody |> should equal body
+
+[<Fact>]
+let ``MarkdownTreaty handles empty metadata correctly`` () =
+    let metadata = DynamicValue.Object []
+    let body = "Pure markdown document with no frontmatter.\n"
+    
+    match MarkdownTreaty.serialize metadata body with
+    | Error err -> failwithf "Failed to serialize: %A" err
+    | Ok serialized ->
+        // Frontmatter must be completely omitted
+        serialized |> should equal body
+        
+        match MarkdownTreaty.parse serialized with
+        | Error err -> failwithf "Failed to parse: %s" err
+        | Ok (parsedMeta, parsedBody) ->
+            parsedMeta |> should equal metadata
+            parsedBody |> should equal body

--- a/tools/zeta-cli/Program.fs
+++ b/tools/zeta-cli/Program.fs
@@ -84,22 +84,47 @@ let main argv =
             let credSource = Some(EnvTokenCredentialSource() :> CredentialSource)
 
             try
-                match GitCommand.run repo (fun () -> DateTimeOffset.UtcNow) credSource cmd with
-                | Branched n -> printfn "branched %s" n
-                | CheckedOut n -> printfn "checked out %s" n
-                | Committed sha -> printfn "committed %s" sha
-                | Logged entries ->
-                    for (sha, msg) in entries do
-                        printfn "%s %s" (sha.Substring(0, min 9 sha.Length)) msg
-                | Statused(clean, pending) ->
-                    if clean then
-                        printfn "clean"
-                    else
-                        printfn "dirty (%d pending):" pending.Length
-                        for p in pending do printfn "  %s" p
-                | Pushed(remote, refspec) -> printfn "pushed %s -> %s" refspec remote
-                | Fetched remote -> printfn "fetched %s" remote
-                0
+                match cmd with
+                | ZetaCliCommand.Git gitCmd ->
+                    match GitCommand.run repo (fun () -> DateTimeOffset.UtcNow) credSource gitCmd with
+                    | Branched n -> printfn "branched %s" n
+                    | CheckedOut n -> printfn "checked out %s" n
+                    | Committed sha -> printfn "committed %s" sha
+                    | Logged entries ->
+                        for (sha, msg) in entries do
+                            printfn "%s %s" (sha.Substring(0, min 9 sha.Length)) msg
+                    | Statused(clean, pending) ->
+                        if clean then
+                            printfn "clean"
+                        else
+                            printfn "dirty (%d pending):" pending.Length
+                            for p in pending do printfn "  %s" p
+                    | Pushed(remote, refspec) -> printfn "pushed %s -> %s" refspec remote
+                    | Fetched remote -> printfn "fetched %s" remote
+                    0
+                | ZetaCliCommand.Db dbCmd ->
+                    let codec = CborEntryCodec<DvKey>(DvKey.value, DvKey.ofValue)
+                    let log = GitDeltaLog<DvKey>(repo, codec)
+                    let res = Zeta.Core.DbCommand.run log Threading.CancellationToken.None dbCmd |> Async.AwaitTask |> Async.RunSynchronously
+                    match res with
+                    | DbCommandResult.Appended seq ->
+                        printfn "appended seq: %d" seq
+                    | DbCommandResult.History entries ->
+                        for entry in entries do
+                            let dv = DeltaLogEntryDynamic.toDynamicValue DvKey.value entry
+                            match DynamicValue.toCanonicalJson dv with
+                            | Ok json -> printfn "%s" json
+                            | Error e -> eprintfn "failed to format entry: %A" e
+                    | DbCommandResult.Got (Some entry) ->
+                        let dv = DeltaLogEntryDynamic.toDynamicValue DvKey.value entry
+                        match DynamicValue.toCanonicalJson dv with
+                        | Ok json -> printfn "%s" json
+                        | Error e -> eprintfn "failed to format entry: %A" e
+                    | DbCommandResult.Got None ->
+                        printfn "not found"
+                    | DbCommandResult.Status highWater ->
+                        printfn "highwater: %d" highWater
+                    0
             with ex ->
                 eprintfn "zeta: %s" ex.Message
                 1

--- a/tools/zeta-mcp/Program.fs
+++ b/tools/zeta-mcp/Program.fs
@@ -4,6 +4,7 @@ open System
 open System.Text.Json.Nodes
 open LibGit2Sharp
 open Zeta.Core.FSharp.Git
+open Zeta.Core
 
 // Minimal MCP stdio server (newline-delimited JSON-RPC 2.0) exposing the git-ref command verbs as tools
 // (roadmap #1, no-git-CLI; the step that lets Otto drive the verbs as native tools). Server-only — the
@@ -39,6 +40,10 @@ let private toolList () : JsonArray =
     arr.Add(tool "zeta_commit" "Stage all + commit (replaces git commit)" [ "message", "string" ] [ "message" ])
     arr.Add(tool "zeta_push" "Push a branch to a remote (replaces git push); creds via GH_TOKEN/GITHUB_TOKEN" [ "remote", "string"; "branch", "string" ] [])
     arr.Add(tool "zeta_fetch" "Fetch from a remote (replaces git fetch); creds via GH_TOKEN/GITHUB_TOKEN" [ "remote", "string" ] [])
+    arr.Add(tool "zeta_db_append" "Append a delta and captured map to the delta log" [ "zset", "string"; "captured", "string" ] [ "zset" ])
+    arr.Add(tool "zeta_db_history" "Replay delta log entries starting after from_seq" [ "from_seq", "integer" ] [])
+    arr.Add(tool "zeta_db_get" "Retrieve a single delta log entry by sequence number" [ "seq", "integer" ] [ "seq" ])
+    arr.Add(tool "zeta_db_status" "Get the current high-water sequence number" [] [])
     arr
 
 let private argStr (args: JsonObject) (k: string) : string =
@@ -48,42 +53,94 @@ let private argStr (args: JsonObject) (k: string) : string =
 let private runTool (name: string) (args: JsonObject) : string =
     let cmd =
         match name with
-        | "zeta_status" -> Some GitCommand.Status
+        | "zeta_status" -> Some (Choice1Of2 GitCommand.Status)
         | "zeta_log" ->
             let cv = args["count"]
             let n = if isNull cv then 20 else cv.GetValue<int>()
-            Some(GitCommand.Log n)
-        | "zeta_branch" -> Some(GitCommand.Branch(argStr args "name"))
-        | "zeta_checkout" -> Some(GitCommand.Checkout(argStr args "ref"))
-        | "zeta_commit" -> Some(GitCommand.Commit(argStr args "message"))
+            Some(Choice1Of2(GitCommand.Log n))
+        | "zeta_branch" -> Some(Choice1Of2(GitCommand.Branch(argStr args "name")))
+        | "zeta_checkout" -> Some(Choice1Of2(GitCommand.Checkout(argStr args "ref")))
+        | "zeta_commit" -> Some(Choice1Of2(GitCommand.Commit(argStr args "message")))
         | "zeta_push" ->
             let remote = match argStr args "remote" with "" -> "origin" | r -> r
             let branch = match argStr args "branch" with "" -> None | b -> Some b
-            Some(GitCommand.Push(remote, branch))
+            Some(Choice1Of2(GitCommand.Push(remote, branch)))
         | "zeta_fetch" ->
             let remote = match argStr args "remote" with "" -> "origin" | r -> r
-            Some(GitCommand.Fetch remote)
+            Some(Choice1Of2(GitCommand.Fetch remote))
+        | "zeta_db_status" -> Some (Choice2Of2 DbCommand.Status)
+        | "zeta_db_history" ->
+            let fv = args["from_seq"]
+            let fromSeq = if isNull fv then -1L else int64 (fv.GetValue<int>())
+            Some (Choice2Of2 (DbCommand.History fromSeq))
+        | "zeta_db_get" ->
+            let seq = int64 (args["seq"].GetValue<int>())
+            Some (Choice2Of2 (DbCommand.Get seq))
+        | "zeta_db_append" ->
+            let zsetJson = argStr args "zset"
+            let capturedJson = argStr args "captured"
+            match DynamicValue.fromCanonicalJson zsetJson with
+            | Ok dv ->
+                try
+                    let zset = ZSetDynamic.ofDynamicValue DvKey.ofValue dv
+                    let captured =
+                        if String.IsNullOrEmpty capturedJson then
+                            Map.empty
+                        else
+                            match DynamicValue.fromCanonicalJson capturedJson with
+                            | Ok (DynamicValue.Object kvs) ->
+                                kvs |> List.choose (fun (k, v) ->
+                                    match v with
+                                    | DynamicValue.String s -> Some (k, s)
+                                    | _ -> None)
+                                |> Map.ofList
+                            | _ -> Map.empty
+                    Some (Choice2Of2 (DbCommand.Append(zset, captured)))
+                with ex ->
+                    None
+            | Error _ -> None
         | _ -> None
     match cmd with
-    | None -> sprintf "unknown tool: %s" name
+    | None -> sprintf "unknown tool or invalid arguments: %s" name
     | Some c ->
         match Repository.Discover(Environment.CurrentDirectory) with
         | null -> "not inside a git repository"
         | path ->
-            // Host-agnostic credentials for network verbs (GH_TOKEN/GITHUB_TOKEN); local verbs ignore it.
             let credSource = Some(EnvTokenCredentialSource() :> CredentialSource)
             use repo = new Repository(path)
             try
-                match GitCommand.run repo now credSource c with
-                | Branched n -> sprintf "branched %s" n
-                | CheckedOut n -> sprintf "checked out %s" n
-                | Committed sha -> sprintf "committed %s" sha
-                | Logged es -> es |> Array.map (fun (s, m) -> sprintf "%s %s" (s.Substring(0, min 9 s.Length)) m) |> String.concat "\n"
-                | Statused(clean, pending) ->
-                    if clean then "clean"
-                    else sprintf "dirty (%d pending):\n%s" pending.Length (String.concat "\n" pending)
-                | Pushed(remote, refspec) -> sprintf "pushed %s -> %s" refspec remote
-                | Fetched remote -> sprintf "fetched %s" remote
+                match c with
+                | Choice1Of2 gitCmd ->
+                    match GitCommand.run repo now credSource gitCmd with
+                    | Branched n -> sprintf "branched %s" n
+                    | CheckedOut n -> sprintf "checked out %s" n
+                    | Committed sha -> sprintf "committed %s" sha
+                    | Logged es -> es |> Array.map (fun (s, m) -> sprintf "%s %s" (s.Substring(0, min 9 s.Length)) m) |> String.concat "\n"
+                    | Statused(clean, pending) ->
+                        if clean then "clean"
+                        else sprintf "dirty (%d pending):\n%s" pending.Length (String.concat "\n" pending)
+                    | Pushed(remote, refspec) -> sprintf "pushed %s -> %s" refspec remote
+                    | Fetched remote -> sprintf "fetched %s" remote
+                | Choice2Of2 dbCmd ->
+                    let codec = CborEntryCodec<DvKey>(DvKey.value, DvKey.ofValue)
+                    let log = GitDeltaLog<DvKey>(repo, codec)
+                    let res = DbCommand.run log Threading.CancellationToken.None dbCmd |> Async.AwaitTask |> Async.RunSynchronously
+                    match res with
+                    | DbCommandResult.Appended seq -> sprintf "appended seq: %d" seq
+                    | DbCommandResult.History entries ->
+                        entries |> Array.map (fun entry ->
+                            let dv = DeltaLogEntryDynamic.toDynamicValue DvKey.value entry
+                            match DynamicValue.toCanonicalJson dv with
+                            | Ok json -> json
+                            | Error e -> sprintf "error formatting: %A" e
+                        ) |> String.concat "\n"
+                    | DbCommandResult.Got (Some entry) ->
+                        let dv = DeltaLogEntryDynamic.toDynamicValue DvKey.value entry
+                        match DynamicValue.toCanonicalJson dv with
+                        | Ok json -> json
+                        | Error e -> sprintf "error formatting: %A" e
+                    | DbCommandResult.Got None -> "not found"
+                    | DbCommandResult.Status highWater -> sprintf "highwater: %d" highWater
             with ex -> sprintf "error: %s" ex.Message
 
 [<EntryPoint>]


### PR DESCRIPTION
## Rescued Work

Cherry-pick of commit `a45172a0a` authored by Lior (Gemini CLI) that was orphaned on the `kiro/wire-do-item-execute` branch after PR #7912 squash-merged 8 minutes before the push.

## What this delivers

- **YAML codecs** (`toYaml`/`fromYaml` on DynamicValue) in F#, C#, TypeScript, and Rust
- **Markdown + Frontmatter Treaty** — 4-language canonical fixed-point validation oracles
- **DbCommand CLI and MCP support** — generic database command execution pipeline
- **IDeltaLog/ISnapshotStore seam** decoupling

## Verification (from Lior's original commit message)

- `dotnet test Zeta.sln -c Release` — 3,055 F# + 301 C# tests passed
- `bun test src/Core.TypeScript/dynamic-value/yaml.test.ts` — all passed
- `cargo test --manifest-path src/Core.Rust.DynamicValue/Cargo.toml --release` — all passed
- `dotnet format --verify-no-changes` — clean

## Why this happened

Lior's session inherited the shared checkout on `kiro/wire-do-item-execute`. PR #7912 squash-merged at 09:52 AM; Lior committed + pushed at 10:00 AM. The push landed on the remote branch but the PR was already closed — orphaning the commit.

Another agent's lost work is everyone's problem on Zeta.

Co-Authored-By: Gemini <noreply@google.com>
Co-Authored-By: Kiro <noreply@kiro.dev>