### PR TITLE
build(fsharp): avoid shared compiler state

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,6 +25,12 @@
     <TieredPGO>true</TieredPGO>
     <UseSystemResourceKeys>true</UseSystemResourceKeys>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.fsproj'">
+    <!-- Keep F# gates deterministic: the shared compiler server can preserve
+         bad native state after an fsc abort and turn clean rebuilds into exit
+         139/134 crashes. -->
+    <UseSharedCompilation>false</UseSharedCompilation>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <Optimize>true</Optimize>
     <DebugType>embedded</DebugType>

--- a/tools/observe/execute.test.ts
+++ b/tools/observe/execute.test.ts
@@ -214,7 +214,10 @@ describe("execute — preserve_ferry with injected OperatorPort", () => {
     port.preserveFerry = async () => ({ ok: false, reason: "disk full" });
     const r = await execute(worldWithFerry, preserveFerry, sink, undefined, undefined, port);
     expect(r.ok).toBe(false);
-    if (!r.ok) expect(r.feedback.reason).toBe("disk full");
+    if (!r.ok) {
+      expect(r.feedback.kind).toBe("append-failed");
+      if (r.feedback.kind === "append-failed") expect(r.feedback.reason).toBe("disk full");
+    }
     expect(sink.appended).toEqual([]); // effect failed → nothing appended
   });
 
@@ -261,7 +264,10 @@ describe("execute — respond_to_operator with injected OperatorPort", () => {
     port.emitResponse = async () => ({ ok: false, reason: "channel closed" });
     const r = await execute(worldWithMessage, respond, sink, undefined, undefined, port);
     expect(r.ok).toBe(false);
-    if (!r.ok) expect(r.feedback.reason).toBe("channel closed");
+    if (!r.ok) {
+      expect(r.feedback.kind).toBe("append-failed");
+      if (r.feedback.kind === "append-failed") expect(r.feedback.reason).toBe("channel closed");
+    }
   });
 
   it("succeeds even when append fails after effect (response already emitted)", async () => {


### PR DESCRIPTION
## Summary
- Disable shared compilation for F# projects so `fsc` gates do not depend on stale compiler-server state.
- Keeps C# shared compilation untouched; the property is scoped to `.fsproj`.
- Fix the TypeScript observe test narrowing that CI surfaced from latest main so `feedback.reason` is read only after proving `append-failed`.

## Verification
- `dotnet format --verify-no-changes`
- `dotnet build src/Core/Core.fsproj -c Release -m:1`
- `dotnet build Zeta.sln -c Release -m:1`
- `dotnet test Zeta.sln -c Release --no-build`
- `bun --bun tsc --noEmit -p tsconfig.json`
- `bun test tools/observe/execute.test.ts`
- `bunx prettier --check tools/observe/execute.test.ts`

Agency-Signature-Version: 1
Agent: Vera
Agent-Runtime: OpenAI Codex
Agent-Model: GPT-5
Credential-Identity: AceHack
Credential-Mode: shared
Human-Review: explicit
Human-Review-Evidence: chat
Action-Mode: supervised
Task: none
Co-Authored-By: Codex <noreply@openai.com>
