### PR TITLE
fix(lint): lint-go verifies formatting (gofmt -l) instead of mutating (go fmt)

### DIFF
--- a/src/Core.Go/mixin/mixin.go
+++ b/src/Core.Go/mixin/mixin.go
@@ -6,7 +6,7 @@ import (
 	"weak"
 )
 
-/// Thread-safe and GC-safe weak-keyed identity table for attaching state to objects.
+// / Thread-safe and GC-safe weak-keyed identity table for attaching state to objects.
 type WeakMap[K any, V any] struct {
 	mu sync.RWMutex
 	m  map[weak.Pointer[K]]V
@@ -18,7 +18,7 @@ func NewWeakMap[K any, V any]() *WeakMap[K, V] {
 	}
 }
 
-/// Attach a state value to the key pointer. Overwrites if it already exists.
+// / Attach a state value to the key pointer. Overwrites if it already exists.
 func (wm *WeakMap[K, V]) Set(key *K, val V) {
 	if key == nil {
 		return
@@ -37,7 +37,7 @@ func (wm *WeakMap[K, V]) Set(key *K, val V) {
 	}, wp)
 }
 
-/// Try to get the state value associated with the key pointer.
+// / Try to get the state value associated with the key pointer.
 func (wm *WeakMap[K, V]) Get(key *K) (V, bool) {
 	var zero V
 	if key == nil {
@@ -51,7 +51,7 @@ func (wm *WeakMap[K, V]) Get(key *K) (V, bool) {
 	return val, ok
 }
 
-/// Delete the entry associated with the key pointer. Returns true if removed, false otherwise.
+// / Delete the entry associated with the key pointer. Returns true if removed, false otherwise.
 func (wm *WeakMap[K, V]) Delete(key *K) bool {
 	if key == nil {
 		return false

--- a/src/Core.Go/mixin/mixin_test.go
+++ b/src/Core.Go/mixin/mixin_test.go
@@ -41,7 +41,7 @@ func TestWeakMapBasic(t *testing.T) {
 
 func TestWeakMapGC(t *testing.T) {
 	wm := NewWeakMap[DummyKey, int]()
-	
+
 	// Create key inside local scope/helper so it gets collected
 	runGCScenario(wm)
 

--- a/src/Core.TypeScript/lint/lint-go.ts
+++ b/src/Core.TypeScript/lint/lint-go.ts
@@ -1,12 +1,19 @@
 #!/usr/bin/env bun
 // lint-go.ts — Go formatting and linting checks.
 //
-// Post-install orchestration of native Go toolchains (go fmt / golangci-lint
+// Post-install orchestration of native Go toolchains (gofmt / golangci-lint
 // in src/Core.Go) — it runs in CI where Bun is already available, so it is
 // OUR CODE, not shell.
 //
+// FORMATTING IS VERIFIED, NOT APPLIED. We run `gofmt -l` (list files that are
+// not formatted) and FAIL if any are listed — like every other language's
+// `--check` / `--verify-no-changes`. The earlier `go fmt ./...` REWROTE files
+// in place and returned 0, so committed Go format drift never failed the gate
+// (it was silently auto-fixed on each run and re-drifted on the next commit).
+//
 // Usage:
 //   bun src/Core.TypeScript/lint/lint-go.ts
+//   # to fix drift locally: (cd src/Core.Go && gofmt -w .)
 
 import { spawnSync } from "node:child_process";
 import { dirname, join, resolve } from "node:path";
@@ -17,35 +24,45 @@ const here = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(here, "..", "..", "..");
 const GO_DIR = join(REPO_ROOT, "src", "Core.Go");
 
-interface Step {
-  readonly label: string;
-  readonly cmd: readonly [string, ...string[]];
+/** gofmt -l lists unformatted files and exits 0 even when it lists some, so we
+ * must FAIL on non-empty output (not on exit code). Never mutates. */
+function checkFormatting(): boolean {
+  console.log("=== Linting Go: gofmt -l (verify, no mutate) ===");
+  const result = spawnSync("gofmt", ["-l", "."], { cwd: GO_DIR, encoding: "utf8" });
+  if (result.error) {
+    console.error(`✗ gofmt: failed to start — ${result.error.message}`);
+    return false;
+  }
+  const listed = (result.stdout ?? "").trim();
+  if (listed.length > 0) {
+    console.error("✗ Go formatting drift — these files are not gofmt-clean:");
+    console.error(listed);
+    console.error("  Fix with: (cd src/Core.Go && gofmt -w .)");
+    return false;
+  }
+  return true;
 }
 
-const STEPS: readonly Step[] = [
-  { label: "Linting Go: go fmt", cmd: ["go", "fmt", "./..."] },
-  { label: "Linting Go: golangci-lint", cmd: ["golangci-lint", "run", "./..."] },
-];
-
-function run(step: Step): boolean {
-  console.log(`=== ${step.label} ===`);
-  const [bin, ...args] = step.cmd;
-  const result = spawnSync(bin, args, { cwd: GO_DIR, stdio: "inherit" });
+/** golangci-lint: exit-code based (0 = clean). */
+function checkLint(): boolean {
+  console.log("=== Linting Go: golangci-lint ===");
+  const result = spawnSync("golangci-lint", ["run", "./..."], { cwd: GO_DIR, stdio: "inherit" });
   if (result.error) {
-    console.error(`✗ ${step.label}: failed to start — ${result.error.message}`);
+    console.error(`✗ golangci-lint: failed to start — ${result.error.message}`);
     return false;
   }
   if (result.status !== 0) {
-    console.error(`✗ ${step.label}: exited with code ${result.status ?? "signal"}`);
+    console.error(`✗ golangci-lint: exited with code ${result.status ?? "signal"}`);
     return false;
   }
   return true;
 }
 
 function main(): number {
-  for (const step of STEPS) {
-    if (!run(step)) return 1;
-  }
+  // Run BOTH (don't short-circuit) so one run surfaces format + lint issues together.
+  const okFmt = checkFormatting();
+  const okLint = checkLint();
+  if (!okFmt || !okLint) return 1;
   console.log("✓ Go linting checks passed successfully!");
   return 0;
 }


### PR DESCRIPTION
Closes the Go format blind spot found while building the preflight (#8143).

## The gap

The Go lint ran `go fmt ./...`, which **rewrites files in place and returns 0** — so committed Go format drift was silently auto-fixed each run and **never failed the gate**, unlike every other language's `--check` / `--verify-no-changes`.

## Fix

- **`lint-go.ts`**: `go fmt ./...` → `gofmt -l .`, FAIL on non-empty output (drift), never mutate. Runs fmt + golangci without short-circuit so one run surfaces both. Remediation hint → `gofmt -w`.
- **`src/Core.Go/mixin/{mixin.go,mixin_test.go}`**: apply the formatting the old check had been silently re-applying each run (the real drift from #8115's Go side, never committed gofmt-clean).

## Verified
`preflight --quick` passes all 9 checks (gofmt -l clean + golangci 0 issues for Go).

🤖 Generated with [Claude Code](https://claude.com/claude-code)