### PR TITLE
fix(pages): escape function term set braces

### DIFF
--- a/docs/linguistic-seed/terms/function.md
+++ b/docs/linguistic-seed/terms/function.md
@@ -31,8 +31,8 @@ A function `f` from `A` to `B` is a [`set`](set.md) of ordered pairs
 Together these say `∀a ∈ A. ∃! b ∈ B. (a, b) ∈ f`. The uniqueness clause
 is [`equality`](equality.md) (`b₁ = b₂`); the pairs live in a
 [`set`](set.md). An **ordered pair** is itself reducible to sets via
-Kuratowski's encoding `(a, b) := {{a}, {a, b}}`, so a function bottoms out
-entirely in sets and equality.
+Kuratowski's encoding {% raw %}`(a, b) := {{a}, {a, b}}`{% endraw %}, so a
+function bottoms out entirely in sets and equality.
 
 ## Lean4 formalisation
 
@@ -78,7 +78,7 @@ of its seed.
 - **Dirichlet, P. G. L.** (1837) — the modern "arbitrary rule" notion of a
   function, freed from formula.
 - **Kuratowski, Kazimierz.** (1921) — the ordered-pair-as-set encoding
-  `(a,b) = {{a},{a,b}}` used above.
+  {% raw %}`(a,b) = {{a},{a,b}}`{% endraw %} used above.
 - **Bourbaki, Nicolas.** *Théorie des ensembles* (1954) — the function-as-
   graph (set of ordered pairs) standardisation.
 


### PR DESCRIPTION
## Summary

GitHub Pages is red on `origin/main` because Jekyll/Liquid parses the literal Kuratowski ordered-pair notation in `docs/linguistic-seed/terms/function.md` as a template expression:

- failing file: `docs/linguistic-seed/terms/function.md`
- failing construct: literal double braces in the set encoding
- CI symptom: `Liquid syntax error ... Variable '{{a}' was not properly terminated`

This wraps only those math snippets in Liquid `{% raw %}` blocks so the rendered docs keep the set notation while Pages stops interpreting it as a template.

## Verification

- `bunx markdownlint-cli2 docs/linguistic-seed/terms/function.md`
- Docker-local GitHub Pages image smoke:
  - `docker run --rm --entrypoint bash -v "$PWD":/github/workspace -w /github/workspace ghcr.io/actions/jekyll-build-pages:v1.0.13 -lc '/usr/local/bundle/bin/jekyll build --source . --destination /tmp/zeta-pages-site --config _config.yml --verbose'`

Agency-Signature-Version: 1
Agent: Vera
Agent-Runtime: OpenAI Codex
Agent-Model: GPT-5
Credential-Identity: AceHack
Credential-Mode: shared
Human-Review: explicit
Human-Review-Evidence: chat
Action-Mode: agent-initiated
Task: none

Co-Authored-By: Codex <noreply@openai.com>