### PR TITLE
ci(gate): run the full hygiene unit-test suite (close the per-PR coverage gap)

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -617,7 +617,14 @@ jobs:
     # Zeta-owned post-install repo scripts should not grow new `.sh`
     # entrypoints after Bucket B reached zero. The retained shell surface is
     # setup/bootstrap, launchd-bootstrap, and the Kiro loop wrapper only.
-    name: lint (bash retirement inventory)
+    #
+    # ALSO runs the full hygiene unit-test suite (bun test
+    # src/Core.TypeScript/hygiene/). Previously NO gate job ran it — only
+    # two named hygiene tests + the lint scripts ran — so an incomplete
+    # change (source allowlist updated, unit-test snapshot not) merged green
+    # and left a test silently red for ~10 PRs (#8216 fix; this step closes
+    # the gap). bun is already provisioned here, so it adds no extra install.
+    name: lint (bash retirement inventory + hygiene unit tests)
     timeout-minutes: 5
     runs-on: ubuntu-24.04
 
@@ -669,6 +676,12 @@ jobs:
 
       - name: Run bash-retirement inventory guard
         run: bun run hygiene:check-bash-retirement-inventory
+
+      - name: Hygiene unit-test suite (closes the per-PR coverage gap)
+        # Runs every src/Core.TypeScript/hygiene/*.test.ts. These are
+        # fixture/in-memory tests (no MEMORY.md / user-scope deps), so they
+        # are CI-safe. This is what would have caught #8216's stale snapshot.
+        run: bun test src/Core.TypeScript/hygiene/
 
   lint-workflows:
     # actionlint catches .github/workflows/*.yml bugs: unknown


### PR DESCRIPTION
Aaron (shadow*): "yes wire it into the gate."

Closes the coverage gap surfaced by #8216: a hygiene unit test was silently red for ~10 PRs because **no gate job ran the hygiene test suite** — only the lint scripts and two named hygiene tests ran.

**Change:** adds `bun test src/Core.TypeScript/hygiene/` as a step in the existing `lint-bash-retirement-inventory` job (bun already provisioned there → **no extra toolchain install**) and broadens the job name. Now the inventory lint and its unit test run in the same job, so an incomplete change (source updated, snapshot not) fails the gate instead of merging green.

**CI-safety:** hygiene tests are fixture/in-memory (no MEMORY.md / user-scope deps); 454 pass / 0 fail locally. **This PR's own gate run is the real CI-safety check** — if any hygiene test is environment-sensitive, it shows here before merge.

The "wire the verifier into the path it guards" fix, one level up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)