### PR TITLE
feat(core): add bounded gset projection

### DIFF
--- a/src/Core/BoundedGSet.fs
+++ b/src/Core/BoundedGSet.fs
@@ -1,0 +1,157 @@
+namespace Zeta.Core
+
+open System.Collections.Immutable
+
+/// Which side of the canonical GSet order survives when a bounded view is full.
+[<RequireQualifiedAccess>]
+type BoundedGSetRetention =
+    /// Keep the lowest-ranked values under the canonical comparison.
+    | KeepLowest
+    /// Keep the highest-ranked values under the canonical comparison.
+    /// Use this for rolling logs when the key contains a monotone tick/sequence.
+    | KeepHighest
+
+/// Construction and merge feedback for bounded GSet views.
+[<RequireQualifiedAccess>]
+type BoundedGSetError =
+    | NonPositiveCapacity of int
+    | ConfigMismatch of left: BoundedGSetConfig * right: BoundedGSetConfig
+
+/// A deterministic capacity bound for a GSet projection.
+and BoundedGSetConfig =
+    { Capacity: int
+      Retention: BoundedGSetRetention }
+
+/// Admission result for adding one value to a bounded GSet view.
+[<RequireQualifiedAccess>]
+type BoundedGSetAdmission =
+    | Admitted
+    | AlreadyPresent
+    | RejectedByBound
+
+/// Result of a single bounded add.
+type BoundedGSetAddResult<'T when 'T : comparison> =
+    { State: BoundedGSet<'T>
+      Admission: BoundedGSetAdmission
+      Evicted: GSet<'T> }
+
+/// A finite, deterministic projection of a grow-only set.
+///
+/// This is intentionally not a replacement for `GSet<'T>`. A true GSet never
+/// forgets. `BoundedGSet<'T>` stores a materialized room-sized view of the GSet
+/// under a deterministic projection, so memory stays bounded and backpressure is
+/// visible as `RejectedByBound` or `Evicted`.
+and BoundedGSet<'T when 'T : comparison> =
+    private
+        { config: BoundedGSetConfig
+          view: GSet<'T> }
+
+    member this.Config = this.config
+    member this.View = this.view
+    member this.Capacity = this.config.Capacity
+    member this.Retention = this.config.Retention
+    member this.Count = GSet.count this.view
+    member this.IsSaturated = this.Count >= this.config.Capacity
+
+[<RequireQualifiedAccess>]
+module BoundedGSet =
+
+    let private validate (config: BoundedGSetConfig) : Result<BoundedGSetConfig, BoundedGSetError> =
+        if config.Capacity <= 0 then
+            Error(BoundedGSetError.NonPositiveCapacity config.Capacity)
+        else
+            Ok config
+
+    let private keep (config: BoundedGSetConfig) (g: GSet<'T>) : GSet<'T> =
+        let items = GSet.toArray g
+        let keepCount = min config.Capacity items.Length
+
+        if keepCount = items.Length then
+            g
+        else
+            let offset =
+                match config.Retention with
+                | BoundedGSetRetention.KeepLowest -> 0
+                | BoundedGSetRetention.KeepHighest -> items.Length - keepCount
+
+            GSet<'T>(ImmutableArray.Create(items, offset, keepCount))
+
+    let private difference (left: GSet<'T>) (right: GSet<'T>) : GSet<'T> =
+        left
+        |> GSet.toSeq
+        |> Seq.filter (fun value -> not (GSet.contains value right))
+        |> GSet.ofSeq
+
+    /// Build an empty bounded view. Invalid capacity stays on the feedback channel.
+    let empty<'T when 'T : comparison>
+        (config: BoundedGSetConfig)
+        : Result<BoundedGSet<'T>, BoundedGSetError> =
+        result {
+            let! valid = validate config
+            return { config = valid; view = GSet.empty<'T> }
+        }
+
+    /// Build a bounded view from arbitrary input by canonicalizing then projecting.
+    let ofSeq<'T when 'T : comparison>
+        (config: BoundedGSetConfig)
+        (values: seq<'T>)
+        : Result<BoundedGSet<'T>, BoundedGSetError> =
+        result {
+            let! valid = validate config
+            let view = values |> GSet.ofSeq |> keep valid
+            return { config = valid; view = view }
+        }
+
+    /// The current finite exterior view.
+    let toGSet (bounded: BoundedGSet<'T>) : GSet<'T> =
+        bounded.View
+
+    let toArray (bounded: BoundedGSet<'T>) : 'T[] =
+        GSet.toArray bounded.View
+
+    let toList (bounded: BoundedGSet<'T>) : 'T list =
+        GSet.toList bounded.View
+
+    let count (bounded: BoundedGSet<'T>) : int =
+        bounded.Count
+
+    let contains (value: 'T) (bounded: BoundedGSet<'T>) : bool =
+        GSet.contains value bounded.View
+
+    /// Merge two bounded views that share the same projection policy.
+    let union
+        (left: BoundedGSet<'T>)
+        (right: BoundedGSet<'T>)
+        : Result<BoundedGSet<'T>, BoundedGSetError> =
+        if left.Config <> right.Config then
+            Error(BoundedGSetError.ConfigMismatch(left.Config, right.Config))
+        else
+            result {
+                let! valid = validate left.Config
+                let merged = GSet.union left.View right.View |> keep valid
+                return { config = valid; view = merged }
+            }
+
+    /// Add one value to the bounded projection and report whether it survived.
+    let add
+        (value: 'T)
+        (bounded: BoundedGSet<'T>)
+        : Result<BoundedGSetAddResult<'T>, BoundedGSetError> =
+        result {
+            let! valid = validate bounded.Config
+            let before = bounded.View
+            let after = GSet.add value before |> keep valid
+
+            let admission =
+                if GSet.contains value before then
+                    BoundedGSetAdmission.AlreadyPresent
+                elif GSet.contains value after then
+                    BoundedGSetAdmission.Admitted
+                else
+                    BoundedGSetAdmission.RejectedByBound
+
+            return
+                { State = { config = valid; view = after }
+                  Admission = admission
+                  Evicted = difference before after }
+        }

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -35,6 +35,7 @@
     <Compile Include="Reconcile.fs" />
     <Compile Include="Pool.fs" />
     <Compile Include="GSet.fs" />
+    <Compile Include="BoundedGSet.fs" />
     <Compile Include="Bag.fs" />
     <Compile Include="ZSet.fs" />
     <Compile Include="FusionReconstruction.fs" />

--- a/tests/Tests.FSharp/Algebra/BoundedGSet.Tests.fs
+++ b/tests/Tests.FSharp/Algebra/BoundedGSet.Tests.fs
@@ -1,0 +1,97 @@
+module Zeta.Tests.Algebra.BoundedGSetTests
+
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Core
+
+let private keepLowest3 =
+    { Capacity = 3
+      Retention = BoundedGSetRetention.KeepLowest }
+
+let private keepHighest3 =
+    { Capacity = 3
+      Retention = BoundedGSetRetention.KeepHighest }
+
+let private unwrap =
+    function
+    | Ok value -> value
+    | Error error -> failwithf "unexpected bounded GSet error: %A" error
+
+let private ofInts config values =
+    BoundedGSet.ofSeq<int> config values |> unwrap
+
+[<Fact>]
+let ``invalid capacity returns feedback instead of throwing`` () =
+    let config =
+        { Capacity = 0
+          Retention = BoundedGSetRetention.KeepHighest }
+
+    match BoundedGSet.empty<int> config with
+    | Error(BoundedGSetError.NonPositiveCapacity 0) -> ()
+    | other -> failwithf "expected NonPositiveCapacity feedback, got %A" other
+
+[<Fact>]
+let ``bounded projection keeps the configured side of canonical GSet order`` () =
+    let values = [ 5; 1; 4; 2; 3; 3 ]
+
+    ofInts keepLowest3 values
+    |> BoundedGSet.toList
+    |> should equal [ 1; 2; 3 ]
+
+    ofInts keepHighest3 values
+    |> BoundedGSet.toList
+    |> should equal [ 3; 4; 5 ]
+
+[<Fact>]
+let ``rolling add reports admission rejection and eviction`` () =
+    let full = ofInts keepHighest3 [ 3; 4; 5 ]
+
+    let low = BoundedGSet.add 2 full |> unwrap
+    low.Admission |> should equal BoundedGSetAdmission.RejectedByBound
+    low.State |> BoundedGSet.toList |> should equal [ 3; 4; 5 ]
+    Assert.Equal<int list>([], GSet.toList low.Evicted)
+
+    let high = BoundedGSet.add 6 full |> unwrap
+    high.Admission |> should equal BoundedGSetAdmission.Admitted
+    high.State |> BoundedGSet.toList |> should equal [ 4; 5; 6 ]
+    high.Evicted |> GSet.toList |> should equal [ 3 ]
+
+    let duplicate = BoundedGSet.add 5 high.State |> unwrap
+    duplicate.Admission |> should equal BoundedGSetAdmission.AlreadyPresent
+    duplicate.State |> BoundedGSet.toList |> should equal [ 4; 5; 6 ]
+    Assert.Equal<int list>([], GSet.toList duplicate.Evicted)
+
+[<Fact>]
+let ``bounded union is idempotent and associative for one projection policy`` () =
+    let a = ofInts keepHighest3 [ 1; 5 ]
+    let b = ofInts keepHighest3 [ 2; 4 ]
+    let c = ofInts keepHighest3 [ 3; 6 ]
+
+    BoundedGSet.union a a
+    |> unwrap
+    |> should equal a
+
+    let left =
+        BoundedGSet.union a b
+        |> unwrap
+        |> fun ab -> BoundedGSet.union ab c |> unwrap
+
+    let right =
+        BoundedGSet.union b c
+        |> unwrap
+        |> fun bc -> BoundedGSet.union a bc |> unwrap
+
+    left |> BoundedGSet.toList |> should equal [ 4; 5; 6 ]
+    right |> BoundedGSet.toList |> should equal [ 4; 5; 6 ]
+    left |> should equal right
+
+[<Fact>]
+let ``bounded union rejects mismatched projection policies`` () =
+    let low = ofInts keepLowest3 [ 1; 2; 3 ]
+    let high = ofInts keepHighest3 [ 4; 5; 6 ]
+
+    match BoundedGSet.union low high with
+    | Error(BoundedGSetError.ConfigMismatch(left, right)) ->
+        left |> should equal keepLowest3
+        right |> should equal keepHighest3
+    | other -> failwithf "expected ConfigMismatch feedback, got %A" other

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -22,6 +22,7 @@
     <Compile Include="Algebra/HexCore.Tests.fs" />
     <Compile Include="Algebra/Units.Tests.fs" />
     <Compile Include="Algebra/GSet.Tests.fs" />
+    <Compile Include="Algebra/BoundedGSet.Tests.fs" />
     <Compile Include="Algebra/Bag.Tests.fs" />
     <Compile Include="Algebra/ZSet.Tests.fs" />
     <Compile Include="Algebra/FusionReconstruction.Tests.fs" />


### PR DESCRIPTION
## What changed

- Added `BoundedGSet<'T>` in F# core as an opaque, finite projection over a canonical `GSet<'T>`.
- Added `KeepLowest` and `KeepHighest` retention policies. `KeepHighest` is the rolling form when the key carries a monotone tick or sequence.
- Added typed feedback for invalid capacity, mismatched merge policy, and per-add admission: `Admitted`, `AlreadyPresent`, or `RejectedByBound`.
- Added focused F# tests covering projection, rolling admission/eviction, idempotent and associative bounded union, and mismatch feedback.

## Why

A true G-set should not forget. This gives finite rooms and schedulers a constrained G-set-shaped exterior view without pretending eviction is still grow-only CRDT state. Backpressure is explicit: rejected facts and evicted finite-view facts are reported instead of disappearing silently.

## Validation

- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter FullyQualifiedName~BoundedGSet --no-restore`
- `dotnet build -c Release -m:1 /p:UseSharedCompilation=false`
- `dotnet format --verify-no-changes`
- `dotnet test Zeta.sln -c Release --no-build -m:1 /p:UseSharedCompilation=false`
- `git diff --check`
