### PR TITLE
fix(docs): satisfy culture rule markdownlint

### DIFF
--- a/.claude/rules/culture-invariant-by-default.md
+++ b/.claude/rules/culture-invariant-by-default.md
@@ -16,6 +16,7 @@ Carved sentence:
 ## Diagnostics and Enforcement
 
 These rules are enforced at compiler/analyzer level for all harnesses in the repository via `.editorconfig` under `[*.{cs,csx}]`:
+
 - `CA1304` (Specify CultureInfo) ➔ `error`
 - `CA1305` (Specify IFormatProvider) ➔ `error`
 - `CA1307` (Specify StringComparison for clarity of intent) ➔ `error`


### PR DESCRIPTION
## What changed

- Added the missing blank line before the analyzer diagnostics list in `.claude/rules/culture-invariant-by-default.md`.

## Why

The post-merge gate for #8140 failed `lint (markdownlint)` with:

```text
.claude/rules/culture-invariant-by-default.md:19 error MD032/blanks-around-lists Lists should be surrounded by blank lines
```

## Validation

- `node_modules/.bin/markdownlint-cli2 .claude/rules/culture-invariant-by-default.md`
- `git diff --check`

Note: local full markdownlint also scans vendored `tools/setup/persona-keys/node_modules/**` markdown in this clone; those files are unrelated to the CI failure and were not edited.
