### PR TITLE
fix(ci): upload the built ISO even when the flaky QEMU full-install gate fails

### DIFF
--- a/.github/workflows/build-ai-cluster-iso.yml
+++ b/.github/workflows/build-ai-cluster-iso.yml
@@ -372,6 +372,7 @@ jobs:
           retention-days: 7
 
       - name: Locate ISO + capture metadata
+        if: ${{ !cancelled() }}   # run even if the flaky QEMU full-install gate failed — a built ISO must still upload
         id: iso
         working-directory: full-ai-cluster
         run: |
@@ -442,6 +443,7 @@ jobs:
       # of THIS workflow (no github.event.* interpolation). Same discipline
       # as the QEMU boot-test step above.
       - name: Install cosign
+        if: ${{ !cancelled() }}   # run even if the flaky QEMU full-install gate failed — a built ISO must still upload
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         # Pin verified via gh API 2026-05-27:
         #   gh api repos/sigstore/cosign-installer/releases/latest
@@ -449,6 +451,7 @@ jobs:
         # Per .claude/rules/dep-pin-search-first-authority.md
 
       - name: Sign ISO with cosign (keyless OIDC + Fulcio + Rekor)
+        if: ${{ !cancelled() }}   # run even if the flaky QEMU full-install gate failed — a built ISO must still upload
         id: sign
         env:
           # Pass ISO path via env (not direct ${{ }} interpolation in run:)
@@ -487,6 +490,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload ISO as workflow artifact
+        if: ${{ !cancelled() }}   # run even if the flaky QEMU full-install gate failed — a built ISO must still upload
         # Available for download from the workflow run page for ~90 days.
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -497,6 +501,7 @@ jobs:
           compression-level: 0 # ISO is already compressed; re-zipping wastes time
 
       - name: Upload cosign bundle as workflow artifact
+        if: ${{ !cancelled() }}   # run even if the flaky QEMU full-install gate failed — a built ISO must still upload
         # B-0853.1 sibling upload — bundle alongside the ISO for consumers.
         # Separate artifact (not bundled with ISO) so consumers downloading
         # just the ISO do not pay the small extra cost; verifiers can grab it.


### PR DESCRIPTION
The B-0891 QEMU full-install tests are a hard gate that flakes (TCG timeouts); on failure GitHub skips the **Upload ISO** step, so a successfully built+audited ISO becomes undownloadable (bit two consecutive main builds). Added `if: ${{ !cancelled() }}` to the Locate/Sign/Upload tail — the artifact always publishes; the run status still reflects the test failure (gate intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)