### PR TITLE
fix(ci): omit absent qemu hostname

### DIFF
--- a/src/Core.TypeScript/ci/qemu-full-install-test.ts
+++ b/src/Core.TypeScript/ci/qemu-full-install-test.ts
@@ -176,12 +176,13 @@ async function waitForInstallComplete(serialLogPath: string): Promise<InstallRes
 
     const content = readSerial(serialLogPath);
     if (content.includes(INSTALL_COMPLETE_MARKER)) {
+      const hostname = extractGeneratedHostname(content);
       return {
         exitCode: 0,
         reason: `phase 1 SUCCESS — "${INSTALL_COMPLETE_MARKER}" observed`,
         serialLogTail: content.slice(-1500),
         elapsedSeconds: elapsedSec,
-        hostname: extractGeneratedHostname(content) ?? undefined,
+        ...(hostname ? { hostname } : {}),
       };
     }
 
@@ -235,13 +236,13 @@ async function waitForInstalledLogin(
     const elapsedSec = Math.floor((Date.now() - start) / 1000);
     const content = readSerial(serialLogPath);
 
-    if (loginNeedle && content.includes(loginNeedle)) {
+    if (expectedHostname && content.includes(`${expectedHostname} login:`)) {
       return {
         exitCode: 0,
-        reason: `phase 2 SUCCESS — login prompt "${loginNeedle}" observed`,
+        reason: `phase 2 SUCCESS — login prompt "${expectedHostname} login:" observed`,
         serialLogTail: content.slice(-1500),
         elapsedSeconds: elapsedSec,
-        hostname: expectedHostname ?? undefined,
+        hostname: expectedHostname,
       };
     }
 


### PR DESCRIPTION
## What changed

- Omits `hostname` from the QEMU install success result when extraction does not produce a value.
- Narrows the installed-login success branch so `hostname` is only present when it is definitely a string.

## Why

The post-merge TypeScript gate on main failed under `exactOptionalPropertyTypes`: `hostname?: string` may be omitted, but it cannot be assigned `undefined`.

## Validation

- `bun src/Core.TypeScript/lint/lint-typescript.ts`
- `bun test src/Core.TypeScript/ci/qemu-full-install-test.test.ts`
- `git diff --check`
