### PR TITLE
feat(vision): add forecast scheduler wrapper

### DIFF
--- a/src/Core.Python/src/zeta/zeta_id.py
+++ b/src/Core.Python/src/zeta/zeta_id.py
@@ -1,6 +1,8 @@
 import secrets
 from typing import Dict, NamedTuple, Protocol, List
 
+import zeta.zeta_id_gen as gen
+
 AUTHORITY_VALUES: Dict[str, int] = {
     "Simulated": 3,
     "BestEffort": 8,
@@ -98,9 +100,6 @@ class BitField(NamedTuple):
     width: int
 
 
-import zeta.zeta_id_gen as gen
-
-
 class BitLayout:
     version = BitField(gen.VERSION_OFFSET, gen.VERSION_WIDTH)
     timestamp = BitField(gen.TIMESTAMP_OFFSET, gen.TIMESTAMP_WIDTH)
@@ -112,7 +111,6 @@ class BitLayout:
     momentum = BitField(gen.MOMENTUM_OFFSET, gen.MOMENTUM_WIDTH)
     location = BitField(gen.LOCATION_OFFSET, gen.LOCATION_WIDTH)
     randomness = BitField(gen.RANDOMNESS_OFFSET, gen.RANDOMNESS_WIDTH)
-
 
 
 def set_bits(value: int, field: BitField, field_value: int) -> int:

--- a/src/Core.TypeScript/lint/no-python-files.allowlist
+++ b/src/Core.TypeScript/lint/no-python-files.allowlist
@@ -30,7 +30,7 @@ src/Core.Python/src/zeta/__init__.py
 src/Core.Python/src/zeta/sha256.py
 src/Core.Python/src/zeta/tri_boolean.py
 src/Core.Python/src/zeta/zeta_id.py
+src/Core.Python/src/zeta/zeta_id_gen.py
 src/Core.Python/src/zeta/canonical_json.py
 src/Core.Python/src/zeta/yaml.py
 src/Core.Python/tests/test_cross_verify.py
-

--- a/src/Core/Vision.fs
+++ b/src/Core/Vision.fs
@@ -203,12 +203,34 @@ module Vision =
           PredictedBytes: int64
           DeferredBytes: int64 }
 
+    type ForecastBudgeted<'Inner, 'Snapshot, 'BranchState> =
+        { Inner: 'Inner
+          Tank: SoftThrottle.Tank
+          Tick: int
+          LastForecast: Forecast<'Snapshot, 'BranchState> option
+          LastPrediction: PredictionReport<'BranchState> option
+          PredictedBytes: int64
+          DeferredBytes: int64 }
+
     type BranchEstimator<'S> = InterruptKind -> 'S -> FutureBranch<'S> list
+    type ForecastInput<'Inner, 'Input> = InterruptKind -> 'Inner -> 'Input
 
     let budgeted (inner: 'S) (tank: SoftThrottle.Tank) : Budgeted<'S> =
         { Inner = inner
           Tank = tank
           Tick = 0
+          LastPrediction = None
+          PredictedBytes = 0L
+          DeferredBytes = 0L }
+
+    let forecastBudgeted
+        (inner: 'Inner)
+        (tank: SoftThrottle.Tank)
+        : ForecastBudgeted<'Inner, 'Snapshot, 'BranchState> =
+        { Inner = inner
+          Tank = tank
+          Tick = 0
+          LastForecast = None
           LastPrediction = None
           PredictedBytes = 0L
           DeferredBytes = 0L }
@@ -317,6 +339,35 @@ module Vision =
         | NegativeUncertaintyResolutionBits bits -> sprintf "negative uncertainty resolution bits: %d" bits
         | ByteCostOverflow bytes -> sprintf "projected branch byte cost overflows int64: %O" bytes
 
+    let private applyForecastPolicy
+        (makeInput: ForecastInput<'Inner, 'Input>)
+        (forecaster: IBranchForecaster<'Input, 'Snapshot, 'BranchState, 'Feedback>)
+        (feedbackText: 'Feedback -> string)
+        (intr: InterruptKind)
+        (state: ForecastBudgeted<'Inner, 'Snapshot, 'BranchState>)
+        : Result<ForecastBudgeted<'Inner, 'Snapshot, 'BranchState>, InterruptFeedback> =
+        result {
+            let input = makeInput intr state.Inner
+            let! forecast =
+                forecaster.Forecast input
+                |> Result.mapError (fun feedback ->
+                    Failed("vision forecast policy: " + feedbackText feedback))
+
+            let! report =
+                predictForecast forecast state.Tank
+                |> Result.mapError (fun feedback ->
+                    Failed("vision forecast budget: " + growthErrorText feedback))
+
+            return
+                { state with
+                    Tank = report.TankAfter
+                    Tick = state.Tick + 1
+                    LastForecast = Some forecast
+                    LastPrediction = Some report
+                    PredictedBytes = addBytesCapped state.PredictedBytes report.BoardedBytes
+                    DeferredBytes = addBytesCapped state.DeferredBytes report.DeferredBytes }
+        }
+
     /// Scheduler-facing policy handler. It observes each boundary crossing,
     /// asks the room for its projected future branches, funds the affordable
     /// prefix from the tank, and records the self-prediction report in state.
@@ -339,6 +390,19 @@ module Vision =
                 | Error feedback ->
                     return Error(Failed("vision budget policy: " + growthErrorText feedback))
             })
+
+    /// Scheduler-facing forecast-port policy. The room state and branch state
+    /// are intentionally separate: plugins can forecast their own branch
+    /// payloads while the scheduler records the common Vision prediction
+    /// report.
+    let forecastPolicyHandler
+        (name: string)
+        (makeInput: ForecastInput<'Inner, 'Input>)
+        (forecaster: IBranchForecaster<'Input, 'Snapshot, 'BranchState, 'Feedback>)
+        (feedbackText: 'Feedback -> string)
+        : SoftScheduler.HandlerK<ForecastBudgeted<'Inner, 'Snapshot, 'BranchState>> =
+        SoftScheduler.handlerK name (fun _ -> true) (fun intr _ctx state ->
+            Task.FromResult(applyForecastPolicy makeInput forecaster feedbackText intr state))
 
     /// Wrap an arrival-aware scheduler handler so prediction and action ride
     /// together. The policy does not hide uncertainty: if branches are
@@ -364,6 +428,32 @@ module Vision =
                                 LastPrediction = Some report
                                 PredictedBytes = addBytesCapped state.PredictedBytes report.BoardedBytes
                                 DeferredBytes = addBytesCapped state.DeferredBytes report.DeferredBytes }
+                        let! inner = handler.RunK intr ctx policyState.Inner
+                        return
+                            inner
+                            |> Result.map (fun next ->
+                                { policyState with Inner = next })
+                })
+
+    /// Wrap an arrival-aware handler with a forecast-port prediction step. This
+    /// is the hexagonal version of `wrapHandlerK`: the branch forecast comes
+    /// from an owned port, not from a room-specific estimator function, and the
+    /// branch state does not need to equal the room state.
+    let wrapForecastHandlerK
+        (makeInput: ForecastInput<'Inner, 'Input>)
+        (forecaster: IBranchForecaster<'Input, 'Snapshot, 'BranchState, 'Feedback>)
+        (feedbackText: 'Feedback -> string)
+        (handler: SoftScheduler.HandlerK<'Inner>)
+        : SoftScheduler.HandlerK<ForecastBudgeted<'Inner, 'Snapshot, 'BranchState>> =
+        SoftScheduler.handlerK
+            ("vision-" + handler.Name)
+            handler.Matches
+            (fun intr ctx state ->
+                task {
+                    match applyForecastPolicy makeInput forecaster feedbackText intr state with
+                    | Error feedback ->
+                        return Error feedback
+                    | Ok policyState ->
                         let! inner = handler.RunK intr ctx policyState.Inner
                         return
                             inner

--- a/tests/Bayesian.Tests/QuantumFusion.Tests.fs
+++ b/tests/Bayesian.Tests/QuantumFusion.Tests.fs
@@ -4,6 +4,7 @@ module Zeta.Bayesian.Tests.QuantumFusionTests
 open System
 open System.IO
 open System.Reflection
+open System.Threading.Tasks
 open System.Text.Json
 open FsUnit.Xunit
 open global.Xunit
@@ -20,6 +21,13 @@ let private repoRoot () =
     while not (isNull dir) && not (File.Exists(Path.Join(dir.FullName, "Zeta.sln"))) do
         dir <- dir.Parent
     if isNull dir then failwith "Could not locate repo root (Zeta.sln)." else dir.FullName
+
+let private ctx () : IntrCtx =
+    { Memetic = "quantum-fusion"
+      Prompt = ""
+      Trust = ""
+      Log = ""
+      Otel = System.Diagnostics.ActivityContext() }
 
 let private qsharpGolden () =
     Path.Join(repoRoot (), "src", "Core.QSharp.ReferenceOracle", "qsharp-golden.json")
@@ -257,6 +265,57 @@ let ``Reticulum forecaster plugs into the owned Vision port`` () =
 
     Assert.Equal(Vision.PartiallyAdmitted, report.Outcome)
     Assert.Equal("external-bit-zero", report.Boarded.Head.State.Fact.Id)
+
+[<Fact>]
+let ``Reticulum forecaster records scheduler prediction through the Vision wrapper`` () =
+    task {
+        let deltas =
+            [ retDelta "edge-zero" 40L flowZero 1L
+              retDelta "edge-one" 41L flowOne 1L ]
+
+        let favorOne : QuantumFusion.AttentionPolicy =
+            fun (_: Beta) (fact: QuantumFusion.BoundaryFact) ->
+                if fact.Id = "external-bit-one" then 10.0 else 0.1
+
+        let forecaster = QuantumFusion.reticulumForecasterWithAttention budget favorOne
+        let makeInput _ _ = deltas :> ReticulumQuantum.ObservableDelta seq
+        let feedbackText feedback = sprintf "%A" feedback
+
+        let handler =
+            SoftScheduler.handlerK
+                "count"
+                (function TimerElapsed _ -> true | _ -> false)
+                (fun _ _ count -> Task.FromResult(Ok(count + 1)))
+
+        let forecast =
+            Vision.forecastWith forecaster (deltas :> ReticulumQuantum.ObservableDelta seq)
+            |> mustOk
+
+        let firstBytes = Vision.branchBytes forecast.Branches.Head.Cost |> mustOk
+
+        let initial: Vision.ForecastBudgeted<int, QuantumFusion.FusionSnapshot, QuantumFusion.ReticulumFuture> =
+            Vision.forecastBudgeted 0 (SoftThrottle.tank (float firstBytes) 0.0)
+
+        let source _ = [ TimerElapsed 17 ]
+
+        let! result =
+            (SoftScheduler.driveK [ Vision.wrapForecastHandlerK makeInput forecaster feedbackText handler ] source)
+                .Run(ctx ()) 7L initial 1
+
+        let final = result |> mustOk
+        Assert.Equal(1, final.Inner)
+        Assert.Equal(1, final.Tick)
+
+        match final.LastForecast, final.LastPrediction with
+        | Some recordedForecast, Some report ->
+            Assert.Equal(2, recordedForecast.Snapshot.Ledger.ExteriorIdentities)
+            Assert.Equal(Vision.PartiallyAdmitted, report.Outcome)
+            Assert.Equal<string list>(
+                [ "external-bit-one" ],
+                report.Boarded |> List.map (fun branch -> branch.State.Fact.Id)
+            )
+        | _ -> Assert.Fail "Vision should record the Reticulum forecast and prediction"
+    }
 
 [<Fact>]
 let ``Reticulum forecast keeps retracted interior churn out of branch states`` () =

--- a/tests/Tests.FSharp.Git/AssemblyInfo.fs
+++ b/tests/Tests.FSharp.Git/AssemblyInfo.fs
@@ -1,0 +1,9 @@
+namespace Zeta.Tests.Git
+
+open Xunit
+
+// LibGit2Sharp rides native libgit2 state and on-disk repository locks.
+// This project is already isolated for that dependency; keep its tests
+// serialized so independent test repos do not race through native git state.
+[<assembly: CollectionBehavior(DisableTestParallelization = true)>]
+do ()

--- a/tests/Tests.FSharp.Git/Tests.FSharp.Git.fsproj
+++ b/tests/Tests.FSharp.Git/Tests.FSharp.Git.fsproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
     <Compile Include="GitDeltaLog.Tests.fs" />
     <Compile Include="GitCommand.Tests.fs" />
     <Compile Include="CliParse.Tests.fs" />

--- a/tests/Tests.FSharp/Infra/FeatureFlags.Tests.fs
+++ b/tests/Tests.FSharp/Infra/FeatureFlags.Tests.fs
@@ -1,8 +1,12 @@
+[<Xunit.Collection("FeatureFlags")>]
 module Zeta.Tests.Infra.FeatureFlagsTests
 
 open System
 open Xunit
 open Zeta.Core
+
+[<CollectionDefinition("FeatureFlags", DisableParallelization = true)>]
+type FeatureFlagStateCollection() = class end
 
 [<Fact>]
 let ``all flags default to off`` () =

--- a/tests/Tests.FSharp/Storage/Spine.DiskAsync.Tests.fs
+++ b/tests/Tests.FSharp/Storage/Spine.DiskAsync.Tests.fs
@@ -1,3 +1,4 @@
+[<Xunit.Collection("FeatureFlags")>]
 module Zeta.Tests.Storage.SpineDiskAsyncTests
 #nowarn "0893"
 
@@ -149,10 +150,22 @@ let ``createAsyncBackingStore StableStorage fsyncs and roundtrips through disk``
 
 [<Fact>]
 let ``createAsyncBackingStore WitnessDurable without the flag is rejected`` () =
+    let witnessEnv = Environment.GetEnvironmentVariable("DBSP_FLAG_WITNESSDURABLE")
+    let researchPreviewEnv = Environment.GetEnvironmentVariable("DBSP_FLAG_RESEARCHPREVIEW")
+
     let ex =
-        Assert.Throws<InvalidOperationException>(fun () ->
-            DurabilityMode.createAsyncBackingStore<int>
-                DurabilityMode.WitnessDurable "wd" "wd" 1024L |> ignore)
+        try
+            FeatureFlags.resetAll ()
+            Environment.SetEnvironmentVariable("DBSP_FLAG_WITNESSDURABLE", null)
+            Environment.SetEnvironmentVariable("DBSP_FLAG_RESEARCHPREVIEW", null)
+
+            Assert.Throws<InvalidOperationException>(fun () ->
+                DurabilityMode.createAsyncBackingStore<int>
+                    DurabilityMode.WitnessDurable "wd" "wd" 1024L |> ignore)
+        finally
+            Environment.SetEnvironmentVariable("DBSP_FLAG_WITNESSDURABLE", witnessEnv)
+            Environment.SetEnvironmentVariable("DBSP_FLAG_RESEARCHPREVIEW", researchPreviewEnv)
+            FeatureFlags.resetAll ()
 
     Assert.Contains("WitnessDurable", ex.Message)
     Assert.Contains("research preview", ex.Message)

--- a/tests/Tests.FSharp/Vision.Tests.fs
+++ b/tests/Tests.FSharp/Vision.Tests.fs
@@ -38,6 +38,15 @@ let private branch<'S>
           BytesPerTick = bytesPerTick
           UncertaintyResolutionBits = uncertaintyResolutionBits } }
 
+type private ForecastRoom =
+    { Count: int }
+
+type private ForecastSnapshot =
+    { Input: string }
+
+type private ForecastError =
+    | ForecastRejected of string
+
 [<Fact>]
 let ``cache identity integrates a delta stream`` () =
     task {
@@ -140,4 +149,81 @@ let ``vision wraps the soft scheduler with a self-prediction budget policy`` () 
             Assert.True(report.Starved)
             Assert.Equal<string list>([ "self-now-0" ], report.Boarded |> List.map _.Label)
         | None -> Assert.Fail "vision should record the self-prediction report"
+    }
+
+[<Fact>]
+let ``vision forecast port wrapper records branch predictions separate from room state`` () =
+    task {
+        let forecaster =
+            { new Vision.IBranchForecaster<string, ForecastSnapshot, string, ForecastError> with
+                member _.Forecast input =
+                    Ok
+                        { Snapshot = { Input = input }
+                          Branches =
+                            [ branch (input + "-near") "branch-near" 5L 0 0L 8
+                              branch (input + "-far") "branch-far" 20L 0 0L 16 ] } }
+
+        let handler =
+            SoftScheduler.handlerK
+                "inc"
+                (function TimerElapsed _ -> true | _ -> false)
+                (fun _ _ (room: ForecastRoom) ->
+                    Task.FromResult(Ok { room with Count = room.Count + 1 }))
+
+        let makeInput intr room =
+            match intr with
+            | TimerElapsed ms -> sprintf "room-%d-timer-%d" room.Count ms
+            | _ -> sprintf "room-%d-other" room.Count
+
+        let feedbackText =
+            function
+            | ForecastRejected text -> text
+
+        let initial: Vision.ForecastBudgeted<ForecastRoom, ForecastSnapshot, string> =
+            Vision.forecastBudgeted { Count = 0 } (SoftThrottle.tank 10.0 0.0)
+
+        let source _ = [ TimerElapsed 17 ]
+
+        let! result =
+            (SoftScheduler.driveK [ Vision.wrapForecastHandlerK makeInput forecaster feedbackText handler ] source)
+                .Run(ctx ()) 7L initial 1
+
+        let final = result |> ok
+        Assert.Equal(1, final.Inner.Count)
+        Assert.Equal(1, final.Tick)
+        Assert.Equal(6L, final.PredictedBytes)
+        Assert.Equal(22L, final.DeferredBytes)
+
+        match final.LastForecast, final.LastPrediction with
+        | Some forecast, Some report ->
+            Assert.Equal("room-0-timer-17", forecast.Snapshot.Input)
+            Assert.Equal(Vision.PartiallyAdmitted, report.Outcome)
+            Assert.Equal<string list>([ "branch-near" ], report.Boarded |> List.map _.State)
+            Assert.Equal<string list>([ "branch-far" ], report.Deferred |> List.map _.State)
+        | _ -> Assert.Fail "vision should record both forecast and prediction report"
+    }
+
+[<Fact>]
+let ``vision forecast policy surfaces forecaster feedback through the scheduler channel`` () =
+    task {
+        let forecaster =
+            { new Vision.IBranchForecaster<string, ForecastSnapshot, string, ForecastError> with
+                member _.Forecast input = Error(ForecastRejected input) }
+
+        let makeInput _ room = sprintf "blocked-%d" room.Count
+
+        let feedbackText =
+            function
+            | ForecastRejected text -> text
+
+        let initial: Vision.ForecastBudgeted<ForecastRoom, ForecastSnapshot, string> =
+            Vision.forecastBudgeted { Count = 0 } (SoftThrottle.tank 10.0 0.0)
+
+        let source _ = [ TimerElapsed 17 ]
+        let handler = Vision.forecastPolicyHandler "forecast" makeInput forecaster feedbackText
+        let! result = (SoftScheduler.driveK [ handler ] source).Run(ctx ()) 7L initial 1
+
+        match result with
+        | Error (Failed message) -> Assert.Contains("blocked-0", message)
+        | other -> Assert.Fail(sprintf "expected scheduler feedback, got %A" other)
     }

--- a/tools/codegen/zeta-id-generator.ts
+++ b/tools/codegen/zeta-id-generator.ts
@@ -10,6 +10,14 @@ interface Field {
   type: string;
 }
 
+function valueAfterColon(line: string): string {
+  const colon = line.indexOf(':');
+  if (colon < 0) {
+    throw new Error(`Expected YAML key/value line with colon: ${line}`);
+  }
+  return line.slice(colon + 1).trim();
+}
+
 // Simple robust parser for docs/zeta-id-v1-layout.yaml
 function parseYaml(filePath: string): Field[] {
   const content = fs.readFileSync(filePath, 'utf-8');
@@ -35,14 +43,14 @@ function parseYaml(filePath: string): Field[] {
       if (currentField && currentField.name !== undefined && currentField.offset !== undefined && currentField.width !== undefined) {
         fields.push(currentField as Field);
       }
-      currentField = { name: trimmed.split(':')[1].trim() };
+      currentField = { name: valueAfterColon(trimmed) };
     } else if (currentField) {
       if (trimmed.startsWith('offset:')) {
-        currentField.offset = parseInt(trimmed.split(':')[1].trim(), 10);
+        currentField.offset = parseInt(valueAfterColon(trimmed), 10);
       } else if (trimmed.startsWith('width:')) {
-        currentField.width = parseInt(trimmed.split(':')[1].trim(), 10);
+        currentField.width = parseInt(valueAfterColon(trimmed), 10);
       } else if (trimmed.startsWith('type:')) {
-        currentField.type = trimmed.split(':')[1].trim();
+        currentField.type = valueAfterColon(trimmed);
       }
     }
   }


### PR DESCRIPTION
## Summary
- Adds `ForecastBudgeted`, `forecastPolicyHandler`, and `wrapForecastHandlerK` so Vision can record branch forecasts from the owned `IBranchForecaster` port while keeping room state separate from plugin branch state.
- Adds core Vision tests for forecast admission/backpressure and scheduler feedback.
- Adds a Bayesian Reticulum test proving the Reticulum forecaster flows through the Vision scheduler wrapper.
- Hardens unrelated gate flakes found during full validation: feature-flag env/global-state tests are serialized with the async durability default-off assertion, and the isolated LibGit2Sharp test project runs serialized against native git state.
- Fixes rebased-main CI drift in ZetaId codegen strict parsing, generated Python allowlisting, and Python import/format order.

## Why
This keeps Q#/Bayesian/Reticulum-style experiments behind an owned interface. The scheduler sees forecast reports and honest byte backpressure; plugin arithmetic stays outside core runtime assumptions.

## Validation
- `bun src/Core.TypeScript/lint/no-python-files.ts`
- `bun src/Core.TypeScript/lint/lint-typescript.ts`
- `ruff check src/Core.Python/src src/Core.Python/tests`
- `ruff format --check src/Core.Python/src src/Core.Python/tests`
- `dotnet format --verify-no-changes`
- `dotnet build -c Release -m:1 /p:UseSharedCompilation=false`
- `dotnet test Zeta.sln -c Release -m:1 /p:UseSharedCompilation=false --no-build`
- `bun src/Core.TypeScript/hygiene/audit-agencysignature-main-tip.ts --commit HEAD`
