### PR TITLE
fix(dst): FerryThrottler async-disposable drain; non-blocking Dispose (no Task.WaitAll)

### DIFF
--- a/src/Core/DiskDeltaLog.fs
+++ b/src/Core/DiskDeltaLog.fs
@@ -272,3 +272,9 @@ type GroupCommitDiskDeltaLog<'K when 'K : comparison>
 
     interface IDisposable with
         member _.Dispose() = (throttler :> IDisposable).Dispose()
+
+    // Deterministic, non-blocking disposal — forwards to the throttler's awaited
+    // drain. Prefer this over `Dispose` wherever an async disposal scope exists
+    // (`use!` in a task/async), so the group-commit ferries flush replayably.
+    interface IAsyncDisposable with
+        member _.DisposeAsync() = (throttler :> IAsyncDisposable).DisposeAsync()

--- a/src/Core/FerryThrottler.fs
+++ b/src/Core/FerryThrottler.fs
@@ -322,10 +322,36 @@ type FerryThrottler<'TItem>
 
     interface IDisposable with
         member _.Dispose() =
+            // Best-effort, NON-BLOCKING shutdown. Signal completion + cancel; the
+            // ferries observe cancellation and exit on their own. We deliberately
+            // do NOT block on the ferry tasks here: a wall-clock
+            // `Task.WaitAll(_, 500)` is DST-hostile (a nondeterministic timeout
+            // DST cannot replay) AND deadlocks the DoP=1 deterministic path — the
+            // injected pump can't run while this thread is blocked, so the ferries
+            // never complete and the 500ms timeout abandons them. The CTS is
+            // disposed only after the ferries actually finish, via an inline
+            // continuation. Callers needing a guaranteed drain use `DisposeAsync`
+            // (deterministic) or `CompleteAsync`.
             inbox.Writer.TryComplete() |> ignore
             cts.Cancel()
-            try Task.WaitAll(ferryTasks, 500) |> ignore with _ -> ()
-            cts.Dispose()
+            (Task.WhenAll ferryTasks).ContinueWith(
+                (fun (_: Task) -> cts.Dispose()),
+                TaskContinuationOptions.ExecuteSynchronously) |> ignore
+
+    interface IAsyncDisposable with
+        member _.DisposeAsync() =
+            // Deterministic drain: signal completion, cancel, then AWAIT every
+            // ferry to finish — no thread blocked, no wall-clock timeout, fully
+            // DST-replayable (on the DoP=1 path the awaited continuations route
+            // through the injected pump). This is the preferred disposal path.
+            inbox.Writer.TryComplete() |> ignore
+            cts.Cancel()
+            ValueTask(
+                task {
+                    try do! Task.WhenAll ferryTasks
+                    with _ -> ()
+                    cts.Dispose()
+                })
 
 
 /// Request/response FerryThrottler arity. Producers submit one item and receive
@@ -546,10 +572,36 @@ type FerryThrottler<'TItem, 'TResult>
 
     interface IDisposable with
         member _.Dispose() =
+            // Best-effort, NON-BLOCKING shutdown. Signal completion + cancel; the
+            // ferries observe cancellation and exit on their own. We deliberately
+            // do NOT block on the ferry tasks here: a wall-clock
+            // `Task.WaitAll(_, 500)` is DST-hostile (a nondeterministic timeout
+            // DST cannot replay) AND deadlocks the DoP=1 deterministic path — the
+            // injected pump can't run while this thread is blocked, so the ferries
+            // never complete and the 500ms timeout abandons them. The CTS is
+            // disposed only after the ferries actually finish, via an inline
+            // continuation. Callers needing a guaranteed drain use `DisposeAsync`
+            // (deterministic) or `CompleteAsync`.
             inbox.Writer.TryComplete() |> ignore
             cts.Cancel()
-            try Task.WaitAll(ferryTasks, 500) |> ignore with _ -> ()
-            cts.Dispose()
+            (Task.WhenAll ferryTasks).ContinueWith(
+                (fun (_: Task) -> cts.Dispose()),
+                TaskContinuationOptions.ExecuteSynchronously) |> ignore
+
+    interface IAsyncDisposable with
+        member _.DisposeAsync() =
+            // Deterministic drain: signal completion, cancel, then AWAIT every
+            // ferry to finish — no thread blocked, no wall-clock timeout, fully
+            // DST-replayable (on the DoP=1 path the awaited continuations route
+            // through the injected pump). This is the preferred disposal path.
+            inbox.Writer.TryComplete() |> ignore
+            cts.Cancel()
+            ValueTask(
+                task {
+                    try do! Task.WhenAll ferryTasks
+                    with _ -> ()
+                    cts.Dispose()
+                })
 
 
 /// **ContextualFerryThrottler** — explicit context threading, the Kleisli-Arrow


### PR DESCRIPTION
First increment of the accidental-`Wait()` / DST cleanup around `IScheduler` + the throttler (Aaron-assigned).

## Problem
`FerryThrottler`'s `IDisposable.Dispose` blocked on `Task.WaitAll(ferryTasks, 500)` — sync-over-async that is **DST-hostile** (wall-clock timeout DST can't replay) **and deadlocks the DoP=1 deterministic path**: with an injected `DeterministicSyncContext` the ferry continuations route to the pump, which can't run while `Dispose` blocks the thread, so the ferries never complete and the 500ms timeout silently abandons them.

## Fix (both throttler arities + DiskDeltaLog)
- **Add `IAsyncDisposable.DisposeAsync`** — deterministic preferred drain: complete + cancel + **await** `Task.WhenAll ferryTasks` (no thread blocked, no timeout), then dispose the CTS.
- **`IDisposable.Dispose` made non-blocking** — complete + cancel; CTS disposed via an inline `ExecuteSynchronously` continuation only after the ferries finish. Best-effort; guaranteed drain via `DisposeAsync`/`CompleteAsync`.
- `DiskDeltaLog` forwards `IAsyncDisposable` to the throttler.

## Verify
No test relied on `Dispose` draining synchronously (verified). Build 0 warnings; FerryThrottler/SoftThrottle suite **53/53** green.

Remaining increments: SpineAsync (`SpinWait`/`worker.Wait`), WorkStealingRuntime (`Completion.Wait`), PluginHarness (sync-over-async ×4), CLI mains.