### PR TITLE
fix(zflash): B-0891 harness CI script paths after relocation

### DIFF
--- a/src/Core.TypeScript/zflash/test-harness/run.ts
+++ b/src/Core.TypeScript/zflash/test-harness/run.ts
@@ -111,6 +111,10 @@ export interface PathForkRuntimeOptions {
 }
 
 const REPO_ROOT = resolve(import.meta.dir, "../../../..");
+const CI_DIR = "src/Core.TypeScript/ci";
+const AUDIT_INSTALLER_ISO = `${CI_DIR}/audit-installer-iso-content.ts`;
+const QEMU_BOOT_TEST = `${CI_DIR}/qemu-boot-test.ts`;
+const QEMU_FULL_INSTALL_TEST = `${CI_DIR}/qemu-full-install-test.ts`;
 const RETENTION_EXECUTION_ENV = "ZFLASH_QEMU_RETENTION_EXECUTE";
 const RETENTION_TIMEOUT_ENV = "ZFLASH_QEMU_RETENTION_TIMEOUT_MS";
 const RETENTION_BOOT_IMAGE_ENV = "ZFLASH_QEMU_RETENTION_BOOT_IMAGE";
@@ -254,7 +258,7 @@ function runInitialFormatScenario(isoPath: string): ScenarioResult {
   const absIso = resolve(isoPath);
   const steps: string[] = [];
 
-  const audit = runHarnessScript("tools/ci/audit-installer-iso-content.ts", ["--iso", absIso]);
+  const audit = runHarnessScript(AUDIT_INSTALLER_ISO, ["--iso", absIso]);
   steps.push("audit-installer-iso-content");
   if (!audit.ok) {
     return {
@@ -286,7 +290,7 @@ function runInitialFormatScenario(isoPath: string): ScenarioResult {
     };
   }
 
-  const boot = runHarnessScript("tools/ci/qemu-boot-test.ts", ["--usb-image", prepared.outputImagePath]);
+  const boot = runHarnessScript(QEMU_BOOT_TEST, ["--usb-image", prepared.outputImagePath]);
   steps.push("qemu-boot-test");
   const durationMs = Date.now() - start;
   if (!boot.ok) {
@@ -310,7 +314,7 @@ function runComposingScenario(scenario: Scenario, isoPath: string): ScenarioResu
   if (scenario.id === "initial-format") {
     return runInitialFormatScenario(isoPath);
   }
-  const harnessPath = "tools/ci/qemu-full-install-test.ts";
+  const harnessPath = QEMU_FULL_INSTALL_TEST;
   const absHarnessPath = resolve(REPO_ROOT, harnessPath);
   if (!existsSync(absHarnessPath)) {
     return {

--- a/src/Core.TypeScript/zflash/test-harness/scenarios.test.ts
+++ b/src/Core.TypeScript/zflash/test-harness/scenarios.test.ts
@@ -56,12 +56,14 @@ describe("B-0891 scenarios.ts invariants", () => {
     }
   });
 
-  it("composes-with-existing scenarios cite tools/ci/ paths", () => {
+  it("composes-with-existing scenarios cite src/Core.TypeScript/ci/ paths", () => {
     const composers = SCENARIOS.filter((s) => s.status === "composes-with-existing");
     expect(composers.length).toBeGreaterThan(0);
     for (const s of composers) {
-      const hasToolsCi = s.composesWith.some((dep) => dep.startsWith("tools/ci/"));
-      expect(hasToolsCi).toBe(true);
+      const hasCiHarness = s.composesWith.some((dep) =>
+        dep.startsWith("src/Core.TypeScript/ci/"),
+      );
+      expect(hasCiHarness).toBe(true);
     }
   });
 

--- a/src/Core.TypeScript/zflash/test-harness/scenarios.ts
+++ b/src/Core.TypeScript/zflash/test-harness/scenarios.ts
@@ -14,22 +14,22 @@
  *
  * PoC scope: declarative scenario definitions + dispatcher contract +
  * status field for partial implementation. Scenarios 1 + 2 can compose
- * with existing `tools/ci/qemu-full-install-test.ts` (B-0831 Slice 1)
+ * with existing `src/Core.TypeScript/ci/qemu-full-install-test.ts` (B-0831 Slice 1)
  * substrate today; scenarios 3-5 require state-preservation between QEMU
  * boots which the existing harness does not have — marked as
  * "scaffolded" pending implementation.
  *
  * Composes with:
- *   - tools/ci/qemu-full-install-test.ts (existing QEMU full-install starter)
- *   - tools/ci/qemu-boot-test.ts (cascade #5 boot smoke-test)
- *   - tools/ci/audit-installer-iso-content.ts (cascade #4 ISO content audit)
+ *   - src/Core.TypeScript/ci/qemu-full-install-test.ts (existing QEMU full-install starter)
+ *   - src/Core.TypeScript/ci/qemu-boot-test.ts (cascade #5 boot smoke-test)
+ *   - src/Core.TypeScript/ci/audit-installer-iso-content.ts (cascade #4 ISO content audit)
  *   - src/Core.TypeScript/zflash/lib.ts (the zflash library under test)
  *   - docs/runbooks/zflash-end-to-end.md (operator-facing runbook)
  *   - docs/research/2026-05-28-zflash-and-usb-credential-substrate-next-steps-plan.md (CP-1..CP-6)
  *
  * Per .claude/rules/rule-0-no-sh-files.md (TS-first for cross-platform DST)
  * + .claude/rules/verify-existing-substrate-before-authoring.md (composes
- * with existing tools/ci/ substrate; does not duplicate).
+ * with existing src/Core.TypeScript/ci/ substrate; does not duplicate).
  */
 
 export type ScenarioId =
@@ -64,12 +64,12 @@ export const SCENARIOS: ReadonlyArray<Scenario> = [
     acceptanceCriteria: [
       "zflash script runs cleanly to completion",
       "produces bootable USB image with operator-chosen credentials baked in",
-      "passes ISO content audit (tools/ci/audit-installer-iso-content.ts)",
+      "passes ISO content audit (src/Core.TypeScript/ci/audit-installer-iso-content.ts)",
       "QEMU boots the produced image to a usable state",
     ],
     composesWith: [
-      "tools/ci/audit-installer-iso-content.ts",
-      "tools/ci/qemu-boot-test.ts",
+      "src/Core.TypeScript/ci/audit-installer-iso-content.ts",
+      "src/Core.TypeScript/ci/qemu-boot-test.ts",
       "src/Core.TypeScript/zflash/cli.ts",
       "src/Core.TypeScript/zflash/lib.ts",
     ],
@@ -89,7 +89,7 @@ export const SCENARIOS: ReadonlyArray<Scenario> = [
       "Kubernetes and ArgoCD health are covered by separate cluster integration tests, not this USB/ISO harness",
     ],
     composesWith: [
-      "tools/ci/qemu-full-install-test.ts",
+      "src/Core.TypeScript/ci/qemu-full-install-test.ts",
       "B-0831 (CI cascade-6 cluster-auto-join)",
       "B-0590 (fleet replication 20 machines)",
     ],
@@ -254,20 +254,20 @@ export function determineRunnability(
       if (scenario.id === "initial-format") {
         return {
           kind: "can-run-now",
-          harnessEntry: "tools/ci/qemu-boot-test.ts + tools/ci/audit-installer-iso-content.ts",
+          harnessEntry: "src/Core.TypeScript/ci/qemu-boot-test.ts + src/Core.TypeScript/ci/audit-installer-iso-content.ts",
         };
       }
       if (scenario.id === "boot-cluster-up") {
         return {
           kind: "can-run-now",
-          harnessEntry: "tools/ci/qemu-full-install-test.ts",
+          harnessEntry: "src/Core.TypeScript/ci/qemu-full-install-test.ts",
         };
       }
       // Future composes-with-existing scenarios fall through to a
       // generic harness-entry; explicit mapping preferred when added.
       return {
         kind: "can-run-now",
-        harnessEntry: "tools/ci/qemu-full-install-test.ts",
+        harnessEntry: "src/Core.TypeScript/ci/qemu-full-install-test.ts",
       };
     }
     case "scaffolded": {


### PR DESCRIPTION
## Summary
- Fix `test-harness/run.ts` to call `src/Core.TypeScript/ci/*` instead of stale `tools/ci/*`
- Update B-0891 scenario metadata + test invariant for new paths

Fixes build-iso **B-0891 scenario 1** failure on main (harness not found after #7893 relocation).

## Test plan
- [x] `bun test src/Core.TypeScript/zflash/test-harness/scenarios.test.ts`
- [ ] build-iso green on PR


Made with [Cursor](https://cursor.com)