### PR TITLE
docs(ferry): sharpen lock-free anchor to Itron AsyncCollection (human prior art)

### DIFF
--- a/src/Core/DeterministicSyncContext.fs
+++ b/src/Core/DeterministicSyncContext.fs
@@ -39,9 +39,12 @@ open System.Threading
 /// `DispatcherSynchronizationContext` (the marshal-to-one-thread shape this mirrors
 /// for determinism rather than UI affinity). Lock-free FIFO: Michael & Scott,
 /// "Simple, Fast, and Practical Non-Blocking and Blocking Concurrent Queue
-/// Algorithms" (PODC 1996) — the lineage `ConcurrentQueue<T>` implements; CAS
-/// primitive (human anchor): the maintainer's Itron
-/// `Platform.DotNet/Source/Threading/AtomicBoolean.cs` (`Interlocked.CompareExchange`).
+/// Algorithms" (PODC 1996) — the lineage `ConcurrentQueue<T>` implements. Human
+/// anchor for the lock-free `ConcurrentQueue` + CAS approach: the maintainer's Itron
+/// `Itron.Extensibility/AsyncCollection.cs` — a lock-free async producer/consumer
+/// rendezvous (two `ConcurrentQueue`s coordinated by a speculative-CAS on a paired
+/// count, `TrySpeculativeUpdate`; Stephen Toub's `AsyncProducerConsumerQueue`
+/// lineage) — and `AtomicBoolean.cs` for the bare `Interlocked.CompareExchange`.
 [<Sealed>]
 type DeterministicSyncContext() =
     inherit SynchronizationContext()


### PR DESCRIPTION
Doc-comment-only follow-up to #8111. Per maintainer review, anchor the lock-free `ConcurrentQueue` + CAS approach in `DeterministicSyncContext` to the actual human prior art: Itron `Itron.Extensibility/AsyncCollection.cs` (a lock-free async producer/consumer rendezvous — two `ConcurrentQueue`s coordinated by a speculative-CAS on a paired count; Stephen Toub's `AsyncProducerConsumerQueue` lineage), alongside `AtomicBoolean.cs` for the bare `Interlocked.CompareExchange`.

Notes that the hand-rolled CAS predates mature BCL `ConcurrentQueue` / .NET 9 `System.Threading.Lock` — we use the modern BCL primitive (fully lock-free here), not a verbatim port (AGENTS.md: rewrite against the latest, don't import the donor's old shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)