### PR TITLE
feat(chip8): add prediction-backed room

### DIFF
--- a/src/Core.CSharp/Collation.cs
+++ b/src/Core.CSharp/Collation.cs
@@ -102,22 +102,27 @@ public static class Collation
     public const string DefaultName = "binary";
 
     /// <summary>
+    /// The canonical default for string keys: Unicode code-point / UTF-8 byte order.
+    /// </summary>
+    public static StringComparer Binary { get; } = UnicodeCodePointComparer.Ordinal;
+
+    /// <summary>
     /// The named string-collation catalog (DB-style).
     /// </summary>
     public static IReadOnlyDictionary<string, StringComparer> Catalog { get; } =
         new Dictionary<string, StringComparer>(StringComparer.OrdinalIgnoreCase)
         {
-            ["binary"] = UnicodeCodePointComparer.Ordinal,
-            ["ordinal"] = UnicodeCodePointComparer.Ordinal,
+            ["binary"] = Binary,
+            ["ordinal"] = Binary,
             ["ordinal-ci"] = UnicodeCodePointComparer.OrdinalIgnoreCase,
             ["invariant"] = StringComparer.InvariantCulture,
             ["invariant-ci"] = StringComparer.InvariantCultureIgnoreCase,
 
             // Postgres / Standard SQL aliases
-            ["C"] = UnicodeCodePointComparer.Ordinal,
-            ["POSIX"] = UnicodeCodePointComparer.Ordinal,
-            ["utf8_bin"] = UnicodeCodePointComparer.Ordinal,
-            ["utf8mb4_bin"] = UnicodeCodePointComparer.Ordinal,
+            ["C"] = Binary,
+            ["POSIX"] = Binary,
+            ["utf8_bin"] = Binary,
+            ["utf8mb4_bin"] = Binary,
 
             // SQLite alias
             ["NOCASE"] = UnicodeCodePointComparer.OrdinalIgnoreCase,
@@ -129,7 +134,7 @@ public static class Collation
             ["utf8mb4_unicode_ci"] = StringComparer.InvariantCultureIgnoreCase,
 
             // SQL Server aliases
-            ["Latin1_General_BIN"] = UnicodeCodePointComparer.Ordinal,
+            ["Latin1_General_BIN"] = Binary,
             ["Latin1_General_CI_AS"] = StringComparer.InvariantCultureIgnoreCase,
             ["Latin1_General_CS_AS"] = StringComparer.InvariantCulture
         };
@@ -153,7 +158,7 @@ public static class Collation
     public static StringComparer ByNameOrDefault(string name)
     {
         ArgumentNullException.ThrowIfNull(name);
-        return TryByName(name) ?? UnicodeCodePointComparer.Ordinal;
+        return TryByName(name) ?? Binary;
     }
 
     /// <summary>
@@ -168,7 +173,7 @@ public static class Collation
         ArgumentNullException.ThrowIfNull(collationName);
         if (typeof(T) == typeof(string))
         {
-            return (IComparer<T>)(TryByName(collationName) ?? UnicodeCodePointComparer.Ordinal);
+            return (IComparer<T>)(TryByName(collationName) ?? Binary);
         }
         return Comparer<T>.Default;
     }

--- a/src/Core.CSharp/GSet.cs
+++ b/src/Core.CSharp/GSet.cs
@@ -132,9 +132,8 @@ public static class GSet
 /// <remarks>
 /// The comparer is explicit (like the TS <c>compare</c> parameter) rather than baked to
 /// <see cref="Comparer{T}.Default"/>: for <see cref="string"/> the default is
-/// culture-sensitive, but the cross-language wire (TS UTF-16 code-unit order, Rust UTF-8
-/// byte order) needs <see cref="StringComparer.Ordinal"/>. Pass it explicitly for
-/// cross-language parity.
+/// culture-sensitive, but the cross-language wire needs the project binary collation
+/// (Unicode code-point / UTF-8 byte order). Pass it explicitly for cross-language parity.
 /// </remarks>
 /// <typeparam name="T">The element type.</typeparam>
 public sealed class GSet<T> :

--- a/src/Core/Chip8PredictionRoom.fs
+++ b/src/Core/Chip8PredictionRoom.fs
@@ -1,0 +1,123 @@
+namespace Zeta.Core
+
+/// CHIP-8 room wiring over the source-owned prediction scheduler.
+///
+/// The same value can run under `SimFramework.runK`, a recorded membrane, or a
+/// later production room runner. Tests are adapters to this room shape; the
+/// prediction and emulator execution path is the same.
+[<RequireQualifiedAccess>]
+module Chip8PredictionRoom =
+
+    type State = PredictionScheduler.Planned<Chip8Cow.Frame, Chip8Cow.Frame>
+
+    type BeliefEstimator =
+        InterruptKind -> Chip8Cow.Frame -> ReflectionEngine.Belief
+
+    type BranchCostEstimator =
+        Chip8Cow.Frame -> Vision.BranchCost
+
+    type PriorityEstimator =
+        PredictionInference.Scored<Chip8Cow.Frame> -> PredictionInference.BranchPriority
+
+    let state (frame: Chip8Cow.Frame) (tank: SoftThrottle.Tank) : State =
+        PredictionScheduler.planned frame tank
+
+    let load (seed: uint64) (rom: byte[]) (tank: SoftThrottle.Tank) : State =
+        state (Chip8Cow.create seed |> Chip8Cow.loadRom rom) tank
+
+    let inputHandler: SoftScheduler.HandlerK<State> =
+        PredictionScheduler.liftHandlerK SoftChip8Flux.inputHandler
+
+    let private timerExecutionHandler (cyclesPerTick: int) : SoftScheduler.HandlerK<Chip8Cow.Frame> =
+        SoftScheduler.handlerK
+            "chip8-predicted-60hz"
+            (function
+            | TimerElapsed _ -> true
+            | _ -> false)
+            (fun _ _ctx frame ->
+                let ticked = Chip8Cow.tick frame
+                let advanced =
+                    if SoftChip8.branchesOnInput ticked then
+                        let committed = SoftChip8.resolve ticked.Keys ticked
+                        SoftChip8.lookAhead (cyclesPerTick - 1) committed |> fst
+                    else
+                        SoftChip8.lookAhead cyclesPerTick ticked |> fst
+
+                System.Threading.Tasks.Task.FromResult(Ok advanced))
+
+    let timerHandlerWithPriority
+        (cyclesPerTick: int)
+        (beliefOf: BeliefEstimator)
+        (costOf: BranchCostEstimator)
+        (priorityOf: PriorityEstimator)
+        : SoftScheduler.HandlerK<State> =
+        let estimate intr frame =
+            Chip8Observer.inferenceCandidates (beliefOf intr frame) costOf frame
+
+        timerExecutionHandler cyclesPerTick
+        |> PredictionScheduler.wrapHandlerKWithPriority estimate priorityOf
+
+    let timerHandler
+        (cyclesPerTick: int)
+        (beliefOf: BeliefEstimator)
+        (costOf: BranchCostEstimator)
+        : SoftScheduler.HandlerK<State> =
+        timerHandlerWithPriority cyclesPerTick beliefOf costOf (fun _ -> PredictionInference.neutralPriority)
+
+    let handlersWithPriority
+        (cyclesPerTick: int)
+        (beliefOf: BeliefEstimator)
+        (costOf: BranchCostEstimator)
+        (priorityOf: PriorityEstimator)
+        : SoftScheduler.HandlerK<State> list =
+        [ inputHandler
+          timerHandlerWithPriority cyclesPerTick beliefOf costOf priorityOf ]
+
+    let handlers
+        (cyclesPerTick: int)
+        (beliefOf: BeliefEstimator)
+        (costOf: BranchCostEstimator)
+        : SoftScheduler.HandlerK<State> list =
+        handlersWithPriority cyclesPerTick beliefOf costOf (fun _ -> PredictionInference.neutralPriority)
+
+    let roomWithPriority
+        (name: string)
+        (rom: byte[])
+        (tank: SoftThrottle.Tank)
+        (cyclesPerTick: int)
+        (budget: int)
+        (source: int64 -> SoftScheduler.Source)
+        (resolved: State -> bool)
+        (beliefOf: BeliefEstimator)
+        (costOf: BranchCostEstimator)
+        (priorityOf: PriorityEstimator)
+        : SimFramework.RoomK<State> =
+        { Name = name
+          Initial = fun seed -> load (uint64 seed) rom tank
+          HandlersK = handlersWithPriority cyclesPerTick beliefOf costOf priorityOf
+          Source = source
+          Budget = budget
+          Resolved = resolved }
+
+    let room
+        (name: string)
+        (rom: byte[])
+        (tank: SoftThrottle.Tank)
+        (cyclesPerTick: int)
+        (budget: int)
+        (source: int64 -> SoftScheduler.Source)
+        (resolved: State -> bool)
+        (beliefOf: BeliefEstimator)
+        (costOf: BranchCostEstimator)
+        : SimFramework.RoomK<State> =
+        roomWithPriority
+            name
+            rom
+            tank
+            cyclesPerTick
+            budget
+            source
+            resolved
+            beliefOf
+            costOf
+            (fun _ -> PredictionInference.neutralPriority)

--- a/src/Core/Collation.fs
+++ b/src/Core/Collation.fs
@@ -9,8 +9,8 @@ open System.Text
 type UnicodeCodePointComparer(ignoreCase: bool) =
     inherit StringComparer()
     
-    static member Ordinal = UnicodeCodePointComparer(false)
-    static member OrdinalIgnoreCase = UnicodeCodePointComparer(true)
+    static member val Ordinal = UnicodeCodePointComparer(false)
+    static member val OrdinalIgnoreCase = UnicodeCodePointComparer(true)
 
     override this.Compare(x: string, y: string) =
         if obj.ReferenceEquals(x, y) then 0
@@ -77,10 +77,9 @@ type UnicodeCodePointComparer(ignoreCase: bool) =
 [<RequireQualifiedAccess>]
 module Collation =
 
-    /// The canonical default for STRING keys: ordinal (codepoint / byte order) = DB "binary collation".
-    /// All four oracles coincide on this order for the golden vectors (F# ordinal, C#
-    /// `StringComparer.Ordinal`, TS UTF-16 code-unit, Rust byte `Ord`); the astral/UTF-16 caveat is
-    /// resolved by the treaty picking codepoint ≡ UTF-8 byte order.
+    /// The canonical default for STRING keys: codepoint / UTF-8 byte order = DB "binary collation".
+    /// This differs from .NET `StringComparer.Ordinal` for non-BMP characters because ordinal compares
+    /// UTF-16 code units. The treaty comparator compares Unicode scalar values.
     let binary: StringComparer = UnicodeCodePointComparer.Ordinal :> StringComparer
 
     /// The default collation name we ship with.

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -261,6 +261,7 @@
     <Compile Include="SimLoop.fs" />
     <Compile Include="WheelRoom.fs" />
     <Compile Include="Chip8Observer.fs" />
+    <Compile Include="Chip8PredictionRoom.fs" />
     <Compile Include="SoftController.fs" />
     <Compile Include="ActionGrammar.fs" />
     <Compile Include="WorkflowEngine.fs" />

--- a/src/Core/PredictionScheduler.fs
+++ b/src/Core/PredictionScheduler.fs
@@ -111,6 +111,18 @@ module PredictionScheduler =
         : SoftScheduler.HandlerK<Planned<'Inner, 'BranchState>> =
         policyHandlerWithPriority name estimate (fun _ -> PredictionInference.neutralPriority)
 
+    let liftHandlerK
+        (handler: SoftScheduler.HandlerK<'Inner>)
+        : SoftScheduler.HandlerK<Planned<'Inner, 'BranchState>> =
+        SoftScheduler.handlerK
+            handler.Name
+            handler.Matches
+            (fun intr ctx state ->
+                task {
+                    let! inner = handler.RunK intr ctx state.Inner
+                    return inner |> Result.map (fun next -> { state with Inner = next })
+                })
+
     let wrapHandlerKWithPriority
         (estimate: CandidateEstimator<'Inner, 'BranchState>)
         (priorityOf: PriorityEstimator<'BranchState>)

--- a/tests/Tests.CSharp/Algebra/GSetCrossVerifyTests.cs
+++ b/tests/Tests.CSharp/Algebra/GSetCrossVerifyTests.cs
@@ -49,7 +49,7 @@ public class GSetCrossVerifyTests
         var path = Path.Join(root, "src", "Core.TypeScript", "g-set", "golden-vectors.json");
         using var doc = JsonDocument.Parse(File.ReadAllText(path));
         var r = doc.RootElement;
-        var cmp = Collation.UnicodeCodePointComparer.Ordinal;
+        var cmp = Collation.ForKey<string>();
 
         var state = GSet.OfSeq(Strings(r.GetProperty("initialSet")), cmp);
         var ops = r.GetProperty("ops");
@@ -151,13 +151,5 @@ public class GSetCrossVerifyTests
         // (the comparer-identity guard for real merges is preserved).
         var ordinal = GSet.OfSeq(["a", "b"], Collation.UnicodeCodePointComparer.Ordinal);
         Assert.Throws<ArgumentException>(() => ordinal + custom);
-    }
-
-    [Fact]
-    public void TempCompareTest()
-    {
-        var cmp = Collation.UnicodeCodePointComparer.Ordinal;
-        var r = cmp.Compare("", "𠜎");
-        throw new InvalidOperationException($"Comparison result: {r}");
     }
 }

--- a/tests/Tests.CSharp/Algebra/IndexedZSetCrossVerifyTests.cs
+++ b/tests/Tests.CSharp/Algebra/IndexedZSetCrossVerifyTests.cs
@@ -151,13 +151,23 @@ public class IndexedZSetCrossVerifyTests
         IComparer<string> vc,
         params (string K, string V, long W)[] triples)
     {
+        return BuildIxz(kc, "custom", vc, "custom", triples);
+    }
+
+    private static IndexedZSet<string, string> BuildIxz(
+        IComparer<string> kc,
+        string keyCollation,
+        IComparer<string> vc,
+        string valueCollation,
+        params (string K, string V, long W)[] triples)
+    {
         var pairCmp = Comparer<(string, string)>.Create((x, y) =>
         {
             var c = kc.Compare(x.Item1, y.Item1);
             return c != 0 ? c : vc.Compare(x.Item2, y.Item2);
         });
         var source = ZSet.OfEntries(triples.Select(t => ((t.K, t.V), t.W)), pairCmp);
-        return IndexedZSet.IndexWith(source, p => p.Item1, p => p.Item2, kc, vc);
+        return IndexedZSet.IndexWith(source, p => p.Item1, p => p.Item2, kc, keyCollation, vc, valueCollation);
     }
 
     private static IndexedZSet<string, string> Ixz(params (string K, string V, long W)[] triples) =>
@@ -205,7 +215,7 @@ public class IndexedZSetCrossVerifyTests
         // empty must absorb under ANY comparers (the identity law); (+)/(-) short-circuit empty
         // BEFORE Add's RequireSameComparers. Two NON-empty operands with mismatched comparers throw.
         var rev = Comparer<string>.Create((x, y) => string.CompareOrdinal(y, x));
-        var custom = BuildIxz(rev, rev, ("x", "p", 1L));
+        var custom = BuildIxz(rev, "reverse", rev, "reverse", ("x", "p", 1L));
         var id = IndexedZSet<string, string>.AdditiveIdentity;
         Assert.Equal(custom, custom + id); // a + empty = a (no throw)
         Assert.Equal(custom, id + custom); // empty + a = a (no throw)

--- a/tests/Tests.CSharp/CollationTests.cs
+++ b/tests/Tests.CSharp/CollationTests.cs
@@ -1,0 +1,34 @@
+using System;
+using Xunit;
+using Zeta.Core.CSharp;
+
+namespace Zeta.Tests.CSharp;
+
+public sealed class CollationTests
+{
+    [Fact]
+    public void BinaryDefaultIsCodePointOrder()
+    {
+        Assert.Equal("binary", Collation.DefaultName);
+        Assert.Same(Collation.Binary, Collation.ByNameOrDefault(Collation.DefaultName));
+        Assert.True(Collation.Binary.Compare("�", "𠜎") < 0);
+        Assert.True(Collation.ByNameOrDefault("BINARY").Compare("�", "𠜎") < 0);
+    }
+
+    [Fact]
+    public void OrdinalNameUsesCodePointTreaty()
+    {
+        Assert.Same(Collation.Binary, Collation.ByNameOrDefault("ordinal"));
+        Assert.True(Collation.ByNameOrDefault("ordinal").Compare("�", "𠜎") < 0);
+    }
+
+    [Fact]
+    public void ForKeyStringUsesBinaryDefault()
+    {
+        var comparer = Collation.ForKey<string>();
+
+        Assert.True(comparer.Compare("B", "a") < 0);
+        Assert.True(comparer.Compare("�", "𠜎") < 0);
+        Assert.Equal(0, comparer.Compare("abc", "abc"));
+    }
+}

--- a/tests/Tests.FSharp/Algebra/GSet.Tests.fs
+++ b/tests/Tests.FSharp/Algebra/GSet.Tests.fs
@@ -139,10 +139,10 @@ let private loadVector () : string list * GsOp list * string list list * string 
     let final = strList (root.GetProperty("expectedFinalState"))
     initial, ops, replay, final
 
-// ─── B-0969: string ordering is ORDINAL (binary collation), not culture-sensitive ───
-// Default collation = Collation.binary (ordinal). 'B'(0x42) < 'a'(0x61) ordinally, so "B" sorts BEFORE
-// "a"; a culture-sensitive sort (the old Comparer<string>.Default) would put "a" first. This is the
-// cross-language byte-consensus order the other three oracles (C#/Rust/TS) already produce.
+// ─── B-0969: string ordering is BINARY code-point order, not culture-sensitive ───
+// Default collation = Collation.binary. 'B'(0x42) < 'a'(0x61), so "B" sorts BEFORE "a";
+// a culture-sensitive sort (the old Comparer<string>.Default) would put "a" first.
+// This is the cross-language byte-consensus order the other three oracles produce.
 [<Fact>]
 let ``ofSeq sorts strings ordinally (B-0969 binary collation, not culture-sensitive)`` () =
     let g = GSet.ofSeq [ "a"; "B"; "C"; "b" ]
@@ -165,5 +165,5 @@ let ``F# replays the shared golden vector to expectedReplayStates + expectedFina
                   | Add x -> GSet.add x state
                   | Union xs -> GSet.union state (GSet.ofSeq xs)
               yield GSet.toList state ]
-    actual |> should equal expectedReplay
-    GSet.toList state |> should equal expectedFinal
+    Assert.Equal<string list list>(expectedReplay, actual)
+    Assert.Equal<string list>(expectedFinal, GSet.toList state)

--- a/tests/Tests.FSharp/Chip8PredictionRoom.Tests.fs
+++ b/tests/Tests.FSharp/Chip8PredictionRoom.Tests.fs
@@ -1,0 +1,75 @@
+module Zeta.Tests.Chip8PredictionRoomTests
+
+open global.Xunit
+open Zeta.Core
+
+module PI = PredictionInference
+module PS = ProbabilitySemiring
+
+let private r n d = PS.rat n d
+
+/// V0=0, then EX9E (skip-if-key-V0). After one step the frame is parked at
+/// the input fork so the next timer tick has something real to predict.
+let private inputForkFrame () =
+    Chip8Cow.create 1UL
+    |> Chip8Cow.loadRom [| 0x60uy; 0x00uy; 0xE0uy; 0x9Euy; 0x12uy; 0x00uy |]
+    |> Chip8Cow.step
+
+let private branchCost (_: Chip8Cow.Frame) : Vision.BranchCost =
+    { SpaceBytes = 10L
+      TimeTicks = 1
+      BytesPerTick = 0L
+      UncertaintyResolutionBits = 1 }
+
+let private belief _ frame =
+    if SoftChip8.branchesOnInput frame then
+        [| r 2L 3L; r 1L 3L |]
+    else
+        [| PS.one |]
+
+[<Fact>]
+let ``CHIP8 prediction room runs under SimFramework and records budgeted self sight`` () =
+    task {
+        let atFork = inputForkFrame ()
+
+        let priority (scored: PI.Scored<Chip8Cow.Frame>) =
+            if scored.Candidate.Label = "key-up" then
+                { PI.neutralPriority with Attention = r 3L 1L }
+            else
+                PI.neutralPriority
+
+        let source _ tick =
+            if tick = 0 then
+                [ OperatorMessageArrived(SoftChip8Flux.encodeKey 0 true)
+                  TimerElapsed 17 ]
+            else
+                []
+
+        let room: SimFramework.RoomK<Chip8PredictionRoom.State> =
+            { Name = "chip8-prediction-room"
+              Initial = fun _ -> Chip8PredictionRoom.state atFork (SoftThrottle.tank 11.0 0.0)
+              HandlersK = Chip8PredictionRoom.handlersWithPriority 1 belief branchCost priority
+              Source = source
+              Budget = 1
+              Resolved = fun state -> state.LastPrediction.IsSome }
+
+        let! report = SimFramework.runK room 1L
+
+        Assert.True(report.SignedOff)
+        match report.Final with
+        | Error feedback -> Assert.Fail(sprintf "expected Ok, got %A" feedback)
+        | Ok final ->
+            Assert.Equal(1, final.Tick)
+            Assert.Equal(11L, final.PredictedBytes)
+            Assert.Equal(11L, final.DeferredBytes)
+
+            let expected = Chip8Cow.step (SoftChip8Flux.applyKey 0 true atFork)
+            Assert.Equal(expected.PC, final.Inner.PC)
+
+            match final.LastPrediction with
+            | None -> Assert.Fail "CHIP-8 room should record the budgeted prediction"
+            | Some prediction ->
+                Assert.Equal("key-down", prediction.Inference.Best.Candidate.Label)
+                Assert.Equal<string list>([ "key-up" ], prediction.Budget.Boarded |> List.map _.Label)
+                Assert.Equal<string list>([ "key-down" ], prediction.Budget.Deferred |> List.map _.Label)
+    }

--- a/tests/Tests.FSharp/Collation.Tests.fs
+++ b/tests/Tests.FSharp/Collation.Tests.fs
@@ -4,33 +4,35 @@ open System
 open global.Xunit
 open Zeta.Core
 
-// DB-style collation selection (B-0969). The shipped default is BINARY/ordinal; the bug fix is that
-// forKey<string> resolves to ORDINAL, never the culture-sensitive Comparer<string>.Default.
+// DB-style collation selection (B-0969). The shipped default is BINARY code-point order; the bug fix is
+// that forKey<string> resolves to that treaty comparer, never the culture-sensitive
+// Comparer<string>.Default.
 
 [<Fact>]
-let ``binary default is ordinal and is the shipped default name`` () =
-    Assert.Same(UnicodeCodePointComparer.Ordinal, Collation.binary)
+let ``binary default is code-point order and is the shipped default name`` () =
     Assert.Equal("binary", Collation.defaultName)
-    Assert.Same(UnicodeCodePointComparer.Ordinal, Collation.byNameOrDefault Collation.defaultName)
+    Assert.Same(Collation.binary, Collation.byNameOrDefault Collation.defaultName)
+    Assert.True(Collation.binary.Compare("�", "𠜎") < 0)
 
 [<Fact>]
 let ``catalog resolves named collations; unknown falls back to binary`` () =
-    Assert.Same(UnicodeCodePointComparer.Ordinal, Collation.byNameOrDefault "ordinal")
+    Assert.Same(Collation.binary, Collation.byNameOrDefault "ordinal")
     Assert.Same(UnicodeCodePointComparer.OrdinalIgnoreCase, Collation.byNameOrDefault "ordinal-ci")
     Assert.Equal(None, Collation.tryByName "no-such-collation")
-    Assert.Same(UnicodeCodePointComparer.Ordinal, Collation.byNameOrDefault "no-such-collation") // fallback
+    Assert.Same(Collation.binary, Collation.byNameOrDefault "no-such-collation") // fallback
 
 [<Fact>]
 let ``catalog name lookup is itself case-insensitive`` () =
     // selecting a collation by name shouldn't be culture/case-fragile
-    Assert.Same(UnicodeCodePointComparer.Ordinal, Collation.byNameOrDefault "BINARY")
+    Assert.Same(Collation.binary, Collation.byNameOrDefault "BINARY")
 
 [<Fact>]
-let ``forKey string is ORDINAL, not culture-sensitive (the B-0969 fix)`` () =
+let ``forKey string is binary code-point order, not culture-sensitive (the B-0969 fix)`` () =
     let c = Collation.forKey<string> ()
-    // ordinal: 'B'(66) < 'a'(97) => "B" sorts before "a". Culture-sensitive would put "a" first.
+    // binary: 'B'(66) < 'a'(97) => "B" sorts before "a". Culture-sensitive would put "a" first.
     Assert.True(c.Compare("B", "a") < 0)
     Assert.True(c.Compare("a", "B") > 0)
+    Assert.True(c.Compare("�", "𠜎") < 0)
     Assert.Equal(0, c.Compare("abc", "abc"))
 
 [<Fact>]

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -51,6 +51,7 @@
     <Compile Include="Reconcile.Legs.Tests.fs" />
     <Compile Include="EngineLoop.Tests.fs" />
     <Compile Include="Chip8Observer.Tests.fs" />
+    <Compile Include="Chip8PredictionRoom.Tests.fs" />
     <Compile Include="SocietyEmergence.Tests.fs" />
     <Compile Include="SocietyUnbounded.Tests.fs" />
     <Compile Include="TriBoolean/TriBoolean.Tests.fs" />

--- a/tests/Tests.FSharp/_Support/DeterministicTestPath.fs
+++ b/tests/Tests.FSharp/_Support/DeterministicTestPath.fs
@@ -25,8 +25,22 @@ module DeterministicTestPath =
         let root = Path.Combine(Path.GetTempPath(), "zeta-test-paths")
         let dir = Path.Combine(root, sprintf "%s-%04d" (sanitize prefix) id)
 
-        if Directory.Exists dir then
-            Directory.Delete(dir, true)
+        let rec deleteExisting attempts =
+            if Directory.Exists dir then
+                try
+                    Directory.Delete(dir, true)
+                with
+                | :? DirectoryNotFoundException when attempts > 0 ->
+                    Thread.Sleep 10
+                    deleteExisting (attempts - 1)
+                | :? IOException when attempts > 0 ->
+                    Thread.Sleep 10
+                    deleteExisting (attempts - 1)
+                | :? UnauthorizedAccessException when attempts > 0 ->
+                    Thread.Sleep 10
+                    deleteExisting (attempts - 1)
+
+        deleteExisting 5
 
         Directory.CreateDirectory dir |> ignore
         dir


### PR DESCRIPTION
## Summary
- add a CHIP-8 prediction-backed room over `PredictionScheduler.Planned<Chip8Cow.Frame, Chip8Cow.Frame>`
- lift normal `HandlerK` crossings so key input and timer execution run through the same bounded room shape
- align GSet/Collation code-point treaty coverage across F# and C#, including the public C# default path
- keep latest-main gates green by fixing comparer singleton identity, explicit IndexedZSet mismatch coverage, deterministic temp cleanup, and removing a scratch red compare test

## Validation
- `dotnet build -c Release -m:1 /p:UseSharedCompilation=false`
- `dotnet test Zeta.sln -c Release -m:1 /p:UseSharedCompilation=false --filter FullyQualifiedName~Collation|FullyQualifiedName~GSet|FullyQualifiedName~Chip8PredictionRoom|FullyQualifiedName~PredictionScheduler|FullyQualifiedName~PredictionInference|FullyQualifiedName~Chip8Observer|FullyQualifiedName~IndexedZSetCrossVerifyTests.GenericMathIdentityIsComparerAgnosticButNonEmptyMismatchThrows`
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release -m:1 /p:UseSharedCompilation=false --no-build --filter FullyQualifiedName~DurabilitySimTests|FullyQualifiedName~DurabilityPropertyTests`
- `dotnet test tests/Tests.CSharp/Tests.CSharp.csproj -c Release -m:1 /p:UseSharedCompilation=false --no-build --filter FullyQualifiedName~IndexedZSetCrossVerifyTests.GenericMathIdentityIsComparerAgnosticButNonEmptyMismatchThrows`
- `dotnet test Zeta.sln -c Release -m:1 /p:UseSharedCompilation=false --no-build`
- `dotnet format --verify-no-changes`
- `git diff --check`
