### PR TITLE
fix(zeta-id): add Go Crockford base32 oracle — close the 6th language (sweep P0)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -37,6 +37,15 @@ tempted to ship.
 
 ### ZetaId Crockford base32 is 5-language, not 6 — Go absent, harness hides it
 
+**STATUS (fixed 2026-06-14, Otto): FIXED.** Added `src/Core.Go/zeta_id/encoding.go`
+with `Format`/`Parse`/`IsCanonical` matching the canonical TS `encoding.ts`
+alphabet+algorithm (lenient I/L→1, O→0 decode; 26-char MSB-first; 128-bit overflow
+reject). `cross_verify_test.go` now emits `crockford` + the canonical
+`roundtripOk`/`matchesExpected` booleans (parse round-trip + isCanonical +
+expected_crockford), and `compare.ts` now asserts the Go `crockford` field. All 6
+oracles agree on 12 vectors. The treaty is now genuinely 6-language and the harness
+can no longer pass with Go silent.
+
 - **Site:** `src/Core.Go/zeta_id/zeta_id.go` (no `Format`/`Parse`/base32) + `tests/cross-verification/zeta-id/compare.ts:130-136` (Go branch compares only hex)
 - **Found:** 2026-06-13 by Kira (harsh-critic), Otto anti-entropy sweep
 - **Severity:** P0

--- a/src/Core.Go/cross_verify_test.go
+++ b/src/Core.Go/cross_verify_test.go
@@ -255,19 +255,20 @@ func TestCrossVerifyTriBoolean(t *testing.T) {
 }
 
 type ZetaIdVector struct {
-	Id            string `yaml:"id"`
-	Version       uint8  `yaml:"version"`
-	Timestamp     uint64 `yaml:"timestamp"`
-	Chromosome    uint8  `yaml:"chromosome"`
-	Category      uint8  `yaml:"category"`
-	Firefly       uint8  `yaml:"firefly"`
-	AuthorityType string `yaml:"authority_type"`
-	AuthorityRaw  *uint8 `yaml:"authority_raw"`
-	Persona       uint8  `yaml:"persona"`
-	MomentumType  string `yaml:"momentum_type"`
-	MomentumRaw   *uint8 `yaml:"momentum_raw"`
-	Location      uint8  `yaml:"location"`
-	ExpectedHex   string `yaml:"expected_hex"`
+	Id                string `yaml:"id"`
+	Version           uint8  `yaml:"version"`
+	Timestamp         uint64 `yaml:"timestamp"`
+	Chromosome        uint8  `yaml:"chromosome"`
+	Category          uint8  `yaml:"category"`
+	Firefly           uint8  `yaml:"firefly"`
+	AuthorityType     string `yaml:"authority_type"`
+	AuthorityRaw      *uint8 `yaml:"authority_raw"`
+	Persona           uint8  `yaml:"persona"`
+	MomentumType      string `yaml:"momentum_type"`
+	MomentumRaw       *uint8 `yaml:"momentum_raw"`
+	Location          uint8  `yaml:"location"`
+	ExpectedHex       string `yaml:"expected_hex"`
+	ExpectedCrockford string `yaml:"expected_crockford"`
 }
 
 type ZetaIdYaml struct {
@@ -276,6 +277,7 @@ type ZetaIdYaml struct {
 
 type ZetaIdOutput struct {
 	Hex             string `json:"hex"`
+	Crockford       string `json:"crockford"`
 	RoundtripOk     bool   `json:"roundtripOk"`
 	MatchesExpected bool   `json:"matchesExpected"`
 }
@@ -341,13 +343,22 @@ func TestCrossVerifyZetaId(t *testing.T) {
 			t.Fatalf("failed to pack observation for %s: %v", v.Id, err)
 		}
 		hexVal := zeta_id.ToHex(packed)
+		crockfordVal := zeta_id.Format(packed)
 
 		unpacked := zeta_id.Unpack(packed)
-		roundtripOk := observationsEqual(obs, unpacked)
-		matchesExpected := hexVal == v.ExpectedHex
+		parsedID, parseErr := zeta_id.Parse(crockfordVal)
+		parseOk := parseErr == nil && parsedID.Cmp(packed) == 0
+		isCanonical := zeta_id.IsCanonical(crockfordVal)
+
+		// Match the canonical (TS/Rust/Python) semantics exactly: roundtripOk
+		// folds in the base32 round-trip + canonical check; matchesExpected folds
+		// in the expected_crockford comparison alongside expected_hex.
+		roundtripOk := observationsEqual(obs, unpacked) && parseOk && isCanonical
+		matchesExpected := hexVal == v.ExpectedHex && crockfordVal == v.ExpectedCrockford
 
 		outMap[v.Id] = ZetaIdOutput{
 			Hex:             hexVal,
+			Crockford:       crockfordVal,
 			RoundtripOk:     roundtripOk,
 			MatchesExpected: matchesExpected,
 		}

--- a/src/Core.Go/zeta_id/encoding.go
+++ b/src/Core.Go/zeta_id/encoding.go
@@ -1,0 +1,111 @@
+package zeta_id
+
+// encoding.go — ZetaId canonical Crockford base32 string encoding.
+//
+// Go oracle for the cross-language treaty defined by the canonical TypeScript
+// implementation (src/Core.TypeScript/zeta-id/encoding.ts) and matched by the
+// F#/C#/Rust/Python oracles. Until B-<this> Go was the one absent oracle — the
+// cross-verify harness compared only hex for Go, so the 6-language byte-lock was
+// really a 5-language treaty wearing a 6 label. This file closes that gap.
+//
+// The 128-bit ZetaId is carried here as a *big.Int (same as Pack/Unpack). Two
+// canonical big-endian (MSB-first) string forms exist; this file is the base32
+// one (hex lives in ToHex). Crockford base32: 26 chars, alphabet [0-9 A-Z] minus
+// the ambiguous I,L,O,U; fixed-width + MSB-first + ASCII-ascending alphabet ⇒
+// string sort == numeric ZetaId sort (filename-safe, sort-preserving). See
+// encoding.ts for the full rationale (B-0682).
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+)
+
+// CrockfordAlphabet — excludes I, L, O, U (ambiguity). ASCII-ascending so a
+// fixed-width string sort preserves numeric order.
+const CrockfordAlphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+// ZetaIdBase32Len — 128 bits / 5 bits-per-char = 25.6 ⇒ 26 chars (top 2 bits are
+// zero padding).
+const ZetaIdBase32Len = 26
+
+// mask128 — the low 128 bits; every form masks to this before encoding.
+var mask128 = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 128), big.NewInt(1))
+
+// crockfordDecode — canonical chars + lowercase + Crockford's lenient aliases
+// (I/i,L/l→1; O/o→0). U/u is NOT a value symbol in Crockford (check-only) so it
+// is absent ⇒ rejected by Parse. Keyed by ASCII byte (all symbols are ASCII).
+var crockfordDecode = func() map[byte]int {
+	m := make(map[byte]int, 64)
+	for i := 0; i < len(CrockfordAlphabet); i++ {
+		c := CrockfordAlphabet[i]
+		m[c] = i
+		if c >= 'A' && c <= 'Z' {
+			m[c+('a'-'A')] = i // lowercase alias
+		}
+	}
+	// Crockford lenient aliases for visually-ambiguous input.
+	m['I'], m['i'] = 1, 1
+	m['L'], m['l'] = 1, 1
+	m['O'], m['o'] = 0, 0
+	return m
+}()
+
+// Format encodes a 128-bit ZetaId as the canonical 26-char Crockford base32
+// string (big-endian, fixed width, sort-preserving, filename-safe).
+func Format(id *big.Int) string {
+	v := new(big.Int).And(id, mask128)
+	out := make([]byte, ZetaIdBase32Len)
+	low5 := big.NewInt(31)
+	digit := new(big.Int)
+	// MSB-first: fill from the right (least-significant 5 bits) backwards.
+	for i := ZetaIdBase32Len - 1; i >= 0; i-- {
+		digit.And(v, low5)
+		out[i] = CrockfordAlphabet[digit.Int64()]
+		v.Rsh(v, 5)
+	}
+	return string(out)
+}
+
+// Parse decodes a canonical (or Crockford-lenient) base32 string back to a
+// ZetaId. Accepts lowercase + the I/L→1, O→0 aliases; rejects wrong length,
+// invalid symbols, and any value that overflows 128 bits (the two leading pad
+// bits must be zero ⇒ first char ∈ 0..7).
+func Parse(s string) (*big.Int, error) {
+	if len(s) != ZetaIdBase32Len {
+		return nil, fmt.Errorf("ZetaId.Parse: expected %d Crockford-base32 chars, got %d (%q)", ZetaIdBase32Len, len(s), s)
+	}
+	v := new(big.Int)
+	for i := 0; i < len(s); i++ {
+		d, ok := crockfordDecode[s[i]]
+		if !ok {
+			return nil, fmt.Errorf("ZetaId.Parse: invalid Crockford-base32 char %q at index %d", string(s[i]), i)
+		}
+		v.Lsh(v, 5)
+		v.Or(v, big.NewInt(int64(d)))
+	}
+	if v.Cmp(mask128) > 0 {
+		return nil, errors.New("ZetaId.Parse: value exceeds 128 bits (leading pad bits must be zero)")
+	}
+	return v, nil
+}
+
+// IsCanonical reports whether s is the strict canonical Crockford form (exactly
+// what Format emits) — 26 chars, uppercase, only the strict alphabet, no lenient
+// aliases, and round-trips. Use to reject non-canonical filenames.
+func IsCanonical(s string) bool {
+	if len(s) != ZetaIdBase32Len {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if !strings.ContainsRune(CrockfordAlphabet, rune(s[i])) {
+			return false
+		}
+	}
+	parsed, err := Parse(s)
+	if err != nil {
+		return false
+	}
+	return Format(parsed) == s
+}

--- a/tests/cross-verification/zeta-id/compare.ts
+++ b/tests/cross-verification/zeta-id/compare.ts
@@ -132,6 +132,11 @@ for (const key of keys) {
       console.error(`Mismatch ${key} hex: TS=${tsHex} Go=${goHex ?? "MISSING"}`);
       mismatches++;
     }
+    const goCrockford = goExists[key]?.crockford;
+    if (tsCrockford !== goCrockford) {
+      console.error(`Mismatch ${key} crockford: TS=${tsCrockford} Go=${goCrockford ?? "MISSING"}`);
+      mismatches++;
+    }
   }
 }
 

--- a/tests/cross-verification/zeta-id/go-output.json
+++ b/tests/cross-verification/zeta-id/go-output.json
@@ -1,61 +1,73 @@
 {
   "authority-best-effort": {
     "hex": "080cb77ed58d18074017000800000000",
+    "crockford": "081JVQXNCD303M05R010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "authority-human-verified": {
     "hex": "080cb77ed58d19c1f80b000800000000",
+    "crockford": "081JVQXNCD370ZG2R010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "authority-raw-0": {
     "hex": "0800000000000001000b000800000000",
+    "crockford": "0800000000000G02R010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "authority-simulated": {
     "hex": "080cb77ed58d18071817c00800000000",
+    "crockford": "081JVQXNCD303HG5Y010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "authority-standard": {
     "hex": "080cb77ed58d18017815001000000000",
+    "crockford": "081JVQXNCD300QG58020000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "authority-trusted-agent": {
     "hex": "080cb77ed58d19c1a00b000800000000",
+    "crockford": "081JVQXNCD370T02R010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "momentum-background": {
     "hex": "080cb77ed58d19c1f809000800000000",
+    "crockford": "081JVQXNCD370ZG28010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "momentum-critical": {
     "hex": "080cb77ed58d19c1f80fc00800000000",
+    "crockford": "081JVQXNCD370ZG3Y010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "momentum-elevated": {
     "hex": "080cb77ed58d19c1a00d000800000000",
+    "crockford": "081JVQXNCD370T038010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "momentum-high": {
     "hex": "080cb77ed58d19c1f80f000800000000",
+    "crockford": "081JVQXNCD370ZG3R010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "momentum-normal": {
     "hex": "080cb77ed58d19c1f80b000800000000",
+    "crockford": "081JVQXNCD370ZG2R010000000",
     "roundtripOk": true,
     "matchesExpected": true
   },
   "momentum-raw-255": {
     "hex": "0ffffffffffff9c1f80ff80800000000",
+    "crockford": "0FZZZZZZZZZ70ZG3ZR10000000",
     "roundtripOk": true,
     "matchesExpected": true
   }


### PR DESCRIPTION
## What

Closes the standing **P0** from Kira's harsh-critic review + Otto's anti-entropy sweep: the "6-language Crockford base32" (#8141) was really **5-language**. Go had no `Format`/`Parse`/base32, and `compare.ts` compared only Go's *hex* — so the cross-verify treaty was unenforced on Go and the harness was written not to notice.

## Changes

- **`src/Core.Go/zeta_id/encoding.go`** (new): `Format`/`Parse`/`IsCanonical` over `*big.Int`, matching the canonical TS `encoding.ts` byte-for-byte — alphabet `0-9 A-Z` minus `I,L,O,U`; 26-char MSB-first; lenient decode (`I/i,L/l→1`; `O/o→0`; lowercase); 128-bit overflow reject.
- **`cross_verify_test.go`**: emit `crockford` + the canonical `roundtripOk`/`matchesExpected` semantics (parse round-trip + `IsCanonical` + `expected_crockford`), matching TS/Rust/Python exactly.
- **`compare.ts`**: assert the Go `crockford` field — closes the harness blind-spot.
- **`docs/BUGS.md`**: P0 marked FIXED.

## Verification

- `go test ./...` green (no regressions)
- `bun compare.ts` → ✅ all **6** oracles agree on 12 vectors
- `gofmt` + markdownlint clean

The treaty is now genuinely 6-language; the harness can no longer pass with Go silent.