### PR TITLE
fix(gate): grandfather tick-shard finding (rest-push.ts->forge-host move)

### DIFF
--- a/src/Core.TypeScript/hygiene/audit-tick-shard-relative-paths.baseline.json
+++ b/src/Core.TypeScript/hygiene/audit-tick-shard-relative-paths.baseline.json
@@ -2235,6 +2235,11 @@
     "target": "../../../../../../.claude/rules/claim-acquire-before-worktree-work.md"
   },
   {
+    "file": "docs/hygiene-history/ticks/2026/05/18/2131Z.md",
+    "line": 20,
+    "target": "../../../../../../src/Core.TypeScript/github/rest-push.ts"
+  },
+  {
     "file": "docs/hygiene-history/ticks/2026/05/18/2133Z.md",
     "line": 18,
     "target": "../../../../../../tools/hygiene/audit-tick-shard-relative-paths.baseline.json"


### PR DESCRIPTION
2026-05-18 history tick doc links to `src/Core.TypeScript/github/rest-push.ts` which #8060 moved to `forge-host/github/`. Immutable history → grandfather into baseline (1255→1256). tick-shard PASS. 🤖 Generated with [Claude Code](https://claude.com/claude-code)