### PR TITLE
ci(B-0891): promote scenario 2 to hard gate after green build-iso

### DIFF
--- a/.github/workflows/build-ai-cluster-iso.yml
+++ b/.github/workflows/build-ai-cluster-iso.yml
@@ -269,24 +269,19 @@ jobs:
           echo "B-0891 initial-format ISO: $iso_abs"
           bun ../src/Core.TypeScript/zflash/test-harness/run.ts --scenario initial-format "$iso_abs"
 
-      # QEMU full-install test (cascade #6 Slice 1 — B-0831 starter):
+      # QEMU full-install test (cascade #6 Slice 1 — B-0831):
       # Extends boot-test by attaching virtual hard disk + NAT internet,
       # waits for `[iter-5.3]` marker in serial log to verify nixos-install
       # + iter-4.2 + iter-5.2 substrate completed.
       #
-      # Gated to push-to-main + workflow_dispatch for STARTER (longer
-      # runtime; TCG fallback may exceed PR-build expectations). Once
-      # B-0831 Slice 1 proves reliable + runs <10min consistently, can
-      # be enabled on every PR per B-0831 acceptance criteria.
-      #
-      # continue-on-error: true for STARTER so initial flakiness doesn't
-      # block merges while we tune the test. Remove once stable.
+      # Hard gate on push-to-main + workflow_dispatch (scenario 1 already
+      # blocking). Scenario 2 promoted from advisory after #8155 pubkey fix
+      # and green build-iso run 27486800503 (2026-06-14).
       #
       # Security: no github.event.* interpolation; ISO path comes from
       # prior workflow step's filesystem find.
       - name: B-0891 scenario 2 — boot + install substrate (B-0831 Slice 1)
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        continue-on-error: true
         working-directory: full-ai-cluster
         env:
           SERIAL_LOG_OUT_PATH: ${{ github.workspace }}/qemu-full-install-serial.log

--- a/docs/backlog/P1/081KSGS9H0008QG0R0011BC7T2-ci-cascade-6-full-install-plus-cluster-auto-join-eliminate-r.md
+++ b/docs/backlog/P1/081KSGS9H0008QG0R0011BC7T2-ci-cascade-6-full-install-plus-cluster-auto-join-eliminate-r.md
@@ -7,7 +7,7 @@ title: CI cascade #6 — full-install-and-cluster-auto-join (post-boot install c
 effort: L
 ask: aaron 2026-05-26
 created: 2026-05-26
-last_updated: 2026-05-26
+last_updated: 2026-06-14
 depends_on:
   - B-0812
   - B-0813
@@ -16,6 +16,16 @@ composes_with:
   - B-0816
 tags: [ci, qemu, cluster-bringup, auto-install, cluster-join, eliminates-human-physical-test, cascade-6]
 ---
+
+## Progress (2026-06-14)
+
+- **Slice 1** landed #8126 — full-install-in-QEMU (B-0891 scenario 2 step)
+- **Slice 2** landed #8129 — cluster-auto-join payload verification
+- **Slice 3** landed #8139 — ArgoCD reconciliation shape verification
+- **Pubkey path fix** #8155 — unblocked scenario 2 green on build-iso run 27486800503
+- **Scenario 2 hard gate** — `continue-on-error: true` removed (scenario 1 already blocking)
+
+Row stays **open**: overall acceptance (physical USB no longer routine gate; periodic hardware-support sanity-checks) not fully met until B-0835 installer bugs addressed and scenarios 3/4 promoted.
 
 ## Problem
 

--- a/docs/trajectories/usb-zflash-installer/RESUME.md
+++ b/docs/trajectories/usb-zflash-installer/RESUME.md
@@ -1,11 +1,11 @@
 # Trajectory - USB / zflash Installer
 
 Status: active — shipped + iterating; first surfaced as a trajectory 2026-05-29 from substrate inventory (the flashing mechanism works on `origin/main`; this surface was missing, so the workstream lived head-only)
-Last refreshed: 2026-05-29
+Last refreshed: 2026-06-14
 Type: workstream (current-focus) — a trajectory the operator is *actively powering*. Many trajectories can be tracked; only a few are workstreams at once (finite-focus / WIP-bounded — a workstream is a trajectory under sustained thrust, and thrust budget is finite, so most trajectories coast). (Genus = "trajectory"; "workstream" is the species: a trajectory under sustained thrust toward a deliverable, vs. emergent-posture trajectories like `anti-infection`. See [`factory-trajectory-surface`](../factory-trajectory-surface/RESUME.md) for the genus/species taxonomy.) One of the operator's three current cluster workstreams (encryption / usb-zflash / ts-workflow-engine).
 Eventual encoding (design-stage — the human maintainer 2026-05-23 genetic-ID substrate + Clifford/HKT): this trajectory's state is trackable as a 128-bit genetic-ID seed (discrete, reversible via parser-combinator ↔ generator-function) → Clifford-space path (continuous, eventual). Mirrors the three-lane I8-lattice / I9-manifold split.
-Current blocker: none operationally; WiFi reproducibility (nixos.org closure-fetch timeouts) is the live edge; **build-iso** run queued on GitHub Actions (scenario 1 blocking, scenario 2 advisory)
-Next concrete action: B-0831 slice 3 (ArgoCD reconcile-shape CI) in PR; flip scenario 2 to hard gate once build-iso scenario 2 is stable
+Current blocker: WiFi reproducibility edge (nixos.org closure-fetch timeouts on physical hardware); CI scenarios 1+2 green on build-iso run 27486800503 after pubkey path fix #8155
+Next concrete action: B-0835 installer config bugs (hostname-not-unique, gh-auth, banner) OR promote B-0891 scenarios 3/4 from workflow_dispatch-only to hard gates
 
 ## Why This Exists
 
@@ -40,7 +40,7 @@ Grounding backlog:
 
 - [`B-0844`](../../backlog/P1/081KSGS9H0008QG0R001EZKNCB-zflash-agent-mode-native-implementation-close-doc-vs-impleme.md) — zflash agent-mode native implementation (**closed** — `--agent` in `cli.ts`)
 - Workitem `081KV1PY2H308QG0R00347547K` — `zeta flash` MCP router (**done** #8104)
-- [`B-0831`](../../backlog/P1/081KSGS9H0008QG0R0011BC7T2-ci-cascade-6-full-install-plus-cluster-auto-join-eliminate-r.md) — CI cascade-6: slices 1–2 landed (#8126, #8129); slice 3 (ArgoCD reconcile-shape) in progress
+- [`B-0831`](../../backlog/P1/081KSGS9H0008QG0R0011BC7T2-ci-cascade-6-full-install-plus-cluster-auto-join-eliminate-r.md) — CI cascade-6: slices 1–3 landed (#8126, #8129, #8139); scenario 2 now hard gate (this PR)
 - [`B-0835`](../../backlog/P1/B-0835-installer-config-bugs-cluster-hostname-not-unique-gh-auth-not-respected-banner-password-disclosure-empirical-aaron-2026-05-26.md) — installer config bugs (hostname-not-unique, gh-auth, banner)
 - [`B-0792`](../../backlog/P1/B-0792-iter5-wifi-credentials-injection-via-usb-esp-for-zero-typing-cluster-bringup-without-ethernet-load-bearing-for-homelab-persona-aaron-2026-05-26.md) — iter-5 WiFi-credentials injection via USB ESP (zero-typing bringup without ethernet)
 - [`B-0789`](../../backlog/P1/B-0789-iter4-ssh-key-and-hashedpassword-substrate-for-cluster-bringup-2026-05-26.md) — iter-4 SSH-key + hashedPassword substrate (shared seam with encryption)
@@ -59,4 +59,4 @@ bringup.
 
 ## Current Next Action
 
-Report B-1030 MCP follow-on, then sequence B-0831 (CI full-install) as the path to retire physical-USB testing. Operator's call on priority vs the sibling workstreams.
+B-0835 installer config bugs (hostname-not-unique, gh-auth, banner) OR promote B-0891 scenarios 3/4 (reformat-with-retention, path-fork migrate vs fresh) from workflow_dispatch-only advisory steps to hard gates once stable.


### PR DESCRIPTION
## Summary

- Remove `continue-on-error: true` from B-0891 scenario 2 (boot + install substrate) in `build-ai-cluster-iso.yml` — scenario 1 was already blocking; scenario 2 now matches
- Triggered by green build-iso run 27486800503 on main after pubkey path fix #8155 (both scenario 1 and 2 passed)
- Refresh `usb-zflash-installer` trajectory RESUME and B-0831 backlog progress (slices 1–3 landed; row stays open)

## Test plan

- [x] Pre-merge gate: build-iso run 27486800503 completed success (scenario 1 + 2 green)
- [ ] CI on this PR (workflow comment-only change; no runtime behavior change until merged to main)

Made with [Cursor](https://cursor.com)