### PR TITLE
fix(zset-merkle): add cross-verify oracle + format Python/Go (restore main-green)

### DIFF
--- a/src/Core.Go/cross_verify_test.go
+++ b/src/Core.Go/cross_verify_test.go
@@ -21,7 +21,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-
 func findRepoRoot() string {
 	dir, err := os.Getwd()
 	if err != nil {

--- a/src/Core.Python/src/zeta/zset_merkle.py
+++ b/src/Core.Python/src/zeta/zset_merkle.py
@@ -2,6 +2,7 @@ import struct
 import xxhash
 from typing import List, Tuple, Dict
 
+
 class MerkleHash:
     def __init__(self, hi: int, lo: int):
         self.hi = hi
@@ -30,12 +31,14 @@ class MerkleHash:
     def to_hex(self) -> str:
         return f"{self.hi:016x}{self.lo:016x}"
 
+
 def leaf_bytes(key_bytes: bytes, weight: int) -> bytes:
     buf = bytearray(4 + len(key_bytes) + 8)
     struct.pack_into("<I", buf, 0, len(key_bytes))
     buf[4 : 4 + len(key_bytes)] = key_bytes
     struct.pack_into("<q", buf, 4 + len(key_bytes), weight)
     return bytes(buf)
+
 
 def fold(level: List[MerkleHash]) -> MerkleHash:
     n = len(level)
@@ -49,6 +52,7 @@ def fold(level: List[MerkleHash]) -> MerkleHash:
         b = level[2 * i + 1] if 2 * i + 1 < n else a
         parents.append(MerkleHash.combine(a, b))
     return fold(parents)
+
 
 def root(entries: List[Tuple[str, int]]) -> MerkleHash:
     # 1. Group by key and sum weights

--- a/tests/cross-verification/zset-merkle/compare.ts
+++ b/tests/cross-verification/zset-merkle/compare.ts
@@ -1,0 +1,100 @@
+// compare.ts — ZSetMerkle cross-language conformance oracle.
+//
+// Verifies every PRESENT language output (cs/go/python/ts/fsharp/rust — read
+// relative to this dir, absent ones skipped) against the CANONICAL vectors in
+// vectors.yaml: each impl must produce `expected_hex` for every vector id, with
+// the exact vector key-set (no missing / extra / renamed vectors). Exits non-zero
+// on any mismatch. assert-don't-skip: a primitive dir with no runnable oracle is
+// an unchecked primitive (cross-verify-all flags it), so this file is required.
+//
+// Output shape: { "<vector id>": "<hex hash>" }. Canonical source is
+// vectors.yaml's `expected_hex` per id (stronger than a TS-as-reference
+// cross-check — a value all impls agree on WRONGLY would still fail here).
+
+import { readFileSync } from "fs";
+
+// --- canonical expected hashes from vectors.yaml ---
+// Line-scan (not full YAML parse): the fixture is a flat list of `- id:` /
+// `expected_hex:` pairs; `id:` appears only as a vector key (entries use `key:`).
+const expected: Record<string, string> = {};
+{
+  let currentId: string | null = null;
+  for (const line of readFileSync("vectors.yaml", "utf8").split("\n")) {
+    const idMatch = line.match(/^\s*-?\s*id:\s*(\S+)\s*$/);
+    if (idMatch) {
+      currentId = idMatch[1] ?? null;
+      continue;
+    }
+    const hexMatch = line.match(/^\s*expected_hex:\s*"([0-9a-fA-F]+)"\s*$/);
+    if (hexMatch && currentId) {
+      expected[currentId] = (hexMatch[1] ?? "").toLowerCase();
+      currentId = null;
+    }
+  }
+}
+
+const expectedKeys = Object.keys(expected);
+if (expectedKeys.length === 0) {
+  console.error("zset-merkle: no expected_hex vectors parsed from vectors.yaml");
+  process.exit(1);
+}
+
+function loadOutput(file: string): Record<string, string> | null {
+  try {
+    return JSON.parse(readFileSync(file, "utf8")) as Record<string, string>;
+  } catch {
+    return null;
+  }
+}
+
+const impls: ReadonlyArray<readonly [string, string]> = [
+  ["TS", "ts-output.json"],
+  ["F#", "fsharp-output.json"],
+  ["C#", "cs-output.json"],
+  ["Rust", "rust-output.json"],
+  ["Py", "python-output.json"],
+  ["Go", "go-output.json"],
+];
+
+let mismatches = 0;
+let present = 0;
+const expectedKeySet = new Set(expectedKeys);
+
+console.log("ZSetMerkle cross-verification (each impl vs canonical vectors.yaml):");
+for (const [name, file] of impls) {
+  const out = loadOutput(file);
+  if (!out) {
+    console.log(`  ${name}: MISSING (skipped)`);
+    continue;
+  }
+  present++;
+  const outKeys = Object.keys(out);
+  console.log(`  ${name}: ${outKeys.length} vectors`);
+
+  for (const k of outKeys) {
+    if (!expectedKeySet.has(k)) {
+      console.error(`Extra vector in ${name} not in vectors.yaml: ${k}`);
+      mismatches++;
+    }
+  }
+  for (const id of expectedKeys) {
+    const got = (out[id] ?? "").toLowerCase();
+    if (got !== expected[id]) {
+      console.error(`Mismatch ${id}: ${name}=${out[id] ?? "MISSING"} expected=${expected[id]}`);
+      mismatches++;
+    }
+  }
+}
+
+if (present === 0) {
+  console.error("zset-merkle: no language outputs present to verify");
+  process.exit(1);
+}
+
+if (mismatches === 0) {
+  console.log(`✅ ${present} implementation(s) agree with the canonical ${expectedKeys.length} vectors.`);
+  process.exit(0);
+} else {
+  console.log(`❌ ${mismatches} mismatch(es).`);
+  process.exit(1);
+}


### PR DESCRIPTION
The new `zset-merkle` primitive (rollout) reddened **three** gate jobs at once — visible together now thanks to the per-language lint split (#8163) instead of one-per-CI-cycle:

- **cross-verify:** `tests/cross-verification/zset-merkle/` had cs/go/python outputs + vectors but **no `compare.ts` oracle** → `cross-verify-all` flagged it (assert-don't-skip). Added `compare.ts` verifying every present language output against `vectors.yaml`'s canonical `expected_hex` (key-set + per-id hash). Confirmed cs/go/python all agree with the canonical 6 vectors (the md5 difference was JSON formatting, not data — **no correctness divergence**).
- **lint (Python):** `ruff format` on `zset_merkle.py`.
- **lint (Go):** `gofmt` on `cross_verify_test.go`.

ts/fsharp/rust zset-merkle outputs are still absent (rollout wired cs/go/python only) — the oracle skips missing impls; completing the 6-language set is the rollout's remaining work.

Verified: cross-verify-all 12/12, lint-python OK, lint-go OK, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)