### PR TITLE
feat: wire all 9 action kinds — observe loop execute() complete

### DIFF
--- a/tools/observe/execute.test.ts
+++ b/tools/observe/execute.test.ts
@@ -55,22 +55,14 @@ describe("execute — free_time + self_reflect slice", () => {
     if (r.ok) expect(r.world).toEqual(simulate(emptyWorld, freeTime));
   });
 
-  it("returns not-yet-executable for kinds that still lack wired effects", async () => {
-    const item = { id: "B-1", title: "x", ready: true, ambiguous: false };
-    const notYet: NextAction[] = [
-      { kind: "decompose", item },
-      { kind: "edit_grammar", reason: "needs new action", item },
-    ];
-    for (const action of notYet) {
-      const sink = fakeSink();
-      const r = await execute(emptyWorld, action, sink);
-      expect(r.ok).toBe(false);
-      expect(sink.appended).toEqual([]); // not-yet-executable → nothing appended
-      if (!r.ok) {
-        expect(r.feedback.kind).toBe("not-yet-executable");
-        if (r.feedback.kind === "not-yet-executable") expect(r.feedback.actionKind).toBe(action.kind);
-      }
-    }
+  it("returns not-yet-executable only for unknown/future action kinds (exhaustiveness guard)", async () => {
+    // All 9 current kinds are wired. This test verifies the guard exists
+    // for future extensions. We can't easily test it without a cast.
+    const sink = fakeSink();
+    const fakeAction = { kind: "future_unknown_kind", reason: "test" } as unknown as NextAction;
+    const r = await execute(emptyWorld, fakeAction, sink);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.feedback.kind).toBe("not-yet-executable");
   });
 
   it("preserve_ferry returns not-yet-executable when no operatorPort is provided", async () => {
@@ -278,5 +270,54 @@ describe("execute — respond_to_operator with injected OperatorPort", () => {
     const r = await execute(worldWithMessage, respond, sink, undefined, undefined, port);
     expect(r.ok).toBe(true);
     expect(port.responses).toEqual(["engaging with operator"]);
+  });
+});
+
+describe("execute — decompose + edit_grammar (zero-effect, backlog transform)", () => {
+  const ambiguousItem = { id: "B-99", title: "big ambiguous thing", ready: false, ambiguous: true };
+  const needsExtItem = { id: "B-100", title: "needs new action", ready: false, ambiguous: false, needsNewAction: true };
+  const worldWithItems: World = { backlog: [ambiguousItem, needsExtItem] };
+
+  it("decompose: appends + splits item into children via simulate", async () => {
+    const sink = fakeSink();
+    const action: NextAction = { kind: "decompose", item: ambiguousItem };
+    const r = await execute(worldWithItems, action, sink);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      // simulate splits into B-99.1 and B-99.2
+      expect(r.world.backlog.find((i) => i.id === "B-99")).toBeUndefined();
+      expect(r.world.backlog.find((i) => i.id === "B-99.1")).toBeDefined();
+      expect(r.world.backlog.find((i) => i.id === "B-99.2")).toBeDefined();
+      expect(sink.appended.length).toBe(1);
+    }
+  });
+
+  it("edit_grammar: appends + marks item as expressible via simulate", async () => {
+    const sink = fakeSink();
+    const action: NextAction = { kind: "edit_grammar", reason: "extend the grammar", item: needsExtItem };
+    const r = await execute(worldWithItems, action, sink);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      const updated = r.world.backlog.find((i) => i.id === "B-100");
+      expect(updated?.needsNewAction).toBe(false);
+      expect(updated?.ready).toBe(true);
+      expect(sink.appended.length).toBe(1);
+    }
+  });
+
+  it("decompose world matches pure simulate path", async () => {
+    const sink = fakeSink();
+    const action: NextAction = { kind: "decompose", item: ambiguousItem };
+    const r = await execute(worldWithItems, action, sink);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.world).toEqual(simulate(worldWithItems, action));
+  });
+
+  it("edit_grammar world matches pure simulate path", async () => {
+    const sink = fakeSink();
+    const action: NextAction = { kind: "edit_grammar", reason: "extend", item: needsExtItem };
+    const r = await execute(worldWithItems, action, sink);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.world).toEqual(simulate(worldWithItems, action));
   });
 });

--- a/tools/observe/execute.ts
+++ b/tools/observe/execute.ts
@@ -22,13 +22,12 @@
  * `mode` is just `fold(initial, events).mode`. So "persist the chosen mode" IS
  * "append the mode-setting NextAction to the log." No mode table — the log is it.
  *
- * ── This slice: zero-effect + do_item + operator channel (2026-06-12/13) ───────
- * Zero-effect kinds (free_time, self_reflect, explore, play) have NO external
- * side-effect. `do_item` delegates to `executeDoItem` (command/observation split).
- * `preserve_ferry` and `respond_to_operator` are the operator-channel effects:
- * they run the effect FIRST (preserve content / emit response) then append to the
- * log — durability-first for ferry content that might be lost to compaction.
- * Remaining kinds (decompose, edit_grammar) are `not-yet-executable`.
+ * ── This slice: ALL 9 action kinds wired (2026-06-13) ─────────────────────────
+ * Zero-effect kinds (free_time, self_reflect, explore, play, decompose,
+ * edit_grammar) have no external side-effect — append + simulate.
+ * `do_item` delegates to `executeDoItem` (command/observation split).
+ * `preserve_ferry` and `respond_to_operator` are operator-channel effects:
+ * effect-first (durability of ferry content / response emission) then append.
  *
  * The `EventSink` is INJECTED (asymmetric-authorship: the sink AUTHORS its own
  * outcome channel) so this slice is testable with a fake sink and no git I/O;
@@ -79,7 +78,7 @@ export function fakeOperatorPort(): OperatorPort & { preserved: string[]; respon
 }
 
 /** The action kinds this slice can execute (zero external side-effect: mode-set + append). */
-const ZERO_EFFECT_KINDS = ["free_time", "self_reflect", "explore", "play"] as const;
+const ZERO_EFFECT_KINDS = ["free_time", "self_reflect", "explore", "play", "decompose", "edit_grammar"] as const;
 type ZeroEffectKind = (typeof ZERO_EFFECT_KINDS)[number];
 
 function isZeroEffectKind(kind: NextAction["kind"]): kind is ZeroEffectKind {
@@ -124,18 +123,13 @@ export type ExecuteResult =
 /**
  * Execute a chosen action. Routes through four paths:
  *
- * 1. **Zero-effect kinds** (free_time, self_reflect, explore, play): mode-set only.
- *    Append the action itself to the log, then transition via `simulate`.
+ * 1. **Zero-effect kinds** (free_time, self_reflect, explore, play, decompose,
+ *    edit_grammar): backlog/mode transform only. Append then simulate.
  *
  * 2. **do_item**: delegates to `executeDoItem` (command/observation event split).
- *    Requires an injected `CommandExecutor` + `DoItemOptions`. If not provided,
- *    returns `not-yet-executable`.
  *
  * 3. **preserve_ferry / respond_to_operator**: operator-channel effects.
- *    Requires an injected `OperatorPort`. Effect first (preserve the ferry content
- *    or emit the response), then append, then simulate.
- *
- * 4. **Everything else** (decompose, edit_grammar): returns `not-yet-executable`.
+ *    Effect first, then append, then simulate.
  *
  * Order matters: for operator actions, EFFECT FIRST (the content might be lost to
  * compaction if we append-then-effect and the effect fails). For zero-effect kinds,
@@ -215,6 +209,7 @@ export async function execute(
     return { ok: true, world: simulate(world, action), appended: action, eventId: outcome.eventId };
   }
 
-  // Path 4: not yet wired
+  // Exhaustiveness guard — all 9 kinds are wired above; this is unreachable
+  // unless the NextAction union is extended without updating execute().
   return { ok: false, feedback: { kind: "not-yet-executable", actionKind: action.kind } };
 }


### PR DESCRIPTION
All 9 NextAction kinds are now executable. The observe loop can run end-to-end.

| Kind | Path |
|------|------|
| free_time | zero-effect |
| self_reflect | zero-effect |
| explore | zero-effect |
| play | zero-effect |
| decompose | zero-effect (NEW) |
| edit_grammar | zero-effect (NEW) |
| do_item | CommandExecutor |
| preserve_ferry | OperatorPort |
| respond_to_operator | OperatorPort |

27 tests pass.

Co-Authored-By: Kiro <noreply@kiro.dev>