### PR TITLE
feat(ci): B-0831 slice 1 — QEMU full install + reboot login verify

### DIFF
--- a/full-ai-cluster/usb-nixos-installer/zeta-install.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-install.sh
@@ -929,7 +929,12 @@ echo "[iter-5.4.0] Default is YES (recommended); press Enter to proceed"
 echo "[iter-5.4.0] OR type 'n' to skip (fallback to iter-4.2 static keys"
 echo "[iter-5.4.0] if injected, OR manual config-edit per the iter-4 v1 flow)."
 echo
-read -r -p "[iter-5.4.0] Run gh auth login now? [Y/n]: " GH_AUTH_REPLY
+if [ -t 0 ]; then
+  read -r -p "[iter-5.4.0] Run gh auth login now? [Y/n]: " GH_AUTH_REPLY
+else
+  echo "[iter-5.4.0] non-TTY stdin (QEMU serial CI); skipping gh auth"
+  GH_AUTH_REPLY=n
+fi
 GH_AUTH_REPLY="${GH_AUTH_REPLY:-Y}"
 if [[ "$GH_AUTH_REPLY" =~ ^[Yy]$ ]]; then
   if ! command -v gh >/dev/null 2>&1; then
@@ -1579,7 +1584,12 @@ if [ -d "$ZETA_HOME" ]; then
     echo "[iter-5.5.0]   - Opens a code prompt; visit URL on this Mac browser; approve."
     echo "[iter-5.5.0]   - Credentials land at $ZETA_HOME/.config/claude/ and survive reboot."
     echo "[iter-5.5.0]   - Default YES (press Enter); 'n' to skip + login post-reboot manually."
-    read -r -p "[iter-5.5.0] Run claude login now? [Y/n]: " CLAUDE_AUTH_REPLY
+    if [ -t 0 ]; then
+      read -r -p "[iter-5.5.0] Run claude login now? [Y/n]: " CLAUDE_AUTH_REPLY
+    else
+      echo "[iter-5.5.0] non-TTY stdin (QEMU serial CI); skipping claude login"
+      CLAUDE_AUTH_REPLY=n
+    fi
     case "${CLAUDE_AUTH_REPLY:-y}" in
       [Yy]*|"")
         echo "[iter-5.5.0]   running 'claude login' (interactive)..."
@@ -1619,7 +1629,12 @@ if [ -d "$ZETA_HOME" ]; then
     echo "[iter-5.5.0]   - ChatGPT Plus/Pro/Business/Edu/Enterprise plans include Codex access."
     echo "[iter-5.5.0]   - Credentials land at $ZETA_HOME/.codex/auth.json (NOT ~/.config/codex)."
     echo "[iter-5.5.0]   - Default YES (press Enter); 'n' to skip + login post-reboot manually."
-    read -r -p "[iter-5.5.0] Run codex login --device-auth now? [Y/n]: " CODEX_AUTH_REPLY
+    if [ -t 0 ]; then
+      read -r -p "[iter-5.5.0] Run codex login --device-auth now? [Y/n]: " CODEX_AUTH_REPLY
+    else
+      echo "[iter-5.5.0] non-TTY stdin (QEMU serial CI); skipping codex login"
+      CODEX_AUTH_REPLY=n
+    fi
     case "${CODEX_AUTH_REPLY:-y}" in
       [Yy]*|"")
         echo "[iter-5.5.0]   running 'codex login --device-auth' (interactive)..."

--- a/src/Core.TypeScript/ci/qemu-full-install-test.test.ts
+++ b/src/Core.TypeScript/ci/qemu-full-install-test.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "bun:test";
+import { extractGeneratedHostname } from "./qemu-full-install-test.ts";
+
+describe("qemu-full-install-test hostname extraction", () => {
+  it("parses iter-5.2.2 generated hostname from serial log", () => {
+    const serial = [
+      "[iter-5.2.2] generating fresh random hostname on-node (per-install unique) ...",
+      "[iter-5.2.2]   generated: zeta-a1b2c3",
+    ].join("\n");
+    expect(extractGeneratedHostname(serial)).toBe("zeta-a1b2c3");
+  });
+
+  it("returns null when marker absent", () => {
+    expect(extractGeneratedHostname("zeta-installer login:")).toBeNull();
+  });
+});

--- a/src/Core.TypeScript/ci/qemu-full-install-test.ts
+++ b/src/Core.TypeScript/ci/qemu-full-install-test.ts
@@ -1,102 +1,44 @@
 #!/usr/bin/env bun
 /**
- * tools/ci/qemu-full-install-test.ts
+ * src/Core.TypeScript/ci/qemu-full-install-test.ts
  *
- * QEMU full-install test (B-0831 Slice 1 starter) for the canonical
- * Zeta installer ISO.
+ * QEMU full-install test (B-0831 Slice 1) for the canonical Zeta installer ISO.
  *
- * Sibling to `qemu-boot-test.ts` (cascade #5 boot smoke-test). This
- * extends boot-test by:
+ * Phase 1 — boot installer ISO + virtual disk; wait for install completion.
+ * Phase 2 — boot installed disk only; verify auto-generated hostname login banner.
  *
- *   - Attaching a virtual hard disk (qcow2) as the install target
- *   - Booting with NAT'd internet so zeta-install can git-clone
- *     and download dependencies
- *   - Waiting for an INSTALL-PROGRESS marker (not just login prompt)
- *     that proves zeta-install completed nixos-install + iter-4.2
- *     pubkey-probe + iter-5.2 hostname-injection phases
- *
- * Per B-0831 Slice 1 acceptance criteria:
- * > Slice 1 acceptance: CI cascade #6 phase 1 step passes on PR
- * > touching `full-ai-cluster/**`. Step runs in under 10 min total
- * > (boot, install, reboot, login-verify). Captures full serial console
- * > as workflow-artifact for debug.
- *
- * SCOPE — STARTER ONLY (this PR):
- *
- *   - Boot installer ISO with virtual hard disk + NAT internet
- *   - Wait for `[iter-5.3]` marker in serial log (proves install reached
- *     iter-4.2 pubkey + iter-5.2 hostname phases; first operator-prompt
- *     gate is at iter-5.3 password)
- *   - Success = marker found within timeout
- *
- * DEFERRED to follow-up PRs (not in this Slice-1-starter):
- *
- *   - Reboot loop (boot from virtual hard disk to verify installed system
- *     comes up) — requires QEMU snapshot/restart logic
- *   - iter-5.3 password auto-confirm (requires injecting Enter via serial
- *     stdin) — bigger scope; CI-test substrate work
- *   - iter-5.4.0 gh auth completion (requires mock GH device-code
- *     endpoint per B-0833 Approach A) — separate substrate work
- *   - Cluster auto-join verification (Slice 2 of B-0831)
- *   - ArgoCD reconciliation (Slice 3 of B-0831)
+ * Composes with qemu-boot-test.ts (cascade #5) and B-0891 scenario 2.
  *
  * Usage:
- *   bun tools/ci/qemu-full-install-test.ts <iso-path>
+ *   bun src/Core.TypeScript/ci/qemu-full-install-test.ts <iso-path>
  *
  * Exit codes:
- *   0 — install reached iter-5.3 marker (proves nixos-install + iter-4.2
- *       + iter-5.2 substrate phases all succeeded)
- *   1 — timeout OR install failure (check serial-log artifact)
- *   2 — usage error (bad args or missing dependencies)
- *
- * GitHub Actions context: ubuntu-24.04 runners have /dev/kvm available
- * for nested KVM acceleration; nixos-install takes ~5-10 min with KVM,
- * 20-30 min with TCG (macOS local testing fallback).
- *
- * Per Rule 0 (TS-over-bash for DST + cross-platform). Composes with
- * cascade #4 (audit-installer-iso-content.ts) + cascade #5
- * (qemu-boot-test.ts) + Layer 1-2 install-substrate sentinels
- * (audit-installer-substrate.ts + test-iter-54-install-flow.test.ts).
+ *   0 — install completed and installed OS reached login prompt
+ *   1 — timeout or failure (check serial-log artifact)
+ *   2 — usage error or missing dependencies
  */
 
 import { execFileSync, spawn } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { appendFileSync, existsSync, mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { serialFirstBootInProgress } from "../zflash/test-harness/serial-markers";
 
-// Success marker: the `[iter-5.1]` prefix appears at the wifi-persistence
-// step in zeta-install.sh (Step 6.7; line 527). This is the correct
-// post-nixos-install marker because it fires AFTER:
-//   - Steps 1-5 (partition + format + mount)
-//   - Step 6 (clone + install) including the nixos-install invocation
-//   - Step 6.5 iter-4.2 SSH pubkey probe
-//   - Step 6.55 iter-5.3 password prompt (gracefully skipped in CI when
-//     stdin returns empty — INJECTED_PW="" → default-keep path)
-//   - Step 6.6 iter-5.2 hostname injection
-// And BEFORE:
-//   - Step 6.8 iter-5.4.0 gh auth prompt (which hangs in CI without
-//     operator stdin to type 'n' OR mock GH device-code endpoint per
-//     B-0833 Approach A)
-//
-// Per Copilot post-merge finding on PR #5379: the prior `[iter-5.3]`
-// marker fired BEFORE the actual `nixos-install` invocation (Step 6.55
-// is at line 372 of zeta-install.sh; the `sudo nixos-install` call is
-// at line 980), so the test could pass without proving the install
-// actually completed. `[iter-5.1]` correctly comes AFTER nixos-install.
-const SUCCESS_MARKER = "[iter-5.1]";
+/** zeta-install.sh success banner (end of install script). */
+const INSTALL_COMPLETE_MARKER = "ZETA CLUSTER NODE INSTALL COMPLETE";
 
-// Hard-fail markers — if any of these appear, fail fast instead of
-// waiting for timeout. Add more as empirical failure modes are observed.
+/** Mid-install progress — nixos-install reached post-install wifi step. */
+const NIXOS_INSTALL_PROGRESS_MARKER = "[iter-5.1]";
+
 const FAILURE_MARKERS: readonly string[] = [
-  "panic", // kernel panic
-  "FATAL", // generic fatal error
-  "Refusing to wipe", // safety-rail abort
-  "no internet", // first-boot couldn't reach DHCP/wifi
-  "bail", // generic flash-usb / zeta-install bail
+  "panic",
+  "FATAL",
+  "Refusing to wipe",
+  "no internet",
+  "bail",
+  "[zeta-first-boot] Install failed",
 ];
 
-/** Idle live-ISO shell on serial while install markers are absent (B-0891). */
 const IDLE_INSTALLER_SHELL_MARKER = "nixos@zeta-installer:~";
 
 const CONSOLE_MIRROR_HINT =
@@ -104,12 +46,12 @@ const CONSOLE_MIRROR_HINT =
   "zeta-first-boot may be running on tty1 only; mirror output to /dev/ttyS0 " +
   "(see full-ai-cluster/usb-nixos-installer/zeta-first-boot.sh)";
 
-const TIMEOUT_SECONDS = 1800; // 30 min — generous for TCG fallback;
-// KVM should finish in 5-10 min
+const INSTALL_TIMEOUT_SECONDS = 1800;
+const DISK_BOOT_TIMEOUT_SECONDS = 600;
 const POLL_INTERVAL_MS = 2000;
-const MEMORY_MB = 4096; // nixos-install needs ~2GB; 4GB gives headroom
+const MEMORY_MB = 4096;
 const CPU_COUNT = 2;
-const DISK_SIZE_GB = 20; // greedy-install target; minimum NixOS comfortable
+const DISK_SIZE_GB = 20;
 const KVM_PATH = "/dev/kvm";
 
 interface InstallResult {
@@ -117,24 +59,29 @@ interface InstallResult {
   readonly reason: string;
   readonly serialLogTail?: string;
   readonly elapsedSeconds?: number;
+  readonly hostname?: string;
+}
+
+/** Exported for unit tests. */
+export function extractGeneratedHostname(serialOutput: string): string | null {
+  const match = serialOutput.match(/\[iter-5\.2\.2\]\s+generated:\s+([a-z0-9-]+)/i);
+  return match?.[1] ?? null;
 }
 
 function usage(): never {
-  console.error("usage: bun tools/ci/qemu-full-install-test.ts <iso-path>");
+  console.error("usage: bun src/Core.TypeScript/ci/qemu-full-install-test.ts <iso-path>");
   process.exit(2);
 }
 
 function checkDependencies(): string | null {
-  // qemu-system-x86_64 must be installed (apt-get install qemu-system-x86)
   try {
     const result = Bun.spawnSync(["qemu-system-x86_64", "--version"]);
     if (result.exitCode !== 0) {
-      return "qemu-system-x86_64 not found or non-zero exit; install via `apt-get install -y qemu-system-x86`";
+      return "qemu-system-x86_64 not found; install via `apt-get install -y qemu-system-x86`";
     }
   } catch {
     return "qemu-system-x86_64 not found in PATH; install via `apt-get install -y qemu-system-x86`";
   }
-  // qemu-img for qcow2 disk creation
   try {
     const result = Bun.spawnSync(["qemu-img", "--version"]);
     if (result.exitCode !== 0) {
@@ -146,124 +93,258 @@ function checkDependencies(): string | null {
   return null;
 }
 
+function kvmEnabled(): boolean {
+  return existsSync(KVM_PATH);
+}
+
+function appendKvmCpu(args: string[]): void {
+  if (kvmEnabled()) {
+    args.push("-enable-kvm", "-cpu", "host");
+  } else {
+    args.push("-cpu", "qemu64");
+    console.warn(`[qemu-full-install-test] ${KVM_PATH} not available; using TCG (slow)`);
+  }
+}
+
 function createVirtualDisk(diskPath: string): void {
-  // qcow2 format with sparse allocation — 20GB virtual size but only
-  // allocates blocks as written. Keeps the test artifact small for CI
-  // upload (only used blocks consume actual space).
   console.log(`[qemu-full-install-test] Creating ${DISK_SIZE_GB}GB qcow2 disk at ${diskPath}`);
   execFileSync("qemu-img", ["create", "-f", "qcow2", diskPath, `${DISK_SIZE_GB}G`], {
     stdio: "inherit",
   });
 }
 
-function buildQemuArgs(isoPath: string, diskPath: string, serialLogPath: string): string[] {
+function buildQemuInstallArgs(isoPath: string, diskPath: string, serialLogPath: string): string[] {
   const args: string[] = [
     "-machine", "q35",
     "-m", String(MEMORY_MB),
     "-smp", String(CPU_COUNT),
-    // ISO as CD-ROM, boot priority d (CD-ROM first)
     "-cdrom", isoPath,
     "-boot", "d",
-    // Virtual hard disk as install target (virtio for speed)
     "-drive", `file=${diskPath},if=virtio,format=qcow2`,
-    // Serial console to file — primary capture channel for pattern matching
     "-serial", `file:${serialLogPath}`,
-    // No display (headless CI)
     "-display", "none",
-    // Reboot on triple-fault (matches normal install behavior) — DON'T
-    // use -no-reboot here because zeta-install might reboot to verify
-    // installed system (though we don't currently test post-reboot)
-    // -no-reboot,
-    // NAT'd internet (zeta-install needs git clone + nix substitution)
     "-netdev", "user,id=net0",
     "-device", "virtio-net-pci,netdev=net0",
   ];
-
-  // KVM acceleration when /dev/kvm is available (GitHub Actions
-  // ubuntu-24.04 supports nested KVM). Falls back to TCG (slow but
-  // works) when KVM unavailable (e.g., macOS local testing).
-  if (existsSync(KVM_PATH)) {
-    args.push("-enable-kvm", "-cpu", "host");
-  } else {
-    args.push("-cpu", "qemu64");
-    console.warn(
-      `[qemu-full-install-test] ${KVM_PATH} not available; using TCG emulation (will be VERY slow; budget 30+ min for full install)`,
-    );
-  }
-
+  appendKvmCpu(args);
   return args;
 }
 
-async function waitForInstallProgress(serialLogPath: string): Promise<InstallResult> {
+function buildQemuDiskBootArgs(diskPath: string, serialLogPath: string): string[] {
+  const args: string[] = [
+    "-machine", "q35",
+    "-m", String(MEMORY_MB),
+    "-smp", String(CPU_COUNT),
+    "-drive", `file=${diskPath},if=virtio,format=qcow2`,
+    "-boot", "c",
+    "-serial", `file:${serialLogPath}`,
+    "-display", "none",
+    "-netdev", "user,id=net0",
+    "-device", "virtio-net-pci,netdev=net0",
+  ];
+  appendKvmCpu(args);
+  return args;
+}
+
+function readSerial(serialLogPath: string): string {
+  return existsSync(serialLogPath) ? readFileSync(serialLogPath, "utf8") : "";
+}
+
+function checkFailureMarkers(content: string): string | null {
+  for (const failMarker of FAILURE_MARKERS) {
+    if (content.includes(failMarker)) {
+      return failMarker;
+    }
+  }
+  return null;
+}
+
+async function waitForInstallComplete(serialLogPath: string): Promise<InstallResult> {
   const start = Date.now();
-  const deadline = start + TIMEOUT_SECONDS * 1000;
+  const deadline = start + INSTALL_TIMEOUT_SECONDS * 1000;
   let lastReportedMinute = -1;
 
   while (Date.now() < deadline) {
     const elapsedSec = Math.floor((Date.now() - start) / 1000);
     const elapsedMin = Math.floor(elapsedSec / 60);
     if (elapsedMin > lastReportedMinute) {
-      console.log(`[qemu-full-install-test] ... ${elapsedMin} min elapsed; still polling for "${SUCCESS_MARKER}"`);
+      console.log(
+        `[qemu-full-install-test] phase 1: ${elapsedMin} min elapsed; waiting for "${INSTALL_COMPLETE_MARKER}"`,
+      );
       lastReportedMinute = elapsedMin;
     }
 
-    if (existsSync(serialLogPath)) {
-      try {
-        const content = readFileSync(serialLogPath, "utf8");
-        if (content.includes(SUCCESS_MARKER)) {
-          const tail = content.slice(-1000);
-          return {
-            exitCode: 0,
-            reason: `SUCCESS — "${SUCCESS_MARKER}" observed in serial log (install reached iter-5.3 phase; nixos-install + iter-4.2 + iter-5.2 substrate all completed)`,
-            serialLogTail: tail,
-            elapsedSeconds: elapsedSec,
-          };
-        }
-        // Hard-fail markers — fail fast instead of waiting full timeout
-        for (const failMarker of FAILURE_MARKERS) {
-          if (content.includes(failMarker)) {
-            const tail = content.slice(-2000);
-            return {
-              exitCode: 1,
-              reason: `FAILURE — hard-fail marker "${failMarker}" observed in serial log`,
-              serialLogTail: tail,
-              elapsedSeconds: elapsedSec,
-            };
-          }
-        }
-        if (
-          elapsedSec >= 120 &&
-          content.includes(IDLE_INSTALLER_SHELL_MARKER) &&
-          !content.includes(SUCCESS_MARKER) &&
-          !content.includes("[zeta-first-boot]") &&
-          !content.includes("[iter-") &&
-          !serialFirstBootInProgress(content)
-        ) {
-          const tail = content.slice(-2000);
-          return {
-            exitCode: 1,
-            reason: `FAILURE — ${CONSOLE_MIRROR_HINT}`,
-            serialLogTail: tail,
-            elapsedSeconds: elapsedSec,
-          };
-        }
-      } catch {
-        // Log file in transit; retry on next poll
-      }
+    const content = readSerial(serialLogPath);
+    if (content.includes(INSTALL_COMPLETE_MARKER)) {
+      return {
+        exitCode: 0,
+        reason: `phase 1 SUCCESS — "${INSTALL_COMPLETE_MARKER}" observed`,
+        serialLogTail: content.slice(-1500),
+        elapsedSeconds: elapsedSec,
+        hostname: extractGeneratedHostname(content) ?? undefined,
+      };
     }
+
+    const failMarker = checkFailureMarkers(content);
+    if (failMarker) {
+      return {
+        exitCode: 1,
+        reason: `phase 1 FAILURE — hard-fail marker "${failMarker}"`,
+        serialLogTail: content.slice(-2000),
+        elapsedSeconds: elapsedSec,
+      };
+    }
+
+    if (
+      elapsedSec >= 120 &&
+      content.includes(IDLE_INSTALLER_SHELL_MARKER) &&
+      !content.includes(NIXOS_INSTALL_PROGRESS_MARKER) &&
+      !content.includes("[zeta-first-boot]") &&
+      !content.includes("[iter-") &&
+      !serialFirstBootInProgress(content)
+    ) {
+      return {
+        exitCode: 1,
+        reason: `phase 1 FAILURE — ${CONSOLE_MIRROR_HINT}`,
+        serialLogTail: content.slice(-2000),
+        elapsedSeconds: elapsedSec,
+      };
+    }
+
     await Bun.sleep(POLL_INTERVAL_MS);
   }
 
-  const elapsedSec = Math.floor((Date.now() - start) / 1000);
-  const tail = existsSync(serialLogPath)
-    ? readFileSync(serialLogPath, "utf8").slice(-3000)
-    : "(serial log empty or never created)";
+  const content = readSerial(serialLogPath);
   return {
     exitCode: 1,
-    reason: `Timeout (${TIMEOUT_SECONDS}s) waiting for "${SUCCESS_MARKER}"`,
-    serialLogTail: tail,
-    elapsedSeconds: elapsedSec,
+    reason: `phase 1 timeout (${INSTALL_TIMEOUT_SECONDS}s) waiting for "${INSTALL_COMPLETE_MARKER}"`,
+    serialLogTail: content.slice(-3000),
+    elapsedSeconds: Math.floor((Date.now() - start) / 1000),
   };
+}
+
+async function waitForInstalledLogin(
+  serialLogPath: string,
+  expectedHostname: string | null,
+): Promise<InstallResult> {
+  const start = Date.now();
+  const deadline = start + DISK_BOOT_TIMEOUT_SECONDS * 1000;
+  const loginNeedle = expectedHostname ? `${expectedHostname} login:` : null;
+
+  while (Date.now() < deadline) {
+    const elapsedSec = Math.floor((Date.now() - start) / 1000);
+    const content = readSerial(serialLogPath);
+
+    if (loginNeedle && content.includes(loginNeedle)) {
+      return {
+        exitCode: 0,
+        reason: `phase 2 SUCCESS — login prompt "${loginNeedle}" observed`,
+        serialLogTail: content.slice(-1500),
+        elapsedSeconds: elapsedSec,
+        hostname: expectedHostname ?? undefined,
+      };
+    }
+
+    if (!loginNeedle) {
+      for (const match of content.matchAll(/(?:^|\n)([a-z0-9-]+) login:/gi)) {
+        const host = match[1];
+        if (host && host !== "zeta-installer") {
+          return {
+            exitCode: 0,
+            reason: `phase 2 SUCCESS — login prompt "${host} login:" observed`,
+            serialLogTail: content.slice(-1500),
+            elapsedSeconds: elapsedSec,
+            hostname: host,
+          };
+        }
+      }
+    }
+
+    const failMarker = checkFailureMarkers(content);
+    if (failMarker) {
+      return {
+        exitCode: 1,
+        reason: `phase 2 FAILURE — hard-fail marker "${failMarker}"`,
+        serialLogTail: content.slice(-2000),
+        elapsedSeconds: elapsedSec,
+      };
+    }
+
+    await Bun.sleep(POLL_INTERVAL_MS);
+  }
+
+  const content = readSerial(serialLogPath);
+  return {
+    exitCode: 1,
+    reason: loginNeedle
+      ? `phase 2 timeout (${DISK_BOOT_TIMEOUT_SECONDS}s) waiting for "${loginNeedle}"`
+      : `phase 2 timeout (${DISK_BOOT_TIMEOUT_SECONDS}s) waiting for installed-system login prompt`,
+    serialLogTail: content.slice(-3000),
+    elapsedSeconds: Math.floor((Date.now() - start) / 1000),
+  };
+}
+
+async function runQemuUntil(
+  args: string[],
+  serialLogPath: string,
+  wait: () => Promise<InstallResult>,
+  phaseLabel: string,
+): Promise<InstallResult> {
+  console.log(`[qemu-full-install-test] ${phaseLabel}: qemu-system-x86_64 ${args.join(" ")}`);
+
+  const qemu = spawn("qemu-system-x86_64", args, {
+    stdio: ["ignore", "inherit", "inherit"],
+  });
+
+  let qemuExited = false;
+  const earlyExit = new Promise<InstallResult>((res) => {
+    qemu.on("exit", (code) => {
+      qemuExited = true;
+      console.log(`[qemu-full-install-test] ${phaseLabel}: QEMU exited with code ${code}`);
+      const tail = readSerial(serialLogPath).slice(-2000);
+      res({
+        exitCode: 1,
+        reason: `${phaseLabel} FAILURE — QEMU exited with code ${code} before success marker`,
+        serialLogTail: tail,
+      });
+    });
+  });
+
+  const result = await Promise.race([wait(), earlyExit]);
+
+  if (!qemuExited) {
+    console.log(`[qemu-full-install-test] ${phaseLabel}: stopping QEMU (PID ${qemu.pid})`);
+    qemu.kill("SIGTERM");
+    await Bun.sleep(2000);
+    if (!qemuExited) {
+      qemu.kill("SIGKILL");
+    }
+  }
+
+  return result;
+}
+
+function reportResult(result: InstallResult, serialLogPath: string): never {
+  console.log("");
+  console.log("=== Result ===");
+  console.log(`Exit code: ${result.exitCode}`);
+  console.log(`Reason: ${result.reason}`);
+  if (result.hostname) {
+    console.log(`Hostname: ${result.hostname}`);
+  }
+  if (result.elapsedSeconds !== undefined) {
+    console.log(
+      `Elapsed: ${result.elapsedSeconds}s (${Math.floor(result.elapsedSeconds / 60)}m ${result.elapsedSeconds % 60}s)`,
+    );
+  }
+  if (result.serialLogTail) {
+    console.log("");
+    console.log("=== Serial log tail ===");
+    console.log(result.serialLogTail);
+  }
+  console.log("");
+  console.log(`Full serial log preserved at: ${serialLogPath}`);
+  process.exit(result.exitCode);
 }
 
 async function main(): Promise<never> {
@@ -283,86 +364,38 @@ async function main(): Promise<never> {
 
   const tmpDir = mkdtempSync(join(tmpdir(), "zeta-qemu-full-install-test-"));
   const diskPath = join(tmpDir, "install-target.qcow2");
-  // Env-overridable serial log path so CI workflow can write to a
-  // known workspace-relative path for artifact upload (per Copilot
-  // post-merge finding on PR #5379: prior tmpdir path was outside
-  // workspace + lost on runner exit).
   const serialLogPath = process.env.SERIAL_LOG_OUT_PATH ?? join(tmpDir, "serial.log");
 
   console.log(`[qemu-full-install-test] ISO: ${isoPath}`);
-  console.log(`[qemu-full-install-test] Virtual disk: ${diskPath} (${DISK_SIZE_GB}GB qcow2 sparse)`);
+  console.log(`[qemu-full-install-test] Virtual disk: ${diskPath}`);
   console.log(`[qemu-full-install-test] Serial log: ${serialLogPath}`);
-  console.log(`[qemu-full-install-test] Memory: ${MEMORY_MB}MB; CPUs: ${CPU_COUNT}; timeout: ${TIMEOUT_SECONDS}s`);
-  console.log(`[qemu-full-install-test] Success marker: "${SUCCESS_MARKER}"`);
-  console.log(`[qemu-full-install-test] Hard-fail markers: ${FAILURE_MARKERS.map((m) => `"${m}"`).join(", ")}`);
 
   createVirtualDisk(diskPath);
 
-  const qemuArgs = buildQemuArgs(isoPath, diskPath, serialLogPath);
-  console.log(`[qemu-full-install-test] Launching: qemu-system-x86_64 ${qemuArgs.join(" ")}`);
-
-  const qemu = spawn("qemu-system-x86_64", qemuArgs, {
-    stdio: ["ignore", "inherit", "inherit"],
-  });
-
-  let qemuExited = false;
-  let qemuExitCode: number | null = null;
-  const qemuExitPromise = new Promise<InstallResult>((res) => {
-    qemu.on("exit", (code) => {
-      qemuExited = true;
-      qemuExitCode = code;
-      console.log(`[qemu-full-install-test] QEMU exited with code ${code}`);
-      // Per Copilot post-merge finding on PR #5379: if QEMU exits early
-      // (bad args, KVM/device failure, disk attach error), the marker-
-      // wait would otherwise sit through the full 30-min timeout
-      // pointlessly. Race the marker wait against this exit so we fail
-      // immediately when QEMU dies before the marker can appear.
-      const tail = existsSync(serialLogPath)
-        ? readFileSync(serialLogPath, "utf8").slice(-2000)
-        : "(serial log empty or never created)";
-      res({
-        exitCode: 1,
-        reason: `FAILURE — QEMU exited prematurely with code ${code} before "${SUCCESS_MARKER}" was observed (bad args / KVM unavailable / disk error / device-init failure)`,
-        serialLogTail: tail,
-      });
-    });
-  });
-
-  // Race the marker-wait against QEMU early-exit. Whichever resolves
-  // first wins; both check the serial log + report consistently.
-  const result = await Promise.race([
-    waitForInstallProgress(serialLogPath),
-    qemuExitPromise,
-  ]);
-
-  if (!qemuExited) {
-    console.log(`[qemu-full-install-test] Killing QEMU (PID ${qemu.pid})`);
-    qemu.kill("SIGTERM");
-    setTimeout(() => {
-      if (!qemuExited) qemu.kill("SIGKILL");
-    }, 5000);
+  const phase1 = await runQemuUntil(
+    buildQemuInstallArgs(isoPath, diskPath, serialLogPath),
+    serialLogPath,
+    () => waitForInstallComplete(serialLogPath),
+    "phase 1 (ISO install)",
+  );
+  if (phase1.exitCode !== 0) {
+    reportResult(phase1, serialLogPath);
   }
-  // Suppress unused-var warning — qemuExitCode is read in the exit
-  // handler above; this acknowledges the captured value to lint.
-  void qemuExitCode;
 
-  console.log("");
-  console.log("=== Result ===");
-  console.log(`Exit code: ${result.exitCode}`);
-  console.log(`Reason: ${result.reason}`);
-  if (result.elapsedSeconds !== undefined) {
-    console.log(`Elapsed: ${result.elapsedSeconds}s (${Math.floor(result.elapsedSeconds / 60)}m ${result.elapsedSeconds % 60}s)`);
-  }
-  if (result.serialLogTail) {
-    console.log("");
-    console.log("=== Serial log tail ===");
-    console.log(result.serialLogTail);
-  }
-  console.log("");
-  console.log(`Full serial log preserved at: ${serialLogPath}`);
-  console.log(`(In CI: upload as workflow artifact for debug)`);
+  const installSerial = readSerial(serialLogPath);
+  const hostname = phase1.hostname ?? extractGeneratedHostname(installSerial);
+  console.log(`[qemu-full-install-test] phase 1 done; expected hostname: ${hostname ?? "(infer at login)"}`);
 
-  process.exit(result.exitCode);
+  appendFileSync(serialLogPath, "\n\n=== PHASE 2: boot installed disk (no ISO) ===\n\n");
+
+  const phase2 = await runQemuUntil(
+    buildQemuDiskBootArgs(diskPath, serialLogPath),
+    serialLogPath,
+    () => waitForInstalledLogin(serialLogPath, hostname),
+    "phase 2 (disk boot)",
+  );
+
+  reportResult(phase2, serialLogPath);
 }
 
 main();

--- a/src/Core.TypeScript/ci/qemu-full-install-test.ts
+++ b/src/Core.TypeScript/ci/qemu-full-install-test.ts
@@ -398,4 +398,6 @@ async function main(): Promise<never> {
   reportResult(phase2, serialLogPath);
 }
 
-main();
+if (import.meta.main) {
+  main();
+}


### PR DESCRIPTION
## Summary
- **Phase 1:** boot ISO + disk; wait for `ZETA CLUSTER NODE INSTALL COMPLETE`
- **Phase 2:** boot installed qcow2 only; verify `iter-5.2.2` hostname login banner
- **Installer:** skip gh/claude/codex interactive prompts on non-TTY serial (QEMU CI hang fix)

Closes the deferred reboot slice from B-0831 starter. Work done from Riven clone (`~/.zeta/agents/cursor/riven-b0831-slice1-2026-06-14`).

## Test plan
- [x] `bun test src/Core.TypeScript/ci/qemu-full-install-test.test.ts`
- [ ] gate green
- [ ] build-iso scenario 2 (push-to-main, continue-on-error today)


Made with [Cursor](https://cursor.com)