### PR TITLE
feat(bayesian): budget quantum fusion attention

### DIFF
--- a/src/Bayesian/QuantumFusion.fs
+++ b/src/Bayesian/QuantumFusion.fs
@@ -42,10 +42,19 @@ module QuantumFusion =
         | VisionBudget of VisionAttention.Feedback
         | QuantumOracle of OracleFeedback
 
+    type EvidenceLedger =
+        { DeltaCount: int
+          TouchedIdentities: int
+          ExteriorIdentities: int
+          HiddenInteriorIdentities: int }
+
     type Report =
         { Exterior: GSet<BoundaryFact>
           Posterior: Beta
+          Ledger: EvidenceLedger
           Prediction: Vision.PredictionReport<BoundaryFact> }
+
+    type AttentionPolicy = Beta -> BoundaryFact -> float
 
     type IQuantumFusionOracle =
         abstract Name: string
@@ -130,7 +139,11 @@ module QuantumFusion =
                   Memory = None }
         }
 
-    let private prediction (facts: GSet<BoundaryFact>) (posterior: Beta) (budget: Budget) (tank: SoftThrottle.Tank)
+    let private predictionWithAttention
+        (attention: BoundaryFact -> float)
+        (facts: GSet<BoundaryFact>)
+        (budget: Budget)
+        (tank: SoftThrottle.Tank)
         : Result<Vision.PredictionReport<BoundaryFact>, Feedback> =
         let rec loop acc rest =
             result {
@@ -138,19 +151,43 @@ module QuantumFusion =
                 | [] ->
                     return! VisionAttention.predict (List.rev acc) tank |> Result.mapError VisionBudget
                 | fact :: tail ->
-                    let! p = proposal (Beta.mean posterior) budget fact
+                    let! p = proposal (attention fact) budget fact
                     return! loop (p :: acc) tail
             }
 
         loop [] (GSet.toList facts)
 
+    let private evidenceLedger
+        (materialized: QuantumObservableDelta array)
+        (touchedFacts: GSet<BoundaryFact>)
+        (exteriorFacts: GSet<BoundaryFact>)
+        : EvidenceLedger =
+        let touched = GSet.count touchedFacts
+        let exterior = GSet.count exteriorFacts
+        { DeltaCount = materialized.Length
+          TouchedIdentities = touched
+          ExteriorIdentities = exterior
+          HiddenInteriorIdentities = max 0 (touched - exterior) }
+
+    let predictExteriorWithAttention
+        (budget: Budget)
+        (tank: SoftThrottle.Tank)
+        (attention: BoundaryFact -> float)
+        (facts: GSet<BoundaryFact>)
+        : Result<Vision.PredictionReport<BoundaryFact>, Feedback> =
+        result {
+            do! validateBudget budget
+            return! predictionWithAttention attention facts budget tank
+        }
+
     /// Compose signed quantum deltas, fuse their positive support into an
     /// exterior G-set, and attach a Bayesian/Vision budget report. Retractions
     /// and multiplicities affect only aggregate confidence; they are not visible
     /// as exterior G-set members.
-    let fuseDeltas
+    let fuseDeltasWithAttention
         (budget: Budget)
         (tank: SoftThrottle.Tank)
+        (attentionPolicy: AttentionPolicy)
         (deltas: QuantumObservableDelta seq)
         : Result<Report, Feedback> =
         result {
@@ -168,13 +205,26 @@ module QuantumFusion =
             let successes = exteriorFacts |> GSet.count |> float
             let failures = max 0 (GSet.count touchedFacts - GSet.count exteriorFacts) |> float
             let posterior = Beta.product budget.Prior (Beta.likelihood successes failures)
-            let! report = prediction exteriorFacts posterior budget tank
+            let ledger = evidenceLedger materialized touchedFacts exteriorFacts
+            let! report =
+                predictionWithAttention (attentionPolicy posterior) exteriorFacts budget tank
 
             return
                 { Exterior = exteriorFacts
                   Posterior = posterior
+                  Ledger = ledger
                   Prediction = report }
         }
+
+    /// Default Bayesian attention: every exterior fact receives the posterior
+    /// mean. This keeps the old arithmetic surface while allowing experiments
+    /// to use `fuseDeltasWithAttention` for attention/gravity priority.
+    let fuseDeltas
+        (budget: Budget)
+        (tank: SoftThrottle.Tank)
+        (deltas: QuantumObservableDelta seq)
+        : Result<Report, Feedback> =
+        fuseDeltasWithAttention budget tank (fun posterior _ -> Beta.mean posterior) deltas
 
     let fuseOracle
         (budget: Budget)
@@ -184,4 +234,15 @@ module QuantumFusion =
         result {
             let! deltas = oracle.Observe() |> Result.mapError QuantumOracle
             return! fuseDeltas budget tank deltas
+        }
+
+    let fuseOracleWithAttention
+        (budget: Budget)
+        (tank: SoftThrottle.Tank)
+        (attentionPolicy: AttentionPolicy)
+        (oracle: IQuantumFusionOracle)
+        : Result<Report, Feedback> =
+        result {
+            let! deltas = oracle.Observe() |> Result.mapError QuantumOracle
+            return! fuseDeltasWithAttention budget tank attentionPolicy deltas
         }

--- a/src/Core.TypeScript/cluster/adapters/container-host.ts
+++ b/src/Core.TypeScript/cluster/adapters/container-host.ts
@@ -1,10 +1,10 @@
 import type { ContainerHost, ContainerHostKind, ProcessRunner } from "../ports.ts";
 import { commandSucceeded } from "./spawn-process-runner.ts";
 
-export function containerHostAdapter(kind: ContainerHostKind, process: ProcessRunner): ContainerHost {
+export function containerHostAdapter(kind: ContainerHostKind, runner: ProcessRunner): ContainerHost {
   return {
     kind,
-    probe: () => commandSucceeded(process, kind, ["--version"]),
+    probe: () => commandSucceeded(runner, kind, ["--version"]),
     clusterDriverEnv: () => (kind === "podman" ? { KIND_EXPERIMENTAL_PROVIDER: "podman" } : undefined),
   };
 }
@@ -27,8 +27,8 @@ export function assertContainerHostReady(host: ContainerHost, repoRoot: string):
   process.exit(1);
 }
 
-export function assertProcessToolReady(process: ProcessRunner, tool: string, repoRoot: string): void {
-  if (commandSucceeded(process, tool, ["--version"])) return;
+export function assertProcessToolReady(runner: ProcessRunner, tool: string, repoRoot: string): void {
+  if (commandSucceeded(runner, tool, ["--version"])) return;
   console.error(`ERROR: ${tool} not found. Install with:`);
   console.error(installHintForTool(tool, repoRoot));
   process.exit(1);

--- a/src/Core.TypeScript/cluster/adapters/local-cluster-drivers.ts
+++ b/src/Core.TypeScript/cluster/adapters/local-cluster-drivers.ts
@@ -2,24 +2,28 @@ import type { ContainerHost, LocalClusterCreateSpec, LocalClusterDriver, Process
 import { runOrExit } from "./spawn-process-runner.ts";
 
 export function kindLocalClusterDriver(process: ProcessRunner, host: ContainerHost): LocalClusterDriver {
-  const env = () => host.clusterDriverEnv();
+  const envOptions = (): { env?: NodeJS.ProcessEnv } => {
+    const env = host.clusterDriverEnv();
+    return env === undefined ? {} : { env };
+  };
 
   return {
     shape: "kind-in-docker",
     list: () =>
       process
-        .run("kind", ["get", "clusters"], { env: env() })
+        .run("kind", ["get", "clusters"], envOptions())
         .stdout.split("\n")
         .map((line) => line.trim())
         .filter((line) => line.length > 0),
     create: (spec: LocalClusterCreateSpec) => {
       const args = ["create", "cluster", "--name", spec.name, "--config", spec.configPath];
       if (spec.waitForReady !== false) {
-        args.push("--wait", `${spec.waitTimeoutSec ?? 180}s`);
+        args.push("--wait", `${String(spec.waitTimeoutSec ?? 180)}s`);
       }
-      runOrExit(process, "kind", args, { env: env(), stdio: "inherit" });
+      runOrExit(process, "kind", args, { ...envOptions(), stdio: "inherit" });
     },
-    delete: (name) => runOrExit(process, "kind", ["delete", "cluster", "--name", name], { env: env(), stdio: "inherit" }),
+    delete: (name) =>
+      runOrExit(process, "kind", ["delete", "cluster", "--name", name], { ...envOptions(), stdio: "inherit" }),
     contextName: (clusterName) => `kind-${clusterName}`,
   };
 }
@@ -34,13 +38,20 @@ export function k3dLocalClusterDriver(process: ProcessRunner): LocalClusterDrive
         .map((line) => line.split(/\s+/)[0] ?? "")
         .filter((name) => name.length > 0 && name !== "NAME"),
     create: (spec) =>
-      runOrExit(process, "k3d", ["cluster", "create", "--config", spec.configPath, "--wait=false"], { stdio: "inherit" }),
+      runOrExit(process, "k3d", ["cluster", "create", "--config", spec.configPath, "--wait=false"], {
+        stdio: "inherit",
+      }),
     delete: (name) => runOrExit(process, "k3d", ["cluster", "delete", name], { stdio: "inherit" }),
     contextName: (clusterName) => `k3d-${clusterName}`,
     mergeCredentials: (clusterName) =>
-      runOrExit(process, "k3d", ["kubeconfig", "merge", clusterName, "--kubeconfig-merge-default", "--kubeconfig-switch-context"], {
-        stdio: "inherit",
-      }),
+      runOrExit(
+        process,
+        "k3d",
+        ["kubeconfig", "merge", clusterName, "--kubeconfig-merge-default", "--kubeconfig-switch-context"],
+        {
+          stdio: "inherit",
+        },
+      ),
     registryName: (clusterName) => `${clusterName}-registry`,
     deleteRegistry: (registryName) => {
       const listed = process.run("k3d", ["registry", "list"]).stdout.split("\n");

--- a/src/Core.TypeScript/cluster/adapters/spawn-process-runner.ts
+++ b/src/Core.TypeScript/cluster/adapters/spawn-process-runner.ts
@@ -33,7 +33,8 @@ export class SpawnProcessRunner implements ProcessRunner {
 
 export function assertCommandSucceeded(result: CommandResult, argv0: string, args: readonly string[]): void {
   if (result.status === 0) return;
-  process.exit(result.status === null ? 1 : result.status);
+  process.stderr.write(`ERROR: command failed: ${[argv0, ...args].join(" ")}\n`);
+  process.exit(result.status ?? 1);
 }
 
 export function runOrExit(

--- a/tests/Bayesian.Tests/QuantumFusion.Tests.fs
+++ b/tests/Bayesian.Tests/QuantumFusion.Tests.fs
@@ -47,6 +47,19 @@ let private piRow =
         "Zeta.ReferenceOracle.ApplyMachZehnderClosedPiPhase"
         Math.PI
 
+let private flowZero = QuantumObservableDbsp.flowBitRow false
+let private flowOne = QuantumObservableDbsp.flowBitRow true
+
+let private exteriorIds (report: QuantumFusion.Report) =
+    report.Exterior
+    |> GSet.toList
+    |> List.map (fun fact -> fact.Id)
+    |> Set.ofList
+
+let private boardedIds (report: QuantumFusion.Report) =
+    report.Prediction.Boarded
+    |> List.map (fun branch -> branch.State.Id)
+
 [<Fact>]
 let ``QSharp Mach-Zehnder deltas fuse into an exterior Bayesian GSet`` () =
     let report =
@@ -69,6 +82,10 @@ let ``QSharp Mach-Zehnder deltas fuse into an exterior Bayesian GSet`` () =
     report.Posterior.Alpha |> should (equalWithin 1e-9) 2.0
     report.Posterior.Beta |> should (equalWithin 1e-9) 2.0
     Beta.mean report.Posterior |> should (equalWithin 1e-9) 0.5
+    Assert.Equal(3, report.Ledger.DeltaCount)
+    Assert.Equal(2, report.Ledger.TouchedIdentities)
+    Assert.Equal(1, report.Ledger.ExteriorIdentities)
+    Assert.Equal(1, report.Ledger.HiddenInteriorIdentities)
 
 [<Fact>]
 let ``fusion hides multiplicity while Bayesian confidence counts exterior identity once`` () =
@@ -82,6 +99,10 @@ let ``fusion hides multiplicity while Bayesian confidence counts exterior identi
     Assert.Equal(1, GSet.count report.Exterior)
     report.Posterior.Alpha |> should (equalWithin 1e-9) 2.0
     report.Posterior.Beta |> should (equalWithin 1e-9) 1.0
+    Assert.Equal(3, report.Ledger.DeltaCount)
+    Assert.Equal(1, report.Ledger.TouchedIdentities)
+    Assert.Equal(1, report.Ledger.ExteriorIdentities)
+    Assert.Equal(0, report.Ledger.HiddenInteriorIdentities)
 
 [<Fact>]
 let ``Vision budget backpressure does not change fused arithmetic truth`` () =
@@ -97,13 +118,10 @@ let ``Vision budget backpressure does not change fused arithmetic truth`` () =
 
 [<Fact>]
 let ``QSharp flow-bit oracle plugin bifurcates flow then fuses one exterior identity`` () =
-    let flow = QuantumObservableDbsp.flowBitRow false
-    let distinction = QuantumObservableDbsp.flowBitRow true
-
     let oracle =
-        [ QuantumObservableDbsp.delta flow 1L
-          QuantumObservableDbsp.delta flow -1L
-          QuantumObservableDbsp.delta distinction 1L ]
+        [ QuantumObservableDbsp.delta flowZero 1L
+          QuantumObservableDbsp.delta flowZero -1L
+          QuantumObservableDbsp.delta flowOne 1L ]
         |> QuantumFusion.oracleFromDeltas "qsharp-flow-bit-golden"
 
     let report =
@@ -117,6 +135,59 @@ let ``QSharp flow-bit oracle plugin bifurcates flow then fuses one exterior iden
     Assert.Equal("external-bit-one", fact.Id)
     Assert.Equal("Zeta.ReferenceOracle.ApplyExternalBitDistinguishOne", fact.Operation)
     Assert.Equal(Vision.Admitted, report.Prediction.Outcome)
+
+[<Fact>]
+let ``attention changes boarding order but not fused DBSP truth`` () =
+    let deltas =
+        [ QuantumObservableDbsp.delta flowZero 1L
+          QuantumObservableDbsp.delta flowOne 1L ]
+
+    let favor id : QuantumFusion.AttentionPolicy =
+        fun (_: Beta) (fact: QuantumFusion.BoundaryFact) -> if fact.Id = id then 10.0 else 0.1
+
+    let oneFirst =
+        deltas
+        |> QuantumFusion.fuseDeltasWithAttention budget (SoftThrottle.tank 100.0 0.0) (favor "external-bit-one")
+        |> mustOk
+
+    let zeroFirst =
+        deltas
+        |> QuantumFusion.fuseDeltasWithAttention budget (SoftThrottle.tank 100.0 0.0) (favor "external-bit-zero")
+        |> mustOk
+
+    Assert.True(exteriorIds oneFirst = exteriorIds zeroFirst)
+    oneFirst.Posterior.Alpha |> should (equalWithin 1e-9) zeroFirst.Posterior.Alpha
+    oneFirst.Posterior.Beta |> should (equalWithin 1e-9) zeroFirst.Posterior.Beta
+    Assert.Equal(Vision.PartiallyAdmitted, oneFirst.Prediction.Outcome)
+    Assert.Equal(Vision.PartiallyAdmitted, zeroFirst.Prediction.Outcome)
+    Assert.Equal<string list>([ "external-bit-one" ], boardedIds oneFirst)
+    Assert.Equal<string list>([ "external-bit-zero" ], boardedIds zeroFirst)
+    Assert.Equal(2, oneFirst.Ledger.ExteriorIdentities)
+    Assert.Equal(0, oneFirst.Ledger.HiddenInteriorIdentities)
+
+[<Fact>]
+let ``time horizon bytes backpressure without changing exterior fusion`` () =
+    let horizon = { budget with TimeTicks = 4; BytesPerTick = 64L }
+
+    let report =
+        [ QuantumObservableDbsp.delta flowOne 1L ]
+        |> QuantumFusion.fuseDeltas horizon (SoftThrottle.tank 100.0 0.0)
+        |> mustOk
+
+    Assert.True(Set.singleton "external-bit-one" = exteriorIds report)
+    Assert.Empty(report.Prediction.Boarded)
+    Assert.Single(report.Prediction.Deferred) |> ignore
+    Assert.Equal(Vision.RejectedWithBackpressure, report.Prediction.Outcome)
+    Assert.True(report.Prediction.DeferredBytes > int64 report.Prediction.TankBefore.Charge)
+
+[<Fact>]
+let ``invalid attention policy returns feedback instead of throwing`` () =
+    match
+        [ QuantumObservableDbsp.delta flowOne 1L ]
+        |> QuantumFusion.fuseDeltasWithAttention budget (SoftThrottle.tank 4096.0 0.0) (fun _ _ -> Double.NaN)
+    with
+    | Error (QuantumFusion.VisionBudget (VisionAttention.InvalidAttentionWeight value)) -> Assert.True(Double.IsNaN value)
+    | other -> Assert.Fail(sprintf "expected InvalidAttentionWeight, got %A" other)
 
 [<Fact>]
 let ``invalid quantum fusion budget returns feedback instead of throwing`` () =

--- a/tests/Tests.FSharp/Storage/Spine.DiskAsync.Tests.fs
+++ b/tests/Tests.FSharp/Storage/Spine.DiskAsync.Tests.fs
@@ -149,10 +149,13 @@ let ``createAsyncBackingStore StableStorage fsyncs and roundtrips through disk``
 
 [<Fact>]
 let ``createAsyncBackingStore WitnessDurable without the flag is rejected`` () =
-    (fun () ->
-        DurabilityMode.createAsyncBackingStore<int>
-            DurabilityMode.WitnessDurable "wd" "wd" 1024L |> ignore)
-    |> should throw typeof<exn>
+    let ex =
+        Assert.Throws<InvalidOperationException>(fun () ->
+            DurabilityMode.createAsyncBackingStore<int>
+                DurabilityMode.WitnessDurable "wd" "wd" 1024L |> ignore)
+
+    Assert.Contains("WitnessDurable", ex.Message)
+    Assert.Contains("research preview", ex.Message)
 
 
 [<Fact>]


### PR DESCRIPTION
## Summary
- adds an evidence ledger to the Bayesian quantum-fusion report: delta count, touched identities, exterior identities, and hidden interior identities
- adds `fuseDeltasWithAttention`, `fuseOracleWithAttention`, and `predictExteriorWithAttention` so experiments can prioritize fused facts under the Vision tank
- pins the invariant that attention changes boarding order, not DBSP arithmetic truth; byte/time horizon pressure backpressures without changing exterior fusion
- repairs latest-main CI drift in the cluster TypeScript adapters and a brittle WitnessDurable exception assertion discovered during the PR gate

## Why
This connects the Vision budget policy to the DBSP uncertainty lane without making Q# or Bayesian inference the runtime. Zeta still owns the signed ZSet -> exterior GSet fusion; attention only decides which already-fused futures get inspected first.

## Validation
- `dotnet test tests/Bayesian.Tests/Bayesian.Tests.fsproj -c Release -m:1 /p:UseSharedCompilation=false /p:Optimize=false`
- `bun --bun tsc --noEmit -p tsconfig.json`
- `bunx eslint src/Core.TypeScript/cluster/adapters/container-host.ts src/Core.TypeScript/cluster/adapters/local-cluster-drivers.ts src/Core.TypeScript/cluster/adapters/spawn-process-runner.ts`
- `bunx prettier --check src/Core.TypeScript/cluster/adapters/container-host.ts src/Core.TypeScript/cluster/adapters/local-cluster-drivers.ts src/Core.TypeScript/cluster/adapters/spawn-process-runner.ts`
- `bun test src/Core.TypeScript/cluster/deps-to-engine-config.test.ts src/Core.TypeScript/cluster/dev-cluster/lib.test.ts src/Core.TypeScript/cluster/dev-cluster/use-cases.test.ts src/Core.TypeScript/cluster/argocd-health-test.test.ts`
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release -m:1 /p:UseSharedCompilation=false /p:Optimize=false --filter FullyQualifiedName~SpineDiskAsyncTests`
- `dotnet format --verify-no-changes`
- `dotnet build -c Release -m:1 /p:UseSharedCompilation=false /p:Optimize=false`
- `dotnet test Zeta.sln -c Release -m:1 /p:UseSharedCompilation=false /p:Optimize=false`