### PR TITLE
fix(bootstrap): SPIRE caSubject+CRDs + Longhorn pre-upgrade-hook deadlock

### DIFF
--- a/full-ai-cluster/k8s/applications/longhorn/Application.yaml
+++ b/full-ai-cluster/k8s/applications/longhorn/Application.yaml
@@ -19,6 +19,12 @@ spec:
     helm:
       releaseName: longhorn
       valuesObject:
+        # The pre-upgrade checker Job is an UPGRADE-only hook; on a fresh
+        # install it deadlocks (its pod needs the ServiceAccount the blocked
+        # sync would create) and stalls the whole Longhorn sync -> no
+        # `longhorn` StorageClass -> every dependent PVC hangs Pending.
+        preUpgradeChecker:
+          jobEnabled: false
         defaultSettings:
           defaultDataPath: /var/lib/longhorn
           # Single control-plane node today. A replica count > the number of

--- a/full-ai-cluster/k8s/applications/spire/Application.yaml
+++ b/full-ai-cluster/k8s/applications/spire/Application.yaml
@@ -31,9 +31,9 @@ spec:
             recommendations:
               enabled: true
         spire-server:
-          ca_subject:
+          caSubject:
             country: US
-            common_name: zeta-spire-ca
+            commonName: zeta-spire-ca
             organization: Zeta
           persistence:
             type: pvc

--- a/full-ai-cluster/k8s/bootstrap/spire-install.yaml
+++ b/full-ai-cluster/k8s/bootstrap/spire-install.yaml
@@ -2,6 +2,23 @@
 # (SPIRE chains to Vault as upstream CA), BEFORE Trust Manager
 # (Trust Manager distributes SPIRE's CA bundle).
 
+# SPIRE CRDs (ClusterSPIFFEID, ClusterFederatedTrustDomain, ClusterStaticEntry)
+# MUST be installed before the spire chart — the hardened chart ships them as a
+# SEPARATE spire-crds chart (Helm CRD best-practice), and `spire` renders
+# ClusterSPIFFEID objects that fail "no matches for kind" without them. k3s'
+# helm-controller retries the spire install until these land.
+apiVersion: helm.cattle.io/v1
+kind: HelmChart
+metadata:
+  name: spire-crds
+  namespace: kube-system
+spec:
+  chart: spire-crds
+  repo: https://spiffe.github.io/helm-charts-hardened/
+  version: 0.5.0
+  targetNamespace: spire
+  createNamespace: true
+---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart
 metadata:
@@ -21,9 +38,9 @@ spec:
         recommendations:
           enabled: true
     spire-server:
-      ca_subject:
+      caSubject:
         country: US
-        common_name: zeta-spire-ca
+        commonName: zeta-spire-ca
         organization: Zeta
       persistence:
         type: pvc


### PR DESCRIPTION
## Diagnosed live on the fresh install (node-f82aa6)

SPIRE crash-looped and the storage zoo (vault/cockroach/mimir/loki/weaviate) hung Pending. Three real bugs:

**SPIRE (both validated live):**
1. values used `ca_subject`/`common_name` (snake) — chart wants `caSubject`/`commonName` (camel) → `caSubject.country must be set`.
2. chart renders `ClusterSPIFFEID` but ships CRDs as a separate `spire-crds` chart that was never installed → `no matches for kind "ClusterSPIFFEID"`. Added a `spire-crds` HelmChart (v0.5.0) ahead of `spire`; helm-controller retries until CRDs land. After both → spire reached `REVISION: 1`.

**Longhorn:** ArgoCD sync stalled forever on the `longhorn-pre-upgrade` hook Job — an upgrade-only hook that deadlocks on a fresh install (its pod needs the SA the blocked sync would create). No `longhorn` SC ever appeared → all dependent PVCs Pending. Fixed with `preUpgradeChecker.jobEnabled=false`.

**Not a bug:** remaining Pending replicas (vault-1/2, cockroach-1/2, mimir zone-b/c) are multi-replica StatefulSets with cross-node anti-affinity — expected on a single node; they schedule as workers join.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
