### PR TITLE
feat(vision): add prediction scheduler adapter

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -180,6 +180,7 @@
     <Compile Include="Dsl.fs" />
     <Compile Include="Vision.fs" />
     <Compile Include="PredictionInference.fs" />
+    <Compile Include="PredictionScheduler.fs" />
     <Compile Include="Query.fs" />
     <Compile Include="Injection.fs" />
     <Compile Include="InjectionExt.fs" />

--- a/src/Core/PredictionScheduler.fs
+++ b/src/Core/PredictionScheduler.fs
@@ -1,0 +1,136 @@
+namespace Zeta.Core
+
+open System
+open System.Numerics
+open System.Threading.Tasks
+
+/// Scheduler adapter for the source-owned prediction kernel.
+///
+/// This is the small bridge from exact posterior inference to the soft
+/// `IScheduler`: candidate generation and attention/gravity priority stay
+/// pluggable, while the scheduler sees one budgeted state record and one
+/// ordinary feedback channel.
+[<RequireQualifiedAccess>]
+module PredictionScheduler =
+
+    type CandidateEstimator<'Inner, 'BranchState> =
+        InterruptKind -> 'Inner -> Result<PredictionInference.Candidate<'BranchState> list, PredictionInference.Feedback>
+
+    type PriorityEstimator<'BranchState> =
+        PredictionInference.Scored<'BranchState> -> PredictionInference.BranchPriority
+
+    type Planned<'Inner, 'BranchState> =
+        { Inner: 'Inner
+          Tank: SoftThrottle.Tank
+          Tick: int
+          LastPrediction: PredictionInference.Prediction<'BranchState> option
+          PredictedBytes: int64
+          DeferredBytes: int64 }
+
+    let planned (inner: 'Inner) (tank: SoftThrottle.Tank) : Planned<'Inner, 'BranchState> =
+        { Inner = inner
+          Tank = tank
+          Tick = 0
+          LastPrediction = None
+          PredictedBytes = 0L
+          DeferredBytes = 0L }
+
+    let private addBytesCapped (a: int64) (b: int64) : int64 =
+        let sum = BigInteger a + BigInteger b
+        if sum > BigInteger Int64.MaxValue then Int64.MaxValue else int64 sum
+
+    let private growthFeedbackText =
+        function
+        | Vision.NegativeTargetBits bits -> sprintf "negative target bits: %d" bits
+        | Vision.NegativeMeasuredBits bits -> sprintf "negative measured bits: %d" bits
+        | Vision.NegativeSpaceBytes bytes -> sprintf "negative projected space bytes: %d" bytes
+        | Vision.NegativeTimeTicks ticks -> sprintf "negative projected time ticks: %d" ticks
+        | Vision.NegativeBytesPerTick bytes -> sprintf "negative bytes per tick: %d" bytes
+        | Vision.NegativeUncertaintyResolutionBits bits -> sprintf "negative uncertainty resolution bits: %d" bits
+        | Vision.ByteCostOverflow bytes -> sprintf "projected branch byte cost overflows int64: %O" bytes
+
+    let private feedbackText =
+        function
+        | PredictionInference.EmptyCandidates -> "empty candidate set"
+        | PredictionInference.NegativePrior(label, value) -> sprintf "negative prior for %s: %A" label value
+        | PredictionInference.NegativeLikelihood(label, value) -> sprintf "negative likelihood for %s: %A" label value
+        | PredictionInference.NegativeAttention(label, value) -> sprintf "negative attention for %s: %A" label value
+        | PredictionInference.NegativeGravity(label, value) -> sprintf "negative gravity for %s: %A" label value
+        | PredictionInference.AllCandidatesRefuted -> "all candidates refuted"
+        | PredictionInference.VisionFeedback feedback -> growthFeedbackText feedback
+        | PredictionInference.SoftValueRefuted -> "soft value refuted"
+
+    let private asInterruptFeedback feedback =
+        Failed("prediction scheduler: " + feedbackText feedback)
+
+    let planWithPriority
+        (estimate: CandidateEstimator<'Inner, 'BranchState>)
+        (priorityOf: PriorityEstimator<'BranchState>)
+        (intr: InterruptKind)
+        (state: Planned<'Inner, 'BranchState>)
+        : Result<Planned<'Inner, 'BranchState>, InterruptFeedback> =
+        result {
+            let! candidates =
+                estimate intr state.Inner
+                |> Result.mapError asInterruptFeedback
+
+            let! prediction =
+                candidates
+                |> PredictionInference.inferAndPredictWithPriority priorityOf state.Tank
+                |> Result.mapError asInterruptFeedback
+
+            let report = prediction.Budget
+
+            return
+                { state with
+                    Tank = report.TankAfter
+                    Tick = state.Tick + 1
+                    LastPrediction = Some prediction
+                    PredictedBytes = addBytesCapped state.PredictedBytes report.BoardedBytes
+                    DeferredBytes = addBytesCapped state.DeferredBytes report.DeferredBytes }
+        }
+
+    let plan
+        (estimate: CandidateEstimator<'Inner, 'BranchState>)
+        (intr: InterruptKind)
+        (state: Planned<'Inner, 'BranchState>)
+        : Result<Planned<'Inner, 'BranchState>, InterruptFeedback> =
+        planWithPriority estimate (fun _ -> PredictionInference.neutralPriority) intr state
+
+    let policyHandlerWithPriority
+        (name: string)
+        (estimate: CandidateEstimator<'Inner, 'BranchState>)
+        (priorityOf: PriorityEstimator<'BranchState>)
+        : SoftScheduler.HandlerK<Planned<'Inner, 'BranchState>> =
+        SoftScheduler.handlerK name (fun _ -> true) (fun intr _ctx state ->
+            Task.FromResult(planWithPriority estimate priorityOf intr state))
+
+    let policyHandler
+        (name: string)
+        (estimate: CandidateEstimator<'Inner, 'BranchState>)
+        : SoftScheduler.HandlerK<Planned<'Inner, 'BranchState>> =
+        policyHandlerWithPriority name estimate (fun _ -> PredictionInference.neutralPriority)
+
+    let wrapHandlerKWithPriority
+        (estimate: CandidateEstimator<'Inner, 'BranchState>)
+        (priorityOf: PriorityEstimator<'BranchState>)
+        (handler: SoftScheduler.HandlerK<'Inner>)
+        : SoftScheduler.HandlerK<Planned<'Inner, 'BranchState>> =
+        SoftScheduler.handlerK
+            ("prediction-" + handler.Name)
+            handler.Matches
+            (fun intr ctx state ->
+                task {
+                    match planWithPriority estimate priorityOf intr state with
+                    | Error feedback ->
+                        return Error feedback
+                    | Ok plannedState ->
+                        let! inner = handler.RunK intr ctx plannedState.Inner
+                        return inner |> Result.map (fun next -> { plannedState with Inner = next })
+                })
+
+    let wrapHandlerK
+        (estimate: CandidateEstimator<'Inner, 'BranchState>)
+        (handler: SoftScheduler.HandlerK<'Inner>)
+        : SoftScheduler.HandlerK<Planned<'Inner, 'BranchState>> =
+        wrapHandlerKWithPriority estimate (fun _ -> PredictionInference.neutralPriority) handler

--- a/tests/Tests.FSharp/PredictionScheduler.Tests.fs
+++ b/tests/Tests.FSharp/PredictionScheduler.Tests.fs
@@ -1,0 +1,97 @@
+module Zeta.Tests.PredictionSchedulerTests
+
+open System.Diagnostics
+open System.Threading.Tasks
+open global.Xunit
+open Zeta.Core
+
+module PI = PredictionInference
+module PS = ProbabilitySemiring
+
+let private ctx () : IntrCtx =
+    { Memetic = "prediction-scheduler"
+      Prompt = ""
+      Trust = ""
+      Log = ""
+      Otel = ActivityContext() }
+
+let private r n d = PS.rat n d
+
+let private cost bytes : Vision.BranchCost =
+    { SpaceBytes = bytes
+      TimeTicks = 0
+      BytesPerTick = 0L
+      UncertaintyResolutionBits = 0 }
+
+let private candidate label state prior bytes : PI.Candidate<string> =
+    { Label = label
+      State = state
+      Prior = prior
+      Likelihood = PS.one
+      Cost = cost bytes }
+
+let private timer =
+    function
+    | TimerElapsed _ -> true
+    | _ -> false
+
+[<Fact>]
+let ``prediction scheduler wraps a soft handler with budgeted self sight`` () =
+    task {
+        let estimate _ current =
+            Ok
+                [ candidate "likely" (sprintf "likely-%d" current) (r 3L 4L) 6L
+                  candidate "attended" (sprintf "attended-%d" current) (r 1L 4L) 6L ]
+
+        let priority (scored: PI.Scored<string>) =
+            if scored.Candidate.Label = "attended" then
+                { PI.neutralPriority with Attention = r 10L 1L }
+            else
+                PI.neutralPriority
+
+        let inc =
+            SoftScheduler.handlerK
+                "inc"
+                timer
+                (fun _ _ current -> Task.FromResult(Ok(current + 1)))
+
+        let initial: PredictionScheduler.Planned<int, string> =
+            PredictionScheduler.planned 0 (SoftThrottle.tank 6.0 0.0)
+
+        let source _ = [ TimerElapsed 17 ]
+
+        let! result =
+            (SoftScheduler.driveK [ PredictionScheduler.wrapHandlerKWithPriority estimate priority inc ] source)
+                .Run(ctx ()) 7L initial 1
+
+        match result with
+        | Error feedback -> Assert.Fail(sprintf "expected Ok, got %A" feedback)
+        | Ok final ->
+            Assert.Equal(1, final.Inner)
+            Assert.Equal(1, final.Tick)
+            Assert.Equal(6L, final.PredictedBytes)
+            Assert.Equal(6L, final.DeferredBytes)
+
+            match final.LastPrediction with
+            | None -> Assert.Fail "prediction scheduler should record a prediction"
+            | Some prediction ->
+                Assert.Equal("likely", prediction.Inference.Best.Candidate.Label)
+                Assert.Equal<string list>([ "attended" ], prediction.Budget.Boarded |> List.map _.Label)
+                Assert.Equal<string list>([ "likely" ], prediction.Budget.Deferred |> List.map _.Label)
+    }
+
+[<Fact>]
+let ``prediction scheduler surfaces inference feedback through the scheduler channel`` () =
+    task {
+        let estimate _ _ = Ok [ candidate "bad" "state" (r -1L 1L) 1L ]
+        let initial: PredictionScheduler.Planned<int, string> =
+            PredictionScheduler.planned 0 (SoftThrottle.tank 1.0 0.0)
+
+        let source _ = [ TimerElapsed 17 ]
+        let handler = PredictionScheduler.policyHandler "predict" estimate
+        let! result = (SoftScheduler.driveK [ handler ] source).Run(ctx ()) 7L initial 1
+
+        match result with
+        | Error(Failed message) -> Assert.Contains("negative prior", message)
+        | other -> Assert.Fail(sprintf "expected Failed feedback, got %A" other)
+    }

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -141,6 +141,7 @@
     <Compile Include="SoftThrottle.Tests.fs" />
     <Compile Include="Vision.Tests.fs" />
     <Compile Include="PredictionInference.Tests.fs" />
+    <Compile Include="PredictionScheduler.Tests.fs" />
     <Compile Include="RecordedSource.Tests.fs" />
     <Compile Include="SoftIsr.Tests.fs" />
     <Compile Include="SimFramework.Tests.fs" />


### PR DESCRIPTION
## What
- Add `PredictionScheduler`, a thin adapter from `PredictionInference` to `SoftScheduler.HandlerK`.
- Add `Planned` scheduler state with tank, tick, last exact prediction, boarded bytes, and deferred bytes.
- Add policy and wrapper handlers so rooms can forecast candidates, apply attention/gravity priority, and still run normal soft scheduler actions.
- Add tests for budgeted self-sight around a soft handler and feedback surfacing through the scheduler channel.

## Why
This keeps the interfaces as freedom and stability: Q#/Bayesian/Reticulum/CHIP-9 experiments can feed candidates into our owned kernel, while the runtime remains pure Core F# and exception-free. Attention changes ordering; posterior arithmetic truth stays exact.

## Validation
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release -m:1 /p:UseSharedCompilation=false --filter "FullyQualifiedName~PredictionScheduler|FullyQualifiedName~PredictionInference|FullyQualifiedName~Chip8Observer"`
- `dotnet build -c Release -m:1 /p:UseSharedCompilation=false`
- `dotnet test Zeta.sln -c Release -m:1 /p:UseSharedCompilation=false --no-build`
- `dotnet format --verify-no-changes`
- `git diff --check`