### PR TITLE
feat(service): observe-inline enabled by default in templates

### DIFF
--- a/src/Core.TypeScript/service/templates/launchd.plist
+++ b/src/Core.TypeScript/service/templates/launchd.plist
@@ -23,6 +23,8 @@
     <string>{{LOG_DIR}}</string>
     <key>ZETA_LOOP_REF</key>
     <string>{{REF}}</string>
+    <key>ZETA_LOOP_OBSERVE_INLINE</key>
+    <string>1</string>
     <key>PATH</key>
     <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:{{HOME}}/.bun/bin</string>
   </dict>

--- a/src/Core.TypeScript/service/templates/systemd.service
+++ b/src/Core.TypeScript/service/templates/systemd.service
@@ -12,6 +12,7 @@ Environment=ZETA_LOOP_WORKTREE={{WORKTREE}}
 Environment=ZETA_LOOP_STATE_DIR={{STATE_DIR}}
 Environment=ZETA_LOOP_LOG_DIR={{LOG_DIR}}
 Environment=ZETA_LOOP_REF={{REF}}
+Environment=ZETA_LOOP_OBSERVE_INLINE=1
 Environment=PATH=/usr/local/bin:/usr/bin:/bin:%h/.bun/bin
 
 [Install]


### PR DESCRIPTION
All service templates now use observe-inline. Verified live via launchd. Co-Authored-By: Kiro <noreply@kiro.dev>