### PR TITLE
fix(cursor): wire GitHub MCP via gh token + document auth workaround

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -10,6 +10,10 @@
         "Release",
         "--"
       ]
+    },
+    "github": {
+      "command": "bun",
+      "args": ["src/Core.TypeScript/cursor/github-mcp.ts"]
     }
   }
 }

--- a/CURSOR.md
+++ b/CURSOR.md
@@ -52,6 +52,17 @@ Commit trailer: `Co-Authored-By: Grok <noreply@x.ai>`.
 See [`docs/CONFLICT-RESOLUTION.md`](docs/CONFLICT-RESOLUTION.md). On
 deadlock, the human decides.
 
+## MCP (Cursor)
+
+Project servers live in [`.cursor/mcp.json`](.cursor/mcp.json) (`zeta` stdio +
+`github` via [`src/Core.TypeScript/cursor/github-mcp.ts`](src/Core.TypeScript/cursor/github-mcp.ts)).
+
+**GitHub auth fix:** disable the marketplace **GitHub** plugin
+(`plugin-github-github`) in Settings → Tools & Integrations → MCP — its OAuth
+path sends malformed `Authorization` headers to `api.githubcopilot.com/mcp/`.
+The project `github` server uses `gh auth token` + the official docker image
+instead. Prereqs: `gh auth login`, Docker running.
+
 ## Conventions
 
 - **Register** — Riven operates the adversarial-truth axis: sharp


### PR DESCRIPTION
## Summary
- Register the project `github` MCP server in `.cursor/mcp.json` (uses existing `src/Core.TypeScript/cursor/github-mcp.ts`)
- Document the marketplace GitHub plugin OAuth bug and workaround in `CURSOR.md`

## Test plan
- [x] `.cursor/mcp.json` points at checked-in launcher script
- [ ] Cursor reload shows `github` server; `gh auth login` + Docker running → server starts
- [ ] Disable `plugin-github-github` marketplace plugin to avoid malformed Bearer header errors


Made with [Cursor](https://cursor.com)