### PR TITLE
feat(core): add budgeted room horizon

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -183,6 +183,7 @@
     <Compile Include="Vision.fs" />
     <Compile Include="PredictionInference.fs" />
     <Compile Include="PredictionScheduler.fs" />
+    <Compile Include="RoomHorizon.fs" />
     <Compile Include="Query.fs" />
     <Compile Include="Injection.fs" />
     <Compile Include="InjectionExt.fs" />

--- a/src/Core/RoomHorizon.fs
+++ b/src/Core/RoomHorizon.fs
@@ -1,0 +1,151 @@
+namespace Zeta.Core
+
+open System
+
+/// A finite room-facing horizon over Vision predictions.
+///
+/// The soft tank answers "which futures can we honestly pay for in bytes?"
+/// The bounded G-set answers "which paid future keys fit in this room-sized
+/// exterior view?" Keeping the two reports separate prevents attention from
+/// rewriting arithmetic truth: attention/gravity may reorder boarding, but
+/// byte cost and finite capacity still backpressure.
+[<RequireQualifiedAccess>]
+module RoomHorizon =
+
+    module PS = ProbabilitySemiring
+
+    type Candidate<'K, 'S when 'K : comparison> =
+        { Key: 'K
+          Branch: Vision.FutureBranch<'S>
+          Priority: PredictionInference.BranchPriority }
+
+    type Feedback =
+        | NegativeAttention of label: string * value: PS.Rational
+        | NegativeGravity of label: string * value: PS.Rational
+        | VisionFeedback of Vision.GrowthFeedback
+        | HorizonFeedback of BoundedGSetError
+
+    type Report<'K, 'S when 'K : comparison> =
+        { HorizonBefore: BoundedGSet<'K>
+          HorizonAfter: BoundedGSet<'K>
+          Ordered: Candidate<'K, 'S> list
+          Boarded: Candidate<'K, 'S> list
+          Deferred: Candidate<'K, 'S> list
+          RetainedKeys: GSet<'K>
+          RejectedByHorizon: GSet<'K>
+          EvictedByHorizon: GSet<'K>
+          Prediction: Vision.PredictionReport<'S> }
+
+    let private nonNegative (r: PS.Rational) : bool =
+        PS.compare r PS.zero >= 0
+
+    let private priorityWeight (candidate: Candidate<'K, 'S>) : PS.Rational =
+        candidate.Priority.Attention
+        |> PS.mul candidate.Priority.Gravity
+
+    let private compareCandidates (left: Candidate<'K, 'S>) (right: Candidate<'K, 'S>) : int =
+        let byPriority = PS.compare (priorityWeight right) (priorityWeight left)
+
+        if byPriority <> 0 then
+            byPriority
+        else
+            let byKey = (Collation.forKey<'K>()).Compare(left.Key, right.Key)
+
+            if byKey <> 0 then
+                byKey
+            else
+                StringComparer.Ordinal.Compare(left.Branch.Label, right.Branch.Label)
+
+    let ordered (candidates: Candidate<'K, 'S> list) : Result<Candidate<'K, 'S> list, Feedback> =
+        let rec loop acc rest =
+            result {
+                match rest with
+                | [] -> return List.sortWith compareCandidates acc
+                | candidate :: tail ->
+                    if not (nonNegative candidate.Priority.Attention) then
+                        return! Error(NegativeAttention(candidate.Branch.Label, candidate.Priority.Attention))
+                    elif not (nonNegative candidate.Priority.Gravity) then
+                        return! Error(NegativeGravity(candidate.Branch.Label, candidate.Priority.Gravity))
+                    else
+                        return! loop (candidate :: acc) tail
+            }
+
+        loop [] candidates
+
+    let private applyVisible
+        (current: BoundedGSet<'K>)
+        (boarded: Candidate<'K, 'S> list)
+        : Result<BoundedGSet<'K> * GSet<'K> * GSet<'K> * GSet<'K>, Feedback> =
+        let rec loop state retained rejected evicted rest =
+            result {
+                match rest with
+                | [] -> return state, retained, rejected, evicted
+                | candidate :: tail ->
+                    let! addResult =
+                        BoundedGSet.add candidate.Key state
+                        |> Result.mapError HorizonFeedback
+
+                    let retained' =
+                        match addResult.Admission with
+                        | BoundedGSetAdmission.RejectedByBound -> retained
+                        | BoundedGSetAdmission.Admitted
+                        | BoundedGSetAdmission.AlreadyPresent -> GSet.add candidate.Key retained
+
+                    let rejected' =
+                        match addResult.Admission with
+                        | BoundedGSetAdmission.RejectedByBound -> GSet.add candidate.Key rejected
+                        | BoundedGSetAdmission.Admitted
+                        | BoundedGSetAdmission.AlreadyPresent -> rejected
+
+                    let evicted' = GSet.union evicted addResult.Evicted
+                    return! loop addResult.State retained' rejected' evicted' tail
+            }
+
+        loop current GSet.empty GSet.empty GSet.empty boarded
+
+    /// Update an existing finite horizon with a newly ordered, byte-budgeted
+    /// set of candidate futures.
+    let update
+        (current: BoundedGSet<'K>)
+        (tank: SoftThrottle.Tank)
+        (candidates: Candidate<'K, 'S> list)
+        : Result<Report<'K, 'S>, Feedback> =
+        result {
+            let! orderedCandidates = ordered candidates
+
+            let! prediction =
+                orderedCandidates
+                |> List.map _.Branch
+                |> fun branches -> Vision.predictBranches branches tank
+                |> Result.mapError VisionFeedback
+
+            let boarded = orderedCandidates |> List.truncate prediction.Boarded.Length
+            let deferred = orderedCandidates |> List.skip prediction.Boarded.Length
+            let! horizonAfter, retained, rejected, evicted = applyVisible current boarded
+
+            return
+                { HorizonBefore = current
+                  HorizonAfter = horizonAfter
+                  Ordered = orderedCandidates
+                  Boarded = boarded
+                  Deferred = deferred
+                  RetainedKeys = retained
+                  RejectedByHorizon = rejected
+                  EvictedByHorizon = evicted
+                  Prediction = prediction }
+        }
+
+    /// Start from an empty bounded horizon and admit the affordable visible
+    /// prefix of candidates.
+    let admit
+        (config: BoundedGSetConfig)
+        (tank: SoftThrottle.Tank)
+        (candidates: Candidate<'K, 'S> list)
+        : Result<Report<'K, 'S>, Feedback> =
+        result {
+            let! empty =
+                BoundedGSet.empty<'K> config
+                |> Result.mapError HorizonFeedback
+
+            return! update empty tank candidates
+        }

--- a/tests/Tests.FSharp/RoomHorizon.Tests.fs
+++ b/tests/Tests.FSharp/RoomHorizon.Tests.fs
@@ -1,0 +1,99 @@
+module Zeta.Tests.RoomHorizonTests
+
+open global.Xunit
+open Zeta.Core
+
+module PS = ProbabilitySemiring
+module RH = RoomHorizon
+
+let private mustOk =
+    function
+    | Ok value -> value
+    | Error feedback -> failwithf "expected Ok, got %A" feedback
+
+let private config capacity retention =
+    { Capacity = capacity
+      Retention = retention }
+
+let private cost bytes : Vision.BranchCost =
+    { SpaceBytes = bytes
+      TimeTicks = 0
+      BytesPerTick = 0L
+      UncertaintyResolutionBits = 0 }
+
+let private candidate key label state attention gravity bytes : RH.Candidate<int, string> =
+    { Key = key
+      Branch =
+        { Label = label
+          State = state
+          Cost = cost bytes }
+      Priority =
+        { Attention = PS.rat attention 1L
+          Gravity = PS.rat gravity 1L } }
+
+[<Fact>]
+let ``attention and gravity change boarding order while byte cost stays honest`` () =
+    let report =
+        [ candidate 1 "likely" "A" 1L 1L 6L
+          candidate 2 "attended" "B" 10L 2L 6L ]
+        |> RH.admit (config 2 BoundedGSetRetention.KeepHighest) (SoftThrottle.tank 6.0 0.0)
+        |> mustOk
+
+    Assert.Equal<string list>([ "attended"; "likely" ], report.Ordered |> List.map _.Branch.Label)
+    Assert.Equal<string list>([ "attended" ], report.Boarded |> List.map _.Branch.Label)
+    Assert.Equal<string list>([ "likely" ], report.Deferred |> List.map _.Branch.Label)
+    Assert.Equal(Vision.PartiallyAdmitted, report.Prediction.Outcome)
+    Assert.Equal(12L, report.Prediction.RequestedBytes)
+    Assert.Equal(6L, report.Prediction.BoardedBytes)
+    Assert.Equal(6L, report.Prediction.DeferredBytes)
+    Assert.Equal<int list>([ 2 ], report.RetainedKeys |> GSet.toList)
+    Assert.Equal<int list>([ 2 ], report.HorizonAfter |> BoundedGSet.toList)
+
+[<Fact>]
+let ``rolling horizon reports finite-view evictions separately from byte admission`` () =
+    let current =
+        BoundedGSet.ofSeq<int> (config 2 BoundedGSetRetention.KeepHighest) [ 1; 2 ]
+        |> mustOk
+
+    let report =
+        [ candidate 3 "newer" "C" 1L 1L 1L ]
+        |> RH.update current (SoftThrottle.tank 1.0 0.0)
+        |> mustOk
+
+    Assert.Equal(Vision.Admitted, report.Prediction.Outcome)
+    Assert.Equal<string list>([ "newer" ], report.Boarded |> List.map _.Branch.Label)
+    Assert.Equal<int list>([ 2; 3 ], report.HorizonAfter |> BoundedGSet.toList)
+    Assert.Equal<int list>([ 3 ], report.RetainedKeys |> GSet.toList)
+    Assert.Equal<int list>([ 1 ], report.EvictedByHorizon |> GSet.toList)
+    Assert.Empty(report.RejectedByHorizon |> GSet.toList)
+
+[<Fact>]
+let ``paid branch can still be rejected by the finite horizon projection`` () =
+    let current =
+        BoundedGSet.ofSeq<int> (config 2 BoundedGSetRetention.KeepHighest) [ 2; 3 ]
+        |> mustOk
+
+    let report =
+        [ candidate 1 "older" "A" 1L 1L 1L ]
+        |> RH.update current (SoftThrottle.tank 1.0 0.0)
+        |> mustOk
+
+    Assert.Equal(Vision.Admitted, report.Prediction.Outcome)
+    Assert.Equal<string list>([ "older" ], report.Boarded |> List.map _.Branch.Label)
+    Assert.Equal<int list>([ 2; 3 ], report.HorizonAfter |> BoundedGSet.toList)
+    Assert.Empty(report.RetainedKeys |> GSet.toList)
+    Assert.Equal<int list>([ 1 ], report.RejectedByHorizon |> GSet.toList)
+    Assert.Empty(report.EvictedByHorizon |> GSet.toList)
+
+[<Fact>]
+let ``negative attention is feedback not an ordering trick`` () =
+    let bad =
+        { candidate 1 "bad" "A" 1L 1L 1L with
+            Priority =
+                { Attention = PS.rat -1L 1L
+                  Gravity = PS.one } }
+
+    match RH.admit (config 2 BoundedGSetRetention.KeepHighest) (SoftThrottle.tank 1.0 0.0) [ bad ] with
+    | Error(RH.NegativeAttention("bad", value)) ->
+        Assert.Equal(0, PS.compare value (PS.rat -1L 1L))
+    | other -> Assert.Fail(sprintf "expected NegativeAttention feedback, got %A" other)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -145,6 +145,7 @@
     <Compile Include="Vision.Tests.fs" />
     <Compile Include="PredictionInference.Tests.fs" />
     <Compile Include="PredictionScheduler.Tests.fs" />
+    <Compile Include="RoomHorizon.Tests.fs" />
     <Compile Include="RecordedSource.Tests.fs" />
     <Compile Include="SoftIsr.Tests.fs" />
     <Compile Include="SimFramework.Tests.fs" />


### PR DESCRIPTION
## What changed

- Added `RoomHorizon` as a finite horizon layer over `Vision.predictBranches` and `BoundedGSet`.
- Candidates are ordered by `attention * gravity`, then the existing Vision byte tank decides which branch prefix can be paid for.
- Boarded keys are applied to a bounded G-set exterior view, with separate reports for retained, rejected, and evicted keys.
- Added focused F# tests covering priority ordering, honest byte accounting, rolling horizon eviction, finite projection rejection, and negative-attention feedback.

## Why

This is the small kernel for bounded room self-sight. Attention/gravity can change which futures board first, but they do not change arithmetic truth: byte cost still spends the tank, and bounded room capacity still reports projection backpressure.

## Validation

- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter FullyQualifiedName~RoomHorizon --no-restore`
- `dotnet build -c Release -m:1 /p:UseSharedCompilation=false`
- `dotnet format --verify-no-changes`
- `dotnet test Zeta.sln -c Release --no-build -m:1 /p:UseSharedCompilation=false`
- `git diff --check`
