### PR TITLE
fix(mirror): persist-credentials:false so MIRROR_TOKEN is used (403 fix)

### DIFF
--- a/.github/workflows/mirror-to-fork.yml
+++ b/.github/workflows/mirror-to-fork.yml
@@ -50,6 +50,12 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          # Do NOT persist the default GITHUB_TOKEN as a global
+          # http.<github>.extraheader — it would override the
+          # x-access-token:${MIRROR_TOKEN} embedded in the mirror remote URL
+          # and push as github-actions[bot] (403 on the fork). origin is
+          # public, so the unauthenticated fetch still works.
+          persist-credentials: false
 
       - name: Mirror all branches and tags to the acehack fork
         env:


### PR DESCRIPTION
Second live-run fix: push got 403 'denied to github-actions[bot]' — actions/checkout's persisted default-token extraheader overrode the mirror URL's token. `persist-credentials: false` fixes it; origin is public so fetch still works. Follow-up to #8049/#8055. 🤖 Generated with [Claude Code](https://claude.com/claude-code)