### PR TITLE
docs(preflight): wire `bun run preflight` into the contribution flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -438,6 +438,26 @@ public-API review gate (see
 `docs/REVIEW-AGENTS.md` — the `public-api-designer`
 role).
 
+**Run the whole gate locally before you open a PR — `preflight`:**
+
+```bash
+bun run preflight          # all dimensions: lints + tsc + build + full test
+bun run preflight:quick    # lints + tsc only (skip the slow dotnet build + test)
+```
+
+`preflight` runs every code-correctness check CI runs — the
+F#/C#/Go/Python/Rust lints, tsc, markdownlint, the
+file-presence lints, and (full mode) build + test — and
+**reports every failure at once**. This matters because the CI
+lint job runs the per-language lints sequentially and
+*short-circuits at the first failure*, so a multi-language
+change can surface only one red per CI cycle (one 2026-06-13
+rollout took 7 PRs to clear breakage CI revealed one language
+at a time). Running `preflight` before you push catches them
+all in one pass. Tools absent locally (e.g. `golangci-lint`)
+report SKIP, not failure — they still run in CI. Source:
+`src/Core.TypeScript/hygiene/preflight.ts`.
+
 ## Code style and conventions (short form)
 
 - **F# first for data-plane code, C# wrapper where

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,10 @@ dotnet build Zeta.sln -c Release
 # Test
 dotnet test Zeta.sln -c Release --no-build
 
+# Before opening a PR: run every gate dimension locally, all failures at once
+# (lints + tsc + build + test; --quick skips the slow build + test)
+bun run preflight
+
 # Health check (optional, diagnose a broken toolchain)
 tools/setup/doctor.sh
 ```
@@ -152,6 +156,7 @@ full branch model.
 
 **PR checklist (self):**
 
+- [ ] `bun run preflight` — all gate dimensions green (covers the two below + every language lint).
 - [ ] `dotnet build -c Release` — 0 W / 0 E.
 - [ ] `dotnet test -c Release` — all green.
 - [ ] Any new claim has a test.

--- a/docs/BOOTSTRAP-TEMPLATE.md
+++ b/docs/BOOTSTRAP-TEMPLATE.md
@@ -45,7 +45,7 @@ discipline, the commit-attribution trailer.
 | 1. Orient | Read `AGENTS.md` → `docs/ALIGNMENT.md` → `docs/GLOSSARY.md` → `GOVERNANCE.md` (scan on §N cite). Read the harness persona/state file. | *Which* persona/state file (`memory/persona/<name>/CURRENT-*.md`, `.codex/CURRENT-codex.md`, etc.) and any harness read-order addendum. |
 | 2. Refresh | Run the worldview refresh; read active `docs/trajectories/*/RESUME.md`. | The exact refresh command + how this harness runs TypeScript / shell (`bun tools/github/refresh-worldview.ts`, etc.). |
 | 3. Pick work | Open `docs/BACKLOG.md` / `docs/backlog/P*/`; complete the backlog-item start gate (prior-art search + dependency check); acquire a claim before worktree work. | The claim mechanism this harness uses (`src/Core.TypeScript/bus/claim.ts` surface-tagged sender ID, claim-branch convention). |
-| 4. Build | `dotnet build -c Release` (0 warnings, 0 errors — `TreatWarningsAsErrors`) then `dotnet test Zeta.sln -c Release`. | Nothing — the build gate is identical for all harnesses. |
+| 4. Build | `dotnet build -c Release` (0 warnings, 0 errors — `TreatWarningsAsErrors`) then `dotnet test Zeta.sln -c Release`. Before opening a PR, `bun run preflight` runs every gate dimension locally and reports all failures at once (vs CI's per-language short-circuit). | Nothing — the build gate is identical for all harnesses. |
 | 5. Ship | Open a PR against `main`; arm auto-merge if green. | The commit-attribution trailer (`Co-Authored-By: <Harness> <...>`) and worktree-isolation discipline for this harness. |
 | 6. When stuck | See `docs/CONFLICT-RESOLUTION.md`; on deadlock, the human decides. | Any harness-specific escalation channel. |
 
@@ -86,6 +86,7 @@ Claim before worktree work: <harness-specific claim mechanism>.
 
 dotnet build -c Release   # 0 warnings, 0 errors
 dotnet test Zeta.sln -c Release
+bun run preflight         # before a PR: all gate dimensions, all failures at once
 
 ## 5. Ship
 

--- a/docs/BUILD-GATES.md
+++ b/docs/BUILD-GATES.md
@@ -9,6 +9,13 @@ locally before you push.
 > build IS the gate (every agent is the build machine). See
 > `memory/project_sovereign_no_pr_mode_local_prepush_build_gate_*`.
 
+**One command for all of it:** `bun run preflight` runs every code-correctness
+gate below (lints + tsc + build + full test) and reports **every** failure at
+once — unlike CI's lint job, which short-circuits at the first failing language.
+Use `bun run preflight:quick` to skip the slow dotnet build + test. Tools absent
+locally report SKIP (they still run in CI). Source:
+`src/Core.TypeScript/hygiene/preflight.ts`.
+
 ## The gates (run all; all must be clean)
 
 | # | Gate | Local command | Checks |


### PR DESCRIPTION
Closes the loop on the preflight runner (#8143): a tool nobody runs prevents nothing. This makes `bun run preflight` the documented pre-PR step on every surface a contributor/harness reads — so the 2026-06-13 main-green saga (rollouts merging without local verification; CI's per-language lint short-circuit hiding downstream reds) stops recurring.

- **AGENTS.md** (Build and test gate) — `preflight` / `:quick` as the run-everything-locally step; the on-load surface every harness reads.
- **docs/BOOTSTRAP-TEMPLATE.md** (step 4 + skeleton) — future harnesses inherit it.
- **docs/BUILD-GATES.md** — the one command that runs every gate at once (this file already declares "the local build IS the gate").
- **CONTRIBUTING.md** — the build/test snippet + the self PR checklist.

Doc-only; markdownlint clean on all four. A pre-push git hook is deliberately left as a future **opt-in** rather than imposed.

Agent-initiated (Otto's pick when asked "what do you want to work on next").

🤖 Generated with [Claude Code](https://claude.com/claude-code)