### PR TITLE
feat(ferry): background-ferry replay seam — injectable SynchronizationContext (Option-A 4a)

### DIFF
--- a/docs/research/2026-06-13-ferrythrottler-background-ferry-replay-injected-synchronizationcontext-increment-4.md
+++ b/docs/research/2026-06-13-ferrythrottler-background-ferry-replay-injected-synchronizationcontext-increment-4.md
@@ -1,0 +1,132 @@
+# FerryThrottler background-ferry replay via an injected `SynchronizationContext` (Option-A increment 4)
+
+**Date:** 2026-06-13 · **Author:** Otto (shadow) · **Status:** design sketch / target
+**Lineage:** Option-A async-context-threading roadmap (increments 1–3 landed: #8094 / #8097 / #8098).
+This is the documented "remaining piece."
+
+## The problem, stated precisely
+
+The `FerryThrottler` is **self-clocked, anti-Nagle** — it adds *no artificial
+timer or delay* (top doc comment; Van Jacobson ACK-clocking, 1988). So, unlike
+most batching machinery, **there is no wall-clock to virtualize** for DST. The
+only source of nondeterminism in the *background* path is the **task scheduling
+of the ferry loops themselves**:
+
+```fsharp
+let runFerry () : Task = backgroundTask { … await reader.WaitToReadAsync ct … }
+let ferryTasks = if isManual then [||] else Array.init ferries (fun _ -> runFerry ())
+```
+
+`backgroundTask { }` deliberately runs on the **threadpool with no captured
+context** (it strips `SynchronizationContext`). Consequences:
+
+- **DoP=N:** the interleaving of the N ferries draining one channel is decided by
+  the threadpool — nondeterministic, not replayable.
+- **DoP=1:** even the single ferry's drain timing *relative to the producer's
+  enqueues* is threadpool-dependent — so batch boundaries (which items ride which
+  boat) are not replayable.
+
+Increment-1–3 work (`ContextualFerryThrottler`, capture-at-boundary, result
+arity) threaded the **caller's** context as data through the queue. The DST seam
+that shipped (Option B, `?manual` + `PumpToIdleAsync`, #8084) sidesteps the
+problem by spawning **no** background ferry — the caller pumps synchronously on
+its own flow. That is fully deterministic but it is **not the background path**:
+you must *choose* manual mode to get determinism.
+
+**Increment 4 goal:** make the *background* path itself replayable, so DST does
+not require giving up the production code path.
+
+## Why `SynchronizationContext`, not `TaskScheduler`
+
+A `TaskScheduler` injected at `Task.Factory.StartNew` only controls where the
+*initial synchronous segment* of the ferry runs. The ferry's nondeterminism is
+in its **`await` continuations** (`WaitToReadAsync` completing when an item is
+written; `processBatch` completing). Continuation routing in .NET is governed by
+the ambient `SynchronizationContext` (the `ConfigureAwait(true)` default that
+F#'s `task { }` honours). So the correct seam is a `SynchronizationContext`:
+
+- Run each ferry **under an injected `SynchronizationContext`**. Every `await` in
+  the loop then `Post`s its continuation back to that context.
+- A **deterministic, single-threaded, pumpable** context runs those `Post`ed
+  continuations in **FIFO order** — so N ferries draining one channel interleave
+  in a fixed, seed-independent, replayable order, driven by the test/sim that
+  pumps the context.
+- This is the "SynchronizationContext game" + the Itron thread-context capture
+  the maintainer named (2026-06-13): *"we likely do want to play the
+  synchronizationcontext game … in my itron version I do captures of thread
+  context so I can pass it through."*
+
+This is the **noninterference discipline** (manifesto §13 / discipline #7) made
+concrete for the ferry: entropy/scheduling enters **only through the injected
+context** (a declared, metered door), never the ambient threadpool. Default =
+no context injected = today's `backgroundTask`/threadpool path, **byte-identical
+for production** and fully reversible (§15).
+
+## The seam (4a — minimal, prod-preserving)
+
+Single additive optional ctor arg on `FerryThrottler<'TItem>` (and later the
+result + contextual arities):
+
+```fsharp
+?syncContext: SynchronizationContext
+```
+
+- **None (default):** `runFerry` uses `backgroundTask { }` exactly as today.
+  Production is untouched; the existing test suite is untouched.
+- **Some sc:** the ferry runs *under* `sc` — the loop body is the **same**
+  `fillBoat`-driven code (single source of boat-building truth preserved), but
+  started so that `SynchronizationContext.SetSynchronizationContext sc` is in
+  effect on the ferry's execution flow (off the ctor thread — never pollute the
+  constructing thread's context), so awaits capture `sc`.
+
+`PumpToIdleAsync` / `?manual` stay exactly as-is — Option B remains the
+zero-dependency DST path; the injected context is the *additional* path that
+makes the **background** ferries replayable.
+
+### What 4a proves (a true, narrow claim — not over-stated)
+
+A focused test with a deterministic pumpable `SynchronizationContext` (test
+scaffolding) proves: **with `syncContext` injected, the background ferry's `await`
+continuations are routed to that context and run only when it is pumped** — i.e.
+the background ferry's scheduling is now under the injected door, not the
+threadpool. This is the load-bearing mechanism; it is *not yet* the full
+"N-ferry deterministic replay across a seeded run" claim.
+
+## Deferred to 4b
+
+- **Full N-ferry deterministic-interleaving replay**: a seeded run that asserts
+  the *boat composition* (which items ride which boat) is byte-identical across
+  replays at DoP≥2. Needs the deterministic context promoted into Core as an
+  **earned** sim primitive (a class with state ⇒ weight ⇒ earned under `rules/`,
+  per `interfaces-free-classes-earned-under-rules` — the DST + injected-Source
+  boundary is the earning) and a golden-vector-style replay assertion.
+- Wiring the same `?syncContext` through `ContextualFerryThrottler` /
+  `ContextualResultFerryThrottler` (the increment-1–3 wrappers forward optional
+  args; the addition is mechanical once the core arity is proven).
+- The result arity (`FerryThrottler<'TItem,'TResult>`) ferry loop.
+
+## Anchors (Beacon)
+
+- **Self-clocking:** Van Jacobson, *Congestion Avoidance and Control* (SIGCOMM
+  1988) — ACK-clocking, the reason there is no timer to virtualize here.
+- **Single-thread deterministic replay:** Zhou et al., *FoundationDB* (SIGMOD
+  2021); Will Wilson, *Testing Distributed Systems w/ Deterministic Simulation*
+  (Strange Loop 2014).
+- **Noninterference:** Goguen & Meseguer, *Security Policies and Security Models*
+  (1982) — entropy only through declared, metered channels.
+- **Thread-context capture (human anchor):** the maintainer's Itron
+  `Platform.Capability/.../Util/AsyncState.cs` (`Lazy<AsyncLocal<T>>` carrier)
+  and `Platform.DotNet` `Threading.Tasks.Throttling`.
+- **The explicit-Arrow alternative to ambient capture:** `IntrCtx.ISR<'A,'B>`,
+  `Traced.withCtx`, and `Tracing.fs`'s "grubby hidden side channel" note — why
+  context travels as data, with the injected `SynchronizationContext` as the
+  *one* sanctioned BCL door for await-continuation routing.
+
+## Pointers
+
+- `src/Core/FerryThrottler.fs` — the seam site (`runFerry`, `ferryTasks`,
+  `?manual`, `PumpToIdleAsync`).
+- `memory/project_option_a_async_context_threading_roadmap_ferrythrottler_2026_06_13.md`
+  — the roadmap this closes.
+- `.claude/rules/async-all-the-way-truthful-signatures.md` ·
+  `.claude/rules/dv2-data-split-discipline-activated.md` (#7 noninterference).

--- a/src/Core/FerryThrottler.fs
+++ b/src/Core/FerryThrottler.fs
@@ -105,10 +105,19 @@ type FerryThrottler<'TItem>
      // caller drives processing synchronously via `PumpToIdleAsync` on its own
      // thread (deterministic, replayable, zero wall-clock). Intended for the
      // DoP=1 simulation / seed / test path. Default false = production background
-     // ferries. Future enhancement (tracked separately): a SynchronizationContext
-     // / Arrow thread-context capture so the BACKGROUND ferries are themselves
-     // replayable — then manual mode is no longer the only deterministic option.
-     ?manual: bool) =
+     // ferries.
+     ?manual: bool,
+     // DST seam (Option A, increment 4): when provided, the background ferries run
+     // *under* this `SynchronizationContext`, so every `await` in the ferry loop
+     // (`WaitToReadAsync`, `processBatch`) routes its continuation to it. Inject a
+     // deterministic, single-threaded, pumpable context and the BACKGROUND ferries
+     // become replayable — without giving up the production code path (the way
+     // `?manual` does). Default `None` = today's threadpool path, byte-identical
+     // for production. This is the noninterference door (manifesto §13): ferry
+     // scheduling enters only through the injected context, never the ambient
+     // threadpool. Design: docs/research/2026-06-13-ferrythrottler-background-
+     // ferry-replay-injected-synchronizationcontext-increment-4.md.
+     ?syncContext: SynchronizationContext) =
 
     do
         if config.MaxDegreeOfParallelism < 1 then
@@ -186,8 +195,16 @@ type FerryThrottler<'TItem>
             | _ -> draining <- false
         n
 
-    let runFerry () : Task =
-        backgroundTask {
+    let injectedSyncContext = syncContext
+
+    // The ferry loop body — a context-CAPTURING `task` (unlike `backgroundTask`,
+    // its `await`s honour the ambient `SynchronizationContext`). WHERE its
+    // continuations resume is therefore decided by the context in effect when it
+    // is launched: null on the threadpool (production), or the injected context
+    // (Option-A increment 4). The body itself is identical on both paths — the
+    // single source of ferry-loop truth, mirroring `fillBoat` for boat-building.
+    let ferryLoop () : Task =
+        task {
             let reader = inbox.Reader
             let buffer = Array.zeroCreate<'TItem> config.MaxBatchSize
             let ct = cts.Token
@@ -211,6 +228,36 @@ type FerryThrottler<'TItem>
                             Array.Clear(buffer, 0, n)
             with :? OperationCanceledException -> ()
         }
+
+    let runFerry () : Task =
+        match injectedSyncContext with
+        | None ->
+            // Production: run on the threadpool with no captured context — awaits
+            // resume on the threadpool (equivalent to `backgroundTask`). The loop's
+            // synchronous prefix reads no ctor-thread-affine state, so launching it
+            // via `Task.Run` rather than the ctor thread is observationally identical.
+            Task.Run(fun () -> ferryLoop ())
+        | Some sc ->
+            // Option-A increment 4: launch the ENTIRE ferry onto the injected
+            // context. The ferry does not begin until the context is pumped, and —
+            // because `sc` is current when it starts — every `await` re-posts its
+            // continuation back to `sc`. So the whole ferry lifecycle is pump-gated:
+            // no threadpool, no startup race, replayable in the order the context
+            // runs its posted callbacks. Never touches the ctor thread's context.
+            let tcs = TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
+            sc.Post(
+                (fun _ ->
+                    SynchronizationContext.SetSynchronizationContext sc
+                    let loop = ferryLoop ()
+                    loop.ContinueWith(
+                        (fun (c: Task) ->
+                            if c.IsFaulted then tcs.TrySetException(c.Exception :> exn) |> ignore
+                            elif c.IsCanceled then tcs.TrySetCanceled() |> ignore
+                            else tcs.TrySetResult() |> ignore),
+                        TaskContinuationOptions.ExecuteSynchronously)
+                    |> ignore),
+                null)
+            tcs.Task
 
     // Production: start `ferries` background ferries now. Manual/DST mode: start
     // none — the caller drives via `PumpToIdleAsync`.

--- a/tests/Tests.FSharp/Runtime/FerryThrottler.Tests.fs
+++ b/tests/Tests.FSharp/Runtime/FerryThrottler.Tests.fs
@@ -456,3 +456,79 @@ let ``contextual result throttler threads context and fans aligned results back`
         do! throttler.CompleteAsync()
         results |> should equal [| "1@a"; "2@b" |]
     }
+
+
+// ═══════════════════════════════════════════════════════════════════
+// Option-A increment 4 — background-ferry replay via an injected
+// SynchronizationContext. Design:
+// docs/research/2026-06-13-ferrythrottler-background-ferry-replay-injected-synchronizationcontext-increment-4.md
+// ═══════════════════════════════════════════════════════════════════
+
+/// A deterministic, single-threaded, pumpable `SynchronizationContext` — test
+/// scaffolding for the increment-4 seam (4b promotes the Core-resident, earned
+/// sim version). `Post` captures the callback into a FIFO queue; NOTHING runs
+/// ambiently. `PumpToIdle` runs queued callbacks in registration order until none
+/// remain (a callback may post more — those run too). `PostedCount` lets a test
+/// assert the ferry routed its continuations through THIS door, not the threadpool.
+type private DeterministicSyncContext() =
+    inherit SynchronizationContext()
+    let queue = System.Collections.Generic.Queue<SendOrPostCallback * obj>()
+    let mutable posted = 0
+    override _.Post(d, state) =
+        lock queue (fun () ->
+            posted <- posted + 1
+            queue.Enqueue(d, state))
+    // Captured copies must still route to THIS queue, or determinism leaks.
+    override this.CreateCopy() = this :> SynchronizationContext
+    /// Total callbacks posted to this context over its lifetime.
+    member _.PostedCount = lock queue (fun () -> posted)
+    /// Run posted callbacks (FIFO) until the queue is empty.
+    member _.PumpToIdle() =
+        let mutable go = true
+        while go do
+            let next =
+                lock queue (fun () ->
+                    if queue.Count > 0 then ValueSome(queue.Dequeue()) else ValueNone)
+            match next with
+            | ValueSome(d, s) -> d.Invoke s
+            | ValueNone -> go <- false
+
+
+[<Fact>]
+let ``background ferry runs under the injected SynchronizationContext — pump-gated, no threadpool`` () : Task =
+    // With a context injected, the WHOLE background ferry is gated on pumping that
+    // context: it does not start, and processes nothing, until the context is
+    // pumped — proving its scheduling routes through the injected door, never the
+    // ambient threadpool. (A true, narrow 4a claim; full N-ferry seeded-replay is 4b.)
+    task {
+        let processed = ConcurrentQueue<int>()
+        let processBatch (boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task =
+            for i in 0 .. boat.Length - 1 do processed.Enqueue(boat.Span.[i])
+            Task.CompletedTask
+        let ctx = DeterministicSyncContext()
+        // DoP=1 background ferry (manual NOT set) bound to the deterministic context.
+        use throttler =
+            new FerryThrottler<int>(FerryThrottlerConfig.deterministic, processBatch, syncContext = ctx)
+
+        // Enqueue synchronously (unbounded channel). The ferry was launched as a
+        // posted callback in the ctor — so it is queued on the door, not running.
+        for x in [ 1; 2; 3; 4; 5 ] do
+            do! throttler.EnqueueAsync(x)
+
+        // BEFORE any pump: nothing processed (race-free — the ferry cannot run
+        // until its launch callback is pumped), yet the door already holds it.
+        List.ofSeq processed |> should equal ([]: int list)
+        ctx.PostedCount |> should be (greaterThanOrEqualTo 1)
+
+        // Pump: the ferry starts, drains every queued item into one boat, then
+        // parks at WaitToReadAsync (queue empty, writer still open).
+        ctx.PumpToIdle()
+        List.ofSeq processed |> should equal [ 1; 2; 3; 4; 5 ]
+
+        // Complete the writer, then pump again so the parked ferry observes
+        // completion and exits — its termination is pump-driven too.
+        let completion = throttler.CompleteAsync()
+        ctx.PumpToIdle()
+        do! completion
+        completion.IsCompletedSuccessfully |> should equal true
+    }


### PR DESCRIPTION
## What

Closes the documented remaining piece of the **Option-A async-context-threading roadmap** (increments 1–3 landed: #8094 / #8097 / #8098) — **background-ferry replay** via an injectable `SynchronizationContext`.

## Why

The `FerryThrottler` is self-clocked anti-Nagle — **no artificial timer**, so there is no wall-clock to virtualize for DST. The only background-path nondeterminism is the ferry loops' **task scheduling**: `backgroundTask {}` runs them on the threadpool with no captured context, so at DoP=N the interleaving (and even at DoP=1 the drain timing vs the producer) is not replayable. The shipped Option-B (`?manual` + `PumpToIdleAsync`, #8084) gets determinism by spawning **no** ferry — you must *choose* manual mode. This PR makes the **background** path itself replayable without giving up the production code path.

## The seam (4a — additive, prod-preserving)

- New optional ctor arg **`?syncContext: SynchronizationContext`** on the single-arity `FerryThrottler`.
  - **`None` (default):** today's threadpool path, **byte-identical for production**; existing tests untouched.
  - **`Some sc`:** the *entire* ferry is launched onto `sc` (via `Post`) — it does not start until the context is pumped, and every `await` re-posts its continuation to `sc`. The whole lifecycle is **pump-gated, race-free, replayable** in the context's run order. Never touches the ctor thread's context.
- Factored the ferry loop body into one context-capturing `task` (single source of ferry-loop truth, mirroring `fillBoat`); prod and injected paths differ only in *how* it is launched.
- This is the **noninterference door** (manifesto §13 / discipline #7): ferry scheduling enters only through the injected context, never the ambient threadpool.

## Why `SynchronizationContext`, not `TaskScheduler`

A `TaskScheduler` only controls the *initial synchronous segment*; the ferry's nondeterminism is in its **`await` continuations** (`WaitToReadAsync`, `processBatch`), and continuation routing is governed by the ambient `SynchronizationContext` (the `ConfigureAwait(true)` default F#'s `task {}` honours). Full rationale + prior art (Itron `AsyncState`, FoundationDB, Goguen–Meseguer) in the design doc.

## Proof (a true, narrow 4a claim — full N-ferry seeded replay is 4b)

A deterministic pumpable `SynchronizationContext` shows the background ferry processes **nothing until the context is pumped** (race-free: asserted *before* any pump), then drains in order, and even its termination is pump-driven. **20/20** FerryThrottler tests pass — including the existing DoP=N / backpressure / cancellation background tests, confirming prod-path equivalence.

## Deferred to 4b (named in the design doc)

Full N-ferry deterministic-interleaving seeded replay; promoting the deterministic context into Core as an *earned* sim primitive; wiring `?syncContext` through the contextual + result arities.

Design + 4a/4b split: `docs/research/2026-06-13-ferrythrottler-background-ferry-replay-injected-synchronizationcontext-increment-4.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
