### PR TITLE
feat(portal): create-Deployable write path — deploy a service from the UI

### DIFF
--- a/full-ai-cluster/k8s/applications/platform/portal.yaml
+++ b/full-ai-cluster/k8s/applications/platform/portal.yaml
@@ -13,8 +13,9 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-10"
 ---
-# Read-only on the platform resources it renders. No write — the only state the
-# portal mutates is its own Room log on the PVC.
+# Reads + operates the platform resources it renders. The deploy wizard creates
+# Deployables and the builder creates Blueprints; the resource console edits
+# config/lifecycle. The durable Room log lives on the PVC, not the API.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -22,9 +23,9 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-10"
 rules:
-  - apiGroups: ["platform.zeta.io"]   # the resource console: read + edit config/lifecycle
+  - apiGroups: ["platform.zeta.io"]   # the deploy wizard creates; console edits config/lifecycle
     resources: ["deployables"]
-    verbs: ["get", "list", "watch", "update", "patch", "delete"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["platform.zeta.io"]   # the Blueprint Builder saves blueprints
     resources: ["blueprints"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]

--- a/full-ai-cluster/portal/src/api.test.ts
+++ b/full-ai-cluster/portal/src/api.test.ts
@@ -1,8 +1,9 @@
 // full-ai-cluster/portal/src/api.test.ts
 //
 // The BFF endpoints over the in-memory platform: resource view, catalog,
-// needs-me board, a single Room, and the human grant write (which clears the
-// pending item). Non-/api paths pass through (null) for static serving.
+// needs-me board, a single Room, the human grant write (which clears the
+// pending item), and the deploy write path (create a Deployable). Non-/api
+// paths pass through (null) for static serving.
 
 import { beforeEach, describe, expect, test } from "bun:test";
 import { encodeResource, handle } from "./api.ts";
@@ -107,5 +108,43 @@ describe("append events (controller / personas write the room log)", () => {
   test("a missing/invalid body → 400", async () => {
     const r = await post(`/api/rooms/${encodeResource("tenant-a", "clan")}/events`, { by: "otto", body: { type: "bogus" } });
     expect(r!.status).toBe(400);
+  });
+});
+
+describe("create Deployable (the deploy write path — a human deploys a service)", () => {
+  const post = (p: string, b: unknown) => handle(new Request(`http://x${p}`, { method: "POST", body: JSON.stringify(b) }), data);
+
+  test("a valid create returns ok and the resource appears, Running (ready)", async () => {
+    const r = await post("/api/deployables", { name: "billing", namespace: "tenant-a", spec: { blueprint: "web", expose: "public", size: { cpu: "500m", memory: "1Gi" }, ai: { admin: "otto", policy: "default", room: "enabled" } } });
+    expect(r!.status).toBe(200);
+    const j = (await body(r)) as any;
+    expect(j.ok).toBe(true);
+
+    // the new resource shows up in the top-down list, healthy/ready (status phase Running)
+    const groups = ((await body(await get("/api/resources"))) as any).groups as Array<{ category: string; resources: any[] }>;
+    const all = groups.flatMap((g) => g.resources);
+    const billing = all.find((res) => res.name === "billing" && res.namespace === "tenant-a");
+    expect(billing).toBeDefined();
+    expect(billing.health).toBe("ready");
+    expect(billing.blueprint).toBe("web");
+  });
+
+  test("missing name or spec.blueprint → 400", async () => {
+    expect((await post("/api/deployables", { namespace: "tenant-a", spec: { blueprint: "web" } }))!.status).toBe(400);
+    expect((await post("/api/deployables", { name: "x", spec: { expose: "public" } }))!.status).toBe(400);
+  });
+
+  test("create is idempotent — same ns/name upserts, not duplicates", async () => {
+    await post("/api/deployables", { name: "dup", namespace: "tenant-a", spec: { blueprint: "web" } });
+    await post("/api/deployables", { name: "dup", namespace: "tenant-a", spec: { blueprint: "web" } });
+    const groups = ((await body(await get("/api/resources"))) as any).groups as Array<{ resources: any[] }>;
+    const dups = groups.flatMap((g) => g.resources).filter((res) => res.name === "dup" && res.namespace === "tenant-a");
+    expect(dups.length).toBe(1);
+  });
+
+  test("405 when the backend has no createDeployable", async () => {
+    const noWrite = { listDeployables: async () => [], listBlueprints: async () => [], listRooms: async () => [], getRoom: async () => undefined, grant: async () => false };
+    const r = await handle(new Request("http://x/api/deployables", { method: "POST", body: JSON.stringify({ name: "z", spec: { blueprint: "web" } }) }), noWrite as any);
+    expect(r!.status).toBe(405);
   });
 });

--- a/full-ai-cluster/portal/src/api.ts
+++ b/full-ai-cluster/portal/src/api.ts
@@ -3,8 +3,8 @@
 // The BFF (backend-for-frontend) — pure request routing over an injected data
 // source, so the whole API is unit-tested without a live cluster. The server
 // (server.ts) wires a real K8s/Room-backed PlatformData into `handle`; tests
-// wire an in-memory one. Read endpoints render view models; the single write
-// endpoint is the human authorization grant (no-directives: only a human grants).
+// wire an in-memory one. Read endpoints render view models; the write endpoints
+// are the deploy path (create a Deployable) + the human authorization grant.
 
 import {
   type BlueprintCR,
@@ -54,6 +54,8 @@ export interface PlatformData {
   admin?: AdminData;
   /** Create/save a Blueprint (the builder). Optional. */
   createBlueprint?(bp: { name: string; namespace?: string; spec: Omit<BlueprintProposal, "name"> }): Promise<{ ok: boolean; message: string }>;
+  /** Create a Deployable instance — the deploy write path (a human deploys a service). Optional. */
+  createDeployable?(d: { name: string; namespace?: string; spec: Record<string, unknown> }): Promise<{ ok: boolean; message: string }>;
 }
 
 /** The typed Event bodies the write endpoint accepts (mirrors the Room substrate). */
@@ -100,6 +102,14 @@ export async function handle(req: Request, data: PlatformData): Promise<Response
       const b = (await req.json().catch(() => ({}))) as { name?: string; namespace?: string; spec?: Omit<BlueprintProposal, "name"> };
       if (!b.name || !b.spec?.image) return json({ error: "name + spec.image required" }, 400);
       return json(await data.createBlueprint({ name: b.name, ...(b.namespace ? { namespace: b.namespace } : {}), spec: b.spec }));
+    }
+
+    // POST /api/deployables — create a Deployable instance (the deploy write path)
+    if (path === "/api/deployables" && req.method === "POST") {
+      if (!data.createDeployable) return json({ error: "deployable creation not available on this backend" }, 405);
+      const b = (await req.json().catch(() => ({}))) as { name?: string; namespace?: string; spec?: Record<string, unknown> };
+      if (!b.name || !b.spec?.blueprint) return json({ error: "name + spec.blueprint required" }, 400);
+      return json(await data.createDeployable({ name: b.name, ...(b.namespace ? { namespace: b.namespace } : {}), spec: b.spec }));
     }
 
     // GET /api/needs-me — pending authorizations across all rooms (the human queue)

--- a/full-ai-cluster/portal/src/data-k8s.ts
+++ b/full-ai-cluster/portal/src/data-k8s.ts
@@ -72,6 +72,21 @@ export class K8sPlatform implements PlatformData {
     if (!r.ok) return { ok: false, message: `save Blueprint ${bp.name}: ${r.status} ${await r.text()}` };
     return { ok: true, message: `Blueprint "${bp.name}" applied to ${ns} — it's in the catalog.` };
   }
+
+  /** Create a Deployable by server-side-applying the Deployable CR — the deploy write path. */
+  async createDeployable(d: { name: string; namespace?: string; spec: Record<string, unknown> }): Promise<{ ok: boolean; message: string }> {
+    const ns = d.namespace ?? "zeta-platform";
+    const body = { apiVersion: `${GROUP}/${VERSION}`, kind: "Deployable", metadata: { name: d.name, namespace: ns }, spec: d.spec };
+    const path = `/apis/${GROUP}/${VERSION}/namespaces/${ns}/deployables/${d.name}`;
+    const r = await fetch(`${this.host}${path}?fieldManager=zeta-portal&force=true`, {
+      method: "PATCH",
+      headers: { Authorization: `Bearer ${this.token}`, "Content-Type": "application/apply-patch+yaml", Accept: "application/json" },
+      body: JSON.stringify(body),
+      tls: { ca: this.ca },
+    } as RequestInit);
+    if (!r.ok) return { ok: false, message: `create Deployable ${d.name}: ${r.status} ${await r.text()}` };
+    return { ok: true, message: `Deployable "${d.name}" applied to ${ns} — the controller is rendering it.` };
+  }
   listRooms(): Promise<RoomData[]> {
     return this.rooms.listRooms();
   }

--- a/full-ai-cluster/portal/src/data-memory.ts
+++ b/full-ai-cluster/portal/src/data-memory.ts
@@ -37,6 +37,23 @@ export class InMemoryPlatform implements PlatformData {
     return { ok: true, message: `Blueprint "${bp.name}" saved — it's now in the catalog and ready to deploy.` };
   }
 
+  /**
+   * Create a Deployable instance (the deploy write path). Upserts by ns/name and
+   * lands it Running so the wizard's resource poll sees it become ready at once —
+   * the demo stand-in for the controller rendering + reconciling the CR.
+   */
+  async createDeployable(d: { name: string; namespace?: string; spec: Record<string, unknown> }): Promise<{ ok: boolean; message: string }> {
+    const ns = d.namespace ?? "zeta-platform";
+    const s = d.spec as { blueprint?: string; expose?: string; host?: string; ai?: { admin?: string; policy?: string; room?: string } };
+    const cr: DeployableCR = {
+      metadata: { name: d.name, namespace: ns },
+      spec: { blueprint: String(s.blueprint ?? ""), ...(s.expose ? { expose: s.expose } : {}), ...(s.host ? { host: s.host } : {}), ...(s.ai ? { ai: s.ai } : {}) },
+      status: { phase: "Running" },
+    };
+    this.deployables = [...this.deployables.filter((x) => !(x.metadata.name === d.name && x.metadata.namespace === ns)), cr];
+    return { ok: true, message: `Deployable "${d.name}" created in ${ns} — it's running and an agent is operating it.` };
+  }
+
   async listDeployables(): Promise<DeployableCR[]> {
     return this.deployables;
   }

--- a/full-ai-cluster/portal/web/src/lib/api.ts
+++ b/full-ai-cluster/portal/web/src/lib/api.ts
@@ -159,6 +159,9 @@ export const api = {
   buildBlueprint: (message: string, draft?: BlueprintProposal) => j<{ reply: string; spec?: BlueprintProposal }>("/api/blueprints/build", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ message, draft }) }),
   saveBlueprint: (name: string, spec: Omit<BlueprintProposal, "name">) => post("/api/blueprints", { name, spec }),
 
+  // deploy: create a Deployable instance (the deploy write path)
+  createDeployable: (body: { name: string; namespace?: string; spec: Record<string, unknown> }) => post("/api/deployables", body),
+
   // admin plane
   cluster: () => j<ClusterCapacity>("/api/admin/cluster"),
   tenants: () => j<{ tenants: TenantUsage[] }>("/api/admin/tenants").then((d) => d.tenants),

--- a/full-ai-cluster/portal/web/src/views/Create.tsx
+++ b/full-ai-cluster/portal/web/src/views/Create.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
-  ArrowLeft, ArrowRight, Check, CircleCheck, Copy, Loader2, Rocket, Server, Sliders, Sparkles,
+  ArrowLeft, ArrowRight, Check, CircleCheck, Copy, Loader2, Rocket, Server, Sliders, Sparkles, TriangleAlert,
 } from "lucide-react";
-import type { CatalogEntryVM } from "@/lib/api";
+import { api, type CatalogEntryVM, type ResourceVM } from "@/lib/api";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -19,7 +19,24 @@ const EXPOSE: Array<{ v: string; label: string; help: string }> = [
   { v: "public", label: "Public HTTPS", help: "Published on a public hostname over TLS via the Gateway. For web apps." },
 ];
 
-type Form = { name: string; namespace: string; expose: string; replicas: string; host: string; values: Record<string, string> };
+type Form = { name: string; namespace: string; expose: string; replicas: string; host: string; size: { cpu: string; memory: string }; values: Record<string, string> };
+
+/** The Deployable `spec` the controller renders — built straight from the form. */
+function buildSpec(bp: CatalogEntryVM, f: Form): Record<string, unknown> {
+  const spec: Record<string, unknown> = { blueprint: bp.blueprint };
+  if (f.expose !== bp.defaultExpose) spec.expose = f.expose;
+  const replicas = Number(f.replicas);
+  if (f.replicas !== "1" && Number.isFinite(replicas)) spec.replicas = replicas;
+  if (f.host) spec.host = f.host;
+  const size: Record<string, string> = {};
+  if (f.size.cpu) size.cpu = f.size.cpu;
+  if (f.size.memory) size.memory = f.size.memory;
+  if (Object.keys(size).length) spec.size = size;
+  const vals = Object.fromEntries(Object.entries(f.values).filter(([, v]) => v !== ""));
+  if (Object.keys(vals).length) spec.values = vals;
+  spec.ai = { admin: "otto", policy: "default", room: "enabled" };
+  return spec;
+}
 
 function buildManifest(bp: CatalogEntryVM, f: Form): string {
   const lines = [
@@ -34,6 +51,7 @@ function buildManifest(bp: CatalogEntryVM, f: Form): string {
   if (f.expose !== bp.defaultExpose) lines.push(`  expose: ${f.expose}`);
   if (f.replicas !== "1") lines.push(`  replicas: ${f.replicas}`);
   if (f.host) lines.push(`  host: ${f.host}`);
+  if (f.size.cpu || f.size.memory) lines.push(`  size: { ${[f.size.cpu && `cpu: ${f.size.cpu}`, f.size.memory && `memory: ${f.size.memory}`].filter(Boolean).join(", ")} }`);
   const vals = Object.entries(f.values).filter(([, v]) => v !== "");
   if (vals.length) { lines.push("  values:"); for (const [k, v] of vals) lines.push(`    ${k}: ${JSON.stringify(v)}`); }
   lines.push("  ai:", "    admin: otto", "    policy: default", "    room: enabled");
@@ -45,7 +63,7 @@ export function Create({ catalog, onChanged }: { catalog: CatalogEntryVM[]; onCh
   const [picked, setPicked] = useState<CatalogEntryVM | null>(null);
   const [building, setBuilding] = useState(false);
   if (building) return <BlueprintBuilder onExit={() => setBuilding(false)} onSaved={() => { setBuilding(false); onChanged?.(); }} />;
-  if (picked) return <DeployWizard bp={picked} onExit={() => setPicked(null)} />;
+  if (picked) return <DeployWizard bp={picked} onExit={() => { setPicked(null); onChanged?.(); }} />;
   return (
     <div>
       <div className="mb-6 flex items-end justify-between gap-4">
@@ -91,7 +109,7 @@ const STEPS: Array<{ id: StepId; label: string; icon: typeof Server }> = [
 function DeployWizard({ bp, onExit }: { bp: CatalogEntryVM; onExit: () => void }) {
   const [step, setStep] = useState<StepId>("basics");
   const [form, setForm] = useState<Form>({
-    name: "", namespace: "default", expose: bp.defaultExpose, replicas: "1", host: "",
+    name: "", namespace: "default", expose: bp.defaultExpose, replicas: "1", host: "", size: { cpu: "500m", memory: "1Gi" },
     values: Object.fromEntries(bp.variables.map((v) => [v.name, v.default ?? ""])),
   });
   const set = (p: Partial<Form>) => setForm((f) => ({ ...f, ...p }));
@@ -140,7 +158,7 @@ function DeployWizard({ bp, onExit }: { bp: CatalogEntryVM; onExit: () => void }
           )}
 
           {step === "options" && (
-            <Step title="Configuration" desc="How this resource is exposed, how many replicas it runs, and its blueprint-specific settings.">
+            <Step title="Configuration" desc="How this resource is exposed, how many replicas it runs, how much CPU/memory it gets, and its blueprint-specific settings.">
               <Field label="Exposure" help={EXPOSE.find((x) => x.v === form.expose)?.help}>
                 <Select value={form.expose} onChange={(e) => set({ expose: e.target.value })}>
                   {EXPOSE.map((x) => <option key={x.v} value={x.v}>{x.label}</option>)}
@@ -154,6 +172,14 @@ function DeployWizard({ bp, onExit }: { bp: CatalogEntryVM; onExit: () => void }
               <Field label="Replicas" help="How many copies to run. Stateful resources (databases, game servers) usually run one.">
                 <Input type="number" min={0} value={form.replicas} onChange={(e) => set({ replicas: e.target.value })} className="w-32" />
               </Field>
+              <div className="flex gap-4">
+                <Field label="CPU" help="Kubernetes CPU request (e.g. 500m = half a core, 1 = one core).">
+                  <Input value={form.size.cpu} onChange={(e) => set({ size: { ...form.size, cpu: e.target.value } })} placeholder="500m" className="w-32" />
+                </Field>
+                <Field label="Memory" help="Kubernetes memory request (e.g. 1Gi, 512Mi).">
+                  <Input value={form.size.memory} onChange={(e) => set({ size: { ...form.size, memory: e.target.value } })} placeholder="1Gi" className="w-32" />
+                </Field>
+              </div>
               {bp.variables.length > 0 && (
                 <div className="pt-2">
                   <div className="mb-1 text-sm font-medium">Blueprint settings</div>
@@ -179,6 +205,7 @@ function DeployWizard({ bp, onExit }: { bp: CatalogEntryVM; onExit: () => void }
                 <Row k="Exposure" v={EXPOSE.find((x) => x.v === form.expose)?.label ?? form.expose} />
                 {form.expose === "public" && form.host && <Row k="Host" v={form.host} />}
                 <Row k="Replicas" v={form.replicas} />
+                <Row k="Size" v={`${form.size.cpu || "—"} CPU · ${form.size.memory || "—"} memory`} />
               </div>
               <ManifestBlock manifest={manifest} />
             </Step>
@@ -190,7 +217,7 @@ function DeployWizard({ bp, onExit }: { bp: CatalogEntryVM; onExit: () => void }
               <ArrowLeft className="size-4" /> {stepIdx === 0 ? "Cancel" : "Back"}
             </Button>
             {step === "review" ? (
-              <Button variant="success" onClick={() => setStep("provision")}><Rocket className="size-4" /> Deploy</Button>
+              <Button variant="success" disabled={!form.name || !nameValid} onClick={() => setStep("provision")}><Rocket className="size-4" /> Deploy</Button>
             ) : (
               <Button disabled={step === "basics" && (!form.name || !nameValid)} onClick={() => setStep(STEPS[stepIdx + 1]!.id)}>
                 Continue <ArrowRight className="size-4" />
@@ -203,71 +230,115 @@ function DeployWizard({ bp, onExit }: { bp: CatalogEntryVM; onExit: () => void }
   );
 }
 
-// ── provisioning (staged progress) ─────────────────────────────────────
-const STAGES = [
-  "Validating the Deployable spec",
-  "Resolving the blueprint",
-  "Creating Kubernetes objects",
-  "Provisioning storage (Longhorn)",
-  "Scheduling pods",
-  "Pulling the container image",
-  "Starting the workload",
-  "Opening the collaboration room",
-];
+// ── provisioning (REAL: create the Deployable, then poll until it's ready) ──
+type ProvState =
+  | { kind: "submitting" }
+  | { kind: "waiting"; phase: string }
+  | { kind: "ready" }
+  | { kind: "error"; message: string };
 
-function Provisioning({ bp, form, onDone }: { bp: CatalogEntryVM; form: Form; onDone: () => void; onBack: () => void }) {
+const READY_TIMEOUT_MS = 120_000; // honest ceiling — past this we surface an error, not a fake success
+const POLL_MS = 2_000;
+
+function Provisioning({ bp, form, onDone, onBack }: { bp: CatalogEntryVM; form: Form; onDone: () => void; onBack: () => void }) {
   const name = form.name || `my-${bp.blueprint}`;
-  const [done, setDone] = useState(0);
-  const [finished, setFinished] = useState(false);
+  const ns = form.namespace || "default";
+  const [state, setState] = useState<ProvState>({ kind: "submitting" });
+  // one-shot guard: React StrictMode double-invokes effects in dev — don't deploy twice
+  const started = useRef(false);
 
   useEffect(() => {
-    let i = 0;
-    let timer: ReturnType<typeof setTimeout>;
-    const tick = () => {
-      i += 1;
-      setDone(i);
-      if (i < STAGES.length) timer = setTimeout(tick, 420 + (i % 3) * 220);
-      else { setFinished(true); toast.success(`${name} provisioned`, { description: "The resource is running and an agent is operating it." }); }
+    if (started.current) return;
+    started.current = true;
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const find = (groups: Awaited<ReturnType<typeof api.resources>>): ResourceVM | undefined =>
+      groups.flatMap((g) => g.resources).find((r) => r.name === name && r.namespace === ns);
+
+    const run = async () => {
+      // 1) create the Deployable (the real write)
+      try {
+        const r = await api.createDeployable({ name, namespace: ns, spec: buildSpec(bp, form) });
+        if (!r.ok) { if (!cancelled) setState({ kind: "error", message: r.message }); return; }
+      } catch (e) {
+        if (!cancelled) setState({ kind: "error", message: (e as Error).message });
+        return;
+      }
+      if (cancelled) return;
+      setState({ kind: "waiting", phase: "Pending" });
+
+      // 2) poll the real resource list until it reports ready (or errors / times out)
+      const deadline = Date.now() + READY_TIMEOUT_MS;
+      const poll = async () => {
+        if (cancelled) return;
+        try {
+          const res = find(await api.resources());
+          if (cancelled) return;
+          if (res?.health === "ready") { setState({ kind: "ready" }); toast.success(`${name} is live`, { description: "The resource is running and an agent is operating it." }); return; }
+          if (res?.health === "error") { setState({ kind: "error", message: res.message ?? `${name} failed to start (${res.phase}).` }); return; }
+          if (Date.now() > deadline) { setState({ kind: "error", message: `${name} is still ${res?.phase ?? "starting"} after ${READY_TIMEOUT_MS / 1000}s — check the resource console.` }); return; }
+          setState({ kind: "waiting", phase: res?.phase ?? "Pending" });
+        } catch (e) {
+          if (!cancelled) setState({ kind: "error", message: (e as Error).message });
+          return;
+        }
+        timer = setTimeout(poll, POLL_MS);
+      };
+      void poll();
     };
-    timer = setTimeout(tick, 400);
-    return () => clearTimeout(timer);
+
+    void run();
+    return () => { cancelled = true; if (timer) clearTimeout(timer); };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  const ready = state.kind === "ready";
+  const failed = state.kind === "error";
+  const title = ready ? "Provisioned" : failed ? "Couldn't deploy" : "Provisioning";
+  const sub = ready ? "Your resource is live." : failed ? "The deploy did not complete." : "Creating the Deployable and waiting for it to come up…";
 
   return (
     <div className="mx-auto max-w-xl">
       <div className="mb-6 flex items-center gap-3">
-        <div className={cn("flex size-10 items-center justify-center rounded-lg border", finished ? "border-success/40 bg-success/10" : "border-border bg-muted/50")}>
-          {finished ? <CircleCheck className="size-5 text-success" /> : <Loader2 className="size-5 animate-spin text-primary" />}
+        <div className={cn("flex size-10 items-center justify-center rounded-lg border", ready ? "border-success/40 bg-success/10" : failed ? "border-destructive/40 bg-destructive/10" : "border-border bg-muted/50")}>
+          {ready ? <CircleCheck className="size-5 text-success" /> : failed ? <TriangleAlert className="size-5 text-destructive" /> : <Loader2 className="size-5 animate-spin text-primary" />}
         </div>
         <div>
-          <h1 className="text-xl font-semibold tracking-tight">{finished ? "Provisioned" : "Provisioning"} {name}</h1>
-          <p className="text-sm text-muted-foreground">{finished ? "Your resource is live." : "Creating and starting your resource…"}</p>
+          <h1 className="text-xl font-semibold tracking-tight">{title} {name}</h1>
+          <p className="text-sm text-muted-foreground">{sub}</p>
         </div>
       </div>
 
-      <ol className="space-y-1">
-        {STAGES.map((s, i) => {
-          const isDone = i < done, current = i === done && !finished;
-          return (
-            <li key={s} className={cn("flex items-center gap-3 rounded-md px-3 py-2 text-sm", current && "bg-accent/50")}>
-              <span className={cn("flex size-5 shrink-0 items-center justify-center rounded-full border", isDone ? "border-success bg-success/15 text-success" : current ? "border-primary text-primary" : "border-border text-muted-foreground")}>
-                {isDone ? <Check className="size-3" /> : current ? <Loader2 className="size-3 animate-spin" /> : <span className="text-[10px]">{i + 1}</span>}
-              </span>
-              <span className={cn(isDone ? "text-foreground" : current ? "text-foreground" : "text-muted-foreground")}>{s}</span>
-            </li>
-          );
-        })}
-      </ol>
+      <div className="rounded-lg border border-border bg-card/40 p-4 text-sm">
+        <StatusRow done={state.kind !== "submitting"} active={state.kind === "submitting"} label="Submitting the Deployable to the cluster" />
+        <StatusRow
+          done={ready}
+          active={state.kind === "waiting"}
+          failed={failed}
+          label={state.kind === "waiting" ? `Waiting for the controller — ${state.phase}` : "Controller renders and starts the workload"}
+        />
+        <StatusRow done={ready} active={false} label="Resource ready, agent operating it" last />
+      </div>
 
-      {finished && (
-        <div className="mt-6 flex gap-2">
-          <Button onClick={onDone}><Sparkles className="size-4" /> Done</Button>
-        </div>
-      )}
+      {failed && state.kind === "error" && <p className="mt-3 text-sm text-destructive">{state.message}</p>}
+
+      <div className="mt-6 flex gap-2">
+        {ready && <Button onClick={onDone}><Sparkles className="size-4" /> Done</Button>}
+        {failed && <Button variant="outline" onClick={onBack}><ArrowLeft className="size-4" /> Back to review</Button>}
+      </div>
     </div>
   );
 }
+
+const StatusRow = ({ done, active, failed, label, last }: { done: boolean; active: boolean; failed?: boolean; label: string; last?: boolean }) => (
+  <div className={cn("flex items-center gap-3 py-1.5", !last && "border-b border-border/50")}>
+    <span className={cn("flex size-5 shrink-0 items-center justify-center rounded-full border", done ? "border-success bg-success/15 text-success" : failed ? "border-destructive text-destructive" : active ? "border-primary text-primary" : "border-border text-muted-foreground")}>
+      {done ? <Check className="size-3" /> : failed ? <TriangleAlert className="size-3" /> : active ? <Loader2 className="size-3 animate-spin" /> : null}
+    </span>
+    <span className={cn(done || active ? "text-foreground" : "text-muted-foreground")}>{label}</span>
+  </div>
+);
 
 // ── small presentational helpers ───────────────────────────────────────
 const Step = ({ title, desc, children }: { title: string; desc: string; children: React.ReactNode }) => (


### PR DESCRIPTION
## Phase 5 — close the create-Deployable write path

The portal could **save a Blueprint** but had **no way to create a Deployable instance** (the thing the controller turns into a Deployment/Service). The Create wizard's "Provisioning" stage was a fake `setTimeout` loop. This PR closes that gap so a user can deploy a service **entirely from the UI**, driven off real cluster state.

### The new deploy flow
1. User picks a blueprint, fills the wizard (name, namespace, exposure, replicas, **CPU/memory size**, blueprint variables), reviews the exact Deployable manifest.
2. On **Deploy**, the web client `POST /api/deployables` with the built spec.
3. The BFF calls `createDeployable`, which (in-cluster) **server-side-applies** a `Deployable` CR (`fieldManager=zeta-portal&force=true`, same SSA shape as `createBlueprint`).
4. The wizard then **polls `api.resources()`** until the new resource reports `health === "ready"` — advancing the progress UI off **real state**, not a timer — or surfaces an honest error/timeout.
5. Everything after the CR exists already worked (controller renders it; the resource console shows it live).

### Changes
- **RBAC** (`k8s/applications/platform/portal.yaml`): add `create` to the SA's `deployables` verbs.
- **BFF** (`portal/src/api.ts`): `createDeployable` on `PlatformData` + `POST /api/deployables` route (405 without the capability, 400 on missing `name`/`spec.blueprint`).
- **K8s impl** (`portal/src/data-k8s.ts`): `K8sPlatform.createDeployable` — SSA `kind: Deployable`, plural `deployables`, into `spec.namespace` (default `zeta-platform`), tls ca.
- **Demo impl** (`portal/src/data-memory.ts`): `InMemoryPlatform.createDeployable` upserts a **Running** Deployable (idempotent by ns/name) so `PORTAL_DEMO=1` + the wizard poll see it become ready.
- **Web client** (`portal/web/src/lib/api.ts`): `api.createDeployable(body)`.
- **Wizard** (`portal/web/src/views/Create.tsx`): real create + poll flow; `size.cpu`/`size.memory` inputs (default `500m`/`1Gi`) added to the form, manifest, and review.

### Verification
- `bun test` — **96 pass / 0 fail** (4 new `createDeployable` tests: ok + resource appears ready, 400 on missing fields, idempotent upsert, 405 without the capability).
- `bunx tsc --noEmit` (BFF/src) — clean.
- `bun run build:web` — succeeds (`tsc -b` + `vite build`). The SPA `dist/` is built into the image by the Dockerfile and stays gitignored per the repo convention, so no `dist/` is committed.
- No live-cluster or browser testing (parent's job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)