### PR TITLE
feat(ferry): background-ferry seeded replay + lock-free DeterministicSyncContext (Option-A 4b)

### DIFF
--- a/docs/research/2026-06-13-ferrythrottler-background-ferry-replay-injected-synchronizationcontext-increment-4.md
+++ b/docs/research/2026-06-13-ferrythrottler-background-ferry-replay-injected-synchronizationcontext-increment-4.md
@@ -92,18 +92,33 @@ the background ferry's scheduling is now under the injected door, not the
 threadpool. This is the load-bearing mechanism; it is *not yet* the full
 "N-ferry deterministic replay across a seeded run" claim.
 
-## Deferred to 4b
+## 4b — LANDED
 
-- **Full N-ferry deterministic-interleaving replay**: a seeded run that asserts
-  the *boat composition* (which items ride which boat) is byte-identical across
-  replays at DoP≥2. Needs the deterministic context promoted into Core as an
-  **earned** sim primitive (a class with state ⇒ weight ⇒ earned under `rules/`,
-  per `interfaces-free-classes-earned-under-rules` — the DST + injected-Source
-  boundary is the earning) and a golden-vector-style replay assertion.
-- Wiring the same `?syncContext` through `ContextualFerryThrottler` /
-  `ContextualResultFerryThrottler` (the increment-1–3 wrappers forward optional
-  args; the addition is mechanical once the core arity is proven).
-- The result arity (`FerryThrottler<'TItem,'TResult>`) ferry loop.
+- **Full N-ferry deterministic-interleaving replay**: `replayScenario` runs a fixed
+  interleaved (enqueue, pump) sequence twice at DoP=2 and DoP=3 and asserts the boat
+  composition (which items ride which boat, in order) is **identical across runs** —
+  the replay claim — plus item conservation. Done.
+- **Deterministic context promoted into Core** as the earned sim primitive
+  `src/Core/DeterministicSyncContext.fs` (class state = the simulated scheduler's
+  run-queue; earned under the DST + injected-`SynchronizationContext` boundary per
+  `interfaces-free-classes-earned-under-rules`). Lock-free (`ConcurrentQueue` +
+  `Interlocked`, discipline #2). The test file now consumes the Core type.
+- **`?syncContext` wired through** the result arity (`FerryThrottler<'TItem,'TResult>`)
+  and both contextual wrappers (`ContextualFerryThrottler` /
+  `ContextualResultFerryThrottler`), forwarding to the composed core throttler.
+- **One launch seam for every arity**: `FerryLaunch.launch` (None → threadpool
+  `Task.Run`; Some → `Post` the whole ferry onto the context). Single source of
+  launch truth.
+
+### Deadlock caught + fixed during 4b (worth recording)
+
+The pump must own the thread's `SynchronizationContext` for the pump's *duration*
+and restore it after. The first cut set the context inside the launch callback
+without restoring it, leaking it onto the pump/caller thread — the caller's own
+later `await`s then captured the (now-idle) context and deadlocked. Fix:
+`PumpToIdle` installs itself as current with a `try/finally` restore (the standard
+message-pump contract); the launcher touches no thread's context. Tests would hang
+silently (no output) — caught via `--blame-hang-timeout`.
 
 ## Anchors (Beacon)
 

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -133,6 +133,7 @@
     <Compile Include="Fusion.Equation.fs" />
     <Compile Include="Spine.fs" />
     <Compile Include="SpineAsync.fs" />
+    <Compile Include="DeterministicSyncContext.fs" />
     <Compile Include="FerryThrottler.fs" />
     <Compile Include="BalancedSpine.fs" />
     <Compile Include="SpineSelector.fs" />

--- a/src/Core/DeterministicSyncContext.fs
+++ b/src/Core/DeterministicSyncContext.fs
@@ -1,0 +1,108 @@
+namespace Zeta.Core
+
+open System
+open System.Collections.Concurrent
+open System.Threading
+
+/// **DeterministicSyncContext** — a single-threaded, pumpable `SynchronizationContext`
+/// for Deterministic Simulation Testing of async code (Option-A increment 4b).
+///
+/// `Post` captures each continuation into a FIFO queue; **nothing runs ambiently**.
+/// `PumpToIdle` runs the queued continuations in registration order until the queue
+/// is empty (a continuation may post more — those run too). Because every `await`
+/// under this context re-`Post`s its continuation here, an async workload launched
+/// onto it advances **only** when pumped, in a fixed, seed-independent, replayable
+/// order — so the same inputs replay to byte-identical results (FoundationDB-style
+/// single-thread determinism; Zhou et al., SIGMOD 2021).
+///
+/// This is the deterministic implementation of the **noninterference door**
+/// (manifesto §13 / discipline #7): scheduling entropy enters async code only
+/// through this declared, metered channel — never the ambient threadpool. Inject it
+/// where production injects nothing (e.g. `FerryThrottler`'s `?syncContext`) to make
+/// the background path replayable without changing that path.
+///
+/// **Earned class** (per `interfaces-free-classes-earned-under-rules`): a class
+/// carries state ⇒ weight, so it must be justified. The earning: this state (the
+/// FIFO run-queue) **is** the simulated scheduler's queue — the very thing replay
+/// reflects over. A pure interface cannot hold a mutable run-queue; the DST +
+/// injected-`SynchronizationContext` boundary is the rule that earns it. It is a
+/// sim/test primitive, not a production scheduler.
+///
+/// The continuation queue is **lock-free** (discipline #2): a `ConcurrentQueue<T>`
+/// with `Interlocked` on the counter, since `Post` runs from arbitrary threads while
+/// one thread pumps. No hand-rolled CAS class — the BCL queue is the earned-correct
+/// implementation of the lock-free FIFO.
+///
+/// Prior art (Beacon): Stephen Cleary, *Nito.AsyncEx* `AsyncContext` (single-thread
+/// pump-based `SynchronizationContext`); Stephen Toub, "await, SynchronizationContext,
+/// and Console Apps" (the single-threaded-pump pattern); WPF/WinForms
+/// `DispatcherSynchronizationContext` (the marshal-to-one-thread shape this mirrors
+/// for determinism rather than UI affinity). Lock-free FIFO: Michael & Scott,
+/// "Simple, Fast, and Practical Non-Blocking and Blocking Concurrent Queue
+/// Algorithms" (PODC 1996) — the lineage `ConcurrentQueue<T>` implements; CAS
+/// primitive (human anchor): the maintainer's Itron
+/// `Platform.DotNet/Source/Threading/AtomicBoolean.cs` (`Interlocked.CompareExchange`).
+[<Sealed>]
+type DeterministicSyncContext() =
+    inherit SynchronizationContext()
+
+    // Lock-free MPSC handoff: `Post` may enqueue from arbitrary threads while a
+    // single thread pumps. `ConcurrentQueue<T>` is the BCL's lock-free queue
+    // (segment-list CAS enqueue/dequeue, FIFO) — discipline #2 (lock/wait-free)
+    // without a hand-rolled CAS class. `posted` is bumped with `Interlocked`, so the
+    // whole context is lock-free.
+    let queue = ConcurrentQueue<SendOrPostCallback * obj>()
+    let mutable posted = 0
+
+    /// Enqueue a continuation (FIFO). Lock-free + thread-safe: the workload's
+    /// completions may fire from arbitrary threads (e.g. a channel write on the
+    /// producer's thread), but they only *enqueue* here — the callback itself runs
+    /// on the pump thread.
+    override _.Post(d: SendOrPostCallback, state: obj) =
+        Interlocked.Increment(&posted) |> ignore
+        queue.Enqueue((d, state))
+
+    /// Synchronous `Send` is unsupported: it would run a continuation off the pump
+    /// thread, breaking the single-threaded determinism this context exists to give.
+    override _.Send(_d: SendOrPostCallback, _state: obj) =
+        raise (NotSupportedException("DeterministicSyncContext.Send breaks single-threaded determinism; use Post + PumpToIdle."))
+
+    /// A captured copy must route to THIS queue, or continuations leak to a fresh
+    /// (threadpool-backed) context and determinism is lost.
+    override this.CreateCopy() = this :> SynchronizationContext
+
+    /// Total continuations posted to this context over its lifetime — lets a test
+    /// assert the workload's continuations routed through this door, not the threadpool.
+    member _.PostedCount = Volatile.Read(&posted)
+
+    /// Continuations currently queued and not yet run.
+    member _.PendingCount = queue.Count
+
+    /// Run queued continuations in registration (FIFO) order until none remain.
+    /// Runs on the calling thread — that thread IS the deterministic single thread.
+    ///
+    /// Installs THIS context as the calling thread's current `SynchronizationContext`
+    /// for the duration of the pump, then restores the previous one. Message-pump
+    /// contract, two ways: (1) a continuation resumed here sees this context as
+    /// current, so its *next* `await` re-captures it and stays on the deterministic
+    /// thread (the replay chain holds); (2) the previous context is restored on exit,
+    /// so the caller's own later awaits are NOT trapped in this (now-idle) context —
+    /// the leak that would otherwise deadlock the caller.
+    member this.PumpToIdle() =
+        let previous = SynchronizationContext.Current
+        SynchronizationContext.SetSynchronizationContext this
+
+        // Tail-recursive drain — pumping is single-threaded, so no mutable sentinel
+        // is needed (the recursion is the loop). `TryDequeue` is the lock-free
+        // counterpart to `Post`'s lock-free `Enqueue`.
+        let rec drain () =
+            match queue.TryDequeue() with
+            | true, (d, s) ->
+                d.Invoke s
+                drain ()
+            | false, _ -> ()
+
+        try
+            drain ()
+        finally
+            SynchronizationContext.SetSynchronizationContext previous

--- a/src/Core/FerryThrottler.fs
+++ b/src/Core/FerryThrottler.fs
@@ -78,6 +78,48 @@ module FerryThrottlerConfig =
         { deterministic with MaxDegreeOfParallelism = max 1 ferries }
 
 
+/// How a ferry loop is launched — the single source of launch truth for every
+/// arity. `None` = production: run on the threadpool with no captured context
+/// (awaits resume on the threadpool, equivalent to `backgroundTask`). `Some sc` =
+/// Option-A increment 4: launch the WHOLE ferry onto the injected
+/// `SynchronizationContext` (via `Post`). It does not begin until the context runs
+/// the posted callback, and because a `SynchronizationContext` is current on its
+/// own thread *while it runs its callbacks* (the standard message-pump contract —
+/// e.g. `DeterministicSyncContext.PumpToIdle` installs itself for the pump's
+/// duration), every `await` in the ferry captures `sc` and re-posts there. So the
+/// entire ferry lifecycle is pump-gated, race-free, and replayable in the context's
+/// run order — the launcher never touches any thread's context itself (which would
+/// leak `sc` onto the caller/pump thread and trap its later awaits). This is the
+/// noninterference door (manifesto §13): ferry scheduling enters only through the
+/// injected context, never the ambient threadpool.
+[<RequireQualifiedAccess>]
+module private FerryLaunch =
+
+    let launch
+        (syncContext: SynchronizationContext option)
+        (ferryLoop: unit -> Task)
+        : Task =
+        match syncContext with
+        | None -> Task.Run(fun () -> ferryLoop ())
+        | Some sc ->
+            let tcs = TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
+            sc.Post(
+                (fun _ ->
+                    // Runs inside `sc`'s pump, so `sc` is already current — do NOT
+                    // set it here (setting without restoring leaks it onto the pump
+                    // thread and deadlocks that thread's own later awaits).
+                    let loop = ferryLoop ()
+                    loop.ContinueWith(
+                        (fun (c: Task) ->
+                            if c.IsFaulted then tcs.TrySetException(c.Exception :> exn) |> ignore
+                            elif c.IsCanceled then tcs.TrySetCanceled() |> ignore
+                            else tcs.TrySetResult() |> ignore),
+                        TaskContinuationOptions.ExecuteSynchronously)
+                    |> ignore),
+                null)
+            tcs.Task
+
+
 /// **FerryThrottler** — a degree-of-parallelism-knobbed work queue whose
 /// batching core is the *Flux Capacitor* (Mirror codename): it accumulates
 /// queued items and discharges them as a *boat* (batch) the instant a ferry is
@@ -229,35 +271,7 @@ type FerryThrottler<'TItem>
             with :? OperationCanceledException -> ()
         }
 
-    let runFerry () : Task =
-        match injectedSyncContext with
-        | None ->
-            // Production: run on the threadpool with no captured context — awaits
-            // resume on the threadpool (equivalent to `backgroundTask`). The loop's
-            // synchronous prefix reads no ctor-thread-affine state, so launching it
-            // via `Task.Run` rather than the ctor thread is observationally identical.
-            Task.Run(fun () -> ferryLoop ())
-        | Some sc ->
-            // Option-A increment 4: launch the ENTIRE ferry onto the injected
-            // context. The ferry does not begin until the context is pumped, and —
-            // because `sc` is current when it starts — every `await` re-posts its
-            // continuation back to `sc`. So the whole ferry lifecycle is pump-gated:
-            // no threadpool, no startup race, replayable in the order the context
-            // runs its posted callbacks. Never touches the ctor thread's context.
-            let tcs = TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
-            sc.Post(
-                (fun _ ->
-                    SynchronizationContext.SetSynchronizationContext sc
-                    let loop = ferryLoop ()
-                    loop.ContinueWith(
-                        (fun (c: Task) ->
-                            if c.IsFaulted then tcs.TrySetException(c.Exception :> exn) |> ignore
-                            elif c.IsCanceled then tcs.TrySetCanceled() |> ignore
-                            else tcs.TrySetResult() |> ignore),
-                        TaskContinuationOptions.ExecuteSynchronously)
-                    |> ignore),
-                null)
-            tcs.Task
+    let runFerry () : Task = FerryLaunch.launch injectedSyncContext ferryLoop
 
     // Production: start `ferries` background ferries now. Manual/DST mode: start
     // none — the caller drives via `PumpToIdleAsync`.
@@ -326,7 +340,13 @@ type FerryThrottler<'TItem>
 type FerryThrottler<'TItem, 'TResult>
     (config: FerryThrottlerConfig,
      processBatch: ReadOnlyMemory<'TItem> -> CancellationToken -> Task<'TResult array>,
-     ?itemSizeBytes: 'TItem -> int) =
+     ?itemSizeBytes: 'TItem -> int,
+     // DST seam (Option A, increment 4): run the background ferries under this
+     // `SynchronizationContext` so their `await` continuations route to it. Inject
+     // a deterministic pumpable context (`DeterministicSyncContext`) and the
+     // request/response ferries become replayable. Default `None` = today's
+     // threadpool path, byte-identical for production. See the single-arity seam.
+     ?syncContext: SynchronizationContext) =
 
     do
         if config.MaxDegreeOfParallelism < 1 then
@@ -416,8 +436,15 @@ type FerryThrottler<'TItem, 'TResult>
             req.TrySetException ex
             Error()
 
-    let runFerry () : Task =
-        backgroundTask {
+    let injectedSyncContext = syncContext
+
+    // The ferry loop body — a context-CAPTURING `task` (its awaits honour the
+    // ambient `SynchronizationContext`), so WHERE its continuations resume is set
+    // by the context in effect when it is launched: null on the threadpool
+    // (production), or the injected context (Option-A increment 4). Single source
+    // of result-arity ferry-loop truth across both launch paths.
+    let ferryLoop () : Task =
+        task {
             let reader = inbox.Reader
             let items = Array.zeroCreate<'TItem> config.MaxBatchSize
             let requests = Array.zeroCreate<FerryRequest<'TItem, 'TResult>> config.MaxBatchSize
@@ -479,6 +506,8 @@ type FerryThrottler<'TItem, 'TResult>
             with :? OperationCanceledException ->
                 cancelRemaining reader pending ct
         }
+
+    let runFerry () : Task = FerryLaunch.launch injectedSyncContext ferryLoop
 
     let ferryTasks : Task array =
         Array.init ferries (fun _ -> runFerry ())
@@ -546,7 +575,10 @@ type ContextualFerryThrottler<'TItem, 'Ctx>
      // `Activity.Current` / `IntrCtx` / a Zeta `AsyncLocal`) is snapshotted at the
      // door and then threaded as DATA — the boundary is the only place the side
      // channel is touched; nothing ambient flows into the background ferry.
-     ?capture: unit -> 'Ctx) =
+     ?capture: unit -> 'Ctx,
+     // DST seam (Option A, increment 4): forwarded to the composed core throttler
+     // so the BACKGROUND ferries replay under an injected `SynchronizationContext`.
+     ?syncContext: SynchronizationContext) =
 
     // Size the PAYLOAD, not the (payload, ctx) pair — the threaded context is
     // metadata that rides along; it does not count against the byte budget.
@@ -555,7 +587,7 @@ type ContextualFerryThrottler<'TItem, 'Ctx>
 
     let inner =
         new FerryThrottler<struct ('TItem * 'Ctx)>(
-            config, processBatch, ?itemSizeBytes = innerSizer, ?manual = manual)
+            config, processBatch, ?itemSizeBytes = innerSizer, ?manual = manual, ?syncContext = syncContext)
 
     /// Enqueue one item together with an explicit context value to thread to its boat.
     member _.EnqueueAsync(item: 'TItem, context: 'Ctx, ?cancellationToken: CancellationToken) : ValueTask =
@@ -587,9 +619,9 @@ type ContextualFerryThrottler<'TItem, 'Ctx>
 /// the caller's context — supplied explicitly or captured at the door — threaded as
 /// DATA to the boat processor; the per-item `Task<'TResult>` still fans back to the
 /// caller. Composes `FerryThrottler<struct('TItem*'Ctx), 'TResult>`, mirroring
-/// `ContextualFerryThrottler` for the result arity. (Background ferries: the
-/// synchronous manual-pump is single-arity-only today — result-arity replay is the
-/// later "full background" increment.)
+/// `ContextualFerryThrottler` for the result arity. Background ferries replay via
+/// the forwarded `?syncContext` (Option-A increment 4b); the synchronous
+/// manual-pump (`PumpToIdleAsync`) remains single-arity-only.
 [<Sealed>]
 type ContextualResultFerryThrottler<'TItem, 'Ctx, 'TResult>
     (config: FerryThrottlerConfig,
@@ -597,14 +629,17 @@ type ContextualResultFerryThrottler<'TItem, 'Ctx, 'TResult>
      ?itemSizeBytes: 'TItem -> int,
      // Capture-at-the-boundary reader (see ContextualFerryThrottler): snapshots the
      // ambient on the caller's flow at ProcessCapturedAsync time, threaded as data.
-     ?capture: unit -> 'Ctx) =
+     ?capture: unit -> 'Ctx,
+     // DST seam (Option A, increment 4): forwarded to the composed core throttler
+     // so the request/response BACKGROUND ferries replay under an injected context.
+     ?syncContext: SynchronizationContext) =
 
     let innerSizer =
         itemSizeBytes |> Option.map (fun f -> fun (struct (item, _ctx): struct ('TItem * 'Ctx)) -> f item)
 
     let inner =
         new FerryThrottler<struct ('TItem * 'Ctx), 'TResult>(
-            config, processBatch, ?itemSizeBytes = innerSizer)
+            config, processBatch, ?itemSizeBytes = innerSizer, ?syncContext = syncContext)
 
     /// Submit one item with an explicit context; returns that item's result task.
     member _.ProcessAsync(item: 'TItem, context: 'Ctx, ?cancellationToken: CancellationToken) : Task<'TResult> =

--- a/tests/Tests.FSharp/Runtime/FerryThrottler.Tests.fs
+++ b/tests/Tests.FSharp/Runtime/FerryThrottler.Tests.fs
@@ -464,34 +464,11 @@ let ``contextual result throttler threads context and fans aligned results back`
 // docs/research/2026-06-13-ferrythrottler-background-ferry-replay-injected-synchronizationcontext-increment-4.md
 // ═══════════════════════════════════════════════════════════════════
 
-/// A deterministic, single-threaded, pumpable `SynchronizationContext` — test
-/// scaffolding for the increment-4 seam (4b promotes the Core-resident, earned
-/// sim version). `Post` captures the callback into a FIFO queue; NOTHING runs
-/// ambiently. `PumpToIdle` runs queued callbacks in registration order until none
-/// remain (a callback may post more — those run too). `PostedCount` lets a test
-/// assert the ferry routed its continuations through THIS door, not the threadpool.
-type private DeterministicSyncContext() =
-    inherit SynchronizationContext()
-    let queue = System.Collections.Generic.Queue<SendOrPostCallback * obj>()
-    let mutable posted = 0
-    override _.Post(d, state) =
-        lock queue (fun () ->
-            posted <- posted + 1
-            queue.Enqueue(d, state))
-    // Captured copies must still route to THIS queue, or determinism leaks.
-    override this.CreateCopy() = this :> SynchronizationContext
-    /// Total callbacks posted to this context over its lifetime.
-    member _.PostedCount = lock queue (fun () -> posted)
-    /// Run posted callbacks (FIFO) until the queue is empty.
-    member _.PumpToIdle() =
-        let mutable go = true
-        while go do
-            let next =
-                lock queue (fun () ->
-                    if queue.Count > 0 then ValueSome(queue.Dequeue()) else ValueNone)
-            match next with
-            | ValueSome(d, s) -> d.Invoke s
-            | ValueNone -> go <- false
+// `DeterministicSyncContext` is the earned Core sim primitive (4b promoted it out
+// of this test file): src/Core/DeterministicSyncContext.fs. Resolved via `open
+// Zeta.Core`. A single-threaded, pumpable SynchronizationContext: Post captures
+// continuations FIFO; PumpToIdle runs them in order; PostedCount proves the
+// workload routed through THIS door, not the threadpool.
 
 
 [<Fact>]
@@ -531,4 +508,108 @@ let ``background ferry runs under the injected SynchronizationContext — pump-g
         ctx.PumpToIdle()
         do! completion
         completion.IsCompletedSuccessfully |> should equal true
+    }
+
+
+// ─── 4b: full background-ferry SEEDED REPLAY + result/contextual arities ───
+
+/// Run a fixed interleaved (enqueue, pump) scenario through a background throttler
+/// bound to a fresh `DeterministicSyncContext` at the given DoP, returning the exact
+/// sequence of boats (which items rode which boat, in order). The schedule is a pure
+/// function of (enqueue sequence, pump sequence) — so two runs MUST agree.
+let private replayScenario (dop: int) : Task<int list list> =
+    task {
+        let boats = ResizeArray<int list>()
+        let processBatch (boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task =
+            boats.Add([ for i in 0 .. boat.Length - 1 -> boat.Span.[i] ])
+            Task.CompletedTask
+        let ctx = DeterministicSyncContext()
+        let config = { FerryThrottlerConfig.withFerries dop with MaxBatchSize = 2 }
+        use throttler = new FerryThrottler<int>(config, processBatch, syncContext = ctx)
+        // Interleave enqueues with pumps so multiple ferries genuinely park and
+        // resume (not one ferry monopolising a single synchronous sweep).
+        for wave in [ [ 1; 2; 3 ]; [ 4; 5 ]; [ 6; 7; 8; 9 ]; [ 10 ] ] do
+            for x in wave do
+                do! throttler.EnqueueAsync(x)
+            ctx.PumpToIdle()
+        let completion = throttler.CompleteAsync()
+        ctx.PumpToIdle()
+        do! completion
+        return List.ofSeq boats
+    }
+
+
+[<Fact>]
+let ``background ferries replay byte-identically under the deterministic context (DoP=2)`` () : Task =
+    // The 4b core claim: with the deterministic context injected, the background
+    // schedule is reproducible — the same inputs yield the same boats every run.
+    task {
+        let! run1 = replayScenario 2
+        let! run2 = replayScenario 2
+        // Replay determinism: identical boat composition across independent runs.
+        run1 |> should equal run2
+        // Correctness: every item processed exactly once, none lost or duplicated.
+        run1 |> List.concat |> List.sort |> should equal [ 1 .. 10 ]
+    }
+
+
+[<Fact>]
+let ``background ferries replay byte-identically under the deterministic context (DoP=3)`` () : Task =
+    // Same claim at a higher DoP — N ferries draining one channel still replay,
+    // because all continuations serialise through the single pumpable context.
+    task {
+        let! run1 = replayScenario 3
+        let! run2 = replayScenario 3
+        run1 |> should equal run2
+        run1 |> List.concat |> List.sort |> should equal [ 1 .. 10 ]
+    }
+
+
+[<Fact>]
+let ``result-arity background ferry replays under the injected context`` () : Task =
+    // 4b(c): the request/response arity now takes ?syncContext, so its background
+    // ferries are pump-gated too — results fan back only when the context is pumped.
+    task {
+        let processBatch (boat: ReadOnlyMemory<int>) (_ct: CancellationToken) : Task<string array> =
+            task { return [| for i in 0 .. boat.Length - 1 -> sprintf "r%d" boat.Span.[i] |] }
+        let ctx = DeterministicSyncContext()
+        use throttler =
+            new FerryThrottler<int, string>(FerryThrottlerConfig.deterministic, processBatch, syncContext = ctx)
+        let t1 = throttler.ProcessAsync(1)
+        let t2 = throttler.ProcessAsync(2)
+        let t3 = throttler.ProcessAsync(3)
+        // Before pumping, no result has resolved — the ferry is gated on the context.
+        t1.IsCompleted |> should equal false
+        ctx.PumpToIdle()
+        let! results = Task.WhenAll [| t1; t2; t3 |]
+        results |> should equal [| "r1"; "r2"; "r3" |]
+        let completion = throttler.CompleteAsync()
+        ctx.PumpToIdle()
+        do! completion
+    }
+
+
+[<Fact>]
+let ``contextual throttler forwards syncContext so background ferries replay`` () : Task =
+    // 4b(c): ContextualFerryThrottler forwards ?syncContext to the composed core
+    // throttler — the threaded context value rides to the boat AND the background
+    // ferry is pump-gated under the injected SynchronizationContext.
+    task {
+        let seen = ConcurrentQueue<struct (int * string)>()
+        let processBatch (boat: ReadOnlyMemory<struct (int * string)>) (_ct: CancellationToken) : Task =
+            for i in 0 .. boat.Length - 1 do seen.Enqueue(boat.Span.[i])
+            Task.CompletedTask
+        let ctx = DeterministicSyncContext()
+        use throttler =
+            new ContextualFerryThrottler<int, string>(
+                FerryThrottlerConfig.deterministic, processBatch, syncContext = ctx)
+        do! throttler.EnqueueAsync(1, "a")
+        do! throttler.EnqueueAsync(2, "b")
+        // Pump-gated: nothing seen until the injected context runs.
+        List.ofSeq seen |> should equal ([]: struct (int * string) list)
+        ctx.PumpToIdle()
+        List.ofSeq seen |> should equal [ struct (1, "a"); struct (2, "b") ]
+        let completion = throttler.CompleteAsync()
+        ctx.PumpToIdle()
+        do! completion
     }


### PR DESCRIPTION
## What

Completes the **Option-A async-context-threading roadmap** — 4b, after 4a (#8102). The FerryThrottler's background path is now deterministically replayable across all arities, and the deterministic context is a reusable, **lock-free** Core sim primitive.

## Changes

- **`DeterministicSyncContext` promoted into Core** (`src/Core/DeterministicSyncContext.fs`) — a single-threaded, pumpable `SynchronizationContext` for DST of async code. **Lock-free**: `ConcurrentQueue` + `Interlocked` (discipline #2), no hand-rolled CAS class — the BCL queue is the earned-correct lock-free FIFO. Earned class: its state *is* the simulated scheduler's run-queue (DST + injected-context boundary earns it, per `interfaces-free-classes-earned-under-rules`).
- **`FerryLaunch`** — one launch seam for every arity (`None` → threadpool `Task.Run`; `Some sc` → `Post` the whole ferry onto the context). Single source of launch truth; the single + result arities both use it.
- **`?syncContext` wired through** the result arity (`FerryThrottler<'TItem,'TResult>`) and both contextual wrappers (`ContextualFerryThrottler` / `ContextualResultFerryThrottler`).
- **Seeded replay proof** — `replayScenario` runs a fixed interleaved (enqueue, pump) sequence **twice at DoP=2 and DoP=3**, asserting boat composition is identical across runs (the replay claim) + item conservation. Plus result-arity and contextual pump-gated tests. **24/24 FerryThrottler tests pass, 0 warnings.**

## Deadlock caught + fixed mid-flight (documented in the design doc)

The pump must own the thread's `SynchronizationContext` for the pump's *duration* and restore it after. The first cut set the context inside the launch callback without restoring it → it leaked onto the caller thread → the caller's own later `await`s captured the now-idle context and **deadlocked** (tests hung silently; caught via `--blame-hang-timeout`). Fix: `PumpToIdle` installs itself current with a `try/finally` restore (the standard message-pump contract); the launcher touches no thread's context.

## Lock-free note (per review)

`lock` is a smell against discipline #2. Swapped `Queue + lock` → `ConcurrentQueue` (lock-free CAS, Michael-Scott PODC'96 lineage) + `Interlocked`; CAS human anchor is the maintainer's Itron `AtomicBoolean`. Also dropped a gratuitous `mutable` loop sentinel for a tail-recursive drain.

Design + full 4a/4b: `docs/research/2026-06-13-ferrythrottler-background-ferry-replay-injected-synchronizationcontext-increment-4.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
