### PR TITLE
test(ferry): de-flake 'boats of one' (windows-11-arm timing)

### DIFF
--- a/tests/Tests.FSharp/Runtime/FerryThrottler.Tests.fs
+++ b/tests/Tests.FSharp/Runtime/FerryThrottler.Tests.fs
@@ -59,7 +59,14 @@ let ``slow traffic ships boats of one — no artificial batching delay`` () =
     use throttler = new FerryThrottler<int>(FerryThrottlerConfig.deterministic, processBatch)
     for x in [ 10; 20; 30 ] do
         throttler.EnqueueAsync(x).AsTask().Wait()
-        gate.Wait(2000) |> should equal true   // wait for this item's boat
+        // Wait for THIS item's boat with no wall-clock bound: the ferry runs on
+        // a background task, so its scheduling latency is nondeterministic — a
+        // fixed timeout (the old 2 s) flaked on slow/loaded runners (windows-11-arm).
+        // Blocking until the gate releases removes the timing threshold entirely;
+        // a genuine hang is caught by the test-runner's overall timeout. (Full
+        // DST determinism — pumping the single ferry synchronously via an injected
+        // scheduler — is a FerryThrottler design change tracked for the async lane.)
+        gate.Wait()   // wait for this item's boat
     throttler.CompleteAsync().Wait()
     List.ofSeq processed |> should equal [ 10; 20; 30 ]
     // Every boat carried exactly one passenger.


### PR DESCRIPTION
`FerryThrottlerTests.'slow traffic ships boats of one'` flaked on windows-11-arm — `gate.Wait(2000)` timed out when the background ferry's threadpool continuation ran slowly on a loaded ARM runner ([2 s] = the bound). **Internal async scheduling, not an external resource.** Fix: bound-free `gate.Wait()` — waits exactly as long as the boat takes (no timing threshold to flake on); hangs caught by the runner timeout. Assertions unchanged; 16/16 pass. Full DST (inject a scheduler to pump the ferry synchronously) flagged as a FerryThrottler design follow-up for the async lane. 🤖 Generated with [Claude Code](https://claude.com/claude-code)