### PR TITLE
fix(bootstrap): SPIRE installs on a single-node cluster (recommendations off + single-namespace + local-path)

### DIFF
--- a/full-ai-cluster/k8s/applications/spire/Application.yaml
+++ b/full-ai-cluster/k8s/applications/spire/Application.yaml
@@ -29,7 +29,7 @@ spec:
             clusterName: zeta
             trustDomain: zeta.local
             recommendations:
-              enabled: true
+              enabled: false
         spire-server:
           caSubject:
             country: US
@@ -38,7 +38,7 @@ spec:
           persistence:
             type: pvc
             size: 5Gi
-            storageClass: longhorn
+            storageClass: zeta-local-path
           # Chain to Vault as the upstream CA. Uncomment + configure
           # after vault/Application.yaml is healthy:
           # upstreamAuthority:
@@ -59,6 +59,8 @@ spec:
               enabled: true
         spiffe-csi-driver:
           enabled: true
+        spiffe-oidc-discovery-provider:
+          enabled: false   # broken pre-delete hook deadlocks uninstall; not needed
   destination:
     server: https://kubernetes.default.svc
     namespace: spire

--- a/full-ai-cluster/k8s/bootstrap/spire-install.yaml
+++ b/full-ai-cluster/k8s/bootstrap/spire-install.yaml
@@ -36,7 +36,7 @@ spec:
         clusterName: zeta
         trustDomain: zeta.local
         recommendations:
-          enabled: true
+          enabled: false
     spire-server:
       caSubject:
         country: US
@@ -45,10 +45,12 @@ spec:
       persistence:
         type: pvc
         size: 5Gi
-        storageClass: longhorn
+        storageClass: zeta-local-path
     spire-agent:
       workloadAttestors:
         k8s: { enabled: true, skipKubeletVerification: false }
         unix: { enabled: true }
     spiffe-csi-driver:
       enabled: true
+    spiffe-oidc-discovery-provider:
+      enabled: false   # broken pre-delete hook deadlocks uninstall; not needed


### PR DESCRIPTION
Live-diagnosed on a fresh install: the spire HelmChart was 100% failing in layers. Root cause: `recommendations.enabled: true` makes the hardened chart expect a multi-namespace topology (`spire-server`/`spire-system`) the single-namespace k3s install never creates → `namespaces spire-system not found`, and the resulting failed install deadlocks the helm-controller's uninstall on the OIDC pre-delete hook. Fix: `recommendations.enabled: false` + disable OIDC provider + `spire-server` persistence on `zeta-local-path` (not late/heavy Longhorn). After this the spire install reaches `Installed spire…` + csi-driver runs (validated live). Builds on the caSubject+spire-crds fix (#8206).

🤖 Generated with [Claude Code](https://claude.com/claude-code)