### PR TITLE
fix(sweep): 3 more relocation depth-bugs (skill-carver/budget/tally)

### DIFF
--- a/src/Core.TypeScript/budget/snapshot-burn.ts
+++ b/src/Core.TypeScript/budget/snapshot-burn.ts
@@ -122,7 +122,9 @@ function ghJsonOrEmpty(path: string, fallback: unknown): {
 
 function repoRoot(): string {
   const here = dirname(fileURLToPath(import.meta.url));
-  return resolve(here, "..", "..");
+  // 3 levels up from src/Core.TypeScript/budget/ (was "..","..", when this
+  // lived at tools/budget/; the relocation added a directory level).
+  return resolve(here, "..", "..", "..");
 }
 
 function gitHeadSha(): string {

--- a/src/Core.TypeScript/invariant-substrates/tally.ts
+++ b/src/Core.TypeScript/invariant-substrates/tally.ts
@@ -48,7 +48,9 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const repoRoot = resolve(here, "..", "..");
+// 3 levels up from src/Core.TypeScript/invariant-substrates/ (was "..",".."
+// at tools/invariant-substrates/; the relocation added a directory level).
+const repoRoot = resolve(here, "..", "..", "..");
 
 type Flags = {
   failOnMismatch: boolean;

--- a/src/Core.TypeScript/skill-carver/audit-descriptions.ts
+++ b/src/Core.TypeScript/skill-carver/audit-descriptions.ts
@@ -8,7 +8,9 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
-const SKILLS_ROOT = join(import.meta.dir, "../../.claude/skills");
+// 3 levels up from src/Core.TypeScript/skill-carver/ to repo root (was "../.."
+// at tools/skill-carver/; the relocation added a directory level).
+const SKILLS_ROOT = join(import.meta.dir, "../../../.claude/skills");
 const MAX_CHARS = 120;
 
 interface SkillReport {


### PR DESCRIPTION
Proactive sweep (you asked) for #8042/45/46/48 relocation regressions — `tools/`→`src/Core.TypeScript/` added a dir level, breaking `import.meta.dir`-relative roots that assumed 2 levels:

- **skill-carver/audit-descriptions.ts** — `SKILLS_ROOT`→`src/.claude/skills` (ENOENT); `skill-description-lint` was silently auditing **zero** skills. → `../../../`
- **budget/snapshot-burn.ts** — `repoRoot()`→`src/Core.TypeScript`; `budget-snapshot-cadence` ENOENT on `docs/budget-history/snapshots.jsonl`. → 3 levels
- **invariant-substrates/tally.ts** — `repoRoot`→`src/`; scanned wrong scope silently (not CI-gated). → 3 levels

All three verified pass; source-only diff (local-run data side-effects reverted).

**Sweep coverage:** gate (#8052) + build-iso (#8059) already fixed; backlog-index/memory guards pass (stale REDs). **Flagged separately (not path bugs):** ci-cache-paths (gate/low-memory cache git-tracked jars — caching strategy/Dejan); memory-index drift (index regen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)