### PR TITLE
fix(lint): blank line before list in kiro unified-loop-service design (MD032)

### DIFF
--- a/.kiro/specs/unified-loop-service/design.md
+++ b/.kiro/specs/unified-loop-service/design.md
@@ -1,6 +1,7 @@
 # Design: Unified Loop Service
 
 All under src/Core.TypeScript/service/:
+
 - persona-registry.ts
 - env-schema.ts
 - service-manager.ts (IServiceManager)


### PR DESCRIPTION
Main's markdownlint gate is red on `.kiro/specs/unified-loop-service/design.md:4` (MD032/blanks-around-lists — the list needs a blank line before it). One-line fix to restore the markdownlint gate green.

This is a Kiro spec from the unified-loop-service work (Otto's `docs/handoffs/unified-loop-service-machinery.md` handoff spawned it). Verified `markdownlint-cli2` clean on the file after the fix.

(Separately, the `lint (F#, C#, Go, Python, Rust)` job is red at the **Go** lint step — that's the active Go/Python rollout, the rollout team's to stabilize, not this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)