### PR TITLE
fix(tsc): type-only imports in z-set-merkle (restore main-green)

### DIFF
--- a/src/Core.TypeScript/z-set-merkle/z-set-merkle.ts
+++ b/src/Core.TypeScript/z-set-merkle/z-set-merkle.ts
@@ -1,5 +1,6 @@
-import { MerkleHash, ofBytes } from "../merkle/merkle";
-import { ZSet } from "../z-set/z-set";
+import { ofBytes } from "../merkle/merkle";
+import type { MerkleHash } from "../merkle/merkle";
+import type { ZSet } from "../z-set/z-set";
 
 /** Lexicographic ordinal comparison of two byte arrays. */
 function byteCompare(a: Uint8Array, b: Uint8Array): number {


### PR DESCRIPTION
`lint (tsc)` is red on `src/Core.TypeScript/z-set-merkle/z-set-merkle.ts` — `MerkleHash` and `ZSet` are imported as values but used only as types, violating `verbatimModuleSyntax` (TS1484). Split into a value import (`ofBytes`) + `import type` for the two types. **tsc now 0 errors.**

Same rollout-drift pattern; `bun run preflight` (#8154) catches this class pre-merge. Found via the preflight's tsc check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)