### PR TITLE
feat(forge-host): ForgeHost interface, types, registry + detection (Wave 1)

### DIFF
--- a/src/Core.TypeScript/forge-host/detect.test.ts
+++ b/src/Core.TypeScript/forge-host/detect.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import { classifyHost, parseRemoteUrl } from "./detect";
+
+describe("classifyHost", () => {
+  test("github.com → github", () => {
+    expect(classifyHost("github.com")).toBe("github");
+  });
+
+  test("self-hosted github → github", () => {
+    expect(classifyHost("github.enterprise.corp")).toBe("github");
+  });
+
+  test("gitlab.com → gitlab", () => {
+    expect(classifyHost("gitlab.com")).toBe("gitlab");
+  });
+
+  test("self-hosted gitlab → gitlab", () => {
+    expect(classifyHost("gitlab.company.io")).toBe("gitlab");
+  });
+
+  test("codeberg.org → codeberg", () => {
+    expect(classifyHost("codeberg.org")).toBe("codeberg");
+  });
+
+  test("gitea instance → gitea", () => {
+    expect(classifyHost("gitea.example.com")).toBe("gitea");
+  });
+
+  test("bitbucket.org → bitbucket", () => {
+    expect(classifyHost("bitbucket.org")).toBe("bitbucket");
+  });
+
+  test("sr.ht → sourcehut", () => {
+    expect(classifyHost("git.sr.ht")).toBe("sourcehut");
+  });
+
+  test("unknown host → unknown", () => {
+    expect(classifyHost("custom-forge.internal")).toBe("unknown");
+  });
+
+  test("case insensitive", () => {
+    expect(classifyHost("GitHub.COM")).toBe("github");
+    expect(classifyHost("GitLab.Com")).toBe("gitlab");
+  });
+});
+
+describe("parseRemoteUrl", () => {
+  test("SSH URL without .git suffix", () => {
+    const result = parseRemoteUrl("git@github.com:Lucent-Financial-Group/Zeta");
+    expect(result).toEqual({ host: "github.com", owner: "Lucent-Financial-Group", repo: "Zeta" });
+  });
+
+  test("SSH URL with .git suffix", () => {
+    const result = parseRemoteUrl("git@github.com:org/repo.git");
+    expect(result).toEqual({ host: "github.com", owner: "org", repo: "repo" });
+  });
+
+  test("HTTPS URL without .git suffix", () => {
+    const result = parseRemoteUrl("https://github.com/Lucent-Financial-Group/Zeta");
+    expect(result).toEqual({ host: "github.com", owner: "Lucent-Financial-Group", repo: "Zeta" });
+  });
+
+  test("HTTPS URL with .git suffix", () => {
+    const result = parseRemoteUrl("https://gitlab.com/team/project.git");
+    expect(result).toEqual({ host: "gitlab.com", owner: "team", repo: "project" });
+  });
+
+  test("HTTP URL (non-TLS)", () => {
+    const result = parseRemoteUrl("http://gitea.local/user/repo.git");
+    expect(result).toEqual({ host: "gitea.local", owner: "user", repo: "repo" });
+  });
+
+  test("self-hosted SSH", () => {
+    const result = parseRemoteUrl("git@gitlab.corp.io:platform/backend.git");
+    expect(result).toEqual({ host: "gitlab.corp.io", owner: "platform", repo: "backend" });
+  });
+
+  test("unparseable URL returns null", () => {
+    expect(parseRemoteUrl("not-a-url")).toBeNull();
+    expect(parseRemoteUrl("")).toBeNull();
+    expect(parseRemoteUrl("/local/path/to/repo")).toBeNull();
+  });
+
+  test("file protocol returns null", () => {
+    expect(parseRemoteUrl("file:///home/user/repo.git")).toBeNull();
+  });
+});

--- a/src/Core.TypeScript/forge-host/detect.ts
+++ b/src/Core.TypeScript/forge-host/detect.ts
@@ -1,0 +1,76 @@
+/**
+ * forge-host/detect.ts — forge detection from git remote URLs.
+ *
+ * Parses the `origin` remote URL (SSH or HTTPS) and classifies the host
+ * into a known forge type. No side effects beyond the `git remote get-url`
+ * read.
+ */
+
+import { spawnSync } from "node:child_process";
+import type { Result, ForgeError, DetectedForge, ForgeType } from "./types";
+import { ok, err, forgeError } from "./result";
+
+const SSH_RE = /^git@([^:]+):([^/]+)\/(.+?)(?:\.git)?$/;
+const HTTPS_RE = /^https?:\/\/([^/]+)\/([^/]+)\/(.+?)(?:\.git)?$/;
+
+/**
+ * Classify a hostname into a known forge type.
+ * Exact matches first, then substring heuristics for self-hosted instances.
+ */
+export function classifyHost(host: string): ForgeType {
+  const lower = host.toLowerCase();
+  if (lower === "github.com" || lower.includes("github")) return "github";
+  if (lower === "gitlab.com" || lower.includes("gitlab")) return "gitlab";
+  if (lower === "codeberg.org") return "codeberg";
+  if (lower.includes("gitea")) return "gitea";
+  if (lower.includes("bitbucket")) return "bitbucket";
+  if (lower.includes("sr.ht")) return "sourcehut";
+  return "unknown";
+}
+
+/**
+ * Parse a git remote URL (SSH or HTTPS) into host, owner, repo.
+ * Returns null if the URL is unparseable.
+ */
+export function parseRemoteUrl(url: string): { host: string; owner: string; repo: string } | null {
+  const sshMatch = url.match(SSH_RE);
+  if (sshMatch) {
+    const [, host, owner, repo] = sshMatch;
+    if (host && owner && repo) return { host, owner, repo };
+  }
+  const httpsMatch = url.match(HTTPS_RE);
+  if (httpsMatch) {
+    const [, host, owner, repo] = httpsMatch;
+    if (host && owner && repo) return { host, owner, repo };
+  }
+  return null;
+}
+
+/**
+ * Detect the forge from the git remote `origin` URL in the given repo root.
+ * Read-only: no side effects beyond shelling out to `git remote get-url`.
+ */
+export function detectForgeFromRemote(repoRoot: string): Result<DetectedForge, ForgeError> {
+  const result = spawnSync("git", ["remote", "get-url", "origin"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    timeout: 5000,
+  });
+
+  if (result.status !== 0) {
+    return err(forgeError("not-found", "no git remote 'origin' found"));
+  }
+
+  const url = result.stdout.trim();
+  if (url.length === 0) {
+    return err(forgeError("not-found", "git remote 'origin' URL is empty"));
+  }
+
+  const parsed = parseRemoteUrl(url);
+  if (!parsed) {
+    return err(forgeError("parse-failure", `cannot parse remote URL: ${url}`));
+  }
+
+  const forge = classifyHost(parsed.host);
+  return ok({ forge, owner: parsed.owner, repo: parsed.repo, host: parsed.host });
+}

--- a/src/Core.TypeScript/forge-host/forge-host.ts
+++ b/src/Core.TypeScript/forge-host/forge-host.ts
@@ -1,0 +1,106 @@
+/**
+ * forge-host/forge-host.ts — the ForgeHost interface.
+ *
+ * The single contract that all forge adapters implement. The core observe loop
+ * and tools depend ONLY on this interface — they never name a specific host.
+ *
+ * All methods return Result<T, ForgeError>. Adapters that haven't implemented
+ * a method return ForgeError with kind "not-supported" — never throw.
+ */
+
+import type {
+  Result,
+  ForgeError,
+  PullRequest,
+  PrGateState,
+  Issue,
+  CheckRollup,
+  CiRun,
+  RepoInfo,
+  BranchProtection,
+  ThreadResolution,
+  BatchResult,
+  CommentRef,
+  TreeEntry,
+  CreateCommitOpts,
+  ListPrOpts,
+  ListMergedPrOpts,
+  CreatePrOpts,
+  ListIssueOpts,
+  CreateIssueOpts,
+  MergeMethod,
+} from "./types";
+
+export interface ForgeHost {
+  /** Human-readable forge name (e.g. "github", "gitlab", "gitea"). */
+  readonly forgeName: string;
+
+  // ─── PR state ───────────────────────────────────────────────────────────
+
+  /** List open pull requests / merge requests. */
+  listOpenPullRequests(opts?: ListPrOpts): Promise<Result<readonly PullRequest[], ForgeError>>;
+
+  /** Get a single PR by number. */
+  getPullRequest(number: number): Promise<Result<PullRequest, ForgeError>>;
+
+  /** Get the full gate state for a PR (checks, threads, merge-readiness). */
+  getPrGateState(number: number): Promise<Result<PrGateState, ForgeError>>;
+
+  /** List recently merged PRs. */
+  listMergedPullRequests(opts?: ListMergedPrOpts): Promise<Result<readonly PullRequest[], ForgeError>>;
+
+  // ─── PR actions ─────────────────────────────────────────────────────────
+
+  /** Resolve a single review thread with a reply body. */
+  resolveThread(threadId: string, body: string): Promise<Result<void, ForgeError>>;
+
+  /** Batch-resolve multiple threads. Partial success is reported, not all-or-nothing. */
+  resolveThreadsBatch(threads: readonly ThreadResolution[]): Promise<Result<BatchResult, ForgeError>>;
+
+  /** Create a new pull request. */
+  createPullRequest(opts: CreatePrOpts): Promise<Result<PullRequest, ForgeError>>;
+
+  /** Enable auto-merge on a PR. */
+  enableAutoMerge(prNumber: number, method?: MergeMethod): Promise<Result<void, ForgeError>>;
+
+  /** Add a comment to a PR. */
+  addPrComment(prNumber: number, body: string): Promise<Result<CommentRef, ForgeError>>;
+
+  // ─── Issues ─────────────────────────────────────────────────────────────
+
+  /** List open issues. */
+  listOpenIssues(opts?: ListIssueOpts): Promise<Result<readonly Issue[], ForgeError>>;
+
+  /** Create a new issue. */
+  createIssue(opts: CreateIssueOpts): Promise<Result<Issue, ForgeError>>;
+
+  // ─── CI state ───────────────────────────────────────────────────────────
+
+  /** Get check/CI status for a ref (branch or SHA). */
+  getCheckStatus(ref: string): Promise<Result<CheckRollup, ForgeError>>;
+
+  /** List pending CI runs. */
+  listPendingRuns(ref: string): Promise<Result<readonly CiRun[], ForgeError>>;
+
+  // ─── Repository info ────────────────────────────────────────────────────
+
+  /** Get repository metadata. */
+  getRepoInfo(): Promise<Result<RepoInfo, ForgeError>>;
+
+  /** Get branch protection rules for a branch. */
+  getBranchProtection(branch: string): Promise<Result<BranchProtection, ForgeError>>;
+
+  // ─── Git data API (bypass for saturated push) ───────────────────────────
+
+  /** Create a blob (file content) via the forge's git data API. Returns blob SHA. */
+  createBlob(content: string, encoding?: "utf-8" | "base64"): Promise<Result<string, ForgeError>>;
+
+  /** Create a tree. Returns tree SHA. */
+  createTree(tree: readonly TreeEntry[], baseTree?: string): Promise<Result<string, ForgeError>>;
+
+  /** Create a commit. Returns commit SHA. */
+  createCommit(opts: CreateCommitOpts): Promise<Result<string, ForgeError>>;
+
+  /** Update a ref to point to a new SHA. */
+  updateRef(ref: string, sha: string, force?: boolean): Promise<Result<void, ForgeError>>;
+}

--- a/src/Core.TypeScript/forge-host/index.ts
+++ b/src/Core.TypeScript/forge-host/index.ts
@@ -1,0 +1,50 @@
+/**
+ * forge-host/index.ts — barrel export for the ForgeHost abstraction layer.
+ */
+
+// Types
+export type {
+  Result,
+  ForgeError,
+  ForgeErrorKind,
+  ForgeType,
+  DetectedForge,
+  PullRequest,
+  PrState,
+  MergeStateStatus,
+  ReviewDecision,
+  MergeMethod,
+  PrGateState,
+  CheckSummary,
+  NextAction,
+  ThreadResolution,
+  BatchResult,
+  Issue,
+  CheckRollup,
+  CiCheck,
+  CiConclusion,
+  CiRun,
+  RepoInfo,
+  BranchProtection,
+  TreeEntry,
+  CreateCommitOpts,
+  CommentRef,
+  ListPrOpts,
+  ListMergedPrOpts,
+  CreatePrOpts,
+  ListIssueOpts,
+  CreateIssueOpts,
+} from "./types";
+
+// Interface
+export type { ForgeHost } from "./forge-host";
+
+// Result helpers
+export { ok, err, forgeError } from "./result";
+
+// Detection
+export { detectForgeFromRemote, classifyHost, parseRemoteUrl } from "./detect";
+
+// Registry
+export { resolveForgeHost, resolveHostFromRemote, registerAdapter, clearRegistrations } from "./registry";
+export type { AdapterFactory } from "./registry";

--- a/src/Core.TypeScript/forge-host/registry.test.ts
+++ b/src/Core.TypeScript/forge-host/registry.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import { resolveHostFromRemote, registerAdapter, clearRegistrations } from "./registry";
+import type { ForgeHost } from "./forge-host";
+import { ok } from "./result";
+
+function stubAdapter(name: string): ForgeHost {
+  return {
+    forgeName: name,
+    listOpenPullRequests: async () => ok([]),
+    getPullRequest: async () => ({ ok: false, error: { kind: "not-supported", message: "stub", retryable: false } }),
+    getPrGateState: async () => ({ ok: false, error: { kind: "not-supported", message: "stub", retryable: false } }),
+    listMergedPullRequests: async () => ok([]),
+    resolveThread: async () => ({ ok: false, error: { kind: "not-supported", message: "stub", retryable: false } }),
+    resolveThreadsBatch: async () => ok({ resolved: 0, failed: [] }),
+    createPullRequest: async () => ({ ok: false, error: { kind: "not-supported", message: "stub", retryable: false } }),
+    enableAutoMerge: async () => ({ ok: false, error: { kind: "not-supported", message: "stub", retryable: false } }),
+    addPrComment: async () => ({ ok: false, error: { kind: "not-supported", message: "stub", retryable: false } }),
+    listOpenIssues: async () => ok([]),
+    createIssue: async () => ({ ok: false, error: { kind: "not-supported", message: "stub", retryable: false } }),
+    getCheckStatus: async () => ({ ok: false, error: { kind: "not-supported", message: "stub", retryable: false } }),
+    listPendingRuns: async () => ok([]),
+    getRepoInfo: async () => ({ ok: false, error: { kind: "not-supported", message: "stub", retryable: false } }),
+    getBranchProtection: async () => ({ ok: false, error: { kind: "not-supported", message: "stub", retryable: false } }),
+    createBlob: async () => ({ ok: false, error: { kind: "not-supported", message: "stub", retryable: false } }),
+    createTree: async () => ({ ok: false, error: { kind: "not-supported", message: "stub", retryable: false } }),
+    createCommit: async () => ({ ok: false, error: { kind: "not-supported", message: "stub", retryable: false } }),
+    updateRef: async () => ({ ok: false, error: { kind: "not-supported", message: "stub", retryable: false } }),
+  } as ForgeHost;
+}
+
+describe("registry", () => {
+  beforeEach(() => {
+    clearRegistrations();
+  });
+
+  test("resolves GitHub adapter when registered", () => {
+    registerAdapter(/github/, (owner, repo) => stubAdapter(`github:${owner}/${repo}`));
+    const result = resolveHostFromRemote("git@github.com:org/repo.git");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.forgeName).toBe("github:org/repo");
+    }
+  });
+
+  test("custom adapter registration takes precedence", () => {
+    registerAdapter(/my-forge\.internal/, (owner, repo) => stubAdapter(`custom:${owner}/${repo}`));
+    registerAdapter(/github/, (owner, repo) => stubAdapter(`github:${owner}/${repo}`));
+    const result = resolveHostFromRemote("https://my-forge.internal/team/project.git");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.forgeName).toBe("custom:team/project");
+    }
+  });
+
+  test("returns not-found error for unknown host with no adapter", () => {
+    const result = resolveHostFromRemote("git@unknown-host.example:org/repo.git");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.kind).toBe("not-found");
+    }
+  });
+
+  test("returns parse-failure for unparseable URL", () => {
+    const result = resolveHostFromRemote("not-a-valid-url");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.kind).toBe("parse-failure");
+    }
+  });
+
+  test("pattern matches against host string", () => {
+    registerAdapter(/gitlab\.corp/, (owner, repo) => stubAdapter(`corp-gitlab:${owner}/${repo}`));
+    const result = resolveHostFromRemote("git@gitlab.corp.io:infra/platform.git");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.forgeName).toBe("corp-gitlab:infra/platform");
+    }
+  });
+});

--- a/src/Core.TypeScript/forge-host/registry.ts
+++ b/src/Core.TypeScript/forge-host/registry.ts
@@ -1,0 +1,103 @@
+/**
+ * forge-host/registry.ts — ForgeHost registry and adapter resolution.
+ *
+ * Detects the forge from git remote URLs and instantiates the correct adapter.
+ * Single entry point for the core loop: `resolveForgeHost(repoRoot)`.
+ *
+ * Supports custom adapter registrations for self-hosted forge instances.
+ */
+
+import type { Result, ForgeError } from "./types";
+import type { ForgeHost } from "./forge-host";
+import { detectForgeFromRemote, classifyHost, parseRemoteUrl } from "./detect";
+import { ok, err, forgeError } from "./result";
+
+export type AdapterFactory = (owner: string, repo: string, host: string) => ForgeHost;
+
+interface Registration {
+  readonly pattern: RegExp;
+  readonly factory: AdapterFactory;
+}
+
+const registrations: Registration[] = [];
+
+/**
+ * Register a custom adapter factory for a host pattern.
+ * Patterns are checked in registration order (first match wins).
+ */
+export function registerAdapter(pattern: RegExp, factory: AdapterFactory): void {
+  registrations.push({ pattern, factory });
+}
+
+/**
+ * Resolve a ForgeHost adapter from a raw remote URL string.
+ * Parses the URL, classifies the host, and finds a matching adapter.
+ */
+export function resolveHostFromRemote(remoteUrl: string): Result<ForgeHost, ForgeError> {
+  const parsed = parseRemoteUrl(remoteUrl);
+  if (!parsed) {
+    return err(forgeError("parse-failure", `cannot parse remote URL: ${remoteUrl}`));
+  }
+
+  // Check custom registrations first (user-registered patterns win)
+  for (const reg of registrations) {
+    if (reg.pattern.test(parsed.host)) {
+      return ok(reg.factory(parsed.owner, parsed.repo, parsed.host));
+    }
+  }
+
+  // Check built-in forge classification
+  const forge = classifyHost(parsed.host);
+  if (forge === "unknown") {
+    return err(forgeError("not-found", `no adapter registered for host: ${parsed.host}`));
+  }
+
+  // Look for a registered adapter matching the forge type name
+  for (const reg of registrations) {
+    if (reg.pattern.test(forge)) {
+      return ok(reg.factory(parsed.owner, parsed.repo, parsed.host));
+    }
+  }
+
+  return err(forgeError("not-found", `forge '${forge}' detected for ${parsed.host} but no adapter registered`));
+}
+
+/**
+ * Resolve a ForgeHost adapter from a repo root directory.
+ * Reads the git remote 'origin', detects the forge, instantiates the adapter.
+ *
+ * This is the primary entry point for consumers.
+ */
+export function resolveForgeHost(repoRoot: string): Result<ForgeHost, ForgeError> {
+  const detected = detectForgeFromRemote(repoRoot);
+  if (!detected.ok) return detected;
+
+  const { forge, owner, repo, host } = detected.value;
+
+  // Check custom registrations first
+  for (const reg of registrations) {
+    if (reg.pattern.test(host)) {
+      return ok(reg.factory(owner, repo, host));
+    }
+  }
+
+  // Check by forge type name
+  for (const reg of registrations) {
+    if (reg.pattern.test(forge)) {
+      return ok(reg.factory(owner, repo, host));
+    }
+  }
+
+  if (forge === "unknown") {
+    return err(forgeError("not-found", `no adapter registered for host: ${host}`));
+  }
+
+  return err(forgeError("not-found", `forge '${forge}' detected for ${host} but no adapter registered`));
+}
+
+/**
+ * Clear all registered adapters. Useful for testing.
+ */
+export function clearRegistrations(): void {
+  registrations.length = 0;
+}

--- a/src/Core.TypeScript/forge-host/result.ts
+++ b/src/Core.TypeScript/forge-host/result.ts
@@ -1,0 +1,48 @@
+/**
+ * forge-host/result.ts — Result helpers for the ForgeHost abstraction.
+ *
+ * Constructors for the Result<T, ForgeError> pattern. These are the only way
+ * to create Result values — keeping construction uniform and type-safe.
+ */
+
+import type { Result, ForgeError, ForgeErrorKind } from "./types";
+
+/** Construct a successful Result. */
+export function ok<T>(value: T): Result<T, never> {
+  return { ok: true, value };
+}
+
+/** Construct a failed Result. */
+export function err<E>(error: E): Result<never, E> {
+  return { ok: false, error };
+}
+
+/** Construct a ForgeError value with consistent retryable classification. */
+export function forgeError(
+  kind: ForgeErrorKind,
+  message: string,
+  raw?: unknown,
+): ForgeError {
+  return { kind, message, retryable: isRetryable(kind), raw };
+}
+
+/**
+ * Retryable classification per R1 acceptance criterion 6:
+ * - rate-limited, network → retryable
+ * - auth-failure, not-supported, permission-denied → not retryable
+ * - not-found, parse-failure, internal → not retryable
+ */
+function isRetryable(kind: ForgeErrorKind): boolean {
+  switch (kind) {
+    case "rate-limited":
+    case "network":
+      return true;
+    case "auth-failure":
+    case "not-supported":
+    case "permission-denied":
+    case "not-found":
+    case "parse-failure":
+    case "internal":
+      return false;
+  }
+}

--- a/src/Core.TypeScript/forge-host/types.ts
+++ b/src/Core.TypeScript/forge-host/types.ts
@@ -1,0 +1,222 @@
+/**
+ * forge-host/types.ts — host-agnostic data types for the ForgeHost abstraction.
+ *
+ * These types define the contract between the core loop/tools and any forge host
+ * (GitHub, GitLab, Gitea, etc.). No host-specific fields leak through this boundary.
+ *
+ * Architectural rule: "GitHub is NOT git-native — it's a plugin."
+ * (src/Core.FSharp.Git/CredentialSource.fs, Aaron 2026-06-07)
+ */
+
+// ─── Result type (project convention: Result-over-exception) ────────────────
+
+export type Result<T, E> =
+  | { readonly ok: true; readonly value: T }
+  | { readonly ok: false; readonly error: E };
+
+// ─── Error types ────────────────────────────────────────────────────────────
+
+export type ForgeErrorKind =
+  | "not-supported"      // adapter hasn't implemented this method
+  | "auth-failure"       // credentials invalid or expired
+  | "rate-limited"       // API rate limit hit
+  | "not-found"          // resource doesn't exist
+  | "network"            // transient network failure
+  | "parse-failure"      // response couldn't be parsed
+  | "permission-denied"  // valid auth but insufficient permissions
+  | "internal";          // unexpected adapter error
+
+export interface ForgeError {
+  readonly kind: ForgeErrorKind;
+  readonly message: string;
+  readonly retryable: boolean;
+  readonly raw?: unknown;
+}
+
+// ─── Forge detection ────────────────────────────────────────────────────────
+
+export type ForgeType =
+  | "github"
+  | "gitlab"
+  | "gitea"
+  | "bitbucket"
+  | "sourcehut"
+  | "codeberg"
+  | "unknown";
+
+export interface DetectedForge {
+  readonly forge: ForgeType;
+  readonly owner: string;
+  readonly repo: string;
+  readonly host: string;
+}
+
+// ─── PR types ───────────────────────────────────────────────────────────────
+
+export type PrState = "open" | "merged" | "closed";
+export type MergeStateStatus = "clean" | "blocked" | "dirty" | "unstable" | "unknown";
+export type ReviewDecision = "approved" | "changes-requested" | "review-required" | null;
+export type MergeMethod = "merge" | "squash" | "rebase";
+
+export interface PullRequest {
+  readonly number: number;
+  readonly title: string;
+  readonly headRef: string;
+  readonly baseRef: string;
+  readonly state: PrState;
+  readonly isDraft: boolean;
+  readonly mergeStateStatus: MergeStateStatus;
+  readonly reviewDecision: ReviewDecision;
+  readonly url: string;
+  readonly updatedAt: string;
+  readonly author: string;
+}
+
+export type NextAction =
+  | "wait-ci"
+  | "fix-failed-checks"
+  | "resolve-threads"
+  | "rebase"
+  | "verify-merge"
+  | "none";
+
+export interface CheckSummary {
+  readonly ok: number;
+  readonly inProgress: number;
+  readonly pending: number;
+  readonly failed: number;
+}
+
+export interface PrGateState {
+  readonly number: number;
+  readonly state: PrState;
+  readonly gate: "clean" | "blocked" | "dirty" | "unstable" | "unknown";
+  readonly checks: CheckSummary;
+  readonly requiredChecks: CheckSummary;
+  readonly unresolvedThreads: number;
+  readonly autoMerge: "armed" | "none";
+  readonly mergeCommit: string | null;
+  readonly warnings: readonly string[];
+  readonly nextAction: NextAction;
+}
+
+// ─── Thread types ───────────────────────────────────────────────────────────
+
+export interface ThreadResolution {
+  readonly threadId: string;
+  readonly body: string;
+}
+
+export interface BatchResult {
+  readonly resolved: number;
+  readonly failed: readonly { readonly threadId: string; readonly error: ForgeError }[];
+}
+
+// ─── Issue types ────────────────────────────────────────────────────────────
+
+export interface Issue {
+  readonly number: number;
+  readonly title: string;
+  readonly body: string;
+  readonly state: "open" | "closed";
+  readonly url: string;
+  readonly labels: readonly string[];
+}
+
+// ─── CI types ───────────────────────────────────────────────────────────────
+
+export type CiConclusion =
+  | "success" | "neutral" | "skipped"
+  | "failure" | "cancelled" | "timed-out"
+  | "startup-failure" | "action-required" | "stale";
+
+export interface CiCheck {
+  readonly name: string;
+  readonly status: "queued" | "in-progress" | "completed";
+  readonly conclusion: CiConclusion | null;
+  readonly required: boolean;
+}
+
+export interface CheckRollup {
+  readonly ref: string;
+  readonly checks: readonly CiCheck[];
+  readonly summary: CheckSummary;
+  readonly requiredSummary: CheckSummary;
+}
+
+export interface CiRun {
+  readonly id: string;
+  readonly name: string;
+  readonly status: "queued" | "in-progress";
+  readonly headSha: string;
+}
+
+// ─── Repository info ────────────────────────────────────────────────────────
+
+export interface RepoInfo {
+  readonly owner: string;
+  readonly name: string;
+  readonly defaultBranch: string;
+  readonly isPrivate: boolean;
+  readonly url: string;
+}
+
+export interface BranchProtection {
+  readonly requiredChecks: readonly string[];
+  readonly requiresReview: boolean;
+  readonly requiredReviewCount: number;
+  readonly dismissesStaleReviews: boolean;
+}
+
+// ─── Git data API types ─────────────────────────────────────────────────────
+
+export interface TreeEntry {
+  readonly path: string;
+  readonly mode: "100644" | "100755" | "040000" | "160000" | "120000";
+  readonly type: "blob" | "tree" | "commit";
+  readonly sha: string;
+}
+
+export interface CreateCommitOpts {
+  readonly message: string;
+  readonly tree: string;
+  readonly parents: readonly string[];
+}
+
+// ─── Comment reference ──────────────────────────────────────────────────────
+
+export interface CommentRef {
+  readonly id: string;
+  readonly url: string;
+}
+
+// ─── Option types ───────────────────────────────────────────────────────────
+
+export interface ListPrOpts {
+  readonly limit?: number;
+  readonly orderBy?: "updated" | "created";
+}
+
+export interface ListMergedPrOpts {
+  readonly limit?: number;
+  readonly since?: string; // ISO 8601
+}
+
+export interface CreatePrOpts {
+  readonly title: string;
+  readonly body: string;
+  readonly head: string;
+  readonly base: string;
+  readonly draft?: boolean;
+}
+
+export interface ListIssueOpts {
+  readonly limit?: number;
+  readonly labels?: readonly string[];
+}
+
+export interface CreateIssueOpts {
+  readonly title: string;
+  readonly body: string;
+  readonly labels?: readonly string[];
+}


### PR DESCRIPTION
## Summary

Wave 1 of the forge-host-adapter spec. Establishes the foundation layer for multi-forge support.

### What's here
- **types.ts** — All host-agnostic data types (Result, ForgeError, PullRequest, PrGateState, Issue, CiCheck, RepoInfo, etc.)
- **forge-host.ts** — The `ForgeHost` interface: PR state/actions, issues, CI, repo info, git data API. All methods return `Result<T, ForgeError>` — never throw.
- **result.ts** — `ok()`, `err()`, `forgeError()` constructors with consistent retryable classification
- **detect.ts** — `detectForgeFromRemote()` + `classifyHost()` + `parseRemoteUrl()` for SSH/HTTPS URL parsing
- **registry.ts** — `resolveForgeHost(repoRoot)` entry point + custom adapter registration
- **index.ts** — barrel export

### Tests
23 tests pass (detect.test.ts + registry.test.ts): URL parsing, host classification, adapter registration, error cases.

### Architecture
```
Core Loop → ForgeHost interface → GitHub/GitLab/Gitea adapters
                                ↗ (registered via registry)
Git-native layer (push-with-retry, refs) stays separate
```

Mirrors: `src/Core.FSharp.Git/CredentialSource.fs` — "GitHub is NOT git-native — it's a plugin."

### Next (Wave 2)
Task 3: GitHub adapter implementing the ForgeHost interface via `gh` CLI.

Co-Authored-By: Kiro <noreply@kiro.dev>