### PR TITLE
fix(gset+lint): C# GSet codepoint comparer + allowlist mixin .py (restore main-green)

### DIFF
--- a/src/Core.TypeScript/lint/no-python-files.allowlist
+++ b/src/Core.TypeScript/lint/no-python-files.allowlist
@@ -34,3 +34,7 @@ src/Core.Python/src/zeta/zeta_id_gen.py
 src/Core.Python/src/zeta/canonical_json.py
 src/Core.Python/src/zeta/yaml.py
 src/Core.Python/tests/test_cross_verify.py
+
+# GC-safe weak-keyed mixin tables, Python oracle (6-language mixin rollout, #8115)
+src/Core.Python/src/zeta/mixin.py
+src/Core.Python/tests/test_mixin.py

--- a/tests/Tests.CSharp/Algebra/GSetCrossVerifyTests.cs
+++ b/tests/Tests.CSharp/Algebra/GSetCrossVerifyTests.cs
@@ -15,8 +15,10 @@ namespace Zeta.Tests.CSharp.Algebra;
 /// <c>expectedReplayStates[i]</c> (after op i) AND <c>expectedFinalState</c>. The
 /// fixture embeds the canonical expected states (no per-language output file), so
 /// passing == agreeing with the TS/F#/Rust oracles. Read with
-/// <see cref="StringComparer.Ordinal"/> to match the fixture's stated ordinal/code-point
-/// order (not culture-sensitive <see cref="System.Collections.Generic.Comparer{T}.Default"/>).
+/// <see cref="Collation.UnicodeCodePointComparer"/> (ascending Unicode code-point /
+/// UTF-8 byte order) to match the fixture's stated comparator — NOT
+/// <see cref="StringComparer.Ordinal"/>, which is UTF-16 code-unit order and diverges
+/// from code-point order on astral (non-BMP) keys such as U+2070E (𠜎).
 /// </summary>
 public class GSetCrossVerifyTests
 {
@@ -47,7 +49,7 @@ public class GSetCrossVerifyTests
         var path = Path.Join(root, "src", "Core.TypeScript", "g-set", "golden-vectors.json");
         using var doc = JsonDocument.Parse(File.ReadAllText(path));
         var r = doc.RootElement;
-        var cmp = StringComparer.Ordinal;
+        var cmp = Collation.UnicodeCodePointComparer.Ordinal;
 
         var state = GSet.OfSeq(Strings(r.GetProperty("initialSet")), cmp);
         var ops = r.GetProperty("ops");
@@ -74,7 +76,7 @@ public class GSetCrossVerifyTests
     [Fact]
     public void UnionObeysCrdtLaws()
     {
-        var cmp = StringComparer.Ordinal;
+        var cmp = Collation.UnicodeCodePointComparer.Ordinal;
         static GSet<string> G(StringComparer cmp, params string[] xs) => GSet.OfSeq(xs, cmp);
 
         var a = G(cmp, "a", "c");
@@ -118,7 +120,7 @@ public class GSetCrossVerifyTests
         // G-Set is an additive, commutative + idempotent monoid, so it surfaces the
         // generic-math IAdditiveIdentity + IAdditionOperators (NOT INumber — no inverse /
         // order / product). (+) == Union for same-comparer operands; AdditiveIdentity is empty.
-        var cmp = StringComparer.Ordinal;
+        var cmp = Collation.UnicodeCodePointComparer.Ordinal;
         static GSet<string> G(StringComparer cmp, params string[] xs) => GSet.OfSeq(xs, cmp);
 
         var a = G(cmp, "a", "c");


### PR DESCRIPTION
Clears the last two main-red items (build-and-test + lint), both from in-flight rollout work.

## GSet cross-verify (C#, was failing on all platforms)

#8121 escalated `g-set/golden-vectors.json` from *UTF-16 code-unit ordinal* to *ascending Unicode code-point order (UTF-8 byte order)* with astral keys (`漢字`, `Кириллица`, `𠜎` U+2070E). The C# test still built the GSet with `StringComparer.Ordinal` (UTF-16 code units), which sorts the astral char *before* U+FFFD — diverging from code-point order (`Collections differ at index 3: Expected �, Actual 𠜎`).

Fix: use the existing `Collation.UnicodeCodePointComparer.Ordinal` (rune/code-point == UTF-8 byte order) in the cross-verify + ASCII-law GSets. This matches the fixture and the other oracles — **F#** already routes through `Collation.forKey` (code-point; its 22 tests pass), **Rust** is byte-`Ord`, **TS** uses `collation.stringCompare` (code-point). Comparer-independence tests keep `StringComparer.Ordinal` (ASCII, comparer-agnostic).

## no-python-files guard

The guard is **allowlist-based** (B-0156: port `.py`→TS by default). The 6-language rollout already allowlisted its cross-verify Python; only #8115's `mixin.py` + `test_mixin.py` were missing. **Added them** (the guard's intended escape hatch) rather than deleting the guard — full retirement reverses B-0156 for *all* future Python, broader than this rollout needs. **@maintainer: say the word if you want the guard fully retired instead.**

## Verified
C# GSet 5/5 · F# GSet 22/22 · no-python-files 0 flagged + its own test 9/9 · C# whitespace clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)