### PR TITLE
docs(pitch): three audience-tuned pitch variants (investor $1M / design-partner / role)

### DIFF
--- a/docs/pitch/pitch-design-partner.md
+++ b/docs/pitch/pitch-design-partner.md
@@ -1,0 +1,32 @@
+# Zeta — design-partner one-pager
+
+**One line:** If AI-generated code is drifting across your services, forks, and CI, Zeta keeps it coherent by distributing the *generator* (not the output) — copies regenerate locally and **self-heal** instead of diverging.
+
+---
+
+## The pain you already have
+
+You adopted AI codegen and the velocity is real — but so is the drift. The same logic lives in five slightly-different copies across services and forks; "which version is correct?" is now a daily question; review can't keep up; and a subtle divergence ships before anyone notices. The tools were built for human-speed change.
+
+## What Zeta does
+
+- **One generator, regenerated everywhere.** You distribute a small, deterministic generator; each service/repo regenerates its code locally — so there's one source of truth and N *views*, not N drifting copies.
+- **Self-healing.** Because the generator is also an error-correcting code, when copies drift they **re-converge** on regeneration (`gen(gen) == gen`) — drift is detected and corrected, not discovered in production.
+- **Verify by re-running, not by reading.** Everything is deterministic and reversible — reproduce any artifact, replay/audit any state across machines and versions. Reviews get cheaper; audits get trivial.
+- **You own it.** Generator and output are yours and redistributable — open-source core, no vendor lock-in, no code leaving your control.
+
+## What's real today (so you can try it)
+
+- A **6-language cross-verification treaty** producing byte-identical results across F#, C#, TypeScript, Rust, Python, Go (+ a Q# reference oracle).
+- A **deterministic, reversible substrate** (deterministic simulation testing; event-sourced reversible logs).
+- Working code-generation: one source → 6 languages + a runnable, sandboxed CHIP-8 cart.
+
+## What we'd build *with you*
+
+The end-to-end `.zeta` → IR compiler and the deploy tooling are in active build, and **we want our first design partners to shape them** against a real pain you have. You get early influence on the roadmap, direct engineering support, and an open-source core you can adopt without lock-in.
+
+## The ask — become a design partner
+
+Pick one concrete drift pain (a service whose AI-generated code keeps diverging across copies/CI). We pilot the self-healing distribution layer on it, measure drift caught before production, and shape the product together. Low risk: open-source, you own the output, no lock-in.
+
+*Technical deep-dive: `docs/research/2026-06-14-zeta-complete-vision-synthesis-*.md`. Founder: distributed systems + 15 years utility-grade metering (Itron-class AMI).*

--- a/docs/pitch/pitch-investor.md
+++ b/docs/pitch/pitch-investor.md
@@ -1,0 +1,40 @@
+# Zeta — pre-seed ($1M) · investor one-pager
+
+**One line:** AI writes code faster than teams can keep it in sync. Zeta ships the *generator*, not the output — so every copy regenerates locally and **self-heals** instead of drifting. We're raising **$1M pre-seed** to take the self-healing distribution layer from open-source proof to a deployable product.
+
+---
+
+## Problem (why now)
+
+AI changed the *rate* of code change; it did not change how code is *distributed*. Packages, forks, branches, review, and sync were built for human-speed change and break at AI speed — you get N copies that have quietly diverged and no cheap way to know which is right. Every team adopting AI codegen is walking into this wall in 2025–26. (ThePrimeagen named it publicly: *how do you distribute code that changes this fast with AI?*)
+
+## Product
+
+**Distribute the generator, not the code.** Ship a small, stable, deterministic generator; regenerate the fast-changing code locally; and because **the generator is also an error-correcting code**, divergence self-corrects — regenerate and copies snap back into agreement (`gen(gen) == gen`). It's **Nix / reproducible builds generalized to all generatable code, plus a self-healing layer Nix doesn't have.**
+
+## Why it wins (moat)
+
+- **Self-healing distribution** — building from the generator *is* the drift-check. Not just reproducible; re-convergent.
+- **Deterministic + reversible** — verify by re-running, not by reading; replay/audit any state across machines and versions. Compliance and audit become features.
+- **User-owned** — generator and output are redistributable, not locked in a vendor cloud (the opposite custody to the AI-browser land-grab).
+- **Open-source flywheel** — the substrate is public; adoption compounds; the company sells the deploy/scale/assurance layer on top.
+
+## Traction (real, open-source, in CI)
+
+- **6-language cross-verification treaty** — identical primitives produce byte-identical results across F#, C#, TypeScript, Rust, Python, Go, with a **Q# reference oracle** for the observable layer.
+- **Deterministic, reversible substrate** — deterministic simulation testing + event-sourced reversible logs (the part that makes "trust without reading" true).
+- **One source → 6 languages + a runnable CHIP-8 cart.** Working code-generation today.
+
+## Market
+
+Wedge: **AI dev-tooling** (every team shipping AI-generated code). Expansions: **regulated / safety-critical** (deterministic+auditable+reversible), **education** (Craft School — a new programming on-ramp), **personal-data ownership** (user-owned Memex). Land on the dev-tooling pain; expand into assurance and education.
+
+## Founder
+
+Distributed systems + 15 years utility-grade metering (Itron-class AMI) — the metering/uncertainty substrate *is* the architecture's core loop. **Self-funded ~$1M of personal capital into this.** Built it in the open, through significant adversity, and emerged fully vindicated. <!-- founder story (self-funded $1M; wrongful prosecution → fully exonerated, all charges dismissed; built in the open, kept building) — wording is Aaron's to set; verbal in the room may be stronger than in print. -->
+
+## The ask — $1M pre-seed
+
+To convert the open-source proof into a product the first teams deploy: harden the self-healing distribution layer, sign 3–5 design partners, and ship the deploy/assurance tooling. Use of funds: core engineering, design-partner delivery, runway to a usage milestone.
+
+*Technical deep-dive: `docs/research/2026-06-14-zeta-complete-vision-synthesis-*.md`. Built in the open — the repo is the proof.*

--- a/docs/pitch/pitch-role.md
+++ b/docs/pitch/pitch-role.md
@@ -1,0 +1,30 @@
+# Zeta — "here's what I build" · role / founder one-pager
+
+**One line:** I built a self-healing code-distribution substrate — solo, in the open, end to end. The repo is the portfolio; this is what I ship.
+
+---
+
+## What I built
+
+**Zeta** answers a real, named problem (ThePrimeagen: *how do you distribute code that changes this fast with AI?*) with a clean thesis — **distribute the generator, not the code.** Ship a small deterministic generator; regenerate artifacts locally; and because the generator doubles as an error-correcting code, copies **self-heal** instead of drifting (`gen(gen) == gen`). It's reproducible builds (Nix-style) generalized to all generatable code, with a self-healing layer on top.
+
+## The engineering (real, open-source, in CI — proof of capability)
+
+- **6-language cross-verification treaty** — the same primitives produce **byte-identical** results across F#, C#, TypeScript, Rust, Python, Go, with a **Q# reference oracle** for the observable/quantum layer. (Cross-language determinism is hard; this is the load-bearing part, and it's green in CI.)
+- **Deterministic, reversible substrate** — deterministic simulation testing (FoundationDB-style) + event-sourced reversible (Z-set/DBSP) logs. I personally swept the codebase to remove every ambient-nondeterminism leak (`.Wait()`/`Task.Run`/wall-clock) so the substrate is genuinely replayable.
+- **Code generation** — one source → 6 languages + a runnable, sandboxed CHIP-8 cart.
+- **Discipline** — 0-warning build gate, per-language CI lint, golden-vector byte-locks, an agent-attributed commit convention. The whole thing is built to be auditable.
+
+## How I work
+
+Distributed systems + **15 years of utility-grade metering (Itron-class AMI)** — the metering/uncertainty substrate *is* this architecture's core loop, so this isn't a side project; it's the through-line of my career. I design for determinism, reversibility, and no-central-point-of-failure by default, and I write it so a new contributor (or a child) can read it.
+
+## The arc
+
+I **self-funded ~$1M** of my own capital into this and kept building it in the open through a **wrongful prosecution** — from which I was **fully exonerated, all charges dismissed.** I came out and kept shipping. The complete arc is in the project record. If you want a founder/principal who builds hard infrastructure, in the open, and does not stop, that's the evidence.
+
+## The ask
+
+A **founding / principal / staff role** (distributed systems · platform · developer tooling · dev-infra) — or a fractional/advisory engagement — where this capability applies. Fastest way to evaluate me: read the repo and run the CHIP-8 cart.
+
+*Deep-dive: `docs/research/2026-06-14-zeta-complete-vision-synthesis-*.md`. Pitch + product: `docs/PITCH-ONE-PAGER.md`, `docs/pitch/`.*


### PR DESCRIPTION
Aaron-requested variants of the one-pager, each re-angled for its reader:

- **pitch-investor.md** — pre-seed **$1M** ask; problem/why-now, product, moat, traction (6-lang byte-lock + Q# oracle + DST, in CI), market wedge, founder + use of funds.
- **pitch-design-partner.md** — leads with the customer's drift pain; deploy-this; what's-real-today; build-it-with-you roadmap; low-risk (open-source, you own it); design-partner ask.
- **pitch-role.md** — "here's what I build"; repo-as-portfolio; engineering depth as proof of capability; founder arc; founding/principal/staff or advisory ask.

Founder arc kept dignified in print (self-funded ~$1M; wrongful prosecution → fully exonerated; built in the open); full arc in the project record; public framing left for Aaron to dial. markdownlint clean.