### PR TITLE
feat(ci): B-0831 slice 2 — cluster-node registration dry-run in QEMU

### DIFF
--- a/docs/trajectories/usb-zflash-installer/RESUME.md
+++ b/docs/trajectories/usb-zflash-installer/RESUME.md
@@ -4,8 +4,8 @@ Status: active — shipped + iterating; first surfaced as a trajectory 2026-05-2
 Last refreshed: 2026-05-29
 Type: workstream (current-focus) — a trajectory the operator is *actively powering*. Many trajectories can be tracked; only a few are workstreams at once (finite-focus / WIP-bounded — a workstream is a trajectory under sustained thrust, and thrust budget is finite, so most trajectories coast). (Genus = "trajectory"; "workstream" is the species: a trajectory under sustained thrust toward a deliverable, vs. emergent-posture trajectories like `anti-infection`. See [`factory-trajectory-surface`](../factory-trajectory-surface/RESUME.md) for the genus/species taxonomy.) One of the operator's three current cluster workstreams (encryption / usb-zflash / ts-workflow-engine).
 Eventual encoding (design-stage — the human maintainer 2026-05-23 genetic-ID substrate + Clifford/HKT): this trajectory's state is trackable as a 128-bit genetic-ID seed (discrete, reversible via parser-combinator ↔ generator-function) → Clifford-space path (continuous, eventual). Mirrors the three-lane I8-lattice / I9-manifold split.
-Current blocker: none operationally; WiFi reproducibility (nixos.org closure-fetch timeouts) is the live edge; B-0844 agent-mode landed in `cli.ts --agent`
-Next concrete action: land B-0831 CI full-install + cluster-auto-join to retire routine human physical-USB testing; finish zeta flash MCP workitem 081KV1PY2H308QG0R00347547K
+Current blocker: none operationally; WiFi reproducibility (nixos.org closure-fetch timeouts) is the live edge
+Next concrete action: B-0831 slice 2 (cluster-node dry-run in QEMU CI) → slice 3 (ArgoCD reconcile shape); build-iso scenario 2 on push-to-main
 
 ## Why This Exists
 
@@ -39,8 +39,8 @@ Shipped artifacts:
 Grounding backlog:
 
 - [`B-0844`](../../backlog/P1/081KSGS9H0008QG0R001EZKNCB-zflash-agent-mode-native-implementation-close-doc-vs-impleme.md) — zflash agent-mode native implementation (**closed** — `--agent` in `cli.ts`)
-- Workitem `081KV1PY2H308QG0R00347547K` — `zeta flash` noun-verb CLI + MCP router (follow-on after #8095)
-- [`B-0831`](../../backlog/P1/B-0831-ci-cascade-6-full-install-plus-cluster-auto-join-eliminate-routine-human-physical-usb-test-aaron-2026-05-26.md) — CI cascade-6 full-install + cluster auto-join (eliminate routine human physical-USB test)
+- Workitem `081KV1PY2H308QG0R00347547K` — `zeta flash` MCP router (**done** #8104)
+- [`B-0831`](../../backlog/P1/081KSGS9H0008QG0R0011BC7T2-ci-cascade-6-full-install-plus-cluster-auto-join-eliminate-r.md) — CI cascade-6: slice 1 landed (#8126); slice 2 in progress (iter-5.4.1-ci dry-run)
 - [`B-0835`](../../backlog/P1/B-0835-installer-config-bugs-cluster-hostname-not-unique-gh-auth-not-respected-banner-password-disclosure-empirical-aaron-2026-05-26.md) — installer config bugs (hostname-not-unique, gh-auth, banner)
 - [`B-0792`](../../backlog/P1/B-0792-iter5-wifi-credentials-injection-via-usb-esp-for-zero-typing-cluster-bringup-without-ethernet-load-bearing-for-homelab-persona-aaron-2026-05-26.md) — iter-5 WiFi-credentials injection via USB ESP (zero-typing bringup without ethernet)
 - [`B-0789`](../../backlog/P1/B-0789-iter4-ssh-key-and-hashedpassword-substrate-for-cluster-bringup-2026-05-26.md) — iter-4 SSH-key + hashedPassword substrate (shared seam with encryption)

--- a/full-ai-cluster/usb-nixos-installer/zeta-install.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-install.sh
@@ -1053,63 +1053,30 @@ echo
 # REQUIREMENT of post-boot fully-operational chain without operator login).
 SELF_REG_OK=0
 SELF_REG_PR_URL=""
-if [ "$GH_AUTH_OK" = 1 ]; then
-  echo "[iter-5.4.1] ── self-registration commit+push (B-0812) ──"
-  echo "[iter-5.4.1] Composing ClusterNode YAML + opening registration PR..."
 
-  # Resolve operator GH user (used for the per-maintainer subtree path).
-  MAINTAINER=$(gh api /user --jq .login 2>/dev/null || echo "")
-  if [ -z "$MAINTAINER" ]; then
-    echo "[iter-5.4.1]   WARN: gh api /user failed; cannot resolve operator GH login; skipping"
+# Shared hostname + ClusterNode YAML compose (B-0812 / B-0813 schema).
+zeta_self_reg_resolve_node_hostname() {
+  if [ -f "$HOSTNAME_DST" ]; then
+    NODE_HOSTNAME=$(cat "$HOSTNAME_DST" | tr -d '[:space:]')
   else
-    # Resolve installed hostname (iter-5.2 substrate writes to
-    # /mnt/etc/zeta/cluster-node-id). Fallback to flake-default $HOST
-    # if the iter-5.2 file is absent (means iter-5.2.2 generation was
-    # skipped or failed — graceful degradation; warn loudly).
-    if [ -f "$HOSTNAME_DST" ]; then
-      NODE_HOSTNAME=$(cat "$HOSTNAME_DST" | tr -d '[:space:]')
-    else
-      NODE_HOSTNAME="$HOST"
-      echo "[iter-5.4.1]   WARN: $HOSTNAME_DST absent; using flake-host '$HOST' as node-name"
-      echo "[iter-5.4.1]          (may produce naming collision if multiple nodes use this flake-host)"
-    fi
-    echo "[iter-5.4.1]   maintainer:  $MAINTAINER"
-    echo "[iter-5.4.1]   node-name:   $NODE_HOSTNAME"
+    NODE_HOSTNAME="$HOST"
+    echo "[iter-5.4.1]   WARN: $HOSTNAME_DST absent; using flake-host '$HOST' as node-name"
+    echo "[iter-5.4.1]          (may produce naming collision if multiple nodes use this flake-host)"
+  fi
+}
 
-    # ── hardware probe ──
-    # Emits the inner fields of the ClusterNode `hardware:` block.
-    # Each field is best-effort; absent fields are omitted from YAML
-    # rather than emitting empty-string values (ArgoCD/k8s consumers
-    # prefer absent over empty).
-    CPU_MODEL=$(grep 'model name' /proc/cpuinfo 2>/dev/null | head -1 | cut -d: -f2- | sed 's/^[[:space:]]*//' | sed 's/"//g' || echo "")
-    MEM_TOTAL=$(free -h --si 2>/dev/null | awk '/Mem:/{print $2}' || echo "")
-    CPU_CORES=$(nproc 2>/dev/null || echo "")
-    GPU_LINE=$(lspci -nn 2>/dev/null | grep -iE 'vga|3d|display' | head -1 | sed 's/"//g' || echo "")
-    IP_ADDR=$(ip -4 -o addr 2>/dev/null | awk '/inet/ && !/lo/{print $4; exit}' || echo "")
-    # MAC extraction: parse field after `link/ether` (Copilot finding on #5352
-    # — prior `$(NF-2)` extracted `brd` not the MAC; `link/ether <MAC> brd <BROADCAST>`
-    # is the standard `ip -o link` output shape; the field after `link/ether` is the MAC).
-    MAC_ADDR=$(ip -o link 2>/dev/null | awk '/state UP/ && !/lo/{for(i=1;i<=NF;i++) if($i=="link/ether"){print $(i+1); exit}}' || echo "")
-    # Storage lines: indented 6 spaces to nest under spec.hardware.storage
-    # (Copilot finding on #5352 — was a sibling of `hardware:` at 4 spaces; the
-    # B-0813 schema places storage under hardware block).
-    # Filter zero-size devices ($2 != "0B"): empty SD card readers, optical
-    # bays, and other placeholder block devices show up in `lsblk -ndo`
-    # output with SIZE=0B and confuse any reconciler that interprets the
-    # storage list as usable. Copilot finding on PR #5380 (Aaron's
-    # 2026-05-27 control-plane registration surfaced `/dev/sda 0B`).
-    STORAGE_LINES=$(lsblk -ndo NAME,SIZE,TYPE -e7 2>/dev/null | awk '$3=="disk" && $2!="0B"{print "      - \"/dev/" $1 " " $2 "\""}' || echo "")
-    REG_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-    FLAKE_COMMIT=$(git -C /mnt/etc/zeta rev-parse HEAD 2>/dev/null | head -c 12 || echo "unknown")
+zeta_self_reg_compose_node_yaml() {
+  CPU_MODEL=$(grep 'model name' /proc/cpuinfo 2>/dev/null | head -1 | cut -d: -f2- | sed 's/^[[:space:]]*//' | sed 's/"//g' || echo "")
+  MEM_TOTAL=$(free -h --si 2>/dev/null | awk '/Mem:/{print $2}' || echo "")
+  CPU_CORES=$(nproc 2>/dev/null || echo "")
+  GPU_LINE=$(lspci -nn 2>/dev/null | grep -iE 'vga|3d|display' | head -1 | sed 's/"//g' || echo "")
+  IP_ADDR=$(ip -4 -o addr 2>/dev/null | awk '/inet/ && !/lo/{print $4; exit}' || echo "")
+  MAC_ADDR=$(ip -o link 2>/dev/null | awk '/state UP/ && !/lo/{for(i=1;i<=NF;i++) if($i=="link/ether"){print $(i+1); exit}}' || echo "")
+  STORAGE_LINES=$(lsblk -ndo NAME,SIZE,TYPE -e7 2>/dev/null | awk '$3=="disk" && $2!="0B"{print "      - \"/dev/" $1 " " $2 "\""}' || echo "")
+  REG_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  FLAKE_COMMIT=$(git -C /mnt/etc/zeta rev-parse HEAD 2>/dev/null | head -c 12 || echo "unknown")
 
-    # ── compose node.yaml ──
-    # Schema per B-0813 (ClusterNode CRD) + B-0817 (register-node tool):
-    # - spec.roles is ARRAY (not scalar)
-    # - spec.registration.maintainer (NOT spec.maintainer; K8s ObjectMeta has fixed shape so
-    #   we keep it under spec.registration where ArgoCD reconciler reads it)
-    # - spec.hardware.storage (NOT spec.storage; storage is part of hardware block)
-    # (Copilot findings on #5352 — schema mismatches fixed per B-0813 + B-0817)
-    NODE_YAML="apiVersion: zeta.lucent-financial-group.com/v1
+  NODE_YAML="apiVersion: zeta.lucent-financial-group.com/v1
 kind: ClusterNode
 metadata:
   name: $NODE_HOSTNAME
@@ -1132,25 +1099,40 @@ spec:
     flake-host: \"$HOST\"
     registered-via: \"iter-5.4.1\"
   hardware:"
-    [ -n "$CPU_MODEL" ] && NODE_YAML="$NODE_YAML
+  [ -n "$CPU_MODEL" ] && NODE_YAML="$NODE_YAML
     cpu: \"$CPU_MODEL\""
-    [ -n "$MEM_TOTAL" ] && NODE_YAML="$NODE_YAML
+  [ -n "$MEM_TOTAL" ] && NODE_YAML="$NODE_YAML
     memory: \"$MEM_TOTAL\""
-    [ -n "$CPU_CORES" ] && NODE_YAML="$NODE_YAML
+  [ -n "$CPU_CORES" ] && NODE_YAML="$NODE_YAML
     cores: $CPU_CORES"
-    [ -n "$GPU_LINE" ] && NODE_YAML="$NODE_YAML
+  [ -n "$GPU_LINE" ] && NODE_YAML="$NODE_YAML
     gpu: \"$GPU_LINE\""
-    [ -n "$STORAGE_LINES" ] && NODE_YAML="$NODE_YAML
+  [ -n "$STORAGE_LINES" ] && NODE_YAML="$NODE_YAML
     storage:
 $STORAGE_LINES"
-    if [ -n "$IP_ADDR" ] || [ -n "$MAC_ADDR" ]; then
-      NODE_YAML="$NODE_YAML
+  if [ -n "$IP_ADDR" ] || [ -n "$MAC_ADDR" ]; then
+    NODE_YAML="$NODE_YAML
     network:"
-      [ -n "$IP_ADDR" ] && NODE_YAML="$NODE_YAML
+    [ -n "$IP_ADDR" ] && NODE_YAML="$NODE_YAML
       ip: \"$IP_ADDR\""
-      [ -n "$MAC_ADDR" ] && NODE_YAML="$NODE_YAML
+    [ -n "$MAC_ADDR" ] && NODE_YAML="$NODE_YAML
       mac: \"$MAC_ADDR\""
-    fi
+  fi
+}
+
+if [ "$GH_AUTH_OK" = 1 ]; then
+  echo "[iter-5.4.1] ── self-registration commit+push (B-0812) ──"
+  echo "[iter-5.4.1] Composing ClusterNode YAML + opening registration PR..."
+
+  # Resolve operator GH user (used for the per-maintainer subtree path).
+  MAINTAINER=$(gh api /user --jq .login 2>/dev/null || echo "")
+  if [ -z "$MAINTAINER" ]; then
+    echo "[iter-5.4.1]   WARN: gh api /user failed; cannot resolve operator GH login; skipping"
+  else
+    zeta_self_reg_resolve_node_hostname
+    echo "[iter-5.4.1]   maintainer:  $MAINTAINER"
+    echo "[iter-5.4.1]   node-name:   $NODE_HOSTNAME"
+    zeta_self_reg_compose_node_yaml
 
     # ── clone repo to temp; write node.yaml; commit + open PR ──
     # CRITICAL: this whole block is wrapped in `|| true` at the subshell
@@ -1264,6 +1246,18 @@ registered-at: ${REG_TIMESTAMP}
 else
   echo "[iter-5.4.1] skipped — iter-5.4.0 gh-auth was skipped or failed; no auth foothold for commit+push"
   echo "[iter-5.4.1] (operator can re-run manually post-install via tools/cluster/register-node.ts when that ships)"
+  # B-0831 slice 2: QEMU/CI dry-run — compose registration YAML without gh push.
+  if [ ! -t 0 ] && [ -f "$HOSTNAME_DST" ]; then
+    MAINTAINER="qemu-ci"
+    zeta_self_reg_resolve_node_hostname
+    zeta_self_reg_compose_node_yaml
+    PREVIEW="/mnt/etc/zeta/cluster-node-registration-preview.yaml"
+    sudo mkdir -p "$(dirname "$PREVIEW")"
+    printf '%s\n' "$NODE_YAML" | sudo tee "$PREVIEW" >/dev/null
+    echo "[iter-5.4.1-ci] composed ClusterNode maintainer=$MAINTAINER node=$NODE_HOSTNAME"
+    echo "[iter-5.4.1-ci] tree-path=maintainers/$MAINTAINER/cluster-nodes/$NODE_HOSTNAME/node.yaml"
+    echo "[iter-5.4.1-ci] preview=$PREVIEW"
+  fi
 fi
 echo
 

--- a/src/Core.TypeScript/ci/cluster-node-yaml.test.ts
+++ b/src/Core.TypeScript/ci/cluster-node-yaml.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { validateClusterNodeYaml } from "./cluster-node-yaml.ts";
+
+describe("validateClusterNodeYaml", () => {
+  it("accepts minimal ClusterNode shape from zeta-install Step 6.9", () => {
+    const yaml = `apiVersion: zeta.lucent-financial-group.com/v1
+kind: ClusterNode
+metadata:
+  name: zeta-a1b2c3
+spec:
+  hostname: zeta-a1b2c3
+  roles:
+    - control-plane
+  registration:
+    maintainer: qemu-ci
+    registered-via: "iter-5.4.1"
+  hardware:
+    cores: 2`;
+    const result = validateClusterNodeYaml(yaml);
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("rejects empty yaml", () => {
+    const result = validateClusterNodeYaml("");
+    expect(result.ok).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+});

--- a/src/Core.TypeScript/ci/cluster-node-yaml.ts
+++ b/src/Core.TypeScript/ci/cluster-node-yaml.ts
@@ -1,0 +1,32 @@
+/**
+ * B-0831 slice 2 — ClusterNode registration YAML shape checks.
+ * Mirrors zeta-install.sh Step 6.9 / B-0813 schema fields.
+ */
+
+export interface ClusterNodeYamlCheck {
+  readonly ok: boolean;
+  readonly errors: readonly string[];
+}
+
+export function validateClusterNodeYaml(yaml: string): ClusterNodeYamlCheck {
+  const errors: string[] = [];
+  if (!yaml.includes("apiVersion: zeta.lucent-financial-group.com/v1")) {
+    errors.push("missing apiVersion");
+  }
+  if (!yaml.includes("kind: ClusterNode")) {
+    errors.push("missing kind ClusterNode");
+  }
+  if (!yaml.includes("spec:")) {
+    errors.push("missing spec");
+  }
+  if (!yaml.includes("registration:")) {
+    errors.push("missing spec.registration");
+  }
+  if (!yaml.includes("registered-via: \"iter-5.4.1\"")) {
+    errors.push("missing registered-via iter-5.4.1");
+  }
+  if (!yaml.includes("roles:")) {
+    errors.push("missing spec.roles array");
+  }
+  return { ok: errors.length === 0, errors };
+}

--- a/src/Core.TypeScript/ci/qemu-full-install-test.ts
+++ b/src/Core.TypeScript/ci/qemu-full-install-test.ts
@@ -188,12 +188,13 @@ async function waitForInstallComplete(serialLogPath: string): Promise<InstallRes
           elapsedSeconds: elapsedSec,
         };
       }
+      const resolvedHostname = extractGeneratedHostname(content);
       return {
         exitCode: 0,
         reason: `phase 1 SUCCESS — install complete + ${SELF_REG_CI_MARKER} observed`,
         serialLogTail: content.slice(-1500),
         elapsedSeconds: elapsedSec,
-        hostname: extractGeneratedHostname(content) ?? undefined,
+        ...(resolvedHostname !== null ? { hostname: resolvedHostname } : {}),
       };
     }
 
@@ -253,7 +254,7 @@ async function waitForInstalledLogin(
         reason: `phase 2 SUCCESS — login prompt "${loginNeedle}" observed`,
         serialLogTail: content.slice(-1500),
         elapsedSeconds: elapsedSec,
-        hostname: expectedHostname ?? undefined,
+        ...(expectedHostname !== null ? { hostname: expectedHostname } : {}),
       };
     }
 

--- a/src/Core.TypeScript/ci/qemu-full-install-test.ts
+++ b/src/Core.TypeScript/ci/qemu-full-install-test.ts
@@ -6,6 +6,7 @@
  *
  * Phase 1 — boot installer ISO + virtual disk; wait for install completion.
  * Phase 2 — boot installed disk only; verify auto-generated hostname login banner.
+ * Phase 1 also asserts iter-5.4.1-ci dry-run registration (B-0831 slice 2).
  *
  * Composes with qemu-boot-test.ts (cascade #5) and B-0891 scenario 2.
  *
@@ -26,6 +27,9 @@ import { serialFirstBootInProgress } from "../zflash/test-harness/serial-markers
 
 /** zeta-install.sh success banner (end of install script). */
 const INSTALL_COMPLETE_MARKER = "ZETA CLUSTER NODE INSTALL COMPLETE";
+
+/** B-0831 slice 2 — non-TTY CI dry-run cluster-node registration compose. */
+const SELF_REG_CI_MARKER = "[iter-5.4.1-ci] composed ClusterNode";
 
 /** Mid-install progress — nixos-install reached post-install wifi step. */
 const NIXOS_INSTALL_PROGRESS_MARKER = "[iter-5.1]";
@@ -176,9 +180,17 @@ async function waitForInstallComplete(serialLogPath: string): Promise<InstallRes
 
     const content = readSerial(serialLogPath);
     if (content.includes(INSTALL_COMPLETE_MARKER)) {
+      if (!content.includes(SELF_REG_CI_MARKER)) {
+        return {
+          exitCode: 1,
+          reason: `phase 1 FAILURE — "${INSTALL_COMPLETE_MARKER}" seen but missing "${SELF_REG_CI_MARKER}" (cluster join dry-run)`,
+          serialLogTail: content.slice(-2000),
+          elapsedSeconds: elapsedSec,
+        };
+      }
       return {
         exitCode: 0,
-        reason: `phase 1 SUCCESS — "${INSTALL_COMPLETE_MARKER}" observed`,
+        reason: `phase 1 SUCCESS — install complete + ${SELF_REG_CI_MARKER} observed`,
         serialLogTail: content.slice(-1500),
         elapsedSeconds: elapsedSec,
         hostname: extractGeneratedHostname(content) ?? undefined,


### PR DESCRIPTION
## Summary
- Refactor Step 6.9 ClusterNode YAML compose into shared shell helpers
- **QEMU CI path:** when gh-auth skipped (non-TTY), compose preview YAML at `/mnt/etc/zeta/cluster-node-registration-preview.yaml` and emit `[iter-5.4.1-ci]` serial markers
- `qemu-full-install-test` phase 1 now requires dry-run marker (slice 2)
- Add `cluster-node-yaml.ts` schema validator + tests
- Update usb-zflash trajectory RESUME (slice 1 done, MCP done)

Riven clone: `~/.zeta/agents/cursor/riven-b0831-slice1-2026-06-14`

## Test plan
- [x] `bun test src/Core.TypeScript/ci/cluster-node-yaml.test.ts`
- [x] `bun test src/Core.TypeScript/ci/qemu-full-install-test.test.ts`
- [ ] gate green
- [ ] build-iso scenario 2 on push-to-main


Made with [Cursor](https://cursor.com)