### PR TITLE
feat(hygiene): local preflight runner — every gate dimension, all failures at once

### DIFF
--- a/.claude/rules/culture-invariant-by-default.md
+++ b/.claude/rules/culture-invariant-by-default.md
@@ -16,6 +16,7 @@ Carved sentence:
 ## Diagnostics and Enforcement
 
 These rules are enforced at compiler/analyzer level for all harnesses in the repository via `.editorconfig` under `[*.{cs,csx}]`:
+
 - `CA1304` (Specify CultureInfo) ➔ `error`
 - `CA1305` (Specify IFormatProvider) ➔ `error`
 - `CA1307` (Specify StringComparison for clarity of intent) ➔ `error`

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -11,7 +11,7 @@
     "BenchmarkDotNet.Artifacts/**",
     "TestResults/**",
     "artifacts/**",
-    "node_modules/**",
+    "**/node_modules/**",
     "bin/**",
     "obj/**",
     // Upstream reference repos under `../` are not part of Zeta.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "format:check": "prettier --check \"**/*.{json,jsonc,md,markdown,ts,toml,yml,yaml,css}\"",
     "format:write": "prettier --write \"**/*.{json,jsonc,md,markdown,ts,toml,yml,yaml,css}\"",
     "typecheck": "tsc --noEmit",
+    "preflight": "bun ./src/Core.TypeScript/hygiene/preflight.ts",
+    "preflight:quick": "bun ./src/Core.TypeScript/hygiene/preflight.ts --quick",
     "test:typescript": "bun test",
     "hygiene:sort-tick-history": "bun ./tools/hygiene/sort-tick-history-canonical.ts",
     "hygiene:fix-markdown": "bun ./tools/hygiene/fix-markdown-md032-md026.ts",

--- a/src/Core.TypeScript/hygiene/preflight.ts
+++ b/src/Core.TypeScript/hygiene/preflight.ts
@@ -1,0 +1,150 @@
+#!/usr/bin/env bun
+// preflight.ts — run every code-correctness gate dimension LOCALLY before merge,
+// and report EVERY failure at once.
+//
+// WHY THIS EXISTS: the CI gate runs language lints sequentially in one job that
+// SHORT-CIRCUITS at the first failing language — so a multi-language change that
+// breaks Go, C#, Python and Rust surfaces ONE red per CI cycle, and "fixing" main
+// becomes whack-a-mole across many round-trips (see the 2026-06-13 rollout: 7 PRs
+// to clear breakage the gate revealed one language at a time). Preflight runs the
+// SAME checks but never bails early: it executes all of them, collects every
+// failure, and prints a single summary — so one local run finds everything.
+//
+// Usage:
+//   bun src/Core.TypeScript/hygiene/preflight.ts            # everything (incl. build + full test)
+//   bun src/Core.TypeScript/hygiene/preflight.ts --quick    # skip the slow dotnet build + test
+//   bun src/Core.TypeScript/hygiene/preflight.ts --help
+//
+// Exit codes:
+//   0   every executed check passed (skipped-because-tool-missing does NOT fail)
+//   1   one or more checks failed
+//
+// Mirrors the gate's code-correctness jobs (.github/workflows/gate.yml): the
+// per-language lints, tsc, markdownlint, the file-presence lints, and
+// build-and-test. The doc/hygiene lints (tick-shard, backlog, archive-header, …)
+// are intentionally out of scope here — this is the code preflight; add them if a
+// future round shows they recur.
+
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+// 3 levels up from src/Core.TypeScript/hygiene/ to repo root.
+const REPO_ROOT = resolve(here, "..", "..", "..");
+
+interface Check {
+  readonly label: string;
+  readonly cmd: readonly [string, ...string[]];
+  /** Slow checks (dotnet build/test) are skipped under --quick. */
+  readonly slow?: boolean;
+}
+
+const CHECKS: readonly Check[] = [
+  // Cheap file-presence + markdown first (fast feedback).
+  { label: "no-conflict-markers", cmd: ["bun", "src/Core.TypeScript/hygiene/check-no-conflict-markers.ts"] },
+  { label: "no-empty-dirs", cmd: ["bun", "src/Core.TypeScript/lint/no-empty-dirs.ts"] },
+  // The glob is REQUIRED: the config has no `globs` key, so a bare invocation
+  // lints zero files (a false pass). Matches the gate: markdownlint-cli2 "**/*.md".
+  { label: "markdownlint", cmd: ["npx", "markdownlint-cli2", "**/*.md"] },
+  // Per-language code lints — the set the gate short-circuits over.
+  { label: "lint: TypeScript (tsc)", cmd: ["bun", "src/Core.TypeScript/lint/lint-typescript.ts"] },
+  { label: "lint: F#", cmd: ["bun", "src/Core.TypeScript/lint/lint-fsharp.ts"] },
+  { label: "lint: C#", cmd: ["bun", "src/Core.TypeScript/lint/lint-csharp.ts"] },
+  { label: "lint: Python", cmd: ["bun", "src/Core.TypeScript/lint/lint-python.ts"] },
+  { label: "lint: Rust", cmd: ["bun", "src/Core.TypeScript/lint/lint-rust.ts"] },
+  // CAVEAT: lint-go.ts runs `go fmt ./...`, which REWRITES files in place rather
+  // than verifying (`gofmt -l`). So this check may modify your Go sources (and
+  // always passes even on drift). Review `git status` after a run. Tracked as a
+  // follow-up: switch lint-go.ts to `gofmt -l` so Go format drift FAILS the gate.
+  { label: "lint: Go", cmd: ["bun", "src/Core.TypeScript/lint/lint-go.ts"] },
+  // The long poles last (skipped under --quick).
+  { label: "dotnet build -c Release", cmd: ["dotnet", "build", "Zeta.sln", "-c", "Release"], slow: true },
+  { label: "dotnet test -c Release", cmd: ["dotnet", "test", "Zeta.sln", "-c", "Release"], slow: true },
+];
+
+type Status = "pass" | "fail" | "skip";
+
+interface Result {
+  readonly label: string;
+  readonly status: Status;
+  /** Captured combined output, kept only for failures (shown in the summary). */
+  readonly output: string;
+  readonly note?: string;
+}
+
+function runCheck(check: Check): Result {
+  process.stdout.write(`▶ ${check.label} … `);
+  const [bin, ...args] = check.cmd;
+  const r = spawnSync(bin, args, { cwd: REPO_ROOT, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
+
+  // Tool genuinely absent (e.g. golangci-lint / dotnet not installed locally) →
+  // SKIP, not FAIL: the dimension was not verified, but that is not breakage.
+  if (r.error && (r.error as NodeJS.ErrnoException).code === "ENOENT") {
+    console.log("SKIP (tool not found)");
+    return { label: check.label, status: "skip", output: "", note: `${bin} not on PATH` };
+  }
+  const output = `${r.stdout ?? ""}${r.stderr ?? ""}`;
+  // A lint script that aborts because its own toolchain is missing → SKIP.
+  if (r.status !== 0 && /not found|Executable not found|command not found/i.test(output)) {
+    console.log("SKIP (toolchain missing)");
+    return { label: check.label, status: "skip", output, note: "underlying tool unavailable" };
+  }
+  if (r.status === 0) {
+    console.log("PASS");
+    return { label: check.label, status: "pass", output };
+  }
+  console.log("FAIL");
+  return { label: check.label, status: "fail", output };
+}
+
+function main(): number {
+  const args = new Set(Bun.argv.slice(2));
+  if (args.has("--help") || args.has("-h")) {
+    console.log(
+      "preflight — run every code-correctness gate dimension locally, report all failures.\n" +
+        "  --quick   skip the slow dotnet build + test\n" +
+        "  --help    this message",
+    );
+    return 0;
+  }
+  const quick = args.has("--quick") || args.has("--no-tests");
+
+  console.log(`Preflight (${quick ? "quick: lints + tsc" : "full: lints + tsc + build + test"})\n`);
+  const results: Result[] = [];
+  for (const check of CHECKS) {
+    if (quick && check.slow) continue;
+    results.push(runCheck(check));
+  }
+
+  const failed = results.filter((r) => r.status === "fail");
+  const skipped = results.filter((r) => r.status === "skip");
+
+  // Dump every failure's output together, so one run shows the whole picture.
+  if (failed.length > 0) {
+    console.log(`\n${"═".repeat(60)}\nFAILURES (${failed.length})\n${"═".repeat(60)}`);
+    for (const f of failed) {
+      console.log(`\n──── ${f.label} ────`);
+      console.log(f.output.trimEnd() || "(no output captured)");
+    }
+  }
+
+  console.log(`\n${"─".repeat(60)}\nSummary`);
+  for (const r of results) {
+    const mark = r.status === "pass" ? "✓" : r.status === "skip" ? "•" : "✗";
+    console.log(`  ${mark} ${r.label}${r.note ? ` — ${r.note}` : ""}`);
+  }
+  if (skipped.length > 0) {
+    console.log(
+      `\n${skipped.length} check(s) SKIPPED (tool unavailable locally) — they will still run in CI.`,
+    );
+  }
+  if (failed.length > 0) {
+    console.log(`\n✗ preflight: ${failed.length} check(s) failed.`);
+    return 1;
+  }
+  console.log(`\n✓ preflight: all ${results.length - skipped.length} executed check(s) passed.`);
+  return 0;
+}
+
+process.exit(main());


### PR DESCRIPTION
## Why

Root-cause fix for the 2026-06-13 main-green saga (7 PRs to clear breakage CI revealed one language at a time). The gate's lint job runs the per-language lints sequentially and **short-circuits at the first failure** — so a multi-language change surfaces one red per CI cycle. `preflight.ts` runs the same checks but **never bails early**: executes all, collects every failure, prints one summary. One local run before merge finds everything.

## What

- **`src/Core.TypeScript/hygiene/preflight.ts`** — runs no-conflict-markers, no-empty-dirs, markdownlint, tsc, and the F#/C#/Python/Rust/Go lints. `--quick` skips the slow dotnet build + test. Missing local tools (golangci-lint, dotnet) report **SKIP** (not FAIL — they still run in CI). Run-all-collect-all; exit 1 iff any check failed.
- **`package.json`** — `preflight` + `preflight:quick` scripts.

## First catches (it proved its value while I was building it)

- **`.claude/rules/culture-invariant-by-default.md`** — a real **MD032** markdownlint red on main (introduced by #8137) that the bare `markdownlint-cli2` invocation **missed**: the config has no `globs` key, so a no-arg run lints zero files (false pass). The preflight passes `"**/*.md"` like the gate — and caught it.
- **`.markdownlint-cli2.jsonc`** — ignore `**/node_modules/**` (was root-only `node_modules/**`) so nested untracked node_modules don't false-positive locally.

## Findings reported separately (NOT in this PR)

- Go format drift in `src/Core.Go/mixin/*.go`.
- `lint-go.ts` uses **mutating** `go fmt ./...` instead of verifying `gofmt -l` — so Go format drift silently auto-fixes and **never reds the gate**. Recommend switching to `gofmt -l`. (The preflight documents this caveat inline.)

## Validated
preflight ran all 9 quick checks PASS · markdownlint exit 0 after the MD032 fix · tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)