### PR TITLE
feat(ferry): capture-at-the-boundary context (Option-A increment 2)

### DIFF
--- a/src/Core/FerryThrottler.fs
+++ b/src/Core/FerryThrottler.fs
@@ -493,7 +493,13 @@ type ContextualFerryThrottler<'TItem, 'Ctx>
     (config: FerryThrottlerConfig,
      processBatch: ReadOnlyMemory<struct ('TItem * 'Ctx)> -> CancellationToken -> Task,
      ?itemSizeBytes: 'TItem -> int,
-     ?manual: bool) =
+     ?manual: bool,
+     // Capture-at-the-boundary: an ambient-context reader run ON THE ENQUEUER'S
+     // flow at each `EnqueueCapturedAsync` call, so the ambient (e.g.
+     // `Activity.Current` / `IntrCtx` / a Zeta `AsyncLocal`) is snapshotted at the
+     // door and then threaded as DATA — the boundary is the only place the side
+     // channel is touched; nothing ambient flows into the background ferry.
+     ?capture: unit -> 'Ctx) =
 
     // Size the PAYLOAD, not the (payload, ctx) pair — the threaded context is
     // metadata that rides along; it does not count against the byte budget.
@@ -504,9 +510,19 @@ type ContextualFerryThrottler<'TItem, 'Ctx>
         new FerryThrottler<struct ('TItem * 'Ctx)>(
             config, processBatch, ?itemSizeBytes = innerSizer, ?manual = manual)
 
-    /// Enqueue one item together with the context value to thread to its boat.
+    /// Enqueue one item together with an explicit context value to thread to its boat.
     member _.EnqueueAsync(item: 'TItem, context: 'Ctx, ?cancellationToken: CancellationToken) : ValueTask =
         inner.EnqueueAsync(struct (item, context), ?cancellationToken = cancellationToken)
+
+    /// Capture-at-the-boundary enqueue (the Itron "capture so I can pass it through"
+    /// pattern): snapshots the ambient context NOW — via the `capture` reader run on
+    /// the caller's flow — and threads that snapshot with the item. Requires a
+    /// `capture` reader at construction.
+    member _.EnqueueCapturedAsync(item: 'TItem, ?cancellationToken: CancellationToken) : ValueTask =
+        match capture with
+        | Some readAmbient ->
+            inner.EnqueueAsync(struct (item, readAmbient ()), ?cancellationToken = cancellationToken)
+        | None -> invalidOp "EnqueueCapturedAsync requires a `capture` reader supplied at construction"
 
     /// Deterministic manual drive (when constructed with `manual = true`).
     member _.PumpToIdleAsync(?cancellationToken: CancellationToken) : Task =

--- a/tests/Tests.FSharp/Runtime/FerryThrottler.Tests.fs
+++ b/tests/Tests.FSharp/Runtime/FerryThrottler.Tests.fs
@@ -406,3 +406,31 @@ let ``contextual throttler threads each item's context to its boat (explicit Arr
         do! throttler.CompleteAsync()
         List.ofSeq seen |> should equal [ struct (1, "ctx-a"); struct (2, "ctx-b") ]
     }
+
+
+[<Fact>]
+let ``contextual throttler captures ambient context AT the enqueue boundary, not at process`` () : Task =
+    // Capture-at-the-boundary (Itron pattern): the ambient is snapshotted on the
+    // enqueuer's flow at EnqueueCapturedAsync time and threaded as data. Mutating
+    // the ambient AFTER enqueue must NOT change what the boat sees — proving the
+    // snapshot happened at the door, not at processing.
+    task {
+        let ambient = AsyncLocal<string>()
+        let seen = ConcurrentQueue<struct (int * string)>()
+        let processBatch (boat: ReadOnlyMemory<struct (int * string)>) (_ct: CancellationToken) : Task =
+            for i in 0 .. boat.Length - 1 do seen.Enqueue(boat.Span.[i])
+            Task.CompletedTask
+        use throttler =
+            new ContextualFerryThrottler<int, string>(
+                FerryThrottlerConfig.deterministic,
+                processBatch,
+                manual = true,
+                capture = (fun () -> ambient.Value))
+        ambient.Value <- "at-enqueue"
+        do! throttler.EnqueueCapturedAsync(1) // snapshots "at-enqueue"
+        ambient.Value <- "changed-after" // mutate the ambient AFTER the door
+        do! throttler.PumpToIdleAsync()
+        do! throttler.CompleteAsync()
+        // The boat sees the enqueue-time snapshot, not the later mutation.
+        List.ofSeq seen |> should equal [ struct (1, "at-enqueue") ]
+    }


### PR DESCRIPTION
Option-A increment 2: capture-at-the-boundary context.

ContextualFerryThrottler gains an optional capture reader + EnqueueCapturedAsync(item) — the ambient (Activity/IntrCtx/AsyncLocal) is snapshotted at the enqueue door and threaded as data (the Itron "capture so I can pass it through" pattern; explicit-Arrow, nothing ambient flows into the ferry). Test proves snapshot-at-enqueue: mutating the ambient after enqueue does not change the boat's value. Full-solution build 0 warnings; 18/18 tests pass.

Roadmap: explicit ctx (#8094) -> capture-at-boundary (this) -> result-arity ctx -> background-ferry replay.

Generated with Claude Code
