### PR TITLE
fix(build-iso): correct audit ROOT after ci/ relocation (main RED)

### DIFF
--- a/src/Core.TypeScript/ci/audit-installer-substrate.ts
+++ b/src/Core.TypeScript/ci/audit-installer-substrate.ts
@@ -48,7 +48,9 @@
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 
-const ROOT = resolve(import.meta.dir, "../..");
+// Repo root is THREE levels up from src/Core.TypeScript/ci/ (was ../.. when
+// this lived at tools/ci/; the #8048-era relocation added a directory level).
+const ROOT = resolve(import.meta.dir, "../../..");
 
 interface FileAssertion {
   readonly path: string;


### PR DESCRIPTION
build-ai-cluster-iso's installer-substrate audit fails on main: `ROOT = resolve(import.meta.dir, '../..')` pointed to repo root from `tools/ci/` but the relocation to `src/Core.TypeScript/ci/` added a level, so ROOT became `src/Core.TypeScript` and every required installer file read as missing. Fix: `../../..`. Audit passes (11 files + 6 sentinels + 1 cross-file OK). Same class as #8052, different workflow. 🤖 Generated with [Claude Code](https://claude.com/claude-code)