### PR TITLE
feat(ferry): ContextualResultFerryThrottler — result-arity context (Option-A increment 3)

### DIFF
--- a/src/Core/FerryThrottler.fs
+++ b/src/Core/FerryThrottler.fs
@@ -533,3 +533,45 @@ type ContextualFerryThrottler<'TItem, 'Ctx>
 
     interface IDisposable with
         member _.Dispose() = (inner :> IDisposable).Dispose()
+
+
+/// **ContextualResultFerryThrottler** — the request/response (result) arity with
+/// explicit context threading (Option-A increment 3). Each submitted item carries
+/// the caller's context — supplied explicitly or captured at the door — threaded as
+/// DATA to the boat processor; the per-item `Task<'TResult>` still fans back to the
+/// caller. Composes `FerryThrottler<struct('TItem*'Ctx), 'TResult>`, mirroring
+/// `ContextualFerryThrottler` for the result arity. (Background ferries: the
+/// synchronous manual-pump is single-arity-only today — result-arity replay is the
+/// later "full background" increment.)
+[<Sealed>]
+type ContextualResultFerryThrottler<'TItem, 'Ctx, 'TResult>
+    (config: FerryThrottlerConfig,
+     processBatch: ReadOnlyMemory<struct ('TItem * 'Ctx)> -> CancellationToken -> Task<'TResult array>,
+     ?itemSizeBytes: 'TItem -> int,
+     // Capture-at-the-boundary reader (see ContextualFerryThrottler): snapshots the
+     // ambient on the caller's flow at ProcessCapturedAsync time, threaded as data.
+     ?capture: unit -> 'Ctx) =
+
+    let innerSizer =
+        itemSizeBytes |> Option.map (fun f -> fun (struct (item, _ctx): struct ('TItem * 'Ctx)) -> f item)
+
+    let inner =
+        new FerryThrottler<struct ('TItem * 'Ctx), 'TResult>(
+            config, processBatch, ?itemSizeBytes = innerSizer)
+
+    /// Submit one item with an explicit context; returns that item's result task.
+    member _.ProcessAsync(item: 'TItem, context: 'Ctx, ?cancellationToken: CancellationToken) : Task<'TResult> =
+        inner.ProcessAsync(struct (item, context), ?cancellationToken = cancellationToken)
+
+    /// Capture-at-the-boundary submit: snapshots the ambient context now and threads it.
+    member _.ProcessCapturedAsync(item: 'TItem, ?cancellationToken: CancellationToken) : Task<'TResult> =
+        match capture with
+        | Some readAmbient ->
+            inner.ProcessAsync(struct (item, readAmbient ()), ?cancellationToken = cancellationToken)
+        | None -> invalidOp "ProcessCapturedAsync requires a `capture` reader supplied at construction"
+
+    /// Signal completion and await the queue draining.
+    member _.CompleteAsync() : Task = inner.CompleteAsync()
+
+    interface IDisposable with
+        member _.Dispose() = (inner :> IDisposable).Dispose()

--- a/tests/Tests.FSharp/Runtime/FerryThrottler.Tests.fs
+++ b/tests/Tests.FSharp/Runtime/FerryThrottler.Tests.fs
@@ -434,3 +434,25 @@ let ``contextual throttler captures ambient context AT the enqueue boundary, not
         // The boat sees the enqueue-time snapshot, not the later mutation.
         List.ofSeq seen |> should equal [ struct (1, "at-enqueue") ]
     }
+
+
+[<Fact>]
+let ``contextual result throttler threads context and fans aligned results back`` () : Task =
+    // Result arity with explicit context: each item's context rides to the boat,
+    // and the per-item Task<'TResult> still returns the aligned result.
+    task {
+        let processBatch (boat: ReadOnlyMemory<struct (int * string)>) (_ct: CancellationToken) : Task<string array> =
+            task {
+                return
+                    [| for i in 0 .. boat.Length - 1 do
+                           let struct (n, ctx) = boat.Span.[i]
+                           sprintf "%d@%s" n ctx |]
+            }
+        use throttler =
+            new ContextualResultFerryThrottler<int, string, string>(FerryThrottlerConfig.deterministic, processBatch)
+        let t1 = throttler.ProcessAsync(1, "a")
+        let t2 = throttler.ProcessAsync(2, "b")
+        let! results = Task.WhenAll([| t1; t2 |])
+        do! throttler.CompleteAsync()
+        results |> should equal [| "1@a"; "2@b" |]
+    }


### PR DESCRIPTION
Option-A increment 3: result-arity context.

ContextualResultFerryThrottler<'TItem,'Ctx,'TResult> — explicit context on the request/response arity: ProcessAsync(item, ctx) or ProcessCapturedAsync(item) (capture-at-boundary); context threaded as data to the boat, per-item Task<'TResult> fans the aligned result back. Composes FerryThrottler<struct('TItem*'Ctx),'TResult>. Background ferries (result-arity manual-pump replay is the later increment). Full-solution build 0 warnings; 19/19 tests pass.

Roadmap: explicit ctx (#8094) -> capture-at-boundary (#8097) -> result-arity ctx (this) -> background-ferry replay.
