### PR TITLE
feat(vision): add prediction inference kernel

### DIFF
--- a/src/Core/Chip8Observer.fs
+++ b/src/Core/Chip8Observer.fs
@@ -39,3 +39,58 @@ module Chip8Observer =
         let branches = SoftChip8.forkOnInput f
         let i = if List.isEmpty branches then 0 else min idx (List.length branches - 1)
         fst (List.item i branches)
+
+    let private branchLabel (f: Chip8Cow.Frame) (index: int) =
+        if SoftChip8.branchesOnInput f then
+            match index with
+            | 0 -> "key-down"
+            | 1 -> "key-up"
+            | _ -> sprintf "key-branch-%d" index
+        else
+            "deterministic"
+
+    /// CHIP-8 adapter over the source-owned prediction kernel. Belief remains
+    /// exact rational; Vision owns the branch budget; no external inference
+    /// library is needed.
+    let inferenceCandidates
+        (belief: ReflectionEngine.Belief)
+        (costOf: Chip8Cow.Frame -> Vision.BranchCost)
+        (f: Chip8Cow.Frame)
+        : Result<PredictionInference.Candidate<Chip8Cow.Frame> list, PredictionInference.Feedback> =
+        let branches = SoftChip8.forkOnInput f |> List.map fst
+        let observation = forkObservation f
+        if belief.Length <> branches.Length || observation.Length <> branches.Length then
+            Error PredictionInference.EmptyCandidates
+        else
+            branches
+            |> List.mapi (fun i frame ->
+                let candidate: PredictionInference.Candidate<Chip8Cow.Frame> =
+                    { Label = branchLabel f i
+                      State = frame
+                      Prior = belief.[i]
+                      Likelihood = observation.[i]
+                      Cost = costOf frame }
+
+                candidate)
+            |> Ok
+
+    let infer
+        (belief: ReflectionEngine.Belief)
+        (costOf: Chip8Cow.Frame -> Vision.BranchCost)
+        (f: Chip8Cow.Frame)
+        : Result<PredictionInference.Inference<Chip8Cow.Frame>, PredictionInference.Feedback> =
+        result {
+            let! candidates = inferenceCandidates belief costOf f
+            return! PredictionInference.infer candidates
+        }
+
+    let predictBudgeted
+        (belief: ReflectionEngine.Belief)
+        (costOf: Chip8Cow.Frame -> Vision.BranchCost)
+        (tank: SoftThrottle.Tank)
+        (f: Chip8Cow.Frame)
+        : Result<PredictionInference.Prediction<Chip8Cow.Frame>, PredictionInference.Feedback> =
+        result {
+            let! inference = infer belief costOf f
+            return! PredictionInference.predict tank inference
+        }

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -178,6 +178,7 @@
     <Compile Include="Incremental.fs" />
     <Compile Include="Dsl.fs" />
     <Compile Include="Vision.fs" />
+    <Compile Include="PredictionInference.fs" />
     <Compile Include="Query.fs" />
     <Compile Include="Injection.fs" />
     <Compile Include="InjectionExt.fs" />

--- a/src/Core/PredictionInference.fs
+++ b/src/Core/PredictionInference.fs
@@ -1,0 +1,125 @@
+namespace Zeta.Core
+
+open System
+
+/// Tiny source-owned prediction inference kernel.
+///
+/// This is deliberately not an adapter to Infer.NET, Q#, or any other oracle:
+/// candidates are scored with the exact rational probability cell already in
+/// Core, ranked deterministically, then handed to Vision for honest
+/// byte/time/uncertainty budgeting.
+[<RequireQualifiedAccess>]
+module PredictionInference =
+
+    module PS = ProbabilitySemiring
+
+    type Candidate<'S> =
+        { Label: string
+          State: 'S
+          Prior: PS.Rational
+          Likelihood: PS.Rational
+          Cost: Vision.BranchCost }
+
+    type Scored<'S> =
+        { Candidate: Candidate<'S>
+          PosteriorWeight: PS.Rational
+          Branch: Vision.FutureBranch<'S> }
+
+    type Inference<'S> =
+        { Ranked: Scored<'S> list
+          TotalWeight: PS.Rational
+          Best: Scored<'S> }
+
+    type Prediction<'S> =
+        { Inference: Inference<'S>
+          Budget: Vision.PredictionReport<'S> }
+
+    type Feedback =
+        | EmptyCandidates
+        | NegativePrior of label: string * value: PS.Rational
+        | NegativeLikelihood of label: string * value: PS.Rational
+        | AllCandidatesRefuted
+        | VisionFeedback of Vision.GrowthFeedback
+        | SoftValueRefuted
+
+    let private nonNegative (r: PS.Rational) =
+        PS.compare r PS.zero >= 0
+
+    let private rationalToFloat (r: PS.Rational) : float =
+        float r.Num / float r.Den
+
+    let private compareScored (left: Scored<'S>) (right: Scored<'S>) =
+        let byWeight = PS.compare right.PosteriorWeight left.PosteriorWeight
+        if byWeight <> 0 then
+            byWeight
+        else
+            String.CompareOrdinal(left.Candidate.Label, right.Candidate.Label)
+
+    let infer (candidates: Candidate<'S> list) : Result<Inference<'S>, Feedback> =
+        let rec validate acc total rest =
+            result {
+                match rest with
+                | [] ->
+                    if List.isEmpty acc then
+                        return! Error EmptyCandidates
+                    elif PS.compare total PS.zero = 0 then
+                        return! Error AllCandidatesRefuted
+                    else
+                        let ranked = acc |> List.sortWith compareScored
+                        return
+                            { Ranked = ranked
+                              TotalWeight = total
+                              Best = ranked.Head }
+                | candidate :: tail ->
+                    if not (nonNegative candidate.Prior) then
+                        return! Error(NegativePrior(candidate.Label, candidate.Prior))
+                    elif not (nonNegative candidate.Likelihood) then
+                        return! Error(NegativeLikelihood(candidate.Label, candidate.Likelihood))
+                    else
+                        let posterior = PS.mul candidate.Prior candidate.Likelihood
+                        let branch: Vision.FutureBranch<'S> =
+                            { Label = candidate.Label
+                              State = candidate.State
+                              Cost = candidate.Cost }
+
+                        return! validate ({ Candidate = candidate; PosteriorWeight = posterior; Branch = branch } :: acc) (PS.add total posterior) tail
+            }
+
+        validate [] PS.zero candidates
+
+    let predict (tank: SoftThrottle.Tank) (inference: Inference<'S>) : Result<Prediction<'S>, Feedback> =
+        inference.Ranked
+        |> List.map _.Branch
+        |> fun branches -> Vision.predictBranches branches tank
+        |> Result.mapError VisionFeedback
+        |> Result.map (fun report ->
+            { Inference = inference
+              Budget = report })
+
+    let inferAndPredict
+        (tank: SoftThrottle.Tank)
+        (candidates: Candidate<'S> list)
+        : Result<Prediction<'S>, Feedback> =
+        result {
+            let! inference = infer candidates
+            return! predict tank inference
+        }
+
+    let posteriorShare (scored: Scored<'S>) (inference: Inference<'S>) : PS.Rational =
+        PS.div scored.PosteriorWeight inference.TotalWeight
+
+    let toSoftValue
+        (valueOf: 'S -> DynamicValue)
+        (inference: Inference<'S>)
+        : Result<SoftValue.SoftValue, Feedback> =
+        inference.Ranked
+        |> List.map (fun scored ->
+            valueOf scored.Candidate.State,
+            posteriorShare scored inference |> rationalToFloat)
+        |> SoftValue.ofWeighted
+        |> function
+            | Some value -> Ok value
+            | None -> Error SoftValueRefuted
+
+    let bestState (inference: Inference<'S>) : 'S =
+        inference.Best.Candidate.State

--- a/tests/Tests.FSharp/Chip8Observer.Tests.fs
+++ b/tests/Tests.FSharp/Chip8Observer.Tests.fs
@@ -23,6 +23,12 @@ let private inputBranchFrame () =
     |> Chip8Cow.loadRom [| 0x60uy; 0x00uy; 0xE0uy; 0x9Euy |]
     |> Chip8Cow.step
 
+let private branchCost (_: Chip8Cow.Frame) : Vision.BranchCost =
+    { SpaceBytes = 10L
+      TimeTicks = 1
+      BytesPerTick = 0L
+      UncertaintyResolutionBits = 1 }
+
 [<Fact>]
 let ``fork observation is uniform exact-rational over the branch count (2 at an input branch)`` () =
     let f = inputBranchFrame ()
@@ -55,3 +61,20 @@ let ``predicted frame maps the observer's branch back to the committed emu frame
     let predictedUp = Chip8Observer.predictedFrame [| r 1L 3L; r 2L 3L |] f
     let expectedUp = fst (List.item 1 branches)
     Assert.Equal(expectedUp.PC, predictedUp.PC)
+
+[<Fact>]
+let ``CHIP8 observer uses the source-owned prediction kernel under Vision budget`` () =
+    let f = inputBranchFrame ()
+    let branches = SoftChip8.forkOnInput f
+
+    let prediction =
+        f
+        |> Chip8Observer.predictBudgeted [| r 1L 3L; r 2L 3L |] branchCost (SoftThrottle.tank 11.0 0.0)
+        |> function
+            | Ok value -> value
+            | Error feedback -> failwithf "expected Ok, got %A" feedback
+
+    Assert.Equal("key-up", prediction.Inference.Best.Candidate.Label)
+    Assert.Equal(Vision.PartiallyAdmitted, prediction.Budget.Outcome)
+    Assert.Equal<string list>([ "key-up" ], prediction.Budget.Boarded |> List.map _.Label)
+    Assert.Equal(fst (List.item 1 branches), prediction.Budget.Boarded.Head.State)

--- a/tests/Tests.FSharp/PredictionInference.Tests.fs
+++ b/tests/Tests.FSharp/PredictionInference.Tests.fs
@@ -1,0 +1,78 @@
+module Zeta.Tests.PredictionInferenceTests
+
+open global.Xunit
+open Zeta.Core
+
+module PI = PredictionInference
+module PS = ProbabilitySemiring
+
+let private mustOk =
+    function
+    | Ok value -> value
+    | Error feedback -> failwithf "expected Ok, got %A" feedback
+
+let private cost bytes : Vision.BranchCost =
+    { SpaceBytes = bytes
+      TimeTicks = 0
+      BytesPerTick = 0L
+      UncertaintyResolutionBits = 0 }
+
+let private candidate label state prior likelihood bytes : PI.Candidate<string> =
+    { Label = label
+      State = state
+      Prior = prior
+      Likelihood = likelihood
+      Cost = cost bytes }
+
+[<Fact>]
+let ``exact prediction inference ranks candidates before Vision budgets the branch list`` () =
+    let a = candidate "low" "A" (PS.rat 1L 2L) (PS.rat 1L 3L) 6L
+    let b = candidate "high" "B" (PS.rat 1L 2L) (PS.rat 2L 3L) 7L
+
+    let prediction =
+        [ a; b ]
+        |> PI.inferAndPredict (SoftThrottle.tank 7.0 0.0)
+        |> mustOk
+
+    Assert.Equal("high", prediction.Inference.Best.Candidate.Label)
+    Assert.Equal(Vision.PartiallyAdmitted, prediction.Budget.Outcome)
+    Assert.Equal<string list>([ "high" ], prediction.Budget.Boarded |> List.map _.Label)
+    Assert.Equal<string list>([ "low" ], prediction.Budget.Deferred |> List.map _.Label)
+
+[<Fact>]
+let ``budget backpressure does not rewrite posterior truth`` () =
+    let a = candidate "low" "A" (PS.rat 1L 2L) (PS.rat 1L 3L) 6L
+    let b = candidate "high" "B" (PS.rat 1L 2L) (PS.rat 2L 3L) 7L
+
+    let prediction =
+        [ a; b ]
+        |> PI.inferAndPredict (SoftThrottle.tank 0.0 0.0)
+        |> mustOk
+
+    Assert.Equal("high", prediction.Inference.Best.Candidate.Label)
+    Assert.Equal(Vision.RejectedWithBackpressure, prediction.Budget.Outcome)
+    Assert.Empty prediction.Budget.Boarded
+    Assert.Equal<string list>([ "high"; "low" ], prediction.Budget.Deferred |> List.map _.Label)
+
+[<Fact>]
+let ``exact prediction inference can project to a soft DynamicValue distribution`` () =
+    let a = candidate "low" "A" (PS.rat 1L 2L) (PS.rat 1L 3L) 1L
+    let b = candidate "high" "B" (PS.rat 1L 2L) (PS.rat 2L 3L) 1L
+
+    let inference = PI.infer [ a; b ] |> mustOk
+    let soft =
+        inference
+        |> PI.toSoftValue (fun s -> DynamicValue.String s)
+        |> mustOk
+
+    Assert.Equal(2, SoftValue.candidates soft |> List.length)
+    Assert.Equal(Some(DynamicValue.String "B"), SoftValue.resolve 0.6 soft)
+
+[<Fact>]
+let ``all-refuted candidates return feedback instead of fabricating certainty`` () =
+    let a = candidate "a" "A" PS.one PS.zero 1L
+    let b = candidate "b" "B" PS.one PS.zero 1L
+
+    match PI.infer [ a; b ] with
+    | Error PI.AllCandidatesRefuted -> ()
+    | other -> Assert.Fail(sprintf "expected AllCandidatesRefuted, got %A" other)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -140,6 +140,7 @@
     <Compile Include="SoftScheduler.Tests.fs" />
     <Compile Include="SoftThrottle.Tests.fs" />
     <Compile Include="Vision.Tests.fs" />
+    <Compile Include="PredictionInference.Tests.fs" />
     <Compile Include="RecordedSource.Tests.fs" />
     <Compile Include="SoftIsr.Tests.fs" />
     <Compile Include="SimFramework.Tests.fs" />


### PR DESCRIPTION
## What
- Add a source-owned `PredictionInference` kernel that scores candidates with exact rational prior * likelihood, ranks deterministically, and then lets `Vision` handle byte/time/uncertainty budget admission.
- Wire `Chip8Observer` into the kernel so soft input forks become budgeted future branches with caller-supplied costs.
- Add focused F# tests for ranking, backpressure, SoftValue projection, refuted evidence, and the CHIP-8 observer seam.

## Why
This keeps Q#/Bayesian/Reticulum-style plugins as oracles/adapters instead of making them the runtime. The first runnable kernel is pure Core F#, exception-free, and small enough to expand toward CHIP-9 self-prediction.

## Validation
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release -m:1 /p:UseSharedCompilation=false --filter "FullyQualifiedName~PredictionInference|FullyQualifiedName~Chip8Observer"`
- `dotnet build -c Release -m:1 /p:UseSharedCompilation=false`
- `dotnet test Zeta.sln -c Release -m:1 /p:UseSharedCompilation=false --no-build`
- `dotnet format --verify-no-changes`
- `git diff --check`