### PR TITLE
docs(governance): shared checkout is view-only — cross-harness rule (§35)

### DIFF
--- a/.claude/rules/shared-checkout-is-view-only.md
+++ b/.claude/rules/shared-checkout-is-view-only.md
@@ -1,5 +1,9 @@
 # Shared checkout is a view, not a workspace
 
+> **Cross-harness:** this is the Claude-side surface of `GOVERNANCE.md §35`
+> (canonical, all harnesses) and `AGENTS.md` §"Shared checkout is VIEW-ONLY"
+> (the on-load surface every harness reads). Same rule, three surfaces.
+
 Carved sentence:
 
 > The shared checkout `/Users/acehack/Documents/src/repos/Zeta` is everyone's

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,22 @@ the form `GOVERNANCE.md §N`.
 
 Every contributor decision flows from that.
 
+## Shared checkout is VIEW-ONLY — work in your own clone (ALL harnesses)
+
+The operator's primary checkout (e.g.
+`/Users/acehack/Documents/src/repos/Zeta`) is everyone's **read-only VIEW** of
+`origin/main` — **never a workspace**, for **any** harness (Claude, Codex,
+Gemini, Kiro/Qwen, Cursor, Copilot, …). Work in your **OWN clone** (one per
+writer / loop / ticksource) and push to `origin/main` from there. In the shared
+checkout: **never edit, commit, branch, or `git stash`** — `git pull` to refresh
+the view, nothing else. Two harnesses writing the same checkout race and churn
+each other's work (the fleet has been bitten repeatedly — concurrent stashes;
+branches left behind in the shared checkout). **A bus/routing address is not
+identity.** Canonical numbered rule: `GOVERNANCE.md §35`. Full model:
+[`docs/writer-actor-routing-model.md`](docs/writer-actor-routing-model.md)
+(clone-per-writer). Claude-specific surface of the same rule:
+`.claude/rules/shared-checkout-is-view-only.md`.
+
 ## The vibe-coded hypothesis
 
 The human maintainer has written **zero lines of code**

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -899,3 +899,29 @@ than renumbering the rest.
     audit critique of narration-over-action ([2026-05-20](docs/research/2026-05-20-shadow-lesson-log-otto-paralysis.md))
     plus the 70+ shadow lesson logs under `docs/research/`
     catalogue the failure mode this rule prevents.
+
+35. **Shared checkout is view-only; work in your own
+    clone.** The operator's primary checkout (e.g.
+    `/Users/acehack/Documents/src/repos/Zeta`) is
+    everyone's read-only VIEW of `origin/main` — never a
+    workspace, for any harness (Claude, Codex, Gemini,
+    Kiro/Qwen, Cursor, Copilot, …). Each writer / loop /
+    ticksource works in its OWN clone and pushes to
+    `origin/main` from there. In the shared checkout:
+    never edit, commit, branch, or `git stash` — `git
+    pull` to refresh the view, nothing else. Two harnesses
+    writing the same checkout race and churn each other's
+    work: a `git stash` is indexed (`stash@{0}`) and the
+    index shifts under concurrent pushes, so a `pop`/`drop`
+    hits the wrong entry. The fleet has been bitten
+    repeatedly (otto-cli 2026-05-31; Otto 2026-06-04,
+    Lior's WIP churned; branches left behind in the shared
+    checkout, 2026-06-13). A bus/routing address is not
+    identity. Full model:
+    [`docs/writer-actor-routing-model.md`](docs/writer-actor-routing-model.md)
+    (clone-per-writer; persona=owner vs actor=clone/loop).
+    Claude-side surface of the same rule:
+    [`.claude/rules/shared-checkout-is-view-only.md`](.claude/rules/shared-checkout-is-view-only.md).
+    Onboarding surface every harness reads on load:
+    [`AGENTS.md`](AGENTS.md) §"Shared checkout is
+    VIEW-ONLY".

--- a/docs/BOOTSTRAP-TEMPLATE.md
+++ b/docs/BOOTSTRAP-TEMPLATE.md
@@ -27,6 +27,12 @@ file is wrong and must be reconciled — not the other way around.
 A harness bootstrap file's content is therefore mostly *pointers* and
 *harness-specific mechanics*, never a re-statement of repo-wide rules.
 
+One floor every harness inherits and must not break: the operator's
+shared checkout is a **read-only view** — every writer/loop works in its
+**own clone** (`GOVERNANCE.md §35`; `AGENTS.md` §"Shared checkout is
+VIEW-ONLY"). A new harness's worktree/isolation mechanics (step 5) fill
+in *how* it gets its own clone, never *whether* it needs one.
+
 ## Universal vs harness-specific
 
 The six-step process is **universal** — identical across every harness.


### PR DESCRIPTION
## Why

Aaron: *"make some rule about shared repo isolation you guys keep forgetting that"* + *"so every agent sees it on load"* + *".claude/rules is only claude"* + *"search out other harnesses do it too."*

The shared-checkout-is-view-only discipline existed **only** as a Claude rule (`.claude/rules/`), so non-Claude harnesses never saw it on load. Kiro/Qwen left local branches in the shared checkout on 2026-06-13 — the exact failure this prevents.

## Survey

Every harness bootstrap already treats `AGENTS.md` as authoritative and reads it on load: CLAUDE ✓, GEMINI ✓, KIRO ✓ (3×), CODEX `.codex/AGENTS.md` ✓ (5×), Copilot ✓ (7×). So `AGENTS.md` is the universal on-load surface; `GOVERNANCE.md §N` is where the citeable numbered rule lives.

## Change (same rule, three surfaces + the template)

- **`AGENTS.md`** — new top-level §"Shared checkout is VIEW-ONLY", placed high (right after Status) so every harness sees it on load.
- **`GOVERNANCE.md §35`** — canonical numbered rule, citeable cross-harness.
- **`docs/BOOTSTRAP-TEMPLATE.md`** — names own-clone isolation as a floor every *new* harness inherits (step-5 mechanics decide *how*, never *whether*).
- **`.claude/rules/shared-checkout-is-view-only.md`** — annotated as the Claude-side surface of §35.

markdownlint clean on all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
