### PR TITLE
feat(vision): add branch forecast port

### DIFF
--- a/src/Bayesian/QuantumFusion.fs
+++ b/src/Bayesian/QuantumFusion.fs
@@ -61,9 +61,7 @@ module QuantumFusion =
           Ledger: EvidenceLedger
           Prediction: Vision.PredictionReport<BoundaryFact> }
 
-    type Forecast<'S> =
-        { Snapshot: FusionSnapshot
-          Branches: Vision.FutureBranch<'S> list }
+    type Forecast<'S> = Vision.Forecast<FusionSnapshot, 'S>
 
     type ReticulumFuture =
         { Fact: BoundaryFact
@@ -418,6 +416,20 @@ module QuantumFusion =
                 { Snapshot = snapshot
                   Branches = branches }
         }
+
+    type ReticulumForecaster =
+        Vision.IBranchForecaster<ReticulumQuantum.ObservableDelta seq, FusionSnapshot, ReticulumFuture, Feedback>
+
+    let reticulumForecasterWithAttention
+        (budget: Budget)
+        (attentionPolicy: AttentionPolicy)
+        : ReticulumForecaster =
+        { new ReticulumForecaster with
+            member _.Forecast(input: ReticulumQuantum.ObservableDelta seq) =
+                forecastReticulumDeltasWithAttention budget attentionPolicy input }
+
+    let reticulumForecaster (budget: Budget) : ReticulumForecaster =
+        reticulumForecasterWithAttention budget (fun posterior _ -> Beta.mean posterior)
 
     /// Default Bayesian attention: every exterior fact receives the posterior
     /// mean. This keeps the old arithmetic surface while allowing experiments

--- a/src/Core/Vision.fs
+++ b/src/Core/Vision.fs
@@ -182,6 +182,19 @@ module Vision =
           Starved: bool
           Confidence: float }
 
+    /// Scheduler-facing forecast envelope. Implementations may carry any
+    /// plugin/domain snapshot, but the scheduler consumes only the ordered
+    /// future branches and their honest byte-denominated costs.
+    type Forecast<'Snapshot, 'S> =
+        { Snapshot: 'Snapshot
+          Branches: FutureBranch<'S> list }
+
+    /// Hexagonal forecast port: a room/plugin turns an input batch into
+    /// budgeted future branches on our Vision interface. Q#, Bayesian,
+    /// Reticulum, or hardware adapters stay behind this boundary.
+    type IBranchForecaster<'Input, 'Snapshot, 'S, 'Feedback> =
+        abstract Forecast: input: 'Input -> Result<Forecast<'Snapshot, 'S>, 'Feedback>
+
     type Budgeted<'S> =
         { Inner: 'S
           Tank: SoftThrottle.Tank
@@ -281,6 +294,18 @@ module Vision =
                   Starved = not (List.isEmpty deferred)
                   Confidence = confidence }
         }
+
+    let forecastWith
+        (forecaster: IBranchForecaster<'Input, 'Snapshot, 'S, 'Feedback>)
+        (input: 'Input)
+        : Result<Forecast<'Snapshot, 'S>, 'Feedback> =
+        forecaster.Forecast input
+
+    let predictForecast
+        (forecast: Forecast<'Snapshot, 'S>)
+        (tank: SoftThrottle.Tank)
+        : Result<PredictionReport<'S>, GrowthFeedback> =
+        predictBranches forecast.Branches tank
 
     let private growthErrorText =
         function

--- a/tests/Bayesian.Tests/QuantumFusion.Tests.fs
+++ b/tests/Bayesian.Tests/QuantumFusion.Tests.fs
@@ -231,6 +231,34 @@ let ``Reticulum forecast turns fused facts into scheduler future branches`` () =
     )
 
 [<Fact>]
+let ``Reticulum forecaster plugs into the owned Vision port`` () =
+    let deltas =
+        [ retDelta "edge-zero" 30L flowZero 1L
+          retDelta "edge-one" 31L flowOne 1L ]
+
+    let favorZero : QuantumFusion.AttentionPolicy =
+        fun (_: Beta) (fact: QuantumFusion.BoundaryFact) ->
+            if fact.Id = "external-bit-zero" then 10.0 else 0.1
+
+    let forecaster = QuantumFusion.reticulumForecasterWithAttention budget favorZero
+
+    let forecast =
+        (deltas :> ReticulumQuantum.ObservableDelta seq)
+        |> Vision.forecastWith forecaster
+        |> mustOk
+
+    Assert.Equal<string list>([ "external-bit-zero"; "external-bit-one" ], forecastIds forecast)
+
+    let firstBytes = Vision.branchBytes forecast.Branches.Head.Cost |> mustOk
+
+    let report =
+        Vision.predictForecast forecast (SoftThrottle.tank (float firstBytes) 0.0)
+        |> mustOk
+
+    Assert.Equal(Vision.PartiallyAdmitted, report.Outcome)
+    Assert.Equal("external-bit-zero", report.Boarded.Head.State.Fact.Id)
+
+[<Fact>]
 let ``Reticulum forecast keeps retracted interior churn out of branch states`` () =
     let deltas =
         [ retDelta "edge" 20L openRow 1L


### PR DESCRIPTION
## Summary
- add a Core-owned `Vision.Forecast` envelope and `Vision.IBranchForecaster` port for scheduler-facing branch prediction
- keep `QuantumFusion.Forecast` as a compatibility alias over the owned Vision forecast shape
- expose a Bayesian Reticulum forecaster adapter so edge experiments can consume forecasts through `Vision.forecastWith` / `Vision.predictForecast` instead of coupling to the Bayesian module shape

## Validation
- `dotnet test tests/Bayesian.Tests/Bayesian.Tests.fsproj -c Release -m:1 /p:UseSharedCompilation=false /p:Optimize=false`
- `dotnet format --verify-no-changes`
- `dotnet build -c Release -m:1 /p:UseSharedCompilation=false /p:Optimize=false`
- `dotnet test Zeta.sln -c Release -m:1 /p:UseSharedCompilation=false /p:Optimize=false`

Agency-Signature-Version: 1
Agent: Vera
Agent-Runtime: OpenAI Codex
Agent-Model: GPT-5
Credential-Identity: AceHack
Credential-Mode: shared
Human-Review: explicit
Human-Review-Evidence: chat
Action-Mode: human-directed
Task: none

Co-Authored-By: Codex <noreply@openai.com>