### PR TITLE
feat(bayesian): forecast Reticulum fusion branches

### DIFF
--- a/src/Bayesian/QuantumFusion.fs
+++ b/src/Bayesian/QuantumFusion.fs
@@ -1,6 +1,7 @@
 namespace Zeta.Bayesian
 
 open System
+open System.Numerics
 open System.Text
 open Zeta.Core
 
@@ -39,6 +40,7 @@ module QuantumFusion =
         | NegativeBytesPerTick of int64
         | NegativeResolutionBits of int
         | ByteCostOverflow of string
+        | MissingReticulumFuture of BoundaryFact
         | VisionBudget of VisionAttention.Feedback
         | QuantumOracle of OracleFeedback
 
@@ -48,11 +50,28 @@ module QuantumFusion =
           ExteriorIdentities: int
           HiddenInteriorIdentities: int }
 
+    type FusionSnapshot =
+        { Exterior: GSet<BoundaryFact>
+          Posterior: Beta
+          Ledger: EvidenceLedger }
+
     type Report =
         { Exterior: GSet<BoundaryFact>
           Posterior: Beta
           Ledger: EvidenceLedger
           Prediction: Vision.PredictionReport<BoundaryFact> }
+
+    type Forecast<'S> =
+        { Snapshot: FusionSnapshot
+          Branches: Vision.FutureBranch<'S> list }
+
+    type ReticulumFuture =
+        { Fact: BoundaryFact
+          Sources: string list
+          FirstSequence: int64
+          LastSequence: int64
+          DeltaCount: int
+          WireBytes: int64 }
 
     type AttentionPolicy = Beta -> BoundaryFact -> float
 
@@ -115,17 +134,34 @@ module QuantumFusion =
         else
             Ok()
 
-    let private branchBaseBytes (budget: Budget) (fact: BoundaryFact) : Result<int64, Feedback> =
-        let dynamicBytes = utf8Bytes fact.Kind + utf8Bytes fact.Id + utf8Bytes fact.Operation
-        if dynamicBytes > Int64.MaxValue - budget.BaseSpaceBytes then
-            Error(ByteCostOverflow fact.Id)
+    let private branchBaseBytesWithExtra
+        (budget: Budget)
+        (extraSpaceBytes: int64)
+        (fact: BoundaryFact)
+        : Result<int64, Feedback> =
+        if extraSpaceBytes < 0L then
+            Error(NegativeBaseSpaceBytes extraSpaceBytes)
         else
-            Ok(budget.BaseSpaceBytes + dynamicBytes)
+            let total =
+                BigInteger budget.BaseSpaceBytes
+                + BigInteger(utf8Bytes fact.Kind)
+                + BigInteger(utf8Bytes fact.Id)
+                + BigInteger(utf8Bytes fact.Operation)
+                + BigInteger extraSpaceBytes
 
-    let private proposal (attentionWeight: float) (budget: Budget) (fact: BoundaryFact)
+            if total > BigInteger Int64.MaxValue then
+                Error(ByteCostOverflow fact.Id)
+            else
+                Ok(int64 total)
+
+    let private proposalWithExtraSpace
+        (extraSpaceBytes: int64)
+        (attentionWeight: float)
+        (budget: Budget)
+        (fact: BoundaryFact)
         : Result<VisionAttention.Proposal<BoundaryFact>, Feedback> =
         result {
-            let! baseBytes = branchBaseBytes budget fact
+            let! baseBytes = branchBaseBytesWithExtra budget extraSpaceBytes fact
             return
                 { Label = fact.Kind + ":" + fact.Id
                   State = fact
@@ -139,23 +175,54 @@ module QuantumFusion =
                   Memory = None }
         }
 
+    let private proposal (attentionWeight: float) (budget: Budget) (fact: BoundaryFact)
+        : Result<VisionAttention.Proposal<BoundaryFact>, Feedback> =
+        proposalWithExtraSpace 0L attentionWeight budget fact
+
+    let private futureBranchesWithExtraSpace
+        (budget: Budget)
+        (attention: BoundaryFact -> float)
+        (extraSpace: BoundaryFact -> int64)
+        (facts: GSet<BoundaryFact>)
+        : Result<Vision.FutureBranch<BoundaryFact> list, Feedback> =
+        let rec loop acc rest =
+            result {
+                match rest with
+                | [] ->
+                    let! ranked =
+                        VisionAttention.rankProposals (List.rev acc)
+                        |> Result.mapError VisionBudget
+
+                    return ranked |> List.map _.Branch
+                | fact :: tail ->
+                    let! p = proposalWithExtraSpace (extraSpace fact) (attention fact) budget fact
+                    return! loop (p :: acc) tail
+            }
+
+        result {
+            do! validateBudget budget
+            return! loop [] (GSet.toList facts)
+        }
+
+    let futureBranchesWithAttention
+        (budget: Budget)
+        (attention: BoundaryFact -> float)
+        (facts: GSet<BoundaryFact>)
+        : Result<Vision.FutureBranch<BoundaryFact> list, Feedback> =
+        futureBranchesWithExtraSpace budget attention (fun _ -> 0L) facts
+
     let private predictionWithAttention
         (attention: BoundaryFact -> float)
         (facts: GSet<BoundaryFact>)
         (budget: Budget)
         (tank: SoftThrottle.Tank)
         : Result<Vision.PredictionReport<BoundaryFact>, Feedback> =
-        let rec loop acc rest =
-            result {
-                match rest with
-                | [] ->
-                    return! VisionAttention.predict (List.rev acc) tank |> Result.mapError VisionBudget
-                | fact :: tail ->
-                    let! p = proposal (attention fact) budget fact
-                    return! loop (p :: acc) tail
-            }
-
-        loop [] (GSet.toList facts)
+        result {
+            let! branches = futureBranchesWithAttention budget attention facts
+            return!
+                Vision.predictBranches branches tank
+                |> Result.mapError (VisionAttention.VisionFeedback >> VisionBudget)
+        }
 
     let private evidenceLedger
         (materialized: QuantumObservableDelta array)
@@ -168,6 +235,32 @@ module QuantumFusion =
           TouchedIdentities = touched
           ExteriorIdentities = exterior
           HiddenInteriorIdentities = max 0 (touched - exterior) }
+
+    let snapshotDeltas
+        (budget: Budget)
+        (deltas: QuantumObservableDelta seq)
+        : Result<FusionSnapshot, Feedback> =
+        result {
+            do! validateBudget budget
+
+            let materialized = deltas |> Seq.toArray
+            let interior = materialized |> QuantumObservableDbsp.zsetOfDeltas
+            let exteriorFacts = exterior interior
+
+            let touchedFacts =
+                materialized
+                |> Seq.map (fun delta -> boundaryFact delta.Row)
+                |> GSet.ofSeq
+
+            let successes = exteriorFacts |> GSet.count |> float
+            let failures = max 0 (GSet.count touchedFacts - GSet.count exteriorFacts) |> float
+            let posterior = Beta.product budget.Prior (Beta.likelihood successes failures)
+
+            return
+                { Exterior = exteriorFacts
+                  Posterior = posterior
+                  Ledger = evidenceLedger materialized touchedFacts exteriorFacts }
+        }
 
     let predictExteriorWithAttention
         (budget: Budget)
@@ -191,29 +284,139 @@ module QuantumFusion =
         (deltas: QuantumObservableDelta seq)
         : Result<Report, Feedback> =
         result {
-            do! validateBudget budget
-
-            let materialized = deltas |> Seq.toArray
-            let interior = materialized |> QuantumObservableDbsp.zsetOfDeltas
-            let exteriorFacts = exterior interior
-
-            let touchedFacts =
-                materialized
-                |> Seq.map (fun delta -> boundaryFact delta.Row)
-                |> GSet.ofSeq
-
-            let successes = exteriorFacts |> GSet.count |> float
-            let failures = max 0 (GSet.count touchedFacts - GSet.count exteriorFacts) |> float
-            let posterior = Beta.product budget.Prior (Beta.likelihood successes failures)
-            let ledger = evidenceLedger materialized touchedFacts exteriorFacts
+            let! snapshot = snapshotDeltas budget deltas
             let! report =
-                predictionWithAttention (attentionPolicy posterior) exteriorFacts budget tank
+                predictionWithAttention (attentionPolicy snapshot.Posterior) snapshot.Exterior budget tank
 
             return
-                { Exterior = exteriorFacts
-                  Posterior = posterior
-                  Ledger = ledger
+                { Exterior = snapshot.Exterior
+                  Posterior = snapshot.Posterior
+                  Ledger = snapshot.Ledger
                   Prediction = report }
+        }
+
+    let forecastDeltasWithAttention
+        (budget: Budget)
+        (attentionPolicy: AttentionPolicy)
+        (deltas: QuantumObservableDelta seq)
+        : Result<Forecast<BoundaryFact>, Feedback> =
+        result {
+            let! snapshot = snapshotDeltas budget deltas
+            let! branches =
+                futureBranchesWithAttention budget (attentionPolicy snapshot.Posterior) snapshot.Exterior
+
+            return
+                { Snapshot = snapshot
+                  Branches = branches }
+        }
+
+    let private reticulumDelta (delta: ReticulumQuantum.ObservableDelta) : QuantumObservableDelta =
+        { Row = delta.Row
+          Weight = delta.Weight }
+
+    let private addWireBytes (fact: BoundaryFact) (left: int64) (right: int64) : Result<int64, Feedback> =
+        let total = BigInteger left + BigInteger right
+        if total > BigInteger Int64.MaxValue then Error(ByteCostOverflow fact.Id)
+        else Ok(int64 total)
+
+    let private reticulumFuture (fact: BoundaryFact) (deltas: ReticulumQuantum.ObservableDelta array)
+        : Result<BoundaryFact * ReticulumFuture, Feedback> =
+        let rec sumWireBytes acc rest =
+            result {
+                match rest with
+                | [] -> return acc
+                | delta :: tail ->
+                    let bytes = ReticulumQuantum.encodeDelta delta |> utf8Bytes
+                    let! total = addWireBytes fact acc bytes
+                    return! sumWireBytes total tail
+            }
+
+        result {
+            let! wireBytes = sumWireBytes 0L (Array.toList deltas)
+            let sequences = deltas |> Array.map _.Sequence
+            let sources =
+                deltas
+                |> Seq.map _.Source
+                |> Seq.distinct
+                |> Seq.sortWith (fun left right -> StringComparer.Ordinal.Compare(left, right))
+                |> Seq.toList
+
+            return
+                fact,
+                { Fact = fact
+                  Sources = sources
+                  FirstSequence = sequences |> Array.min
+                  LastSequence = sequences |> Array.max
+                  DeltaCount = deltas.Length
+                  WireBytes = wireBytes }
+        }
+
+    let private reticulumFuturesByFact
+        (deltas: ReticulumQuantum.ObservableDelta array)
+        : Result<Map<BoundaryFact, ReticulumFuture>, Feedback> =
+        let groups =
+            deltas
+            |> Array.groupBy (fun delta -> boundaryFact delta.Row)
+            |> Array.toList
+
+        let rec loop acc rest =
+            result {
+                match rest with
+                | [] -> return Map.ofList (List.rev acc)
+                | (fact, factDeltas) :: tail ->
+                    let! pair = reticulumFuture fact factDeltas
+                    return! loop (pair :: acc) tail
+            }
+
+        loop [] groups
+
+    let forecastReticulumDeltasWithAttention
+        (budget: Budget)
+        (attentionPolicy: AttentionPolicy)
+        (deltas: ReticulumQuantum.ObservableDelta seq)
+        : Result<Forecast<ReticulumFuture>, Feedback> =
+        result {
+            let materialized = deltas |> Seq.toArray
+            let! snapshot = materialized |> Seq.map reticulumDelta |> snapshotDeltas budget
+            let! futureByFact = reticulumFuturesByFact materialized
+
+            let extraSpace fact =
+                futureByFact
+                |> Map.tryFind fact
+                |> Option.map _.WireBytes
+                |> Option.defaultValue 0L
+
+            let! factBranches =
+                futureBranchesWithExtraSpace
+                    budget
+                    (attentionPolicy snapshot.Posterior)
+                    extraSpace
+                    snapshot.Exterior
+
+            let rec mapBranches
+                (acc: Vision.FutureBranch<ReticulumFuture> list)
+                (rest: Vision.FutureBranch<BoundaryFact> list)
+                : Result<Vision.FutureBranch<ReticulumFuture> list, Feedback> =
+                result {
+                    match rest with
+                    | [] -> return List.rev acc
+                    | branch :: tail ->
+                        match futureByFact |> Map.tryFind branch.State with
+                        | Some future ->
+                            let next: Vision.FutureBranch<ReticulumFuture> =
+                                { Label = branch.Label
+                                  State = future
+                                  Cost = branch.Cost }
+
+                            return! mapBranches (next :: acc) tail
+                        | None ->
+                            return! Error(MissingReticulumFuture branch.State)
+                }
+
+            let! branches = mapBranches [] factBranches
+            return
+                { Snapshot = snapshot
+                  Branches = branches }
         }
 
     /// Default Bayesian attention: every exterior fact receives the posterior

--- a/tests/Bayesian.Tests/QuantumFusion.Tests.fs
+++ b/tests/Bayesian.Tests/QuantumFusion.Tests.fs
@@ -50,6 +50,12 @@ let private piRow =
 let private flowZero = QuantumObservableDbsp.flowBitRow false
 let private flowOne = QuantumObservableDbsp.flowBitRow true
 
+let private retDelta source sequence row weight : ReticulumQuantum.ObservableDelta =
+    { Source = source
+      Sequence = sequence
+      Row = row
+      Weight = weight }
+
 let private exteriorIds (report: QuantumFusion.Report) =
     report.Exterior
     |> GSet.toList
@@ -59,6 +65,10 @@ let private exteriorIds (report: QuantumFusion.Report) =
 let private boardedIds (report: QuantumFusion.Report) =
     report.Prediction.Boarded
     |> List.map (fun branch -> branch.State.Id)
+
+let private forecastIds (forecast: QuantumFusion.Forecast<QuantumFusion.ReticulumFuture>) =
+    forecast.Branches
+    |> List.map (fun branch -> branch.State.Fact.Id)
 
 [<Fact>]
 let ``QSharp Mach-Zehnder deltas fuse into an exterior Bayesian GSet`` () =
@@ -179,6 +189,69 @@ let ``time horizon bytes backpressure without changing exterior fusion`` () =
     Assert.Single(report.Prediction.Deferred) |> ignore
     Assert.Equal(Vision.RejectedWithBackpressure, report.Prediction.Outcome)
     Assert.True(report.Prediction.DeferredBytes > int64 report.Prediction.TankBefore.Charge)
+
+[<Fact>]
+let ``Reticulum forecast turns fused facts into scheduler future branches`` () =
+    let deltas =
+        [ retDelta "edge-zero" 10L flowZero 1L
+          retDelta "edge-one" 11L flowOne 1L ]
+
+    let favorOne : QuantumFusion.AttentionPolicy =
+        fun (_: Beta) (fact: QuantumFusion.BoundaryFact) ->
+            if fact.Id = "external-bit-one" then 10.0 else 0.1
+
+    let forecast =
+        deltas
+        |> QuantumFusion.forecastReticulumDeltasWithAttention budget favorOne
+        |> mustOk
+
+    Assert.Equal(2, forecast.Snapshot.Ledger.ExteriorIdentities)
+    Assert.Equal<string list>([ "external-bit-one"; "external-bit-zero" ], forecastIds forecast)
+
+    let first = forecast.Branches.Head
+    Assert.Equal("external-bit-one", first.State.Fact.Id)
+    Assert.Equal<string list>([ "edge-one" ], first.State.Sources)
+    Assert.Equal(11L, first.State.FirstSequence)
+    Assert.Equal(11L, first.State.LastSequence)
+    Assert.Equal(1, first.State.DeltaCount)
+    Assert.True(first.State.WireBytes > 0L)
+    Assert.True(first.Cost.SpaceBytes >= first.State.WireBytes)
+
+    let firstBytes = Vision.branchBytes first.Cost |> mustOk
+
+    let report =
+        Vision.predictBranches forecast.Branches (SoftThrottle.tank (float firstBytes) 0.0)
+        |> mustOk
+
+    Assert.Equal(Vision.PartiallyAdmitted, report.Outcome)
+
+    Assert.Equal<string list>(
+        [ "external-bit-one" ],
+        report.Boarded |> List.map (fun branch -> branch.State.Fact.Id)
+    )
+
+[<Fact>]
+let ``Reticulum forecast keeps retracted interior churn out of branch states`` () =
+    let deltas =
+        [ retDelta "edge" 20L openRow 1L
+          retDelta "edge" 21L openRow -1L
+          retDelta "edge" 22L piRow 1L ]
+
+    let forecast =
+        deltas
+        |> QuantumFusion.forecastReticulumDeltasWithAttention budget (fun posterior _ -> Beta.mean posterior)
+        |> mustOk
+
+    Assert.Equal(3, forecast.Snapshot.Ledger.DeltaCount)
+    Assert.Equal(2, forecast.Snapshot.Ledger.TouchedIdentities)
+    Assert.Equal(1, forecast.Snapshot.Ledger.ExteriorIdentities)
+    Assert.Equal(1, forecast.Snapshot.Ledger.HiddenInteriorIdentities)
+
+    let branch = Assert.Single forecast.Branches
+    Assert.Equal("mach-zehnder-closed-pi-phase", branch.State.Fact.Id)
+    Assert.Equal(1, branch.State.DeltaCount)
+    Assert.Equal(22L, branch.State.FirstSequence)
+    Assert.Equal(22L, branch.State.LastSequence)
 
 [<Fact>]
 let ``invalid attention policy returns feedback instead of throwing`` () =


### PR DESCRIPTION
## Summary
- add a scheduler-facing `FusionSnapshot`/`Forecast` surface for Bayesian quantum fusion
- price Reticulum observable-delta wire bytes into each Vision future branch
- carry Reticulum source/sequence metadata in `ReticulumFuture` while keeping exterior DBSP fusion as a G-set view
- add tests proving attention changes boarding order without changing arithmetic truth or leaking retracted interior churn

## Validation
- `dotnet test tests/Bayesian.Tests/Bayesian.Tests.fsproj -c Release -m:1 /p:UseSharedCompilation=false /p:Optimize=false`
- `dotnet format --verify-no-changes`
- `dotnet build -c Release -m:1 /p:UseSharedCompilation=false /p:Optimize=false`
- `dotnet test Zeta.sln -c Release -m:1 /p:UseSharedCompilation=false /p:Optimize=false`

Agency-Signature-Version: 1
Agent: Vera
Agent-Runtime: OpenAI Codex
Agent-Model: GPT-5
Credential-Identity: AceHack
Credential-Mode: shared
Human-Review: explicit
Human-Review-Evidence: chat
Action-Mode: human-directed
Task: none

Co-Authored-By: Codex <noreply@openai.com>