### PR TITLE
feat(zeta-id): implement Crockford base32 string encoding and parity checks

### DIFF
--- a/.claude/rules/culture-invariant-by-default.md
+++ b/.claude/rules/culture-invariant-by-default.md
@@ -16,6 +16,7 @@ Carved sentence:
 ## Diagnostics and Enforcement
 
 These rules are enforced at compiler/analyzer level for all harnesses in the repository via `.editorconfig` under `[*.{cs,csx}]`:
+
 - `CA1304` (Specify CultureInfo) ➔ `error`
 - `CA1305` (Specify IFormatProvider) ➔ `error`
 - `CA1307` (Specify StringComparison for clarity of intent) ➔ `error`

--- a/docs/backlog/P2/081KS3X9Y0008QG0R000W00V73-zeta-id-canonical-string-encoding-endianness-2026-05-21.md
+++ b/docs/backlog/P2/081KS3X9Y0008QG0R000W00V73-zeta-id-canonical-string-encoding-endianness-2026-05-21.md
@@ -2,13 +2,14 @@
 id: B-0682
 zetaid: 081KS3X9Y0008QG0R000W00V73
 priority: P1
-status: in-progress
+status: closed
 title: ZetaId canonical string encoding (Crockford base32) + endianness + bit-numbering spec
 tier: research-grade
 effort: S
 ask: maintainer Aaron + Kestrel-claude.ai 2026-05-21
 created: 2026-05-21
-last_updated: 2026-06-06
+last_updated: 2026-06-13
+completed: 2026-06-13
 depends_on: []
 composes_with: [B-0635, B-0679, B-0680, B-0681]
 tags: [zeta-id, cross-language, git-filename]
@@ -111,3 +112,12 @@ Add to `tests/cross-verification/zeta-id/`:
 - B-0681 (v2 spec hardening) — these fields may shift bit positions
 - B-0679 / B-0680 (Rust + Python) — implementations adopt the encoding
 - Git-filename-first deployment per Aaron (B-0517 substrate)
+
+## Resolution
+
+The Crockford Base32 canonical string encoding for the 128-bit `ZetaId` has been fully implemented and verified.
+1. **Specification**: Documented in [zeta-id-canonical-string-encoding.md](file:///Users/acehack/Documents/src/repos/Zeta/docs/zeta-id-canonical-string-encoding.md).
+2. **Implementation**: Added formatting, parsing, lenient alias mapping, and 128-bit overflow checks in C#, F#, Rust, and TypeScript.
+3. **Consensus**: Updated [compare.ts](file:///Users/acehack/Documents/src/repos/Zeta/tests/cross-verification/zeta-id/compare.ts) to compare both `hex` and `crockford` string outputs across the 5 language implementations, passing with 100% agreement on all 12 test vectors.
+4. **Pull Request**: Submitted Pull Request [PR #8141](https://github.com/Lucent-Financial-Group/Zeta/pull/8141).
+

--- a/docs/backlog/P2/081KS3X9Y0008QG0R000W00V73-zeta-id-canonical-string-encoding-endianness-2026-05-21.md
+++ b/docs/backlog/P2/081KS3X9Y0008QG0R000W00V73-zeta-id-canonical-string-encoding-endianness-2026-05-21.md
@@ -116,8 +116,8 @@ Add to `tests/cross-verification/zeta-id/`:
 ## Resolution
 
 The Crockford Base32 canonical string encoding for the 128-bit `ZetaId` has been fully implemented and verified.
+
 1. **Specification**: Documented in [zeta-id-canonical-string-encoding.md](file:///Users/acehack/Documents/src/repos/Zeta/docs/zeta-id-canonical-string-encoding.md).
 2. **Implementation**: Added formatting, parsing, lenient alias mapping, and 128-bit overflow checks in C#, F#, Rust, and TypeScript.
 3. **Consensus**: Updated [compare.ts](file:///Users/acehack/Documents/src/repos/Zeta/tests/cross-verification/zeta-id/compare.ts) to compare both `hex` and `crockford` string outputs across the 5 language implementations, passing with 100% agreement on all 12 test vectors.
 4. **Pull Request**: Submitted Pull Request [PR #8141](https://github.com/Lucent-Financial-Group/Zeta/pull/8141).
-

--- a/docs/zeta-id-canonical-string-encoding.md
+++ b/docs/zeta-id-canonical-string-encoding.md
@@ -8,6 +8,7 @@ This format is designed to be filename-safe, sort-preserving, and visually resil
 The canonical string encoding for ZetaId is **Crockford Base32** (with modifications for fixed length and strict validation).
 
 ### Alphabet
+
 The alphabet contains 32 symbols, strictly ordered by ascending ASCII values:
 ```
 0123456789ABCDEFGHJKMNPQRSTVWXYZ
@@ -15,11 +16,14 @@ The alphabet contains 32 symbols, strictly ordered by ascending ASCII values:
 This alphabet excludes the ambiguous characters `I`, `L`, `O`, and `U` to minimize visual confusion.
 
 ### Width
+
 Every packed ZetaId is represented by exactly **26 characters**.
+
 - $26 \times 5 = 130$ bits.
 - The top 2 bits are zero-padded (so the maximum value represented by the first character is `7`).
 
 ### Case Sensitivity & Lenient Aliases
+
 1. **Canonical Form**: Strictly uppercase. Only contains symbols from the canonical alphabet.
 2. **Parsing (Lenient)**:
    - Case-insensitive (lowercase symbols are folded to uppercase).
@@ -31,12 +35,14 @@ Every packed ZetaId is represented by exactly **26 characters**.
 ## 2. Endianness
 
 The string serialization represents the 128-bit integer in **big-endian (network byte order)**.
+
 - The first character (index 0) represents the most-significant bits of the ZetaId.
 - The 26th character (index 25) represents the least-significant 5 bits of the ZetaId.
 
 ## 3. Bit-Numbering
 
 We use the **LSB-0** bit-numbering convention:
+
 - Bit `0` is the least-significant bit of the 128-bit integer.
 - Bit `127` is the most-significant bit.
 

--- a/docs/zeta-id-canonical-string-encoding.md
+++ b/docs/zeta-id-canonical-string-encoding.md
@@ -1,0 +1,63 @@
+# ZetaId Canonical String Encoding Specification
+
+This document specifies the canonical string representation for the 128-bit ZetaId.
+This format is designed to be filename-safe, sort-preserving, and visually resilient.
+
+## 1. Encoding: Crockford Base32
+
+The canonical string encoding for ZetaId is **Crockford Base32** (with modifications for fixed length and strict validation).
+
+### Alphabet
+The alphabet contains 32 symbols, strictly ordered by ascending ASCII values:
+```
+0123456789ABCDEFGHJKMNPQRSTVWXYZ
+```
+This alphabet excludes the ambiguous characters `I`, `L`, `O`, and `U` to minimize visual confusion.
+
+### Width
+Every packed ZetaId is represented by exactly **26 characters**.
+- $26 \times 5 = 130$ bits.
+- The top 2 bits are zero-padded (so the maximum value represented by the first character is `7`).
+
+### Case Sensitivity & Lenient Aliases
+1. **Canonical Form**: Strictly uppercase. Only contains symbols from the canonical alphabet.
+2. **Parsing (Lenient)**:
+   - Case-insensitive (lowercase symbols are folded to uppercase).
+   - Ambiguous characters are accepted and mapped:
+     - `I`, `i`, `L`, `l` map to `1`
+     - `O`, `o` map to `0`
+     - `U`, `u` are rejected (used only as checksum symbols in standard Crockford base32, which we do not use).
+
+## 2. Endianness
+
+The string serialization represents the 128-bit integer in **big-endian (network byte order)**.
+- The first character (index 0) represents the most-significant bits of the ZetaId.
+- The 26th character (index 25) represents the least-significant 5 bits of the ZetaId.
+
+## 3. Bit-Numbering
+
+We use the **LSB-0** bit-numbering convention:
+- Bit `0` is the least-significant bit of the 128-bit integer.
+- Bit `127` is the most-significant bit.
+
+## 4. 128-bit Overflow Rejection
+
+Since 26 Crockford base32 symbols can encode up to 130 bits, any string where the first character decodes to a value $\ge 8$ (occupying bits 128 and 129) represents an integer greater than $2^{128} - 1$.
+Such values are invalid and MUST be rejected during parsing.
+
+## 5. Canonical Vectors
+
+| Vector ID | Hexadecimal Representation | Crockford Base32 Representation |
+|---|---|---|
+| `authority-human-verified` | `080cb77ed58d19c1f80b000800000000` | `081JVQXNCD370ZG2R010000000` |
+| `authority-trusted-agent` | `080cb77ed58d19c1a00b000800000000` | `081JVQXNCD370T02R010000000` |
+| `authority-standard` | `080cb77ed58d18017815001000000000` | `081JVQXNCD300QG58020000000` |
+| `authority-best-effort` | `080cb77ed58d18074017000800000000` | `081JVQXNCD303M05R010000000` |
+| `authority-simulated` | `080cb77ed58d18071817c00800000000` | `081JVQXNCD303HG5Y010000000` |
+| `momentum-background` | `080cb77ed58d19c1f809000800000000` | `081JVQXNCD370ZG28010000000` |
+| `momentum-normal` | `080cb77ed58d19c1f80b000800000000` | `081JVQXNCD370ZG2R010000000` |
+| `momentum-elevated` | `080cb77ed58d19c1a00d000800000000` | `081JVQXNCD370T038010000000` |
+| `momentum-high` | `080cb77ed58d19c1f80f000800000000` | `081JVQXNCD370ZG3R010000000` |
+| `momentum-critical` | `080cb77ed58d19c1f80fc00800000000` | `081JVQXNCD370ZG3Y010000000` |
+| `authority-raw-0` | `0800000000000001000b000800000000` | `0800000000000G02R010000000` |
+| `momentum-raw-255` | `0ffffffffffff9c1f80ff80800000000` | `0FZZZZZZZZZ70ZG3ZR10000000` |

--- a/src/Core.CSharp.ZetaId/ZetaIdCodec.cs
+++ b/src/Core.CSharp.ZetaId/ZetaIdCodec.cs
@@ -170,5 +170,92 @@ public static class ZetaIdCodec
         UInt128 mask = (UInt128.One << width) - UInt128.One;
         return (ulong)((value >> offset) & mask);
     }
+
+    private const string CrockfordAlphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+    private const int Base32Length = 26;
+
+    private static readonly sbyte[] DecodeMap = CreateDecodeMap();
+
+    private static sbyte[] CreateDecodeMap()
+    {
+        var map = new sbyte[128];
+        System.Array.Fill(map, (sbyte)-1);
+        for (int i = 0; i < CrockfordAlphabet.Length; i++)
+        {
+            char c = CrockfordAlphabet[i];
+            map[c] = (sbyte)i;
+            map[System.Char.ToLowerInvariant(c)] = (sbyte)i;
+        }
+        // Lenient aliases:
+        map['I'] = 1; map['i'] = 1;
+        map['L'] = 1; map['l'] = 1;
+        map['O'] = 0; map['o'] = 0;
+        return map;
+    }
+
+    public static string Format(UInt128 id)
+    {
+        UInt128 v = id;
+        char[] chars = new char[Base32Length];
+        for (int i = Base32Length - 1; i >= 0; i--)
+        {
+            chars[i] = CrockfordAlphabet[(int)(v & 31)];
+            v >>= 5;
+        }
+        return new string(chars);
+    }
+
+    public static UInt128 Parse(string s)
+    {
+        System.ArgumentNullException.ThrowIfNull(s);
+        if (s.Length != Base32Length)
+            throw new System.ArgumentException($"Expected exactly {Base32Length} characters, got {s.Length}", nameof(s));
+
+        char firstChar = s[0];
+        if (firstChar >= 128 || DecodeMap[firstChar] >= 8)
+            throw new System.ArgumentException("Value exceeds 128 bits (leading pad bits must be zero)", nameof(s));
+
+        UInt128 result = 0;
+        for (int i = 0; i < s.Length; i++)
+        {
+            char c = s[i];
+            if (c >= 128)
+                throw new System.ArgumentException($"Invalid Crockford base32 character '{c}' at index {i}", nameof(s));
+            sbyte val = DecodeMap[c];
+            if (val < 0)
+                throw new System.ArgumentException($"Invalid Crockford base32 character '{c}' at index {i}", nameof(s));
+
+            result = (result << 5) | (byte)val;
+        }
+
+        return result;
+    }
+
+    public static bool IsCanonical(string s)
+    {
+        if (s == null || s.Length != Base32Length)
+            return false;
+
+        for (int i = 0; i < s.Length; i++)
+        {
+            char c = s[i];
+            if (CrockfordAlphabet.IndexOf(c, System.StringComparison.Ordinal) < 0)
+                return false;
+        }
+
+        char firstChar = s[0];
+        sbyte firstVal = DecodeMap[firstChar];
+        if (firstVal < 0 || firstVal >= 8)
+            return false;
+
+        try
+        {
+            return string.Equals(Format(Parse(s)), s, System.StringComparison.Ordinal);
+        }
+        catch
+        {
+            return false;
+        }
+    }
 }
 

--- a/src/Core.CSharp.ZetaId/ZetaIdCodec.cs
+++ b/src/Core.CSharp.ZetaId/ZetaIdCodec.cs
@@ -252,7 +252,7 @@ public static class ZetaIdCodec
         {
             return string.Equals(Format(Parse(s)), s, System.StringComparison.Ordinal);
         }
-        catch
+        catch (System.ArgumentException)
         {
             return false;
         }

--- a/src/Core.FSharp.ZetaId/Codec.fs
+++ b/src/Core.FSharp.ZetaId/Codec.fs
@@ -172,3 +172,76 @@ module ZetaIdCodec =
         else
             ZetaIdPayload.Generic (ver, cat, pay)
 
+    let private crockfordAlphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+    let private base32Length = 26
+
+    let private decodeMap =
+        let arr = Array.create 128 -1y
+        for i = 0 to crockfordAlphabet.Length - 1 do
+            let c = crockfordAlphabet.[i]
+            let v = sbyte i
+            arr.[int c] <- v
+            arr.[int (System.Char.ToLowerInvariant c)] <- v
+        arr.[int 'I'] <- 1y
+        arr.[int 'i'] <- 1y
+        arr.[int 'L'] <- 1y
+        arr.[int 'l'] <- 1y
+        arr.[int 'O'] <- 0y
+        arr.[int 'o'] <- 0y
+        arr
+
+    /// Encode a 128-bit ZetaId as the canonical 26-char Crockford base32 string.
+    let format (id: System.UInt128) : string =
+        let chars = Array.zeroCreate base32Length
+        let mutable v = id
+        for i = base32Length - 1 downto 0 do
+            let idx = int (v &&& System.UInt128(0UL, 31UL))
+            chars.[i] <- crockfordAlphabet.[idx]
+            v <- v >>> 5
+        System.String(chars)
+
+    /// Parse a canonical (or Crockford-lenient) base32 string back to a ZetaId.
+    let parse (s: string) : System.UInt128 =
+        if isNull s then
+            raise (System.ArgumentNullException("s"))
+        if s.Length <> base32Length then
+            raise (System.ArgumentException(sprintf "Expected exactly %d characters, got %d" base32Length s.Length, "s"))
+        
+        let firstChar = s.[0]
+        if int firstChar >= 128 || decodeMap.[int firstChar] >= 8y then
+            raise (System.ArgumentException("Value exceeds 128 bits (leading pad bits must be zero)", "s"))
+
+        let mutable result = System.UInt128.Zero
+        for i = 0 to s.Length - 1 do
+            let c = s.[i]
+            if int c >= 128 then
+                raise (System.ArgumentException(sprintf "Invalid Crockford base32 character '%c' at index %d" c i, "s"))
+            let valByte = decodeMap.[int c]
+            if valByte < 0y then
+                raise (System.ArgumentException(sprintf "Invalid Crockford base32 character '%c' at index %d" c i, "s"))
+            result <- (result <<< 5) ||| System.UInt128(0UL, uint64 valByte)
+        result
+
+    /// True iff s is the strict canonical Crockford form (26 chars, uppercase, strict alphabet, no aliases, round-trips).
+    let isCanonical (s: string) : bool =
+        if isNull s || s.Length <> base32Length then
+            false
+        else
+            let mutable ok = true
+            for i = 0 to s.Length - 1 do
+                if crockfordAlphabet.IndexOf(s.[i]) < 0 then
+                    ok <- false
+            if ok then
+                let firstChar = s.[0]
+                let firstVal = decodeMap.[int firstChar]
+                if firstVal < 0y || firstVal >= 8y then
+                    false
+                else
+                    try
+                        format (parse s) = s
+                    with _ ->
+                        false
+            else
+                false
+
+

--- a/src/Core.Python/tests/test_cross_verify.py
+++ b/src/Core.Python/tests/test_cross_verify.py
@@ -215,13 +215,23 @@ def test_cross_verify_zeta_id():
 
         packed = zeta_id.pack(obs, zeta_id.DETERMINISTIC_ENV)
         hex_val = zeta_id.to_hex(packed)
+        crockford_val = zeta_id.format_b32(packed)
 
         unpacked = zeta_id.unpack(packed)
         roundtrip_ok = obs_equal(obs, unpacked)
+        parsed_id = zeta_id.parse_b32(crockford_val)
+        parse_ok = parsed_id == packed
+        is_canonical = zeta_id.is_canonical(crockford_val)
+
         matches_expected = hex_val == v["expected_hex"]
+        crockford_matches = crockford_val == v["expected_crockford"]
+
+        roundtrip_ok = roundtrip_ok and parse_ok and is_canonical
+        matches_expected = matches_expected and crockford_matches
 
         out_map[v_id] = {
             "hex": hex_val,
+            "crockford": crockford_val,
             "roundtripOk": roundtrip_ok,
             "matchesExpected": matches_expected,
         }

--- a/src/Core.Rust.ZetaId/src/lib.rs
+++ b/src/Core.Rust.ZetaId/src/lib.rs
@@ -29,7 +29,7 @@ pub mod bit_layout;
 pub mod bit_layout_gen;
 pub mod zeta_id;
 
-pub use zeta_id::{PackError, pack, to_hex, unpack};
+pub use zeta_id::{PackError, pack, to_hex, unpack, format_b32, parse_b32, is_canonical, ZETAID_BASE32_LEN};
 
 /// Version field value for V1 (5-bit field; the only version today).
 pub const VERSION_V1: u8 = 1;

--- a/src/Core.Rust.ZetaId/src/zeta_id.rs
+++ b/src/Core.Rust.ZetaId/src/zeta_id.rs
@@ -168,6 +168,96 @@ pub fn to_hex(id: u128) -> String {
     format!("{id:032x}")
 }
 
+const CROCKFORD_ALPHABET: &[u8] = b"0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+/// Length of the canonical Crockford base32 representation.
+pub const ZETAID_BASE32_LEN: usize = 26;
+
+fn decode_char(c: u8) -> Result<u8, String> {
+    match c {
+        b'0'..=b'9' => Ok(c - b'0'),
+        b'A'..=b'H' => Ok(c - b'A' + 10),
+        b'a'..=b'h' => Ok(c - b'a' + 10),
+        b'J'..=b'K' => Ok(c - b'J' + 18),
+        b'j'..=b'k' => Ok(c - b'j' + 18),
+        b'M'..=b'N' => Ok(c - b'M' + 20),
+        b'm'..=b'n' => Ok(c - b'm' + 20),
+        b'P'..=b'T' => Ok(c - b'P' + 22),
+        b'p'..=b't' => Ok(c - b'p' + 22),
+        b'V'..=b'Z' => Ok(c - b'V' + 27),
+        b'v'..=b'z' => Ok(c - b'v' + 27),
+        b'I' | b'i' | b'L' | b'l' => Ok(1),
+        b'O' | b'o' => Ok(0),
+        _ => Err(format!("invalid Crockford base32 character '{}'", c as char)),
+    }
+}
+
+/// Encode a 128-bit ZetaId as the canonical 26-char Crockford base32 string.
+#[must_use]
+pub fn format_b32(id: u128) -> String {
+    let mut v = id;
+    let mut out = [0u8; ZETAID_BASE32_LEN];
+    for i in (0..ZETAID_BASE32_LEN).rev() {
+        out[i] = CROCKFORD_ALPHABET[(v & 31) as usize];
+        v >>= 5;
+    }
+    std::str::from_utf8(&out).unwrap().to_string()
+}
+
+/// Parse a canonical (or Crockford-lenient) base32 string back to a 128-bit ZetaId.
+///
+/// # Errors
+/// Returns an error message string if the string is of wrong length, contains
+/// invalid characters, or overflows 128 bits.
+pub fn parse_b32(s: &str) -> Result<u128, String> {
+    if s.len() != ZETAID_BASE32_LEN {
+        return Err(format!(
+            "expected exactly {} Crockford base32 characters, got {}",
+            ZETAID_BASE32_LEN,
+            s.len()
+        ));
+    }
+    let bytes = s.as_bytes();
+    let first_val = decode_char(bytes[0])?;
+    if first_val >= 8 {
+        return Err("value exceeds 128 bits (leading pad bits must be zero)".to_string());
+    }
+
+    let mut result = 0u128;
+    for &b in bytes {
+        let val = decode_char(b)?;
+        result = (result << 5) | u128::from(val);
+    }
+    Ok(result)
+}
+
+/// True iff `s` is the strict canonical Crockford form (exactly what `format_b32`
+/// emits) — 26 chars, uppercase, only the strict alphabet, no lenient aliases,
+/// and round-trips.
+#[must_use]
+pub fn is_canonical(s: &str) -> bool {
+    if s.len() != ZETAID_BASE32_LEN {
+        return false;
+    }
+    for &b in s.as_bytes() {
+        if !CROCKFORD_ALPHABET.contains(&b) {
+            return false;
+        }
+    }
+    if let Some(&first) = s.as_bytes().first() {
+        if let Ok(val) = decode_char(first) {
+            if val >= 8 {
+                return false;
+            }
+        } else {
+            return false;
+        }
+    }
+    match parse_b32(s) {
+        Ok(id) => format_b32(id) == s,
+        Err(_) => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/Core.Rust.ZetaId/tests/cross_verify.rs
+++ b/src/Core.Rust.ZetaId/tests/cross_verify.rs
@@ -17,6 +17,7 @@ use std::path::PathBuf;
 
 use zeta_core_zeta_id::{
     Authority, DeterministicEnv, Momentum, ZetaObservation, pack, to_hex, unpack,
+    format_b32, parse_b32, is_canonical,
 };
 
 /// Walk up from the crate dir to the repo root (`Zeta.sln` sentinel), matching the
@@ -150,10 +151,11 @@ fn cross_verify_matches_shared_vectors() {
     let records = parse_vectors(&text);
     assert!(!records.is_empty(), "no vectors parsed");
 
-    // (id, hex, roundtrip_ok, matches_expected) in fixture order.
-    let mut results: Vec<(String, String, bool, bool)> = Vec::with_capacity(records.len());
+    // (id, hex, crockford, roundtrip_ok, matches_expected) in fixture order.
+    let mut results: Vec<(String, String, String, bool, bool)> = Vec::with_capacity(records.len());
     let mut roundtrip_mismatches = 0usize;
     let mut hex_mismatches = 0usize;
+    let mut crockford_mismatches = 0usize;
 
     for rec in &records {
         let id = field(rec, "id").to_string();
@@ -177,28 +179,40 @@ fn cross_verify_matches_shared_vectors() {
 
         let id_value = pack(&obs, &DeterministicEnv).expect("pack");
         let hex = to_hex(id_value);
-        let roundtrip_ok = unpack(id_value) == obs;
+        let crockford = format_b32(id_value);
+        let parsed_id = parse_b32(&crockford);
+        let parse_ok = parsed_id == Ok(id_value);
+        let canonical = is_canonical(&crockford);
+
+        let roundtrip_ok = unpack(id_value) == obs && parse_ok && canonical;
         let expected_hex = field(rec, "expected_hex");
+        let expected_crockford = field(rec, "expected_crockford");
         let matches_expected = hex == expected_hex;
+        let crockford_matches = crockford == expected_crockford;
 
         if !roundtrip_ok {
             roundtrip_mismatches += 1;
-            eprintln!("Roundtrip MISMATCH for {id}");
+            eprintln!("Roundtrip/CrockfordParse/Canonical MISMATCH for {id}");
         }
         if !matches_expected {
             hex_mismatches += 1;
             eprintln!("Hex MISMATCH for {id}: got {hex}, expected {expected_hex}");
         }
-        results.push((id, hex, roundtrip_ok, matches_expected));
+        if !crockford_matches {
+            crockford_mismatches += 1;
+            eprintln!("Crockford MISMATCH for {id}: got {crockford}, expected {expected_crockford}");
+        }
+        results.push((id, hex, crockford, roundtrip_ok, matches_expected && crockford_matches));
     }
 
-    // Emit rust-output.json in the shared shape: { id: { hex, roundtripOk, matchesExpected } }.
+    // Emit rust-output.json in the shared shape: { id: { hex, crockford, roundtripOk, matchesExpected } }.
     let mut out = String::from("{\n");
-    for (i, (id, hex, rt, me)) in results.iter().enumerate() {
+    for (i, (id, hex, crockford, rt, me)) in results.iter().enumerate() {
         out.push_str(&format!(
-            "  {}: {{\n    \"hex\": {},\n    \"roundtripOk\": {},\n    \"matchesExpected\": {}\n  }}",
+            "  {}: {{\n    \"hex\": {},\n    \"crockford\": {},\n    \"roundtripOk\": {},\n    \"matchesExpected\": {}\n  }}",
             json_str(id),
             json_str(hex),
+            json_str(crockford),
             rt,
             me,
         ));
@@ -223,9 +237,10 @@ fn cross_verify_matches_shared_vectors() {
 
     let n = results.len();
     println!(
-        "Cross-verify: {n} vectors. Roundtrip {}/{n} OK. Hex matches expected {}/{n}.",
+        "Cross-verify: {n} vectors. Roundtrip {}/{n} OK. Hex matches expected {}/{n}. Crockford matches expected {}/{n}.",
         n - roundtrip_mismatches,
         n - hex_mismatches,
+        n - crockford_mismatches,
     );
 
     assert_eq!(
@@ -233,4 +248,5 @@ fn cross_verify_matches_shared_vectors() {
         "{roundtrip_mismatches} roundtrip mismatch(es)"
     );
     assert_eq!(hex_mismatches, 0, "{hex_mismatches} hex mismatch(es)");
+    assert_eq!(crockford_mismatches, 0, "{crockford_mismatches} crockford mismatch(es)");
 }

--- a/src/Core.TypeScript/zeta-id/cross-verify.ts
+++ b/src/Core.TypeScript/zeta-id/cross-verify.ts
@@ -1,4 +1,5 @@
 import { pack, unpack, DETERMINISTIC_ENV } from "./zeta-id";
+import { format as formatB32, parse as parseB32, isCanonical } from "./encoding";
 import type { ZetaObservation, Authority, Momentum } from "./types";
 import { parse } from "../yaml/dom";
 import type { YamlValue } from "../yaml/dom";
@@ -17,6 +18,7 @@ interface FlatVector {
   momentum_raw: number | null;
   location: number;
   expected_hex: string;
+  expected_crockford: string;
 }
 
 // --- YamlValue → FlatVector[] navigation (own-the-interface: route through our port,
@@ -72,6 +74,7 @@ function yamlValueToFlatVectors(root: YamlValue): FlatVector[] {
       momentum_raw: asNumOrNull(field(m, "momentum_raw", ctx), `${ctx}.momentum_raw`),
       location: asNum(field(m, "location", ctx), `${ctx}.location`),
       expected_hex: asStr(field(m, "expected_hex", ctx), `${ctx}.expected_hex`),
+      expected_crockford: asStr(field(m, "expected_crockford", ctx), `${ctx}.expected_crockford`),
     };
   });
 }
@@ -107,40 +110,55 @@ if (!parsed.ok) {
 }
 const vectors = yamlValueToFlatVectors(parsed.value);
 
-const results: Record<string, { hex: string; roundtripOk: boolean; matchesExpected: boolean }> = {};
+const results: Record<
+  string,
+  { hex: string; crockford: string; roundtripOk: boolean; matchesExpected: boolean }
+> = {};
 let unpackMismatches = 0;
 let hexMismatches = 0;
+let crockfordMismatches = 0;
 
 for (const v of vectors) {
   const obs = toObservation(v);
   const packed = pack(obs, DETERMINISTIC_ENV);
   const hex = packed.toString(16).padStart(32, "0");
+  const crockford = formatB32(packed);
 
   const unpacked = unpack(packed);
   const roundtripOk = Bun.deepEquals(unpacked, obs);
   const matchesExpected = hex === v.expected_hex;
+  const parsedId = parseB32(crockford);
+  const parseOk = parsedId === packed;
+  const canonicalOk = isCanonical(crockford);
+  const crockfordMatches = crockford === v.expected_crockford;
 
-  results[v.id] = { hex, roundtripOk, matchesExpected };
+  results[v.id] = {
+    hex,
+    crockford,
+    roundtripOk: roundtripOk && parseOk && canonicalOk,
+    matchesExpected: matchesExpected && crockfordMatches,
+  };
 
-  if (!roundtripOk) {
+  if (!roundtripOk || !parseOk || !canonicalOk) {
     unpackMismatches++;
-    console.error(`Roundtrip MISMATCH for ${v.id}`);
+    console.error(`Roundtrip/CrockfordParse/Canonical MISMATCH for ${v.id}`);
   }
   if (!matchesExpected) {
     hexMismatches++;
     console.error(`Hex MISMATCH for ${v.id}: got ${hex}, expected ${v.expected_hex}`);
   }
+  if (!crockfordMatches) {
+    crockfordMismatches++;
+    console.error(`Crockford MISMATCH for ${v.id}: got ${crockford}, expected ${v.expected_crockford}`);
+  }
 }
 
 await Bun.write("ts-output.json", JSON.stringify(results, null, 2));
 console.log(
-  `Cross-verify: ${vectors.length} vectors. Roundtrip ${vectors.length - unpackMismatches}/${vectors.length} OK. Hex matches expected ${vectors.length - hexMismatches}/${vectors.length}.`,
+  `Cross-verify: ${vectors.length} vectors. Roundtrip ${vectors.length - unpackMismatches}/${vectors.length} OK. Hex matches expected ${vectors.length - hexMismatches}/${vectors.length}. Crockford matches expected ${vectors.length - crockfordMismatches}/${vectors.length}.`,
 );
 
-// Enforce: non-zero exit on any mismatch so CI / automation catches regressions.
-// Per Codex P1 finding (PR #4517 cross-verify.ts:72) — silent-non-enforcing
-// harness is a known antipattern.
-if (unpackMismatches > 0 || hexMismatches > 0) {
-  console.error(`FAIL: ${unpackMismatches} roundtrip mismatch + ${hexMismatches} hex mismatch`);
+if (unpackMismatches > 0 || hexMismatches > 0 || crockfordMismatches > 0) {
+  console.error(`FAIL: ${unpackMismatches} roundtrip mismatch + ${hexMismatches} hex mismatch + ${crockfordMismatches} crockford mismatch`);
   process.exit(1);
 }

--- a/tests/Tests.CSharp/ZetaId/CrossVerifyTests.cs
+++ b/tests/Tests.CSharp/ZetaId/CrossVerifyTests.cs
@@ -70,6 +70,7 @@ public class CrossVerifyTests
             MomentumRaw = AsIntOrNull(Field(m, "momentum_raw", ctx), $"{ctx}.momentum_raw"),
             Location = AsInt(Field(m, "location", ctx), $"{ctx}.location"),
             ExpectedHex = AsStr(Field(m, "expected_hex", ctx), $"{ctx}.expected_hex"),
+            ExpectedCrockford = AsStr(Field(m, "expected_crockford", ctx), $"{ctx}.expected_crockford"),
         };
     }
 
@@ -169,6 +170,7 @@ public class CrossVerifyTests
 
         var results = new Dictionary<string, object>(StringComparer.Ordinal);
         int hexMismatches = 0;
+        int crockfordMismatches = 0;
         int roundtripMismatches = 0;
 
         foreach (var v in vectors)
@@ -176,15 +178,22 @@ public class CrossVerifyTests
             var obs = ToObservation(v);
             var id = ZetaIdCodec.Pack(obs, DeterministicEnv.Instance);
             var hex = id.ToString("x32", CultureInfo.InvariantCulture);
+            var crockford = ZetaIdCodec.Format(id);
 
             var unpacked = ZetaIdCodec.Unpack(id);
             var roundtripOk = unpacked == obs;
+            var parsedId = ZetaIdCodec.Parse(crockford);
+            var parseOk = parsedId == id;
+            var isCanonical = ZetaIdCodec.IsCanonical(crockford);
+
             var matchesExpected = string.Equals(hex, v.ExpectedHex, StringComparison.Ordinal);
+            var crockfordMatches = string.Equals(crockford, v.ExpectedCrockford, StringComparison.Ordinal);
 
-            results[v.Id] = new { hex, roundtripOk, matchesExpected };
+            results[v.Id] = new { hex, crockford, roundtripOk = roundtripOk && parseOk && isCanonical, matchesExpected = matchesExpected && crockfordMatches };
 
-            if (!roundtripOk) roundtripMismatches++;
+            if (!roundtripOk || !parseOk || !isCanonical) roundtripMismatches++;
             if (!matchesExpected) hexMismatches++;
+            if (!crockfordMatches) crockfordMismatches++;
         }
 
         var outputPath = Path.Join(root, "tests", "cross-verification", "zeta-id", "cs-output.json");
@@ -193,5 +202,6 @@ public class CrossVerifyTests
 
         Assert.Equal(0, roundtripMismatches);
         Assert.Equal(0, hexMismatches);
+        Assert.Equal(0, crockfordMismatches);
     }
 }

--- a/tests/Tests.CSharp/ZetaId/FlatVector.cs
+++ b/tests/Tests.CSharp/ZetaId/FlatVector.cs
@@ -29,4 +29,6 @@ public sealed class FlatVector
     public int Location { get; set; }
 
     public string ExpectedHex { get; set; } = string.Empty;
+
+    public string ExpectedCrockford { get; set; } = string.Empty;
 }

--- a/tests/Tests.FSharp/ZetaId/CrossVerifyTests.fs
+++ b/tests/Tests.FSharp/ZetaId/CrossVerifyTests.fs
@@ -27,6 +27,7 @@ type FlatVector = {
     MomentumRaw: Nullable<int>
     Location: int
     ExpectedHex: string
+    ExpectedCrockford: string
 }
 
 // --- YamlValue → FlatVector list navigation. The fixture is a top-level VMap with a
@@ -80,6 +81,7 @@ let private toFlatVector (idx: int) (item: YamlValue) : FlatVector =
         MomentumRaw   = asIntOrNull (field m "momentum_raw" ctx)  (ctx + ".momentum_raw")
         Location      = asInt     (field m "location" ctx)       (ctx + ".location")
         ExpectedHex   = asStr     (field m "expected_hex" ctx)   (ctx + ".expected_hex")
+        ExpectedCrockford = asStr (field m "expected_crockford" ctx) (ctx + ".expected_crockford")
     }
 
 let private yamlValueToFlatVectors (root: YamlValue) : FlatVector list =
@@ -148,13 +150,9 @@ let private repoRoot () : string =
 [<Fact>]
 let ``cross-verify twelve vectors match TS+C# bootstrap hex`` () =
     let root = repoRoot ()
-    // Path.Join (not Path.Combine) — Path.Join always concatenates segments;
-    // Path.Combine silently drops earlier args if a later arg looks rooted.
     let yamlPath = Path.Join(root, "tests", "cross-verification", "zeta-id", "vectors.yaml")
     let yamlText = File.ReadAllText(yamlPath)
 
-    // Own-the-interface: parse through our YAML port (Zeta.Core.FSharp.Yaml.Dom.parse),
-    // not YamlDotNet directly. Decline surfaces as a YamlFeedback, not an exception.
     let vectors =
         match parse yamlText with
         | Ok value -> yamlValueToFlatVectors value
@@ -163,21 +161,29 @@ let ``cross-verify twelve vectors match TS+C# bootstrap hex`` () =
 
     let results = System.Collections.Generic.Dictionary<string, obj>(StringComparer.Ordinal)
     let mutable hexMismatches = 0
+    let mutable crockfordMismatches = 0
     let mutable roundtripMismatches = 0
 
     for v in vectors do
         let obs = toObservation v
         let id = ZetaIdCodec.pack obs DeterministicEnv.Instance
         let hex = id.ToString("x32", CultureInfo.InvariantCulture)
+        let crockford = ZetaIdCodec.format id
 
         let unpacked = ZetaIdCodec.unpack id
         let roundtripOk = unpacked = obs
+        let parsedId = ZetaIdCodec.parse crockford
+        let parseOk = parsedId = id
+        let isCanonical = ZetaIdCodec.isCanonical crockford
+
         let matchesExpected = String.Equals(hex, v.ExpectedHex, StringComparison.Ordinal)
+        let crockfordMatches = String.Equals(crockford, v.ExpectedCrockford, StringComparison.Ordinal)
 
-        results.[v.Id] <- box {| hex = hex; roundtripOk = roundtripOk; matchesExpected = matchesExpected |}
+        results.[v.Id] <- box {| hex = hex; crockford = crockford; roundtripOk = (roundtripOk && parseOk && isCanonical); matchesExpected = (matchesExpected && crockfordMatches) |}
 
-        if not roundtripOk then roundtripMismatches <- roundtripMismatches + 1
+        if not (roundtripOk && parseOk && isCanonical) then roundtripMismatches <- roundtripMismatches + 1
         if not matchesExpected then hexMismatches <- hexMismatches + 1
+        if not crockfordMatches then crockfordMismatches <- crockfordMismatches + 1
 
     // compare.ts reads `fsharp-output.json` (not `fs-output.json`) — match per Copilot #4548 thread
     let outputPath = Path.Join(root, "tests", "cross-verification", "zeta-id", "fsharp-output.json")
@@ -187,3 +193,5 @@ let ``cross-verify twelve vectors match TS+C# bootstrap hex`` () =
 
     Assert.Equal(0, roundtripMismatches)
     Assert.Equal(0, hexMismatches)
+    Assert.Equal(0, crockfordMismatches)
+

--- a/tests/cross-verification/zeta-id/compare.ts
+++ b/tests/cross-verification/zeta-id/compare.ts
@@ -76,38 +76,60 @@ for (const [name, impl] of [
 
 for (const key of keys) {
   const tsHex = typeof ts[key] === "string" ? ts[key] : ts[key].hex;
+  const tsCrockford = typeof ts[key] === "string" ? undefined : ts[key].crockford;
+
   if (fsExists) {
     const fsHex = typeof fsExists[key] === "string" ? fsExists[key] : fsExists[key]?.hex;
     if (tsHex !== fsHex) {
-      console.error(`Mismatch ${key}: TS=${tsHex} F#=${fsHex ?? "MISSING"}`);
+      console.error(`Mismatch ${key} hex: TS=${tsHex} F#=${fsHex ?? "MISSING"}`);
+      mismatches++;
+    }
+    const fsCrockford = fsExists[key]?.crockford;
+    if (tsCrockford !== fsCrockford) {
+      console.error(`Mismatch ${key} crockford: TS=${tsCrockford} F#=${fsCrockford ?? "MISSING"}`);
       mismatches++;
     }
   }
   if (csExists) {
     const csHex = typeof csExists[key] === "string" ? csExists[key] : csExists[key]?.hex;
     if (tsHex !== csHex) {
-      console.error(`Mismatch ${key}: TS=${tsHex} C#=${csHex ?? "MISSING"}`);
+      console.error(`Mismatch ${key} hex: TS=${tsHex} C#=${csHex ?? "MISSING"}`);
+      mismatches++;
+    }
+    const csCrockford = csExists[key]?.crockford;
+    if (tsCrockford !== csCrockford) {
+      console.error(`Mismatch ${key} crockford: TS=${tsCrockford} C#=${csCrockford ?? "MISSING"}`);
       mismatches++;
     }
   }
   if (rustExists) {
     const rustHex = typeof rustExists[key] === "string" ? rustExists[key] : rustExists[key]?.hex;
     if (tsHex !== rustHex) {
-      console.error(`Mismatch ${key}: TS=${tsHex} Rust=${rustHex ?? "MISSING"}`);
+      console.error(`Mismatch ${key} hex: TS=${tsHex} Rust=${rustHex ?? "MISSING"}`);
+      mismatches++;
+    }
+    const rustCrockford = rustExists[key]?.crockford;
+    if (tsCrockford !== rustCrockford) {
+      console.error(`Mismatch ${key} crockford: TS=${tsCrockford} Rust=${rustCrockford ?? "MISSING"}`);
       mismatches++;
     }
   }
   if (pyExists) {
     const pyHex = typeof pyExists[key] === "string" ? pyExists[key] : pyExists[key]?.hex;
     if (tsHex !== pyHex) {
-      console.error(`Mismatch ${key}: TS=${tsHex} Py=${pyHex ?? "MISSING"}`);
+      console.error(`Mismatch ${key} hex: TS=${tsHex} Py=${pyHex ?? "MISSING"}`);
+      mismatches++;
+    }
+    const pyCrockford = pyExists[key]?.crockford;
+    if (tsCrockford !== pyCrockford) {
+      console.error(`Mismatch ${key} crockford: TS=${tsCrockford} Py=${pyCrockford ?? "MISSING"}`);
       mismatches++;
     }
   }
   if (goExists) {
     const goHex = typeof goExists[key] === "string" ? goExists[key] : goExists[key]?.hex;
     if (tsHex !== goHex) {
-      console.error(`Mismatch ${key}: TS=${tsHex} Go=${goHex ?? "MISSING"}`);
+      console.error(`Mismatch ${key} hex: TS=${tsHex} Go=${goHex ?? "MISSING"}`);
       mismatches++;
     }
   }

--- a/tests/cross-verification/zeta-id/cs-output.json
+++ b/tests/cross-verification/zeta-id/cs-output.json
@@ -1,61 +1,73 @@
 {
   "authority-human-verified": {
     "hex": "080cb77ed58d19c1f80b000800000000",
+    "crockford": "081JVQXNCD370ZG2R010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "authority-trusted-agent": {
     "hex": "080cb77ed58d19c1a00b000800000000",
+    "crockford": "081JVQXNCD370T02R010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "authority-standard": {
     "hex": "080cb77ed58d18017815001000000000",
+    "crockford": "081JVQXNCD300QG58020000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "authority-best-effort": {
     "hex": "080cb77ed58d18074017000800000000",
+    "crockford": "081JVQXNCD303M05R010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "authority-simulated": {
     "hex": "080cb77ed58d18071817c00800000000",
+    "crockford": "081JVQXNCD303HG5Y010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "momentum-background": {
     "hex": "080cb77ed58d19c1f809000800000000",
+    "crockford": "081JVQXNCD370ZG28010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "momentum-normal": {
     "hex": "080cb77ed58d19c1f80b000800000000",
+    "crockford": "081JVQXNCD370ZG2R010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "momentum-elevated": {
     "hex": "080cb77ed58d19c1a00d000800000000",
+    "crockford": "081JVQXNCD370T038010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "momentum-high": {
     "hex": "080cb77ed58d19c1f80f000800000000",
+    "crockford": "081JVQXNCD370ZG3R010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "momentum-critical": {
     "hex": "080cb77ed58d19c1f80fc00800000000",
+    "crockford": "081JVQXNCD370ZG3Y010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "authority-raw-0": {
     "hex": "0800000000000001000b000800000000",
+    "crockford": "0800000000000G02R010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "momentum-raw-255": {
     "hex": "0ffffffffffff9c1f80ff80800000000",
+    "crockford": "0FZZZZZZZZZ70ZG3ZR10000000",
     "roundtripOk": true,
     "matchesExpected": true
   }

--- a/tests/cross-verification/zeta-id/fsharp-output.json
+++ b/tests/cross-verification/zeta-id/fsharp-output.json
@@ -1,60 +1,72 @@
 {
   "authority-human-verified": {
+    "crockford": "081JVQXNCD370ZG2R010000000",
     "hex": "080cb77ed58d19c1f80b000800000000",
     "matchesExpected": true,
     "roundtripOk": true
   },
   "authority-trusted-agent": {
+    "crockford": "081JVQXNCD370T02R010000000",
     "hex": "080cb77ed58d19c1a00b000800000000",
     "matchesExpected": true,
     "roundtripOk": true
   },
   "authority-standard": {
+    "crockford": "081JVQXNCD300QG58020000000",
     "hex": "080cb77ed58d18017815001000000000",
     "matchesExpected": true,
     "roundtripOk": true
   },
   "authority-best-effort": {
+    "crockford": "081JVQXNCD303M05R010000000",
     "hex": "080cb77ed58d18074017000800000000",
     "matchesExpected": true,
     "roundtripOk": true
   },
   "authority-simulated": {
+    "crockford": "081JVQXNCD303HG5Y010000000",
     "hex": "080cb77ed58d18071817c00800000000",
     "matchesExpected": true,
     "roundtripOk": true
   },
   "momentum-background": {
+    "crockford": "081JVQXNCD370ZG28010000000",
     "hex": "080cb77ed58d19c1f809000800000000",
     "matchesExpected": true,
     "roundtripOk": true
   },
   "momentum-normal": {
+    "crockford": "081JVQXNCD370ZG2R010000000",
     "hex": "080cb77ed58d19c1f80b000800000000",
     "matchesExpected": true,
     "roundtripOk": true
   },
   "momentum-elevated": {
+    "crockford": "081JVQXNCD370T038010000000",
     "hex": "080cb77ed58d19c1a00d000800000000",
     "matchesExpected": true,
     "roundtripOk": true
   },
   "momentum-high": {
+    "crockford": "081JVQXNCD370ZG3R010000000",
     "hex": "080cb77ed58d19c1f80f000800000000",
     "matchesExpected": true,
     "roundtripOk": true
   },
   "momentum-critical": {
+    "crockford": "081JVQXNCD370ZG3Y010000000",
     "hex": "080cb77ed58d19c1f80fc00800000000",
     "matchesExpected": true,
     "roundtripOk": true
   },
   "authority-raw-0": {
+    "crockford": "0800000000000G02R010000000",
     "hex": "0800000000000001000b000800000000",
     "matchesExpected": true,
     "roundtripOk": true
   },
   "momentum-raw-255": {
+    "crockford": "0FZZZZZZZZZ70ZG3ZR10000000",
     "hex": "0ffffffffffff9c1f80ff80800000000",
     "matchesExpected": true,
     "roundtripOk": true

--- a/tests/cross-verification/zeta-id/python-output.json
+++ b/tests/cross-verification/zeta-id/python-output.json
@@ -1,60 +1,72 @@
 {
   "authority-best-effort": {
+    "crockford": "081JVQXNCD303M05R010000000",
     "hex": "080cb77ed58d18074017000800000000",
     "matchesExpected": true,
     "roundtripOk": true
   },
   "authority-human-verified": {
+    "crockford": "081JVQXNCD370ZG2R010000000",
     "hex": "080cb77ed58d19c1f80b000800000000",
     "matchesExpected": true,
     "roundtripOk": true
   },
   "authority-raw-0": {
+    "crockford": "0800000000000G02R010000000",
     "hex": "0800000000000001000b000800000000",
     "matchesExpected": true,
     "roundtripOk": true
   },
   "authority-simulated": {
+    "crockford": "081JVQXNCD303HG5Y010000000",
     "hex": "080cb77ed58d18071817c00800000000",
     "matchesExpected": true,
     "roundtripOk": true
   },
   "authority-standard": {
+    "crockford": "081JVQXNCD300QG58020000000",
     "hex": "080cb77ed58d18017815001000000000",
     "matchesExpected": true,
     "roundtripOk": true
   },
   "authority-trusted-agent": {
+    "crockford": "081JVQXNCD370T02R010000000",
     "hex": "080cb77ed58d19c1a00b000800000000",
     "matchesExpected": true,
     "roundtripOk": true
   },
   "momentum-background": {
+    "crockford": "081JVQXNCD370ZG28010000000",
     "hex": "080cb77ed58d19c1f809000800000000",
     "matchesExpected": true,
     "roundtripOk": true
   },
   "momentum-critical": {
+    "crockford": "081JVQXNCD370ZG3Y010000000",
     "hex": "080cb77ed58d19c1f80fc00800000000",
     "matchesExpected": true,
     "roundtripOk": true
   },
   "momentum-elevated": {
+    "crockford": "081JVQXNCD370T038010000000",
     "hex": "080cb77ed58d19c1a00d000800000000",
     "matchesExpected": true,
     "roundtripOk": true
   },
   "momentum-high": {
+    "crockford": "081JVQXNCD370ZG3R010000000",
     "hex": "080cb77ed58d19c1f80f000800000000",
     "matchesExpected": true,
     "roundtripOk": true
   },
   "momentum-normal": {
+    "crockford": "081JVQXNCD370ZG2R010000000",
     "hex": "080cb77ed58d19c1f80b000800000000",
     "matchesExpected": true,
     "roundtripOk": true
   },
   "momentum-raw-255": {
+    "crockford": "0FZZZZZZZZZ70ZG3ZR10000000",
     "hex": "0ffffffffffff9c1f80ff80800000000",
     "matchesExpected": true,
     "roundtripOk": true

--- a/tests/cross-verification/zeta-id/rust-output.json
+++ b/tests/cross-verification/zeta-id/rust-output.json
@@ -1,61 +1,73 @@
 {
   "authority-human-verified": {
     "hex": "080cb77ed58d19c1f80b000800000000",
+    "crockford": "081JVQXNCD370ZG2R010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "authority-trusted-agent": {
     "hex": "080cb77ed58d19c1a00b000800000000",
+    "crockford": "081JVQXNCD370T02R010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "authority-standard": {
     "hex": "080cb77ed58d18017815001000000000",
+    "crockford": "081JVQXNCD300QG58020000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "authority-best-effort": {
     "hex": "080cb77ed58d18074017000800000000",
+    "crockford": "081JVQXNCD303M05R010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "authority-simulated": {
     "hex": "080cb77ed58d18071817c00800000000",
+    "crockford": "081JVQXNCD303HG5Y010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "momentum-background": {
     "hex": "080cb77ed58d19c1f809000800000000",
+    "crockford": "081JVQXNCD370ZG28010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "momentum-normal": {
     "hex": "080cb77ed58d19c1f80b000800000000",
+    "crockford": "081JVQXNCD370ZG2R010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "momentum-elevated": {
     "hex": "080cb77ed58d19c1a00d000800000000",
+    "crockford": "081JVQXNCD370T038010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "momentum-high": {
     "hex": "080cb77ed58d19c1f80f000800000000",
+    "crockford": "081JVQXNCD370ZG3R010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "momentum-critical": {
     "hex": "080cb77ed58d19c1f80fc00800000000",
+    "crockford": "081JVQXNCD370ZG3Y010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "authority-raw-0": {
     "hex": "0800000000000001000b000800000000",
+    "crockford": "0800000000000G02R010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "momentum-raw-255": {
     "hex": "0ffffffffffff9c1f80ff80800000000",
+    "crockford": "0FZZZZZZZZZ70ZG3ZR10000000",
     "roundtripOk": true,
     "matchesExpected": true
   }

--- a/tests/cross-verification/zeta-id/ts-output.json
+++ b/tests/cross-verification/zeta-id/ts-output.json
@@ -1,61 +1,73 @@
 {
   "authority-human-verified": {
     "hex": "080cb77ed58d19c1f80b000800000000",
+    "crockford": "081JVQXNCD370ZG2R010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "authority-trusted-agent": {
     "hex": "080cb77ed58d19c1a00b000800000000",
+    "crockford": "081JVQXNCD370T02R010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "authority-standard": {
     "hex": "080cb77ed58d18017815001000000000",
+    "crockford": "081JVQXNCD300QG58020000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "authority-best-effort": {
     "hex": "080cb77ed58d18074017000800000000",
+    "crockford": "081JVQXNCD303M05R010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "authority-simulated": {
     "hex": "080cb77ed58d18071817c00800000000",
+    "crockford": "081JVQXNCD303HG5Y010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "momentum-background": {
     "hex": "080cb77ed58d19c1f809000800000000",
+    "crockford": "081JVQXNCD370ZG28010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "momentum-normal": {
     "hex": "080cb77ed58d19c1f80b000800000000",
+    "crockford": "081JVQXNCD370ZG2R010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "momentum-elevated": {
     "hex": "080cb77ed58d19c1a00d000800000000",
+    "crockford": "081JVQXNCD370T038010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "momentum-high": {
     "hex": "080cb77ed58d19c1f80f000800000000",
+    "crockford": "081JVQXNCD370ZG3R010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "momentum-critical": {
     "hex": "080cb77ed58d19c1f80fc00800000000",
+    "crockford": "081JVQXNCD370ZG3Y010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "authority-raw-0": {
     "hex": "0800000000000001000b000800000000",
+    "crockford": "0800000000000G02R010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "momentum-raw-255": {
     "hex": "0ffffffffffff9c1f80ff80800000000",
+    "crockford": "0FZZZZZZZZZ70ZG3ZR10000000",
     "roundtripOk": true,
     "matchesExpected": true
   }

--- a/tests/cross-verification/zeta-id/vectors.yaml
+++ b/tests/cross-verification/zeta-id/vectors.yaml
@@ -15,6 +15,7 @@ vectors:
     momentum_raw: null
     location: 1
     expected_hex: "080cb77ed58d19c1f80b000800000000"
+    expected_crockford: "081JVQXNCD370ZG2R010000000"
 
   - id: authority-trusted-agent
     version: 1
@@ -29,6 +30,7 @@ vectors:
     momentum_raw: null
     location: 1
     expected_hex: "080cb77ed58d19c1a00b000800000000"
+    expected_crockford: "081JVQXNCD370T02R010000000"
 
   - id: authority-standard
     version: 1
@@ -43,6 +45,7 @@ vectors:
     momentum_raw: null
     location: 2
     expected_hex: "080cb77ed58d18017815001000000000"
+    expected_crockford: "081JVQXNCD300QG58020000000"
 
   - id: authority-best-effort
     version: 1
@@ -57,6 +60,7 @@ vectors:
     momentum_raw: null
     location: 1
     expected_hex: "080cb77ed58d18074017000800000000"
+    expected_crockford: "081JVQXNCD303M05R010000000"
 
   - id: authority-simulated
     version: 1
@@ -71,6 +75,7 @@ vectors:
     momentum_raw: null
     location: 1
     expected_hex: "080cb77ed58d18071817c00800000000"
+    expected_crockford: "081JVQXNCD303HG5Y010000000"
 
   - id: momentum-background
     version: 1
@@ -85,6 +90,7 @@ vectors:
     momentum_raw: null
     location: 1
     expected_hex: "080cb77ed58d19c1f809000800000000"
+    expected_crockford: "081JVQXNCD370ZG28010000000"
 
   - id: momentum-normal
     version: 1
@@ -99,6 +105,7 @@ vectors:
     momentum_raw: null
     location: 1
     expected_hex: "080cb77ed58d19c1f80b000800000000"
+    expected_crockford: "081JVQXNCD370ZG2R010000000"
 
   - id: momentum-elevated
     version: 1
@@ -113,6 +120,7 @@ vectors:
     momentum_raw: null
     location: 1
     expected_hex: "080cb77ed58d19c1a00d000800000000"
+    expected_crockford: "081JVQXNCD370T038010000000"
 
   - id: momentum-high
     version: 1
@@ -127,6 +135,7 @@ vectors:
     momentum_raw: null
     location: 1
     expected_hex: "080cb77ed58d19c1f80f000800000000"
+    expected_crockford: "081JVQXNCD370ZG3R010000000"
 
   - id: momentum-critical
     version: 1
@@ -141,6 +150,7 @@ vectors:
     momentum_raw: null
     location: 1
     expected_hex: "080cb77ed58d19c1f80fc00800000000"
+    expected_crockford: "081JVQXNCD370ZG3Y010000000"
 
   - id: authority-raw-0
     version: 1
@@ -155,6 +165,7 @@ vectors:
     momentum_raw: null
     location: 1
     expected_hex: "0800000000000001000b000800000000"
+    expected_crockford: "0800000000000G02R010000000"
 
   - id: momentum-raw-255
     version: 1
@@ -169,3 +180,4 @@ vectors:
     momentum_raw: 255
     location: 1
     expected_hex: "0ffffffffffff9c1f80ff80800000000"
+    expected_crockford: "0FZZZZZZZZZ70ZG3ZR10000000"


### PR DESCRIPTION
feat(zeta-id): implement Crockford base32 string encoding and parity checks

Why:
- The 128-bit ZetaId needs a canonical string representation that is filename-safe, sort-preserving, and visually resilient.
- Crockford base32 avoids ambiguous characters and preserves chronological/lexicographical sorting when big-endian bytes are mapped directly.
- Multi-language cross-verification is needed to guarantee binary-compatible parsing and formatting behavior across typescript, c#, f#, rust, and python.

What:
- Wrote docs/zeta-id-canonical-string-encoding.md specification.
- Updated tests/cross-verification/zeta-id/vectors.yaml with expected_crockford keys.
- Implemented Format/Parse/IsCanonical in C#, F#, and Rust.
- Updated test suites in TS, C#, F#, Rust, and Python to generate and cross-verify Crockford outputs.
- Updated comparison script to assert crockford agreement across implementations.

Proof:
- Verified with bun src/Core.TypeScript/ci/cross-verify-all.ts (all 11/11 primitives passed, including zeta-id).
- Verified with dotnet build -c Release (0 warnings, 0 errors).
- Verified with cargo test, pytest, and dotnet test (all tests green).
- Attribution recorded via git trailers because shared GitHub credential identity makes host actor fields insufficient.

Limits:
- Visual alias mapping (I/i/L/l -> 1, O/o -> 0) is supported, but standard Crockford checksum character 'U/u' is rejected as it is not part of canonical ZetaId.

Agency-Signature-Version: 1
Agent: Gemini
Agent-Runtime: Gemini CLI
Agent-Model: Gemini
Credential-Identity: AceHack
Credential-Mode: shared
Human-Review: not-implied-by-credential
Human-Review-Evidence: none
Action-Mode: autonomous-fail-open
Task: B-0682
Co-Authored-By: Gemini <noreply@google.com>
