### PR TITLE
fix(tsc): allow explicit undefined on InstallResult.hostname (restore main-green)

### DIFF
--- a/src/Core.TypeScript/ci/qemu-full-install-test.ts
+++ b/src/Core.TypeScript/ci/qemu-full-install-test.ts
@@ -59,7 +59,7 @@ interface InstallResult {
   readonly reason: string;
   readonly serialLogTail?: string;
   readonly elapsedSeconds?: number;
-  readonly hostname?: string;
+  readonly hostname?: string | undefined;
 }
 
 /** Exported for unit tests. */


### PR DESCRIPTION
`lint (tsc TypeScript)` is red on `src/Core.TypeScript/ci/qemu-full-install-test.ts` (TS2375 under `exactOptionalPropertyTypes`): the result objects assign `hostname: … ?? undefined` but the field was typed `hostname?: string` (absent-or-string, not string|undefined). Widened to `hostname?: string | undefined` to match intent. **tsc now 0 errors.**

Comprehensive local sweep on current main + this fix: tsc ✓, F# ✓, C# ✓, Python ✓, Rust ✓, Go ✓ (all lint dimensions green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)