### PR TITLE
feat(ci): B-0831 slice 3 — ArgoCD reconcile-shape + serial coherence

### DIFF
--- a/.claude/rules/culture-invariant-by-default.md
+++ b/.claude/rules/culture-invariant-by-default.md
@@ -16,6 +16,7 @@ Carved sentence:
 ## Diagnostics and Enforcement
 
 These rules are enforced at compiler/analyzer level for all harnesses in the repository via `.editorconfig` under `[*.{cs,csx}]`:
+
 - `CA1304` (Specify CultureInfo) ➔ `error`
 - `CA1305` (Specify IFormatProvider) ➔ `error`
 - `CA1307` (Specify StringComparison for clarity of intent) ➔ `error`

--- a/docs/trajectories/usb-zflash-installer/RESUME.md
+++ b/docs/trajectories/usb-zflash-installer/RESUME.md
@@ -4,8 +4,8 @@ Status: active — shipped + iterating; first surfaced as a trajectory 2026-05-2
 Last refreshed: 2026-05-29
 Type: workstream (current-focus) — a trajectory the operator is *actively powering*. Many trajectories can be tracked; only a few are workstreams at once (finite-focus / WIP-bounded — a workstream is a trajectory under sustained thrust, and thrust budget is finite, so most trajectories coast). (Genus = "trajectory"; "workstream" is the species: a trajectory under sustained thrust toward a deliverable, vs. emergent-posture trajectories like `anti-infection`. See [`factory-trajectory-surface`](../factory-trajectory-surface/RESUME.md) for the genus/species taxonomy.) One of the operator's three current cluster workstreams (encryption / usb-zflash / ts-workflow-engine).
 Eventual encoding (design-stage — the human maintainer 2026-05-23 genetic-ID substrate + Clifford/HKT): this trajectory's state is trackable as a 128-bit genetic-ID seed (discrete, reversible via parser-combinator ↔ generator-function) → Clifford-space path (continuous, eventual). Mirrors the three-lane I8-lattice / I9-manifold split.
-Current blocker: none operationally; WiFi reproducibility (nixos.org closure-fetch timeouts) is the live edge
-Next concrete action: B-0831 slice 2 (cluster-node dry-run in QEMU CI) → slice 3 (ArgoCD reconcile shape); build-iso scenario 2 on push-to-main
+Current blocker: none operationally; WiFi reproducibility (nixos.org closure-fetch timeouts) is the live edge; **build-iso** run queued on GitHub Actions (scenario 1 blocking, scenario 2 advisory)
+Next concrete action: B-0831 slice 3 (ArgoCD reconcile-shape CI) in PR; flip scenario 2 to hard gate once build-iso scenario 2 is stable
 
 ## Why This Exists
 
@@ -40,7 +40,7 @@ Grounding backlog:
 
 - [`B-0844`](../../backlog/P1/081KSGS9H0008QG0R001EZKNCB-zflash-agent-mode-native-implementation-close-doc-vs-impleme.md) — zflash agent-mode native implementation (**closed** — `--agent` in `cli.ts`)
 - Workitem `081KV1PY2H308QG0R00347547K` — `zeta flash` MCP router (**done** #8104)
-- [`B-0831`](../../backlog/P1/081KSGS9H0008QG0R0011BC7T2-ci-cascade-6-full-install-plus-cluster-auto-join-eliminate-r.md) — CI cascade-6: slice 1 landed (#8126); slice 2 in progress (iter-5.4.1-ci dry-run)
+- [`B-0831`](../../backlog/P1/081KSGS9H0008QG0R0011BC7T2-ci-cascade-6-full-install-plus-cluster-auto-join-eliminate-r.md) — CI cascade-6: slices 1–2 landed (#8126, #8129); slice 3 (ArgoCD reconcile-shape) in progress
 - [`B-0835`](../../backlog/P1/B-0835-installer-config-bugs-cluster-hostname-not-unique-gh-auth-not-respected-banner-password-disclosure-empirical-aaron-2026-05-26.md) — installer config bugs (hostname-not-unique, gh-auth, banner)
 - [`B-0792`](../../backlog/P1/B-0792-iter5-wifi-credentials-injection-via-usb-esp-for-zero-typing-cluster-bringup-without-ethernet-load-bearing-for-homelab-persona-aaron-2026-05-26.md) — iter-5 WiFi-credentials injection via USB ESP (zero-typing bringup without ethernet)
 - [`B-0789`](../../backlog/P1/B-0789-iter4-ssh-key-and-hashedpassword-substrate-for-cluster-bringup-2026-05-26.md) — iter-4 SSH-key + hashedPassword substrate (shared seam with encryption)

--- a/src/Core.TypeScript/ci/argocd-cluster-node-reconcile.test.ts
+++ b/src/Core.TypeScript/ci/argocd-cluster-node-reconcile.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+import { planClusterNodeReconcile } from "./argocd-cluster-node-reconcile.ts";
+import { parseSelfRegCiSerial } from "./self-reg-serial.ts";
+
+const SAMPLE_YAML = `apiVersion: zeta.lucent-financial-group.com/v1
+kind: ClusterNode
+metadata:
+  name: zeta-a1b2c3
+  namespace: zeta-cluster
+spec:
+  hostname: zeta-a1b2c3
+  roles:
+    - control-plane
+  registration:
+    maintainer: qemu-ci
+    registered-via: "iter-5.4.1"
+`;
+
+describe("planClusterNodeReconcile", () => {
+  it("accepts a coherent tree-path + yaml + serial dry-run", () => {
+    const serial = parseSelfRegCiSerial(`
+[iter-5.4.1-ci] composed ClusterNode maintainer=qemu-ci node=zeta-a1b2c3
+[iter-5.4.1-ci] tree-path=maintainers/qemu-ci/cluster-nodes/zeta-a1b2c3/node.yaml
+`);
+    const plan = planClusterNodeReconcile({
+      treePath: "maintainers/qemu-ci/cluster-nodes/zeta-a1b2c3/node.yaml",
+      yaml: SAMPLE_YAML,
+      serial,
+    });
+    expect(plan.ok).toBe(true);
+    expect(plan.crName).toBe("zeta-a1b2c3");
+    expect(plan.namespace).toBe("zeta-cluster");
+    expect(plan.roles).toEqual(["control-plane"]);
+    expect(plan.nodeLabels?.["zeta.lcg/role"]).toBe("control-plane");
+  });
+
+  it("rejects metadata.name mismatch vs tree-path hostname", () => {
+    const plan = planClusterNodeReconcile({
+      treePath: "maintainers/qemu-ci/cluster-nodes/zeta-other/node.yaml",
+      yaml: SAMPLE_YAML,
+    });
+    expect(plan.ok).toBe(false);
+    expect(plan.errors.some((e) => e.includes("metadata.name"))).toBe(true);
+  });
+});

--- a/src/Core.TypeScript/ci/argocd-cluster-node-reconcile.ts
+++ b/src/Core.TypeScript/ci/argocd-cluster-node-reconcile.ts
@@ -1,0 +1,118 @@
+/**
+ * B-0831 slice 3 — mock ArgoCD reconcile planner for ClusterNode registration.
+ * Pure function: given git tree path + node.yaml body, derive the reconcile
+ * shape ArgoCD iter-5.4.2 would apply (B-0813). No live cluster required.
+ */
+
+import { validateClusterNodeYaml } from "./cluster-node-yaml.ts";
+import {
+  expectedClusterNodeTreePath,
+  type SelfRegCiSerial,
+} from "./self-reg-serial.ts";
+
+export interface ClusterNodeReconcilePlan {
+  readonly ok: boolean;
+  readonly errors: readonly string[];
+  readonly crName?: string;
+  readonly namespace?: string;
+  readonly nodeLabels?: Readonly<Record<string, string>>;
+  readonly roles?: readonly string[];
+}
+
+const METADATA_NAME_RE = /^\s*name:\s*(\S+)\s*$/m;
+const ROLES_BLOCK_RE = /roles:\s*\n((?:\s+-\s+\S+\n)+)/;
+const ROLE_LINE_RE = /^\s+-\s+(\S+)\s*$/gm;
+
+function extractMetadataName(yaml: string): string | null {
+  return yaml.match(METADATA_NAME_RE)?.[1] ?? null;
+}
+
+function extractRoles(yaml: string): string[] {
+  const block = yaml.match(ROLES_BLOCK_RE)?.[1];
+  if (!block) {
+    return [];
+  }
+  return [...block.matchAll(ROLE_LINE_RE)].map((m) => m[1]!);
+}
+
+/** Plan the post-merge ArgoCD reconcile for a ClusterNode registration. */
+export function planClusterNodeReconcile(input: {
+  readonly treePath: string;
+  readonly yaml: string;
+  readonly serial?: SelfRegCiSerial | null;
+}): ClusterNodeReconcilePlan {
+  const errors: string[] = [];
+  const shape = validateClusterNodeYaml(input.yaml);
+  if (!shape.ok) {
+    errors.push(...shape.errors);
+  }
+
+  const crName = extractMetadataName(input.yaml);
+  if (!crName) {
+    errors.push("missing metadata.name");
+  }
+
+  const roles = extractRoles(input.yaml);
+  if (roles.length === 0) {
+    errors.push("missing spec.roles entries");
+  }
+
+  const pathMatch = input.treePath.match(
+    /^maintainers\/([^/]+)\/cluster-nodes\/([^/]+)\/node\.yaml$/,
+  );
+  if (!pathMatch) {
+    errors.push(`tree-path not under maintainers/*/cluster-nodes/*/node.yaml: ${input.treePath}`);
+  } else {
+    const [, maintainer, hostFromPath] = pathMatch;
+    const expected = expectedClusterNodeTreePath(maintainer!, hostFromPath!);
+    if (input.treePath !== expected) {
+      errors.push(`tree-path canonical mismatch: got ${input.treePath}, want ${expected}`);
+    }
+    if (crName && crName !== hostFromPath) {
+      errors.push(
+        `metadata.name '${crName}' must match hostname segment in tree-path '${hostFromPath}'`,
+      );
+    }
+    if (input.serial) {
+      if (input.serial.maintainer !== maintainer) {
+        errors.push(
+          `serial maintainer '${input.serial.maintainer}' != tree-path maintainer '${maintainer}'`,
+        );
+      }
+      if (input.serial.nodeHostname !== hostFromPath) {
+        errors.push(
+          `serial node '${input.serial.nodeHostname}' != tree-path host '${hostFromPath}'`,
+        );
+      }
+      if (input.serial.treePath !== input.treePath) {
+        errors.push("serial tree-path != supplied tree-path");
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  const nodeLabels: Record<string, string> = {
+    "zeta.lucent-financial-group.com/maintainer": pathMatch![1]!,
+  };
+  for (const role of roles) {
+    nodeLabels[`zeta.lcg/role`] = role;
+    if (role.includes("gpu")) {
+      nodeLabels["accelerator"] = "nvidia";
+    }
+    if (role.includes("storage")) {
+      nodeLabels["storage"] = "longhorn";
+    }
+  }
+
+  return {
+    ok: true,
+    errors: [],
+    crName: crName!,
+    namespace: "zeta-cluster",
+    nodeLabels,
+    roles,
+  };
+}

--- a/src/Core.TypeScript/ci/qemu-full-install-test.test.ts
+++ b/src/Core.TypeScript/ci/qemu-full-install-test.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, it } from "bun:test";
+import { validateSelfRegCiCoherent } from "./self-reg-serial.ts";
 import { extractGeneratedHostname } from "./qemu-full-install-test.ts";
+
+describe("validateSelfRegCiCoherent", () => {
+  it("accepts matching maintainer/node/tree-path lines", () => {
+    const serial = `
+[iter-5.4.1-ci] composed ClusterNode maintainer=qemu-ci node=zeta-a1b2c3
+[iter-5.4.1-ci] tree-path=maintainers/qemu-ci/cluster-nodes/zeta-a1b2c3/node.yaml
+`;
+    expect(validateSelfRegCiCoherent(serial).ok).toBe(true);
+  });
+});
 
 describe("qemu-full-install-test hostname extraction", () => {
   it("parses iter-5.2.2 generated hostname from serial log", () => {

--- a/src/Core.TypeScript/ci/qemu-full-install-test.ts
+++ b/src/Core.TypeScript/ci/qemu-full-install-test.ts
@@ -6,7 +6,8 @@
  *
  * Phase 1 — boot installer ISO + virtual disk; wait for install completion.
  * Phase 2 — boot installed disk only; verify auto-generated hostname login banner.
- * Phase 1 also asserts iter-5.4.1-ci dry-run registration (B-0831 slice 2).
+ * Phase 1 also asserts iter-5.4.1-ci dry-run registration (B-0831 slice 2)
+ * and tree-path coherence (B-0831 slice 3).
  *
  * Composes with qemu-boot-test.ts (cascade #5) and B-0891 scenario 2.
  *
@@ -24,6 +25,7 @@ import { appendFileSync, existsSync, mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { serialFirstBootInProgress } from "../zflash/test-harness/serial-markers";
+import { validateSelfRegCiCoherent } from "./self-reg-serial.ts";
 
 /** zeta-install.sh success banner (end of install script). */
 const INSTALL_COMPLETE_MARKER = "ZETA CLUSTER NODE INSTALL COMPLETE";
@@ -63,7 +65,7 @@ interface InstallResult {
   readonly reason: string;
   readonly serialLogTail?: string;
   readonly elapsedSeconds?: number;
-  readonly hostname?: string | undefined;
+  readonly hostname?: string;
 }
 
 /** Exported for unit tests. */
@@ -184,6 +186,15 @@ async function waitForInstallComplete(serialLogPath: string): Promise<InstallRes
         return {
           exitCode: 1,
           reason: `phase 1 FAILURE — "${INSTALL_COMPLETE_MARKER}" seen but missing "${SELF_REG_CI_MARKER}" (cluster join dry-run)`,
+          serialLogTail: content.slice(-2000),
+          elapsedSeconds: elapsedSec,
+        };
+      }
+      const selfReg = validateSelfRegCiCoherent(content);
+      if (!selfReg.ok) {
+        return {
+          exitCode: 1,
+          reason: `phase 1 FAILURE — iter-5.4.1-ci dry-run incoherent: ${selfReg.reason}`,
           serialLogTail: content.slice(-2000),
           elapsedSeconds: elapsedSec,
         };

--- a/src/Core.TypeScript/ci/self-reg-serial.test.ts
+++ b/src/Core.TypeScript/ci/self-reg-serial.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import {
+  expectedClusterNodeTreePath,
+  parseSelfRegCiSerial,
+} from "./self-reg-serial.ts";
+
+describe("parseSelfRegCiSerial", () => {
+  it("parses iter-5.4.1-ci dry-run lines from zeta-install.sh", () => {
+    const serial = `
+[iter-5.4.1-ci] composed ClusterNode maintainer=qemu-ci node=zeta-a1b2c3
+[iter-5.4.1-ci] tree-path=maintainers/qemu-ci/cluster-nodes/zeta-a1b2c3/node.yaml
+[iter-5.4.1-ci] preview=/mnt/etc/zeta/cluster-node-registration-preview.yaml
+ZETA CLUSTER NODE INSTALL COMPLETE
+`;
+    expect(parseSelfRegCiSerial(serial)).toEqual({
+      maintainer: "qemu-ci",
+      nodeHostname: "zeta-a1b2c3",
+      treePath: "maintainers/qemu-ci/cluster-nodes/zeta-a1b2c3/node.yaml",
+      previewPath: "/mnt/etc/zeta/cluster-node-registration-preview.yaml",
+    });
+  });
+
+  it("returns null when tree-path line is missing", () => {
+    const serial =
+      "[iter-5.4.1-ci] composed ClusterNode maintainer=qemu-ci node=zeta-a1b2c3\n";
+    expect(parseSelfRegCiSerial(serial)).toBeNull();
+  });
+});
+
+describe("expectedClusterNodeTreePath", () => {
+  it("matches B-0812 maintainers/<op>/cluster-nodes/<host>/node.yaml shape", () => {
+    expect(expectedClusterNodeTreePath("qemu-ci", "zeta-deadbe")).toBe(
+      "maintainers/qemu-ci/cluster-nodes/zeta-deadbe/node.yaml",
+    );
+  });
+});

--- a/src/Core.TypeScript/ci/self-reg-serial.ts
+++ b/src/Core.TypeScript/ci/self-reg-serial.ts
@@ -1,0 +1,65 @@
+/**
+ * B-0831 slice 3 — parse iter-5.4.1-ci dry-run lines from QEMU serial output.
+ * Composes with zeta-install.sh Step 6.9 non-TTY CI path.
+ */
+
+export interface SelfRegCiSerial {
+  readonly maintainer: string;
+  readonly nodeHostname: string;
+  readonly treePath: string;
+  readonly previewPath?: string;
+}
+
+const COMPOSED_RE =
+  /\[iter-5\.4\.1-ci\] composed ClusterNode maintainer=(\S+) node=(\S+)/;
+const TREE_PATH_RE =
+  /\[iter-5\.4\.1-ci\] tree-path=(maintainers\/\S+\/cluster-nodes\/\S+\/node\.yaml)/;
+const PREVIEW_RE = /\[iter-5\.4\.1-ci\] preview=(\S+)/;
+
+/** Exported for unit tests and qemu-full-install-test.ts phase-1 assertions. */
+export function parseSelfRegCiSerial(serialOutput: string): SelfRegCiSerial | null {
+  const composed = serialOutput.match(COMPOSED_RE);
+  const tree = serialOutput.match(TREE_PATH_RE);
+  if (!composed || !tree) {
+    return null;
+  }
+
+  const preview = serialOutput.match(PREVIEW_RE);
+  return {
+    maintainer: composed[1]!,
+    nodeHostname: composed[2]!,
+    treePath: tree[1]!,
+    ...(preview ? { previewPath: preview[1]! } : {}),
+  };
+}
+
+/** B-0794 / B-0812 per-maintainer tree convention. */
+export function expectedClusterNodeTreePath(
+  maintainer: string,
+  nodeHostname: string,
+): string {
+  return `maintainers/${maintainer}/cluster-nodes/${nodeHostname}/node.yaml`;
+}
+
+export type SelfRegCiValidation =
+  | { readonly ok: true; readonly parsed: SelfRegCiSerial }
+  | { readonly ok: false; readonly reason: string };
+
+/** Cross-check iter-5.4.1-ci serial lines for internal consistency (B-0831 slice 3). */
+export function validateSelfRegCiCoherent(serialOutput: string): SelfRegCiValidation {
+  const parsed = parseSelfRegCiSerial(serialOutput);
+  if (!parsed) {
+    return {
+      ok: false,
+      reason: "missing iter-5.4.1-ci composed/tree-path serial lines",
+    };
+  }
+  const expectedPath = expectedClusterNodeTreePath(parsed.maintainer, parsed.nodeHostname);
+  if (parsed.treePath !== expectedPath) {
+    return {
+      ok: false,
+      reason: `tree-path ${parsed.treePath} != expected ${expectedPath}`,
+    };
+  }
+  return { ok: true, parsed };
+}


### PR DESCRIPTION
## Summary
- **`self-reg-serial.ts`**: parse + validate `[iter-5.4.1-ci]` dry-run lines (maintainer, node, tree-path) from QEMU serial output.
- **`argocd-cluster-node-reconcile.ts`**: pure-function reconcile planner for B-0813 — given `maintainers/<op>/cluster-nodes/<host>/node.yaml` + ClusterNode YAML, derive expected CR name, namespace, role labels (no live ArgoCD).
- **`qemu-full-install-test.ts`**: phase 1 now fails if iter-5.4.1-ci tree-path is internally inconsistent.
- Trajectory RESUME updated: slices 1–2 landed; slice 3 in progress.

## Waiting (not in this PR)
- `build-iso` on main still queued — scenario 2 advisory run will exercise slice 2 markers end-to-end once runners pick it up.

## Test plan
- [x] `bun test src/Core.TypeScript/ci/{self-reg-serial,argocd-cluster-node-reconcile,qemu-full-install-test,cluster-node-yaml}.test.ts` — 10/10
- [ ] gate lint (tsc) + build-and-test


Made with [Cursor](https://cursor.com)