### PR TITLE
fix(core): restore main-green — collation singletons + comparer guard

### DIFF
--- a/src/Core.CSharp/IndexedZSet.cs
+++ b/src/Core.CSharp/IndexedZSet.cs
@@ -738,8 +738,13 @@ public sealed class IndexedZSet<TKey, TValue> :
 
     private void RequireSameComparers(IndexedZSet<TKey, TValue> other)
     {
-        if ((!string.Equals(KeyCollationName, other.KeyCollationName, StringComparison.Ordinal) && !_compareK.Equals(other._compareK)) ||
-            (!string.Equals(ValueCollationName, other.ValueCollationName, StringComparison.Ordinal) && !_compareV.Equals(other._compareV)))
+        var sameKeyCollation = !string.Equals(KeyCollationName, "custom", StringComparison.Ordinal) &&
+                               string.Equals(KeyCollationName, other.KeyCollationName, StringComparison.Ordinal);
+        var sameValCollation = !string.Equals(ValueCollationName, "custom", StringComparison.Ordinal) &&
+                               string.Equals(ValueCollationName, other.ValueCollationName, StringComparison.Ordinal);
+
+        if ((!sameKeyCollation && !_compareK.Equals(other._compareK)) ||
+            (!sameValCollation && !_compareV.Equals(other._compareV)))
         {
             throw new ArgumentException(
                 $"IndexedZSet ops require both operands to use the same collation name or equivalent comparers (this key: '{KeyCollationName}', other key: '{other.KeyCollationName}'; this value: '{ValueCollationName}', other value: '{other.ValueCollationName}').",

--- a/src/Core/Collation.fs
+++ b/src/Core/Collation.fs
@@ -9,8 +9,10 @@ open System.Text
 type UnicodeCodePointComparer(ignoreCase: bool) =
     inherit StringComparer()
     
-    static member Ordinal = UnicodeCodePointComparer(false)
-    static member OrdinalIgnoreCase = UnicodeCodePointComparer(true)
+    static let ordinal = UnicodeCodePointComparer(false)
+    static let ordinalIgnoreCase = UnicodeCodePointComparer(true)
+    static member Ordinal = ordinal
+    static member OrdinalIgnoreCase = ordinalIgnoreCase
 
     override this.Compare(x: string, y: string) =
         if obj.ReferenceEquals(x, y) then 0

--- a/tests/Tests.CSharp/Algebra/GSetCrossVerifyTests.cs
+++ b/tests/Tests.CSharp/Algebra/GSetCrossVerifyTests.cs
@@ -152,12 +152,4 @@ public class GSetCrossVerifyTests
         var ordinal = GSet.OfSeq(["a", "b"], Collation.UnicodeCodePointComparer.Ordinal);
         Assert.Throws<ArgumentException>(() => ordinal + custom);
     }
-
-    [Fact]
-    public void TempCompareTest()
-    {
-        var cmp = Collation.UnicodeCodePointComparer.Ordinal;
-        var r = cmp.Compare("", "𠜎");
-        throw new InvalidOperationException($"Comparison result: {r}");
-    }
 }


### PR DESCRIPTION
## Summary
- **F# `UnicodeCodePointComparer`**: use `static let` singletons so `Ordinal`/`OrdinalIgnoreCase` are stable instances (fixes 3 `CollationTests` `Assert.Same` failures — each property access was allocating a new comparer).
- **`IndexedZSet.RequireSameComparers`**: align guard with `GSet`/`Equals` — two `"custom"`-named operands with different comparers must throw (fixes `GenericMathIdentityIsComparerAgnosticButNonEmptyMismatchThrows`).
- **Remove `TempCompareTest`**: accidental debug test from #8128 rollout that always throws.

## Test plan
- [x] `dotnet test tests/Tests.FSharp --filter CollationTests` — 5/5
- [x] `dotnet test tests/Tests.CSharp --filter GSetCrossVerifyTests|IndexedZSetCrossVerifyTests.GenericMathIdentity` — 6/6
- [ ] gate `build-and-test` all matrix legs green

Unblocks #8129 gate once merged to main.


Made with [Cursor](https://cursor.com)