### PR TITLE
fix(ci): allowlist zeta-self-register.sh in bash-retirement inventory (restore main green)

### DIFF
--- a/src/Core.TypeScript/hygiene/check-bash-retirement-inventory.ts
+++ b/src/Core.TypeScript/hygiene/check-bash-retirement-inventory.ts
@@ -80,6 +80,7 @@ export const EXPECTED_RETAINED_SHELL: readonly string[] = [
   ".gemini/service/lior-loop.sh",
   "full-ai-cluster/usb-nixos-installer/zeta-first-boot.sh",
   "full-ai-cluster/usb-nixos-installer/zeta-install.sh",
+  "tools/installer/zeta-self-register.sh",
   "tools/setup/common/agent-clis.sh",
   "tools/setup/common/curl-fetch.sh",
   "tools/setup/common/dotnet-tools.sh",
@@ -119,6 +120,10 @@ export const RETAINED_SHELL_CATEGORY_BY_FILE: Readonly<Record<string, RetainedSh
   ".gemini/service/lior-loop.sh": "host-service wrappers",
   "full-ai-cluster/usb-nixos-installer/zeta-first-boot.sh": "nixos installer",
   "full-ai-cluster/usb-nixos-installer/zeta-install.sh": "nixos installer",
+  // B-0855.2 post-boot self-registration: a first-boot systemd oneshot (invoked
+  // by nixos/modules/zeta-self-register.nix) that probes /proc + runs gh/git at
+  // the OS boot edge — retained shell "where the script runs at the OS edge".
+  "tools/installer/zeta-self-register.sh": "nixos installer",
   "tools/setup/common/agent-clis.sh": "setup/bootstrap",
   "tools/setup/common/curl-fetch.sh": "setup/bootstrap",
   "tools/setup/common/dotnet-tools.sh": "setup/bootstrap",


### PR DESCRIPTION
#8203 added `tools/installer/zeta-self-register.sh` (B-0855.2 post-boot self-registration) without registering it in the bash-retirement inventory → `lint (bash retirement inventory)` red on main (54c083a80, still failing on tip).

The script is a **legit retained-shell file**: a first-boot systemd oneshot (via `nixos/modules/zeta-self-register.nix`) probing /proc + running gh/git at the OS boot edge — the rule's "runs at the OS edge" carve-out (category: nixos installer), not app logic for TS. Author just forgot the inventory entry.

Fix: add to `EXPECTED_RETAINED_SHELL` + `RETAINED_SHELL_CATEGORY_BY_FILE` (sorted, categorized). Guard now: expected 28, unexpected 0, OK. (Follow-up option: keyring.sh-style thin-edge + TS logic, if preferred.)