### PR TITLE
fix(zflash): resolve test-infra pubkey path for build-iso scenario 1

### DIFF
--- a/src/Core.TypeScript/zflash/cli.ts
+++ b/src/Core.TypeScript/zflash/cli.ts
@@ -73,7 +73,7 @@ import {
 import {
   composeAuthorizedKeysFileContent,
   parseUuidFromDiskutilInfo,
-  ZETA_TEST_INFRA_PUBKEY_REPO_RELATIVE_PATH,
+  resolveZetaTestInfraPubkeyFromZflashModule,
 } from "./lib.ts";
 
 const ISO_GLOB_PREFIX = "zeta-installer-";
@@ -696,8 +696,7 @@ function writeCredBlobToEsp(mountPoint: string, espPart: string, credBake: CredB
 }
 
 function resolveTestInfraPubkeyPath(): string {
-  const scriptDir = dirname(fileURLToPath(import.meta.url));
-  return resolve(scriptDir, "../../", ZETA_TEST_INFRA_PUBKEY_REPO_RELATIVE_PATH);
+  return resolveZetaTestInfraPubkeyFromZflashModule(import.meta.url);
 }
 
 function readAuthorizedKeysContent(pubkeyPath: string, testMode: boolean): string {

--- a/src/Core.TypeScript/zflash/file-backed.ts
+++ b/src/Core.TypeScript/zflash/file-backed.ts
@@ -1,7 +1,5 @@
 #!/usr/bin/env bun
 import { existsSync, readFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
 import {
   createNodeFileBackedZflashImageExecutor,
   createNodeFileBackedZflashInlineStagingDirectory,
@@ -11,7 +9,7 @@ import {
   executeFileBackedZflashImageExecutionPlan,
   planFileBackedZflashImage,
   planFileBackedZflashImageExecution,
-  ZETA_TEST_INFRA_PUBKEY_REPO_RELATIVE_PATH,
+  resolveZetaTestInfraPubkeyFromZflashModule,
 } from "./lib.ts";
 import type {
   FileBackedZflashImageExecution,
@@ -59,8 +57,7 @@ const USAGE =
   "  --inline-staging-dir <path>  optional staging root for inline content files\n";
 
 function resolveTestInfraPubkeyPath(): string {
-  const scriptDir = dirname(fileURLToPath(import.meta.url));
-  return resolve(scriptDir, "../../", ZETA_TEST_INFRA_PUBKEY_REPO_RELATIVE_PATH);
+  return resolveZetaTestInfraPubkeyFromZflashModule(import.meta.url);
 }
 
 function resolveAuthorizedKeysContent(

--- a/src/Core.TypeScript/zflash/lib.test.ts
+++ b/src/Core.TypeScript/zflash/lib.test.ts
@@ -15,6 +15,7 @@
 // Run via: bun test src/Core.TypeScript/zflash/lib.test.ts
 // Or as part of the full suite: bun test
 
+import { existsSync } from "node:fs";
 import { describe, expect, test } from "bun:test";
 import {
   composeAuthorizedKeysFileContent,
@@ -28,6 +29,7 @@ import {
   parseUuidFromDiskutilInfo,
   planFileBackedZflashImage,
   planFileBackedZflashImageExecution,
+  resolveZetaTestInfraPubkeyFromZflashModule,
   VALID_HOSTNAME_REGEX,
   ZETA_TEST_INFRA_PUBKEY_REPO_RELATIVE_PATH,
 } from "./lib.ts";
@@ -37,6 +39,15 @@ describe("ZETA_TEST_INFRA_PUBKEY_REPO_RELATIVE_PATH", () => {
     expect(ZETA_TEST_INFRA_PUBKEY_REPO_RELATIVE_PATH).toBe(
       "src/Core.TypeScript/zflash/test-harness/keys/zeta-test-infra.pub",
     );
+  });
+});
+
+describe("resolveZetaTestInfraPubkeyFromZflashModule", () => {
+  test("resolves committed pubkey without double-src prefix", () => {
+    const path = resolveZetaTestInfraPubkeyFromZflashModule(import.meta.url);
+    expect(path.endsWith("zflash/test-harness/keys/zeta-test-infra.pub")).toBe(true);
+    expect(path).not.toContain("/src/src/");
+    expect(existsSync(path)).toBe(true);
   });
 });
 

--- a/src/Core.TypeScript/zflash/lib.ts
+++ b/src/Core.TypeScript/zflash/lib.ts
@@ -2,6 +2,9 @@
 //
 // Pure-logic library for zflash — unit-testable without I/O.
 
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
 /**
  * RFC1123 hostname regex.
  *
@@ -23,6 +26,16 @@ export const VALID_HOSTNAME_REGEX = /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])
  */
 export const ZETA_TEST_INFRA_PUBKEY_REPO_RELATIVE_PATH =
   "src/Core.TypeScript/zflash/test-harness/keys/zeta-test-infra.pub";
+
+/**
+ * Absolute path to zeta-test-infra.pub from a module file under zflash/
+ * (e.g. cli.ts, file-backed.ts). Joining {@link ZETA_TEST_INFRA_PUBKEY_REPO_RELATIVE_PATH}
+ * from scriptDir with only `../../` produced `src/src/...` after the tools→src move.
+ */
+export function resolveZetaTestInfraPubkeyFromZflashModule(moduleUrl: string | URL): string {
+  const zflashDir = dirname(fileURLToPath(moduleUrl));
+  return resolve(zflashDir, "test-harness/keys/zeta-test-infra.pub");
+}
 
 /**
  * Structural validator for a single OpenSSH authorized_keys line.


### PR DESCRIPTION
## Summary
- fix zflash test-infra key resolution to use module-local path joining and avoid the `src/src/...` regression after the tools->src move
- update `cli.ts` and `file-backed.ts` to call `resolveZetaTestInfraPubkeyFromZflashModule()`
- add a regression test that asserts no double-src path and verifies the committed pubkey exists

## Context
This addresses B-0891 CI failures in build-iso scenario 1 where test-infra pubkey resolution could produce an invalid double-src path.

## Test Plan
- [x] `bun test src/Core.TypeScript/zflash/lib.test.ts`

Made with [Cursor](https://cursor.com)