### PR TITLE
feat(observe): oracle picks merge-ready PRs via ForgeState

### DIFF
--- a/src/Core.TypeScript/observe/observe.ts
+++ b/src/Core.TypeScript/observe/observe.ts
@@ -259,6 +259,24 @@ export function observe(world: World): NextAction {
   const doable = world.backlog.find((i) => i.ready && !i.ambiguous);
   if (doable) return { kind: "do_item", item: doable };
 
+  // Forge-aware: if no backlog work is ready but clean PRs exist, signal
+  // that merge work is available. The action is "do_item" with a synthetic
+  // item representing the merge task — the executor recognizes it by the
+  // "merge-pr-" prefix on the id.
+  if (world.forgeState && world.forgeState.cleanPrCount > 0 && !doable) {
+    const prNum = world.forgeState.cleanPrNumbers[0]!;
+    return {
+      kind: "do_item",
+      item: {
+        id: `merge-pr-${prNum}`,
+        title: `Merge clean PR #${prNum}`,
+        ready: true,
+        ambiguous: false,
+        needsNewAction: false,
+      },
+    };
+  }
+
   const toDecompose = world.backlog.find((i) => i.ambiguous);
   if (toDecompose) return { kind: "decompose", item: toDecompose };
 


### PR DESCRIPTION
The observe oracle now uses World.forgeState to pick merge-ready PRs as do_item when no backlog work is pending. 178 tests pass.

Co-Authored-By: Kiro <noreply@kiro.dev>