### PR TITLE
fix(collation): enforce invariant culture, ordinal collation, and ConfigureAwait(false) guidelines

### DIFF
--- a/.claude/rules/culture-invariant-by-default.md
+++ b/.claude/rules/culture-invariant-by-default.md
@@ -6,9 +6,21 @@ Carved sentence:
 > the math, the golden vectors, and all four language oracles.** Never use
 > platform-default string comparison in primitives (`Comparer<string>.Default`,
 > `String.Compare`, `ToLower`/`ToUpper` are culture-SENSITIVE) — use
-> `StringComparer.Ordinal` / `ToLowerInvariant`. NOT `InvariantCulture` either:
-> it's locale-fixed but still *linguistic* — not byte-identical, not codepoint
-> order, not bit-perfect. Use ordinal.
+> `StringComparer.Ordinal` / `ToLowerInvariant` / `StringComparison.Ordinal`.
+> NOT `InvariantCulture` for strings: it's locale-fixed but still *linguistic* —
+> not byte-identical, not codepoint order, not bit-perfect. Use ordinal.
+> For numeric parsing, formatting, and string interpolations, explicitly use
+> `CultureInfo.InvariantCulture` / `FormattableString.Invariant`.
+> Explicitly use `ConfigureAwait(false)` on awaits in library paths.
+
+## Diagnostics and Enforcement
+
+These rules are enforced at compiler/analyzer level for all harnesses in the repository via `.editorconfig` under `[*.{cs,csx}]`:
+- `CA1304` (Specify CultureInfo) ➔ `error`
+- `CA1305` (Specify IFormatProvider) ➔ `error`
+- `CA1307` (Specify StringComparison for clarity of intent) ➔ `error`
+- `CA1310` (Use Ordinal comparison when possible) ➔ `error`
+- `CA2007` (Do not directly await a Task / specify ConfigureAwait) ➔ `error`
 
 ## Bit-perfect caveat: "ordinal" still diverges across languages
 
@@ -27,6 +39,10 @@ low-level byte/order/UoM mismatch must not compound into AI↔human collision �
 Mars Climate Orbiter lesson (lbf vs N) generalized; get the bytes right so the
 morals stand on them. Culture-aware comparison is a UI/display concern, opt in at
 the edge.
+
+Library paths also require non-blocking, execution-context-independent awaits via
+`ConfigureAwait(false)` (CA2007) to prevent deadlocks in UI / synchronization-context
+bound platforms.
 
 ## Pointers
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -52,6 +52,13 @@ fsharp_single_argument_web_mode = true
 dotnet_sort_system_directives_first = true
 dotnet_separate_import_directive_groups = false
 
+# B-0969 invariant culture + ConfigureAwait(false) enforcement
+dotnet_diagnostic.CA1304.severity = error
+dotnet_diagnostic.CA1305.severity = error
+dotnet_diagnostic.CA1307.severity = error
+dotnet_diagnostic.CA1310.severity = error
+dotnet_diagnostic.CA2007.severity = error
+
 dotnet_style_qualification_for_field = false:suggestion
 dotnet_style_qualification_for_property = false:suggestion
 dotnet_style_qualification_for_method = false:suggestion

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -446,6 +446,8 @@ role).
 - **Result-over-exception.** Errors flow as values.
 - **No partial functions on the public surface.**
   If a function can fail, its return type says so.
+- **Collation and Culture.** Default to `StringComparison.Ordinal` / `CultureInfo.InvariantCulture` for string comparisons/formatting to ensure bit-identical, culture-invariant determinism. Enforced by `.editorconfig` build error level diagnostics (CA1304, CA1305, CA1307, CA1310).
+- **ConfigureAwait(false).** Explicitly use `ConfigureAwait(false)` on all awaits in library paths. Enforced by `.editorconfig` build error level diagnostics (CA2007).
 - **Immutable by default.** Mutation is a local
   optimisation with a reviewer justification.
 - **Generic by default.** Specialise only with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ See [`docs/CONFLICT-RESOLUTION.md`](docs/CONFLICT-RESOLUTION.md). On deadlock, t
 
 - **Agents, not bots** — every AI carries agency; correct "bot" gently (GOVERNANCE.md §3).
 - **Result-over-exception** — errors surface as `Result<_, DbspError>`; no exceptions on hot paths.
+- **Collation and Culture / Async** — Default to `StringComparison.Ordinal` / `CultureInfo.InvariantCulture` for string comparisons/formatting, and explicitly use `ConfigureAwait(false)` on all awaits in library paths. Enforced by `.editorconfig` build error level diagnostics (CA1304, CA1305, CA1307, CA1310, CA2007).
 - **Memory fast-path** — read `~/.claude/projects/<slug>/memory/CURRENT-*.md` before raw
   `feedback_*.md` logs; CURRENT files win on conflict with older raw memories.
 - **`references/prior-art/` — explicit-target searches ONLY; NOT our code.** Gitignored, gigabytes,

--- a/src/Core.CSharp.DynamicValue/DynamicValues.cs
+++ b/src/Core.CSharp.DynamicValue/DynamicValues.cs
@@ -130,7 +130,7 @@ public static class DynamicValues
         if (firstBracket != 0)
         {
             string keyPart = firstBracket < 0 ? segment : segment[..firstBracket];
-            if (keyPart.Contains(']'))
+            if (keyPart.Contains(']', StringComparison.Ordinal))
             {
                 return false; // stray ']' in the key part
             }

--- a/src/Core.CSharp/FourCornerOwnership.cs
+++ b/src/Core.CSharp/FourCornerOwnership.cs
@@ -33,7 +33,10 @@ public sealed record FourCornerOwnership(
     public bool HasFeedback => TOutFeedback is not null || TInFeedback is not null;
 
     private static string Esc(string s) =>
-        s.Replace("\\", "\\\\").Replace("\t", "\\t").Replace("\n", "\\n").Replace("\r", "\\r");
+        s.Replace("\\", "\\\\", StringComparison.Ordinal)
+         .Replace("\t", "\\t", StringComparison.Ordinal)
+         .Replace("\n", "\\n", StringComparison.Ordinal)
+         .Replace("\r", "\\r", StringComparison.Ordinal);
 
     private static string Unesc(string s)
     {

--- a/src/Core.CSharp/MembraneCrossing.cs
+++ b/src/Core.CSharp/MembraneCrossing.cs
@@ -26,7 +26,10 @@ public sealed record MembraneCrossing(int Tick, string Kind, int? IntArg, string
     private static bool IsStrKind(string k) => Array.IndexOf(StrKinds, k) >= 0;
 
     private static string Esc(string s) =>
-        s.Replace("\\", "\\\\").Replace("\t", "\\t").Replace("\n", "\\n").Replace("\r", "\\r");
+        s.Replace("\\", "\\\\", StringComparison.Ordinal)
+         .Replace("\t", "\\t", StringComparison.Ordinal)
+         .Replace("\n", "\\n", StringComparison.Ordinal)
+         .Replace("\r", "\\r", StringComparison.Ordinal);
 
     private static string Unesc(string s)
     {

--- a/tests/Tests.CSharp/MeshPongCrossVerifyTests.cs
+++ b/tests/Tests.CSharp/MeshPongCrossVerifyTests.cs
@@ -31,7 +31,7 @@ public sealed class MeshPongCrossVerifyTests
             .Where(l => !l.StartsWith('#') && l.Length > 0)
             .Select(l =>
             {
-                var i1 = l.IndexOf('\t');
+                var i1 = l.IndexOf('\t', StringComparison.Ordinal);
                 var i2 = l.IndexOf('\t', i1 + 1);
                 return (l[..i1], l[(i2 + 1)..]); // kind, rest (skip the tick; replay is order-driven)
             })

--- a/tests/Tests.CSharp/Sha256/CrossVerifyTests.cs
+++ b/tests/Tests.CSharp/Sha256/CrossVerifyTests.cs
@@ -115,7 +115,7 @@ public class CrossVerifyTests
         // Use UTF-8 without BOM, LF line endings (cross-platform consistency).
         var outputPath = Path.Join(root, "tests", "cross-verification", "sha256", "cs-output.json");
         var json = JsonSerializer.Serialize(results, JsonOptions);
-        var lfJson = json.Replace("\r\n", "\n").Replace("\r", "\n");
+        var lfJson = json.Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal);
         File.WriteAllText(outputPath, lfJson, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
 
         Assert.Equal(0, mismatches);

--- a/tests/Tests.CSharp/TriBoolean/CrossVerifyTests.cs
+++ b/tests/Tests.CSharp/TriBoolean/CrossVerifyTests.cs
@@ -239,7 +239,7 @@ public class CrossVerifyTests
         // Write cs-output.json for compare.ts.
         var outputPath = Path.Join(root, "tests", "cross-verification", "tri-boolean", "cs-output.json");
         var json = JsonSerializer.Serialize(results, JsonOptions);
-        var lfJson = json.Replace("\r\n", "\n").Replace("\r", "\n");
+        var lfJson = json.Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal);
         File.WriteAllText(outputPath, lfJson, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
     }
 }


### PR DESCRIPTION
### Why

- Align C# library and test code to satisfy strict ordinal collation and invariant culture rules (B-0969).
- Enable static analysis rules globally to prevent regressions in future loops.
- Standardize and document the conventions across all agent harnesses (Gemini, Claude, Codex, Cursor, etc.).

### What

- Enabled CA1304, CA1305, CA1307, CA1310, and CA2007 as error-level diagnostics in .editorconfig.
- Updated C# library code in `src/Core.CSharp.DynamicValue/DynamicValues.cs`, `src/Core.CSharp/FourCornerOwnership.cs`, and `src/Core.CSharp/MembraneCrossing.cs` to specify `StringComparison.Ordinal` in `Contains` and `Replace` methods.
- Updated C# test code in `tests/Tests.CSharp/MeshPongCrossVerifyTests.cs`, `tests/Tests.CSharp/Sha256/CrossVerifyTests.cs`, and `tests/Tests.CSharp/TriBoolean/CrossVerifyTests.cs` to use `StringComparison.Ordinal` in `IndexOf` and `Replace`.
- Documented these invariant culture and `ConfigureAwait(false)` guidelines in `AGENTS.md`, `CLAUDE.md`, and `.claude/rules/culture-invariant-by-default.md`.

### Proof

- Succeeded warnings-as-errors release build (`dotnet build -c Release`).
- Verified full test suite runs successfully: all F# and C# tests passed cleanly.
- Verified `dotnet format` runs cleanly with zero changes required.

Agency-Signature-Version: 1
Agent: Gemini
Agent-Runtime: Gemini CLI
Agent-Model: Gemini Deep Think
Credential-Identity: AceHack
Credential-Mode: shared
Human-Review: explicit
Human-Review-Evidence: chat
Action-Mode: human-directed
Task: d7abe1fa-5c0b-4381-987b-21a48c6a18c2
Co-Authored-By: Gemini <noreply@google.com>
