### PR TITLE
fix(dst): PluginHarness never blocks — remove sync-over-async ×4

### DIFF
--- a/src/Core/PluginHarness.fs
+++ b/src/Core/PluginHarness.fs
@@ -28,6 +28,23 @@ module PluginHarness =
         override _.StepAsync(_ct) = ValueTask.CompletedTask
         member this.Feed(v: 'TIn) = this.SetValue v
 
+    /// Observe a per-tick step result WITHOUT blocking. A synchronous test
+    /// harness requires operators that complete StepAsync/AfterStepAsync
+    /// synchronously; we never do sync-over-async here (`AsTask().GetAwaiter()
+    /// .GetResult()` is DST-hostile — it deadlocks the DoP=1 deterministic pump
+    /// and adds a nondeterministic wait). If the ValueTask already completed we
+    /// observe it inline — success is a no-op, a fault/cancel rethrows
+    /// synchronously (no block). Only a GENUINELY pending step fails loudly:
+    /// this harness is synchronous-only by design.
+    let inline private requireSync (vt: ValueTask) (what: string) : unit =
+        if vt.IsCompletedSuccessfully then ()
+        elif vt.IsCompleted then vt.GetAwaiter().GetResult() // completed-faulted/cancelled: surface synchronously, never blocks
+        else
+            invalidOp (
+                sprintf
+                    "PluginHarness: %s did not complete synchronously. The plugin harness is synchronous-only — it never blocks on a pending step (sync-over-async breaks DST determinism). Operators driven here must complete each step synchronously."
+                    what)
+
     /// Drive a single-input plugin operator through a list of
     /// inputs. `makeOp` receives a mock `Stream<'TIn>` bound to
     /// the harness source and must return the plugin op ready to
@@ -65,9 +82,7 @@ module PluginHarness =
         for input in inputs do
             source.Feed input
             let before = adapter.PublishCount.Value
-            let vt = (adapter :> Op).StepAsync ct
-            if not vt.IsCompletedSuccessfully then
-                vt.AsTask().GetAwaiter().GetResult()
+            requireSync ((adapter :> Op).StepAsync ct) "StepAsync"
             let after = adapter.PublishCount.Value
             let delta = after - before
             if delta <> 1 then
@@ -80,9 +95,7 @@ module PluginHarness =
             // rationale; same fix applies symmetrically to single-
             // input strict plugins (e.g. IStrictOperator-tagged
             // ops exercised via LawRunner.checkLinear).
-            let postVt = (adapter :> Op).AfterStepAsync ct
-            if not postVt.IsCompletedSuccessfully then
-                postVt.AsTask().GetAwaiter().GetResult()
+            requireSync ((adapter :> Op).AfterStepAsync ct) "AfterStepAsync"
             // nosemgrep: plain-tick-increment -- method-local loop counter, not shared across threads
             tick <- tick + 1
         List.ofSeq outputs
@@ -129,9 +142,7 @@ module PluginHarness =
             source1.Feed in1
             source2.Feed in2
             let before = adapter.PublishCount.Value
-            let vt = (adapter :> Op).StepAsync ct
-            if not vt.IsCompletedSuccessfully then
-                vt.AsTask().GetAwaiter().GetResult()
+            requireSync ((adapter :> Op).StepAsync ct) "StepAsync"
             let after = adapter.PublishCount.Value
             let delta = after - before
             if delta <> 1 then
@@ -148,9 +159,7 @@ module PluginHarness =
             // semantics in `runTwoInputs` than in real circuit
             // execution, and `LawRunner.checkBilinear` would
             // validate against incorrect strict-op state.
-            let postVt = (adapter :> Op).AfterStepAsync ct
-            if not postVt.IsCompletedSuccessfully then
-                postVt.AsTask().GetAwaiter().GetResult()
+            requireSync ((adapter :> Op).AfterStepAsync ct) "AfterStepAsync"
             // nosemgrep: plain-tick-increment -- method-local loop counter, not shared across threads
             tick <- tick + 1
         List.ofSeq outputs


### PR DESCRIPTION
Fourth increment of the accidental-`Wait()` / DST cleanup (after #8184/#8185/#8186).

The harness drove each tick with `vt.AsTask().GetAwaiter().GetResult()` on the slow path (×4) — a silent sync-over-async block (DST-hostile; deadlocks the DoP=1 pump).

Replaced with a `requireSync` helper:
- completed-successfully → no-op
- completed-faulted/cancelled → `GetResult()` rethrows **synchronously** (already complete, no block) — faults still surface
- **genuinely pending** → `invalidOp`: the harness is synchronous-only by design, never blocks

No internal callers (public plugin-author test API); synchronous plugin ops unaffected. Build 0 warnings; full F# suite **243** green.

Remaining: CLI mains (entry points) — converting to `task` mains so even those drop `Async.RunSynchronously`/`GetResult`.