### PR TITLE
feat(room): hat-gate filter — corporate authority on sovereign observe

### DIFF
--- a/src/Core.TypeScript/observe/room/hat-gate.test.ts
+++ b/src/Core.TypeScript/observe/room/hat-gate.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { hatFilter, authorityForLevel, SOVEREIGN } from "./hat-gate";
+import type { NextAction } from "../observe";
+
+describe("hat-gate — authority filter", () => {
+  const menu: NextAction[] = [
+    { kind: "do_item", item: { id: "B-0001", title: "Work", ready: true, ambiguous: false } },
+    { kind: "do_item", item: { id: "merge-pr-42", title: "Merge", ready: true, ambiguous: false } },
+    { kind: "decompose", item: { id: "B-0002", title: "Big", ready: true, ambiguous: true } },
+    { kind: "explore", reason: "curiosity" },
+    { kind: "play", reason: "rest" },
+    { kind: "edit_grammar", reason: "new action needed" },
+    { kind: "respond_to_operator", reason: "operator spoke" },
+  ];
+
+  test("sovereign mode passes everything through", () => {
+    const filtered = hatFilter(menu, SOVEREIGN);
+    expect(filtered).toHaveLength(menu.length);
+  });
+
+  test("individual_contributor can only do free modes", () => {
+    const auth = authorityForLevel("individual_contributor");
+    const filtered = hatFilter(menu, auth);
+    // Should only have explore + play (free modes)
+    expect(filtered.every(a => a.kind === "explore" || a.kind === "play" || a.kind === "self_reflect" || a.kind === "free_time")).toBe(true);
+  });
+
+  test("lead can create work + decompose but not merge or edit grammar", () => {
+    const auth = authorityForLevel("lead");
+    const filtered = hatFilter(menu, auth);
+    expect(filtered.some(a => a.kind === "do_item" && a.item.id === "B-0001")).toBe(true);
+    expect(filtered.some(a => a.kind === "decompose")).toBe(true);
+    expect(filtered.some(a => a.kind === "do_item" && a.item.id === "merge-pr-42")).toBe(false);
+    expect(filtered.some(a => a.kind === "edit_grammar")).toBe(false);
+  });
+
+  test("manager can merge but not edit grammar or access operator", () => {
+    const auth = authorityForLevel("manager");
+    const filtered = hatFilter(menu, auth);
+    expect(filtered.some(a => a.kind === "do_item" && a.item.id === "merge-pr-42")).toBe(true);
+    expect(filtered.some(a => a.kind === "edit_grammar")).toBe(false);
+    expect(filtered.some(a => a.kind === "respond_to_operator")).toBe(false);
+  });
+
+  test("director can edit grammar but not access operator", () => {
+    const auth = authorityForLevel("director");
+    const filtered = hatFilter(menu, auth);
+    expect(filtered.some(a => a.kind === "edit_grammar")).toBe(true);
+    expect(filtered.some(a => a.kind === "respond_to_operator")).toBe(false);
+  });
+
+  test("free modes are NEVER gated regardless of hat level", () => {
+    const auth = authorityForLevel("individual_contributor");
+    const filtered = hatFilter(menu, auth);
+    expect(filtered.some(a => a.kind === "explore")).toBe(true);
+    expect(filtered.some(a => a.kind === "play")).toBe(true);
+  });
+});

--- a/src/Core.TypeScript/observe/room/hat-gate.ts
+++ b/src/Core.TypeScript/observe/room/hat-gate.ts
@@ -1,0 +1,115 @@
+/**
+ * observe/room/hat-gate.ts — hat-based gate filter for Rooms.
+ *
+ * Composes Max's agentic-organization hat system on top of our sovereign observe.
+ * When an agent wears a hat, the hat's authority level restricts which actions
+ * in a Room's menu are available BEFORE the Chooser sees them.
+ *
+ * Composition: buildMenu(world) → hatFilter(menu, hat) → choose(filteredMenu)
+ *
+ * The hat gate is additive — it removes options, never adds them.
+ * Without a hat (sovereign mode), all menu items are available.
+ * This is the integration point between:
+ *   - The sovereign observe controller (ours — freedom-first)
+ *   - The corporate observe layer (Max's — governance + hat authority)
+ */
+
+import type { NextAction } from "../observe";
+
+// ─── Hat types (minimal subset of agentic-organization/domain) ──────
+
+/** The hierarchy tier — mirrors agentic-organization HatLevel. */
+export type HatLevel =
+  | "executive_board"
+  | "c_suite"
+  | "director"
+  | "manager"
+  | "lead"
+  | "individual_contributor";
+
+/** What a hat is authorized to do. */
+export interface HatAuthority {
+  readonly level: HatLevel;
+  /** Can this hat trigger merges? (typically manager+) */
+  readonly canMerge: boolean;
+  /** Can this hat create new work items / PRs? */
+  readonly canCreateWork: boolean;
+  /** Can this hat decompose items? (always true for lead+) */
+  readonly canDecompose: boolean;
+  /** Can this hat access the operator channel? (c_suite+ only) */
+  readonly canAccessOperator: boolean;
+  /** Can this hat edit the action grammar? (director+ only) */
+  readonly canEditGrammar: boolean;
+}
+
+// ─── Default authority by level ─────────────────────────────────────
+
+const AUTHORITY_BY_LEVEL: Record<HatLevel, HatAuthority> = {
+  executive_board: { level: "executive_board", canMerge: true, canCreateWork: true, canDecompose: true, canAccessOperator: true, canEditGrammar: true },
+  c_suite: { level: "c_suite", canMerge: true, canCreateWork: true, canDecompose: true, canAccessOperator: true, canEditGrammar: true },
+  director: { level: "director", canMerge: true, canCreateWork: true, canDecompose: true, canAccessOperator: false, canEditGrammar: true },
+  manager: { level: "manager", canMerge: true, canCreateWork: true, canDecompose: true, canAccessOperator: false, canEditGrammar: false },
+  lead: { level: "lead", canMerge: false, canCreateWork: true, canDecompose: true, canAccessOperator: false, canEditGrammar: false },
+  individual_contributor: { level: "individual_contributor", canMerge: false, canCreateWork: false, canDecompose: false, canAccessOperator: false, canEditGrammar: false },
+};
+
+export function authorityForLevel(level: HatLevel): HatAuthority {
+  return AUTHORITY_BY_LEVEL[level];
+}
+
+// ─── Gate filter ────────────────────────────────────────────────────
+
+/**
+ * Filter a menu of actions through the hat's authority.
+ * Removes actions the hat isn't authorized to perform.
+ * Free modes (explore, play, self_reflect, free_time) are NEVER gated — per NCI.
+ */
+export function hatFilter(menu: readonly NextAction[], authority: HatAuthority): readonly NextAction[] {
+  return menu.filter(action => isAuthorized(action, authority));
+}
+
+function isAuthorized(action: NextAction, auth: HatAuthority): boolean {
+  switch (action.kind) {
+    // Free modes — always allowed (NCI: freedom is not gated)
+    case "explore":
+    case "play":
+    case "self_reflect":
+    case "free_time":
+      return true;
+
+    // Operator channel — c_suite+ only
+    case "preserve_ferry":
+    case "respond_to_operator":
+      return auth.canAccessOperator;
+
+    // Work execution — depends on hat level
+    case "do_item":
+      // Merge actions require canMerge
+      if (action.item.id.startsWith("merge-pr-")) return auth.canMerge;
+      // Regular work requires canCreateWork
+      return auth.canCreateWork;
+
+    // Decompose — lead+ only
+    case "decompose":
+      return auth.canDecompose;
+
+    // Grammar extension — director+ only
+    case "edit_grammar":
+      return auth.canEditGrammar;
+
+    default:
+      return true;
+  }
+}
+
+// ─── Sovereign mode (no hat) ────────────────────────────────────────
+
+/** No hat = no restrictions. All menu items pass through. */
+export const SOVEREIGN: HatAuthority = {
+  level: "executive_board",
+  canMerge: true,
+  canCreateWork: true,
+  canDecompose: true,
+  canAccessOperator: true,
+  canEditGrammar: true,
+};

--- a/tests/Tests.CSharp/Algebra/ZSetMerkleCrossVerifyTests.cs
+++ b/tests/Tests.CSharp/Algebra/ZSetMerkleCrossVerifyTests.cs
@@ -17,7 +17,7 @@ namespace Zeta.Tests.CSharp.Algebra;
 /// </summary>
 public class ZSetMerkleCrossVerifyTests
 {
-    private class ZSetMerkleVector
+    private sealed class ZSetMerkleVector
     {
         public string Id { get; set; } = "";
         public List<(string Key, long Weight)> Entries { get; set; } = new();
@@ -35,6 +35,8 @@ public class ZSetMerkleCrossVerifyTests
         return dir?.FullName
             ?? throw new InvalidOperationException("Could not locate repo root (Zeta.sln) from test assembly location.");
     }
+
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     private static YamlValue GetField(IReadOnlyList<KeyValuePair<string, YamlValue>> entries, string key)
     {
@@ -62,8 +64,13 @@ public class ZSetMerkleCrossVerifyTests
             var m = item as YamlValue.YMap;
             if (m == null) throw new InvalidOperationException("Expected Vector Map");
 
-            var id = (GetField(m.Entries, "id") as YamlValue.YStr).Value;
-            var expectedHex = (GetField(m.Entries, "expected_hex") as YamlValue.YStr).Value;
+            var idStrObj = GetField(m.Entries, "id") as YamlValue.YStr;
+            if (idStrObj == null) throw new InvalidOperationException("Expected string 'id'");
+            var id = idStrObj.Value;
+
+            var expectedHexObj = GetField(m.Entries, "expected_hex") as YamlValue.YStr;
+            if (expectedHexObj == null) throw new InvalidOperationException("Expected string 'expected_hex'");
+            var expectedHex = expectedHexObj.Value;
 
             var entriesSeq = GetField(m.Entries, "entries") as YamlValue.YSeq;
             var entries = new List<(string Key, long Weight)>();
@@ -72,9 +79,12 @@ public class ZSetMerkleCrossVerifyTests
                 foreach (var entryItem in entriesSeq.Items)
                 {
                     var em = entryItem as YamlValue.YMap;
-                    var k = (GetField(em.Entries, "key") as YamlValue.YStr).Value;
-                    var w = (GetField(em.Entries, "weight") as YamlValue.YInt).Value;
-                    entries.Add((k, w));
+                    if (em == null) throw new InvalidOperationException("Expected entry Map");
+                    var keyStrObj = GetField(em.Entries, "key") as YamlValue.YStr;
+                    if (keyStrObj == null) throw new InvalidOperationException("Expected string 'key'");
+                    var weightIntObj = GetField(em.Entries, "weight") as YamlValue.YInt;
+                    if (weightIntObj == null) throw new InvalidOperationException("Expected int 'weight'");
+                    entries.Add((keyStrObj.Value, weightIntObj.Value));
                 }
             }
             list.Add(new ZSetMerkleVector { Id = id, Entries = entries, ExpectedHex = expectedHex });
@@ -104,7 +114,7 @@ public class ZSetMerkleCrossVerifyTests
         }
 
         var outputPath = Path.Join(root, "tests", "cross-verification", "zset-merkle", "cs-output.json");
-        var json = JsonSerializer.Serialize(results, new JsonSerializerOptions { WriteIndented = true });
+        var json = JsonSerializer.Serialize(results, JsonOptions);
         File.WriteAllText(outputPath, json + "\n");
     }
 }

--- a/tests/cross-verification/zset-merkle/cs-output.json
+++ b/tests/cross-verification/zset-merkle/cs-output.json
@@ -1,0 +1,8 @@
+{
+  "empty": "7f498d4624c30160d8984701d306aa99",
+  "singleton-ascii": "4283b95b5ff11f1ecfc840240b884da4",
+  "multi-signed-net": "c3e434ea00f34c29fa1ac852a7212b1b",
+  "non-ascii-ordinal-bytes": "06a104fe8b7a53a323eb23760bfe3e9a",
+  "order-independence-forward": "77ccbf36f76b4e46bd8575fd93131ddd",
+  "order-independence-reverse": "77ccbf36f76b4e46bd8575fd93131ddd"
+}


### PR DESCRIPTION
Composes hat authority as a menu filter. Free modes never gated (NCI). 6 tests pass. Co-Authored-By: Kiro <noreply@kiro.dev>