### PR TITLE
ci(gate): combine TS into the per-language lint family — lint (TS)

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -1108,17 +1108,23 @@ jobs:
         # Type check and lint checks for TypeScript files via dedicated orchestrator
         run: bun src/Core.TypeScript/lint/lint-typescript.ts
 
-  lint-go-python:
-    # Run formatter, linter, and type checker for F#, C#, Go, Python, and Rust
-    # implementation files to prevent syntax, lint, and formatting regressions.
-    name: lint (F#, C#, Go, Python, Rust)
+  # Per-language lint jobs (split from the former single sequential
+  # "lint (F#, C#, Go, Python, Rust)" job, 2026-06-13). The combined job ran the
+  # five lint scripts in sequence and SHORT-CIRCUITED at the first failure, so a
+  # multi-language change surfaced one red per CI cycle (the 2026-06-13 rollout
+  # took several PRs to clear breakage CI revealed one language at a time). Five
+  # parallel jobs run independently: CI surfaces ALL language reds in one run, and
+  # each shows as its own status check. Setup is replicated per-job (the gate's
+  # established pattern — 20 jobs inline `install.sh`; no composite action in repo).
+  # `bun run preflight` is the local mirror.
+
+  lint-fsharp:
+    name: lint (F#)
     timeout-minutes: 15
     runs-on: ubuntu-24.04
-
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
       - name: Cache install.sh outputs (mise runtimes + dotnet tools + verifier jars)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -1130,7 +1136,6 @@ jobs:
             ~/.elan
             ~/.config/zeta
           key: install-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.mise.toml', 'tools/setup/**', 'global.json') }}
-
       - name: Install toolchain via three-way-parity script (GOVERNANCE §24)
         run: |
           set -euo pipefail
@@ -1146,19 +1151,150 @@ jobs:
             echo "install.sh attempt $attempt failed; retrying in ${backoff}s..." >&2
             sleep "$backoff"
           done
-
       - name: Run F# Lint Script
         run: bun src/Core.TypeScript/lint/lint-fsharp.ts
 
+  lint-csharp:
+    name: lint (C#)
+    timeout-minutes: 15
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Cache install.sh outputs (mise runtimes + dotnet tools + verifier jars)
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.local/bin/mise
+            ~/.local/share/mise
+            ~/.cache/mise
+            ~/.dotnet/tools
+            ~/.elan
+            ~/.config/zeta
+          key: install-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.mise.toml', 'tools/setup/**', 'global.json') }}
+      - name: Install toolchain via three-way-parity script (GOVERNANCE §24)
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3 4 5; do
+            if ./tools/setup/install.sh; then exit 0; fi
+            [ "$attempt" = "5" ] && { echo "install.sh failed after 5 attempts"; exit 1; }
+            case "$attempt" in
+              1) backoff=10 ;;
+              2) backoff=30 ;;
+              3) backoff=60 ;;
+              4) backoff=120 ;;
+            esac
+            echo "install.sh attempt $attempt failed; retrying in ${backoff}s..." >&2
+            sleep "$backoff"
+          done
       - name: Run C# Lint Script
         run: bun src/Core.TypeScript/lint/lint-csharp.ts
 
+  lint-go:
+    name: lint (Go)
+    timeout-minutes: 15
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Cache install.sh outputs (mise runtimes + dotnet tools + verifier jars)
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.local/bin/mise
+            ~/.local/share/mise
+            ~/.cache/mise
+            ~/.dotnet/tools
+            ~/.elan
+            ~/.config/zeta
+          key: install-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.mise.toml', 'tools/setup/**', 'global.json') }}
+      - name: Install toolchain via three-way-parity script (GOVERNANCE §24)
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3 4 5; do
+            if ./tools/setup/install.sh; then exit 0; fi
+            [ "$attempt" = "5" ] && { echo "install.sh failed after 5 attempts"; exit 1; }
+            case "$attempt" in
+              1) backoff=10 ;;
+              2) backoff=30 ;;
+              3) backoff=60 ;;
+              4) backoff=120 ;;
+            esac
+            echo "install.sh attempt $attempt failed; retrying in ${backoff}s..." >&2
+            sleep "$backoff"
+          done
       - name: Run Go Lint Script
         run: bun src/Core.TypeScript/lint/lint-go.ts
 
+  lint-python:
+    name: lint (Python)
+    timeout-minutes: 15
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Cache install.sh outputs (mise runtimes + dotnet tools + verifier jars)
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.local/bin/mise
+            ~/.local/share/mise
+            ~/.cache/mise
+            ~/.dotnet/tools
+            ~/.elan
+            ~/.config/zeta
+          key: install-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.mise.toml', 'tools/setup/**', 'global.json') }}
+      - name: Install toolchain via three-way-parity script (GOVERNANCE §24)
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3 4 5; do
+            if ./tools/setup/install.sh; then exit 0; fi
+            [ "$attempt" = "5" ] && { echo "install.sh failed after 5 attempts"; exit 1; }
+            case "$attempt" in
+              1) backoff=10 ;;
+              2) backoff=30 ;;
+              3) backoff=60 ;;
+              4) backoff=120 ;;
+            esac
+            echo "install.sh attempt $attempt failed; retrying in ${backoff}s..." >&2
+            sleep "$backoff"
+          done
       - name: Run Python Lint Script
         run: bun src/Core.TypeScript/lint/lint-python.ts
 
+  lint-rust:
+    name: lint (Rust)
+    timeout-minutes: 15
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Cache install.sh outputs (mise runtimes + dotnet tools + verifier jars)
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.local/bin/mise
+            ~/.local/share/mise
+            ~/.cache/mise
+            ~/.dotnet/tools
+            ~/.elan
+            ~/.config/zeta
+          key: install-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.mise.toml', 'tools/setup/**', 'global.json') }}
+      - name: Install toolchain via three-way-parity script (GOVERNANCE §24)
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3 4 5; do
+            if ./tools/setup/install.sh; then exit 0; fi
+            [ "$attempt" = "5" ] && { echo "install.sh failed after 5 attempts"; exit 1; }
+            case "$attempt" in
+              1) backoff=10 ;;
+              2) backoff=30 ;;
+              3) backoff=60 ;;
+              4) backoff=120 ;;
+            esac
+            echo "install.sh attempt $attempt failed; retrying in ${backoff}s..." >&2
+            sleep "$backoff"
+          done
       - name: Run Rust Lint Script
         run: bun src/Core.TypeScript/lint/lint-rust.ts
 

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -1043,9 +1043,10 @@ jobs:
       - name: Run markdownlint
         run: mise exec -- markdownlint-cli2 "**/*.md"
 
-  lint-tsc-tools:
-    # Strict typecheck on every TypeScript file via `tsc --noEmit -p
-    # tsconfig.json`. Round 35 static-analysis expansion per B-0106:
+  lint-typescript:
+    # The TypeScript member of the per-language lint family (lint (F#) / (C#) /
+    # (Go) / (Python) / (Rust) / (TS)). Strict typecheck on every TypeScript file
+    # via `tsc --noEmit -p tsconfig.json`. Round 35 static-analysis expansion per B-0106:
     # ESLint with typed-linting catches *most* TS issues but not all
     # assignability narrowings. Slice 9 (PR #882) shipped a real
     # TS2322 (`Type 'string' is not assignable to type "head" | ...`)
@@ -1054,7 +1055,7 @@ jobs:
     # job is the missing gate that prevents the class. Same shape as
     # round-30 semgrep elevation: codified rules (tsconfig strict mode)
     # without a gate aren't a control.
-    name: lint (tsc TypeScript)
+    name: lint (TS)
     timeout-minutes: 5
     runs-on: ubuntu-24.04
 
@@ -1300,7 +1301,7 @@ jobs:
 
   cross-verify:
     # Enforce the trust-core cross-language byte-lock + golden-vector oracles + the Ace
-    # package-manager suite. Previously only `lint (tsc TypeScript)` type-checked these, so a
+    # package-manager suite. Previously only `lint (TS)` type-checked these, so a
     # regression to a committed golden vector, or a 4-language disagreement, could merge green.
     # This job runs the ASSERTIONS (assert-dont-skip): every tests/cross-verification/<primitive>/
     # oracle via src/Core.TypeScript/ci/cross-verify-all.ts (compare.ts = TS/F#/C#/Rust committed outputs vs the
@@ -1334,7 +1335,7 @@ jobs:
 
       - name: Install toolchain via three-way-parity script (GOVERNANCE §24)
         # Provides bun via mise (.mise.toml pin); shellenv wires BASH_ENV so later run: steps
-        # have bun on PATH. Retry rationale per lint-tsc-tools (mise+bun CDN 502 flake class).
+        # have bun on PATH. Retry rationale per lint-typescript (mise+bun CDN 502 flake class).
         run: |
           set -euo pipefail
           for attempt in 1 2 3 4 5; do
@@ -1353,7 +1354,7 @@ jobs:
       - name: Install npm devDependencies (z3-solver for the ace solver Z3 differential, etc.)
         # The ace suite's solver.z3.test.ts spawns node to require('z3-solver') (assert-dont-skip:
         # it FAILS rather than skips if the dep is absent). --frozen-lockfile fails if the lockfile
-        # is stale vs package.json (same discipline as lint-tsc-tools).
+        # is stale vs package.json (same discipline as lint-typescript).
         run: bun install --frozen-lockfile
 
       - name: Ace package-manager suite


### PR DESCRIPTION
Follow-up to the per-language lint split (#8163). TypeScript was already its own job but named `lint (tsc TypeScript)` (id `lint-tsc-tools`), off the new convention. Renamed → **`lint (TS)`** / `lint-typescript` so the lint family reads consistently: **lint (F#) / (C#) / (Go) / (Python) / (Rust) / (TS)**.

Behavior unchanged (still install.sh + `bun install --frozen-lockfile` + `lint-typescript.ts`; it needs the npm devDeps for tsc/eslint, which the other 5 don't). Updated the in-gate.yml rationale comment refs. No `needs:`/required-check depends on the old name (0 branch protection). **actionlint clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)