### PR TITLE
fix(ci): keep Stryker in C# project mode

### DIFF
--- a/.github/workflows/stryker-mutation.yml
+++ b/.github/workflows/stryker-mutation.yml
@@ -132,7 +132,11 @@ jobs:
         run: dotnet build Zeta.sln -c Release
 
       - name: Run Stryker
-        run: dotnet stryker
+        # Run from the C# test project so Stryker stays in project mode.
+        # Root solution discovery currently walks unrelated F# test projects and
+        # crashes while reading generated AssemblyInfo paths.
+        working-directory: tests/Core.CSharp.Tests
+        run: dotnet stryker --config-file ../../stryker-config.json --configuration Release --output ../../StrykerOutput
 
       - name: Upload Stryker reports
         if: always()

--- a/src/Core.Rust.ZetaId/src/lib.rs
+++ b/src/Core.Rust.ZetaId/src/lib.rs
@@ -29,7 +29,9 @@ pub mod bit_layout;
 pub mod bit_layout_gen;
 pub mod zeta_id;
 
-pub use zeta_id::{PackError, pack, to_hex, unpack, format_b32, parse_b32, is_canonical, ZETAID_BASE32_LEN};
+pub use zeta_id::{
+    PackError, ZETAID_BASE32_LEN, format_b32, is_canonical, pack, parse_b32, to_hex, unpack,
+};
 
 /// Version field value for V1 (5-bit field; the only version today).
 pub const VERSION_V1: u8 = 1;

--- a/src/Core.Rust.ZetaId/src/zeta_id.rs
+++ b/src/Core.Rust.ZetaId/src/zeta_id.rs
@@ -187,7 +187,10 @@ fn decode_char(c: u8) -> Result<u8, String> {
         b'v'..=b'z' => Ok(c - b'v' + 27),
         b'I' | b'i' | b'L' | b'l' => Ok(1),
         b'O' | b'o' => Ok(0),
-        _ => Err(format!("invalid Crockford base32 character '{}'", c as char)),
+        _ => Err(format!(
+            "invalid Crockford base32 character '{}'",
+            c as char
+        )),
     }
 }
 

--- a/src/Core.Rust.ZetaId/tests/cross_verify.rs
+++ b/src/Core.Rust.ZetaId/tests/cross_verify.rs
@@ -16,8 +16,8 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use zeta_core_zeta_id::{
-    Authority, DeterministicEnv, Momentum, ZetaObservation, pack, to_hex, unpack,
-    format_b32, parse_b32, is_canonical,
+    Authority, DeterministicEnv, Momentum, ZetaObservation, format_b32, is_canonical, pack,
+    parse_b32, to_hex, unpack,
 };
 
 /// Walk up from the crate dir to the repo root (`Zeta.sln` sentinel), matching the
@@ -200,9 +200,17 @@ fn cross_verify_matches_shared_vectors() {
         }
         if !crockford_matches {
             crockford_mismatches += 1;
-            eprintln!("Crockford MISMATCH for {id}: got {crockford}, expected {expected_crockford}");
+            eprintln!(
+                "Crockford MISMATCH for {id}: got {crockford}, expected {expected_crockford}"
+            );
         }
-        results.push((id, hex, crockford, roundtrip_ok, matches_expected && crockford_matches));
+        results.push((
+            id,
+            hex,
+            crockford,
+            roundtrip_ok,
+            matches_expected && crockford_matches,
+        ));
     }
 
     // Emit rust-output.json in the shared shape: { id: { hex, crockford, roundtripOk, matchesExpected } }.
@@ -248,5 +256,8 @@ fn cross_verify_matches_shared_vectors() {
         "{roundtrip_mismatches} roundtrip mismatch(es)"
     );
     assert_eq!(hex_mismatches, 0, "{hex_mismatches} hex mismatch(es)");
-    assert_eq!(crockford_mismatches, 0, "{crockford_mismatches} crockford mismatch(es)");
+    assert_eq!(
+        crockford_mismatches, 0,
+        "{crockford_mismatches} crockford mismatch(es)"
+    );
 }

--- a/stryker-config.json
+++ b/stryker-config.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/stryker-mutator/stryker-net/master/docs/stryker-config.schema.json",
   "stryker-config": {
-    "project": "src/Core.CSharp/Core.CSharp.csproj",
+    "project": "Core.CSharp.csproj",
     "test-projects": [
-      "tests/Core.CSharp.Tests/Core.CSharp.Tests.csproj"
+      "Core.CSharp.Tests.csproj"
     ],
     "mutate": [
       "Variance.cs",


### PR DESCRIPTION
## Summary
- keep Stryker.NET in project mode by running from `tests/Core.CSharp.Tests`
- make the root `stryker-config.json` paths match that C# test-project working directory
- keep Stryker reports uploaded from the repository-root `StrykerOutput/` path

## Why
PR #8151 reached main, but the Stryker workflow failed before mutation testing began. The log showed Stryker root invocation entering solution discovery, using Debug by default, and crashing while reading generated F# AssemblyInfo paths for unrelated test projects:

`DirectoryNotFoundException: .../obj/Debug/net10.0/Tests.FSharp.AssemblyInfo.fs`

Running Stryker from the C# test project avoids solution-wide F# test discovery and still targets the intended `Core.CSharp.csproj` mutation surface.

## Verification
- `dotnet stryker --config-file ../../stryker-config.json --configuration Release --output ../../StrykerOutput` from `tests/Core.CSharp.Tests` exits 0
- `actionlint .github/workflows/stryker-mutation.yml`
- `dotnet format --verify-no-changes`
- `git diff --check`
- `jq . stryker-config.json >/dev/null`
- `dotnet build -c Release -m:1 /p:UseSharedCompilation=false`
