### PR TITLE
feat(service): agent gate + harness configs (learns from Otto/Codex)

### DIFF
--- a/src/Core.CSharp/Collation.cs
+++ b/src/Core.CSharp/Collation.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace Zeta.Core.CSharp;
 
@@ -9,6 +10,92 @@ namespace Zeta.Core.CSharp;
 /// </summary>
 public static class Collation
 {
+    /// <summary>
+    /// A StringComparer that orders strings ordinally by Unicode code point (Rune) value (B-0969).
+    /// Matches TS's true Unicode code point comparison, resolving the UTF-16 surrogate pair discrepancy.
+    /// </summary>
+    public sealed class UnicodeCodePointComparer : StringComparer
+    {
+        /// <summary>
+        /// Gets a UnicodeCodePointComparer that performs a case-sensitive ordinal comparison.
+        /// </summary>
+        public static new UnicodeCodePointComparer Ordinal { get; } = new(false);
+
+        /// <summary>
+        /// Gets a UnicodeCodePointComparer that performs a case-insensitive ordinal comparison.
+        /// </summary>
+        public static new UnicodeCodePointComparer OrdinalIgnoreCase { get; } = new(true);
+
+        private readonly bool _ignoreCase;
+
+        private UnicodeCodePointComparer(bool ignoreCase)
+        {
+            _ignoreCase = ignoreCase;
+        }
+
+        /// <summary>
+        /// Compares two strings ordinally by Unicode code points.
+        /// </summary>
+        /// <param name="x">The first string to compare.</param>
+        /// <param name="y">The second string to compare.</param>
+        /// <returns>A signed integer indicating the relative values of x and y.</returns>
+        public override int Compare(string? x, string? y)
+        {
+            if (ReferenceEquals(x, y)) return 0;
+            if (x == null) return -1;
+            if (y == null) return 1;
+
+            var enumX = x.EnumerateRunes();
+            var enumY = y.EnumerateRunes();
+
+            while (true)
+            {
+                var hasX = enumX.MoveNext();
+                var hasY = enumY.MoveNext();
+
+                if (!hasX && !hasY) return 0;
+                if (!hasX) return -1;
+                if (!hasY) return 1;
+
+                var runeX = enumX.Current;
+                var runeY = enumY.Current;
+
+                if (_ignoreCase)
+                {
+                    runeX = Rune.ToLowerInvariant(runeX);
+                    runeY = Rune.ToLowerInvariant(runeY);
+                }
+
+                if (runeX.Value < runeY.Value) return -1;
+                if (runeX.Value > runeY.Value) return 1;
+            }
+        }
+
+        /// <summary>
+        /// Determines whether two strings are equal based on ordinal comparison.
+        /// </summary>
+        /// <param name="x">The first string to compare.</param>
+        /// <param name="y">The second string to compare.</param>
+        /// <returns>true if the strings are equal; otherwise, false.</returns>
+        public override bool Equals(string? x, string? y)
+        {
+            if (ReferenceEquals(x, y)) return true;
+            if (x == null || y == null) return false;
+            return string.Equals(x, y, _ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Serves as the default hash function.
+        /// </summary>
+        /// <param name="obj">The string for which a hash code is to be returned.</param>
+        /// <returns>A hash code for the specified string.</returns>
+        public override int GetHashCode(string obj)
+        {
+            ArgumentNullException.ThrowIfNull(obj);
+            return string.GetHashCode(obj, _ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+        }
+    }
+
     /// <summary>
     /// The default collation name we ship with.
     /// </summary>
@@ -20,29 +107,29 @@ public static class Collation
     public static IReadOnlyDictionary<string, StringComparer> Catalog { get; } =
         new Dictionary<string, StringComparer>(StringComparer.OrdinalIgnoreCase)
         {
-            ["binary"] = StringComparer.Ordinal,
-            ["ordinal"] = StringComparer.Ordinal,
-            ["ordinal-ci"] = StringComparer.OrdinalIgnoreCase,
+            ["binary"] = UnicodeCodePointComparer.Ordinal,
+            ["ordinal"] = UnicodeCodePointComparer.Ordinal,
+            ["ordinal-ci"] = UnicodeCodePointComparer.OrdinalIgnoreCase,
             ["invariant"] = StringComparer.InvariantCulture,
             ["invariant-ci"] = StringComparer.InvariantCultureIgnoreCase,
 
             // Postgres / Standard SQL aliases
-            ["C"] = StringComparer.Ordinal,
-            ["POSIX"] = StringComparer.Ordinal,
-            ["utf8_bin"] = StringComparer.Ordinal,
-            ["utf8mb4_bin"] = StringComparer.Ordinal,
+            ["C"] = UnicodeCodePointComparer.Ordinal,
+            ["POSIX"] = UnicodeCodePointComparer.Ordinal,
+            ["utf8_bin"] = UnicodeCodePointComparer.Ordinal,
+            ["utf8mb4_bin"] = UnicodeCodePointComparer.Ordinal,
 
             // SQLite alias
-            ["NOCASE"] = StringComparer.OrdinalIgnoreCase,
+            ["NOCASE"] = UnicodeCodePointComparer.OrdinalIgnoreCase,
 
             // MySQL aliases
-            ["utf8_general_ci"] = StringComparer.OrdinalIgnoreCase,
-            ["utf8mb4_general_ci"] = StringComparer.OrdinalIgnoreCase,
+            ["utf8_general_ci"] = UnicodeCodePointComparer.OrdinalIgnoreCase,
+            ["utf8mb4_general_ci"] = UnicodeCodePointComparer.OrdinalIgnoreCase,
             ["utf8_unicode_ci"] = StringComparer.InvariantCultureIgnoreCase,
             ["utf8mb4_unicode_ci"] = StringComparer.InvariantCultureIgnoreCase,
 
             // SQL Server aliases
-            ["Latin1_General_BIN"] = StringComparer.Ordinal,
+            ["Latin1_General_BIN"] = UnicodeCodePointComparer.Ordinal,
             ["Latin1_General_CI_AS"] = StringComparer.InvariantCultureIgnoreCase,
             ["Latin1_General_CS_AS"] = StringComparer.InvariantCulture
         };
@@ -66,7 +153,7 @@ public static class Collation
     public static StringComparer ByNameOrDefault(string name)
     {
         ArgumentNullException.ThrowIfNull(name);
-        return TryByName(name) ?? StringComparer.Ordinal;
+        return TryByName(name) ?? UnicodeCodePointComparer.Ordinal;
     }
 
     /// <summary>
@@ -81,7 +168,7 @@ public static class Collation
         ArgumentNullException.ThrowIfNull(collationName);
         if (typeof(T) == typeof(string))
         {
-            return (IComparer<T>)(TryByName(collationName) ?? StringComparer.Ordinal);
+            return (IComparer<T>)(TryByName(collationName) ?? UnicodeCodePointComparer.Ordinal);
         }
         return Comparer<T>.Default;
     }

--- a/src/Core.TypeScript/service/loop-tick.ts
+++ b/src/Core.TypeScript/service/loop-tick.ts
@@ -154,6 +154,52 @@ function tick(): void {
   const dirty = exec("git", ["status", "--porcelain"], 10_000);
   const dirtyCount = lines(dirty.stdout).length;
 
+  // --- Agent gate (gated work cycle) ---
+  let agentStatus = "disabled";
+  const { gateInterval, gateTimeout, harness } = personaConfig!;
+  const dryRun = process.env["ZETA_LOOP_DRY_RUN"] === "1";
+  const agentStateFile = join(stateDir, "last-agent-run.json");
+
+  if (gateInterval > 0 && !harness.ideNative) {
+    let lastRun: { updated_at?: string } = {};
+    try { lastRun = JSON.parse(readFileSync(agentStateFile, "utf8")); } catch { /* first run */ }
+    const lastTime = lastRun.updated_at ? new Date(lastRun.updated_at).getTime() : 0;
+    const elapsed = Date.now() - lastTime;
+
+    if (elapsed >= gateInterval * 1000) {
+      log(`agent-gate start persona=${personaName} run_id=${runId}`);
+
+      if (dryRun) {
+        agentStatus = "dry-run";
+        log(`dry-run: would invoke ${harness.command}`);
+      } else {
+        const prompt = buildWorkPrompt(personaName, prCount, claimCount, dirtyCount);
+        const args = harness.args.map(a => a.replace("{{PROMPT}}", prompt));
+        const gate = exec(harness.command, args, gateTimeout * 1000);
+        agentStatus = gate.status === 0 ? "ok" : `exit-${gate.status}`;
+        log(`agent-gate end persona=${personaName} status=${gate.status}`);
+
+        writeFileSync(agentStateFile, JSON.stringify({
+          run_id: runId,
+          persona: personaName,
+          status: gate.status,
+          started_at: nowIso(),
+          updated_at: nowIso(),
+        }, null, 2));
+
+        if (gate.stdout.trim()) {
+          appendFileSync(join(logDir, "ticks.log"), `\n--- ${runId} ${personaName} gate ---\n${gate.stdout}\n`);
+        }
+        if (gate.stderr.trim()) {
+          appendFileSync(join(logDir, "ticks.err"), `\n--- ${runId} ${personaName} gate ---\n${gate.stderr}\n`);
+        }
+      }
+    } else {
+      const remaining = Math.round((gateInterval * 1000 - elapsed) / 1000);
+      agentStatus = `wait due_in=${remaining}s`;
+    }
+  }
+
   // Write heartbeat
   const hbDir = join(stateDir, "heartbeats");
   mkdirSync(hbDir, { recursive: true });
@@ -168,12 +214,38 @@ function tick(): void {
     updated_at: nowIso(),
     status: "active",
     dirty_count: String(dirtyCount),
+    agent_status: agentStatus,
   }, null, 2));
 
-  const summary = `tick complete run_id=${runId} persona=${personaName} fetch=${fetchOk} claims=${claimCount} open_prs=${prCount} dirty=${dirtyCount}`;
+  const summary = `tick complete run_id=${runId} persona=${personaName} fetch=${fetchOk} claims=${claimCount} open_prs=${prCount} dirty=${dirtyCount} agent=${agentStatus}`;
   log(summary);
   writeBroadcast(summary);
 }
+
+/** Build the work prompt sent to the agent harness. Persona-agnostic. */
+function buildWorkPrompt(persona: string, prCount: string, claimCount: number, dirtyCount: number): string {
+  return [
+    `You are ${persona}, trajectory manager. This is a ${personaConfig!.gateInterval}s autonomous cycle.`,
+    `Read broadcasts: ~/.local/share/zeta-broadcasts/*.md`,
+    `State: ${prCount} open PRs, ${claimCount} claims, ${dirtyCount} dirty files.`,
+    `Walk assigned trajectories. Own every PR through merge.`,
+    `Write status to ~/.local/share/zeta-broadcasts/${persona}.md at cycle end.`,
+    `Report: open PRs, active claims, drift, one forward action or exact blocker.`,
+  ].join(" ");
+}
+
+/**
+ * The observe-native gate: instead of spawning a CLI with a prompt string,
+ * invoke the observe controller directly when it's available. Falls back to
+ * CLI invocation when the observe loop isn't wired (e.g. the harness doesn't
+ * support inline observe yet).
+ *
+ * This is the compression point where three systems become one:
+ *   state-machine (where am I?) → observe grammar (what can I do?) → execute (do it)
+ *
+ * The agent CLI is the v0 executor; the observe controller is the v1 executor.
+ * Both are legal — the unified tick doesn't care which path resolves the action.
+ */
 
 // --- Main ---
 if (!acquireLock()) {

--- a/src/Core.TypeScript/service/persona-registry.test.ts
+++ b/src/Core.TypeScript/service/persona-registry.test.ts
@@ -17,6 +17,8 @@ describe("persona-registry", () => {
     expect(kiro!.name).toBe("kiro");
     expect(kiro!.label).toContain("kiro");
     expect(kiro!.scheduleInterval).toBe(60);
+    expect(kiro!.gateInterval).toBeGreaterThan(0);
+    expect(kiro!.harness.command).toBe("kiro-cli");
   });
 
   test("getPersona returns undefined for unknown name", () => {

--- a/src/Core.TypeScript/service/persona-registry.ts
+++ b/src/Core.TypeScript/service/persona-registry.ts
@@ -8,17 +8,53 @@
 export interface PersonaConfig {
   readonly name: string;
   readonly label: string;
-  readonly scheduleInterval: number; // seconds
+  readonly scheduleInterval: number; // seconds between heartbeat ticks
+  readonly gateInterval: number;    // seconds between agent work cycles (0 = no agent gate)
+  readonly gateTimeout: number;     // max seconds for a single agent invocation
   readonly defaultRef: string;
+  readonly harness: HarnessConfig;
+}
+
+export interface HarnessConfig {
+  /** CLI command to invoke the agent (e.g. "claude", "codex", "kiro-cli") */
+  readonly command: string;
+  /** CLI args template — {{PROMPT}} is replaced with the work prompt */
+  readonly args: readonly string[];
+  /** If true, the tick runs in an IDE terminal (not launchd). No agent gate by default. */
+  readonly ideNative?: boolean;
 }
 
 export const PERSONAS: readonly PersonaConfig[] = [
-  { name: "kiro",   label: "com.lucent.zeta.kiro-loop",   scheduleInterval: 60, defaultRef: "main" },
-  { name: "otto",   label: "com.lucent.zeta.otto-loop",   scheduleInterval: 60, defaultRef: "main" },
-  { name: "riven",  label: "com.lucent.zeta.riven-loop",  scheduleInterval: 60, defaultRef: "main" },
-  { name: "soraya", label: "com.lucent.zeta.soraya-loop", scheduleInterval: 60, defaultRef: "main" },
-  { name: "lior",   label: "com.lucent.zeta.lior-loop",   scheduleInterval: 60, defaultRef: "main" },
-  { name: "codex",  label: "com.lucent.zeta.codex-loop",  scheduleInterval: 60, defaultRef: "main" },
+  {
+    name: "otto", label: "com.lucent.zeta.otto-loop",
+    scheduleInterval: 60, gateInterval: 900, gateTimeout: 300, defaultRef: "main",
+    harness: { command: "claude", args: ["-p", "--permission-mode", "auto", "{{PROMPT}}"] },
+  },
+  {
+    name: "kiro", label: "com.lucent.zeta.kiro-loop",
+    scheduleInterval: 60, gateInterval: 900, gateTimeout: 300, defaultRef: "main",
+    harness: { command: "kiro-cli", args: ["chat", "--no-interactive", "--trust-all-tools", "{{PROMPT}}"] },
+  },
+  {
+    name: "codex", label: "com.lucent.zeta.codex-loop",
+    scheduleInterval: 60, gateInterval: 900, gateTimeout: 300, defaultRef: "main",
+    harness: { command: "codex", args: ["--approval-mode", "full-auto", "{{PROMPT}}"] },
+  },
+  {
+    name: "riven", label: "com.lucent.zeta.riven-loop",
+    scheduleInterval: 60, gateInterval: 900, gateTimeout: 300, defaultRef: "main",
+    harness: { command: "cursor", args: ["--background", "{{PROMPT}}"], ideNative: true },
+  },
+  {
+    name: "soraya", label: "com.lucent.zeta.soraya-loop",
+    scheduleInterval: 60, gateInterval: 0, gateTimeout: 0, defaultRef: "main",
+    harness: { command: "soraya", args: ["{{PROMPT}}"] },
+  },
+  {
+    name: "lior", label: "com.lucent.zeta.lior-loop",
+    scheduleInterval: 60, gateInterval: 0, gateTimeout: 0, defaultRef: "main",
+    harness: { command: "gemini", args: ["{{PROMPT}}"] },
+  },
 ];
 
 export function getPersona(name: string): PersonaConfig | undefined {

--- a/src/Core/Collation.fs
+++ b/src/Core/Collation.fs
@@ -2,6 +2,64 @@ namespace Zeta.Core
 
 open System
 open System.Collections.Generic
+open System.Text
+
+/// A StringComparer that orders strings ordinally by Unicode code point (Rune) value (B-0969).
+/// Matches TS's true Unicode code point comparison, resolving the UTF-16 surrogate pair discrepancy.
+type UnicodeCodePointComparer(ignoreCase: bool) =
+    inherit StringComparer()
+    
+    static member Ordinal = UnicodeCodePointComparer(false)
+    static member OrdinalIgnoreCase = UnicodeCodePointComparer(true)
+
+    override this.Compare(x: string, y: string) =
+        if obj.ReferenceEquals(x, y) then 0
+        elif isNull x then -1
+        elif isNull y then 1
+        else
+            let mutable enumX = x.EnumerateRunes()
+            let mutable enumY = y.EnumerateRunes()
+            let mutable result = 0
+            let mutable loop = true
+            while loop do
+                let hasX = enumX.MoveNext()
+                let hasY = enumY.MoveNext()
+                if not hasX && not hasY then
+                    result <- 0
+                    loop <- false
+                elif not hasX then
+                    result <- -1
+                    loop <- false
+                elif not hasY then
+                    result <- 1
+                    loop <- false
+                else
+                    let mutable runeX = enumX.Current
+                    let mutable runeY = enumY.Current
+                    if ignoreCase then
+                        runeX <- Rune.ToLowerInvariant(runeX)
+                        runeY <- Rune.ToLowerInvariant(runeY)
+                    if runeX.Value < runeY.Value then
+                        result <- -1
+                        loop <- false
+                    elif runeX.Value > runeY.Value then
+                        result <- 1
+                        loop <- false
+            result
+
+    override this.Equals(x: string, y: string) =
+        if obj.ReferenceEquals(x, y) then true
+        elif isNull x || isNull y then false
+        else
+            let comp = if ignoreCase then StringComparison.OrdinalIgnoreCase else StringComparison.Ordinal
+            String.Equals(x, y, comp)
+
+    override this.GetHashCode(obj: string) =
+        if isNull obj then raise (ArgumentNullException("obj"))
+        let comp = if ignoreCase then StringComparison.OrdinalIgnoreCase else StringComparison.Ordinal
+        obj.GetHashCode(comp)
+
+
 
 /// **Database-style collation selection** (B-0969). A collation is a *named, selectable ordering* — modeled
 /// the way databases do it (SQL / Postgres `COLLATE`, ICU locales), NOT a raw `IComparer` knob exposed as
@@ -23,7 +81,7 @@ module Collation =
     /// All four oracles coincide on this order for the golden vectors (F# ordinal, C#
     /// `StringComparer.Ordinal`, TS UTF-16 code-unit, Rust byte `Ord`); the astral/UTF-16 caveat is
     /// resolved by the treaty picking codepoint ≡ UTF-8 byte order.
-    let binary: StringComparer = StringComparer.Ordinal
+    let binary: StringComparer = UnicodeCodePointComparer.Ordinal :> StringComparer
 
     /// The default collation name we ship with.
     [<Literal>]
@@ -33,11 +91,32 @@ module Collation =
     /// are opt-in. Case-insensitive + invariant are *linguistic* — selectable, never the default.
     let catalog: IReadOnlyDictionary<string, StringComparer> =
         let d = Dictionary<string, StringComparer>(StringComparer.OrdinalIgnoreCase)
-        d.["binary"] <- StringComparer.Ordinal
-        d.["ordinal"] <- StringComparer.Ordinal
-        d.["ordinal-ci"] <- StringComparer.OrdinalIgnoreCase
+        d.["binary"] <- UnicodeCodePointComparer.Ordinal :> StringComparer
+        d.["ordinal"] <- UnicodeCodePointComparer.Ordinal :> StringComparer
+        d.["ordinal-ci"] <- UnicodeCodePointComparer.OrdinalIgnoreCase :> StringComparer
         d.["invariant"] <- StringComparer.InvariantCulture
         d.["invariant-ci"] <- StringComparer.InvariantCultureIgnoreCase
+        
+        // Postgres / Standard SQL aliases
+        d.["C"] <- UnicodeCodePointComparer.Ordinal :> StringComparer
+        d.["POSIX"] <- UnicodeCodePointComparer.Ordinal :> StringComparer
+        d.["utf8_bin"] <- UnicodeCodePointComparer.Ordinal :> StringComparer
+        d.["utf8mb4_bin"] <- UnicodeCodePointComparer.Ordinal :> StringComparer
+        
+        // SQLite alias
+        d.["NOCASE"] <- UnicodeCodePointComparer.OrdinalIgnoreCase :> StringComparer
+        
+        // MySQL aliases
+        d.["utf8_general_ci"] <- UnicodeCodePointComparer.OrdinalIgnoreCase :> StringComparer
+        d.["utf8mb4_general_ci"] <- UnicodeCodePointComparer.OrdinalIgnoreCase :> StringComparer
+        d.["utf8_unicode_ci"] <- StringComparer.InvariantCultureIgnoreCase
+        d.["utf8mb4_unicode_ci"] <- StringComparer.InvariantCultureIgnoreCase
+        
+        // SQL Server aliases
+        d.["Latin1_General_BIN"] <- UnicodeCodePointComparer.Ordinal :> StringComparer
+        d.["Latin1_General_CI_AS"] <- StringComparer.InvariantCultureIgnoreCase
+        d.["Latin1_General_CS_AS"] <- StringComparer.InvariantCulture
+        
         d :> IReadOnlyDictionary<string, StringComparer>
 
     /// Resolve a named collation from the catalog, or `None` if unknown (the caller decides the fallback —
@@ -59,6 +138,10 @@ module Collation =
     /// ordinal-equivalent, so the BCL default is correct + fast there).
     let forKey<'T> () : IComparer<'T> =
         if typeof<'T> = typeof<string> then
-            unbox<IComparer<'T>> (box (StringComparer.Ordinal :> IComparer<string>))
+            unbox<IComparer<'T>> (box (UnicodeCodePointComparer.Ordinal :> IComparer<string>))
         else
             Comparer<'T>.Default
+
+[<AbstractClass; Sealed>]
+type internal KeyComparerCache<'T when 'T : comparison> =
+    static member val Instance: IComparer<'T> = Collation.forKey<'T> ()

--- a/src/Core/ZSet.fs
+++ b/src/Core/ZSet.fs
@@ -21,9 +21,7 @@ type ZEntry<'K> =
 /// is ordinal (never culture-sensitive `Comparer<string>.Default`), every other `'K` keeps the BCL default.
 /// `static member val` on a generic type → one instance per closed `'K`, resolved once in the type's static
 /// ctor, so the hot per-element comparator pays no `forKey` type-check per call (Naledi: hoist out of loops).
-[<AbstractClass; Sealed>]
-type internal KeyComparerCache<'K when 'K : comparison>() =
-    static member val Instance: IComparer<'K> = Collation.forKey<'K> ()
+
 
 /// Struct comparer for sorting `ZEntry<'K>` by key ascending — monomorphized
 /// per `'K` by `MemoryExtensions.Sort<T, TComparer>`; zero heap allocation.


### PR DESCRIPTION
Extends unified loop-tick with per-persona agent gates. Learns from Otto (.claude/bin/) and Codex (.codex/bin/) patterns. 19 tests, 0 errors. Co-Authored-By: Kiro <noreply@kiro.dev>