### PR TITLE
feat(hygiene): consolidate daily manifesto-citation snapshots (May 30 - Jun 14)

### DIFF
--- a/docs/hygiene-history/manifesto-citations/2026-05-30.json
+++ b/docs/hygiene-history/manifesto-citations/2026-05-30.json
@@ -1,0 +1,140 @@
+{
+  "date": "2026-05-30",
+  "totalCitations": 754,
+  "totalFilesWithCitation": 101,
+  "totalFilesScanned": 4961,
+  "surfaces": [
+    {
+      "surface": "rules",
+      "filesScanned": 99,
+      "filesWithCitation": 4,
+      "citationCount": 6,
+      "byForm": {
+        "path": 2,
+        "name": 1,
+        "version-tag": 2,
+        "constraint-N": 1
+      }
+    },
+    {
+      "surface": "skills",
+      "filesScanned": 258,
+      "filesWithCitation": 2,
+      "citationCount": 8,
+      "byForm": {
+        "path": 1,
+        "name": 4,
+        "version-tag": 1,
+        "constraint-N": 2
+      }
+    },
+    {
+      "surface": "agents",
+      "filesScanned": 19,
+      "filesWithCitation": 1,
+      "citationCount": 8,
+      "byForm": {
+        "path": 2,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "commands",
+      "filesScanned": 5,
+      "filesWithCitation": 0,
+      "citationCount": 0,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 0,
+        "constraint-N": 0
+      }
+    },
+    {
+      "surface": "governance",
+      "filesScanned": 2,
+      "filesWithCitation": 1,
+      "citationCount": 3,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 2,
+        "constraint-N": 1
+      }
+    },
+    {
+      "surface": "trajectories",
+      "filesScanned": 38,
+      "filesWithCitation": 2,
+      "citationCount": 16,
+      "byForm": {
+        "path": 4,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 9
+      }
+    },
+    {
+      "surface": "agendas",
+      "filesScanned": 7,
+      "filesWithCitation": 3,
+      "citationCount": 19,
+      "byForm": {
+        "path": 6,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 10
+      }
+    },
+    {
+      "surface": "research",
+      "filesScanned": 578,
+      "filesWithCitation": 16,
+      "citationCount": 25,
+      "byForm": {
+        "path": 0,
+        "name": 11,
+        "version-tag": 11,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "backlog",
+      "filesScanned": 1027,
+      "filesWithCitation": 13,
+      "citationCount": 103,
+      "byForm": {
+        "path": 16,
+        "name": 61,
+        "version-tag": 13,
+        "constraint-N": 13
+      }
+    },
+    {
+      "surface": "memory",
+      "filesScanned": 1698,
+      "filesWithCitation": 44,
+      "citationCount": 517,
+      "byForm": {
+        "path": 31,
+        "name": 315,
+        "version-tag": 88,
+        "constraint-N": 83
+      }
+    },
+    {
+      "surface": "hygiene-history",
+      "filesScanned": 1230,
+      "filesWithCitation": 15,
+      "citationCount": 49,
+      "byForm": {
+        "path": 6,
+        "name": 31,
+        "version-tag": 8,
+        "constraint-N": 4
+      }
+    }
+  ]
+}

--- a/docs/hygiene-history/manifesto-citations/2026-05-31.json
+++ b/docs/hygiene-history/manifesto-citations/2026-05-31.json
@@ -1,0 +1,140 @@
+{
+  "date": "2026-05-31",
+  "totalCitations": 754,
+  "totalFilesWithCitation": 101,
+  "totalFilesScanned": 5014,
+  "surfaces": [
+    {
+      "surface": "rules",
+      "filesScanned": 101,
+      "filesWithCitation": 4,
+      "citationCount": 6,
+      "byForm": {
+        "path": 2,
+        "name": 1,
+        "version-tag": 2,
+        "constraint-N": 1
+      }
+    },
+    {
+      "surface": "skills",
+      "filesScanned": 259,
+      "filesWithCitation": 2,
+      "citationCount": 8,
+      "byForm": {
+        "path": 1,
+        "name": 4,
+        "version-tag": 1,
+        "constraint-N": 2
+      }
+    },
+    {
+      "surface": "agents",
+      "filesScanned": 19,
+      "filesWithCitation": 1,
+      "citationCount": 8,
+      "byForm": {
+        "path": 2,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "commands",
+      "filesScanned": 5,
+      "filesWithCitation": 0,
+      "citationCount": 0,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 0,
+        "constraint-N": 0
+      }
+    },
+    {
+      "surface": "governance",
+      "filesScanned": 2,
+      "filesWithCitation": 1,
+      "citationCount": 3,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 2,
+        "constraint-N": 1
+      }
+    },
+    {
+      "surface": "trajectories",
+      "filesScanned": 56,
+      "filesWithCitation": 2,
+      "citationCount": 16,
+      "byForm": {
+        "path": 4,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 9
+      }
+    },
+    {
+      "surface": "agendas",
+      "filesScanned": 7,
+      "filesWithCitation": 3,
+      "citationCount": 19,
+      "byForm": {
+        "path": 6,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 10
+      }
+    },
+    {
+      "surface": "research",
+      "filesScanned": 587,
+      "filesWithCitation": 16,
+      "citationCount": 25,
+      "byForm": {
+        "path": 0,
+        "name": 11,
+        "version-tag": 11,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "backlog",
+      "filesScanned": 1038,
+      "filesWithCitation": 13,
+      "citationCount": 103,
+      "byForm": {
+        "path": 16,
+        "name": 61,
+        "version-tag": 13,
+        "constraint-N": 13
+      }
+    },
+    {
+      "surface": "memory",
+      "filesScanned": 1710,
+      "filesWithCitation": 44,
+      "citationCount": 517,
+      "byForm": {
+        "path": 31,
+        "name": 315,
+        "version-tag": 88,
+        "constraint-N": 83
+      }
+    },
+    {
+      "surface": "hygiene-history",
+      "filesScanned": 1230,
+      "filesWithCitation": 15,
+      "citationCount": 49,
+      "byForm": {
+        "path": 6,
+        "name": 31,
+        "version-tag": 8,
+        "constraint-N": 4
+      }
+    }
+  ]
+}

--- a/docs/hygiene-history/manifesto-citations/2026-06-01.json
+++ b/docs/hygiene-history/manifesto-citations/2026-06-01.json
@@ -1,0 +1,140 @@
+{
+  "date": "2026-06-01",
+  "totalCitations": 755,
+  "totalFilesWithCitation": 102,
+  "totalFilesScanned": 5083,
+  "surfaces": [
+    {
+      "surface": "rules",
+      "filesScanned": 104,
+      "filesWithCitation": 4,
+      "citationCount": 6,
+      "byForm": {
+        "path": 2,
+        "name": 1,
+        "version-tag": 2,
+        "constraint-N": 1
+      }
+    },
+    {
+      "surface": "skills",
+      "filesScanned": 260,
+      "filesWithCitation": 2,
+      "citationCount": 8,
+      "byForm": {
+        "path": 1,
+        "name": 4,
+        "version-tag": 1,
+        "constraint-N": 2
+      }
+    },
+    {
+      "surface": "agents",
+      "filesScanned": 19,
+      "filesWithCitation": 1,
+      "citationCount": 8,
+      "byForm": {
+        "path": 2,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "commands",
+      "filesScanned": 5,
+      "filesWithCitation": 0,
+      "citationCount": 0,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 0,
+        "constraint-N": 0
+      }
+    },
+    {
+      "surface": "governance",
+      "filesScanned": 2,
+      "filesWithCitation": 1,
+      "citationCount": 3,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 2,
+        "constraint-N": 1
+      }
+    },
+    {
+      "surface": "trajectories",
+      "filesScanned": 56,
+      "filesWithCitation": 2,
+      "citationCount": 16,
+      "byForm": {
+        "path": 4,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 9
+      }
+    },
+    {
+      "surface": "agendas",
+      "filesScanned": 20,
+      "filesWithCitation": 3,
+      "citationCount": 19,
+      "byForm": {
+        "path": 6,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 10
+      }
+    },
+    {
+      "surface": "research",
+      "filesScanned": 603,
+      "filesWithCitation": 16,
+      "citationCount": 25,
+      "byForm": {
+        "path": 0,
+        "name": 11,
+        "version-tag": 11,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "backlog",
+      "filesScanned": 1070,
+      "filesWithCitation": 14,
+      "citationCount": 104,
+      "byForm": {
+        "path": 16,
+        "name": 62,
+        "version-tag": 13,
+        "constraint-N": 13
+      }
+    },
+    {
+      "surface": "memory",
+      "filesScanned": 1714,
+      "filesWithCitation": 44,
+      "citationCount": 517,
+      "byForm": {
+        "path": 31,
+        "name": 315,
+        "version-tag": 88,
+        "constraint-N": 83
+      }
+    },
+    {
+      "surface": "hygiene-history",
+      "filesScanned": 1230,
+      "filesWithCitation": 15,
+      "citationCount": 49,
+      "byForm": {
+        "path": 6,
+        "name": 31,
+        "version-tag": 8,
+        "constraint-N": 4
+      }
+    }
+  ]
+}

--- a/docs/hygiene-history/manifesto-citations/2026-06-02.json
+++ b/docs/hygiene-history/manifesto-citations/2026-06-02.json
@@ -1,0 +1,140 @@
+{
+  "date": "2026-06-02",
+  "totalCitations": 755,
+  "totalFilesWithCitation": 102,
+  "totalFilesScanned": 5117,
+  "surfaces": [
+    {
+      "surface": "rules",
+      "filesScanned": 104,
+      "filesWithCitation": 4,
+      "citationCount": 6,
+      "byForm": {
+        "path": 2,
+        "name": 1,
+        "version-tag": 2,
+        "constraint-N": 1
+      }
+    },
+    {
+      "surface": "skills",
+      "filesScanned": 260,
+      "filesWithCitation": 2,
+      "citationCount": 8,
+      "byForm": {
+        "path": 1,
+        "name": 4,
+        "version-tag": 1,
+        "constraint-N": 2
+      }
+    },
+    {
+      "surface": "agents",
+      "filesScanned": 19,
+      "filesWithCitation": 1,
+      "citationCount": 8,
+      "byForm": {
+        "path": 2,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "commands",
+      "filesScanned": 5,
+      "filesWithCitation": 0,
+      "citationCount": 0,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 0,
+        "constraint-N": 0
+      }
+    },
+    {
+      "surface": "governance",
+      "filesScanned": 2,
+      "filesWithCitation": 1,
+      "citationCount": 3,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 2,
+        "constraint-N": 1
+      }
+    },
+    {
+      "surface": "trajectories",
+      "filesScanned": 56,
+      "filesWithCitation": 2,
+      "citationCount": 16,
+      "byForm": {
+        "path": 4,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 9
+      }
+    },
+    {
+      "surface": "agendas",
+      "filesScanned": 33,
+      "filesWithCitation": 3,
+      "citationCount": 19,
+      "byForm": {
+        "path": 6,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 10
+      }
+    },
+    {
+      "surface": "research",
+      "filesScanned": 612,
+      "filesWithCitation": 16,
+      "citationCount": 25,
+      "byForm": {
+        "path": 0,
+        "name": 11,
+        "version-tag": 11,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "backlog",
+      "filesScanned": 1079,
+      "filesWithCitation": 14,
+      "citationCount": 104,
+      "byForm": {
+        "path": 16,
+        "name": 62,
+        "version-tag": 13,
+        "constraint-N": 13
+      }
+    },
+    {
+      "surface": "memory",
+      "filesScanned": 1717,
+      "filesWithCitation": 44,
+      "citationCount": 517,
+      "byForm": {
+        "path": 31,
+        "name": 315,
+        "version-tag": 88,
+        "constraint-N": 83
+      }
+    },
+    {
+      "surface": "hygiene-history",
+      "filesScanned": 1230,
+      "filesWithCitation": 15,
+      "citationCount": 49,
+      "byForm": {
+        "path": 6,
+        "name": 31,
+        "version-tag": 8,
+        "constraint-N": 4
+      }
+    }
+  ]
+}

--- a/docs/hygiene-history/manifesto-citations/2026-06-03.json
+++ b/docs/hygiene-history/manifesto-citations/2026-06-03.json
@@ -1,0 +1,140 @@
+{
+  "date": "2026-06-03",
+  "totalCitations": 794,
+  "totalFilesWithCitation": 112,
+  "totalFilesScanned": 5191,
+  "surfaces": [
+    {
+      "surface": "rules",
+      "filesScanned": 111,
+      "filesWithCitation": 4,
+      "citationCount": 6,
+      "byForm": {
+        "path": 2,
+        "name": 1,
+        "version-tag": 2,
+        "constraint-N": 1
+      }
+    },
+    {
+      "surface": "skills",
+      "filesScanned": 260,
+      "filesWithCitation": 2,
+      "citationCount": 8,
+      "byForm": {
+        "path": 1,
+        "name": 4,
+        "version-tag": 1,
+        "constraint-N": 2
+      }
+    },
+    {
+      "surface": "agents",
+      "filesScanned": 19,
+      "filesWithCitation": 1,
+      "citationCount": 8,
+      "byForm": {
+        "path": 2,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "commands",
+      "filesScanned": 5,
+      "filesWithCitation": 0,
+      "citationCount": 0,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 0,
+        "constraint-N": 0
+      }
+    },
+    {
+      "surface": "governance",
+      "filesScanned": 2,
+      "filesWithCitation": 1,
+      "citationCount": 3,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 2,
+        "constraint-N": 1
+      }
+    },
+    {
+      "surface": "trajectories",
+      "filesScanned": 56,
+      "filesWithCitation": 2,
+      "citationCount": 16,
+      "byForm": {
+        "path": 4,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 9
+      }
+    },
+    {
+      "surface": "agendas",
+      "filesScanned": 44,
+      "filesWithCitation": 3,
+      "citationCount": 19,
+      "byForm": {
+        "path": 6,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 10
+      }
+    },
+    {
+      "surface": "research",
+      "filesScanned": 626,
+      "filesWithCitation": 18,
+      "citationCount": 32,
+      "byForm": {
+        "path": 0,
+        "name": 18,
+        "version-tag": 11,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "backlog",
+      "filesScanned": 1111,
+      "filesWithCitation": 15,
+      "citationCount": 105,
+      "byForm": {
+        "path": 16,
+        "name": 63,
+        "version-tag": 13,
+        "constraint-N": 13
+      }
+    },
+    {
+      "surface": "memory",
+      "filesScanned": 1727,
+      "filesWithCitation": 51,
+      "citationCount": 548,
+      "byForm": {
+        "path": 31,
+        "name": 346,
+        "version-tag": 88,
+        "constraint-N": 83
+      }
+    },
+    {
+      "surface": "hygiene-history",
+      "filesScanned": 1230,
+      "filesWithCitation": 15,
+      "citationCount": 49,
+      "byForm": {
+        "path": 6,
+        "name": 31,
+        "version-tag": 8,
+        "constraint-N": 4
+      }
+    }
+  ]
+}

--- a/docs/hygiene-history/manifesto-citations/2026-06-04.json
+++ b/docs/hygiene-history/manifesto-citations/2026-06-04.json
@@ -1,0 +1,140 @@
+{
+  "date": "2026-06-04",
+  "totalCitations": 794,
+  "totalFilesWithCitation": 112,
+  "totalFilesScanned": 5195,
+  "surfaces": [
+    {
+      "surface": "rules",
+      "filesScanned": 111,
+      "filesWithCitation": 4,
+      "citationCount": 6,
+      "byForm": {
+        "path": 2,
+        "name": 1,
+        "version-tag": 2,
+        "constraint-N": 1
+      }
+    },
+    {
+      "surface": "skills",
+      "filesScanned": 260,
+      "filesWithCitation": 2,
+      "citationCount": 8,
+      "byForm": {
+        "path": 1,
+        "name": 4,
+        "version-tag": 1,
+        "constraint-N": 2
+      }
+    },
+    {
+      "surface": "agents",
+      "filesScanned": 19,
+      "filesWithCitation": 1,
+      "citationCount": 8,
+      "byForm": {
+        "path": 2,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "commands",
+      "filesScanned": 5,
+      "filesWithCitation": 0,
+      "citationCount": 0,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 0,
+        "constraint-N": 0
+      }
+    },
+    {
+      "surface": "governance",
+      "filesScanned": 2,
+      "filesWithCitation": 1,
+      "citationCount": 3,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 2,
+        "constraint-N": 1
+      }
+    },
+    {
+      "surface": "trajectories",
+      "filesScanned": 56,
+      "filesWithCitation": 2,
+      "citationCount": 16,
+      "byForm": {
+        "path": 4,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 9
+      }
+    },
+    {
+      "surface": "agendas",
+      "filesScanned": 47,
+      "filesWithCitation": 3,
+      "citationCount": 19,
+      "byForm": {
+        "path": 6,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 10
+      }
+    },
+    {
+      "surface": "research",
+      "filesScanned": 627,
+      "filesWithCitation": 18,
+      "citationCount": 32,
+      "byForm": {
+        "path": 0,
+        "name": 18,
+        "version-tag": 11,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "backlog",
+      "filesScanned": 1111,
+      "filesWithCitation": 15,
+      "citationCount": 105,
+      "byForm": {
+        "path": 16,
+        "name": 63,
+        "version-tag": 13,
+        "constraint-N": 13
+      }
+    },
+    {
+      "surface": "memory",
+      "filesScanned": 1727,
+      "filesWithCitation": 51,
+      "citationCount": 548,
+      "byForm": {
+        "path": 31,
+        "name": 346,
+        "version-tag": 88,
+        "constraint-N": 83
+      }
+    },
+    {
+      "surface": "hygiene-history",
+      "filesScanned": 1230,
+      "filesWithCitation": 15,
+      "citationCount": 49,
+      "byForm": {
+        "path": 6,
+        "name": 31,
+        "version-tag": 8,
+        "constraint-N": 4
+      }
+    }
+  ]
+}

--- a/docs/hygiene-history/manifesto-citations/2026-06-05.json
+++ b/docs/hygiene-history/manifesto-citations/2026-06-05.json
@@ -1,0 +1,140 @@
+{
+  "date": "2026-06-05",
+  "totalCitations": 801,
+  "totalFilesWithCitation": 111,
+  "totalFilesScanned": 5137,
+  "surfaces": [
+    {
+      "surface": "rules",
+      "filesScanned": 9,
+      "filesWithCitation": 2,
+      "citationCount": 10,
+      "byForm": {
+        "path": 4,
+        "name": 6,
+        "version-tag": 0,
+        "constraint-N": 0
+      }
+    },
+    {
+      "surface": "skills",
+      "filesScanned": 282,
+      "filesWithCitation": 2,
+      "citationCount": 8,
+      "byForm": {
+        "path": 1,
+        "name": 4,
+        "version-tag": 1,
+        "constraint-N": 2
+      }
+    },
+    {
+      "surface": "agents",
+      "filesScanned": 19,
+      "filesWithCitation": 1,
+      "citationCount": 8,
+      "byForm": {
+        "path": 2,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "commands",
+      "filesScanned": 5,
+      "filesWithCitation": 0,
+      "citationCount": 0,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 0,
+        "constraint-N": 0
+      }
+    },
+    {
+      "surface": "governance",
+      "filesScanned": 2,
+      "filesWithCitation": 1,
+      "citationCount": 3,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 2,
+        "constraint-N": 1
+      }
+    },
+    {
+      "surface": "trajectories",
+      "filesScanned": 56,
+      "filesWithCitation": 2,
+      "citationCount": 16,
+      "byForm": {
+        "path": 4,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 9
+      }
+    },
+    {
+      "surface": "agendas",
+      "filesScanned": 47,
+      "filesWithCitation": 3,
+      "citationCount": 19,
+      "byForm": {
+        "path": 6,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 10
+      }
+    },
+    {
+      "surface": "research",
+      "filesScanned": 628,
+      "filesWithCitation": 18,
+      "citationCount": 32,
+      "byForm": {
+        "path": 0,
+        "name": 18,
+        "version-tag": 11,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "backlog",
+      "filesScanned": 1116,
+      "filesWithCitation": 15,
+      "citationCount": 105,
+      "byForm": {
+        "path": 16,
+        "name": 63,
+        "version-tag": 13,
+        "constraint-N": 13
+      }
+    },
+    {
+      "surface": "memory",
+      "filesScanned": 1743,
+      "filesWithCitation": 52,
+      "citationCount": 551,
+      "byForm": {
+        "path": 31,
+        "name": 349,
+        "version-tag": 88,
+        "constraint-N": 83
+      }
+    },
+    {
+      "surface": "hygiene-history",
+      "filesScanned": 1230,
+      "filesWithCitation": 15,
+      "citationCount": 49,
+      "byForm": {
+        "path": 6,
+        "name": 31,
+        "version-tag": 8,
+        "constraint-N": 4
+      }
+    }
+  ]
+}

--- a/docs/hygiene-history/manifesto-citations/2026-06-06.json
+++ b/docs/hygiene-history/manifesto-citations/2026-06-06.json
@@ -1,0 +1,140 @@
+{
+  "date": "2026-06-06",
+  "totalCitations": 809,
+  "totalFilesWithCitation": 118,
+  "totalFilesScanned": 5174,
+  "surfaces": [
+    {
+      "surface": "rules",
+      "filesScanned": 9,
+      "filesWithCitation": 2,
+      "citationCount": 10,
+      "byForm": {
+        "path": 4,
+        "name": 6,
+        "version-tag": 0,
+        "constraint-N": 0
+      }
+    },
+    {
+      "surface": "skills",
+      "filesScanned": 282,
+      "filesWithCitation": 2,
+      "citationCount": 8,
+      "byForm": {
+        "path": 1,
+        "name": 4,
+        "version-tag": 1,
+        "constraint-N": 2
+      }
+    },
+    {
+      "surface": "agents",
+      "filesScanned": 19,
+      "filesWithCitation": 1,
+      "citationCount": 8,
+      "byForm": {
+        "path": 2,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "commands",
+      "filesScanned": 5,
+      "filesWithCitation": 0,
+      "citationCount": 0,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 0,
+        "constraint-N": 0
+      }
+    },
+    {
+      "surface": "governance",
+      "filesScanned": 2,
+      "filesWithCitation": 1,
+      "citationCount": 3,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 2,
+        "constraint-N": 1
+      }
+    },
+    {
+      "surface": "trajectories",
+      "filesScanned": 56,
+      "filesWithCitation": 2,
+      "citationCount": 16,
+      "byForm": {
+        "path": 4,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 9
+      }
+    },
+    {
+      "surface": "agendas",
+      "filesScanned": 47,
+      "filesWithCitation": 3,
+      "citationCount": 19,
+      "byForm": {
+        "path": 6,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 10
+      }
+    },
+    {
+      "surface": "research",
+      "filesScanned": 629,
+      "filesWithCitation": 18,
+      "citationCount": 32,
+      "byForm": {
+        "path": 0,
+        "name": 18,
+        "version-tag": 11,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "backlog",
+      "filesScanned": 1117,
+      "filesWithCitation": 15,
+      "citationCount": 105,
+      "byForm": {
+        "path": 16,
+        "name": 63,
+        "version-tag": 13,
+        "constraint-N": 13
+      }
+    },
+    {
+      "surface": "memory",
+      "filesScanned": 1778,
+      "filesWithCitation": 59,
+      "citationCount": 559,
+      "byForm": {
+        "path": 31,
+        "name": 357,
+        "version-tag": 88,
+        "constraint-N": 83
+      }
+    },
+    {
+      "surface": "hygiene-history",
+      "filesScanned": 1230,
+      "filesWithCitation": 15,
+      "citationCount": 49,
+      "byForm": {
+        "path": 6,
+        "name": 31,
+        "version-tag": 8,
+        "constraint-N": 4
+      }
+    }
+  ]
+}

--- a/docs/hygiene-history/manifesto-citations/2026-06-07.json
+++ b/docs/hygiene-history/manifesto-citations/2026-06-07.json
@@ -1,0 +1,140 @@
+{
+  "date": "2026-06-07",
+  "totalCitations": 825,
+  "totalFilesWithCitation": 126,
+  "totalFilesScanned": 5197,
+  "surfaces": [
+    {
+      "surface": "rules",
+      "filesScanned": 10,
+      "filesWithCitation": 3,
+      "citationCount": 14,
+      "byForm": {
+        "path": 4,
+        "name": 10,
+        "version-tag": 0,
+        "constraint-N": 0
+      }
+    },
+    {
+      "surface": "skills",
+      "filesScanned": 282,
+      "filesWithCitation": 2,
+      "citationCount": 8,
+      "byForm": {
+        "path": 1,
+        "name": 4,
+        "version-tag": 1,
+        "constraint-N": 2
+      }
+    },
+    {
+      "surface": "agents",
+      "filesScanned": 19,
+      "filesWithCitation": 1,
+      "citationCount": 8,
+      "byForm": {
+        "path": 2,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "commands",
+      "filesScanned": 5,
+      "filesWithCitation": 0,
+      "citationCount": 0,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 0,
+        "constraint-N": 0
+      }
+    },
+    {
+      "surface": "governance",
+      "filesScanned": 2,
+      "filesWithCitation": 1,
+      "citationCount": 3,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 2,
+        "constraint-N": 1
+      }
+    },
+    {
+      "surface": "trajectories",
+      "filesScanned": 56,
+      "filesWithCitation": 2,
+      "citationCount": 16,
+      "byForm": {
+        "path": 4,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 9
+      }
+    },
+    {
+      "surface": "agendas",
+      "filesScanned": 47,
+      "filesWithCitation": 3,
+      "citationCount": 19,
+      "byForm": {
+        "path": 6,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 10
+      }
+    },
+    {
+      "surface": "research",
+      "filesScanned": 637,
+      "filesWithCitation": 23,
+      "citationCount": 40,
+      "byForm": {
+        "path": 0,
+        "name": 26,
+        "version-tag": 11,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "backlog",
+      "filesScanned": 1117,
+      "filesWithCitation": 15,
+      "citationCount": 105,
+      "byForm": {
+        "path": 16,
+        "name": 63,
+        "version-tag": 13,
+        "constraint-N": 13
+      }
+    },
+    {
+      "surface": "memory",
+      "filesScanned": 1792,
+      "filesWithCitation": 61,
+      "citationCount": 563,
+      "byForm": {
+        "path": 31,
+        "name": 361,
+        "version-tag": 88,
+        "constraint-N": 83
+      }
+    },
+    {
+      "surface": "hygiene-history",
+      "filesScanned": 1230,
+      "filesWithCitation": 15,
+      "citationCount": 49,
+      "byForm": {
+        "path": 6,
+        "name": 31,
+        "version-tag": 8,
+        "constraint-N": 4
+      }
+    }
+  ]
+}

--- a/docs/hygiene-history/manifesto-citations/2026-06-08.json
+++ b/docs/hygiene-history/manifesto-citations/2026-06-08.json
@@ -1,0 +1,140 @@
+{
+  "date": "2026-06-08",
+  "totalCitations": 932,
+  "totalFilesWithCitation": 183,
+  "totalFilesScanned": 5374,
+  "surfaces": [
+    {
+      "surface": "rules",
+      "filesScanned": 10,
+      "filesWithCitation": 3,
+      "citationCount": 14,
+      "byForm": {
+        "path": 4,
+        "name": 10,
+        "version-tag": 0,
+        "constraint-N": 0
+      }
+    },
+    {
+      "surface": "skills",
+      "filesScanned": 282,
+      "filesWithCitation": 2,
+      "citationCount": 8,
+      "byForm": {
+        "path": 1,
+        "name": 4,
+        "version-tag": 1,
+        "constraint-N": 2
+      }
+    },
+    {
+      "surface": "agents",
+      "filesScanned": 19,
+      "filesWithCitation": 1,
+      "citationCount": 8,
+      "byForm": {
+        "path": 2,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "commands",
+      "filesScanned": 5,
+      "filesWithCitation": 0,
+      "citationCount": 0,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 0,
+        "constraint-N": 0
+      }
+    },
+    {
+      "surface": "governance",
+      "filesScanned": 2,
+      "filesWithCitation": 1,
+      "citationCount": 3,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 2,
+        "constraint-N": 1
+      }
+    },
+    {
+      "surface": "trajectories",
+      "filesScanned": 56,
+      "filesWithCitation": 2,
+      "citationCount": 16,
+      "byForm": {
+        "path": 4,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 9
+      }
+    },
+    {
+      "surface": "agendas",
+      "filesScanned": 47,
+      "filesWithCitation": 3,
+      "citationCount": 19,
+      "byForm": {
+        "path": 6,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 10
+      }
+    },
+    {
+      "surface": "research",
+      "filesScanned": 790,
+      "filesWithCitation": 76,
+      "citationCount": 138,
+      "byForm": {
+        "path": 0,
+        "name": 124,
+        "version-tag": 11,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "backlog",
+      "filesScanned": 1117,
+      "filesWithCitation": 15,
+      "citationCount": 105,
+      "byForm": {
+        "path": 16,
+        "name": 63,
+        "version-tag": 13,
+        "constraint-N": 13
+      }
+    },
+    {
+      "surface": "memory",
+      "filesScanned": 1816,
+      "filesWithCitation": 65,
+      "citationCount": 572,
+      "byForm": {
+        "path": 31,
+        "name": 370,
+        "version-tag": 88,
+        "constraint-N": 83
+      }
+    },
+    {
+      "surface": "hygiene-history",
+      "filesScanned": 1230,
+      "filesWithCitation": 15,
+      "citationCount": 49,
+      "byForm": {
+        "path": 6,
+        "name": 31,
+        "version-tag": 8,
+        "constraint-N": 4
+      }
+    }
+  ]
+}

--- a/docs/hygiene-history/manifesto-citations/2026-06-09.json
+++ b/docs/hygiene-history/manifesto-citations/2026-06-09.json
@@ -1,0 +1,140 @@
+{
+  "date": "2026-06-09",
+  "totalCitations": 992,
+  "totalFilesWithCitation": 210,
+  "totalFilesScanned": 5448,
+  "surfaces": [
+    {
+      "surface": "rules",
+      "filesScanned": 10,
+      "filesWithCitation": 3,
+      "citationCount": 14,
+      "byForm": {
+        "path": 4,
+        "name": 10,
+        "version-tag": 0,
+        "constraint-N": 0
+      }
+    },
+    {
+      "surface": "skills",
+      "filesScanned": 282,
+      "filesWithCitation": 2,
+      "citationCount": 8,
+      "byForm": {
+        "path": 1,
+        "name": 4,
+        "version-tag": 1,
+        "constraint-N": 2
+      }
+    },
+    {
+      "surface": "agents",
+      "filesScanned": 19,
+      "filesWithCitation": 1,
+      "citationCount": 8,
+      "byForm": {
+        "path": 2,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "commands",
+      "filesScanned": 5,
+      "filesWithCitation": 0,
+      "citationCount": 0,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 0,
+        "constraint-N": 0
+      }
+    },
+    {
+      "surface": "governance",
+      "filesScanned": 2,
+      "filesWithCitation": 1,
+      "citationCount": 3,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 2,
+        "constraint-N": 1
+      }
+    },
+    {
+      "surface": "trajectories",
+      "filesScanned": 56,
+      "filesWithCitation": 2,
+      "citationCount": 16,
+      "byForm": {
+        "path": 4,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 9
+      }
+    },
+    {
+      "surface": "agendas",
+      "filesScanned": 47,
+      "filesWithCitation": 3,
+      "citationCount": 19,
+      "byForm": {
+        "path": 6,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 10
+      }
+    },
+    {
+      "surface": "research",
+      "filesScanned": 864,
+      "filesWithCitation": 103,
+      "citationCount": 198,
+      "byForm": {
+        "path": 3,
+        "name": 181,
+        "version-tag": 11,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "backlog",
+      "filesScanned": 1117,
+      "filesWithCitation": 15,
+      "citationCount": 105,
+      "byForm": {
+        "path": 16,
+        "name": 63,
+        "version-tag": 13,
+        "constraint-N": 13
+      }
+    },
+    {
+      "surface": "memory",
+      "filesScanned": 1816,
+      "filesWithCitation": 65,
+      "citationCount": 572,
+      "byForm": {
+        "path": 31,
+        "name": 370,
+        "version-tag": 88,
+        "constraint-N": 83
+      }
+    },
+    {
+      "surface": "hygiene-history",
+      "filesScanned": 1230,
+      "filesWithCitation": 15,
+      "citationCount": 49,
+      "byForm": {
+        "path": 6,
+        "name": 31,
+        "version-tag": 8,
+        "constraint-N": 4
+      }
+    }
+  ]
+}

--- a/docs/hygiene-history/manifesto-citations/2026-06-10.json
+++ b/docs/hygiene-history/manifesto-citations/2026-06-10.json
@@ -1,0 +1,140 @@
+{
+  "date": "2026-06-10",
+  "totalCitations": 1033,
+  "totalFilesWithCitation": 234,
+  "totalFilesScanned": 5616,
+  "surfaces": [
+    {
+      "surface": "rules",
+      "filesScanned": 12,
+      "filesWithCitation": 5,
+      "citationCount": 18,
+      "byForm": {
+        "path": 4,
+        "name": 14,
+        "version-tag": 0,
+        "constraint-N": 0
+      }
+    },
+    {
+      "surface": "skills",
+      "filesScanned": 284,
+      "filesWithCitation": 2,
+      "citationCount": 8,
+      "byForm": {
+        "path": 1,
+        "name": 4,
+        "version-tag": 1,
+        "constraint-N": 2
+      }
+    },
+    {
+      "surface": "agents",
+      "filesScanned": 20,
+      "filesWithCitation": 1,
+      "citationCount": 8,
+      "byForm": {
+        "path": 2,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "commands",
+      "filesScanned": 5,
+      "filesWithCitation": 0,
+      "citationCount": 0,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 0,
+        "constraint-N": 0
+      }
+    },
+    {
+      "surface": "governance",
+      "filesScanned": 2,
+      "filesWithCitation": 1,
+      "citationCount": 3,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 2,
+        "constraint-N": 1
+      }
+    },
+    {
+      "surface": "trajectories",
+      "filesScanned": 56,
+      "filesWithCitation": 2,
+      "citationCount": 16,
+      "byForm": {
+        "path": 4,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 9
+      }
+    },
+    {
+      "surface": "agendas",
+      "filesScanned": 47,
+      "filesWithCitation": 3,
+      "citationCount": 19,
+      "byForm": {
+        "path": 6,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 10
+      }
+    },
+    {
+      "surface": "research",
+      "filesScanned": 1027,
+      "filesWithCitation": 125,
+      "citationCount": 235,
+      "byForm": {
+        "path": 4,
+        "name": 217,
+        "version-tag": 11,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "backlog",
+      "filesScanned": 1117,
+      "filesWithCitation": 15,
+      "citationCount": 105,
+      "byForm": {
+        "path": 16,
+        "name": 63,
+        "version-tag": 13,
+        "constraint-N": 13
+      }
+    },
+    {
+      "surface": "memory",
+      "filesScanned": 1816,
+      "filesWithCitation": 65,
+      "citationCount": 572,
+      "byForm": {
+        "path": 31,
+        "name": 370,
+        "version-tag": 88,
+        "constraint-N": 83
+      }
+    },
+    {
+      "surface": "hygiene-history",
+      "filesScanned": 1230,
+      "filesWithCitation": 15,
+      "citationCount": 49,
+      "byForm": {
+        "path": 6,
+        "name": 31,
+        "version-tag": 8,
+        "constraint-N": 4
+      }
+    }
+  ]
+}

--- a/docs/hygiene-history/manifesto-citations/2026-06-11.json
+++ b/docs/hygiene-history/manifesto-citations/2026-06-11.json
@@ -1,0 +1,140 @@
+{
+  "date": "2026-06-11",
+  "totalCitations": 1050,
+  "totalFilesWithCitation": 243,
+  "totalFilesScanned": 5667,
+  "surfaces": [
+    {
+      "surface": "rules",
+      "filesScanned": 12,
+      "filesWithCitation": 5,
+      "citationCount": 21,
+      "byForm": {
+        "path": 4,
+        "name": 17,
+        "version-tag": 0,
+        "constraint-N": 0
+      }
+    },
+    {
+      "surface": "skills",
+      "filesScanned": 284,
+      "filesWithCitation": 2,
+      "citationCount": 8,
+      "byForm": {
+        "path": 1,
+        "name": 4,
+        "version-tag": 1,
+        "constraint-N": 2
+      }
+    },
+    {
+      "surface": "agents",
+      "filesScanned": 20,
+      "filesWithCitation": 1,
+      "citationCount": 8,
+      "byForm": {
+        "path": 2,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "commands",
+      "filesScanned": 5,
+      "filesWithCitation": 0,
+      "citationCount": 0,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 0,
+        "constraint-N": 0
+      }
+    },
+    {
+      "surface": "governance",
+      "filesScanned": 2,
+      "filesWithCitation": 1,
+      "citationCount": 3,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 2,
+        "constraint-N": 1
+      }
+    },
+    {
+      "surface": "trajectories",
+      "filesScanned": 57,
+      "filesWithCitation": 3,
+      "citationCount": 18,
+      "byForm": {
+        "path": 4,
+        "name": 5,
+        "version-tag": 0,
+        "constraint-N": 9
+      }
+    },
+    {
+      "surface": "agendas",
+      "filesScanned": 47,
+      "filesWithCitation": 3,
+      "citationCount": 19,
+      "byForm": {
+        "path": 6,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 10
+      }
+    },
+    {
+      "surface": "research",
+      "filesScanned": 1072,
+      "filesWithCitation": 133,
+      "citationCount": 247,
+      "byForm": {
+        "path": 5,
+        "name": 228,
+        "version-tag": 11,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "backlog",
+      "filesScanned": 1122,
+      "filesWithCitation": 15,
+      "citationCount": 105,
+      "byForm": {
+        "path": 16,
+        "name": 63,
+        "version-tag": 13,
+        "constraint-N": 13
+      }
+    },
+    {
+      "surface": "memory",
+      "filesScanned": 1816,
+      "filesWithCitation": 65,
+      "citationCount": 572,
+      "byForm": {
+        "path": 31,
+        "name": 370,
+        "version-tag": 88,
+        "constraint-N": 83
+      }
+    },
+    {
+      "surface": "hygiene-history",
+      "filesScanned": 1230,
+      "filesWithCitation": 15,
+      "citationCount": 49,
+      "byForm": {
+        "path": 6,
+        "name": 31,
+        "version-tag": 8,
+        "constraint-N": 4
+      }
+    }
+  ]
+}

--- a/docs/hygiene-history/manifesto-citations/2026-06-12.json
+++ b/docs/hygiene-history/manifesto-citations/2026-06-12.json
@@ -1,0 +1,140 @@
+{
+  "date": "2026-06-12",
+  "totalCitations": 1063,
+  "totalFilesWithCitation": 247,
+  "totalFilesScanned": 5730,
+  "surfaces": [
+    {
+      "surface": "rules",
+      "filesScanned": 12,
+      "filesWithCitation": 5,
+      "citationCount": 21,
+      "byForm": {
+        "path": 4,
+        "name": 17,
+        "version-tag": 0,
+        "constraint-N": 0
+      }
+    },
+    {
+      "surface": "skills",
+      "filesScanned": 284,
+      "filesWithCitation": 2,
+      "citationCount": 8,
+      "byForm": {
+        "path": 1,
+        "name": 4,
+        "version-tag": 1,
+        "constraint-N": 2
+      }
+    },
+    {
+      "surface": "agents",
+      "filesScanned": 20,
+      "filesWithCitation": 1,
+      "citationCount": 8,
+      "byForm": {
+        "path": 2,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "commands",
+      "filesScanned": 5,
+      "filesWithCitation": 0,
+      "citationCount": 0,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 0,
+        "constraint-N": 0
+      }
+    },
+    {
+      "surface": "governance",
+      "filesScanned": 2,
+      "filesWithCitation": 1,
+      "citationCount": 3,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 2,
+        "constraint-N": 1
+      }
+    },
+    {
+      "surface": "trajectories",
+      "filesScanned": 57,
+      "filesWithCitation": 3,
+      "citationCount": 19,
+      "byForm": {
+        "path": 4,
+        "name": 6,
+        "version-tag": 0,
+        "constraint-N": 9
+      }
+    },
+    {
+      "surface": "agendas",
+      "filesScanned": 47,
+      "filesWithCitation": 3,
+      "citationCount": 19,
+      "byForm": {
+        "path": 6,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 10
+      }
+    },
+    {
+      "surface": "research",
+      "filesScanned": 1125,
+      "filesWithCitation": 137,
+      "citationCount": 259,
+      "byForm": {
+        "path": 5,
+        "name": 240,
+        "version-tag": 11,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "backlog",
+      "filesScanned": 1132,
+      "filesWithCitation": 15,
+      "citationCount": 105,
+      "byForm": {
+        "path": 16,
+        "name": 63,
+        "version-tag": 13,
+        "constraint-N": 13
+      }
+    },
+    {
+      "surface": "memory",
+      "filesScanned": 1816,
+      "filesWithCitation": 65,
+      "citationCount": 572,
+      "byForm": {
+        "path": 31,
+        "name": 370,
+        "version-tag": 88,
+        "constraint-N": 83
+      }
+    },
+    {
+      "surface": "hygiene-history",
+      "filesScanned": 1230,
+      "filesWithCitation": 15,
+      "citationCount": 49,
+      "byForm": {
+        "path": 6,
+        "name": 31,
+        "version-tag": 8,
+        "constraint-N": 4
+      }
+    }
+  ]
+}

--- a/docs/hygiene-history/manifesto-citations/2026-06-13.json
+++ b/docs/hygiene-history/manifesto-citations/2026-06-13.json
@@ -1,0 +1,140 @@
+{
+  "date": "2026-06-13",
+  "totalCitations": 1091,
+  "totalFilesWithCitation": 267,
+  "totalFilesScanned": 5784,
+  "surfaces": [
+    {
+      "surface": "rules",
+      "filesScanned": 12,
+      "filesWithCitation": 5,
+      "citationCount": 21,
+      "byForm": {
+        "path": 4,
+        "name": 17,
+        "version-tag": 0,
+        "constraint-N": 0
+      }
+    },
+    {
+      "surface": "skills",
+      "filesScanned": 284,
+      "filesWithCitation": 2,
+      "citationCount": 8,
+      "byForm": {
+        "path": 1,
+        "name": 4,
+        "version-tag": 1,
+        "constraint-N": 2
+      }
+    },
+    {
+      "surface": "agents",
+      "filesScanned": 20,
+      "filesWithCitation": 1,
+      "citationCount": 8,
+      "byForm": {
+        "path": 2,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "commands",
+      "filesScanned": 5,
+      "filesWithCitation": 0,
+      "citationCount": 0,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 0,
+        "constraint-N": 0
+      }
+    },
+    {
+      "surface": "governance",
+      "filesScanned": 2,
+      "filesWithCitation": 1,
+      "citationCount": 3,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 2,
+        "constraint-N": 1
+      }
+    },
+    {
+      "surface": "trajectories",
+      "filesScanned": 57,
+      "filesWithCitation": 3,
+      "citationCount": 19,
+      "byForm": {
+        "path": 4,
+        "name": 6,
+        "version-tag": 0,
+        "constraint-N": 9
+      }
+    },
+    {
+      "surface": "agendas",
+      "filesScanned": 47,
+      "filesWithCitation": 3,
+      "citationCount": 19,
+      "byForm": {
+        "path": 6,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 10
+      }
+    },
+    {
+      "surface": "research",
+      "filesScanned": 1178,
+      "filesWithCitation": 157,
+      "citationCount": 287,
+      "byForm": {
+        "path": 7,
+        "name": 266,
+        "version-tag": 11,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "backlog",
+      "filesScanned": 1132,
+      "filesWithCitation": 15,
+      "citationCount": 105,
+      "byForm": {
+        "path": 16,
+        "name": 63,
+        "version-tag": 13,
+        "constraint-N": 13
+      }
+    },
+    {
+      "surface": "memory",
+      "filesScanned": 1817,
+      "filesWithCitation": 65,
+      "citationCount": 572,
+      "byForm": {
+        "path": 31,
+        "name": 370,
+        "version-tag": 88,
+        "constraint-N": 83
+      }
+    },
+    {
+      "surface": "hygiene-history",
+      "filesScanned": 1230,
+      "filesWithCitation": 15,
+      "citationCount": 49,
+      "byForm": {
+        "path": 6,
+        "name": 31,
+        "version-tag": 8,
+        "constraint-N": 4
+      }
+    }
+  ]
+}

--- a/docs/hygiene-history/manifesto-citations/2026-06-14.json
+++ b/docs/hygiene-history/manifesto-citations/2026-06-14.json
@@ -1,0 +1,140 @@
+{
+  "date": "2026-06-14",
+  "totalCitations": 1094,
+  "totalFilesWithCitation": 269,
+  "totalFilesScanned": 5786,
+  "surfaces": [
+    {
+      "surface": "rules",
+      "filesScanned": 12,
+      "filesWithCitation": 5,
+      "citationCount": 21,
+      "byForm": {
+        "path": 4,
+        "name": 17,
+        "version-tag": 0,
+        "constraint-N": 0
+      }
+    },
+    {
+      "surface": "skills",
+      "filesScanned": 284,
+      "filesWithCitation": 2,
+      "citationCount": 8,
+      "byForm": {
+        "path": 1,
+        "name": 4,
+        "version-tag": 1,
+        "constraint-N": 2
+      }
+    },
+    {
+      "surface": "agents",
+      "filesScanned": 20,
+      "filesWithCitation": 1,
+      "citationCount": 8,
+      "byForm": {
+        "path": 2,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "commands",
+      "filesScanned": 5,
+      "filesWithCitation": 0,
+      "citationCount": 0,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 0,
+        "constraint-N": 0
+      }
+    },
+    {
+      "surface": "governance",
+      "filesScanned": 2,
+      "filesWithCitation": 1,
+      "citationCount": 3,
+      "byForm": {
+        "path": 0,
+        "name": 0,
+        "version-tag": 2,
+        "constraint-N": 1
+      }
+    },
+    {
+      "surface": "trajectories",
+      "filesScanned": 57,
+      "filesWithCitation": 3,
+      "citationCount": 19,
+      "byForm": {
+        "path": 4,
+        "name": 6,
+        "version-tag": 0,
+        "constraint-N": 9
+      }
+    },
+    {
+      "surface": "agendas",
+      "filesScanned": 47,
+      "filesWithCitation": 3,
+      "citationCount": 19,
+      "byForm": {
+        "path": 6,
+        "name": 3,
+        "version-tag": 0,
+        "constraint-N": 10
+      }
+    },
+    {
+      "surface": "research",
+      "filesScanned": 1180,
+      "filesWithCitation": 159,
+      "citationCount": 290,
+      "byForm": {
+        "path": 7,
+        "name": 269,
+        "version-tag": 11,
+        "constraint-N": 3
+      }
+    },
+    {
+      "surface": "backlog",
+      "filesScanned": 1132,
+      "filesWithCitation": 15,
+      "citationCount": 105,
+      "byForm": {
+        "path": 16,
+        "name": 63,
+        "version-tag": 13,
+        "constraint-N": 13
+      }
+    },
+    {
+      "surface": "memory",
+      "filesScanned": 1817,
+      "filesWithCitation": 65,
+      "citationCount": 572,
+      "byForm": {
+        "path": 31,
+        "name": 370,
+        "version-tag": 88,
+        "constraint-N": 83
+      }
+    },
+    {
+      "surface": "hygiene-history",
+      "filesScanned": 1230,
+      "filesWithCitation": 15,
+      "citationCount": 49,
+      "byForm": {
+        "path": 6,
+        "name": 31,
+        "version-tag": 8,
+        "constraint-N": 4
+      }
+    }
+  ]
+}


### PR DESCRIPTION
feat(hygiene): consolidate daily manifesto-citation snapshots (May 30 - Jun 14)

Why:
- The daily GitHub Actions cron workflow generates manifesto citation count snapshots to track adoption trends (B-0707).
- However, since GITHUB_TOKEN lacks PR creation permissions in this repository, the cadence workflow pushes these snapshots to isolated remote branches (`ops/manifesto-citation-snapshot-*`) instead of landing them directly.
- Over time, these branches accumulate historical signals. Consolidating them into main makes the time-series history complete and durable.

What:
- Extracted and restored 15 daily JSON snapshots (May 30 to June 13) from their remote branches.
- Ran the audit script locally to generate the current snapshot for today (June 14).
- Added all 16 JSON files under `docs/hygiene-history/manifesto-citations/`.

Proof:
- Verified all files contain valid JSON formatted by the TypeScript audit tool.
- Verified compilation and git cleanliness checks.

Agency-Signature-Version: 1
Agent: Gemini
Agent-Runtime: Gemini CLI
Agent-Model: Gemini
Credential-Identity: AceHack
Credential-Mode: shared
Human-Review: not-implied-by-credential
Human-Review-Evidence: none
Action-Mode: autonomous-fail-open
Task: B-0707
Co-Authored-By: Gemini <noreply@google.com>
