### PR TITLE
[codex] Add flow-bit fusion oracle plugin

### DIFF
--- a/src/Bayesian/QuantumFusion.fs
+++ b/src/Bayesian/QuantumFusion.fs
@@ -28,6 +28,10 @@ module QuantumFusion =
           BytesPerTick: int64
           ResolutionBits: int }
 
+    type OracleFeedback =
+        | EmptyOracleName
+        | OracleUnavailable of string
+
     type Feedback =
         | InvalidPrior of Beta
         | NegativeBaseSpaceBytes of int64
@@ -36,11 +40,26 @@ module QuantumFusion =
         | NegativeResolutionBits of int
         | ByteCostOverflow of string
         | VisionBudget of VisionAttention.Feedback
+        | QuantumOracle of OracleFeedback
 
     type Report =
         { Exterior: GSet<BoundaryFact>
           Posterior: Beta
           Prediction: Vision.PredictionReport<BoundaryFact> }
+
+    type IQuantumFusionOracle =
+        abstract Name: string
+        abstract Observe: unit -> Result<QuantumObservableDelta list, OracleFeedback>
+
+    let oracleFromDeltas (name: string) (deltas: QuantumObservableDelta seq) : IQuantumFusionOracle =
+        { new IQuantumFusionOracle with
+            member _.Name = name
+
+            member _.Observe() =
+                if String.IsNullOrWhiteSpace name then
+                    Error EmptyOracleName
+                else
+                    Ok(Seq.toList deltas) }
 
     let private utf8Bytes (s: string) : int64 =
         if isNull s then 0L else int64 (Encoding.UTF8.GetByteCount s)
@@ -59,6 +78,8 @@ module QuantumFusion =
             { Kind = "BellCoincidence"; Id = value.Id; Operation = value.Operation }
         | QuantumObservableRow.InterferenceVisibility value ->
             { Kind = "InterferenceVisibility"; Id = value.Id; Operation = value.Operation }
+        | QuantumObservableRow.FlowBitDistinction value ->
+            { Kind = "FlowBitDistinction"; Id = value.Id; Operation = value.Operation }
 
     /// Re-view a composed signed quantum Z-set as the outside monotone G-set.
     let exterior (rows: ZSet<QuantumObservableRow>) : GSet<BoundaryFact> =
@@ -153,4 +174,14 @@ module QuantumFusion =
                 { Exterior = exteriorFacts
                   Posterior = posterior
                   Prediction = report }
+        }
+
+    let fuseOracle
+        (budget: Budget)
+        (tank: SoftThrottle.Tank)
+        (oracle: IQuantumFusionOracle)
+        : Result<Report, Feedback> =
+        result {
+            let! deltas = oracle.Observe() |> Result.mapError QuantumOracle
+            return! fuseDeltas budget tank deltas
         }

--- a/src/Core.TypeScript/hygiene/check-bash-retirement-inventory.ts
+++ b/src/Core.TypeScript/hygiene/check-bash-retirement-inventory.ts
@@ -73,7 +73,8 @@ export interface InventoryReport {
 const SPAWN_MAX_BUFFER = 64 * 1024 * 1024;
 const SHEBANG_READ_BYTES = 512;
 const SHELL_FILE_EXTENSIONS: readonly string[] = [".sh", ".bash", ".zsh", ".ksh", ".command"];
-export const RETAINED_SHELL_SCOPE = "repo-wide setup/bootstrap/service-wrapper/installer/dev-cluster allowlist";
+export const RETAINED_SHELL_SCOPE =
+  "repo-wide setup/bootstrap/service-wrapper/lint-wrapper/installer/dev-cluster allowlist";
 export const TRACKED_SHELL_FILE_GLOBS: readonly string[] = SHELL_FILE_EXTENSIONS.map((extension) => `*${extension}`);
 const SHELL_INTERPRETERS = new Set(["bash", "dash", "sh", "zsh", "ksh"]);
 const ENV_OPTIONS_WITH_SEPARATE_OPERAND = new Set(["-a", "-P", "-u", "--argv0", "--chdir", "--path", "--unset"]);

--- a/src/Core.TypeScript/quantum-observable/oracle.ts
+++ b/src/Core.TypeScript/quantum-observable/oracle.ts
@@ -6,6 +6,7 @@ import type {
   BellCorner,
   BellCoincidence,
   InterferenceVisibility,
+  FlowBitDistinction,
 } from "./types";
 
 export interface IQuantumObservableOracle {
@@ -35,6 +36,7 @@ export interface IQuantumObservableOracle {
     event: string,
   ): BellCoincidence;
   runInterferenceVisibility(id: string, operation: string, phase?: number): InterferenceVisibility;
+  runFlowBitDistinction(id: string, operation: string, externalBit: boolean): FlowBitDistinction;
 }
 
 function getProb(amp: unknown): number {
@@ -231,6 +233,26 @@ export class QuantumObservableOracle implements IQuantumObservableOracle {
       PhaseRadians: phase,
       Probabilities: { Zero: probZero, One: probOne },
       Visibility: operation.endsWith("Open") ? undefined : 1.0,
+    };
+  }
+
+  runFlowBitDistinction(id: string, operation: string, externalBit: boolean): FlowBitDistinction {
+    const circuit = new QuantumCircuit(1);
+    circuit.appendGate("h", 0);
+    if (externalBit) {
+      circuit.appendGate("z", 0);
+    }
+    circuit.appendGate("h", 0);
+    circuit.run();
+
+    const probOne = circuit.probabilities()[0] ?? 0;
+    const probZero = 1 - probOne;
+
+    return {
+      Id: id,
+      Operation: operation,
+      ExternalBit: externalBit,
+      Probabilities: { Zero: probZero, One: probOne },
     };
   }
 }

--- a/src/Core.TypeScript/quantum-observable/quantum-observable.test.ts
+++ b/src/Core.TypeScript/quantum-observable/quantum-observable.test.ts
@@ -118,4 +118,24 @@ describe("QuantumObservableOracle simulator", () => {
     expect(closedPi.Probabilities.Zero).toBeCloseTo(0.0, 5);
     expect(closedPi.Probabilities.One).toBeCloseTo(1.0, 5);
   });
+
+  test("flow-bit distinction turns one external bit into a measured identity", () => {
+    const zero = oracle.runFlowBitDistinction(
+      "external-bit-zero",
+      "Zeta.ReferenceOracle.ApplyExternalBitDistinguishZero",
+      false,
+    );
+    expect(zero.ExternalBit).toBe(false);
+    expect(zero.Probabilities.Zero).toBeCloseTo(1.0, 5);
+    expect(zero.Probabilities.One).toBeCloseTo(0.0, 5);
+
+    const one = oracle.runFlowBitDistinction(
+      "external-bit-one",
+      "Zeta.ReferenceOracle.ApplyExternalBitDistinguishOne",
+      true,
+    );
+    expect(one.ExternalBit).toBe(true);
+    expect(one.Probabilities.Zero).toBeCloseTo(0.0, 5);
+    expect(one.Probabilities.One).toBeCloseTo(1.0, 5);
+  });
 });

--- a/src/Core.TypeScript/quantum-observable/reticulum-quantum.test.ts
+++ b/src/Core.TypeScript/quantum-observable/reticulum-quantum.test.ts
@@ -149,6 +149,33 @@ describe("ReticulumQuantum symmetry and codec", () => {
     expect(consolidated.map((delta) => delta.weight)).toEqual([1]);
   });
 
+  test("flow-bit rows survive the Reticulum delta codec", () => {
+    const row: QuantumObservableRow = {
+      type: "FlowBitDistinction",
+      value: {
+        Id: "external-bit-one",
+        Operation: "Zeta.ReferenceOracle.ApplyExternalBitDistinguishOne",
+        ExternalBit: true,
+        Probabilities: { Zero: 0, One: 1 },
+      },
+    };
+
+    const payload = encodeDelta({
+      source: "qsharp-flow-bit",
+      sequence: 7,
+      row,
+      weight: 1,
+    });
+
+    const decoded = decodeDelta(payload);
+    expect(decoded.ok).toBe(true);
+    if (!decoded.ok) {
+      throw new Error(decoded.error.reason);
+    }
+    expect(decoded.value.row).toEqual(row);
+    expect(decoded.value.weight).toBe(1);
+  });
+
   test("delta decode returns malformed error for invalid schema", () => {
     const decoded = decodeDelta('{"schema":"wrong","delta":{}}');
     expect(decoded.ok).toBe(false);

--- a/src/Core.TypeScript/quantum-observable/reticulum-quantum.ts
+++ b/src/Core.TypeScript/quantum-observable/reticulum-quantum.ts
@@ -5,6 +5,7 @@ import type {
   CanonicalChsh,
   ChshAngles,
   ChshCorrelators,
+  FlowBitDistinction,
   InterferenceVisibility,
   Probabilities,
   QuantumObservableDelta,
@@ -117,13 +118,21 @@ interface WireInterferenceVisibility {
   readonly visibility: number | null;
 }
 
+interface WireFlowBitDistinction {
+  readonly id: string;
+  readonly operation: string;
+  readonly externalBit: boolean;
+  readonly probabilities: WireProbabilities;
+}
+
 type WireQuantumObservableRow =
   | { readonly type: "SingleQubit"; readonly value: WireSingleQubitMeasurement }
   | { readonly type: "CanonicalChsh"; readonly value: WireCanonicalChsh }
   | { readonly type: "SingletChsh"; readonly value: WireSingletChsh }
   | { readonly type: "BellCorner"; readonly value: WireBellCorner }
   | { readonly type: "BellCoincidence"; readonly value: WireBellCoincidence }
-  | { readonly type: "InterferenceVisibility"; readonly value: WireInterferenceVisibility };
+  | { readonly type: "InterferenceVisibility"; readonly value: WireInterferenceVisibility }
+  | { readonly type: "FlowBitDistinction"; readonly value: WireFlowBitDistinction };
 
 interface WireObservableDelta {
   readonly source: string;
@@ -299,6 +308,18 @@ function toWireQuantumObservableRow(row: QuantumObservableRow): WireQuantumObser
         },
       };
     }
+    case "FlowBitDistinction": {
+      const v = row.value;
+      return {
+        type: "FlowBitDistinction",
+        value: {
+          id: v.Id,
+          operation: v.Operation,
+          externalBit: v.ExternalBit,
+          probabilities: toWireProbabilities(v.Probabilities),
+        },
+      };
+    }
   }
 }
 
@@ -358,6 +379,15 @@ function fromWireQuantumObservableRow(row: WireQuantumObservableRow): QuantumObs
       };
       return { type: "InterferenceVisibility", value: v };
     }
+    case "FlowBitDistinction": {
+      const v: FlowBitDistinction = {
+        Id: row.value.id,
+        Operation: row.value.operation,
+        ExternalBit: row.value.externalBit,
+        Probabilities: fromWireProbabilities(row.value.probabilities),
+      };
+      return { type: "FlowBitDistinction", value: v };
+    }
   }
 }
 
@@ -376,6 +406,14 @@ function readRecord(parent: Record<string, unknown>, field: string): Result<Reco
 function readString(parent: Record<string, unknown>, field: string): Result<string, PacketError> {
   const value = parent[field];
   if (typeof value !== "string") {
+    return malformed(field);
+  }
+  return ok(value);
+}
+
+function readBoolean(parent: Record<string, unknown>, field: string): Result<boolean, PacketError> {
+  const value = parent[field];
+  if (typeof value !== "boolean") {
     return malformed(field);
   }
   return ok(value);
@@ -630,6 +668,28 @@ function readInterferenceVisibilityRow(value: Record<string, unknown>): Result<W
   });
 }
 
+function readFlowBitDistinctionRow(value: Record<string, unknown>): Result<WireQuantumObservableRow, PacketError> {
+  const id = readString(value, "id");
+  if (!id.ok) return id;
+  const operation = readString(value, "operation");
+  if (!operation.ok) return operation;
+  const externalBit = readBoolean(value, "externalBit");
+  if (!externalBit.ok) return externalBit;
+  const probabilitiesRecord = readRecord(value, "probabilities");
+  if (!probabilitiesRecord.ok) return probabilitiesRecord;
+  const probabilities = readProbabilities(probabilitiesRecord.value);
+  if (!probabilities.ok) return probabilities;
+  return ok({
+    type: "FlowBitDistinction",
+    value: {
+      id: id.value,
+      operation: operation.value,
+      externalBit: externalBit.value,
+      probabilities: probabilities.value,
+    },
+  });
+}
+
 function readWireQuantumObservableRow(value: unknown): Result<WireQuantumObservableRow, PacketError> {
   if (!isRecord(value)) {
     return malformed("row");
@@ -653,6 +713,8 @@ function readWireQuantumObservableRow(value: unknown): Result<WireQuantumObserva
       return readBellCoincidenceRow(valueRecord.value);
     case "InterferenceVisibility":
       return readInterferenceVisibilityRow(valueRecord.value);
+    case "FlowBitDistinction":
+      return readFlowBitDistinctionRow(valueRecord.value);
     default:
       return malformed("row.type");
   }
@@ -956,6 +1018,18 @@ export function ofQuantumObservableRow(source: string, sequence: bigint, row: Qu
       const v = row.value;
       return {
         Room: "arcade",
+        Source: source,
+        Name: v.Id,
+        Value: v.Probabilities.One,
+        Norm: v.Probabilities.Zero + v.Probabilities.One,
+        Support: 2,
+        Sequence: sequence,
+      };
+    }
+    case "FlowBitDistinction": {
+      const v = row.value;
+      return {
+        Room: "salon",
         Source: source,
         Name: v.Id,
         Value: v.Probabilities.One,

--- a/src/Core.TypeScript/quantum-observable/types.ts
+++ b/src/Core.TypeScript/quantum-observable/types.ts
@@ -70,13 +70,21 @@ export interface InterferenceVisibility {
   readonly Visibility?: number | undefined;
 }
 
+export interface FlowBitDistinction {
+  readonly Id: string;
+  readonly Operation: string;
+  readonly ExternalBit: boolean;
+  readonly Probabilities: Probabilities;
+}
+
 export type QuantumObservableRow =
   | { readonly type: "SingleQubit"; readonly value: SingleQubitMeasurement }
   | { readonly type: "CanonicalChsh"; readonly value: CanonicalChsh }
   | { readonly type: "SingletChsh"; readonly value: SingletChsh }
   | { readonly type: "BellCorner"; readonly value: BellCorner }
   | { readonly type: "BellCoincidence"; readonly value: BellCoincidence }
-  | { readonly type: "InterferenceVisibility"; readonly value: InterferenceVisibility };
+  | { readonly type: "InterferenceVisibility"; readonly value: InterferenceVisibility }
+  | { readonly type: "FlowBitDistinction"; readonly value: FlowBitDistinction };
 
 export interface QuantumObservableDelta {
   readonly row: QuantumObservableRow;
@@ -125,6 +133,8 @@ function tagOrder(type: QuantumObservableRow["type"]): number {
       return 4;
     case "InterferenceVisibility":
       return 5;
+    case "FlowBitDistinction":
+      return 6;
   }
 }
 
@@ -228,6 +238,21 @@ function compareInterferenceVisibility(va: InterferenceVisibility, vb: Interfere
   return compareNumbers(va.Visibility, vb.Visibility);
 }
 
+function compareBooleans(a: boolean, b: boolean): number {
+  if (a === b) return 0;
+  return a ? 1 : -1;
+}
+
+function compareFlowBitDistinction(va: FlowBitDistinction, vb: FlowBitDistinction): number {
+  let cmp = compareStrings(va.Operation, vb.Operation);
+  if (cmp !== 0) return cmp;
+  cmp = compareBooleans(va.ExternalBit, vb.ExternalBit);
+  if (cmp !== 0) return cmp;
+  cmp = compareNumbers(va.Probabilities.Zero, vb.Probabilities.Zero);
+  if (cmp !== 0) return cmp;
+  return compareNumbers(va.Probabilities.One, vb.Probabilities.One);
+}
+
 export function compareQuantumObservableRow(a: QuantumObservableRow, b: QuantumObservableRow): number {
   if (a.type !== b.type) {
     return tagOrder(a.type) - tagOrder(b.type);
@@ -253,5 +278,7 @@ export function compareQuantumObservableRow(a: QuantumObservableRow, b: QuantumO
       return compareBellCoincidence(a.value, b.value as BellCoincidence);
     case "InterferenceVisibility":
       return compareInterferenceVisibility(a.value, b.value as InterferenceVisibility);
+    case "FlowBitDistinction":
+      return compareFlowBitDistinction(a.value, b.value as FlowBitDistinction);
   }
 }

--- a/src/Core/QuantumObservableDbsp.fs
+++ b/src/Core/QuantumObservableDbsp.fs
@@ -32,6 +32,9 @@ type QuantumObservableRowConverter() =
         | "InterferenceVisibility" ->
             let v = JsonSerializer.Deserialize<QuantumObservableTreaty.InterferenceVisibility>(valueVal.GetRawText(), options)
             QuantumObservableRow.InterferenceVisibility v
+        | "FlowBitDistinction" ->
+            let v = JsonSerializer.Deserialize<QuantumObservableTreaty.FlowBitDistinction>(valueVal.GetRawText(), options)
+            QuantumObservableRow.FlowBitDistinction v
         | _ -> failwithf "Unknown quantum observable row type: %s" typ
 
     override _.Write(writer: Utf8JsonWriter, value: QuantumObservableRow, options: JsonSerializerOptions) =
@@ -61,6 +64,10 @@ type QuantumObservableRowConverter() =
             writer.WriteString("type", "InterferenceVisibility")
             writer.WritePropertyName("value")
             JsonSerializer.Serialize(writer, v, options)
+        | QuantumObservableRow.FlowBitDistinction v ->
+            writer.WriteString("type", "FlowBitDistinction")
+            writer.WritePropertyName("value")
+            JsonSerializer.Serialize(writer, v, options)
         writer.WriteEndObject()
 
 and [<JsonConverter(typeof<QuantumObservableRowConverter>)>] QuantumObservableRow =
@@ -70,6 +77,7 @@ and [<JsonConverter(typeof<QuantumObservableRowConverter>)>] QuantumObservableRo
     | BellCorner of QuantumObservableTreaty.BellCorner
     | BellCoincidence of QuantumObservableTreaty.BellCoincidence
     | InterferenceVisibility of QuantumObservableTreaty.InterferenceVisibility
+    | FlowBitDistinction of QuantumObservableTreaty.FlowBitDistinction
 
 type QuantumObservableDelta =
     { [<JsonPropertyName("row")>] Row: QuantumObservableRow
@@ -144,3 +152,20 @@ module QuantumObservableDbsp =
 
     let machZehnderZSet () : ZSet<QuantumObservableRow> =
         machZehnderDeltas () |> zsetOfDeltas
+
+    let flowBitRows () : QuantumObservableRow list =
+        QuantumObservableTreaty.flowBitDistinctions ()
+        |> List.map QuantumObservableRow.FlowBitDistinction
+
+    let flowBitRow (externalBit: bool) : QuantumObservableRow =
+        flowBitRows ()
+        |> List.find (fun row ->
+            match row with
+            | QuantumObservableRow.FlowBitDistinction value -> value.ExternalBit = externalBit
+            | _ -> false)
+
+    let flowBitDeltas () : QuantumObservableDelta list =
+        flowBitRows () |> List.map (fun row -> delta row 1L)
+
+    let flowBitZSet () : ZSet<QuantumObservableRow> =
+        flowBitDeltas () |> zsetOfDeltas

--- a/src/Core/QuantumObservableTreaty.fs
+++ b/src/Core/QuantumObservableTreaty.fs
@@ -70,6 +70,12 @@ module QuantumObservableTreaty =
           Probabilities: Probabilities
           Visibility: float option }
 
+    type FlowBitDistinction =
+        { Id: string
+          Operation: string
+          ExternalBit: bool
+          Probabilities: Probabilities }
+
     let private c = ImaginaryStack.complex
 
     let private real (value: float) : Complex =
@@ -235,3 +241,22 @@ module QuantumObservableTreaty =
           closed "mach-zehnder-closed-pi-over-2-phase" "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiOver2Phase" (System.Math.PI / 2.0)
           closed "mach-zehnder-closed-two-pi-over-3-phase" "Zeta.ReferenceOracle.ApplyMachZehnderClosedTwoPiOver3Phase" (2.0 * System.Math.PI / 3.0)
           closed "mach-zehnder-closed-pi-phase" "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiPhase" System.Math.PI ]
+
+    let private flowBitProbabilities externalBit =
+        let state =
+            zero
+            |> QubitIso.hadamard
+            |> (if externalBit then QubitIso.pauliZ else id)
+            |> QubitIso.hadamard
+
+        probabilitiesFromState state
+
+    let flowBitDistinctions () : FlowBitDistinction list =
+        [ { Id = "external-bit-zero"
+            Operation = "Zeta.ReferenceOracle.ApplyExternalBitDistinguishZero"
+            ExternalBit = false
+            Probabilities = flowBitProbabilities false }
+          { Id = "external-bit-one"
+            Operation = "Zeta.ReferenceOracle.ApplyExternalBitDistinguishOne"
+            ExternalBit = true
+            Probabilities = flowBitProbabilities true } ]

--- a/tests/Bayesian.Tests/QuantumFusion.Tests.fs
+++ b/tests/Bayesian.Tests/QuantumFusion.Tests.fs
@@ -96,6 +96,29 @@ let ``Vision budget backpressure does not change fused arithmetic truth`` () =
     Assert.Equal(Vision.RejectedWithBackpressure, report.Prediction.Outcome)
 
 [<Fact>]
+let ``QSharp flow-bit oracle plugin bifurcates flow then fuses one exterior identity`` () =
+    let flow = QuantumObservableDbsp.flowBitRow false
+    let distinction = QuantumObservableDbsp.flowBitRow true
+
+    let oracle =
+        [ QuantumObservableDbsp.delta flow 1L
+          QuantumObservableDbsp.delta flow -1L
+          QuantumObservableDbsp.delta distinction 1L ]
+        |> QuantumFusion.oracleFromDeltas "qsharp-flow-bit-golden"
+
+    let report =
+        oracle
+        |> QuantumFusion.fuseOracle budget (SoftThrottle.tank 4096.0 0.0)
+        |> mustOk
+
+    Assert.Equal(1, GSet.count report.Exterior)
+    let fact = report.Exterior |> GSet.toList |> List.exactlyOne
+    Assert.Equal("FlowBitDistinction", fact.Kind)
+    Assert.Equal("external-bit-one", fact.Id)
+    Assert.Equal("Zeta.ReferenceOracle.ApplyExternalBitDistinguishOne", fact.Operation)
+    Assert.Equal(Vision.Admitted, report.Prediction.Outcome)
+
+[<Fact>]
 let ``invalid quantum fusion budget returns feedback instead of throwing`` () =
     let invalid = { budget with ResolutionBits = -1 }
 

--- a/tests/Tests.FSharp/QSharpOracle.Tests.fs
+++ b/tests/Tests.FSharp/QSharpOracle.Tests.fs
@@ -142,6 +142,10 @@ let private fsharpInterferenceCase id =
     QuantumObservableTreaty.interferenceVisibility()
     |> List.find (fun item -> item.Id = id)
 
+let private fsharpFlowBitCase id =
+    QuantumObservableTreaty.flowBitDistinctions()
+    |> List.find (fun item -> item.Id = id)
+
 let private assertQSharpColumn (matrix: JsonElement) col (state: QubitIso.JoinState) =
     complexCloseTo (matrixEntry matrix 0 col) state.A
     complexCloseTo (matrixEntry matrix 1 col) state.B
@@ -232,18 +236,22 @@ let ``QubitIso raw kernels match Q# gate matrices on computational basis states`
 [<Fact>]
 let ``Q# flow-bit oracle turns external entropy into deterministic distinction`` () =
     let zero = flowBitCase "external-bit-zero"
+    let expectedZero = fsharpFlowBitCase "external-bit-zero"
     let zeroProb = zero.GetProperty("probabilities")
-    Assert.False(zero.GetProperty("externalBit").GetBoolean())
-    Assert.Equal("Zeta.ReferenceOracle.ApplyExternalBitDistinguishZero", zero.GetProperty("operation").GetString())
-    closeTo 1.0 (zeroProb.GetProperty("Zero").GetDouble())
-    closeTo 0.0 (zeroProb.GetProperty("One").GetDouble())
+    Assert.False(expectedZero.ExternalBit)
+    Assert.Equal(expectedZero.ExternalBit, zero.GetProperty("externalBit").GetBoolean())
+    Assert.Equal(expectedZero.Operation, zero.GetProperty("operation").GetString())
+    closeTo expectedZero.Probabilities.Zero (zeroProb.GetProperty("Zero").GetDouble())
+    closeTo expectedZero.Probabilities.One (zeroProb.GetProperty("One").GetDouble())
 
     let one = flowBitCase "external-bit-one"
+    let expectedOne = fsharpFlowBitCase "external-bit-one"
     let oneProb = one.GetProperty("probabilities")
-    Assert.True(one.GetProperty("externalBit").GetBoolean())
-    Assert.Equal("Zeta.ReferenceOracle.ApplyExternalBitDistinguishOne", one.GetProperty("operation").GetString())
-    closeTo 0.0 (oneProb.GetProperty("Zero").GetDouble())
-    closeTo 1.0 (oneProb.GetProperty("One").GetDouble())
+    Assert.True(expectedOne.ExternalBit)
+    Assert.Equal(expectedOne.ExternalBit, one.GetProperty("externalBit").GetBoolean())
+    Assert.Equal(expectedOne.Operation, one.GetProperty("operation").GetString())
+    closeTo expectedOne.Probabilities.Zero (oneProb.GetProperty("Zero").GetDouble())
+    closeTo expectedOne.Probabilities.One (oneProb.GetProperty("One").GetDouble())
 
 [<Fact>]
 let ``BellTest canonical CHSH observables match the Q# golden vector`` () =

--- a/tests/Tests.FSharp/ReticulumQuantum.Tests.fs
+++ b/tests/Tests.FSharp/ReticulumQuantum.Tests.fs
@@ -85,6 +85,7 @@ let private rowId row =
     | QuantumObservableRow.BellCorner value -> value.Id
     | QuantumObservableRow.BellCoincidence value -> value.Id
     | QuantumObservableRow.InterferenceVisibility value -> value.Id
+    | QuantumObservableRow.FlowBitDistinction value -> value.Id
 
 [<Fact>]
 let ``qubit Born observable crosses Reticulum as a deterministic finite-room packet`` () =


### PR DESCRIPTION
## What changed

- Added a flow-bit observable treaty case for the one-bit distinction experiment: `H -> optional Z -> H`, producing deterministic zero/one measurement probabilities.
- Threaded that row through F# DBSP deltas/ZSet fusion, the TypeScript quantum observable oracle, and Reticulum delta encode/decode.
- Added `IQuantumFusionOracle` so Q#/simulator-backed references stay behind a hexagonal interface instead of becoming the DBSP runtime.
- Categorized the retained Go/Python shell lint wrapper in the bash-retirement inventory guard.

## Why

This is the small non-physics PoC for the DBSP/uncertainty path: an internal signed ledger can retract an undifferentiated flow row and expose one fused exterior identity after a single external bit distinguishes it. Q#/quantum-circuit remain reference oracles; arithmetic truth and byte-budget backpressure stay owned by Zeta.

## Validation

- `bun test`
- `bun run typecheck`
- `bunx prettier --check src/Core.TypeScript/hygiene/check-bash-retirement-inventory.ts src/Core.TypeScript/hygiene/check-bash-retirement-inventory.test.ts src/Core.TypeScript/quantum-observable/types.ts src/Core.TypeScript/quantum-observable/oracle.ts src/Core.TypeScript/quantum-observable/reticulum-quantum.ts src/Core.TypeScript/quantum-observable/quantum-observable.test.ts src/Core.TypeScript/quantum-observable/reticulum-quantum.test.ts`
- `bun test src/Core.QSharp.ReferenceOracle/quantum-circuit.test.ts src/Core.QSharp.ReferenceOracle/qsharp-golden.test.ts src/Core.TypeScript/quantum-observable/quantum-observable.test.ts`
- `bun test src/Core.TypeScript/hygiene/check-bash-retirement-inventory.test.ts && bun src/Core.TypeScript/hygiene/check-bash-retirement-inventory.ts --enforce`
- `dotnet build -c Release -m:1 /p:UseSharedCompilation=false /p:Optimize=false`
- `dotnet format --verify-no-changes`
- `dotnet test Zeta.sln -c Release -m:1 /p:UseSharedCompilation=false /p:Optimize=false`
