### PR TITLE
fix(lint): cargo fmt the ZetaId base32 Rust (restore main-green)

### DIFF
--- a/src/Core.Rust.ZetaId/src/lib.rs
+++ b/src/Core.Rust.ZetaId/src/lib.rs
@@ -29,7 +29,9 @@ pub mod bit_layout;
 pub mod bit_layout_gen;
 pub mod zeta_id;
 
-pub use zeta_id::{PackError, pack, to_hex, unpack, format_b32, parse_b32, is_canonical, ZETAID_BASE32_LEN};
+pub use zeta_id::{
+    PackError, ZETAID_BASE32_LEN, format_b32, is_canonical, pack, parse_b32, to_hex, unpack,
+};
 
 /// Version field value for V1 (5-bit field; the only version today).
 pub const VERSION_V1: u8 = 1;

--- a/src/Core.Rust.ZetaId/src/zeta_id.rs
+++ b/src/Core.Rust.ZetaId/src/zeta_id.rs
@@ -187,7 +187,10 @@ fn decode_char(c: u8) -> Result<u8, String> {
         b'v'..=b'z' => Ok(c - b'v' + 27),
         b'I' | b'i' | b'L' | b'l' => Ok(1),
         b'O' | b'o' => Ok(0),
-        _ => Err(format!("invalid Crockford base32 character '{}'", c as char)),
+        _ => Err(format!(
+            "invalid Crockford base32 character '{}'",
+            c as char
+        )),
     }
 }
 

--- a/src/Core.Rust.ZetaId/tests/cross_verify.rs
+++ b/src/Core.Rust.ZetaId/tests/cross_verify.rs
@@ -16,8 +16,8 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use zeta_core_zeta_id::{
-    Authority, DeterministicEnv, Momentum, ZetaObservation, pack, to_hex, unpack,
-    format_b32, parse_b32, is_canonical,
+    Authority, DeterministicEnv, Momentum, ZetaObservation, format_b32, is_canonical, pack,
+    parse_b32, to_hex, unpack,
 };
 
 /// Walk up from the crate dir to the repo root (`Zeta.sln` sentinel), matching the
@@ -200,9 +200,17 @@ fn cross_verify_matches_shared_vectors() {
         }
         if !crockford_matches {
             crockford_mismatches += 1;
-            eprintln!("Crockford MISMATCH for {id}: got {crockford}, expected {expected_crockford}");
+            eprintln!(
+                "Crockford MISMATCH for {id}: got {crockford}, expected {expected_crockford}"
+            );
         }
-        results.push((id, hex, crockford, roundtrip_ok, matches_expected && crockford_matches));
+        results.push((
+            id,
+            hex,
+            crockford,
+            roundtrip_ok,
+            matches_expected && crockford_matches,
+        ));
     }
 
     // Emit rust-output.json in the shared shape: { id: { hex, crockford, roundtripOk, matchesExpected } }.
@@ -248,5 +256,8 @@ fn cross_verify_matches_shared_vectors() {
         "{roundtrip_mismatches} roundtrip mismatch(es)"
     );
     assert_eq!(hex_mismatches, 0, "{hex_mismatches} hex mismatch(es)");
-    assert_eq!(crockford_mismatches, 0, "{crockford_mismatches} crockford mismatch(es)");
+    assert_eq!(
+        crockford_mismatches, 0,
+        "{crockford_mismatches} crockford mismatch(es)"
+    );
 }


### PR DESCRIPTION
Multi-language lint gate's **Rust** step (`cargo fmt --check`) is red on `src/Core.Rust.ZetaId` — #8141 (Crockford base32) landed un-`cargo fmt` Rust in `src/zeta_id.rs`, `src/lib.rs`, `tests/cross_verify.rs`. Applied `cargo fmt`.

Verified: `lint-rust.ts` passes (fmt clean + clippy 0). This is exactly the drift `bun run preflight` (#8154) catches pre-merge — the base32 PR predates the preflight being documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)