### PR TITLE
fix(csharp): strip trailing whitespace in Mixin.cs (restore main-green)

### DIFF
--- a/src/Core.CSharp/Mixin.cs
+++ b/src/Core.CSharp/Mixin.cs
@@ -11,8 +11,8 @@ namespace Zeta.Core.CSharp;
 /// </summary>
 [DebuggerDisplay("Count = {DebuggerCount}")]
 [DebuggerTypeProxy(typeof(WeakMapDebugView<,>))]
-public sealed class WeakMap<TKey, TValue> 
-    where TKey : class 
+public sealed class WeakMap<TKey, TValue>
+    where TKey : class
     where TValue : class
 {
     private readonly ConditionalWeakTable<TKey, TValue> _table = new();
@@ -65,8 +65,8 @@ public sealed class WeakMap<TKey, TValue>
     }
 }
 
-internal sealed class WeakMapDebugView<TKey, TValue> 
-    where TKey : class 
+internal sealed class WeakMapDebugView<TKey, TValue>
+    where TKey : class
     where TValue : class
 {
     private readonly WeakMap<TKey, TValue> _weakMap;


### PR DESCRIPTION
## Why

The multi-language lint gate's **C# step** (`dotnet format whitespace --verify-no-changes`) is red on `src/Core.CSharp/Mixin.cs` lines 14, 15, 68, 69 — trailing spaces after the type declaration and `where` clause, introduced by #8115 (6-language mixin tables).

## Fix

Ran `dotnet format whitespace` (the exact tool CI verifies with) — removes the trailing whitespace, nothing else. Diff is whitespace-only.

## Verified

Full `lint-csharp.ts` (whitespace + style + analyzer) passes locally; `--verify-no-changes` clean.

This is the third and final lint-green fix: #8113 (markdownlint) + #8117 (Go typecheck) + this (C# whitespace). With all three, the multi-language lint gate + markdownlint should both be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)