### PR TITLE
feat(B-0855.2): post-boot node self-registration — close the cred-restore gap

### DIFF
--- a/full-ai-cluster/nixos/modules/common.nix
+++ b/full-ai-cluster/nixos/modules/common.nix
@@ -79,6 +79,11 @@
     passphraseMode = lib.mkDefault "interactive";
   };
 
+  # B-0855.2: every node self-registers on first boot (opens a
+  # maintainers/<gh-user>/cluster-nodes/<host> PR) once cred-restore has put gh
+  # auth back. Idempotent; per-host opt-out: zeta.selfRegister.enable = false;
+  zeta.selfRegister.enable = lib.mkDefault true;
+
   nix.settings = {
     experimental-features = [ "nix-command" "flakes" ];
     auto-optimise-store = true;

--- a/full-ai-cluster/nixos/modules/zeta-self-register.nix
+++ b/full-ai-cluster/nixos/modules/zeta-self-register.nix
@@ -1,17 +1,19 @@
 # full-ai-cluster/nixos/modules/zeta-self-register.nix
 #
-# B-0855.1: NixOS service surface for post-install self-registration.
-# The service is intentionally disabled by default until B-0855.2 ships
-# the TypeScript implementation at tools/installer/zeta-self-register.ts.
-# Once enabled by a host config, it fires after the installed OS reaches
-# network-online and credential-restore ordering, then keeps retrying
-# until the local marker confirms registration intent was written.
+# B-0855.1 surface + B-0855.2 wiring: post-install first-boot self-registration.
+# Fires once the installed OS reaches network-online AND zeta-creds-restore has
+# put gh auth back (the cred-blob restores creds on first boot — AFTER the
+# installer ran, which is exactly why the install-time Step 6.9 registration was
+# always gated off). The ExecStart script opens a
+# maintainers/<gh-user>/cluster-nodes/<host>/node.yaml PR, then writes a marker so
+# subsequent boots no-op (idempotent; also no-ops if already on main).
+#
+# Enabled cluster-wide in common.nix. Per-host opt-out: zeta.selfRegister.enable = false;
 
 { config, lib, ... }:
 
 let
   cfg = config.zeta.selfRegister;
-  bunShimPath = "${cfg.home}/.local/share/mise/shims/bun";
 in
 {
   options.zeta.selfRegister = {
@@ -20,7 +22,7 @@ in
     user = lib.mkOption {
       type = lib.types.str;
       default = "zeta";
-      description = "User that runs zeta-self-register.service.";
+      description = "User that runs zeta-self-register.service (must hold the restored gh auth).";
     };
 
     group = lib.mkOption {
@@ -32,37 +34,31 @@ in
     home = lib.mkOption {
       type = lib.types.str;
       default = "/home/zeta";
-      description = "Home directory used for credentials and local marker state.";
+      description = "Home directory (carries the restored ~/.config/gh credentials).";
     };
 
     repoRoot = lib.mkOption {
       type = lib.types.str;
-      default = "${cfg.home}/Zeta";
-      description = "Path to the checked-out Zeta repository on the installed node.";
+      default = "/etc/zeta";
+      description = "Checked-out Zeta repo on the installed node (the flake source used by nixos-install).";
     };
 
     scriptPath = lib.mkOption {
       type = lib.types.str;
-      default = "${cfg.repoRoot}/tools/installer/zeta-self-register.ts";
-      description = "Bun TypeScript entrypoint for composing self-registration intent.";
+      default = "${cfg.repoRoot}/tools/installer/zeta-self-register.sh";
+      description = "Registration entrypoint (bash; self-contained, clones fresh, needs only gh+git).";
     };
 
     markerPath = lib.mkOption {
       type = lib.types.str;
-      default = "${cfg.home}/.config/zeta/self-registered.marker";
-      description = "Fast-path local marker written after registration intent exists.";
-    };
-
-    intentDir = lib.mkOption {
-      type = lib.types.str;
-      default = "${cfg.home}/.config/zeta/self-registration-intent";
-      description = "Directory where the service writes registration intent for the local agent steward.";
+      default = "/var/lib/zeta-self-register/self-registered.marker";
+      description = "Marker written after a successful (or already-registered) run; gates re-runs.";
     };
   };
 
   config = lib.mkIf cfg.enable {
     systemd.services.zeta-self-register = {
-      description = "Zeta node self-registration intent writer (B-0855.1)";
+      description = "Zeta node self-registration (B-0855.2): first-boot maintainers/<user>/cluster-nodes/<host> PR";
       wantedBy = [ "multi-user.target" ];
       wants = [ "network-online.target" ];
       after = [
@@ -70,11 +66,11 @@ in
         "zeta-creds-restore.service"
       ];
 
+      # Skip cleanly once the marker exists, and never fire without the script present.
       unitConfig = {
         ConditionPathExists = [
           "!${cfg.markerPath}"
           cfg.scriptPath
-          bunShimPath
         ];
       };
 
@@ -82,16 +78,17 @@ in
         Type = "oneshot";
         User = cfg.user;
         Group = cfg.group;
-        WorkingDirectory = cfg.repoRoot;
+        # systemd creates /var/lib/zeta-self-register owned by the service user, so
+        # the marker write succeeds even though ~/.config may be root-owned (creds).
+        StateDirectory = "zeta-self-register";
+        WorkingDirectory = cfg.home;
         Environment = [
           "HOME=${cfg.home}"
-          "PATH=${cfg.home}/.local/share/mise/shims:${cfg.home}/.bun/bin:/run/current-system/sw/bin:/usr/bin:/bin"
-          "BUN_INSTALL=${cfg.home}/.bun"
+          "PATH=/run/current-system/sw/bin:${cfg.home}/.nix-profile/bin"
           "ZETA_SELF_REGISTER_MARKER=${cfg.markerPath}"
-          "ZETA_SELF_REGISTER_INTENT_DIR=${cfg.intentDir}"
-          "ZETA_SELF_REGISTER_REPO=${cfg.repoRoot}"
         ];
-        ExecStart = "${bunShimPath} ${cfg.scriptPath}";
+        ExecStart = "/run/current-system/sw/bin/bash ${cfg.scriptPath}";
+        # gh auth may arrive a beat after boot; retry a few times rather than fail hard.
         Restart = "on-failure";
         RestartSec = "30s";
       };

--- a/tools/installer/zeta-self-register.sh
+++ b/tools/installer/zeta-self-register.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# tools/installer/zeta-self-register.sh — B-0855.2 post-boot node self-registration.
+#
+# Runs as a first-boot systemd oneshot (see nixos/modules/zeta-self-register.nix)
+# AFTER network-online + zeta-creds-restore, so gh auth is present. Opens a PR
+# adding maintainers/<gh-user>/cluster-nodes/<host>/node.yaml (B-0813 ClusterNode).
+#
+# WHY post-boot (not install-time, Step 6.9): a zero-typing install restores gh
+# creds on first boot via the cred-blob — AFTER the installer ran — so the
+# install-time registration was always gated off (no auth yet). This closes that
+# gap: it fires once the restored creds exist.
+#
+# Idempotent + safe to retry: no-ops if a local marker exists OR the node is
+# already on main. Never edits the in-place repo working tree (fresh shallow
+# clone in a tempdir). Honest exit: skips cleanly (exit 0) when gh isn't authed.
+set -euo pipefail
+
+MARKER="${ZETA_SELF_REGISTER_MARKER:-$HOME/.config/zeta/self-registered.marker}"
+REPO_SLUG="${ZETA_SELF_REGISTER_REPO_SLUG:-Lucent-Financial-Group/Zeta}"
+log() { echo "[self-register] $*"; }
+
+if [ -f "$MARKER" ]; then log "marker present ($MARKER) — already registered; nothing to do"; exit 0; fi
+command -v gh  >/dev/null || { log "gh not found — cannot register"; exit 1; }
+command -v git >/dev/null || { log "git not found — cannot register"; exit 1; }
+if ! gh auth status >/dev/null 2>&1; then log "gh not authenticated yet — skipping (will retry next boot)"; exit 0; fi
+
+MAINTAINER="$(gh api /user --jq .login)"
+HOST="$(hostname | tr -d '[:space:]')"
+NODE_PATH="maintainers/${MAINTAINER}/cluster-nodes/${HOST}/node.yaml"
+log "maintainer=${MAINTAINER} host=${HOST}"
+
+# Idempotency: already on main? (write marker so we never poll the API again.)
+if gh api "repos/${REPO_SLUG}/contents/${NODE_PATH}" >/dev/null 2>&1; then
+  log "already registered on main: ${NODE_PATH}"
+  mkdir -p "$(dirname "$MARKER")"; date -u +%FT%TZ > "$MARKER"
+  exit 0
+fi
+
+# ── hardware probe (best-effort; absent fields emit empty strings) ──
+CPU="$(grep -m1 'model name' /proc/cpuinfo 2>/dev/null | cut -d: -f2- | sed 's/^[[:space:]]*//;s/"//g' || true)"
+CORES="$(nproc 2>/dev/null || echo 0)"
+MEM="$(free -h --si 2>/dev/null | awk '/Mem:/{print $2}' || true)"
+GPU="$(lspci -nn 2>/dev/null | grep -iE 'vga|3d|display' | head -1 | sed 's/"//g' | cut -d: -f3- | sed 's/^[[:space:]]*//' || true)"
+IP="$(ip -4 -o addr 2>/dev/null | awk '/inet/ && !/lo/{print $4; exit}' || true)"
+MAC="$(ip -o link 2>/dev/null | awk '/state UP/ && !/lo/{for(i=1;i<=NF;i++) if($i=="link/ether"){print $(i+1); exit}}' || true)"
+KVER="$(uname -r 2>/dev/null || true)"
+TS="$(date -u +%FT%TZ)"
+
+# ── fresh shallow clone (never touch an in-place working tree) ──
+WORK="$(mktemp -d -t zeta-self-register.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+log "cloning ${REPO_SLUG} (shallow)…"
+git clone --depth 1 "https://github.com/${REPO_SLUG}.git" "$WORK/Zeta" >/dev/null 2>&1
+cd "$WORK/Zeta"
+gh auth setup-git >/dev/null 2>&1 || true
+
+mkdir -p "$(dirname "$NODE_PATH")"
+cat > "$NODE_PATH" <<YAML
+apiVersion: zeta.lucent-financial-group.com/v1
+kind: ClusterNode
+metadata:
+  name: ${HOST}
+  namespace: zeta-cluster
+  annotations:
+    zeta.lucent-financial-group.com/registered-at: "${TS}"
+    zeta.lucent-financial-group.com/registered-via: "B-0855.2-postboot"
+  labels:
+    zeta.lucent-financial-group.com/maintainer: "${MAINTAINER}"
+spec:
+  hostname: ${HOST}
+  registration:
+    maintainer: ${MAINTAINER}
+    timestamp: "${TS}"
+    via: post-boot-self-register
+  hardware:
+    cpu: "${CPU}"
+    cores: ${CORES}
+    memory: "${MEM}"
+    gpu: "${GPU}"
+    kernel: "${KVER}"
+    network:
+      ip: "${IP}"
+      mac: "${MAC}"
+YAML
+
+BRANCH="register-${HOST}-$(date -u +%Y%m%dT%H%M%SZ)"
+git checkout -b "$BRANCH" >/dev/null
+git add "$NODE_PATH"
+# Guard: never push an empty commit (the Step 6.9 / node-09485d failure mode).
+if git diff --cached --quiet; then log "ERROR: nothing staged — aborting (not registering)"; exit 1; fi
+git -c user.name="${MAINTAINER}" -c user.email="${MAINTAINER}@users.noreply.github.com" \
+    commit -q -m "feat(node-register): ${HOST} self-registers (post-boot, B-0855.2)"
+log "pushing ${BRANCH}…"
+git push -u origin "$BRANCH" >/dev/null 2>&1
+PR_URL="$(gh pr create --base main --head "$BRANCH" \
+  --title "feat(node-register): ${HOST} self-registers" \
+  --body "Automated post-boot self-registration of \`${HOST}\` (B-0855.2). Maintainer: @${MAINTAINER}. CPU: ${CPU:-?} · ${CORES} cores · ${MEM:-?} RAM." 2>&1 | tail -1)" || {
+    log "gh pr create failed; cleaning up branch"; git push origin --delete "$BRANCH" >/dev/null 2>&1 || true; exit 1; }
+log "registered: ${PR_URL}"
+mkdir -p "$(dirname "$MARKER")"; printf '%s\n' "$PR_URL" > "$MARKER"


### PR DESCRIPTION
## The bug (diagnosed live on a fresh reinstall)

A zero-typing install **never self-registers**. Confirmed on `node-f82aa6`: clean install, healthy cluster, gh authed — but no `maintainers/maximdolphin/` entry and no PR.

**Root cause:** registration was an **install-time** step (`zeta-install.sh` Step 6.9), gated on `gh auth` *during the installer*. But the cred-blob restores gh creds on **first boot** — after the installer finished. So Step 6.9 always saw no auth and skipped. (Other maintainers' nodes registered because they did install-time `gh auth login`; the cred-restore path never could.)

## The fix

Ship the never-shipped B-0855.2 implementation and enable the existing B-0855.1 service so registration runs **post-boot, after `zeta-creds-restore`**:

- **`tools/installer/zeta-self-register.sh`** — robust bash (no bun dependency; the node has `gh`+`git`+`bash` at `/run/current-system/sw/bin`). Opens a `maintainers/<gh-user>/cluster-nodes/<host>/node.yaml` PR (B-0813 ClusterNode + hardware probe). **Idempotent** (no-ops on marker or if already on main), fresh shallow clone (never touches the in-place tree), guards empty commits (the node-09485d failure mode), skips cleanly if gh isn't authed yet.
- **`zeta-self-register.nix`** — rewired from the bun/mise scaffold to the bash `ExecStart`; marker moved to a systemd **`StateDirectory`** (`/var/lib/zeta-self-register`) so the write succeeds even though `~/.config` is root-owned from cred-restore; `repoRoot → /etc/zeta`.
- **`common.nix`** — `zeta.selfRegister.enable = mkDefault true` (every node; per-host opt-out).

## Verified live

Ran the script on `node-f82aa6` → opened [#8203](https://github.com/Lucent-Financial-Group/Zeta/pull/8203) with real hardware (Intel Core Ultra 9 185H, 22 cores, 66G). The original *"why didn't my node register itself as a PR?"* is now both **answered and fixed** for every future install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
