### PR TITLE
feat(ts/io-boundary): implement IoBoundary in TypeScript

### DIFF
--- a/src/Core.TypeScript/dynamic-value/markdown.ts
+++ b/src/Core.TypeScript/dynamic-value/markdown.ts
@@ -1,4 +1,4 @@
-import { Tagged } from "./cbor";
+import type { Tagged } from "./cbor";
 import { canonicalYaml, fromCanonicalYaml } from "./yaml";
 
 export type MarkdownParseResult = { ok: true; metadata: Tagged; body: string } | { ok: false; error: string };

--- a/src/Core.TypeScript/dynamic-value/yaml.test.ts
+++ b/src/Core.TypeScript/dynamic-value/yaml.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, describe } from "bun:test";
-import { Tagged } from "./cbor";
+import type { Tagged } from "./cbor";
 import { canonicalYaml, fromCanonicalYaml } from "./yaml";
 import { parseMarkdown, serializeMarkdown } from "./markdown";
 

--- a/src/Core.TypeScript/dynamic-value/yaml.ts
+++ b/src/Core.TypeScript/dynamic-value/yaml.ts
@@ -1,4 +1,4 @@
-import { Tagged } from "./cbor";
+import type { Tagged } from "./cbor";
 import { parse as parseYaml } from "../yaml/dom";
 import type { YamlValue } from "../yaml/dom";
 import { encode as encodeYaml } from "../yaml/encoder";

--- a/src/Core.TypeScript/io-boundary/index.ts
+++ b/src/Core.TypeScript/io-boundary/index.ts
@@ -1,0 +1,1 @@
+export * from "./io-boundary";

--- a/src/Core.TypeScript/io-boundary/io-boundary.test.ts
+++ b/src/Core.TypeScript/io-boundary/io-boundary.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "bun:test";
+import { stringCompare } from "../z-set/z-set";
+import * as ZSet from "../z-set/z-set";
+import * as GSet from "../g-set/g-set";
+import {
+  emit,
+  retract,
+  compose,
+  composeAll,
+  fuse,
+  input,
+  genesis,
+  output,
+  toList,
+  count,
+  isEmpty,
+} from "./io-boundary";
+
+const cmp = stringCompare;
+
+describe("I/O Boundary — Laws & Transition Properties", () => {
+  it("I/O boundary fuses composed signed interior into exterior G-set", () => {
+    const interior = composeAll(cmp, [
+      emit("life"),
+      emit("life"),
+      emit("identity"),
+      retract("identity"),
+      retract("void"),
+    ]);
+
+    const exterior = fuse(interior);
+
+    expect(toList(exterior)).toEqual(["life"]);
+    expect(count(exterior)).toBe(1);
+  });
+
+  it("I/O boundary composes before output so internal ledgers do not leak", () => {
+    const insert = emit("boundary");
+    const ret = retract("boundary");
+
+    const composedOutput = fuse(compose(cmp, insert, ret));
+
+    const leakedIfObservedTooEarly = GSet.union(cmp, output(fuse(insert)), output(fuse(ret)));
+
+    expect(isEmpty(composedOutput)).toBe(true);
+    expect(GSet.toArray(leakedIfObservedTooEarly)).toEqual(["boundary"]);
+  });
+
+  it("input and output name the I/O passage without exposing signed history", () => {
+    const exterior = output(
+      fuse(
+        input(
+          ZSet.ofEntries(cmp, [
+            { e: "inside", w: 3 },
+            { e: "outside", w: 1 },
+            { e: "inside", w: -3 },
+          ]),
+        ),
+      ),
+    );
+
+    expect(GSet.toArray(exterior)).toEqual(["outside"]);
+  });
+
+  it("genesis enters as add-only facts and exits sorted unique", () => {
+    const exterior = fuse(genesis(cmp, ["zeta", "genesis", "zeta", "boundary"]));
+
+    expect(toList(exterior)).toEqual(["boundary", "genesis", "zeta"]);
+  });
+
+  it("outside stays monotone after the boundary", () => {
+    const first = output(fuse(emit("mark")));
+    const absent = output(fuse(retract("mark")));
+
+    const combined = GSet.union(cmp, first, absent);
+    expect(GSet.toArray(combined)).toEqual(["mark"]);
+  });
+});

--- a/src/Core.TypeScript/io-boundary/io-boundary.ts
+++ b/src/Core.TypeScript/io-boundary/io-boundary.ts
@@ -1,0 +1,128 @@
+/**
+ * io-boundary.ts — typed inside/outside boundary for the signed-ledger-to-grow-only transition.
+ *
+ * `Inside` holds a signed Z-set ledger where emissions and retractions can cancel before
+ * observation. `Outside` holds only the fused G-set view: monotone presence, with
+ * multiplicity, negative evidence, and the path that produced the result kept behind the boundary.
+ *
+ * Mirroring the F# canonical shape (src/Core/IoBoundary.fs).
+ */
+
+import * as ZSet from "../z-set/z-set";
+import * as GSet from "../g-set/g-set";
+
+// Unexported symbols to keep internal states inaccessible from outside this file
+export const ledgerSymbol = Symbol("ledger");
+export const viewSymbol = Symbol("view");
+
+/**
+ * Inside boundary wrapper: holds a signed Z-set ledger.
+ */
+export class Inside<K> {
+  /** @internal */
+  readonly [ledgerSymbol]: ZSet.ZSet<K>;
+
+  constructor(ledger: ZSet.ZSet<K>) {
+    this[ledgerSymbol] = ledger;
+  }
+}
+
+/**
+ * Outside boundary wrapper: holds the public fused G-set view.
+ */
+export class Outside<K> {
+  /** @internal */
+  readonly [viewSymbol]: GSet.GSet<K>;
+
+  constructor(view: GSet.GSet<K>) {
+    this[viewSymbol] = view;
+  }
+}
+
+/** The empty Inside boundary. */
+export function emptyInside<K>(): Inside<K> {
+  return new Inside(ZSet.empty<K>());
+}
+
+/** The empty Outside boundary. */
+export function emptyOutside<K>(): Outside<K> {
+  return new Outside(GSet.empty<K>());
+}
+
+/** Enter the boundary with an already-composed signed ledger. */
+export function input<K>(z: ZSet.ZSet<K>): Inside<K> {
+  return new Inside(z);
+}
+
+/** Enter the boundary with add-only genesis facts. */
+export function genesis<K>(compare: ZSet.Compare<K>, keys: readonly K[]): Inside<K> {
+  return new Inside(ZSet.ofArray(compare, keys));
+}
+
+/** One positive internal event. */
+export function emit<K>(key: K): Inside<K> {
+  return new Inside(ZSet.singleton(key, 1));
+}
+
+/** One negative internal event. */
+export function retract<K>(key: K): Inside<K> {
+  return new Inside(ZSet.singleton(key, -1));
+}
+
+/** Compose signed interiors before any exterior observation occurs. */
+export function compose<K>(compare: ZSet.Compare<K>, left: Inside<K>, right: Inside<K>): Inside<K> {
+  return new Inside(ZSet.union(compare, left[ledgerSymbol], right[ledgerSymbol]));
+}
+
+/** Compose a sequence of signed interiors. */
+export function composeAll<K>(compare: ZSet.Compare<K>, insides: readonly Inside<K>[]): Inside<K> {
+  let acc = ZSet.empty<K>();
+  for (const inside of insides) {
+    acc = ZSet.union(compare, acc, inside[ledgerSymbol]);
+  }
+  return new Inside(acc);
+}
+
+/** Cross the I/O boundary: only positive support becomes exterior identity. */
+export function fuse<K>(inside: Inside<K>): Outside<K> {
+  const ledger = inside[ledgerSymbol];
+  const view: K[] = [];
+  for (const entry of ledger) {
+    if (entry.w > 0) {
+      view.push(entry.e);
+    }
+  }
+  // The resulting view is guaranteed to be GSet-compliant (sorted and unique)
+  // because the source ZSet entries are already sorted and unique by key.
+  return new Outside(view);
+}
+
+/** Leave the boundary with the public grow-only view. */
+export function output<K>(outside: Outside<K>): GSet.GSet<K> {
+  return outside[viewSymbol];
+}
+
+/** Return the exterior view as a fresh array. */
+export function toArray<K>(outside: Outside<K>): K[] {
+  return [...outside[viewSymbol]];
+}
+
+/** Return the exterior view as a fresh list array (matching F# toList). */
+export function toList<K>(outside: Outside<K>): K[] {
+  return [...outside[viewSymbol]];
+}
+
+/** Membership: check if the key is present in the GSet view. */
+export function contains<K>(compare: ZSet.Compare<K>, key: K, outside: Outside<K>): boolean {
+  return GSet.contains(compare, outside[viewSymbol], key);
+}
+
+/** Count of elements in the exterior view. */
+export function count<K>(outside: Outside<K>): number {
+  return outside[viewSymbol].length;
+}
+
+/** Check if the exterior view is empty. */
+export function isEmpty<K>(outside: Outside<K>): boolean {
+  return outside[viewSymbol].length === 0;
+}


### PR DESCRIPTION
Port IoBoundary and its transition properties to TypeScript to align with F# (#8030). Verified clean build, format, and passing unit tests.