### PR TITLE
fix(go): convert Bits constants to uint in zeta_id BitLayout (restore main-green)

### DIFF
--- a/src/Core.Go/zeta_id/zeta_id.go
+++ b/src/Core.Go/zeta_id/zeta_id.go
@@ -160,16 +160,19 @@ var BitLayout = struct {
 	Location   BitField
 	Randomness BitField
 }{
-	Version:    BitField{Offset: VersionOffset, Width: VersionWidth},
-	Timestamp:  BitField{Offset: TimestampOffset, Width: TimestampWidth},
-	Chromosome: BitField{Offset: ChromosomeOffset, Width: ChromosomeWidth},
-	Category:   BitField{Offset: CategoryOffset, Width: CategoryWidth},
-	Firefly:    BitField{Offset: FireflyOffset, Width: FireflyWidth},
-	Authority:  BitField{Offset: AuthorityOffset, Width: AuthorityWidth},
-	Persona:    BitField{Offset: PersonaOffset, Width: PersonaWidth},
-	Momentum:   BitField{Offset: MomentumOffset, Width: MomentumWidth},
-	Location:   BitField{Offset: LocationOffset, Width: LocationWidth},
-	Randomness: BitField{Offset: RandomnessOffset, Width: RandomnessWidth},
+	// The generated *Offset/*Width constants are typed `Bits` (uint32);
+	// BitField.Offset/Width are `uint` (they feed big.Int.Lsh/Rsh, which take
+	// uint). Go has no implicit numeric conversion, so convert at the boundary.
+	Version:    BitField{Offset: uint(VersionOffset), Width: uint(VersionWidth)},
+	Timestamp:  BitField{Offset: uint(TimestampOffset), Width: uint(TimestampWidth)},
+	Chromosome: BitField{Offset: uint(ChromosomeOffset), Width: uint(ChromosomeWidth)},
+	Category:   BitField{Offset: uint(CategoryOffset), Width: uint(CategoryWidth)},
+	Firefly:    BitField{Offset: uint(FireflyOffset), Width: uint(FireflyWidth)},
+	Authority:  BitField{Offset: uint(AuthorityOffset), Width: uint(AuthorityWidth)},
+	Persona:    BitField{Offset: uint(PersonaOffset), Width: uint(PersonaWidth)},
+	Momentum:   BitField{Offset: uint(MomentumOffset), Width: uint(MomentumWidth)},
+	Location:   BitField{Offset: uint(LocationOffset), Width: uint(LocationWidth)},
+	Randomness: BitField{Offset: uint(RandomnessOffset), Width: uint(RandomnessWidth)},
 }
 
 func setBits(target *big.Int, field BitField, val uint64) {


### PR DESCRIPTION
## Why

The multi-language lint gate (`lint (F#, C#, Go, Python, Rust)`) has been red at the **Go** step, keeping main red. Root cause: `src/Core.Go/zeta_id/zeta_id.go` fails to typecheck —

```
zeta_id.go:163: cannot use VersionOffset (constant 123 of uint32 type Bits) as uint value in struct literal
```

The generated `*Offset`/`*Width` constants (in `zeta_id.gen.go`) are typed `Bits` (= `uint32`), but `BitField.Offset/Width` are `uint`, and Go has no implicit numeric conversion.

## Fix

`BitField.Offset/Width` **must stay `uint`** — they feed `big.Int.Lsh/Rsh`, which take `uint`. So convert the constants to `uint` **at the literal** (the hand-written consumer), not the regenerated `.gen.go`. Zero type-ripple, durable across regeneration.

## Verified with the CI toolchain

- `go build ./...` ✓ · `go vet ./...` ✓ · `gofmt -l` clean
- `go test ./...` ✓ (incl. `zeta` cross-language oracle)
- **golangci-lint v2.12.2** (the exact CI version) → **0 issues** — confirms fixing the typecheck error doesn't unmask other linters
- gate's `lint-go.ts` passes end-to-end

Together with #8113 (markdownlint), this restores both lint halves of the gate to green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)