### PR TITLE
docs(linguistic-seed): v2 — close membership edge + self-describing pair (axiom, definition)

### DIFF
--- a/docs/linguistic-seed/README.md
+++ b/docs/linguistic-seed/README.md
@@ -128,30 +128,40 @@ what the factory currently needs**. Don't pre-populate
 memories / docs cite, backwards-chain to the axioms as
 surface-contact surfaces the gaps.
 
-## Initial term candidates (to land in v1)
+## Landed terms (the DAG is in `prereq-graph.json`)
 
-**v1 landed (6 terms; the DAG is in `prereq-graph.json`):**
+**v2 landed (9 terms; two roots; self-describing).** The seed now carries
+the vocabulary to describe its *own* structure (`axiom` + `definition`),
+with no dangling edges.
+
+Roots (axiomatic, `dependencies: []`):
 
 - **truth** (Tarski's predicate; metalanguage-scoped) — `terms/truth.md`
+- **membership** (the primitive `∈` "is one of"; second root) —
+  `terms/membership.md`
+
+Derived:
+
 - **implication** (material conditional; Meredith-derivable) —
   `terms/implication.md`, deps `[truth]`
 - **equality** (Leibniz indiscernibility; reflexive / symmetric /
   transitive) — `terms/equality.md`, deps `[implication]`
 - **set** (extensional; Zermelo-Fraenkel) — `terms/set.md`,
-  deps `[equality, implication]`
+  deps `[equality, implication, membership]`
 - **function** (set-theoretic: single-valued total relation) —
   `terms/function.md`, deps `[set, equality]`
 - **retraction** (Zeta-adjacent; Z-set negative-weight inverse;
   the formal twin of the five-year-old walk's "honest take-back") —
   `terms/retraction.md`, deps `[function]`
+- **axiom** (self-referential: a claim posited true without proof — what a
+  root *is*; Tarski-careful) — `terms/axiom.md`, deps `[truth]`
+- **definition** (self-referential: stipulative, eliminable + non-creative
+  introduction of a term — what every non-root file *is*) —
+  `terms/definition.md`, deps `[equality]`
 
 **Candidates next** (backwards-chained as downstream need surfaces):
-
-- **membership** (the `∈` primitive set.md currently leaves untermed —
-  the one honest dangling edge in the graph)
-- **axiom** (self-referential: a seed-term whose `defined-by: axiomatic`)
-- **definition** (self-referential: a seed-term that makes another precise)
-- **relation** / **order** / **number** (as Craft / soulfile need them)
+**relation** / **order** / **number** / **proof** / **negation** (as
+Craft / soulfile / prompt-injection-resistance consumers need them).
 
 Per the backwards-chain discipline, each new term may depend only on
 already-landed terms (no dangling references; `prereq-graph.json` enforces

--- a/docs/linguistic-seed/prereq-graph.json
+++ b/docs/linguistic-seed/prereq-graph.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "description": "Linguistic-seed term dependency DAG. Each term's dependencies are the seed terms directly invoked in its mathematical definition. Constraints: no cycles; root terms have empty dependencies (axiomatic); every dependency names a landed term. Grows by backwards-chaining from downstream need (README S growth-discipline).",
   "constraints": {
     "acyclic": true,
@@ -8,15 +8,17 @@
   },
   "terms": {
     "truth": [],
+    "membership": [],
     "implication": ["truth"],
     "equality": ["implication"],
-    "set": ["equality", "implication"],
+    "set": ["equality", "implication", "membership"],
     "function": ["set", "equality"],
-    "retraction": ["function"]
+    "retraction": ["function"],
+    "axiom": ["truth"],
+    "definition": ["equality"]
   },
-  "primitives-not-yet-termed": {
-    "membership": "The set-membership relation (x is-in A) is taken primitive in set.md but has no seed term yet; an honest dangling edge to be backwards-chained when a downstream term forces it."
-  },
-  "landed": ["truth", "implication", "equality", "set", "function", "retraction"],
-  "candidates-next": ["axiom", "definition", "membership", "relation", "order", "number"]
+  "roots": ["truth", "membership"],
+  "primitives-not-yet-termed": {},
+  "landed": ["truth", "membership", "implication", "equality", "set", "function", "retraction", "axiom", "definition"],
+  "candidates-next": ["relation", "order", "number", "proof", "negation"]
 }

--- a/docs/linguistic-seed/terms/axiom.md
+++ b/docs/linguistic-seed/terms/axiom.md
@@ -1,0 +1,95 @@
+---
+name: axiom
+defined-by: axiomatic (self-referential — an axiom is a claim posited true without proof)
+formalised: draft
+dependencies: [truth]
+---
+
+# axiom
+
+## Plain English
+
+An **axiom** is a claim you start from — accepted as [`true`](truth.md)
+without proof, because it is where the proving *begins*. You can't prove
+everything from something earlier forever; eventually you reach the first
+stones you simply lay down. Those first stones are the axioms.
+
+In this seed, the **root** terms are the axioms: [`truth`](truth.md) and
+[`membership`](membership.md) are laid down (their `dependencies` are
+empty), and every other term is built on them. So `axiom` is the seed
+describing its own foundation — the word for what a root *is*.
+
+## Mathematical definition
+
+In a formal system, an **axiom** is a sentence taken as a theorem without
+derivation — a leaf of every proof tree, never itself the conclusion of an
+inference step. A system is the closure of its axioms under its inference
+rules (e.g. *modus ponens*; see [`implication`](implication.md)). Formally
+a term/file in this seed is an axiom exactly when its frontmatter carries
+
+```
+dependencies: []        and        defined-by: axiomatic
+```
+
+i.e. it is asserted, not reduced to earlier seed terms.
+
+**Self-reference, Tarski-carefully.** Saying "the root terms are the
+axioms" is the seed talking *about* its own structure. This is a
+**metalanguage** statement (a claim about the term-files), not an
+object-level paradox — exactly the stratification [`truth`](truth.md)'s
+T-schema requires. The seed describes itself one level up; it does not
+assert its own truth at its own level (which is what the liar paradox
+needs and what Tarski's theorem forbids).
+
+## Lean4 formalisation
+
+```lean4
+-- In Lean, an axiom is introduced with the `axiom` keyword: a declaration
+-- asserted to inhabit a type with NO proof term. (Used sparingly — each
+-- axiom is an unproven trust assumption.)
+axiom choice_example {α : Type} : Nonempty (α → α)
+
+-- The seed prefers proofs to axioms wherever a proof exists; an axiom is
+-- the honest marker for "trusted, not derived" — auditable by `#print axioms`.
+```
+
+`#print axioms f` lists exactly which axioms a result `f` leans on — the
+machine-checkable version of "name your unproven assumptions," which is the
+auditing posture the seed wants for every root.
+
+## Grounding point (per Otto-21 Craft discipline)
+
+**The rules of a board game.** Before you can play, someone reads the rules
+off the box: *the token starts on GO; you roll two dice.* Nobody proves
+those — they're agreed, and play proceeds from them. Change the box rules
+and you're playing a different game. Axioms are the box rules of a formal
+system; the README's foundation-agnosticism is exactly "an adopter may
+swap the box rules" (ZFC for type theory) and get a different but coherent
+game.
+
+## What this term DOES NOT mean
+
+- **Not a self-evident eternal truth.** A modern axiom is a *chosen*
+  starting assumption, not a claim no sane person could doubt. Different
+  axiom sets (Euclidean vs. non-Euclidean) are all legitimate.
+- **Not a definition.** An axiom *asserts* something true; a
+  [`definition`](definition.md) *introduces a new term* without asserting a
+  new fact. (Pairing term — they are the two kinds of "starting line.")
+- **Not unrevisable.** Axioms can be dropped or replaced; doing so changes
+  the system, openly. The seed records that as adopter-pluggability.
+
+## Citations
+
+- **Euclid.** *Elements* (c. 300 BCE) — postulates/common-notions, the
+  archetype of axiomatic method.
+- **Hilbert, David.** *Grundlagen der Geometrie* (1899) — the modern view:
+  axioms as implicit definitions, freely chosen, judged by consistency.
+- **Tarski, Alfred.** (1933) — the metalanguage stratification that makes
+  the seed's "the roots are axioms" self-description paradox-free.
+
+## What this term IS (summary)
+
+A claim posited true without proof — the starting stone of a system; in
+this seed, a root term (`dependencies: []`, `defined-by: axiomatic`). The
+self-description is metalanguage-level (Tarski-careful), not a self-truth
+claim. Paired with [`definition`](definition.md).

--- a/docs/linguistic-seed/terms/definition.md
+++ b/docs/linguistic-seed/terms/definition.md
@@ -1,0 +1,97 @@
+---
+name: definition
+defined-by: Definitional equality (stipulative introduction of a new term by abbreviation)
+formalised: draft
+dependencies: [equality]
+---
+
+# definition
+
+## Plain English
+
+A **definition** introduces a new word by saying it stands for something
+already understood. *"A square is a rectangle with equal sides."* You learn
+"square" for free, because "rectangle," "equal," and "sides" were already
+yours. A definition adds no new *fact* about the world — it adds a shorter
+name for a thing you could already describe the long way.
+
+In this seed, **every non-root term-file is a definition**: it introduces
+its term using only terms already landed. So `definition` is the seed's
+word for *what those files are* — the partner of [`axiom`](axiom.md)
+(axioms assert; definitions abbreviate).
+
+## Mathematical definition
+
+A **definition** stipulates that a new symbol is [`equal`](equality.md), by
+introduction, to an expression in already-defined symbols:
+
+```
+newTerm  :=  expression-in-existing-terms
+```
+
+This is **definitional equality** (equality by stipulation), distinct from
+a proved equation. Two soundness conditions make a definition admissible —
+the conservativity criteria (Leśniewski / Suppes):
+
+- **Eliminability** — every use of `newTerm` can be rewritten back into the
+  old vocabulary; the new word is pure abbreviation.
+- **Non-creativity** — adding the definition proves no new statement in the
+  old vocabulary; it adds names, never facts.
+
+A definition that fails these (e.g. one that smuggles in an existence claim)
+is really a disguised [`axiom`](axiom.md), and the seed flags it as such.
+
+**Self-reference, Tarski-carefully.** "Every non-root file is a definition"
+is a metalanguage statement about the seed's files, one level above the
+terms themselves — the same stratification [`axiom`](axiom.md) uses. No
+file defines itself; each defines its term from *earlier* terms, which is
+why the dependency graph is acyclic.
+
+## Lean4 formalisation
+
+```lean4
+-- A Lean `def` is exactly a (non-creative, eliminable) definition:
+def IsSquare (r : Rectangle) : Prop := r.width = r.height
+-- `IsSquare` is definitionally equal to its body; unfolding it recovers the
+-- old vocabulary (eliminability), and it asserts no new theorem
+-- (non-creativity). `abbrev` makes the definitional-equality transparent.
+```
+
+Lean enforces the conservativity in practice: a `def` cannot make a
+previously-unprovable proposition provable; only an `axiom` can.
+
+## Grounding point (per Otto-21 Craft discipline)
+
+**A nickname.** "Let's call the tall barista 'Stretch.'" Now everyone says
+"Stretch" instead of "the tall barista" — shorter, but it added no new
+person and no new fact, and you can always expand it back. A good
+definition is a nickname for an idea: convenient, removable, fact-free.
+A bad "definition" that sneaks in a new claim ("Stretch, who owns the
+shop") is really asserting something — an axiom wearing a nickname's coat.
+
+## What this term DOES NOT mean
+
+- **Not an axiom.** A definition asserts no new fact (non-creative); an
+  [`axiom`](axiom.md) does. Conflating them is the classic error this term
+  guards against.
+- **Not a proof.** A definition introduces a term; it does not demonstrate
+  a claim true. `newTerm := …` is stipulation, not derivation.
+- **Not a dictionary gloss.** The seed sense is *formal* definition
+  (eliminable + non-creative), stronger than a plain-language synonym.
+
+## Citations
+
+- **Leśniewski, Stanisław** / **Suppes, Patrick.** *Introduction to Logic*
+  (1957) — the eliminability + non-creativity criteria for admissible
+  definitions.
+- **Pascal, Blaise.** *De l'esprit géométrique* (c. 1657) — definitions as
+  abbreviations that must be removable.
+- **Frege, Gottlob.** *Grundgesetze* (1893) — the demand that definitions
+  introduce, never covertly assert.
+
+## What this term IS (summary)
+
+The stipulative introduction of a new term as definitionally equal to an
+expression in existing terms — eliminable and non-creative (adds a name,
+not a fact). Every non-root seed file is one. Paired with
+[`axiom`](axiom.md); the metalanguage self-description is Tarski-careful.

--- a/docs/linguistic-seed/terms/membership.md
+++ b/docs/linguistic-seed/terms/membership.md
@@ -1,0 +1,93 @@
+---
+name: membership
+defined-by: The primitive set-membership relation (∈) of axiomatic set theory
+formalised: draft
+dependencies: []
+---
+
+# membership
+
+## Plain English
+
+**Membership** is the "is one of" link. *The cat is one of the animals in
+the barn.* `x ∈ A` means **`x` is in `A`** — `x` is one of the things the
+collection `A` gathers up. It is the most basic question you can ask about
+a collection: *is this thing in it, yes or no?*
+
+Membership is so basic that we do not build it out of anything simpler — we
+just point at it. It is a **root** of the seed, like [`truth`](truth.md):
+taken as given, and everything about collections is said using it.
+
+## Mathematical definition
+
+Membership `∈` is a **primitive binary relation** — in axiomatic set
+theory it is the single undefined non-logical symbol. It is not defined in
+terms of other things; instead it is *characterised* by the axioms that
+govern it. For any `x` and any collection `A`:
+
+```
+x ∈ A      is a proposition  (it is true or false — grounds through truth)
+x ∉ A  :=  ¬(x ∈ A)
+```
+
+Because `∈` is undefined, its `dependencies` are empty: it is axiomatic.
+The terms that *use* it ([`set`](set.md) — extensionality is stated with
+`∈`) depend on **it**, not the other way round. This is what keeps the seed
+graph acyclic: membership is more primitive than set, so the edge runs
+`set → membership`, never back.
+
+> **Why a primitive and not "definable from set":** it is tempting to say
+> "`x ∈ A` means `A` contains `x`" — but "contains" is just `∈` again. Every
+> attempt to define membership smuggles it back in. Recognising that and
+> stopping (rather than circling) is the discipline; `∈` is where the
+> regress honestly bottoms out.
+
+## Lean4 formalisation
+
+```lean4
+-- Lean exposes membership through the `Membership` type class and the
+-- `∈` notation; for `Set α := α → Prop` (Mathlib), `x ∈ A` unfolds to `A x`:
+example (A : Set α) (x : α) : (x ∈ A) = A x := rfl
+
+-- Non-membership is the negation (grounds through implication's ¬):
+example (A : Set α) (x : α) : x ∉ A ↔ ¬ (x ∈ A) := Iff.rfl
+```
+
+In Lean, `∈` is a notation backed by a type class rather than a single
+global primitive, but the role is identical: the unreduced "is one of"
+relation other definitions are written against.
+
+## Grounding point (per Otto-21 Craft discipline)
+
+**A club roster.** *"Are you a member?"* The roster answers exactly one
+question about each person: in, or not in. You don't explain membership by
+appeal to something deeper — being a member just *is* being on the roster.
+Everything else about the club (its size, who's equal to whom, who chairs
+it) is computed from that one in/out fact.
+
+## What this term DOES NOT mean
+
+- **Not the subset relation.** `x ∈ A` is *an element is in a set*;
+  `B ⊆ A` is *every element of one set is in another*. Subset is built
+  from membership (`∀x. x ∈ B → x ∈ A`), not the same as it.
+- **Not containment-as-substring / part-of.** "Cat is in concatenate" is a
+  spelling fact, not set membership. Seed membership is the in/out relation
+  on a collection's elements.
+- **Not typed-ness.** "`x` has type `T`" and "`x ∈ S`" coincide in some
+  foundations and diverge in others; the seed keeps `∈` as the set-relation
+  and stays foundation-agnostic (README §What-this-skeleton-does-NOT-do).
+
+## Citations
+
+- **Peano, Giuseppe.** *Arithmetices principia* (1889) — introduced the
+  `∈` symbol (from Greek ἐστί, "is").
+- **Zermelo, Ernst.** (1908) — `∈` as the primitive relation of the
+  axiomatic theory; membership characterised by axioms, not defined.
+- **Fraenkel / Skolem.** (1922) — the first-order formulation in which `∈`
+  is the sole non-logical symbol.
+
+## What this term IS (summary)
+
+The primitive "is one of" relation `x ∈ A`, taken as given (a second root
+of the seed alongside truth) and characterised by axioms rather than
+defined. Sets are described with it; subset and the rest are built from it.

--- a/docs/linguistic-seed/terms/set.md
+++ b/docs/linguistic-seed/terms/set.md
@@ -2,7 +2,7 @@
 name: set
 defined-by: The axiom of extensionality (Zermelo–Fraenkel); Cantor's collection
 formalised: draft
-dependencies: [equality, implication]
+dependencies: [equality, implication, membership]
 ---
 
 # set
@@ -20,22 +20,22 @@ exactly when they have the same members — nothing else about them counts.
 
 ## Mathematical definition
 
-Take membership `∈` as primitive (`x ∈ A` means "`x` is in `A`"). The
-defining law is the **axiom of extensionality**:
+[`Membership`](membership.md) `∈` is the primitive (`x ∈ A` means "`x` is
+in `A`"). The defining law is the **axiom of extensionality**:
 
 ```
 A = B   ↔   ∀x. (x ∈ A  ↔  x ∈ B)
 ```
 
 Two sets are [`equal`](equality.md) iff they have exactly the same
-elements. The biconditionals are [`implication`](implication.md). This one
-axiom is what makes order and repetition invisible: `{1, 2}`, `{2, 1}`, and
-`{1, 1, 2}` all have the same members, so by extensionality they are the
-same set.
+[members](membership.md). The biconditionals are
+[`implication`](implication.md). This one axiom is what makes order and
+repetition invisible: `{1, 2}`, `{2, 1}`, and `{1, 1, 2}` all have the same
+members, so by extensionality they are the same set.
 
-(Membership `∈` is itself a primitive not yet given its own seed term —
-an honest dangling edge recorded in the prereq graph, to be backwards-
-chained when a downstream term needs it.)
+(Membership is more primitive than set — it is a seed root — so the edge
+runs `set → membership`, keeping the graph acyclic. This was the one honest
+dangling edge left at v1; landing [`membership`](membership.md) closes it.)
 
 ## Lean4 formalisation
 


### PR DESCRIPTION
## What

Finishes the linguistic seed to a clean **v2** — **9 terms, two roots, no dangling edges**, and now **self-describing**.

Builds on the v1 chain (#8031) and the five-year-old walk (#8029).

## The three new terms

| Term | Role | Anchor | Deps |
|------|------|--------|------|
| `membership` (∈) | **second root** — closes the one honest dangling edge v1 left | Peano (the ∈ symbol), Zermelo | `[]` |
| `axiom` | self-referential: what a **root** is (a claim posited true without proof) | Euclid, Hilbert, Tarski | `[truth]` |
| `definition` | self-referential: what every **non-root file** is (stipulative, eliminable + non-creative) | Leśniewski/Suppes, Pascal, Frege | `[equality]` |

`axiom` + `definition` give the seed the vocabulary to describe its **own** structure — the roots *are* axioms, the rest *are* definitions. The self-reference is **Tarski-careful**: metalanguage-level (a claim about the term-files), not a self-truth claim — no liar paradox.

## Integrity fix

v1 left `∈` as an untermed primitive in `set.md` — a documented dangling edge. v2 lands `membership` as an axiomatic second root; `set`'s deps gain `membership` (edge `set → membership`), and the graph stays acyclic. **No dangling edges remain.**

## Validation

- `prereq-graph.json` bumped to v2: `roots: [truth, membership]`, `primitives-not-yet-termed: {}`.
- Checked: acyclic / no dangling refs / roots-empty / every term has a file and vice-versa (9 terms).
- markdownlint clean.
- Lean blocks remain honest **draft sketches** (real Mathlib: membership unfold, `axiom`/`#print axioms`, `def`/`abbrev`) — Soraya's lane to harden.

## Authorization

Aaron: *"lets do it"* on the offered fork-1 (finish the seed to v2). Docs-only, no gated class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)