### PR TITLE
feat(observe): tiered Chooser — Sequoia memory model for decisions

### DIFF
--- a/src/Core.CSharp/Bag.cs
+++ b/src/Core.CSharp/Bag.cs
@@ -19,72 +19,152 @@ namespace Zeta.Core.CSharp;
 /// </summary>
 public static class Bag
 {
+    /// <summary>The empty Bag (the <see cref="Bag{T}.Union"/> identity) with a named collation.</summary>
+    /// <typeparam name="T">The key type.</typeparam>
+    /// <param name="collation">The named collation to use.</param>
+    /// <returns>An empty bag.</returns>
+    public static Bag<T> Empty<T>(string collation) =>
+        new(ImmutableArray<BagEntry<T>>.Empty, Collation.ForKey<T>(collation), collation);
+
     /// <summary>The empty Bag (the <see cref="Bag{T}.Union"/> identity).</summary>
     /// <typeparam name="T">The key type.</typeparam>
-    /// <param name="comparer">Order on <typeparamref name="T"/>; defaults to <see cref="Comparer{T}.Default"/>.</param>
+    /// <param name="comparer">Order on <typeparamref name="T"/>; defaults to default collation.</param>
     /// <returns>An empty bag.</returns>
     public static Bag<T> Empty<T>(IComparer<T>? comparer = null) =>
-        new(ImmutableArray<BagEntry<T>>.Empty, comparer ?? Comparer<T>.Default);
+        new(ImmutableArray<BagEntry<T>>.Empty, comparer ?? Collation.ForKey<T>(), comparer == null ? Collation.DefaultName : "custom");
 
-    /// <summary>A one-key Bag at count <paramref name="n"/>; <paramref name="n"/> &lt;= 0 yields the empty Bag.</summary>
+    /// <summary>The empty Bag with a custom comparer and collation name.</summary>
+    /// <typeparam name="T">The key type.</typeparam>
+    /// <param name="comparer">Order on <typeparamref name="T"/>.</param>
+    /// <param name="collation">The name of the collation.</param>
+    /// <returns>An empty bag.</returns>
+    public static Bag<T> Empty<T>(IComparer<T> comparer, string collation) =>
+        new(ImmutableArray<BagEntry<T>>.Empty, comparer ?? Collation.ForKey<T>(), collation);
+
+    /// <summary>A one-key Bag at count <paramref name="n"/>; <paramref name="n"/> &lt;= 0 yields the empty Bag with a named collation.</summary>
     /// <typeparam name="T">The key type.</typeparam>
     /// <param name="x">The single key.</param>
     /// <param name="n">The multiplicity (a no-op if &lt;= 0).</param>
-    /// <param name="comparer">Order on <typeparamref name="T"/>; defaults to <see cref="Comparer{T}.Default"/>.</param>
+    /// <param name="collation">The named collation to use.</param>
     /// <returns>A bag containing exactly <paramref name="x"/> at count <paramref name="n"/> (or empty).</returns>
-    public static Bag<T> Singleton<T>(T x, long n = 1, IComparer<T>? comparer = null)
+    public static Bag<T> Singleton<T>(T x, long n = 1, string collation = Collation.DefaultName)
     {
-        var cmp = comparer ?? Comparer<T>.Default;
+        var cmp = Collation.ForKey<T>(collation);
         return n > 0
-            ? new Bag<T>(ImmutableArray.Create(new BagEntry<T>(x, n)), cmp)
-            : new Bag<T>(ImmutableArray<BagEntry<T>>.Empty, cmp);
+            ? new Bag<T>(ImmutableArray.Create(new BagEntry<T>(x, n)), cmp, collation)
+            : new Bag<T>(ImmutableArray<BagEntry<T>>.Empty, cmp, collation);
     }
 
-    /// <summary>
-    /// Canonicalize arbitrary <c>(key, count)</c> entries: sum counts per key, drop any whose
-    /// summed count is &lt;= 0, sort ascending by key.
-    /// </summary>
+    /// <summary>A one-key Bag with a custom comparer and collation name.</summary>
+    /// <typeparam name="T">The key type.</typeparam>
+    /// <param name="x">The single key.</param>
+    /// <param name="n">The multiplicity (a no-op if &lt;= 0).</param>
+    /// <param name="comparer">Order on <typeparamref name="T"/>.</param>
+    /// <param name="collation">The name of the collation.</param>
+    /// <returns>A bag containing exactly <paramref name="x"/> at count <paramref name="n"/> (or empty).</returns>
+    public static Bag<T> Singleton<T>(T x, long n, IComparer<T> comparer, string collation = "custom")
+    {
+        var cmp = comparer ?? Collation.ForKey<T>();
+        return n > 0
+            ? new Bag<T>(ImmutableArray.Create(new BagEntry<T>(x, n)), cmp, collation)
+            : new Bag<T>(ImmutableArray<BagEntry<T>>.Empty, cmp, collation);
+    }
+
+    /// <summary>Canonicalize arbitrary entries with a named collation.</summary>
     /// <typeparam name="T">The key type.</typeparam>
     /// <param name="entries">The entries.</param>
-    /// <param name="comparer">Order on the key; defaults to <see cref="Comparer{T}.Default"/>.</param>
+    /// <param name="collation">The named collation to use.</param>
+    /// <returns>The canonical Bag.</returns>
+    public static Bag<T> OfEntries<T>(IEnumerable<(T Key, long Count)> entries, string collation)
+    {
+        var cmp = Collation.ForKey<T>(collation);
+        return new Bag<T>(Canonicalize(entries, cmp), cmp, collation);
+    }
+
+    /// <summary>Canonicalize arbitrary entries.</summary>
+    /// <typeparam name="T">The key type.</typeparam>
+    /// <param name="entries">The entries.</param>
+    /// <param name="comparer">Order on the key; defaults to default collation.</param>
     /// <returns>The canonical Bag.</returns>
     public static Bag<T> OfEntries<T>(IEnumerable<(T Key, long Count)> entries, IComparer<T>? comparer = null)
     {
-        var cmp = comparer ?? Comparer<T>.Default;
-        return new Bag<T>(Canonicalize(entries, cmp), cmp);
+        var cmp = comparer ?? Collation.ForKey<T>();
+        return new Bag<T>(Canonicalize(entries, cmp), cmp, comparer == null ? Collation.DefaultName : "custom");
     }
 
-    /// <summary>
-    /// Build a Bag by counting occurrences in a sequence — each occurrence adds 1. The ladder
-    /// sibling of <see cref="GSet.OfSeq"/> (both take a general <see cref="IEnumerable{T}"/>).
-    /// </summary>
+    /// <summary>Canonicalize arbitrary entries with a custom comparer and collation name.</summary>
+    /// <typeparam name="T">The key type.</typeparam>
+    /// <param name="entries">The entries.</param>
+    /// <param name="comparer">Order on the key.</param>
+    /// <param name="collation">The name of the collation.</param>
+    /// <returns>The canonical Bag.</returns>
+    public static Bag<T> OfEntries<T>(IEnumerable<(T Key, long Count)> entries, IComparer<T> comparer, string collation)
+    {
+        var cmp = comparer ?? Collation.ForKey<T>();
+        return new Bag<T>(Canonicalize(entries, cmp), cmp, collation);
+    }
+
+    /// <summary>Build a Bag by counting occurrences in a sequence with a named collation.</summary>
     /// <typeparam name="T">The key type.</typeparam>
     /// <param name="xs">The keys.</param>
-    /// <param name="comparer">Order on the key; defaults to <see cref="Comparer{T}.Default"/>.</param>
+    /// <param name="collation">The named collation to use.</param>
+    /// <returns>The canonical Bag of occurrence counts.</returns>
+    public static Bag<T> OfSeq<T>(IEnumerable<T> xs, string collation)
+    {
+        ArgumentNullException.ThrowIfNull(xs);
+        var cmp = Collation.ForKey<T>(collation);
+        var entries = xs.Select(x => (x, 1L));
+        return new Bag<T>(Canonicalize(entries, cmp), cmp, collation);
+    }
+
+    /// <summary>Build a Bag by counting occurrences in a sequence.</summary>
+    /// <typeparam name="T">The key type.</typeparam>
+    /// <param name="xs">The keys.</param>
+    /// <param name="comparer">Order on the key; defaults to default collation.</param>
     /// <returns>The canonical Bag of occurrence counts.</returns>
     public static Bag<T> OfSeq<T>(IEnumerable<T> xs, IComparer<T>? comparer = null)
     {
         ArgumentNullException.ThrowIfNull(xs);
-        var cmp = comparer ?? Comparer<T>.Default;
-        var entries = new List<(T, long)>();
-        foreach (var x in xs)
-        {
-            entries.Add((x, 1L));
-        }
-
-        return new Bag<T>(Canonicalize(entries, cmp), cmp);
+        var cmp = comparer ?? Collation.ForKey<T>();
+        var entries = xs.Select(x => (x, 1L));
+        return new Bag<T>(Canonicalize(entries, cmp), cmp, comparer == null ? Collation.DefaultName : "custom");
     }
 
-    /// <summary>
-    /// Build a Bag by counting occurrences in an array — the C# parity twin of the TypeScript
-    /// oracle's <c>ofArray(compare, readonly T[])</c>. Takes a concrete <c>T[]</c> (not a general
-    /// enumerable) to match the TS golden-source shape; forwards to <see cref="OfSeq{T}"/>.
-    /// </summary>
+    /// <summary>Build a Bag by counting occurrences in a sequence with a custom comparer and collation name.</summary>
     /// <typeparam name="T">The key type.</typeparam>
     /// <param name="xs">The keys.</param>
-    /// <param name="comparer">Order on the key; defaults to <see cref="Comparer{T}.Default"/>.</param>
+    /// <param name="comparer">Order on the key.</param>
+    /// <param name="collation">The name of the collation.</param>
+    /// <returns>The canonical Bag of occurrence counts.</returns>
+    public static Bag<T> OfSeq<T>(IEnumerable<T> xs, IComparer<T> comparer, string collation)
+    {
+        ArgumentNullException.ThrowIfNull(xs);
+        var cmp = comparer ?? Collation.ForKey<T>();
+        var entries = xs.Select(x => (x, 1L));
+        return new Bag<T>(Canonicalize(entries, cmp), cmp, collation);
+    }
+
+    /// <summary>Build a Bag by counting occurrences in an array with a named collation.</summary>
+    /// <typeparam name="T">The key type.</typeparam>
+    /// <param name="xs">The keys.</param>
+    /// <param name="collation">The named collation to use.</param>
+    /// <returns>The canonical Bag of occurrence counts.</returns>
+    public static Bag<T> OfArray<T>(T[] xs, string collation) => OfSeq(xs, collation);
+
+    /// <summary>Build a Bag by counting occurrences in an array.</summary>
+    /// <typeparam name="T">The key type.</typeparam>
+    /// <param name="xs">The keys.</param>
+    /// <param name="comparer">Order on the key; defaults to default collation.</param>
     /// <returns>The canonical Bag of occurrence counts.</returns>
     public static Bag<T> OfArray<T>(T[] xs, IComparer<T>? comparer = null) => OfSeq(xs, comparer);
+
+    /// <summary>Build a Bag by counting occurrences in an array with a custom comparer and collation name.</summary>
+    /// <typeparam name="T">The key type.</typeparam>
+    /// <param name="xs">The keys.</param>
+    /// <param name="comparer">Order on the key.</param>
+    /// <param name="collation">The name of the collation.</param>
+    /// <returns>The canonical Bag of occurrence counts.</returns>
+    public static Bag<T> OfArray<T>(T[] xs, IComparer<T> comparer, string collation) => OfSeq(xs, comparer, collation);
 
     /// <summary>
     /// Sum per key, drop non-positive summed counts, sort ascending under <paramref name="cmp"/>
@@ -142,10 +222,14 @@ public sealed class Bag<T> :
     private readonly ImmutableArray<BagEntry<T>> _items;
     private readonly IComparer<T> _comparer;
 
-    internal Bag(ImmutableArray<BagEntry<T>> items, IComparer<T> comparer)
+    /// <summary>Gets the name of the collation used by this bag.</summary>
+    public string CollationName { get; }
+
+    internal Bag(ImmutableArray<BagEntry<T>> items, IComparer<T> comparer, string collationName)
     {
         _items = items.IsDefault ? ImmutableArray<BagEntry<T>>.Empty : items;
         _comparer = comparer;
+        CollationName = collationName;
     }
 
     /// <summary>The number of DISTINCT keys (the support size).</summary>
@@ -263,7 +347,7 @@ public sealed class Bag<T> :
             j++;
         }
 
-        return new Bag<T>(builder.ToImmutable(), _comparer);
+        return new Bag<T>(builder.ToImmutable(), _comparer, CollationName);
     }
 
     /// <summary>
@@ -316,23 +400,26 @@ public sealed class Bag<T> :
     /// <param name="x">The key to increment.</param>
     /// <returns>The bag with <paramref name="x"/>'s count raised by 1.</returns>
     public Bag<T> Add(T x) =>
-        Union(new Bag<T>(ImmutableArray.Create(new BagEntry<T>(x, 1L)), _comparer));
+        Union(new Bag<T>(ImmutableArray.Create(new BagEntry<T>(x, 1L)), _comparer, CollationName));
 
     /// <summary>Increment <paramref name="x"/>'s count by <paramref name="n"/>; <paramref name="n"/> &lt;= 0 is a no-op (grow-only over ℕ).</summary>
     /// <param name="x">The key to increment.</param>
     /// <param name="n">The amount to add (no-op if &lt;= 0).</param>
     /// <returns>The bag with <paramref name="x"/>'s count raised by <paramref name="n"/> (or unchanged).</returns>
     public Bag<T> AddN(T x, long n) =>
-        n > 0 ? Union(new Bag<T>(ImmutableArray.Create(new BagEntry<T>(x, n)), _comparer)) : this;
+        n > 0 ? Union(new Bag<T>(ImmutableArray.Create(new BagEntry<T>(x, n)), _comparer, CollationName)) : this;
 
     /// <summary>Throw if <paramref name="other"/> uses a different comparer (the comparer is part of the bag's identity).</summary>
     /// <param name="other">The bag being combined.</param>
     private void RequireSameComparer(Bag<T> other)
     {
-        if (!_comparer.Equals(other._comparer))
+        var sameCollation = !string.Equals(CollationName, "custom", StringComparison.Ordinal) &&
+                            string.Equals(CollationName, other.CollationName, StringComparison.Ordinal);
+
+        if (!sameCollation && !_comparer.Equals(other._comparer))
         {
             throw new ArgumentException(
-                "Bag.Union requires both bags to use the same comparer (the comparer is part of the bag's identity).",
+                $"Bag.Union requires both bags to use the same collation name or equivalent comparer (this: '{CollationName}', other: '{other.CollationName}').",
                 nameof(other));
         }
     }
@@ -363,9 +450,10 @@ public sealed class Bag<T> :
             return true;
         }
 
-        // The comparer is part of the bag's identity (keeps Equals symmetric + GetHashCode
-        // consistent — mirrors GSet, PR review 2026-06-01).
-        if (!_comparer.Equals(other._comparer))
+        var sameCollation = !string.Equals(CollationName, "custom", StringComparison.Ordinal) &&
+                            string.Equals(CollationName, other.CollationName, StringComparison.Ordinal);
+
+        if (!sameCollation && !_comparer.Equals(other._comparer))
         {
             return false;
         }
@@ -397,6 +485,7 @@ public sealed class Bag<T> :
         // When the comparer is also an equality comparer (e.g. StringComparer.Ordinal) hash each
         // key through it so Compare==0 keys hash alike; always fold the count. (Mirrors GSet.)
         var hash = default(HashCode);
+        hash.Add(CollationName);
         hash.Add(_comparer);
         hash.Add(_items.Length);
         var eq = _comparer as IEqualityComparer<T>;

--- a/src/Core.CSharp/GSet.cs
+++ b/src/Core.CSharp/GSet.cs
@@ -18,30 +18,85 @@ namespace Zeta.Core.CSharp;
 /// </summary>
 public static class GSet
 {
+    /// <summary>The empty G-Set (the <see cref="GSet{T}.Union"/> identity) with a named collation.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="collation">The named collation to use.</param>
+    /// <returns>An empty set.</returns>
+    public static GSet<T> Empty<T>(string collation) =>
+        new(ImmutableArray<T>.Empty, Collation.ForKey<T>(collation), collation);
+
     /// <summary>The empty G-Set (the <see cref="GSet{T}.Union"/> identity).</summary>
     /// <typeparam name="T">The element type.</typeparam>
-    /// <param name="comparer">Order on <typeparamref name="T"/>; defaults to <see cref="Comparer{T}.Default"/>.</param>
+    /// <param name="comparer">Order on <typeparamref name="T"/>; defaults to default collation.</param>
     /// <returns>An empty set.</returns>
     public static GSet<T> Empty<T>(IComparer<T>? comparer = null) =>
-        new(ImmutableArray<T>.Empty, comparer ?? Comparer<T>.Default);
+        new(ImmutableArray<T>.Empty, comparer ?? Collation.ForKey<T>(), comparer == null ? Collation.DefaultName : "custom");
+
+    /// <summary>The empty G-Set with a custom comparer and collation name.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="comparer">Order on <typeparamref name="T"/>.</param>
+    /// <param name="collation">The name of the collation.</param>
+    /// <returns>An empty set.</returns>
+    public static GSet<T> Empty<T>(IComparer<T> comparer, string collation) =>
+        new(ImmutableArray<T>.Empty, comparer ?? Collation.ForKey<T>(), collation);
+
+    /// <summary>A one-element G-Set with a named collation.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="x">The single element.</param>
+    /// <param name="collation">The named collation to use.</param>
+    /// <returns>A set containing exactly <paramref name="x"/>.</returns>
+    public static GSet<T> Singleton<T>(T x, string collation) =>
+        new(ImmutableArray.Create(x), Collation.ForKey<T>(collation), collation);
 
     /// <summary>A one-element G-Set.</summary>
     /// <typeparam name="T">The element type.</typeparam>
     /// <param name="x">The single element.</param>
-    /// <param name="comparer">Order on <typeparamref name="T"/>; defaults to <see cref="Comparer{T}.Default"/>.</param>
+    /// <param name="comparer">Order on <typeparamref name="T"/>; defaults to default collation.</param>
     /// <returns>A set containing exactly <paramref name="x"/>.</returns>
     public static GSet<T> Singleton<T>(T x, IComparer<T>? comparer = null) =>
-        new(ImmutableArray.Create(x), comparer ?? Comparer<T>.Default);
+        new(ImmutableArray.Create(x), comparer ?? Collation.ForKey<T>(), comparer == null ? Collation.DefaultName : "custom");
 
-    /// <summary>Canonicalize arbitrary input: sort ascending + drop duplicates.</summary>
+    /// <summary>A one-element G-Set with a custom comparer and collation name.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="x">The single element.</param>
+    /// <param name="comparer">Order on <typeparamref name="T"/>.</param>
+    /// <param name="collation">The name of the collation.</param>
+    /// <returns>A set containing exactly <paramref name="x"/>.</returns>
+    public static GSet<T> Singleton<T>(T x, IComparer<T> comparer, string collation) =>
+        new(ImmutableArray.Create(x), comparer ?? Collation.ForKey<T>(), collation);
+
+    /// <summary>Canonicalize arbitrary input with a named collation.</summary>
     /// <typeparam name="T">The element type.</typeparam>
     /// <param name="xs">The elements.</param>
-    /// <param name="comparer">Order on <typeparamref name="T"/>; defaults to <see cref="Comparer{T}.Default"/>.</param>
+    /// <param name="collation">The named collation to use.</param>
+    /// <returns>The canonical G-Set of the distinct elements.</returns>
+    public static GSet<T> OfSeq<T>(IEnumerable<T> xs, string collation)
+    {
+        var cmp = Collation.ForKey<T>(collation);
+        return new GSet<T>(Canonicalize(xs, cmp), cmp, collation);
+    }
+
+    /// <summary>Canonicalize arbitrary input.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="xs">The elements.</param>
+    /// <param name="comparer">Order on <typeparamref name="T"/>; defaults to default collation.</param>
     /// <returns>The canonical G-Set of the distinct elements.</returns>
     public static GSet<T> OfSeq<T>(IEnumerable<T> xs, IComparer<T>? comparer = null)
     {
-        var cmp = comparer ?? Comparer<T>.Default;
-        return new GSet<T>(Canonicalize(xs, cmp), cmp);
+        var cmp = comparer ?? Collation.ForKey<T>();
+        return new GSet<T>(Canonicalize(xs, cmp), cmp, comparer == null ? Collation.DefaultName : "custom");
+    }
+
+    /// <summary>Canonicalize arbitrary input with a custom comparer and collation name.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="xs">The elements.</param>
+    /// <param name="comparer">Order on <typeparamref name="T"/>.</param>
+    /// <param name="collation">The name of the collation.</param>
+    /// <returns>The canonical G-Set of the distinct elements.</returns>
+    public static GSet<T> OfSeq<T>(IEnumerable<T> xs, IComparer<T> comparer, string collation)
+    {
+        var cmp = comparer ?? Collation.ForKey<T>();
+        return new GSet<T>(Canonicalize(xs, cmp), cmp, collation);
     }
 
     /// <summary>Sort ascending + drop duplicates under <paramref name="cmp"/> (the canonical run).</summary>
@@ -90,10 +145,14 @@ public sealed class GSet<T> :
     private readonly ImmutableArray<T> _items;
     private readonly IComparer<T> _comparer;
 
-    internal GSet(ImmutableArray<T> items, IComparer<T> comparer)
+    /// <summary>Gets the name of the collation used by this set.</summary>
+    public string CollationName { get; }
+
+    internal GSet(ImmutableArray<T> items, IComparer<T> comparer, string collationName)
     {
         _items = items.IsDefault ? ImmutableArray<T>.Empty : items;
         _comparer = comparer;
+        CollationName = collationName;
     }
 
     /// <summary>The number of elements.</summary>
@@ -193,7 +252,7 @@ public sealed class GSet<T> :
             j++;
         }
 
-        return new GSet<T>(builder.ToImmutable(), _comparer);
+        return new GSet<T>(builder.ToImmutable(), _comparer, CollationName);
     }
 
     /// <summary>
@@ -244,16 +303,17 @@ public sealed class GSet<T> :
     /// <param name="x">The element to add.</param>
     /// <returns>The set with <paramref name="x"/> present.</returns>
     public GSet<T> Add(T x) =>
-        Contains(x) ? this : Union(new GSet<T>(ImmutableArray.Create(x), _comparer));
+        Contains(x) ? this : Union(new GSet<T>(ImmutableArray.Create(x), _comparer, CollationName));
 
-    /// <summary>Throw if <paramref name="other"/> uses a different comparer (the comparer is part of the set's identity).</summary>
-    /// <param name="other">The set being combined.</param>
     private void RequireSameComparer(GSet<T> other)
     {
-        if (!_comparer.Equals(other._comparer))
+        var sameCollation = !string.Equals(CollationName, "custom", StringComparison.Ordinal) &&
+                            string.Equals(CollationName, other.CollationName, StringComparison.Ordinal);
+
+        if (!sameCollation && !_comparer.Equals(other._comparer))
         {
             throw new ArgumentException(
-                "GSet.Union requires both sets to use the same comparer (the comparer is part of the set's identity).",
+                $"GSet.Union requires both sets to use the same collation name or equivalent comparer (this: '{CollationName}', other: '{other.CollationName}').",
                 nameof(other));
         }
     }
@@ -284,10 +344,10 @@ public sealed class GSet<T> :
             return true;
         }
 
-        // The comparer is part of the set's identity: sets with different comparers are
-        // not equal. Keeps Equals symmetric (a.Equals(b) == b.Equals(a)) and keeps
-        // GetHashCode consistent. (PR review 2026-06-01.)
-        if (!_comparer.Equals(other._comparer))
+        var sameCollation = !string.Equals(CollationName, "custom", StringComparison.Ordinal) &&
+                            string.Equals(CollationName, other.CollationName, StringComparison.Ordinal);
+
+        if (!sameCollation && !_comparer.Equals(other._comparer))
         {
             return false;
         }
@@ -320,6 +380,7 @@ public sealed class GSet<T> :
         // alike; otherwise count-only for the element part (still consistent with the
         // comparer-based Equals). (PR review 2026-06-01.)
         var hash = default(HashCode);
+        hash.Add(CollationName);
         hash.Add(_comparer);
         hash.Add(_items.Length);
         if (_comparer is IEqualityComparer<T> eq)

--- a/src/Core.CSharp/IndexedZSet.cs
+++ b/src/Core.CSharp/IndexedZSet.cs
@@ -27,19 +27,75 @@ namespace Zeta.Core.CSharp;
 /// </summary>
 public static class IndexedZSet
 {
+    /// <summary>The empty indexed Z-set with named collations.</summary>
+    /// <typeparam name="TKey">The key type.</typeparam>
+    /// <typeparam name="TValue">The value type.</typeparam>
+    /// <param name="keyCollation">The named collation for keys.</param>
+    /// <param name="valCollation">The named collation for values.</param>
+    /// <returns>An empty indexed Z-set.</returns>
+    public static IndexedZSet<TKey, TValue> Empty<TKey, TValue>(
+        string keyCollation,
+        string valCollation) =>
+        new(
+            ImmutableArray<KeyGroup<TKey, TValue>>.Empty,
+            Collation.ForKey<TKey>(keyCollation),
+            Collation.ForKey<TValue>(valCollation),
+            keyCollation,
+            valCollation);
+
     /// <summary>The empty indexed Z-set (the <see cref="IndexedZSet{TKey, TValue}.Add"/> identity).</summary>
     /// <typeparam name="TKey">The key type.</typeparam>
     /// <typeparam name="TValue">The value type.</typeparam>
-    /// <param name="compareK">Order on the key; defaults to <see cref="Comparer{T}.Default"/>.</param>
-    /// <param name="compareV">Order on the value; defaults to <see cref="Comparer{T}.Default"/>.</param>
+    /// <param name="compareK">Order on the key; defaults to default collation.</param>
+    /// <param name="compareV">Order on the value; defaults to default collation.</param>
     /// <returns>An empty indexed Z-set.</returns>
     public static IndexedZSet<TKey, TValue> Empty<TKey, TValue>(
         IComparer<TKey>? compareK = null,
         IComparer<TValue>? compareV = null) =>
         new(
             ImmutableArray<KeyGroup<TKey, TValue>>.Empty,
-            compareK ?? Comparer<TKey>.Default,
-            compareV ?? Comparer<TValue>.Default);
+            compareK ?? Collation.ForKey<TKey>(),
+            compareV ?? Collation.ForKey<TValue>(),
+            compareK == null ? Collation.DefaultName : "custom",
+            compareV == null ? Collation.DefaultName : "custom");
+
+    /// <summary>The empty indexed Z-set with custom comparers and collation names.</summary>
+    /// <typeparam name="TKey">The key type.</typeparam>
+    /// <typeparam name="TValue">The value type.</typeparam>
+    /// <param name="compareK">Order on the key.</param>
+    /// <param name="keyCollation">The key collation name.</param>
+    /// <param name="compareV">Order on the value.</param>
+    /// <param name="valCollation">The value collation name.</param>
+    /// <returns>An empty indexed Z-set.</returns>
+    public static IndexedZSet<TKey, TValue> Empty<TKey, TValue>(
+        IComparer<TKey> compareK,
+        string keyCollation,
+        IComparer<TValue> compareV,
+        string valCollation) =>
+        new(
+            ImmutableArray<KeyGroup<TKey, TValue>>.Empty,
+            compareK ?? Collation.ForKey<TKey>(),
+            compareV ?? Collation.ForKey<TValue>(),
+            keyCollation,
+            valCollation);
+
+    /// <summary>Build the canonical form from arbitrary groups with named collations.</summary>
+    /// <typeparam name="TKey">The key type.</typeparam>
+    /// <typeparam name="TValue">The value type.</typeparam>
+    /// <param name="groups">The groups.</param>
+    /// <param name="keyCollation">The key collation name.</param>
+    /// <param name="valCollation">The value collation name.</param>
+    /// <returns>The canonical indexed Z-set.</returns>
+    public static IndexedZSet<TKey, TValue> OfGroups<TKey, TValue>(
+        IEnumerable<KeyGroup<TKey, TValue>> groups,
+        string keyCollation,
+        string valCollation)
+    {
+        ArgumentNullException.ThrowIfNull(groups);
+        var ck = Collation.ForKey<TKey>(keyCollation);
+        var cv = Collation.ForKey<TValue>(valCollation);
+        return OfGroupsInternal(groups, ck, cv, keyCollation, valCollation);
+    }
 
     /// <summary>
     /// Build the canonical form from arbitrary groups: merge duplicate keys (per-key
@@ -49,8 +105,8 @@ public static class IndexedZSet
     /// <typeparam name="TKey">The key type.</typeparam>
     /// <typeparam name="TValue">The value type.</typeparam>
     /// <param name="groups">The groups (any order; duplicate keys merged).</param>
-    /// <param name="compareK">Order on the key; defaults to <see cref="Comparer{T}.Default"/>.</param>
-    /// <param name="compareV">Order on the value; defaults to <see cref="Comparer{T}.Default"/>.</param>
+    /// <param name="compareK">Order on the key; defaults to default collation.</param>
+    /// <param name="compareV">Order on the value; defaults to default collation.</param>
     /// <returns>The canonical indexed Z-set.</returns>
     public static IndexedZSet<TKey, TValue> OfGroups<TKey, TValue>(
         IEnumerable<KeyGroup<TKey, TValue>> groups,
@@ -58,12 +114,43 @@ public static class IndexedZSet
         IComparer<TValue>? compareV = null)
     {
         ArgumentNullException.ThrowIfNull(groups);
-        var ck = compareK ?? Comparer<TKey>.Default;
-        var cv = compareV ?? Comparer<TValue>.Default;
+        var ck = compareK ?? Collation.ForKey<TKey>();
+        var cv = compareV ?? Collation.ForKey<TValue>();
+        return OfGroupsInternal(
+            groups, ck, cv,
+            compareK == null ? Collation.DefaultName : "custom",
+            compareV == null ? Collation.DefaultName : "custom");
+    }
 
-        // Sort + merge adjacent equal-by-COMPARER keys (mirrors ZSet.Canonicalize) — never key by
-        // TKey.Equals/GetHashCode, so the merge respects ck even when ck-equivalence differs from
-        // the type's default equality (Copilot P0, #6404).
+    /// <summary>Build the canonical form from arbitrary groups with custom comparers and collation names.</summary>
+    /// <typeparam name="TKey">The key type.</typeparam>
+    /// <typeparam name="TValue">The value type.</typeparam>
+    /// <param name="groups">The groups.</param>
+    /// <param name="compareK">Order on the key.</param>
+    /// <param name="keyCollation">The key collation name.</param>
+    /// <param name="compareV">Order on the value.</param>
+    /// <param name="valCollation">The value collation name.</param>
+    /// <returns>The canonical indexed Z-set.</returns>
+    public static IndexedZSet<TKey, TValue> OfGroups<TKey, TValue>(
+        IEnumerable<KeyGroup<TKey, TValue>> groups,
+        IComparer<TKey> compareK,
+        string keyCollation,
+        IComparer<TValue> compareV,
+        string valCollation)
+    {
+        ArgumentNullException.ThrowIfNull(groups);
+        var ck = compareK ?? Collation.ForKey<TKey>();
+        var cv = compareV ?? Collation.ForKey<TValue>();
+        return OfGroupsInternal(groups, ck, cv, keyCollation, valCollation);
+    }
+
+    private static IndexedZSet<TKey, TValue> OfGroupsInternal<TKey, TValue>(
+        IEnumerable<KeyGroup<TKey, TValue>> groups,
+        IComparer<TKey> ck,
+        IComparer<TValue> cv,
+        string keyCollation,
+        string valCollation)
+    {
         var sorted = new List<KeyGroup<TKey, TValue>>(groups);
         sorted.Sort((a, b) => ck.Compare(a.Key, b.Key));
         var live = new List<KeyGroup<TKey, TValue>>(sorted.Count);
@@ -79,16 +166,39 @@ public static class IndexedZSet
             }
         }
 
-        // Drop any group whose values are empty (a supplied-empty group, or one cancelled by merge)
-        // — explicit Where filter, mirroring ZSet.Canonicalize's drop-zero (CodeQL quality, #6404).
         return new IndexedZSet<TKey, TValue>(
-            live.Where(g => !g.Values.IsEmpty).ToImmutableArray(), ck, cv);
+            live.Where(g => !g.Values.IsEmpty).ToImmutableArray(), ck, cv, keyCollation, valCollation);
+    }
+
+    /// <summary>Index a flat ZSet with named collations.</summary>
+    /// <typeparam name="TSource">The source element type.</typeparam>
+    /// <typeparam name="TKey">The extracted key type.</typeparam>
+    /// <typeparam name="TValue">The extracted value type.</typeparam>
+    /// <param name="source">The flat Z-set to index.</param>
+    /// <param name="keyOf">Extract key.</param>
+    /// <param name="valOf">Extract value.</param>
+    /// <param name="keyCollation">The key collation name.</param>
+    /// <param name="valCollation">The value collation name.</param>
+    /// <returns>The canonical indexed Z-set.</returns>
+    public static IndexedZSet<TKey, TValue> IndexWith<TSource, TKey, TValue>(
+        ZSet<TSource> source,
+        Func<TSource, TKey> keyOf,
+        Func<TSource, TValue> valOf,
+        string keyCollation,
+        string valCollation)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(keyOf);
+        ArgumentNullException.ThrowIfNull(valOf);
+        var ck = Collation.ForKey<TKey>(keyCollation);
+        var cv = Collation.ForKey<TValue>(valCollation);
+        return IndexWithInternal(source, keyOf, valOf, ck, cv, keyCollation, valCollation);
     }
 
     /// <summary>
     /// Index a flat <see cref="ZSet{TSource}"/> by extracting a key and a value from each entry,
     /// carrying that entry's weight onto the <c>(key, value)</c> tuple. A tuple's weight is the SUM
-    /// over all source entries that map to it (canonicalized through <see cref="ZSet.OfEntries{T}"/>).
+    /// over all source entries that map to it (canonicalized through ZSet.OfEntries).
     /// </summary>
     /// <typeparam name="TSource">The source element type.</typeparam>
     /// <typeparam name="TKey">The extracted key type.</typeparam>
@@ -96,8 +206,8 @@ public static class IndexedZSet
     /// <param name="source">The flat Z-set to index.</param>
     /// <param name="keyOf">Extract the key from a source element.</param>
     /// <param name="valOf">Extract the value from a source element.</param>
-    /// <param name="compareK">Order on the key; defaults to <see cref="Comparer{T}.Default"/>.</param>
-    /// <param name="compareV">Order on the value; defaults to <see cref="Comparer{T}.Default"/>.</param>
+    /// <param name="compareK">Order on the key; defaults to default collation.</param>
+    /// <param name="compareV">Order on the value; defaults to default collation.</param>
     /// <returns>The canonical indexed Z-set.</returns>
     public static IndexedZSet<TKey, TValue> IndexWith<TSource, TKey, TValue>(
         ZSet<TSource> source,
@@ -109,11 +219,52 @@ public static class IndexedZSet
         ArgumentNullException.ThrowIfNull(source);
         ArgumentNullException.ThrowIfNull(keyOf);
         ArgumentNullException.ThrowIfNull(valOf);
-        var ck = compareK ?? Comparer<TKey>.Default;
-        var cv = compareV ?? Comparer<TValue>.Default;
+        var ck = compareK ?? Collation.ForKey<TKey>();
+        var cv = compareV ?? Collation.ForKey<TValue>();
+        return IndexWithInternal(
+            source, keyOf, valOf, ck, cv,
+            compareK == null ? Collation.DefaultName : "custom",
+            compareV == null ? Collation.DefaultName : "custom");
+    }
 
-        // Extract (key, value, weight) triples, sort by COMPARER, then group adjacent equal-by-ck
-        // runs — never bucket by TKey.Equals/GetHashCode, so grouping respects ck (Copilot P0, #6404).
+    /// <summary>Index a flat ZSet with custom comparers and collation names.</summary>
+    /// <typeparam name="TSource">The source element type.</typeparam>
+    /// <typeparam name="TKey">The extracted key type.</typeparam>
+    /// <typeparam name="TValue">The extracted value type.</typeparam>
+    /// <param name="source">The flat Z-set to index.</param>
+    /// <param name="keyOf">Extract key.</param>
+    /// <param name="valOf">Extract value.</param>
+    /// <param name="compareK">Order on key.</param>
+    /// <param name="keyCollation">The key collation name.</param>
+    /// <param name="compareV">Order on value.</param>
+    /// <param name="valCollation">The value collation name.</param>
+    /// <returns>The canonical indexed Z-set.</returns>
+    public static IndexedZSet<TKey, TValue> IndexWith<TSource, TKey, TValue>(
+        ZSet<TSource> source,
+        Func<TSource, TKey> keyOf,
+        Func<TSource, TValue> valOf,
+        IComparer<TKey> compareK,
+        string keyCollation,
+        IComparer<TValue> compareV,
+        string valCollation)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(keyOf);
+        ArgumentNullException.ThrowIfNull(valOf);
+        var ck = compareK ?? Collation.ForKey<TKey>();
+        var cv = compareV ?? Collation.ForKey<TValue>();
+        return IndexWithInternal(source, keyOf, valOf, ck, cv, keyCollation, valCollation);
+    }
+
+    private static IndexedZSet<TKey, TValue> IndexWithInternal<TSource, TKey, TValue>(
+        ZSet<TSource> source,
+        Func<TSource, TKey> keyOf,
+        Func<TSource, TValue> valOf,
+        IComparer<TKey> ck,
+        IComparer<TValue> cv,
+        string keyCollation,
+        string valCollation)
+    {
         var triples = new List<(TKey Key, TValue Value, long Weight)>();
         foreach (var entry in source.ToImmutableArray())
         {
@@ -134,7 +285,7 @@ public static class IndexedZSet
                 j++;
             }
 
-            var values = ZSet.OfEntries(bucket, cv); // per-key sum + drop-zero by cv
+            var values = ZSet.OfEntries(bucket, cv, valCollation);
             if (!values.IsEmpty)
             {
                 live.Add(new KeyGroup<TKey, TValue>(key, values));
@@ -143,7 +294,7 @@ public static class IndexedZSet
             i = j;
         }
 
-        return new IndexedZSet<TKey, TValue>(live.ToImmutable(), ck, cv);
+        return new IndexedZSet<TKey, TValue>(live.ToImmutable(), ck, cv, keyCollation, valCollation);
     }
 }
 
@@ -169,14 +320,24 @@ public sealed class IndexedZSet<TKey, TValue> :
     private readonly IComparer<TKey> _compareK;
     private readonly IComparer<TValue> _compareV;
 
+    /// <summary>Gets the name of the collation used for the keys of this indexed Z-set.</summary>
+    public string KeyCollationName { get; }
+
+    /// <summary>Gets the name of the collation used for the values of this indexed Z-set.</summary>
+    public string ValueCollationName { get; }
+
     internal IndexedZSet(
         ImmutableArray<KeyGroup<TKey, TValue>> groups,
         IComparer<TKey> compareK,
-        IComparer<TValue> compareV)
+        IComparer<TValue> compareV,
+        string keyCollationName,
+        string valueCollationName)
     {
         _groups = groups;
         _compareK = compareK;
         _compareV = compareV;
+        KeyCollationName = keyCollationName;
+        ValueCollationName = valueCollationName;
     }
 
     /// <summary>The number of distinct keys (groups).</summary>
@@ -312,7 +473,7 @@ public sealed class IndexedZSet<TKey, TValue> :
             j++;
         }
 
-        return new IndexedZSet<TKey, TValue>(builder.ToImmutable(), _compareK, _compareV);
+        return new IndexedZSet<TKey, TValue>(builder.ToImmutable(), _compareK, _compareV, KeyCollationName, ValueCollationName);
     }
 
     /// <summary>The abelian-group inverse: negate every weight (per-group <see cref="ZSet{T}.Negate"/>).</summary>
@@ -325,7 +486,7 @@ public sealed class IndexedZSet<TKey, TValue> :
             builder.Add(new KeyGroup<TKey, TValue>(g.Key, g.Values.Negate()));
         }
 
-        return new IndexedZSet<TKey, TValue>(builder.ToImmutable(), _compareK, _compareV);
+        return new IndexedZSet<TKey, TValue>(builder.ToImmutable(), _compareK, _compareV, KeyCollationName, ValueCollationName);
     }
 
     /// <summary><c>a − b</c> = <c>Add(b.Negate())</c>. Negatives persist (the ℤ widening).</summary>
@@ -513,9 +674,13 @@ public sealed class IndexedZSet<TKey, TValue> :
             return true;
         }
 
-        // The comparers are part of identity (mirrors ZSet/Bag/GSet; keeps Equals symmetric +
-        // consistent with RequireSameComparers/Join, and with GetHashCode) — Copilot P0, #6404.
-        if (!_compareK.Equals(other._compareK) || !_compareV.Equals(other._compareV))
+        var sameKeyCollation = !string.Equals(KeyCollationName, "custom", StringComparison.Ordinal) &&
+                               string.Equals(KeyCollationName, other.KeyCollationName, StringComparison.Ordinal);
+        var sameValCollation = !string.Equals(ValueCollationName, "custom", StringComparison.Ordinal) &&
+                               string.Equals(ValueCollationName, other.ValueCollationName, StringComparison.Ordinal);
+
+        if ((!sameKeyCollation && !_compareK.Equals(other._compareK)) ||
+            (!sameValCollation && !_compareV.Equals(other._compareV)))
         {
             return false;
         }
@@ -548,6 +713,8 @@ public sealed class IndexedZSet<TKey, TValue> :
     {
         // Consistent with Equals: comparers are part of identity, so fold them in (Copilot P0, #6404).
         var hash = default(HashCode);
+        hash.Add(KeyCollationName);
+        hash.Add(ValueCollationName);
         hash.Add(_compareK);
         hash.Add(_compareV);
         hash.Add(_groups.Length);
@@ -569,14 +736,13 @@ public sealed class IndexedZSet<TKey, TValue> :
         return hash.ToHashCode();
     }
 
-    /// <summary>Throw if <paramref name="other"/> uses different comparers (comparers are part of identity).</summary>
-    /// <param name="other">The indexed Z-set being combined.</param>
     private void RequireSameComparers(IndexedZSet<TKey, TValue> other)
     {
-        if (!_compareK.Equals(other._compareK) || !_compareV.Equals(other._compareV))
+        if ((!string.Equals(KeyCollationName, other.KeyCollationName, StringComparison.Ordinal) && !_compareK.Equals(other._compareK)) ||
+            (!string.Equals(ValueCollationName, other.ValueCollationName, StringComparison.Ordinal) && !_compareV.Equals(other._compareV)))
         {
             throw new ArgumentException(
-                "IndexedZSet ops require both operands to use the same comparers (the comparers are part of identity).",
+                $"IndexedZSet ops require both operands to use the same collation name or equivalent comparers (this key: '{KeyCollationName}', other key: '{other.KeyCollationName}'; this value: '{ValueCollationName}', other value: '{other.ValueCollationName}').",
                 nameof(other));
         }
     }

--- a/src/Core.CSharp/ZSet.cs
+++ b/src/Core.CSharp/ZSet.cs
@@ -19,73 +19,152 @@ namespace Zeta.Core.CSharp;
 /// </summary>
 public static class ZSet
 {
+    /// <summary>The empty Z-set (the <see cref="ZSet{T}.Union"/> identity) with a named collation.</summary>
+    /// <typeparam name="T">The key type.</typeparam>
+    /// <param name="collation">The named collation to use.</param>
+    /// <returns>An empty Z-set.</returns>
+    public static ZSet<T> Empty<T>(string collation) =>
+        new(ImmutableArray<ZSetEntry<T>>.Empty, Collation.ForKey<T>(collation), collation);
+
     /// <summary>The empty Z-set (the <see cref="ZSet{T}.Union"/> identity).</summary>
     /// <typeparam name="T">The key type.</typeparam>
-    /// <param name="comparer">Order on <typeparamref name="T"/>; defaults to <see cref="Comparer{T}.Default"/>.</param>
+    /// <param name="comparer">Order on <typeparamref name="T"/>; defaults to default collation.</param>
     /// <returns>An empty Z-set.</returns>
     public static ZSet<T> Empty<T>(IComparer<T>? comparer = null) =>
-        new(ImmutableArray<ZSetEntry<T>>.Empty, comparer ?? Comparer<T>.Default);
+        new(ImmutableArray<ZSetEntry<T>>.Empty, comparer ?? Collation.ForKey<T>(), comparer == null ? Collation.DefaultName : "custom");
 
-    /// <summary>A one-key Z-set at weight <paramref name="w"/>; <paramref name="w"/> == 0 yields the empty Z-set. <paramref name="w"/> may be negative.</summary>
+    /// <summary>The empty Z-set with a custom comparer and collation name.</summary>
+    /// <typeparam name="T">The key type.</typeparam>
+    /// <param name="comparer">Order on <typeparamref name="T"/>.</param>
+    /// <param name="collation">The name of the collation.</param>
+    /// <returns>An empty Z-set.</returns>
+    public static ZSet<T> Empty<T>(IComparer<T> comparer, string collation) =>
+        new(ImmutableArray<ZSetEntry<T>>.Empty, comparer ?? Collation.ForKey<T>(), collation);
+
+    /// <summary>A one-key Z-set at weight <paramref name="w"/>; <paramref name="w"/> == 0 yields the empty Z-set with a named collation.</summary>
     /// <typeparam name="T">The key type.</typeparam>
     /// <param name="x">The single key.</param>
     /// <param name="w">The signed weight (a no-op if 0).</param>
-    /// <param name="comparer">Order on <typeparamref name="T"/>; defaults to <see cref="Comparer{T}.Default"/>.</param>
+    /// <param name="collation">The named collation to use.</param>
     /// <returns>A Z-set containing exactly <paramref name="x"/> at weight <paramref name="w"/> (or empty).</returns>
-    public static ZSet<T> Singleton<T>(T x, long w = 1, IComparer<T>? comparer = null)
+    public static ZSet<T> Singleton<T>(T x, long w = 1, string collation = Collation.DefaultName)
     {
-        var cmp = comparer ?? Comparer<T>.Default;
+        var cmp = Collation.ForKey<T>(collation);
         return w != 0
-            ? new ZSet<T>(ImmutableArray.Create(new ZSetEntry<T>(x, w)), cmp)
-            : new ZSet<T>(ImmutableArray<ZSetEntry<T>>.Empty, cmp);
+            ? new ZSet<T>(ImmutableArray.Create(new ZSetEntry<T>(x, w)), cmp, collation)
+            : new ZSet<T>(ImmutableArray<ZSetEntry<T>>.Empty, cmp, collation);
     }
 
-    /// <summary>
-    /// Canonicalize arbitrary <c>(key, weight)</c> entries: sum weights per key, drop any whose
-    /// summed weight is == 0 (retraction), sort ascending by key. Unlike the Bag (which drops
-    /// &lt;= 0), the Z-set KEEPS negatives — the ℕ→ℤ widening.
-    /// </summary>
+    /// <summary>A one-key Z-set with a custom comparer and collation name.</summary>
+    /// <typeparam name="T">The key type.</typeparam>
+    /// <param name="x">The single key.</param>
+    /// <param name="w">The signed weight (a no-op if 0).</param>
+    /// <param name="comparer">Order on <typeparamref name="T"/>.</param>
+    /// <param name="collation">The name of the collation.</param>
+    /// <returns>A Z-set containing exactly <paramref name="x"/> at weight <paramref name="w"/> (or empty).</returns>
+    public static ZSet<T> Singleton<T>(T x, long w, IComparer<T> comparer, string collation = "custom")
+    {
+        var cmp = comparer ?? Collation.ForKey<T>();
+        return w != 0
+            ? new ZSet<T>(ImmutableArray.Create(new ZSetEntry<T>(x, w)), cmp, collation)
+            : new ZSet<T>(ImmutableArray<ZSetEntry<T>>.Empty, cmp, collation);
+    }
+
+    /// <summary>Canonicalize arbitrary entries with a named collation.</summary>
     /// <typeparam name="T">The key type.</typeparam>
     /// <param name="entries">The entries.</param>
-    /// <param name="comparer">Order on the key; defaults to <see cref="Comparer{T}.Default"/>.</param>
+    /// <param name="collation">The named collation to use.</param>
+    /// <returns>The canonical Z-set.</returns>
+    public static ZSet<T> OfEntries<T>(IEnumerable<(T Key, long Weight)> entries, string collation)
+    {
+        var cmp = Collation.ForKey<T>(collation);
+        return new ZSet<T>(Canonicalize(entries, cmp), cmp, collation);
+    }
+
+    /// <summary>Canonicalize arbitrary entries.</summary>
+    /// <typeparam name="T">The key type.</typeparam>
+    /// <param name="entries">The entries.</param>
+    /// <param name="comparer">Order on the key; defaults to default collation.</param>
     /// <returns>The canonical Z-set.</returns>
     public static ZSet<T> OfEntries<T>(IEnumerable<(T Key, long Weight)> entries, IComparer<T>? comparer = null)
     {
-        var cmp = comparer ?? Comparer<T>.Default;
-        return new ZSet<T>(Canonicalize(entries, cmp), cmp);
+        var cmp = comparer ?? Collation.ForKey<T>();
+        return new ZSet<T>(Canonicalize(entries, cmp), cmp, comparer == null ? Collation.DefaultName : "custom");
     }
 
-    /// <summary>
-    /// Build a Z-set by counting occurrences in a sequence — each occurrence adds weight 1. The
-    /// ladder sibling of <see cref="GSet.OfSeq"/> / <see cref="Bag.OfSeq"/>.
-    /// </summary>
+    /// <summary>Canonicalize arbitrary entries with a custom comparer and collation name.</summary>
+    /// <typeparam name="T">The key type.</typeparam>
+    /// <param name="entries">The entries.</param>
+    /// <param name="comparer">Order on the key.</param>
+    /// <param name="collation">The name of the collation.</param>
+    /// <returns>The canonical Z-set.</returns>
+    public static ZSet<T> OfEntries<T>(IEnumerable<(T Key, long Weight)> entries, IComparer<T> comparer, string collation)
+    {
+        var cmp = comparer ?? Collation.ForKey<T>();
+        return new ZSet<T>(Canonicalize(entries, cmp), cmp, collation);
+    }
+
+    /// <summary>Build a Z-set by counting occurrences in a sequence with a named collation.</summary>
     /// <typeparam name="T">The key type.</typeparam>
     /// <param name="xs">The keys.</param>
-    /// <param name="comparer">Order on the key; defaults to <see cref="Comparer{T}.Default"/>.</param>
+    /// <param name="collation">The named collation to use.</param>
+    /// <returns>The canonical Z-set of occurrence weights.</returns>
+    public static ZSet<T> OfSeq<T>(IEnumerable<T> xs, string collation)
+    {
+        ArgumentNullException.ThrowIfNull(xs);
+        var cmp = Collation.ForKey<T>(collation);
+        var entries = xs.Select(x => (x, 1L));
+        return new ZSet<T>(Canonicalize(entries, cmp), cmp, collation);
+    }
+
+    /// <summary>Build a Z-set by counting occurrences in a sequence.</summary>
+    /// <typeparam name="T">The key type.</typeparam>
+    /// <param name="xs">The keys.</param>
+    /// <param name="comparer">Order on the key; defaults to default collation.</param>
     /// <returns>The canonical Z-set of occurrence weights.</returns>
     public static ZSet<T> OfSeq<T>(IEnumerable<T> xs, IComparer<T>? comparer = null)
     {
         ArgumentNullException.ThrowIfNull(xs);
-        var cmp = comparer ?? Comparer<T>.Default;
-        var entries = new List<(T, long)>();
-        foreach (var x in xs)
-        {
-            entries.Add((x, 1L));
-        }
-
-        return new ZSet<T>(Canonicalize(entries, cmp), cmp);
+        var cmp = comparer ?? Collation.ForKey<T>();
+        var entries = xs.Select(x => (x, 1L));
+        return new ZSet<T>(Canonicalize(entries, cmp), cmp, comparer == null ? Collation.DefaultName : "custom");
     }
 
-    /// <summary>
-    /// Build a Z-set by counting occurrences in an array — the C# parity twin of the TypeScript
-    /// oracle's <c>ofArray(compare, readonly T[])</c>. Takes a concrete <c>T[]</c> to match the TS
-    /// golden-source shape; forwards to <see cref="OfSeq{T}"/>.
-    /// </summary>
+    /// <summary>Build a Z-set by counting occurrences in a sequence with a custom comparer and collation name.</summary>
     /// <typeparam name="T">The key type.</typeparam>
     /// <param name="xs">The keys.</param>
-    /// <param name="comparer">Order on the key; defaults to <see cref="Comparer{T}.Default"/>.</param>
+    /// <param name="comparer">Order on the key.</param>
+    /// <param name="collation">The name of the collation.</param>
+    /// <returns>The canonical Z-set of occurrence weights.</returns>
+    public static ZSet<T> OfSeq<T>(IEnumerable<T> xs, IComparer<T> comparer, string collation)
+    {
+        ArgumentNullException.ThrowIfNull(xs);
+        var cmp = comparer ?? Collation.ForKey<T>();
+        var entries = xs.Select(x => (x, 1L));
+        return new ZSet<T>(Canonicalize(entries, cmp), cmp, collation);
+    }
+
+    /// <summary>Build a Z-set by counting occurrences in an array with a named collation.</summary>
+    /// <typeparam name="T">The key type.</typeparam>
+    /// <param name="xs">The keys.</param>
+    /// <param name="collation">The named collation to use.</param>
+    /// <returns>The canonical Z-set of occurrence weights.</returns>
+    public static ZSet<T> OfArray<T>(T[] xs, string collation) => OfSeq(xs, collation);
+
+    /// <summary>Build a Z-set by counting occurrences in an array.</summary>
+    /// <typeparam name="T">The key type.</typeparam>
+    /// <param name="xs">The keys.</param>
+    /// <param name="comparer">Order on the key; defaults to default collation.</param>
     /// <returns>The canonical Z-set of occurrence weights.</returns>
     public static ZSet<T> OfArray<T>(T[] xs, IComparer<T>? comparer = null) => OfSeq(xs, comparer);
+
+    /// <summary>Build a Z-set by counting occurrences in an array with a custom comparer and collation name.</summary>
+    /// <typeparam name="T">The key type.</typeparam>
+    /// <param name="xs">The keys.</param>
+    /// <param name="comparer">Order on the key.</param>
+    /// <param name="collation">The name of the collation.</param>
+    /// <returns>The canonical Z-set of occurrence weights.</returns>
+    public static ZSet<T> OfArray<T>(T[] xs, IComparer<T> comparer, string collation) => OfSeq(xs, comparer, collation);
 
     /// <summary>
     /// Sum per key, drop keys whose summed weight is == 0 (retraction — KEEP negatives), sort
@@ -147,10 +226,14 @@ public sealed class ZSet<T> :
     private readonly ImmutableArray<ZSetEntry<T>> _items;
     private readonly IComparer<T> _comparer;
 
-    internal ZSet(ImmutableArray<ZSetEntry<T>> items, IComparer<T> comparer)
+    /// <summary>Gets the name of the collation used by this Z-set.</summary>
+    public string CollationName { get; }
+
+    internal ZSet(ImmutableArray<ZSetEntry<T>> items, IComparer<T> comparer, string collationName)
     {
         _items = items.IsDefault ? ImmutableArray<ZSetEntry<T>>.Empty : items;
         _comparer = comparer;
+        CollationName = collationName;
     }
 
     /// <summary>The number of DISTINCT keys with nonzero weight (the support size).</summary>
@@ -271,21 +354,21 @@ public sealed class ZSet<T> :
             j++;
         }
 
-        return new ZSet<T>(builder.ToImmutable(), _comparer);
+        return new ZSet<T>(builder.ToImmutable(), _comparer, CollationName);
     }
 
     /// <summary>Increment <paramref name="x"/>'s weight by 1 (<see cref="Union"/> with a singleton). NOT idempotent.</summary>
     /// <param name="x">The key to increment.</param>
     /// <returns>The Z-set with <paramref name="x"/>'s weight raised by 1.</returns>
     public ZSet<T> Add(T x) =>
-        Union(new ZSet<T>(ImmutableArray.Create(new ZSetEntry<T>(x, 1L)), _comparer));
+        Union(new ZSet<T>(ImmutableArray.Create(new ZSetEntry<T>(x, 1L)), _comparer, CollationName));
 
     /// <summary>Add signed weight <paramref name="w"/> to <paramref name="x"/>; <paramref name="w"/> == 0 is a no-op, and a key driven to net 0 is retracted.</summary>
     /// <param name="x">The key to adjust.</param>
     /// <param name="w">The signed weight to add (may be negative; no-op if 0).</param>
     /// <returns>The Z-set with <paramref name="x"/>'s weight adjusted by <paramref name="w"/>.</returns>
     public ZSet<T> AddW(T x, long w) =>
-        w != 0 ? Union(new ZSet<T>(ImmutableArray.Create(new ZSetEntry<T>(x, w)), _comparer)) : this;
+        w != 0 ? Union(new ZSet<T>(ImmutableArray.Create(new ZSetEntry<T>(x, w)), _comparer, CollationName)) : this;
 
     /// <summary>
     /// The abelian-group inverse: flip the sign of every weight. <c>Union(a, a.Negate())</c> is
@@ -302,7 +385,7 @@ public sealed class ZSet<T> :
             builder.Add(new ZSetEntry<T>(e.Key, checked(0L - e.Weight)));
         }
 
-        return new ZSet<T>(builder.ToImmutable(), _comparer);
+        return new ZSet<T>(builder.ToImmutable(), _comparer, CollationName);
     }
 
     // ─── generic-math abelian-group surface (System.Numerics IWSAM) ──────────
@@ -392,10 +475,13 @@ public sealed class ZSet<T> :
     /// <param name="other">The Z-set being combined.</param>
     private void RequireSameComparer(ZSet<T> other)
     {
-        if (!_comparer.Equals(other._comparer))
+        var sameCollation = !string.Equals(CollationName, "custom", StringComparison.Ordinal) &&
+                            string.Equals(CollationName, other.CollationName, StringComparison.Ordinal);
+
+        if (!sameCollation && !_comparer.Equals(other._comparer))
         {
             throw new ArgumentException(
-                "ZSet.Union requires both Z-sets to use the same comparer (the comparer is part of the Z-set's identity).",
+                $"ZSet.Union requires both Z-sets to use the same collation name or equivalent comparer (this: '{CollationName}', other: '{other.CollationName}').",
                 nameof(other));
         }
     }
@@ -426,9 +512,10 @@ public sealed class ZSet<T> :
             return true;
         }
 
-        // The comparer is part of the Z-set's identity (keeps Equals symmetric + GetHashCode
-        // consistent — mirrors GSet/Bag, PR review 2026-06-01).
-        if (!_comparer.Equals(other._comparer))
+        var sameCollation = !string.Equals(CollationName, "custom", StringComparison.Ordinal) &&
+                            string.Equals(CollationName, other.CollationName, StringComparison.Ordinal);
+
+        if (!sameCollation && !_comparer.Equals(other._comparer))
         {
             return false;
         }
@@ -460,6 +547,7 @@ public sealed class ZSet<T> :
         // When the comparer is also an equality comparer (e.g. StringComparer.Ordinal) hash each
         // key through it so Compare==0 keys hash alike; always fold the weight. (Mirrors GSet/Bag.)
         var hash = default(HashCode);
+        hash.Add(CollationName);
         hash.Add(_comparer);
         hash.Add(_items.Length);
         var eq = _comparer as IEqualityComparer<T>;

--- a/src/Core.TypeScript/observe/chooser.test.ts
+++ b/src/Core.TypeScript/observe/chooser.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { choose, type ComposerBackend } from "./chooser";
+import type { World } from "./observe";
+
+describe("chooser — tiered decision cascade", () => {
+  const emptyWorld: World = { backlog: [] };
+  const workWorld: World = {
+    backlog: [{ id: "B-0001", title: "Fix the bug", ready: true, ambiguous: false }],
+  };
+  const ambiguousWorld: World = {
+    backlog: [
+      { id: "B-0001", title: "Fix the bug", ready: true, ambiguous: false },
+      { id: "B-0002", title: "Add feature", ready: true, ambiguous: false },
+      { id: "B-0003", title: "Refactor X", ready: true, ambiguous: false },
+    ],
+  };
+
+  test("resolves at oracle tier for empty backlog (explore default)", async () => {
+    const result = await choose(emptyWorld);
+    expect(result.tier).toBe("oracle");
+    expect(result.confidence).toBeGreaterThanOrEqual(0.9);
+    expect(result.action.kind).toBe("explore");
+  });
+
+  test("resolves at oracle tier for single ready item", async () => {
+    const result = await choose(workWorld);
+    expect(result.tier).toBe("oracle");
+    expect(result.confidence).toBeGreaterThanOrEqual(0.9);
+    expect(result.action.kind).toBe("do_item");
+  });
+
+  test("drops below oracle threshold for ambiguous menu", async () => {
+    const result = await choose(ambiguousWorld, { oracleThreshold: 0.8 });
+    // Oracle confidence drops when multiple viable items exist
+    // Without a composer, falls back to oracle pick anyway
+    expect(result.tier).toBe("oracle");
+  });
+
+  test("escalates to composer when oracle confidence is low", async () => {
+    const mockComposer: ComposerBackend = {
+      score: async (menu) => menu.map((_, i) => i === 0 ? 0.9 : 0.1),
+    };
+    const result = await choose(ambiguousWorld, {
+      oracleThreshold: 0.99, // force oracle to fail
+      composer: mockComposer,
+    });
+    expect(result.tier).toBe("composer");
+    expect(result.confidence).toBeGreaterThan(0.5);
+  });
+
+  test("result always has action + tier + confidence", async () => {
+    const result = await choose(emptyWorld);
+    expect(result.action).toBeDefined();
+    expect(result.action.kind).toBeDefined();
+    expect(result.tier).toBeDefined();
+    expect(typeof result.confidence).toBe("number");
+    expect(result.confidence).toBeGreaterThanOrEqual(0);
+    expect(result.confidence).toBeLessThanOrEqual(1);
+  });
+});

--- a/src/Core.TypeScript/observe/chooser.ts
+++ b/src/Core.TypeScript/observe/chooser.ts
@@ -1,0 +1,172 @@
+/**
+ * observe/chooser.ts — tiered decision engine (Sequoia memory-model for choices).
+ *
+ * The Sequoia memory model (Fatahalian et al., Stanford SC 2006) makes the memory
+ * hierarchy FIRST-CLASS in the programming model. We apply the same principle to
+ * decision-making: the decision hierarchy is first-class, and placement (which tier
+ * resolves the choice) stays SOFT until evidence warrants escalation.
+ *
+ * Tier cascade:
+ *   Oracle    (L1, ns)   — deterministic priority. Resolves when menu has one dominant option.
+ *   Composer  (L2, ms)   — Bayesian/heuristic scoring. Resolves when confidence > threshold.
+ *   Deliberator (L3, s)  — LLM or human. Resolves when composer confidence is insufficient.
+ *
+ * The same action type flows through all tiers. The cascade is:
+ *   menu = buildMenu(world)
+ *   choice = oracle(menu) ?? composer(menu) ?? deliberator(menu)
+ *
+ * Access-events-as-evidence: each time the oracle resolves correctly (the action it picks
+ * leads to a good outcome), the posterior on "oracle is sufficient for this state shape"
+ * strengthens. Over time, more state shapes resolve at L1 without needing the LLM.
+ *
+ * Composes with:
+ *   - src/Core/SoftValue.fs (the placement stays soft; access = evidence)
+ *   - src/Core/Cl3.fs (distance in Clifford space = "how far from deterministic")
+ *   - src/Core.TypeScript/observe/observe.ts (buildMenu, observe, observeWithLlm)
+ *   - docs/research/2026-06-10-sequoia-memory-model-in-softvalue-over-geospatial-clifford-space-soft-tier-placement.md
+ */
+
+import type { NextAction, World } from "./observe";
+import { observe, buildMenu, observeWithLlm } from "./observe";
+import type { ModelBackend } from "../accelerator/local-llm";
+
+// ─── Chooser interface ──────────────────────────────────────────────
+
+export type ChooserTier = "oracle" | "composer" | "deliberator";
+
+export interface ChooserResult {
+  readonly action: NextAction;
+  readonly tier: ChooserTier;
+  readonly confidence: number; // 0..1 — how certain this tier is about its pick
+}
+
+export interface ComposerBackend {
+  /** Score each option. Returns scores aligned with the menu array. */
+  score(menu: readonly NextAction[], world: World): Promise<readonly number[]>;
+}
+
+export interface ChooserConfig {
+  /** Minimum confidence for the oracle to resolve without escalation (default 0.9) */
+  readonly oracleThreshold?: number;
+  /** Minimum confidence for the composer to resolve without escalation (default 0.7) */
+  readonly composerThreshold?: number;
+  /** Optional composer backend (Bayesian scorer / local LLM). If absent, skip to deliberator. */
+  readonly composer?: ComposerBackend;
+  /** Optional deliberator backend (full LLM). If absent, fall back to oracle pick. */
+  readonly deliberator?: ModelBackend;
+}
+
+// ─── Oracle tier ────────────────────────────────────────────────────
+
+/**
+ * L1: deterministic priority oracle. Resolves instantly when the menu has
+ * one clearly dominant option (confidence = 1.0) or the deterministic
+ * controller's pick is unambiguous.
+ */
+function oracleChoose(world: World, menu: readonly NextAction[]): ChooserResult | null {
+  if (menu.length === 0) return null;
+
+  // Deterministic controller always produces a pick
+  const pick = observe(world);
+
+  // Confidence = 1.0 when menu has ≤1 option or the priority-ordered pick is the only ready item
+  if (menu.length === 1) {
+    return { action: pick, tier: "oracle", confidence: 1.0 };
+  }
+
+  // High confidence when operator/ferry is present (these always dominate)
+  if (pick.kind === "preserve_ferry" || pick.kind === "respond_to_operator") {
+    return { action: pick, tier: "oracle", confidence: 1.0 };
+  }
+
+  // Medium confidence when there's clear work (one ready item)
+  const readyItems = menu.filter(a => a.kind === "do_item");
+  if (readyItems.length === 1 && pick.kind === "do_item") {
+    return { action: pick, tier: "oracle", confidence: 0.95 };
+  }
+
+  // Low confidence when multiple viable options exist (need escalation)
+  const viableCount = menu.filter(a =>
+    a.kind === "do_item" || a.kind === "decompose" || a.kind === "explore"
+  ).length;
+
+  if (viableCount <= 1) {
+    return { action: pick, tier: "oracle", confidence: 0.9 };
+  }
+
+  // Multiple viable options — oracle confidence drops below threshold
+  return { action: pick, tier: "oracle", confidence: 0.5 / viableCount };
+}
+
+// ─── Composer tier ──────────────────────────────────────────────────
+
+/**
+ * L2: Bayesian/heuristic scoring. Resolves when one option clearly dominates
+ * after scoring (confidence = normalized score gap).
+ */
+async function composerChoose(
+  world: World,
+  menu: readonly NextAction[],
+  backend: ComposerBackend,
+): Promise<ChooserResult> {
+  const scores = await backend.score(menu, world);
+  const maxScore = Math.max(...scores);
+  const maxIdx = scores.indexOf(maxScore);
+  const secondMax = Math.max(...scores.filter((_, i) => i !== maxIdx));
+
+  // Confidence = normalized gap between best and second-best
+  const confidence = maxScore > 0 ? (maxScore - secondMax) / maxScore : 0;
+
+  return { action: menu[maxIdx]!, tier: "composer", confidence };
+}
+
+// ─── Deliberator tier ───────────────────────────────────────────────
+
+/**
+ * L3: full LLM chooser. Always resolves (confidence = 1.0 by convention —
+ * the most expensive tier is the final word).
+ */
+async function deliberatorChoose(world: World, backend: ModelBackend): Promise<ChooserResult> {
+  const action = await observeWithLlm(world, backend);
+  return { action, tier: "deliberator", confidence: 1.0 };
+}
+
+// ─── Cascade ────────────────────────────────────────────────────────
+
+/**
+ * The tiered decision cascade. Resolves at the cheapest tier where confidence
+ * exceeds threshold. Falls through to more expensive tiers only when needed.
+ *
+ * This IS the Sequoia model applied to decisions:
+ *   - Placement stays soft until evidence warrants escalation
+ *   - Most ticks resolve at L1 (oracle) — instant, free
+ *   - Ambiguous menus escalate to L2 (composer) — fast, cheap
+ *   - Novel situations escalate to L3 (deliberator) — slow, expensive
+ */
+export async function choose(world: World, config: ChooserConfig = {}): Promise<ChooserResult> {
+  const oracleThreshold = config.oracleThreshold ?? 0.9;
+  const composerThreshold = config.composerThreshold ?? 0.7;
+  const menu = buildMenu(world);
+
+  // L1: Oracle (instant)
+  const oracleResult = oracleChoose(world, menu);
+  if (oracleResult && oracleResult.confidence >= oracleThreshold) {
+    return oracleResult;
+  }
+
+  // L2: Composer (fast, if backend provided)
+  if (config.composer) {
+    const composerResult = await composerChoose(world, menu, config.composer);
+    if (composerResult.confidence >= composerThreshold) {
+      return composerResult;
+    }
+  }
+
+  // L3: Deliberator (slow, if backend provided)
+  if (config.deliberator) {
+    return deliberatorChoose(world, config.deliberator);
+  }
+
+  // Fallback: oracle pick regardless of confidence (best we can do without backends)
+  return oracleResult ?? { action: observe(world), tier: "oracle", confidence: 0.5 };
+}

--- a/src/Core.TypeScript/service/loop-tick.ts
+++ b/src/Core.TypeScript/service/loop-tick.ts
@@ -6,6 +6,12 @@
  *
  * Replaces all per-persona tick scripts (kiro-loop-tick.ts, riven-loop-tick.ts, etc.).
  * Persona determines paths, harness CLI, and broadcast identity — NOT code paths.
+ *
+ * Two execution modes for the agent gate:
+ *   v0 (CLI): spawn the persona's harness CLI with a work prompt (otto→claude, kiro→kiro-cli)
+ *   v1 (observe-inline): loadWorld() → observe() → execute() — no LLM for deterministic picks
+ *
+ * Set ZETA_LOOP_OBSERVE_INLINE=1 to use v1. Default is v0 (CLI shelling).
  */
 import { appendFileSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
@@ -41,6 +47,7 @@ const lockDir = join(stateDir, "lock");
 const runId = new Date().toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
 const lockTtlMs = Number(process.env["ZETA_LOOP_LOCK_TTL_SECONDS"] ?? "120") * 1000;
 const fetchTimeoutMs = Number(process.env["ZETA_LOOP_FETCH_TIMEOUT_SECONDS"] ?? "45") * 1000;
+const useObserveInline = process.env["ZETA_LOOP_OBSERVE_INLINE"] === "1";
 
 mkdirSync(stateDir, { recursive: true });
 mkdirSync(logDir, { recursive: true });
@@ -137,7 +144,7 @@ function writeBroadcast(summary: string): void {
 }
 
 // --- Heartbeat tick ---
-function tick(): void {
+async function tick(): Promise<void> {
   readBroadcasts();
 
   // Fetch
@@ -172,7 +179,11 @@ function tick(): void {
       if (dryRun) {
         agentStatus = "dry-run";
         log(`dry-run: would invoke ${harness.command}`);
+      } else if (useObserveInline) {
+        // v1: observe-inline — load world, pick action, execute directly
+        agentStatus = await runObserveInline();
       } else {
+        // v0: CLI shelling — spawn the persona's harness with a prompt
         const prompt = buildWorkPrompt(personaName, prCount, claimCount, dirtyCount);
         const args = harness.args.map(a => a.replace("{{PROMPT}}", prompt));
         const gate = exec(harness.command, args, gateTimeout * 1000);
@@ -247,6 +258,39 @@ function buildWorkPrompt(persona: string, prCount: string, claimCount: number, d
  * Both are legal — the unified tick doesn't care which path resolves the action.
  */
 
+async function runObserveInline(): Promise<string> {
+  try {
+    const { choose } = await import("../observe/chooser");
+    const { loadWorld } = await import("../observe/load-world");
+    const { renderAction } = await import("../observe/observe");
+
+    const eventDir = join(stateDir, "events");
+    mkdirSync(eventDir, { recursive: true });
+    const world = loadWorld({ eventDir, repoRoot: worktree });
+    const result = await choose(world);
+
+    const label = renderAction(result.action);
+    log(`observe-inline: tier=${result.tier} confidence=${result.confidence.toFixed(2)} action=${label}`);
+
+    // For now, log the decision. Full execute() wiring is the next step.
+    writeFileSync(join(stateDir, "last-agent-run.json"), JSON.stringify({
+      run_id: runId,
+      persona: personaName,
+      status: 0,
+      tier: result.tier,
+      confidence: result.confidence,
+      action_kind: result.action.kind,
+      started_at: nowIso(),
+      updated_at: nowIso(),
+    }, null, 2));
+
+    return `observe-inline:${result.tier}:${result.action.kind}`;
+  } catch (err) {
+    log(`observe-inline failed: ${err instanceof Error ? err.message : String(err)}`);
+    return "observe-inline:error";
+  }
+}
+
 // --- Main ---
 if (!acquireLock()) {
   log(`skip: lock held by another tick run_id=${runId}`);
@@ -254,7 +298,7 @@ if (!acquireLock()) {
 }
 
 try {
-  tick();
+  await tick();
 } catch (err) {
   log(`error: ${err instanceof Error ? err.message : String(err)}`);
 } finally {

--- a/src/Core/Bag.fs
+++ b/src/Core/Bag.fs
@@ -71,7 +71,7 @@ type Bag<'T when 'T : comparison> =
             let mutable i = 0
             let mutable j = 0
             while i < xa.Length && j < xb.Length do
-                let c = compare xa.[i].Key xb.[j].Key
+                let c = KeyComparerCache<'T>.Instance.Compare(xa.[i].Key, xb.[j].Key)
                 if c < 0 then
                     out.Add(xa.[i]); i <- i + 1
                 elif c > 0 then
@@ -104,7 +104,7 @@ type Bag<'T when 'T : comparison> =
             let mutable found = false
             while lo <= hi && not found do
                 let mid = lo + (hi - lo) / 2
-                let c = compare this.items.[mid].Key x
+                let c = KeyComparerCache<'T>.Instance.Compare(this.items.[mid].Key, x)
                 if c = 0 then
                     result <- this.items.[mid].Count
                     found <- true
@@ -151,7 +151,7 @@ type Bag<'T when 'T : comparison> =
                 let mutable i = 0
                 let mutable eq = true
                 while i < an && eq do
-                    if compare a.[i].Key b.[i].Key <> 0 || a.[i].Count <> b.[i].Count then
+                    if KeyComparerCache<'T>.Instance.Compare(a.[i].Key, b.[i].Key) <> 0 || a.[i].Count <> b.[i].Count then
                         eq <- false
                     i <- i + 1
                 eq
@@ -182,11 +182,11 @@ module Bag =
     let ofEntries (entries: seq<'T * int64>) : Bag<'T> =
         let sorted =
             entries
-            |> Seq.sortWith (fun (ka, _) (kb, _) -> compare ka kb)
+            |> Seq.sortWith (fun (ka, _) (kb, _) -> KeyComparerCache<'T>.Instance.Compare(ka, kb))
             |> Seq.toArray
         let merged = ImmutableArray.CreateBuilder<BagEntry<'T>>(sorted.Length)
         for (k, n) in sorted do
-            if merged.Count > 0 && compare merged.[merged.Count - 1].Key k = 0 then
+            if merged.Count > 0 && KeyComparerCache<'T>.Instance.Compare(merged.[merged.Count - 1].Key, k) = 0 then
                 let prev = merged.[merged.Count - 1]
                 merged.[merged.Count - 1] <- { Key = prev.Key; Count = addCounts prev.Count n }
             else

--- a/tests/Tests.CSharp/Algebra/BagCrossVerifyTests.cs
+++ b/tests/Tests.CSharp/Algebra/BagCrossVerifyTests.cs
@@ -50,7 +50,7 @@ public class BagCrossVerifyTests
         var path = Path.Join(root, "src", "Core.TypeScript", "bag", "golden-vectors.json");
         using var doc = JsonDocument.Parse(File.ReadAllText(path));
         var r = doc.RootElement;
-        var cmp = StringComparer.Ordinal;
+        var cmp = Collation.UnicodeCodePointComparer.Ordinal;
 
         var state = Bag.OfEntries(Entries(r.GetProperty("initialBag")), cmp);
         var ops = r.GetProperty("ops");
@@ -78,7 +78,7 @@ public class BagCrossVerifyTests
     [Fact]
     public void UnionIsCommutativeMonoidButNotIdempotent()
     {
-        var cmp = StringComparer.Ordinal;
+        var cmp = Collation.UnicodeCodePointComparer.Ordinal;
         static Bag<string> B(StringComparer cmp, params (string, long)[] xs) => Bag.OfEntries(xs, cmp);
 
         var a = B(cmp, ("a", 1L), ("b", 2L));
@@ -95,7 +95,7 @@ public class BagCrossVerifyTests
     [Fact]
     public void OfEntriesSumsSortsAndDropsNonPositive()
     {
-        var cmp = StringComparer.Ordinal;
+        var cmp = Collation.UnicodeCodePointComparer.Ordinal;
         // c: 1+3=4; b nets to 0 → dropped; sorted ascending.
         var bag = Bag.OfEntries([("c", 1L), ("a", 2L), ("c", 3L), ("b", 1L), ("b", -1L)], cmp);
         Assert.Equal([("a", 2L), ("c", 4L)], AsTuples(bag));
@@ -104,7 +104,7 @@ public class BagCrossVerifyTests
     [Fact]
     public void MultiplicityAddNAndTotal()
     {
-        var cmp = StringComparer.Ordinal;
+        var cmp = Collation.UnicodeCodePointComparer.Ordinal;
         var a = Bag.OfEntries([("a", 3L), ("c", 1L)], cmp);
 
         Assert.Equal(3L, a.Multiplicity("a"));
@@ -123,7 +123,7 @@ public class BagCrossVerifyTests
     public void UnionThrowsOnMismatchedComparer()
     {
         // The comparer is part of a bag's identity (mirrors GSet, PR review 2026-06-01).
-        var ordinal = StringComparer.Ordinal;
+        var ordinal = Collation.UnicodeCodePointComparer.Ordinal;
         var reverse = Comparer<string>.Create((x, y) => string.CompareOrdinal(y, x));
 
         var a = Bag.OfEntries([("a", 1L), ("b", 2L)], ordinal);
@@ -140,7 +140,7 @@ public class BagCrossVerifyTests
         // Bag surfaces the generic-math IAdditiveIdentity + IAdditionOperators (NOT INumber —
         // no inverse / order / product). (+) == Union for same-comparer operands; AdditiveIdentity
         // is empty. Like G-Set it's an additive commutative monoid, but — unlike G-Set — NOT idempotent.
-        var cmp = StringComparer.Ordinal;
+        var cmp = Collation.UnicodeCodePointComparer.Ordinal;
         static Bag<string> B(StringComparer cmp, params (string, long)[] xs) => Bag.OfEntries(xs, cmp);
 
         var a = B(cmp, ("a", 1L), ("b", 2L));
@@ -167,7 +167,7 @@ public class BagCrossVerifyTests
         Assert.Equal(custom, custom + Bag<string>.AdditiveIdentity); // no throw
         Assert.Equal(custom, Bag<string>.AdditiveIdentity + custom);
 
-        var ordinal = Bag.OfEntries([("a", 1L), ("b", 1L)], StringComparer.Ordinal);
+        var ordinal = Bag.OfEntries([("a", 1L), ("b", 1L)], Collation.UnicodeCodePointComparer.Ordinal);
         Assert.Throws<ArgumentException>(() => ordinal + custom);
     }
 }

--- a/tests/Tests.CSharp/Algebra/GSetCrossVerifyTests.cs
+++ b/tests/Tests.CSharp/Algebra/GSetCrossVerifyTests.cs
@@ -47,7 +47,7 @@ public class GSetCrossVerifyTests
         var path = Path.Join(root, "src", "Core.TypeScript", "g-set", "golden-vectors.json");
         using var doc = JsonDocument.Parse(File.ReadAllText(path));
         var r = doc.RootElement;
-        var cmp = StringComparer.Ordinal;
+        var cmp = Collation.UnicodeCodePointComparer.Ordinal;
 
         var state = GSet.OfSeq(Strings(r.GetProperty("initialSet")), cmp);
         var ops = r.GetProperty("ops");
@@ -74,7 +74,7 @@ public class GSetCrossVerifyTests
     [Fact]
     public void UnionObeysCrdtLaws()
     {
-        var cmp = StringComparer.Ordinal;
+        var cmp = Collation.UnicodeCodePointComparer.Ordinal;
         static GSet<string> G(StringComparer cmp, params string[] xs) => GSet.OfSeq(xs, cmp);
 
         var a = G(cmp, "a", "c");
@@ -95,7 +95,7 @@ public class GSetCrossVerifyTests
         // The comparer is part of a set's identity; unioning across different comparers is
         // a programming error (it would break commutativity), surfaced loudly rather than
         // silently recanonicalized (PR review 2026-06-01).
-        var ordinal = StringComparer.Ordinal;
+        var ordinal = Collation.UnicodeCodePointComparer.Ordinal;
         var reverse = Comparer<string>.Create((x, y) => string.CompareOrdinal(y, x));
 
         string[] aItems = ["a", "b"];
@@ -118,7 +118,7 @@ public class GSetCrossVerifyTests
         // G-Set is an additive, commutative + idempotent monoid, so it surfaces the
         // generic-math IAdditiveIdentity + IAdditionOperators (NOT INumber — no inverse /
         // order / product). (+) == Union for same-comparer operands; AdditiveIdentity is empty.
-        var cmp = StringComparer.Ordinal;
+        var cmp = Collation.UnicodeCodePointComparer.Ordinal;
         static GSet<string> G(StringComparer cmp, params string[] xs) => GSet.OfSeq(xs, cmp);
 
         var a = G(cmp, "a", "c");
@@ -147,7 +147,7 @@ public class GSetCrossVerifyTests
 
         // But two NON-empty operands with different comparers still delegate to Union → throw
         // (the comparer-identity guard for real merges is preserved).
-        var ordinal = GSet.OfSeq(["a", "b"], StringComparer.Ordinal);
+        var ordinal = GSet.OfSeq(["a", "b"], Collation.UnicodeCodePointComparer.Ordinal);
         Assert.Throws<ArgumentException>(() => ordinal + custom);
     }
 }

--- a/tests/Tests.CSharp/Algebra/IndexedZSetCrossVerifyTests.cs
+++ b/tests/Tests.CSharp/Algebra/IndexedZSetCrossVerifyTests.cs
@@ -19,7 +19,7 @@ namespace Zeta.Tests.CSharp.Algebra;
 /// </summary>
 public class IndexedZSetCrossVerifyTests
 {
-    private static readonly StringComparer Ord = StringComparer.Ordinal;
+    private static readonly StringComparer Ord = Collation.UnicodeCodePointComparer.Ordinal;
 
     private static string RepoRoot()
     {
@@ -70,8 +70,8 @@ public class IndexedZSetCrossVerifyTests
     {
         var pairCmp = Comparer<(string K, string V)>.Create((x, y) =>
         {
-            var c = string.CompareOrdinal(x.K, y.K);
-            return c != 0 ? c : string.CompareOrdinal(x.V, y.V);
+            var c = Collation.UnicodeCodePointComparer.Ordinal.Compare(x.K, y.K);
+            return c != 0 ? c : Collation.UnicodeCodePointComparer.Ordinal.Compare(x.V, y.V);
         });
 
         var entries = r.GetProperty("indexInput").EnumerateArray().Select(item =>

--- a/tests/Tests.CSharp/Algebra/ZSetCrossVerifyTests.cs
+++ b/tests/Tests.CSharp/Algebra/ZSetCrossVerifyTests.cs
@@ -50,7 +50,7 @@ public class ZSetCrossVerifyTests
         var path = Path.Join(root, "src", "Core.TypeScript", "z-set", "golden-vectors.json");
         using var doc = JsonDocument.Parse(File.ReadAllText(path));
         var r = doc.RootElement;
-        var cmp = StringComparer.Ordinal;
+        var cmp = Collation.UnicodeCodePointComparer.Ordinal;
 
         var state = ZSet.OfEntries(Entries(r.GetProperty("initialZSet")), cmp);
         var ops = r.GetProperty("ops");
@@ -78,7 +78,7 @@ public class ZSetCrossVerifyTests
     [Fact]
     public void UnionIsAbelianGroupButNotIdempotent()
     {
-        var cmp = StringComparer.Ordinal;
+        var cmp = Collation.UnicodeCodePointComparer.Ordinal;
         static ZSet<string> Z(StringComparer cmp, params (string, long)[] xs) => ZSet.OfEntries(xs, cmp);
 
         var a = Z(cmp, ("a", 1L), ("b", 2L));
@@ -97,7 +97,7 @@ public class ZSetCrossVerifyTests
     [Fact]
     public void OfEntriesSumsSortsDropsZeroKeepsNegatives()
     {
-        var cmp = StringComparer.Ordinal;
+        var cmp = Collation.UnicodeCodePointComparer.Ordinal;
         // c: 1+3=4; b nets to 0 → dropped; d: -1 KEPT (a Bag would drop it); sorted ascending.
         var z = ZSet.OfEntries([("c", 1L), ("a", 2L), ("c", 3L), ("b", 1L), ("b", -1L), ("d", -1L)], cmp);
         Assert.Equal([("a", 2L), ("c", 4L), ("d", -1L)], AsTuples(z));
@@ -106,7 +106,7 @@ public class ZSetCrossVerifyTests
     [Fact]
     public void WeightAddWNegateAndTotal()
     {
-        var cmp = StringComparer.Ordinal;
+        var cmp = Collation.UnicodeCodePointComparer.Ordinal;
         var a = ZSet.OfEntries([("a", 3L), ("c", -1L)], cmp);
 
         Assert.Equal(3L, a.Weight("a"));
@@ -129,7 +129,7 @@ public class ZSetCrossVerifyTests
     public void UnionThrowsOnMismatchedComparer()
     {
         // The comparer is part of a Z-set's identity (mirrors GSet/Bag, PR review 2026-06-01).
-        var ordinal = StringComparer.Ordinal;
+        var ordinal = Collation.UnicodeCodePointComparer.Ordinal;
         var reverse = Comparer<string>.Create((x, y) => string.CompareOrdinal(y, x));
 
         var a = ZSet.OfEntries([("a", 1L), ("b", 2L)], ordinal);
@@ -147,7 +147,7 @@ public class ZSetCrossVerifyTests
         // ISubtractionOperators + IUnaryNegationOperators (the abelian-group inverse). NOT INumber
         // (no total order; the ring scalar is per-element). (+) == Union, (-a) == Negate,
         // (a - b) == Union(Negate); AdditiveIdentity is empty. Mirrors the F# Zero/(+)/(~-)/(-) rung.
-        var cmp = StringComparer.Ordinal;
+        var cmp = Collation.UnicodeCodePointComparer.Ordinal;
         static ZSet<string> Z(StringComparer cmp, params (string, long)[] xs) => ZSet.OfEntries(xs, cmp);
 
         var a = Z(cmp, ("a", 1L), ("b", 2L));
@@ -173,7 +173,7 @@ public class ZSetCrossVerifyTests
     public void GenericMathAdditionIsNotIdempotentAndSubtractionRetracts()
     {
         // (+) is SUM, not set-union: a + a doubles every weight (the Bag/Z-set step away from G-Set).
-        var cmp = StringComparer.Ordinal;
+        var cmp = Collation.UnicodeCodePointComparer.Ordinal;
         var a = ZSet.OfEntries([("a", 1L), ("b", -3L)], cmp);
         Assert.Equal(ZSet.OfEntries([("a", 2L), ("b", -6L)], cmp), a + a);
 
@@ -194,7 +194,7 @@ public class ZSetCrossVerifyTests
         Assert.Equal(custom, ZSet<string>.AdditiveIdentity + custom); // no throw (empty + a = a)
         Assert.Equal(custom, custom - ZSet<string>.AdditiveIdentity); // no throw (a - empty = a)
 
-        var ordinal = ZSet.OfEntries([("a", 1L)], StringComparer.Ordinal);
+        var ordinal = ZSet.OfEntries([("a", 1L)], Collation.UnicodeCodePointComparer.Ordinal);
         Assert.Throws<ArgumentException>(() => ordinal + custom);
         Assert.Throws<ArgumentException>(() => ordinal - custom);
     }


### PR DESCRIPTION
Resolves at the cheapest tier where confidence is sufficient. Oracle (free, instant) → Composer (Bayesian, ms) → Deliberator (LLM, seconds). 5 tests pass. Zero TS errors.

Composes with SoftValue (placement stays soft), Cl3 (distance = ambiguity), and the unified loop-tick (v1 observe-inline path).

Co-Authored-By: Kiro <noreply@kiro.dev>