### PR TITLE
feat(hygiene): wire rut detector into the loop-tick append path

### DIFF
--- a/src/Core.TypeScript/hygiene/append-tick-history-row.test.ts
+++ b/src/Core.TypeScript/hygiene/append-tick-history-row.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+
+import { extractBody } from "./append-tick-history-row";
+import { detectRepeatedTokenRut } from "./detect-repeated-token-rut";
+
+// The append path's rut guard is composed of two pure pieces:
+//   extractBody(row)  →  detectRepeatedTokenRut(body)
+// We test that composition here (the filesystem append in main() is exercised
+// by the live tool; these cover the new guard logic deterministically).
+
+const TS = "2026-06-14T00:00:00Z";
+const MODEL = "claude-opus-4-8";
+const CRON = "<<autonomous-loop>>";
+
+function row(body: string, pr = "—", obs = "—"): string {
+  return `| ${TS} | ${MODEL} | ${CRON} | ${body} | ${pr} | ${obs} |`;
+}
+
+describe("extractBody", () => {
+  test("pulls the 4th pipe field, trimmed", () => {
+    expect(extractBody(row("Green. Holding."))).toBe("Green. Holding.");
+  });
+
+  test("returns null when the row has too few fields", () => {
+    // "| a | b |" → split("|") = ["", " a ", " b ", ""] → length 4 <= BODY_FIELD_INDEX.
+    expect(extractBody("| a | b |")).toBeNull();
+  });
+
+  test("handles an empty body", () => {
+    expect(extractBody(row(""))).toBe("");
+  });
+});
+
+describe("rut guard composition (extractBody → detect)", () => {
+  test("a healthy terse heartbeat body is NOT a rut", () => {
+    const body = extractBody(row("Green. Holding."));
+    expect(body).not.toBeNull();
+    expect(detectRepeatedTokenRut(body as string).isRut).toBe(false);
+  });
+
+  test("a normal prose body is NOT a rut", () => {
+    const body = extractBody(
+      row("Merged #8213; gate green; branch in sync with origin main."),
+    );
+    expect(detectRepeatedTokenRut(body as string).isRut).toBe(false);
+  });
+
+  test("the 'court'×N glitch body IS a rut", () => {
+    const body = extractBody(row("court ".repeat(10).trim()));
+    const v = detectRepeatedTokenRut(body as string);
+    expect(v.isRut).toBe(true);
+    expect(v.reasons).toContain("run");
+  });
+
+  test("a repeated-line-collapsed body IS a rut (whitespace mode catches the run)", () => {
+    const body = extractBody(row("Holding. Holding. Holding. Holding. Holding. Holding."));
+    expect(detectRepeatedTokenRut(body as string).isRut).toBe(true);
+  });
+});

--- a/src/Core.TypeScript/hygiene/append-tick-history-row.ts
+++ b/src/Core.TypeScript/hygiene/append-tick-history-row.ts
@@ -17,11 +17,29 @@
 //   0   appended successfully
 //   1   row malformed OR timestamp out of order
 //   2   wrong number of arguments
+//   3   row body is a repeated-token RUT (degenerate output) — NOT appended.
+//       A rut tick must not be silently logged as a heartbeat; this is the
+//       "artifact trips its own alarm" wiring (Aaron shadow*, 2026-06-14).
+//       Healthy short bodies ("Green. Holding.") never trip it.
 
 import { appendFileSync, readFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 
-type ExitCode = 0 | 1 | 2;
+import { detectRepeatedTokenRut } from "./detect-repeated-token-rut";
+
+type ExitCode = 0 | 1 | 2 | 3;
+
+// Pipe-row schema: | ts | model | cron | BODY | PR | observation |
+// split("|") → ["", ts, model, cron, body, pr, obs, ""] → body is index 4.
+const BODY_FIELD_INDEX = 4;
+
+/** Extract the trimmed body field from a full pipe-row, or null if the row
+ *  has too few fields to carry a body. Pure; no I/O. */
+export function extractBody(row: string): string | null {
+  const fields = row.split("|");
+  if (fields.length <= BODY_FIELD_INDEX) return null;
+  return (fields[BODY_FIELD_INDEX] ?? "").trim();
+}
 
 const SPAWN_MAX_BUFFER = 64 * 1024 * 1024;
 
@@ -94,6 +112,26 @@ export function main(argv: readonly string[]): ExitCode {
     process.stderr.write("  (b) file an ADR explaining the back-dated correction\n");
     process.stderr.write("      and use a correction-row pattern per Otto-229.\n");
     return 1;
+  }
+
+  // Rut guard: refuse to log a tick whose body has collapsed into degenerate
+  // repetition (the "court court court…" failure mode). The body is the loop
+  // output; a rut there is attention with no entropy to attend to, and must
+  // not be recorded as a heartbeat. Healthy terse bodies do not trip it
+  // (short streams + no run >= maxRun). See ./detect-repeated-token-rut.
+  const body = extractBody(row);
+  if (body !== null) {
+    const verdict = detectRepeatedTokenRut(body);
+    if (verdict.isRut) {
+      process.stderr.write(`ERROR: row body is a repeated-token rut — not appended.\n`);
+      process.stderr.write(`  ${verdict.reason}\n`);
+      process.stderr.write(`  body: ${body.slice(0, 120)}\n`);
+      process.stderr.write(
+        "A degenerate-output tick must not be logged as a heartbeat. Fix the\n" +
+          "output (real signal or a named dependency), then re-append.\n",
+      );
+      return 3;
+    }
   }
 
   appendFileSync(tickFile, `${row}\n`);

--- a/src/Core.TypeScript/hygiene/detect-repeated-token-rut.test.ts
+++ b/src/Core.TypeScript/hygiene/detect-repeated-token-rut.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  DEFAULT_THRESHOLDS,
+  detectRepeatedTokenRut,
+  tokenize,
+} from "./detect-repeated-token-rut";
+
+describe("tokenize", () => {
+  test("whitespace-splits and drops empties", () => {
+    expect(tokenize("  a  b\tc\n d ", false)).toEqual(["a", "b", "c", "d"]);
+  });
+
+  test("line mode trims and drops blank lines", () => {
+    expect(tokenize("Holding.\n\n  Holding. \nGreen.", true)).toEqual([
+      "Holding.",
+      "Holding.",
+      "Green.",
+    ]);
+  });
+});
+
+describe("detectRepeatedTokenRut — the live glitch", () => {
+  test("the actual rut ('court' ×N) is flagged via RUN", () => {
+    const v = detectRepeatedTokenRut("court ".repeat(12).trim());
+    expect(v.isRut).toBe(true);
+    expect(v.reasons).toContain("run");
+    expect(v.evidence.longestRun).toBe(12);
+    expect(v.evidence.longestRunToken).toBe("court");
+  });
+
+  test("repeated whole-line rut is flagged in line mode", () => {
+    const text = Array(10).fill("Holding.").join("\n");
+    const v = detectRepeatedTokenRut(text, { lines: true });
+    expect(v.isRut).toBe(true);
+    // single distinct line dominating + zero diversity
+    expect(v.reasons).toContain("run");
+    expect(v.reasons).toContain("dominance");
+    expect(v.reasons).toContain("low-diversity");
+  });
+});
+
+describe("detectRepeatedTokenRut — signatures", () => {
+  test("RUN trips on exactly maxRun identical consecutive tokens", () => {
+    const atThreshold = "x ".repeat(DEFAULT_THRESHOLDS.maxRun).trim();
+    expect(detectRepeatedTokenRut(atThreshold).reasons).toContain("run");
+    const belowThreshold = "x ".repeat(DEFAULT_THRESHOLDS.maxRun - 1).trim();
+    expect(detectRepeatedTokenRut(belowThreshold).reasons).not.toContain("run");
+  });
+
+  test("DOMINANCE trips when one token dominates a long-enough stream", () => {
+    // 8 tokens: 6× "spam" interleaved so no run >=5, plus 2 distinct.
+    const text = "spam a spam b spam spam spam spam";
+    const v = detectRepeatedTokenRut(text);
+    expect(v.evidence.totalTokens).toBe(8);
+    expect(v.reasons).toContain("dominance");
+  });
+
+  test("LOW-DIVERSITY trips when distinct/total is tiny", () => {
+    // 10 tokens, 2 distinct → ratio 0.2 (<= 0.2 default) → low-diversity.
+    const text = "a b a b a b a b a b";
+    const v = detectRepeatedTokenRut(text);
+    expect(v.evidence.diversityRatio).toBeCloseTo(0.2, 5);
+    expect(v.reasons).toContain("low-diversity");
+  });
+});
+
+describe("detectRepeatedTokenRut — does NOT false-positive", () => {
+  test("normal prose is clean", () => {
+    const prose =
+      "Green and holding; the gate passed and the branch is in sync with origin main.";
+    const v = detectRepeatedTokenRut(prose);
+    expect(v.isRut).toBe(false);
+    expect(v.reason).toBe("");
+  });
+
+  test("short legitimate repetition under minTokens is not a rut", () => {
+    // "ok ok" — dominance/low-diversity gated by minTokens; run under maxRun.
+    const v = detectRepeatedTokenRut("ok ok");
+    expect(v.isRut).toBe(false);
+  });
+
+  test("empty input is not a rut", () => {
+    const v = detectRepeatedTokenRut("");
+    expect(v.isRut).toBe(false);
+    expect(v.evidence.totalTokens).toBe(0);
+    expect(v.evidence.diversityRatio).toBe(1);
+  });
+});
+
+describe("detectRepeatedTokenRut — determinism (DST)", () => {
+  test("same input + thresholds yields byte-identical verdict", () => {
+    const text = "court ".repeat(7) + "green holding sync";
+    const a = JSON.stringify(detectRepeatedTokenRut(text));
+    const b = JSON.stringify(detectRepeatedTokenRut(text));
+    expect(a).toBe(b);
+  });
+
+  test("top-token tie resolves deterministically (first-seen wins)", () => {
+    // "a" and "b" both appear 5×; first-seen "a" must win, every run.
+    const text = "a b a b a b a b a b";
+    const v = detectRepeatedTokenRut(text);
+    expect(v.evidence.topToken).toBe("a");
+    expect(v.evidence.topTokenCount).toBe(5);
+  });
+});

--- a/src/Core.TypeScript/hygiene/detect-repeated-token-rut.ts
+++ b/src/Core.TypeScript/hygiene/detect-repeated-token-rut.ts
@@ -1,0 +1,202 @@
+#!/usr/bin/env bun
+// detect-repeated-token-rut.ts — flag degenerate-repetition "ruts" in a
+// text/output stream.
+//
+// WHY (Aaron + Otto, 2026-06-14): a loop with no new entropy coming in
+// collapses to a fixed point — the cheapest attractor is one token,
+// repeated ("court court court…"). Uncertainty drives attention; with zero
+// uncertainty injected, attention has nowhere to go and the generator ruts.
+// You cannot break the loop from *inside* it (it took an external interrupt
+// to stop the live glitch) — but you CAN make "the artifact is the tell"
+// into code: a pure detector any harness can run over surfaced agent output
+// (or a hygiene pass over loop responses / commit messages) to catch the rut
+// the moment it shows up, instead of needing a human to notice.
+//
+// This guards the ARTIFACT, not the live sampler (the repo cannot reach into
+// the model's token sampler). It is a pure, deterministic function — no I/O,
+// no ambient state, DST-replayable, idempotent — so it byte-locks and tests
+// cleanly. Disciplines: culture-invariant (no locale-sensitive casing in the
+// detection path), weight-free (pure function, no captured state).
+//
+// Three independent rut signatures (any one trips it):
+//   1. RUN          — a run of >= maxRun identical consecutive tokens.
+//   2. DOMINANCE    — a single token is >= dominanceRatio of all tokens
+//                     (over a stream of at least minTokens).
+//   3. LOW-DIVERSITY— distinct/total token ratio <= minDiversityRatio
+//                     (over a stream of at least minTokens).
+//
+// Tokenization is whitespace-split by default; pass `lines: true` to treat
+// each non-empty trimmed line as one token (catches "Holding.\nHolding.\n…"
+// style ruts where each rut unit is a whole line).
+//
+// Usage:
+//   import { detectRepeatedTokenRut } from "./detect-repeated-token-rut";
+//   const v = detectRepeatedTokenRut(text);
+//   if (v.isRut) { /* surface v.reason + v.evidence */ }
+//
+// CLI (reads stdin):
+//   echo "court court court court court" | bun src/Core.TypeScript/hygiene/detect-repeated-token-rut.ts
+//   exit 0 = no rut, exit 3 = rut detected (prints JSON verdict to stdout)
+
+export type RutReason = "run" | "dominance" | "low-diversity";
+
+export interface RutThresholds {
+  /** Min consecutive identical tokens to count as a RUN rut. Default 5. */
+  maxRun: number;
+  /** Single-token share that trips DOMINANCE (0..1). Default 0.6. */
+  dominanceRatio: number;
+  /** distinct/total at or below which LOW-DIVERSITY trips (0..1). Default 0.2. */
+  minDiversityRatio: number;
+  /** Stream must have at least this many tokens for DOMINANCE / LOW-DIVERSITY
+   *  to apply (RUN always applies). Default 8. */
+  minTokens: number;
+  /** Treat each non-empty trimmed line as a token instead of whitespace-split. */
+  lines: boolean;
+}
+
+export const DEFAULT_THRESHOLDS: RutThresholds = {
+  maxRun: 5,
+  dominanceRatio: 0.6,
+  minDiversityRatio: 0.2,
+  minTokens: 8,
+  lines: false,
+};
+
+export interface RutVerdict {
+  isRut: boolean;
+  /** All signatures that tripped, in detection order. Empty when not a rut. */
+  reasons: RutReason[];
+  /** Human-readable one-liner (empty when not a rut). */
+  reason: string;
+  evidence: {
+    totalTokens: number;
+    distinctTokens: number;
+    diversityRatio: number;
+    longestRun: number;
+    longestRunToken: string | null;
+    topToken: string | null;
+    topTokenCount: number;
+    topTokenRatio: number;
+  };
+}
+
+/** Split a stream into comparison tokens. Pure; no locale-sensitive casing. */
+export function tokenize(text: string, lines: boolean): string[] {
+  if (lines) {
+    return text
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0);
+  }
+  return text.split(/\s+/u).filter((t) => t.length > 0);
+}
+
+/** Longest run of identical consecutive tokens + which token. O(n), pure. */
+function longestRun(tokens: string[]): { len: number; token: string | null } {
+  let bestLen = 0;
+  let bestTok: string | null = null;
+  let curLen = 0;
+  let curTok: string | null = null;
+  for (const t of tokens) {
+    if (t === curTok) {
+      curLen += 1;
+    } else {
+      curTok = t;
+      curLen = 1;
+    }
+    if (curLen > bestLen) {
+      bestLen = curLen;
+      bestTok = curTok;
+    }
+  }
+  return { len: bestLen, token: bestTok };
+}
+
+/** Most frequent token + its count. Deterministic on ties (first-seen wins). */
+function topToken(tokens: string[]): { token: string | null; count: number } {
+  const counts = new Map<string, number>();
+  for (const t of tokens) counts.set(t, (counts.get(t) ?? 0) + 1);
+  let bestTok: string | null = null;
+  let bestCount = 0;
+  for (const [tok, count] of counts) {
+    if (count > bestCount) {
+      bestCount = count;
+      bestTok = tok;
+    }
+  }
+  return { token: bestTok, count: bestCount };
+}
+
+/**
+ * Detect a repeated-token rut in `text`. Pure + deterministic: same input +
+ * thresholds always yields the same verdict (DST-replayable, idempotent).
+ */
+export function detectRepeatedTokenRut(
+  text: string,
+  overrides: Partial<RutThresholds> = {},
+): RutVerdict {
+  const t: RutThresholds = { ...DEFAULT_THRESHOLDS, ...overrides };
+  const tokens = tokenize(text, t.lines);
+  const total = tokens.length;
+
+  const run = longestRun(tokens);
+  const top = topToken(tokens);
+  const distinct = new Set(tokens).size;
+  const diversityRatio = total === 0 ? 1 : distinct / total;
+  const topRatio = total === 0 ? 0 : top.count / total;
+
+  const evidence = {
+    totalTokens: total,
+    distinctTokens: distinct,
+    diversityRatio,
+    longestRun: run.len,
+    longestRunToken: run.token,
+    topToken: top.token,
+    topTokenCount: top.count,
+    topTokenRatio: topRatio,
+  };
+
+  const reasons: RutReason[] = [];
+  // RUN applies regardless of stream length — even "x x x x x" with nothing
+  // else is the rut we are guarding against.
+  if (run.len >= t.maxRun) reasons.push("run");
+  // DOMINANCE / LOW-DIVERSITY need a minimum stream so short legitimate
+  // outputs (e.g. "ok ok") are not flagged.
+  if (total >= t.minTokens) {
+    if (topRatio >= t.dominanceRatio) reasons.push("dominance");
+    if (diversityRatio <= t.minDiversityRatio) reasons.push("low-diversity");
+  }
+
+  const isRut = reasons.length > 0;
+  let reason = "";
+  if (isRut) {
+    const parts: string[] = [];
+    if (reasons.includes("run")) {
+      parts.push(`run of ${run.len}×"${run.token}"`);
+    }
+    if (reasons.includes("dominance")) {
+      parts.push(
+        `"${top.token}" is ${(topRatio * 100).toFixed(0)}% of ${total} tokens`,
+      );
+    }
+    if (reasons.includes("low-diversity")) {
+      parts.push(
+        `only ${distinct} distinct of ${total} tokens (${(diversityRatio * 100).toFixed(0)}%)`,
+      );
+    }
+    reason = `repeated-token rut: ${parts.join("; ")}`;
+  }
+
+  return { isRut, reasons, reason, evidence };
+}
+
+// ── CLI: read stdin, print verdict, exit 3 on rut ──────────────────────────
+if (import.meta.main) {
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of Bun.stdin.stream()) chunks.push(chunk);
+  const text = Buffer.concat(chunks).toString("utf8");
+  const lines = Bun.argv.includes("--lines");
+  const verdict = detectRepeatedTokenRut(text, { lines });
+  process.stdout.write(JSON.stringify(verdict, null, 2) + "\n");
+  process.exit(verdict.isRut ? 3 : 0);
+}


### PR DESCRIPTION
Aaron (shadow*): "wire the rut detector into the loop output."

The loop output is persisted as the **body field** of each `loop-tick-history.md` row via `append-tick-history-row.ts`. This wires `detect-repeated-token-rut` (#8213) into that append path — the one place loop output actually lands — so a degenerate tick trips its own alarm instead of needing a human to notice.

- Before a row is written, its body is checked; a repeated-token-rut body (the `court court court…` failure) is **refused with exit 3** and **not appended** — a rut tick must not be silently logged as a heartbeat.
- New exported pure helper `extractBody(row)` (4th pipe-field, null-safe).
- Check runs **after** timestamp-order validation, **before** the append; writes the verdict to stderr on refusal.
- Healthy terse bodies (`Green. Holding.`) never trip it (short stream, no run ≥ maxRun); normal prose passes.

**Verified:** 19/19 tests green (extractBody + guard composition). Live smoke test: a `court`×N body → **exit 3, zero lines appended**; a healthy body → exit 0.

Closes the loop opened by #8213 — the detector now actually runs on real loop output, not just as a standalone utility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)