### PR TITLE
test(ferry): full DST + async-all-the-way for the whole FerryThrottler suite

### DIFF
--- a/tests/Tests.FSharp/Runtime/FerryThrottler.Tests.fs
+++ b/tests/Tests.FSharp/Runtime/FerryThrottler.Tests.fs
@@ -12,45 +12,76 @@ open Zeta.Core
 // ═══════════════════════════════════════════════════════════════════
 // FerryThrottler — self-clocked, anti-Nagle batching with a DoP knob.
 // "Beautiful on 1, scales to N." DoP=1 is the deterministic path.
+//
+// DST DISCIPLINE: these tests are async-all-the-way (Task signatures + do!/let!,
+// NO .Wait/.Result) and, where DoP=1 makes it possible, drive the throttler in
+// `manual = true` mode via PumpToIdleAsync — no background ferry, no Task.Delay
+// timeout race, no wall-clock. The few tests that genuinely need background
+// concurrency (DoP=N parallelism, bounded-queue backpressure, in-flight
+// cancellation) keep background ferries but await real completion with no
+// fixed-millisecond bound (a genuine hang surfaces via the runner timeout).
 // ═══════════════════════════════════════════════════════════════════
 
 
-/// Collect every item the throttler hands to `processBatch`, plus the size of
-/// each boat it formed, then drive all `items` through and complete.
+/// Drive `items` through a MANUAL (DST) throttler — no background ferry, pumped
+/// synchronously on this thread — collecting processed items + boat sizes. Fully
+/// deterministic: enqueue-all-then-pump, so bursts coalesce exactly.
+let private runCollectingManual
+    (config: FerryThrottlerConfig)
+    (items: int list)
+    : Task<int list * int list> =
+    task {
+        let processed = ConcurrentQueue<int>()
+        let boatSizes = ConcurrentQueue<int>()
+        let processBatch (boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task =
+            boatSizes.Enqueue boat.Length
+            for i in 0 .. boat.Length - 1 do processed.Enqueue(boat.Span.[i])
+            Task.CompletedTask
+        use throttler = new FerryThrottler<int>(config, processBatch, manual = true)
+        for x in items do
+            do! throttler.EnqueueAsync(x)
+        do! throttler.PumpToIdleAsync()
+        do! throttler.CompleteAsync()
+        return List.ofSeq processed, List.ofSeq boatSizes
+    }
+
+
+/// Drive `items` through a BACKGROUND throttler (for DoP=N / backpressure tests
+/// where parallelism or producer-blocking is the point), async-all-the-way.
 let private runCollecting
     (config: FerryThrottlerConfig)
     (items: int list)
-    : int list * int list =   // (processed items, boat sizes)
-    let processed = ConcurrentQueue<int>()
-    let boatSizes = ConcurrentQueue<int>()
-    let processBatch (boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task =
-        boatSizes.Enqueue boat.Length
-        for i in 0 .. boat.Length - 1 do
-            processed.Enqueue(boat.Span.[i])
-        Task.CompletedTask
-    use throttler = new FerryThrottler<int>(config, processBatch)
-    for x in items do
-        throttler.EnqueueAsync(x).AsTask().Wait()
-    throttler.CompleteAsync().Wait()
-    List.ofSeq processed, List.ofSeq boatSizes
+    : Task<int list * int list> =
+    task {
+        let processed = ConcurrentQueue<int>()
+        let boatSizes = ConcurrentQueue<int>()
+        let processBatch (boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task =
+            boatSizes.Enqueue boat.Length
+            for i in 0 .. boat.Length - 1 do processed.Enqueue(boat.Span.[i])
+            Task.CompletedTask
+        use throttler = new FerryThrottler<int>(config, processBatch)
+        for x in items do
+            do! throttler.EnqueueAsync(x)
+        do! throttler.CompleteAsync()
+        return List.ofSeq processed, List.ofSeq boatSizes
+    }
 
 
 [<Fact>]
-let ``DoP=1 processes every item exactly once, in order`` () =
-    let items = [ 1 .. 100 ]
-    let processed, _ = runCollecting FerryThrottlerConfig.deterministic items
-    // Single ferry, single reader: deterministic FIFO order preserved.
-    processed |> should equal items
+let ``DoP=1 processes every item exactly once, in order`` () : Task =
+    task {
+        let items = [ 1 .. 100 ]
+        let! processed, _ = runCollectingManual FerryThrottlerConfig.deterministic items
+        // Single ferry, deterministic FIFO order preserved.
+        processed |> should equal items
+    }
 
 
 [<Fact>]
 let ``slow traffic ships boats of one — no artificial batching delay`` () : Task =
-    // Fully DETERMINISTIC and async-all-the-way (no wall-clock, no background
-    // ferry, NO blocking .Wait/.Result): `manual = true` starts no ferry; we drive
-    // each item's boat with PumpToIdleAsync, `do!`-awaited. "Slow traffic" = enqueue
-    // ONE, then pump — so each must ship as a boat of 1 (the anti-Nagle property),
-    // replaying identically every run. (Replaces the SemaphoreSlim+timeout that
-    // flaked on windows-11-arm.)
+    // Fully DETERMINISTIC and async-all-the-way: `manual = true` starts no ferry;
+    // we drive each item's boat with PumpToIdleAsync, `do!`-awaited. "Slow traffic"
+    // = enqueue ONE, then pump — so each ships as a boat of 1 (anti-Nagle).
     task {
         let processed = ConcurrentQueue<int>()
         let boats = ConcurrentQueue<int>()
@@ -70,74 +101,90 @@ let ``slow traffic ships boats of one — no artificial batching delay`` () : Ta
 
 
 [<Fact>]
-let ``bursty traffic coalesces into larger boats up to MaxBatchSize`` () =
-    // Pre-load the queue, THEN start draining by completing — a single ferry
-    // should scoop multiple items per boat. We assert boats can exceed 1 and
-    // never exceed MaxBatchSize, and that totals are conserved.
-    let config = { FerryThrottlerConfig.deterministic with MaxBatchSize = 4 }
-    let _processed, boats = runCollecting config [ 1 .. 50 ]
-    boats |> List.sum |> should equal 50
-    boats |> List.forall (fun n -> n >= 1 && n <= 4) |> should equal true
+let ``bursty traffic coalesces into larger boats up to MaxBatchSize`` () : Task =
+    // Pre-load the queue (enqueue all), THEN pump — a single ferry should scoop
+    // multiple items per boat. Boats can exceed 1, never exceed MaxBatchSize.
+    task {
+        let config = { FerryThrottlerConfig.deterministic with MaxBatchSize = 4 }
+        let! _processed, boats = runCollectingManual config [ 1 .. 50 ]
+        boats |> List.sum |> should equal 50
+        boats |> List.forall (fun n -> n >= 1 && n <= 4) |> should equal true
+        // Coalescing actually happened (at least one boat carried > 1).
+        boats |> List.exists (fun n -> n > 1) |> should equal true
+    }
 
 
 [<Fact>]
-let ``DoP=N processes every item exactly once (set-equal; order not guaranteed)`` () =
-    let items = [ 1 .. 500 ]
-    let processed, _ = runCollecting (FerryThrottlerConfig.withFerries 4) items
-    processed.Length |> should equal 500
-    (Set.ofList processed) |> should equal (Set.ofList items)
+let ``DoP=N processes every item exactly once (set-equal; order not guaranteed)`` () : Task =
+    task {
+        let items = [ 1 .. 500 ]
+        let! processed, _ = runCollecting (FerryThrottlerConfig.withFerries 4) items
+        processed.Length |> should equal 500
+        (Set.ofList processed) |> should equal (Set.ofList items)
+    }
 
 
 [<Fact>]
-let ``bounded queue applies backpressure without dropping work`` () =
+let ``bounded queue applies backpressure without dropping work`` () : Task =
     // Tiny bounded queue + a slow processor. Producer must block on EnqueueAsync
-    // rather than drop; all items still arrive.
-    let processed = ConcurrentQueue<int>()
-    let processBatch (boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task =
-        task {
-            do! Task.Delay 1
-            for i in 0 .. boat.Length - 1 do processed.Enqueue(boat.Span.[i])
-        } :> Task
-    let config = { FerryThrottlerConfig.deterministic with MaxQueueSize = Some 2 }
-    use throttler = new FerryThrottler<int>(config, processBatch)
-    for x in [ 1 .. 30 ] do
-        throttler.EnqueueAsync(x).AsTask().Wait()
-    throttler.CompleteAsync().Wait()
-    processed.Count |> should equal 30
-    (Set.ofSeq processed) |> should equal (Set.ofList [ 1 .. 30 ])
+    // (awaited cooperatively) rather than drop; all items still arrive. This one
+    // genuinely needs background ferries draining concurrently with the producer.
+    task {
+        let processed = ConcurrentQueue<int>()
+        let processBatch (boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task =
+            task {
+                do! Task.Delay 1
+                for i in 0 .. boat.Length - 1 do processed.Enqueue(boat.Span.[i])
+            }
+            :> Task
+        let config = { FerryThrottlerConfig.deterministic with MaxQueueSize = Some 2 }
+        use throttler = new FerryThrottler<int>(config, processBatch)
+        for x in [ 1 .. 30 ] do
+            do! throttler.EnqueueAsync(x)
+        do! throttler.CompleteAsync()
+        processed.Count |> should equal 30
+        (Set.ofSeq processed) |> should equal (Set.ofList [ 1 .. 30 ])
+    }
 
 
 [<Fact>]
-let ``byte budget closes boats to match serialization size`` () =
+let ``byte budget closes boats to match serialization size`` () : Task =
     // Each item is 10 bytes; budget 25 ⇒ boats of at most 2 items (20 <= 25,
     // adding a 3rd would be 30 > 25). All items still ship, totals conserved.
-    let boats = ConcurrentQueue<int>()
-    let processed = ConcurrentQueue<int>()
-    let processBatch (boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task =
-        boats.Enqueue boat.Length
-        for i in 0 .. boat.Length - 1 do processed.Enqueue(boat.Span.[i])
-        Task.CompletedTask
-    let config = { FerryThrottlerConfig.deterministic with MaxBatchSize = 100; MaxBatchBytes = Some 25 }
-    use throttler = new FerryThrottler<int>(config, processBatch, itemSizeBytes = (fun _ -> 10))
-    for x in [ 1 .. 10 ] do throttler.EnqueueAsync(x).AsTask().Wait()
-    throttler.CompleteAsync().Wait()
-    (Set.ofSeq processed) |> should equal (Set.ofList [ 1 .. 10 ])
-    // No boat exceeds the 2-item byte budget.
-    List.ofSeq boats |> List.forall (fun n -> n >= 1 && n <= 2) |> should equal true
+    task {
+        let boats = ConcurrentQueue<int>()
+        let processed = ConcurrentQueue<int>()
+        let processBatch (boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task =
+            boats.Enqueue boat.Length
+            for i in 0 .. boat.Length - 1 do processed.Enqueue(boat.Span.[i])
+            Task.CompletedTask
+        let config = { FerryThrottlerConfig.deterministic with MaxBatchSize = 100; MaxBatchBytes = Some 25 }
+        use throttler = new FerryThrottler<int>(config, processBatch, itemSizeBytes = (fun _ -> 10), manual = true)
+        for x in [ 1 .. 10 ] do
+            do! throttler.EnqueueAsync(x)
+        do! throttler.PumpToIdleAsync()
+        do! throttler.CompleteAsync()
+        (Set.ofSeq processed) |> should equal (Set.ofList [ 1 .. 10 ])
+        // No boat exceeds the 2-item byte budget.
+        List.ofSeq boats |> List.forall (fun n -> n >= 1 && n <= 2) |> should equal true
+    }
 
 
 [<Fact>]
-let ``a single oversized item still ships alone`` () =
+let ``a single oversized item still ships alone`` () : Task =
     // Item is 100 bytes, budget is 25 — it exceeds the budget but must not stall.
-    let processed = ConcurrentQueue<int>()
-    let processBatch (boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task =
-        for i in 0 .. boat.Length - 1 do processed.Enqueue(boat.Span.[i])
-        Task.CompletedTask
-    let config = { FerryThrottlerConfig.deterministic with MaxBatchBytes = Some 25 }
-    use throttler = new FerryThrottler<int>(config, processBatch, itemSizeBytes = (fun _ -> 100))
-    throttler.EnqueueAsync(42).AsTask().Wait()
-    throttler.CompleteAsync().Wait()
-    List.ofSeq processed |> should equal [ 42 ]
+    task {
+        let processed = ConcurrentQueue<int>()
+        let processBatch (boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task =
+            for i in 0 .. boat.Length - 1 do processed.Enqueue(boat.Span.[i])
+            Task.CompletedTask
+        let config = { FerryThrottlerConfig.deterministic with MaxBatchBytes = Some 25 }
+        use throttler = new FerryThrottler<int>(config, processBatch, itemSizeBytes = (fun _ -> 100), manual = true)
+        do! throttler.EnqueueAsync(42)
+        do! throttler.PumpToIdleAsync()
+        do! throttler.CompleteAsync()
+        List.ofSeq processed |> should equal [ 42 ]
+    }
 
 
 [<Fact>]
@@ -157,145 +204,185 @@ let ``invalid configuration is rejected at construction`` () =
 
 
 [<Fact>]
-let ``result arity returns one aligned result per item`` () =
-    let processBatch (boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task<int array> =
-        task {
-            return
-                [| for i in 0 .. boat.Length - 1 do
-                       boat.Span.[i] * 10 |]
-        }
-    use throttler = new FerryThrottler<int, int>(FerryThrottlerConfig.deterministic, processBatch)
-    let tasks =
-        [ 1 .. 20 ]
-        |> List.map (fun x -> throttler.ProcessAsync x)
-        |> Array.ofList
-    Task.WaitAll(tasks |> Array.map (fun t -> t :> Task))
-    throttler.CompleteAsync().Wait()
-    tasks |> Array.map (fun t -> t.Result) |> should equal [| for x in 1 .. 20 -> x * 10 |]
+let ``result arity returns one aligned result per item`` () : Task =
+    task {
+        let processBatch (boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task<int array> =
+            task {
+                return
+                    [| for i in 0 .. boat.Length - 1 do
+                           boat.Span.[i] * 10 |]
+            }
+        use throttler = new FerryThrottler<int, int>(FerryThrottlerConfig.deterministic, processBatch)
+        let tasks =
+            [ 1 .. 20 ]
+            |> List.map (fun x -> throttler.ProcessAsync x)
+            |> Array.ofList
+        let! results = Task.WhenAll(tasks)
+        do! throttler.CompleteAsync()
+        results |> should equal [| for x in 1 .. 20 -> x * 10 |]
+    }
 
 
 [<Fact>]
-let ``result arity faults entire boat on result-length mismatch`` () =
-    let processBatch (_boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task<int array> =
-        Task.FromResult [||]
-    let config = { FerryThrottlerConfig.deterministic with MaxBatchSize = 4 }
-    use throttler = new FerryThrottler<int, int>(config, processBatch)
-    let tasks =
-        [ 1 .. 4 ]
-        |> List.map (fun x -> throttler.ProcessAsync x)
-        |> Array.ofList
-    (fun () -> Task.WaitAll(tasks |> Array.map (fun t -> t :> Task))) |> should throw typeof<AggregateException>
-    throttler.CompleteAsync().Wait()
-    tasks
-    |> Array.forall (fun t -> t.IsFaulted && t.Exception.InnerExceptions |> Seq.exists (fun ex -> ex :? InvalidOperationException))
-    |> should equal true
+let ``result arity faults entire boat on result-length mismatch`` () : Task =
+    task {
+        let processBatch (_boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task<int array> =
+            Task.FromResult [||]
+        let config = { FerryThrottlerConfig.deterministic with MaxBatchSize = 4 }
+        use throttler = new FerryThrottler<int, int>(config, processBatch)
+        let tasks =
+            [ 1 .. 4 ]
+            |> List.map (fun x -> throttler.ProcessAsync x)
+            |> Array.ofList
+        // Await to completion; the boat faults, so swallow the await-throw — the
+        // real assertion is the per-task fault state below.
+        try
+            let! _ = Task.WhenAll(tasks)
+            ()
+        with _ -> ()
+        do! throttler.CompleteAsync()
+        tasks
+        |> Array.forall (fun t -> t.IsFaulted && t.Exception.InnerExceptions |> Seq.exists (fun ex -> ex :? InvalidOperationException))
+        |> should equal true
+    }
 
 
 [<Fact>]
-let ``result arity faults every item when processor throws`` () =
-    let boom = InvalidOperationException "boom"
-    let processBatch (_boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task<int array> =
-        Task.FromException<int array> boom
-    use throttler = new FerryThrottler<int, int>(FerryThrottlerConfig.deterministic, processBatch)
-    let tasks =
-        [ 1 .. 3 ]
-        |> List.map (fun x -> throttler.ProcessAsync x)
-        |> Array.ofList
-    (fun () -> Task.WaitAll(tasks |> Array.map (fun t -> t :> Task))) |> should throw typeof<AggregateException>
-    throttler.CompleteAsync().Wait()
-    tasks |> Array.forall (fun t -> t.IsFaulted) |> should equal true
+let ``result arity faults every item when processor throws`` () : Task =
+    task {
+        let boom = InvalidOperationException "boom"
+        let processBatch (_boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task<int array> =
+            Task.FromException<int array> boom
+        use throttler = new FerryThrottler<int, int>(FerryThrottlerConfig.deterministic, processBatch)
+        let tasks =
+            [ 1 .. 3 ]
+            |> List.map (fun x -> throttler.ProcessAsync x)
+            |> Array.ofList
+        try
+            let! _ = Task.WhenAll(tasks)
+            ()
+        with _ -> ()
+        do! throttler.CompleteAsync()
+        tasks |> Array.forall (fun t -> t.IsFaulted) |> should equal true
+    }
 
 
 [<Fact>]
-let ``result arity cancels queued item before shipping`` () =
-    let processed = ConcurrentQueue<int>()
-    let gate = new TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
-    let entered = new TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
-    let processBatch (boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task<int array> =
-        task {
-            processed.Enqueue boat.Span.[0]
-            entered.TrySetResult() |> ignore
-            do! gate.Task
-            return [| boat.Span.[0] |]
-        }
-    let config = { FerryThrottlerConfig.deterministic with MaxBatchSize = 1 }
-    use throttler = new FerryThrottler<int, int>(config, processBatch)
-    let first = throttler.ProcessAsync 1
-    entered.Task.Wait 2000 |> should equal true
-    use cts = new CancellationTokenSource()
-    let second = throttler.ProcessAsync(2, cts.Token)
-    cts.Cancel()
-    gate.SetResult()
-    first.Wait 2000 |> should equal true
-    (fun () -> second.Wait()) |> should throw typeof<AggregateException>
-    throttler.CompleteAsync().Wait()
-    second.IsCanceled |> should equal true
-    List.ofSeq processed |> should equal [ 1 ]
+let ``result arity cancels queued item before shipping`` () : Task =
+    // Genuinely concurrent: the first boat is held in-flight (gate) while a second
+    // is queued and cancelled. Coordinated by TCS handshakes (entered/gate), not a
+    // wall-clock — bare awaits, no fixed-ms bound.
+    task {
+        let processed = ConcurrentQueue<int>()
+        let gate = new TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+        let entered = new TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+        let processBatch (boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task<int array> =
+            task {
+                processed.Enqueue boat.Span.[0]
+                entered.TrySetResult() |> ignore
+                do! gate.Task
+                return [| boat.Span.[0] |]
+            }
+        let config = { FerryThrottlerConfig.deterministic with MaxBatchSize = 1 }
+        use throttler = new FerryThrottler<int, int>(config, processBatch)
+        let first = throttler.ProcessAsync 1
+        do! entered.Task // first boat is now in-flight
+        use cts = new CancellationTokenSource()
+        let second = throttler.ProcessAsync(2, cts.Token)
+        cts.Cancel()
+        gate.SetResult()
+        let! _ = first
+        // second was cancelled while queued — awaiting it throws; swallow, assert state.
+        try
+            let! _ = second
+            ()
+        with _ -> ()
+        do! throttler.CompleteAsync()
+        second.IsCanceled |> should equal true
+        List.ofSeq processed |> should equal [ 1 ]
+    }
 
 
 [<Fact>]
-let ``result arity dispose cancels queued caller tasks`` () =
-    let entered = new TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
-    let processBatch (boat: ReadOnlyMemory<int>) (ct: CancellationToken) : Task<int array> =
-        task {
-            entered.TrySetResult() |> ignore
-            do! Task.Delay(Timeout.Infinite, ct)
-            return [| boat.Span.[0] |]
-        }
-    let config = { FerryThrottlerConfig.deterministic with MaxBatchSize = 1 }
-    let throttler = new FerryThrottler<int, int>(config, processBatch)
-    let first = throttler.ProcessAsync 1
-    entered.Task.Wait 2000 |> should equal true
-    let second = throttler.ProcessAsync 2
-    (throttler :> IDisposable).Dispose()
-    Task.WhenAny(second :> Task, Task.Delay 2000).Result |> should equal (second :> Task)
-    second.IsCanceled |> should equal true
-    Task.WhenAny(first :> Task, Task.Delay 2000).Result |> should equal (first :> Task)
-    (first.IsCanceled || first.IsFaulted) |> should equal true
+let ``result arity dispose cancels queued caller tasks`` () : Task =
+    task {
+        let entered = new TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+        let processBatch (boat: ReadOnlyMemory<int>) (ct: CancellationToken) : Task<int array> =
+            task {
+                entered.TrySetResult() |> ignore
+                do! Task.Delay(Timeout.Infinite, ct)
+                return [| boat.Span.[0] |]
+            }
+        let config = { FerryThrottlerConfig.deterministic with MaxBatchSize = 1 }
+        let throttler = new FerryThrottler<int, int>(config, processBatch)
+        let first = throttler.ProcessAsync 1
+        do! entered.Task
+        let second = throttler.ProcessAsync 2
+        (throttler :> IDisposable).Dispose()
+        // Dispose cancels both the queued and the in-flight caller — bare awaits
+        // (no Task.Delay race); they complete via cancel/fault, then assert state.
+        try
+            let! _ = second
+            ()
+        with _ -> ()
+        second.IsCanceled |> should equal true
+        try
+            let! _ = first
+            ()
+        with _ -> ()
+        (first.IsCanceled || first.IsFaulted) |> should equal true
+    }
 
 
 [<Fact>]
-let ``result arity honors byte budget while preserving aligned results`` () =
-    let boats = ConcurrentQueue<int>()
-    let processBatch (boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task<int array> =
-        task {
-            boats.Enqueue boat.Length
-            return [| for i in 0 .. boat.Length - 1 -> boat.Span.[i] + 1 |]
-        }
-    let config = { FerryThrottlerConfig.deterministic with MaxBatchSize = 100; MaxBatchBytes = Some 25 }
-    use throttler = new FerryThrottler<int, int>(config, processBatch, itemSizeBytes = (fun _ -> 10))
-    let tasks =
-        [ 1 .. 10 ]
-        |> List.map (fun x -> throttler.ProcessAsync x)
-        |> Array.ofList
-    Task.WaitAll(tasks |> Array.map (fun t -> t :> Task))
-    throttler.CompleteAsync().Wait()
-    tasks |> Array.map (fun t -> t.Result) |> should equal [| for x in 1 .. 10 -> x + 1 |]
-    List.ofSeq boats |> List.forall (fun n -> n >= 1 && n <= 2) |> should equal true
+let ``result arity honors byte budget while preserving aligned results`` () : Task =
+    task {
+        let boats = ConcurrentQueue<int>()
+        let processBatch (boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task<int array> =
+            task {
+                boats.Enqueue boat.Length
+                return [| for i in 0 .. boat.Length - 1 -> boat.Span.[i] + 1 |]
+            }
+        let config = { FerryThrottlerConfig.deterministic with MaxBatchSize = 100; MaxBatchBytes = Some 25 }
+        use throttler = new FerryThrottler<int, int>(config, processBatch, itemSizeBytes = (fun _ -> 10))
+        let tasks =
+            [ 1 .. 10 ]
+            |> List.map (fun x -> throttler.ProcessAsync x)
+            |> Array.ofList
+        let! results = Task.WhenAll(tasks)
+        do! throttler.CompleteAsync()
+        results |> should equal [| for x in 1 .. 10 -> x + 1 |]
+        List.ofSeq boats |> List.forall (fun n -> n >= 1 && n <= 2) |> should equal true
+    }
 
 
 [<Fact>]
-let ``result arity faults request when byte sizer throws`` () =
-    let processed = ConcurrentQueue<int>()
-    let processBatch (boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task<int array> =
-        task {
-            for i in 0 .. boat.Length - 1 do
-                processed.Enqueue boat.Span.[i]
-            return [| for i in 0 .. boat.Length - 1 -> boat.Span.[i] |]
-        }
-    let config = { FerryThrottlerConfig.deterministic with MaxBatchSize = 4; MaxBatchBytes = Some 100 }
-    let sizer item =
-        if item = 2 then invalidOp "size failed"
-        10
-    use throttler = new FerryThrottler<int, int>(config, processBatch, itemSizeBytes = sizer)
-    let ok1 = throttler.ProcessAsync 1
-    let bad = throttler.ProcessAsync 2
-    let ok3 = throttler.ProcessAsync 3
-    Task.WhenAll([| ok1; ok3 |]).Wait()
-    Task.WhenAny(bad :> Task, Task.Delay 2000).Result |> should equal (bad :> Task)
-    bad.IsFaulted |> should equal true
-    bad.Exception.InnerExceptions |> Seq.exists (fun ex -> ex.Message = "size failed") |> should equal true
-    throttler.CompleteAsync().Wait()
-    ok1.Result |> should equal 1
-    ok3.Result |> should equal 3
-    List.ofSeq processed |> should equal [ 1; 3 ]
+let ``result arity faults request when byte sizer throws`` () : Task =
+    task {
+        let processed = ConcurrentQueue<int>()
+        let processBatch (boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task<int array> =
+            task {
+                for i in 0 .. boat.Length - 1 do
+                    processed.Enqueue boat.Span.[i]
+                return [| for i in 0 .. boat.Length - 1 -> boat.Span.[i] |]
+            }
+        let config = { FerryThrottlerConfig.deterministic with MaxBatchSize = 4; MaxBatchBytes = Some 100 }
+        let sizer item =
+            if item = 2 then invalidOp "size failed"
+            10
+        use throttler = new FerryThrottler<int, int>(config, processBatch, itemSizeBytes = sizer)
+        let ok1 = throttler.ProcessAsync 1
+        let bad = throttler.ProcessAsync 2
+        let ok3 = throttler.ProcessAsync 3
+        let! oks = Task.WhenAll([| ok1; ok3 |])
+        // `bad` faults when the sizer throws — swallow the await-throw, assert state.
+        try
+            let! _ = bad
+            ()
+        with _ -> ()
+        bad.IsFaulted |> should equal true
+        bad.Exception.InnerExceptions |> Seq.exists (fun ex -> ex.Message = "size failed") |> should equal true
+        do! throttler.CompleteAsync()
+        oks |> should equal [| 1; 3 |]
+        List.ofSeq processed |> should equal [ 1; 3 ]
+    }


### PR DESCRIPTION
Every test Task-returning, do!/let!, **no .Wait/.Result**. DoP=1 final-state tests → `manual=true`+`PumpToIdleAsync` (synchronous DST); DoP=N/backpressure keep background, await with no fixed-ms bound; result-arity `let! Task.WhenAll`, Task.Delay 2000 races removed. 16/16 pass, 0 warnings. Builds on #8084. 🤖 Generated with [Claude Code](https://claude.com/claude-code)