### PR TITLE
fix(gate): drop kiro .sh from bash-retirement allowlist (converted to .ts)

### DIFF
--- a/src/Core.TypeScript/hygiene/check-bash-retirement-inventory.test.ts
+++ b/src/Core.TypeScript/hygiene/check-bash-retirement-inventory.test.ts
@@ -163,14 +163,6 @@ describe("buildInventoryReport", () => {
         files: [".gemini/service/install-lior-service.sh", ".gemini/service/lior-loop.sh"],
       },
       {
-        category: "launchd bootstrap",
-        files: ["tools/kiro/launchd/install.sh"],
-      },
-      {
-        category: "kiro loop wrapper",
-        files: ["tools/kiro/kiro-loop-wrapper.sh"],
-      },
-      {
         category: "nixos installer",
         files: [
           "full-ai-cluster/usb-nixos-installer/zeta-first-boot.sh",

--- a/src/Core.TypeScript/hygiene/check-bash-retirement-inventory.ts
+++ b/src/Core.TypeScript/hygiene/check-bash-retirement-inventory.ts
@@ -50,8 +50,6 @@ interface AllowlistIntegrity {
 
 export type RetainedShellCategory =
   | "host-service wrappers"
-  | "kiro loop wrapper"
-  | "launchd bootstrap"
   | "nixos installer"
   | "setup/bootstrap";
 
@@ -82,8 +80,6 @@ export const EXPECTED_RETAINED_SHELL: readonly string[] = [
   ".gemini/service/lior-loop.sh",
   "full-ai-cluster/usb-nixos-installer/zeta-first-boot.sh",
   "full-ai-cluster/usb-nixos-installer/zeta-install.sh",
-  "tools/kiro/kiro-loop-wrapper.sh",
-  "tools/kiro/launchd/install.sh",
   "tools/setup/common/agent-clis.sh",
   "tools/setup/common/curl-fetch.sh",
   "tools/setup/common/dotnet-tools.sh",
@@ -115,8 +111,6 @@ export const EXPECTED_RETAINED_BASH = EXPECTED_RETAINED_SHELL;
 const RETAINED_SHELL_CATEGORY_ORDER: readonly RetainedShellCategory[] = [
   "setup/bootstrap",
   "host-service wrappers",
-  "launchd bootstrap",
-  "kiro loop wrapper",
   "nixos installer",
 ];
 
@@ -125,8 +119,6 @@ export const RETAINED_SHELL_CATEGORY_BY_FILE: Readonly<Record<string, RetainedSh
   ".gemini/service/lior-loop.sh": "host-service wrappers",
   "full-ai-cluster/usb-nixos-installer/zeta-first-boot.sh": "nixos installer",
   "full-ai-cluster/usb-nixos-installer/zeta-install.sh": "nixos installer",
-  "tools/kiro/kiro-loop-wrapper.sh": "kiro loop wrapper",
-  "tools/kiro/launchd/install.sh": "launchd bootstrap",
   "tools/setup/common/agent-clis.sh": "setup/bootstrap",
   "tools/setup/common/curl-fetch.sh": "setup/bootstrap",
   "tools/setup/common/dotnet-tools.sh": "setup/bootstrap",


### PR DESCRIPTION
Kiro's shell→ts conversion removed `tools/kiro/*.sh` but left them in the retained-shell allowlist → gate RED (`missing_retained: 2`). Drops the 2 dead entries + their orphaned categories. Guard + 18 tests pass. 🤖 Generated with [Claude Code](https://claude.com/claude-code)