### PR TITLE
feat(vision): add attention priority budget ordering

### DIFF
--- a/src/Core/PredictionInference.fs
+++ b/src/Core/PredictionInference.fs
@@ -34,13 +34,27 @@ module PredictionInference =
         { Inference: Inference<'S>
           Budget: Vision.PredictionReport<'S> }
 
+    type BranchPriority =
+        { Attention: PS.Rational
+          Gravity: PS.Rational }
+
     type Feedback =
         | EmptyCandidates
         | NegativePrior of label: string * value: PS.Rational
         | NegativeLikelihood of label: string * value: PS.Rational
+        | NegativeAttention of label: string * value: PS.Rational
+        | NegativeGravity of label: string * value: PS.Rational
         | AllCandidatesRefuted
         | VisionFeedback of Vision.GrowthFeedback
         | SoftValueRefuted
+
+    type private Prioritized<'S> =
+        { Scored: Scored<'S>
+          BoardingWeight: PS.Rational }
+
+    let neutralPriority: BranchPriority =
+        { Attention = PS.one
+          Gravity = PS.one }
 
     let private nonNegative (r: PS.Rational) =
         PS.compare r PS.zero >= 0
@@ -54,6 +68,13 @@ module PredictionInference =
             byWeight
         else
             String.CompareOrdinal(left.Candidate.Label, right.Candidate.Label)
+
+    let private comparePrioritized (left: Prioritized<'S>) (right: Prioritized<'S>) =
+        let byPriority = PS.compare right.BoardingWeight left.BoardingWeight
+        if byPriority <> 0 then
+            byPriority
+        else
+            compareScored left.Scored right.Scored
 
     let infer (candidates: Candidate<'S> list) : Result<Inference<'S>, Feedback> =
         let rec validate acc total rest =
@@ -96,6 +117,44 @@ module PredictionInference =
             { Inference = inference
               Budget = report })
 
+    let predictWithPriority
+        (priorityOf: Scored<'S> -> BranchPriority)
+        (tank: SoftThrottle.Tank)
+        (inference: Inference<'S>)
+        : Result<Prediction<'S>, Feedback> =
+        let rec collect acc rest =
+            result {
+                match rest with
+                | [] ->
+                    let ordered =
+                        acc
+                        |> List.sortWith comparePrioritized
+                        |> List.map (fun prioritized -> prioritized.Scored.Branch)
+
+                    return!
+                        Vision.predictBranches ordered tank
+                        |> Result.mapError VisionFeedback
+                        |> Result.map (fun report ->
+                            { Inference = inference
+                              Budget = report })
+                | scored :: tail ->
+                    let priority = priorityOf scored
+
+                    if not (nonNegative priority.Attention) then
+                        return! Error(NegativeAttention(scored.Candidate.Label, priority.Attention))
+                    elif not (nonNegative priority.Gravity) then
+                        return! Error(NegativeGravity(scored.Candidate.Label, priority.Gravity))
+                    else
+                        let boardingWeight =
+                            scored.PosteriorWeight
+                            |> PS.mul priority.Attention
+                            |> PS.mul priority.Gravity
+
+                        return! collect ({ Scored = scored; BoardingWeight = boardingWeight } :: acc) tail
+            }
+
+        collect [] inference.Ranked
+
     let inferAndPredict
         (tank: SoftThrottle.Tank)
         (candidates: Candidate<'S> list)
@@ -103,6 +162,16 @@ module PredictionInference =
         result {
             let! inference = infer candidates
             return! predict tank inference
+        }
+
+    let inferAndPredictWithPriority
+        (priorityOf: Scored<'S> -> BranchPriority)
+        (tank: SoftThrottle.Tank)
+        (candidates: Candidate<'S> list)
+        : Result<Prediction<'S>, Feedback> =
+        result {
+            let! inference = infer candidates
+            return! predictWithPriority priorityOf tank inference
         }
 
     let posteriorShare (scored: Scored<'S>) (inference: Inference<'S>) : PS.Rational =

--- a/tests/Tests.FSharp/PredictionInference.Tests.fs
+++ b/tests/Tests.FSharp/PredictionInference.Tests.fs
@@ -55,6 +55,40 @@ let ``budget backpressure does not rewrite posterior truth`` () =
     Assert.Equal<string list>([ "high"; "low" ], prediction.Budget.Deferred |> List.map _.Label)
 
 [<Fact>]
+let ``attention priority changes boarding order without rewriting posterior truth`` () =
+    let likely = candidate "likely" "A" (PS.rat 3L 4L) PS.one 6L
+    let attended = candidate "attended" "B" (PS.rat 1L 4L) PS.one 6L
+
+    let prediction =
+        [ likely; attended ]
+        |> PI.inferAndPredictWithPriority
+            (fun scored ->
+                if scored.Candidate.Label = "attended" then
+                    { PI.neutralPriority with Attention = PS.rat 10L 1L }
+                else
+                    PI.neutralPriority)
+            (SoftThrottle.tank 6.0 0.0)
+        |> mustOk
+
+    Assert.Equal("likely", prediction.Inference.Best.Candidate.Label)
+    Assert.Equal<string list>([ "attended" ], prediction.Budget.Boarded |> List.map _.Label)
+    Assert.Equal<string list>([ "likely" ], prediction.Budget.Deferred |> List.map _.Label)
+
+[<Fact>]
+let ``negative attention returns feedback instead of changing arithmetic truth`` () =
+    let candidate = candidate "branch" "A" PS.one PS.one 1L
+
+    match
+        [ candidate ]
+        |> PI.inferAndPredictWithPriority
+            (fun _ -> { PI.neutralPriority with Attention = PS.rat -1L 1L })
+            (SoftThrottle.tank 1.0 0.0)
+    with
+    | Error(PI.NegativeAttention("branch", value)) ->
+        Assert.Equal(0, PS.compare value (PS.rat -1L 1L))
+    | other -> Assert.Fail(sprintf "expected NegativeAttention, got %A" other)
+
+[<Fact>]
 let ``exact prediction inference can project to a soft DynamicValue distribution`` () =
     let a = candidate "low" "A" (PS.rat 1L 2L) (PS.rat 1L 3L) 1L
     let b = candidate "high" "B" (PS.rat 1L 2L) (PS.rat 2L 3L) 1L


### PR DESCRIPTION
## What
- Add exact-rational `BranchPriority` with attention and gravity factors.
- Add `predictWithPriority` and `inferAndPredictWithPriority`, preserving posterior inference while reordering only the `Vision` branch admission list.
- Add tests proving high attention boards first without changing `Inference.Best`, and negative attention returns typed feedback.

## Why
This codifies the rule we want for self-budgeting: attention and gravity change ordering, not arithmetic truth. The byte/time/uncertainty tank remains honest, so high-priority futures still backpressure when they do not fit.

## Validation
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release -m:1 /p:UseSharedCompilation=false --filter "FullyQualifiedName~PredictionInference|FullyQualifiedName~Chip8Observer"`
- `dotnet build -c Release -m:1 /p:UseSharedCompilation=false`
- `dotnet test Zeta.sln -c Release -m:1 /p:UseSharedCompilation=false --no-build`
- `dotnet format --verify-no-changes`
- `git diff --check`