### PR TITLE
feat(platform): Flowdent blueprints (opendental-suite + fd-webapp + mssql)

### DIFF
--- a/full-ai-cluster/k8s/applications/platform/Application.yaml
+++ b/full-ai-cluster/k8s/applications/platform/Application.yaml
@@ -26,7 +26,7 @@ spec:
     targetRevision: main
     path: full-ai-cluster/k8s/applications/platform
     directory:
-      include: '{namespace,crd-policy,crd-gameserver,crd-app,crd-webapp,crd-blueprint,crd-deployable,crd-tenant,policy-default,blueprints,controller,portal,clusterissuer,gateway}.yaml'
+      include: '{namespace,crd-policy,crd-gameserver,crd-app,crd-webapp,crd-blueprint,crd-deployable,crd-tenant,policy-default,blueprints,blueprints-flowdent,controller,portal,clusterissuer,gateway}.yaml'
   destination:
     server: https://kubernetes.default.svc
     namespace: zeta-platform

--- a/full-ai-cluster/k8s/applications/platform/blueprints-flowdent.yaml
+++ b/full-ai-cluster/k8s/applications/platform/blueprints-flowdent.yaml
@@ -1,0 +1,107 @@
+# Flowdent Blueprint LIBRARY — pure DATA. The FlowDent stack (a dental-practice
+# suite) made deployable as Blueprints the SAME generic engine renders: a .NET
+# backend (app), a Next.js frontend (web), and a SQL Server 2022 database. ZERO
+# new controller code — credentials arrive via envFrom (secretKeyRef), health is
+# gated by probes, and the DB binds durable storage. See blueprint.ts.
+---
+# OpenDental suite — the FlowDent .NET backend. Stateless app pod on :8080.
+# Connection string + JWT signing key arrive from Secrets (never inline);
+# readiness gates on /health, liveness restarts on /test. Exposed on the LAN
+# as a raw LoadBalancer IP (no public host routing).
+apiVersion: platform.zeta.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: opendental-suite
+  namespace: zeta-platform
+spec:
+  category: app
+  stateful: false
+  image: ghcr.io/flowdent/cloudservice:latest
+  env:
+    ASPNETCORE_ENVIRONMENT: Production
+    ASPNETCORE_URLS: "http://+:8080"
+    JwtSettings__Issuer: "https://api.flowdent.net"
+    JwtSettings__Audience: "https://app.flowdent.net"
+  envFrom:
+    - { name: ConnectionStrings__DefaultConnection, secret: flowdent-db, key: sqlserver-conn }
+    - { name: FLOWDENT_JWT_PRIVATE_KEY_PEM, secret: flowdent-jwt, key: private-pem }
+  ports:
+    - { name: http, port: 8080 }
+  resources: { cpu: "1", memory: "1Gi" }
+  # Probe paths confirmed against D:/OpenDentalSuiteService Program.cs:
+  # MapHealthChecks("/health") (readiness) + MapGet("/test") (liveness).
+  probe:
+    readiness: { httpGet: { path: /health, port: 8080 } }
+    liveness: { httpGet: { path: /test, port: 8080 } }
+  defaultExpose: lan
+---
+# FlowDent web app — the Next.js frontend. Stateless, single HTTP port :3000,
+# web-routable. The public API/app URLs are variables so a Deployable can point
+# the frontend at any backend; API_URL must match the image's build-arg.
+# Exposed on the LAN as a raw LoadBalancer IP.
+apiVersion: platform.zeta.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: fd-webapp
+  namespace: zeta-platform
+spec:
+  category: web
+  stateful: false
+  image: ghcr.io/flowdent/fd-webclient:latest
+  env:
+    NODE_ENV: production
+    NEXT_PUBLIC_API_URL: "${API_URL}"
+    NEXT_PUBLIC_APP_URL: "${APP_URL}"
+    NEXT_PUBLIC_APP_NAME: FlowDent
+  ports:
+    - { name: http, port: 3000, web: true }
+  resources: { cpu: "500m", memory: "1Gi" }
+  probe:
+    readiness: { httpGet: { path: /, port: 3000 } }
+    liveness: { httpGet: { path: /, port: 3000 } }
+  variables:
+    - { name: API_URL, default: "http://192.168.1.243:8080", description: "backend base URL; must match the image build-arg" }
+    - { name: APP_URL, default: "http://192.168.1.79:3000", description: "public URL of this frontend" }
+  defaultExpose: lan
+---
+# SQL Server 2022 — the FlowDent database. Stateful, TDS on :1433, durable
+# storage on zeta-local-path, cluster-internal only (never LAN/public).
+# SA password arrives from a Secret. Single-replica by design: a single-writer
+# DB must NOT be scaled to 2 (no multi-primary). mssql needs >=2Gi RAM; the
+# in-process limit (MSSQL_MEMORY_LIMIT_MB) sits below the 3Gi pod limit.
+apiVersion: platform.zeta.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: mssql
+  namespace: zeta-platform
+spec:
+  category: database
+  stateful: true
+  image: mcr.microsoft.com/mssql/server:2022-latest
+  env:
+    ACCEPT_EULA: "Y"
+    MSSQL_PID: Developer
+    MSSQL_COLLATION: SQL_Latin1_General_CP1_CI_AS
+    MSSQL_MEMORY_LIMIT_MB: "2560"
+  envFrom:
+    - { name: MSSQL_SA_PASSWORD, secret: flowdent-db, key: sa-password }
+  ports:
+    - { name: tds, port: 1433, protocol: TCP }
+  storage: { size: "8Gi", mountPath: /var/opt/mssql }
+  storageClassName: zeta-local-path
+  resources: { cpu: "2", memory: "3Gi" }
+  probe:
+    readiness:
+      exec:
+        command:
+          - /opt/mssql-tools18/bin/sqlcmd
+          - -C
+          - -S
+          - localhost
+          - -U
+          - sa
+          - -P
+          - "$(MSSQL_SA_PASSWORD)"
+          - -Q
+          - SELECT 1
+  defaultExpose: cluster


### PR DESCRIPTION
## What

Author the **FlowDent** services as platform **Blueprints** — pure DATA the generic `renderDeployable` engine turns into Kubernetes objects, with **ZERO new controller code**. New file `full-ai-cluster/k8s/applications/platform/blueprints-flowdent.yaml` holds three Blueprint CRs (namespace `zeta-platform`), wired into the platform Application's `include` glob.

This is the proof of "support wide arrays of deployables as data": a .NET backend, a Next.js frontend, and a SQL Server database are all just Blueprints the same engine renders.

## The three blueprints

| name | category | workload | port | exposure | notes |
|---|---|---|---|---|---|
| `opendental-suite` | app | Deployment | 8080 (http) | lan (raw LB IP) | conn-string + JWT key via `envFrom`/secretKeyRef (`flowdent-db`, `flowdent-jwt`); readiness `/health`, liveness `/test` |
| `fd-webapp` | web | Deployment | 3000 (http, web) | lan (raw LB IP) | `API_URL`/`APP_URL` as variables (`API_URL` matches the image build-arg); probes on `/` |
| `mssql` | database | StatefulSet | 1433 (tds) | cluster (ClusterIP only) | SA password via `envFrom`; 8Gi on `zeta-local-path`; exec readiness (`sqlcmd SELECT 1`); single-replica by design, ≥2Gi RAM |

## Engine features exercised (just merged in #8222)

- `envFrom: [{name, secret, key}]` → `secretKeyRef` (credentials never inline)
- `probe: {readiness?, liveness?}` (httpGet + exec handlers)
- `storageClassName` (mssql overrides the `longhorn` default with `zeta-local-path`)

## Validation

- Probe paths `/health` (readiness) + `/test` (liveness) **confirmed** against `D:/OpenDentalSuiteService` `Program.cs` (`MapHealthChecks("/health")`, `MapGet("/test")`).
- `cd full-ai-cluster && bun test tools/k8s-manifests.test.ts` → **12 pass, 0 fail** (platform include list references files that exist; apiVersion/kind present).
- Multi-doc YAML parses to 3 Blueprint CRs.
- Render-checked: fed each blueprint through `renderDeployable` — env (plaintext + secretKeyRef), ports, probes, resource limits, Service type (LoadBalancer ×2 / ClusterIP), and the mssql `volumeClaimTemplate` (storageClass `zeta-local-path`, 8Gi) all render as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)