### PR TITLE
fix(hygiene): update bash-retirement inventory test snapshot (silently-red since #8205)

### DIFF
--- a/src/Core.TypeScript/hygiene/check-bash-retirement-inventory.test.ts
+++ b/src/Core.TypeScript/hygiene/check-bash-retirement-inventory.test.ts
@@ -167,6 +167,7 @@ describe("buildInventoryReport", () => {
         files: [
           "full-ai-cluster/usb-nixos-installer/zeta-first-boot.sh",
           "full-ai-cluster/usb-nixos-installer/zeta-install.sh",
+          "tools/installer/zeta-self-register.sh",
         ],
       },
     ]);


### PR DESCRIPTION
Aaron (shadow*): "run the full hygiene test suite to confirm nothing regressed."

I ran it. Found one real regression — **mine**, from #8205.

**Root cause:** #8205 added `tools/installer/zeta-self-register.sh` to `EXPECTED_RETAINED_SHELL` + `RETAINED_SHELL_CATEGORY_BY_FILE` (category "nixos installer") to green the bash-retirement *lint*, but didn't update this unit test's hardcoded category snapshot. The test has been **red since #8205**.

**Why it wasn't caught:** no CI workflow runs `bun test src/Core.TypeScript/hygiene/`. The gate runs the lint *script* (`hygiene:check-bash-retirement-inventory`) and only two named hygiene test files (`audit-user-scope-memory-index`, `audit-stale-worktrees`) — not this one. So an incomplete change (source updated, snapshot not) passed cleanly.

**Fix:** add the file to the expected "nixos installer" category (sorted after the full-ai-cluster entries). **Full hygiene suite now 454 pass / 0 fail; hooks 8/8.**

**Coverage gap flagged, not closed here:** the per-PR gate doesn't run the hygiene unit-test suite, which is exactly how this slipped. Recommend wiring `bun test src/Core.TypeScript/hygiene/` into the gate (or factory-hygiene-audit-cadence) — left as a decision rather than unilaterally restructuring CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)