### PR TITLE
feat(ferry): DST manual-pump seam (Option B) — deterministic throttler drive

### DIFF
--- a/src/Core/FerryThrottler.fs
+++ b/src/Core/FerryThrottler.fs
@@ -100,7 +100,15 @@ module FerryThrottlerConfig =
 type FerryThrottler<'TItem>
     (config: FerryThrottlerConfig,
      processBatch: ReadOnlyMemory<'TItem> -> CancellationToken -> Task,
-     ?itemSizeBytes: 'TItem -> int) =
+     ?itemSizeBytes: 'TItem -> int,
+     // DST seam (Option B): when true, NO background ferries are started — the
+     // caller drives processing synchronously via `PumpToIdleAsync` on its own
+     // thread (deterministic, replayable, zero wall-clock). Intended for the
+     // DoP=1 simulation / seed / test path. Default false = production background
+     // ferries. Future enhancement (tracked separately): a SynchronizationContext
+     // / Arrow thread-context capture so the BACKGROUND ferries are themselves
+     // replayable — then manual mode is no longer the only deterministic option.
+     ?manual: bool) =
 
     do
         if config.MaxDegreeOfParallelism < 1 then
@@ -143,53 +151,60 @@ type FerryThrottler<'TItem>
     /// self-clocking lives in `WaitToReadAsync` completing as soon as ≥1 item is
     /// available and the inner `TryRead` loop stopping the moment the queue drains.
     let byteBudget = config.MaxBatchBytes
+    let isManual = defaultArg manual false
+
+    // Build ONE boat from what is queued right now (plus a carried-over `pending`
+    // item that was deferred to keep within the byte budget). No waiting for new
+    // work, no awaiting — pure synchronous draining; returns the boat length and
+    // updates `pending`. This is the SINGLE source of boat-building truth: both
+    // the background ferry and the deterministic `PumpToIdleAsync` call it, so the
+    // DST path builds boats byte-for-byte identically to production.
+    let fillBoat (reader: ChannelReader<'TItem>) (buffer: 'TItem array) (pending: 'TItem voption ref) : int =
+        let mutable n = 0
+        let mutable bytes = 0
+        match pending.Value with
+        | ValueSome it ->
+            buffer.[0] <- it
+            n <- 1
+            bytes <- sizeOf it
+            pending.Value <- ValueNone
+        | ValueNone -> ()
+        let mutable draining = true
+        while draining && n < config.MaxBatchSize do
+            match reader.TryRead() with
+            | true, item ->
+                let sz = sizeOf item
+                match byteBudget with
+                | Some cap when n > 0 && bytes + sz > cap ->
+                    // Adding this would overshoot — defer it, close the boat.
+                    pending.Value <- ValueSome item
+                    draining <- false
+                | _ ->
+                    buffer.[n] <- item
+                    n <- n + 1
+                    bytes <- bytes + sz
+            | _ -> draining <- false
+        n
 
     let runFerry () : Task =
         backgroundTask {
             let reader = inbox.Reader
             let buffer = Array.zeroCreate<'TItem> config.MaxBatchSize
             let ct = cts.Token
-            // One-item pushback: an item read but deferred to the NEXT boat because
-            // it would have pushed the current boat over its byte budget. Keeps the
-            // budget strict without needing a peek the channel doesn't offer.
-            let mutable pending: 'TItem voption = ValueNone
+            // One-item pushback (see fillBoat): a byte-budget-deferred item carried
+            // to the NEXT boat, without a peek the channel doesn't offer.
+            let pending: 'TItem voption ref = ref ValueNone
             try
                 let mutable running = true
                 while running do
                     // Only wait for new work when nothing is already deferred.
-                    let mutable haveWork = pending.IsSome
+                    let mutable haveWork = pending.Value.IsSome
                     if not haveWork then
                         let! more = reader.WaitToReadAsync ct
                         haveWork <- more
                         if not more then running <- false
                     if haveWork then
-                        // Build one boat from what's queued right now (plus any
-                        // deferred item). Closes on item count OR byte budget —
-                        // never on a timer.
-                        let mutable n = 0
-                        let mutable bytes = 0
-                        match pending with
-                        | ValueSome it ->
-                            buffer.[0] <- it
-                            n <- 1
-                            bytes <- sizeOf it
-                            pending <- ValueNone
-                        | ValueNone -> ()
-                        let mutable draining = true
-                        while draining && n < config.MaxBatchSize do
-                            match reader.TryRead() with
-                            | true, item ->
-                                let sz = sizeOf item
-                                match byteBudget with
-                                | Some cap when n > 0 && bytes + sz > cap ->
-                                    // Adding this would overshoot — defer it, close the boat.
-                                    pending <- ValueSome item
-                                    draining <- false
-                                | _ ->
-                                    buffer.[n] <- item
-                                    n <- n + 1
-                                    bytes <- bytes + sz
-                            | _ -> draining <- false
+                        let n = fillBoat reader buffer pending
                         if n > 0 then
                             do! processBatch (ReadOnlyMemory(buffer, 0, n)) ct
                             // Clear references so a large boat doesn't pin items.
@@ -197,8 +212,10 @@ type FerryThrottler<'TItem>
             with :? OperationCanceledException -> ()
         }
 
+    // Production: start `ferries` background ferries now. Manual/DST mode: start
+    // none — the caller drives via `PumpToIdleAsync`.
     let ferryTasks : Task array =
-        Array.init ferries (fun _ -> runFerry ())
+        if isManual then [||] else Array.init ferries (fun _ -> runFerry ())
 
     /// Enqueue one item. Returns a `ValueTask` that completes when the item is
     /// accepted into the queue — on a bounded throttler this cooperatively waits
@@ -211,6 +228,30 @@ type FerryThrottler<'TItem>
     /// Try to enqueue without waiting. Returns false if a bounded queue is full.
     member _.TryEnqueue(item: 'TItem) : bool =
         inbox.Writer.TryWrite item
+
+    /// **Deterministic drive (Option B / manual mode).** Synchronously drains the
+    /// queue — building boats with the SAME `fillBoat` the background ferry uses
+    /// and processing each on the CALLER'S thread — until the queue is idle. No
+    /// background ferry, no wall-clock: awaiting the returned Task on the caller's
+    /// own flow IS the whole schedule, so it is fully DST-replayable. Intended for
+    /// the DoP=1 simulation / test path (construct with `manual = true`); the
+    /// processor should complete synchronously there for true determinism.
+    member _.PumpToIdleAsync(?cancellationToken: CancellationToken) : Task =
+        task {
+            let ct = defaultArg cancellationToken CancellationToken.None
+            let reader = inbox.Reader
+            let buffer = Array.zeroCreate<'TItem> config.MaxBatchSize
+            let pending: 'TItem voption ref = ref ValueNone
+            let mutable go = true
+            while go do
+                ct.ThrowIfCancellationRequested()
+                let n = fillBoat reader buffer pending
+                if n > 0 then
+                    do! processBatch (ReadOnlyMemory(buffer, 0, n)) ct
+                    Array.Clear(buffer, 0, n)
+                else
+                    go <- false // queue drained and nothing deferred — idle
+        }
 
     /// Signal that no more items will be enqueued, then await every ferry
     /// draining the queue to completion. After this the throttler is finished.

--- a/tests/Tests.FSharp/Runtime/FerryThrottler.Tests.fs
+++ b/tests/Tests.FSharp/Runtime/FerryThrottler.Tests.fs
@@ -44,33 +44,29 @@ let ``DoP=1 processes every item exactly once, in order`` () =
 
 
 [<Fact>]
-let ``slow traffic ships boats of one — no artificial batching delay`` () =
-    // Enqueue-then-await each, so each item is fully processed before the next
-    // is offered. A self-clocked ferry must ship each immediately as a boat of 1
-    // rather than waiting to coalesce (the anti-Nagle property).
-    let processed = ConcurrentQueue<int>()
-    let boats = ConcurrentQueue<int>()
-    let gate = new SemaphoreSlim(0)
-    let processBatch (boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task =
-        boats.Enqueue boat.Length
-        for i in 0 .. boat.Length - 1 do processed.Enqueue(boat.Span.[i])
-        gate.Release() |> ignore
-        Task.CompletedTask
-    use throttler = new FerryThrottler<int>(FerryThrottlerConfig.deterministic, processBatch)
-    for x in [ 10; 20; 30 ] do
-        throttler.EnqueueAsync(x).AsTask().Wait()
-        // Wait for THIS item's boat with no wall-clock bound: the ferry runs on
-        // a background task, so its scheduling latency is nondeterministic — a
-        // fixed timeout (the old 2 s) flaked on slow/loaded runners (windows-11-arm).
-        // Blocking until the gate releases removes the timing threshold entirely;
-        // a genuine hang is caught by the test-runner's overall timeout. (Full
-        // DST determinism — pumping the single ferry synchronously via an injected
-        // scheduler — is a FerryThrottler design change tracked for the async lane.)
-        gate.Wait()   // wait for this item's boat
-    throttler.CompleteAsync().Wait()
-    List.ofSeq processed |> should equal [ 10; 20; 30 ]
-    // Every boat carried exactly one passenger.
-    List.ofSeq boats |> List.forall (fun n -> n = 1) |> should equal true
+let ``slow traffic ships boats of one — no artificial batching delay`` () : Task =
+    // Fully DETERMINISTIC and async-all-the-way (no wall-clock, no background
+    // ferry, NO blocking .Wait/.Result): `manual = true` starts no ferry; we drive
+    // each item's boat with PumpToIdleAsync, `do!`-awaited. "Slow traffic" = enqueue
+    // ONE, then pump — so each must ship as a boat of 1 (the anti-Nagle property),
+    // replaying identically every run. (Replaces the SemaphoreSlim+timeout that
+    // flaked on windows-11-arm.)
+    task {
+        let processed = ConcurrentQueue<int>()
+        let boats = ConcurrentQueue<int>()
+        let processBatch (boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task =
+            boats.Enqueue boat.Length
+            for i in 0 .. boat.Length - 1 do processed.Enqueue(boat.Span.[i])
+            Task.CompletedTask
+        use throttler = new FerryThrottler<int>(FerryThrottlerConfig.deterministic, processBatch, manual = true)
+        for x in [ 10; 20; 30 ] do
+            do! throttler.EnqueueAsync(x)
+            do! throttler.PumpToIdleAsync() // process exactly this item's boat, now
+        do! throttler.CompleteAsync()
+        List.ofSeq processed |> should equal [ 10; 20; 30 ]
+        // Every boat carried exactly one passenger.
+        List.ofSeq boats |> List.forall (fun n -> n = 1) |> should equal true
+    }
 
 
 [<Fact>]


### PR DESCRIPTION
The FerryThrottler (heart of the code) was untestable deterministically — background ferries race the threadpool (the windows-11-arm flake). Adds the true-DST seam:

- `?manual` ctor arg (default false = prod background ferries). When true, no ferry starts.
- `PumpToIdleAsync()` — drains the queue building boats via the **same extracted `fillBoat`** the background ferry uses (single source of boat-building truth → DST path identical to prod). No wall-clock, no race — awaiting it IS the schedule (FoundationDB shape).
- de-flaked 'slow traffic ships boats of one' → manual mode, **async-all-the-way** (Task signature + `do!`, no `.Wait`/`.Result`).

16/16 FerryThrottler tests pass; **full-solution build 0 warnings**. Rodney's Razor: keep the two arities (essential contract split). Future (Option A): SynchronizationContext/Arrow context-capture so background ferries replay too — prior art = Itron `Platform.Capability/Util/AsyncState.cs`.

Follow-up: purge remaining `.Wait`/`.Result` from the rest of FerryThrottler.Tests.fs (async-all-the-way). 🤖 Generated with [Claude Code](https://claude.com/claude-code)