### PR TITLE
fix(hat-system): Gatekeeper policy sync for kind included E2E

### DIFF
--- a/full-ai-cluster/dev-cluster/SYNC-WAVES.md
+++ b/full-ai-cluster/dev-cluster/SYNC-WAVES.md
@@ -121,3 +121,20 @@ waves until it recovers or the operator manually intervenes
 
 This is what makes dev/prod parity reliable: same Applications,
 same waves, same reconciliation order on both substrates.
+
+## hat-system internal waves (Gatekeeper)
+
+Within the `hat-system` Application directory (not the App-of-Apps
+wave `-10` on `Application.yaml` itself):
+
+| Wave | Resources |
+|------|-----------|
+| 0 | society.zeta.io CRDs, namespace, seed hats, operator Deployment |
+| 1 | ConstraintTemplates (`templates.gatekeeper.sh`) |
+| 2 | Sync hook Job `wait-gatekeeper-hat-constraint-crds` — polls until Gatekeeper registers constraint CRDs |
+| 3 | Constraints (`constraints.gatekeeper.sh`) |
+
+ArgoCD sync-waves alone are insufficient on a cold cluster: Gatekeeper
+registers constraint CRDs asynchronously after ConstraintTemplates land.
+The wave-2 hook closes that gap so kind/CI included proofs can ship
+`policies/**` without manual resync.

--- a/full-ai-cluster/k8s/applications/hat-system/Application.yaml
+++ b/full-ai-cluster/k8s/applications/hat-system/Application.yaml
@@ -35,6 +35,17 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: hat-system
+  ignoreDifferences:
+    # K8s 1.35+ populates status.terminatingReplicas before OpenAPI catches up;
+    # ArgoCD structured merge diff then fails with ComparisonError (B-0967 CI).
+    - group: apps
+      kind: Deployment
+      jqPathExpressions:
+        - .status.terminatingReplicas
+    - group: apps
+      kind: StatefulSet
+      jqPathExpressions:
+        - .status.terminatingReplicas
   syncPolicy:
     automated:
       prune: true

--- a/full-ai-cluster/k8s/applications/hat-system/Application.yaml
+++ b/full-ai-cluster/k8s/applications/hat-system/Application.yaml
@@ -31,10 +31,7 @@ spec:
       recurse: true
       # Skip the operator's Go source — it's not a manifest. Same for
       # the graph/render helper and the queries docs.
-      # Policies require Gatekeeper ConstraintTemplate CRD registration; on kind/CI
-      # the constraint kinds are applied via a follow-on homelab sync once CTs are
-      # Established. CRDs + seed hats + operator (replicas:0) are enough here.
-      exclude: '{operator/**,graph/**,queries/**,Application.yaml,policies/**}'
+      exclude: '{operator/**,graph/**,queries/**,Application.yaml}'
   destination:
     server: https://kubernetes.default.svc
     namespace: hat-system

--- a/full-ai-cluster/k8s/applications/hat-system/gatekeeper-crd-wait.yaml
+++ b/full-ai-cluster/k8s/applications/hat-system/gatekeeper-crd-wait.yaml
@@ -1,0 +1,91 @@
+# ArgoCD Sync hook: wait for Gatekeeper to register Constraint CRDs after
+# ConstraintTemplates (wave 1) before Constraints (wave 3) apply.
+#
+# Without this, cold-start sync fails with "could not find
+# constraints.gatekeeper.sh/HatWarmup" even when sync-waves are set.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gatekeeper-crd-wait
+  namespace: hat-system
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hat-system-gatekeeper-crd-wait
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+rules:
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["templates.gatekeeper.sh"]
+    resources: ["constrainttemplates"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hat-system-gatekeeper-crd-wait
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hat-system-gatekeeper-crd-wait
+subjects:
+  - kind: ServiceAccount
+    name: gatekeeper-crd-wait
+    namespace: hat-system
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wait-gatekeeper-hat-constraint-crds
+  namespace: hat-system
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  backoffLimit: 2
+  template:
+    spec:
+      serviceAccountName: gatekeeper-crd-wait
+      restartPolicy: Never
+      containers:
+        - name: wait
+          image: bitnami/kubectl:1.32.3
+          command:
+            - /bin/bash
+            - -ec
+            - |
+              set -o pipefail
+              KINDS=(HatCooldown HatMaxBindings HatConflict HatQuorum HatWarmup HatMaxNew HatNoCycle)
+              TEMPLATES=(hatcooldown hatmaxbindings hatconflict hatquorum hatwarmup hatmaxnew hatnocycle)
+              echo "waiting for hat ConstraintTemplates to exist..."
+              for t in "${TEMPLATES[@]}"; do
+                for i in $(seq 1 150); do
+                  if kubectl get constrainttemplate "$t" >/dev/null 2>&1; then
+                    echo "  constrainttemplate/$t present"
+                    break
+                  fi
+                  sleep 2
+                done
+              done
+              echo "waiting for hat constraint CRDs (Established)..."
+              for kind in "${KINDS[@]}"; do
+                for i in $(seq 1 150); do
+                  name="$(kubectl get crd -o jsonpath="{range .items[?(@.spec.names.kind=='${kind}')]}{.metadata.name}{end}")"
+                  if [ -n "$name" ]; then
+                    kubectl wait --for=condition=Established "crd/${name}" --timeout=120s
+                    echo "  ${kind} -> ${name}"
+                    break
+                  fi
+                  sleep 2
+                done
+              done
+              echo "all hat Gatekeeper constraint CRDs ready"

--- a/full-ai-cluster/k8s/applications/hat-system/policies/01-cooldown.yaml
+++ b/full-ai-cluster/k8s/applications/hat-system/policies/01-cooldown.yaml
@@ -69,7 +69,7 @@ kind: HatCooldown
 metadata:
   name: hat-cooldown-default
   annotations:
-    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-wave: "3"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   match:

--- a/full-ai-cluster/k8s/applications/hat-system/policies/02-max-bindings.yaml
+++ b/full-ai-cluster/k8s/applications/hat-system/policies/02-max-bindings.yaml
@@ -48,7 +48,7 @@ kind: HatMaxBindings
 metadata:
   name: hat-max-bindings-default
   annotations:
-    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-wave: "3"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   match:

--- a/full-ai-cluster/k8s/applications/hat-system/policies/03-conflict-of-interest.yaml
+++ b/full-ai-cluster/k8s/applications/hat-system/policies/03-conflict-of-interest.yaml
@@ -49,7 +49,7 @@ kind: HatConflict
 metadata:
   name: hat-conflict-default
   annotations:
-    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-wave: "3"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   match:

--- a/full-ai-cluster/k8s/applications/hat-system/policies/04-quorum.yaml
+++ b/full-ai-cluster/k8s/applications/hat-system/policies/04-quorum.yaml
@@ -45,7 +45,7 @@ kind: HatQuorum
 metadata:
   name: hat-quorum-default
   annotations:
-    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-wave: "3"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   match:

--- a/full-ai-cluster/k8s/applications/hat-system/policies/05-warmup.yaml
+++ b/full-ai-cluster/k8s/applications/hat-system/policies/05-warmup.yaml
@@ -45,7 +45,7 @@ kind: HatWarmup
 metadata:
   name: hat-warmup-default
   annotations:
-    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-wave: "3"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   match:

--- a/full-ai-cluster/k8s/applications/hat-system/policies/06-max-new-hats.yaml
+++ b/full-ai-cluster/k8s/applications/hat-system/policies/06-max-new-hats.yaml
@@ -53,7 +53,7 @@ kind: HatMaxNew
 metadata:
   name: hat-max-new-default
   annotations:
-    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-wave: "3"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   match:

--- a/full-ai-cluster/k8s/applications/hat-system/policies/07-no-supervisor-cycles.yaml
+++ b/full-ai-cluster/k8s/applications/hat-system/policies/07-no-supervisor-cycles.yaml
@@ -63,7 +63,7 @@ kind: HatNoCycle
 metadata:
   name: hat-no-cycle-default
   annotations:
-    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-wave: "3"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   match:

--- a/src/Core.TypeScript/cluster/argocd-health-test.test.ts
+++ b/src/Core.TypeScript/cluster/argocd-health-test.test.ts
@@ -11,6 +11,7 @@ import {
   isExcludedFromIncludedProof,
   isApplicationSynced,
   isIncludedScope,
+  isZetaGitDirectoryApplicationSource,
   parseApplicationList,
   parseApplicationName,
   parseArgs,
@@ -416,6 +417,23 @@ describe("B-0967 argocd-health-test planning", () => {
     expect(included).not.toContain("gitlab");
     expect(included).not.toContain("forgejo");
     expect(included).not.toContain("agent-memory");
+  });
+
+  test("detects repo-backed child Applications that should track the harness git ref", () => {
+    expect(
+      isZetaGitDirectoryApplicationSource({
+        repoURL: "https://github.com/Lucent-Financial-Group/Zeta",
+        targetRevision: "main",
+        path: "full-ai-cluster/k8s/applications/hat-system",
+      }),
+    ).toBe(true);
+    expect(
+      isZetaGitDirectoryApplicationSource({
+        repoURL: "https://grafana.github.io/helm-charts",
+        chart: "loki",
+        targetRevision: "6.18.0",
+      }),
+    ).toBe(false);
   });
 
   test("architecture guard names the supported hardware classes", () => {

--- a/src/Core.TypeScript/cluster/argocd-health-test.ts
+++ b/src/Core.TypeScript/cluster/argocd-health-test.ts
@@ -861,6 +861,46 @@ function bootstrapCluster(plan: HarnessPlan, options: CliOptions): Failure | nul
   );
 }
 
+const ZETA_GITHUB_REPO_MARKER = "Lucent-Financial-Group/Zeta";
+
+export function isZetaGitDirectoryApplicationSource(source: Record<string, unknown>): boolean {
+  if (stringAt(source, "chart").length > 0) return false;
+  const repoURL = stringAt(source, "repoURL");
+  const path = stringAt(source, "path");
+  if (!repoURL.includes(ZETA_GITHUB_REPO_MARKER)) return false;
+  return path.startsWith("full-ai-cluster/k8s/applications");
+}
+
+function patchGitBackedApplicationsToGitRef(gitRef: string): Failure | null {
+  if (gitRef === "main") return null;
+  const command = ["-n", "argocd", "get", "applications.argoproj.io", "-o", "json"];
+  const result = kubectl(command, 30);
+  if (result.status !== 0) {
+    return kubectlFailure("could not list ArgoCD Applications for git-ref patch", command, result);
+  }
+  const root = asRecord(JSON.parse(result.stdout));
+  const items = Array.isArray(root?.items) ? root.items : [];
+  for (const item of items) {
+    const itemRecord = asRecord(item);
+    const metadata = itemRecord ? recordAt(itemRecord, "metadata") : null;
+    const spec = itemRecord ? recordAt(itemRecord, "spec") : null;
+    const source = spec ? recordAt(spec, "source") : null;
+    const name = metadata ? stringAt(metadata, "name") : "";
+    if (name.length === 0 || source === null || !isZetaGitDirectoryApplicationSource(source)) continue;
+    const currentRevision = stringAt(source, "targetRevision");
+    if (currentRevision === gitRef) continue;
+    const patch = JSON.stringify({ spec: { source: { targetRevision: gitRef } } });
+    const patchFailure = runOrFail(
+      "kubectl",
+      ["-n", "argocd", "patch", "application", name, "--type=merge", "-p", patch],
+      "KubectlFailed",
+      30,
+    );
+    if (patchFailure !== null) return patchFailure;
+  }
+  return null;
+}
+
 async function waitForArgoCd(plan: HarnessPlan, options: CliOptions): Promise<Failure | null> {
   const timeout = options.timeoutSeconds;
   const poll = options.pollSeconds;
@@ -891,12 +931,25 @@ async function waitForArgoCd(plan: HarnessPlan, options: CliOptions): Promise<Fa
     if (failure !== null) return failure;
   }
 
-  return waitForKubectl(
+  const rootFailure = await waitForKubectl(
     ["-n", "argocd", "get", "application", "zeta-root-dev"],
     timeout,
     poll,
     `timed out waiting for zeta-root-dev root Application in ${plan.clusterName}`,
   );
+  if (rootFailure !== null) return rootFailure;
+
+  if (plan.gitRef === "main") return null;
+
+  const childFailure = await waitForKubectl(
+    ["-n", "argocd", "get", "application", "hat-system"],
+    timeout,
+    poll,
+    "timed out waiting for repo-backed child Applications before git-ref patch",
+  );
+  if (childFailure !== null) return childFailure;
+
+  return patchGitBackedApplicationsToGitRef(plan.gitRef);
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {


### PR DESCRIPTION
## Summary
- Re-enable `policies/**` in the hat-system Application (removed kind/CI exclude).
- Add wave-2 ArgoCD Sync hook Job that waits for Gatekeeper to register hat constraint CRDs before constraints (wave 3) apply.
- Document hat-system internal sync waves in `full-ai-cluster/dev-cluster/SYNC-WAVES.md`.

Toward **Kubernetes E2E on main**: included-scope proof (`live-kind-included`) should now reconcile hat-system with all seven Gatekeeper constraints on a cold kind cluster.

## Test plan
- [ ] `bun test src/Core.TypeScript/cluster/argocd-health-test.test.ts`
- [ ] Local: `bun src/Core.TypeScript/cluster/argocd-health-test.ts --run --provider kind --scope included --runtime docker --config full-ai-cluster/dev-cluster/profiles/ci.kind-config.yaml --cluster-name zeta-local-included --git-ref riven/k8s-e2e-hat-system-gatekeeper`
- [ ] CI `live-kind-included` green on PR


Made with [Cursor](https://cursor.com)