### PR TITLE
fix(dst): WorkStealingRuntime async-disposable drain; non-blocking Dispose

### DIFF
--- a/src/Core/WorkStealingRuntime.fs
+++ b/src/Core/WorkStealingRuntime.fs
@@ -99,5 +99,22 @@ type WorkStealingRuntime<'K when 'K : comparison>
 
     interface IDisposable with
         member _.Dispose() =
+            // Non-blocking shutdown (mirrors FerryThrottler/SpineAsync). A
+            // wall-clock `Completion.Wait 500` is DST-hostile (a timeout DST
+            // cannot replay) and deadlocks the DoP=1 deterministic path: the
+            // dataflow block's continuations route to the pump, which cannot
+            // run while this thread is blocked. Just signal completion; the
+            // block drains on its own. Guaranteed drain via DisposeAsync.
             stepBlock.Complete()
-            stepBlock.Completion.Wait 500 |> ignore
+
+    interface IAsyncDisposable with
+        member _.DisposeAsync() =
+            // Deterministic drain: signal completion, then AWAIT the block —
+            // no thread blocked, no wall-clock timeout, replayable on the
+            // DoP=1 pump.
+            stepBlock.Complete()
+            ValueTask(
+                task {
+                    try do! stepBlock.Completion
+                    with _ -> ()
+                })


### PR DESCRIPTION
Third increment of the accidental-`Wait()` / DST cleanup (after #8184, #8185).

`WorkStealingRuntime.Dispose` blocked on `stepBlock.Completion.Wait 500` — same DST-hostile sync-over-async (timeout DST can't replay; deadlocks the DoP=1 pump).

- **Add `IAsyncDisposable.DisposeAsync`**: `Complete()` + **await** `stepBlock.Completion`.
- **`Dispose` non-blocking**: just `Complete()`; the dataflow block drains on its own.

Build 0 warnings; WorkStealing test green.

Remaining: PluginHarness (sync-over-async ×4), CLI mains.