### PR TITLE
fix(storage): local-path-provisioner pods create/delete — stateful pods were stuck Pending

### DIFF
--- a/full-ai-cluster/nixos/modules/local-storage.nix
+++ b/full-ai-cluster/nixos/modules/local-storage.nix
@@ -126,6 +126,14 @@
           resources: ["persistentvolumes"]
           verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
         - apiGroups: [""]
+          # The v0.0.30 helper-pod model spawns a short-lived pod in
+          # local-path-storage to mkdir/rm each volume's host dir; the SA must be
+          # able to create + delete it. Without this, EVERY PVC on this class
+          # fails to provision ("cannot create resource pods") and every stateful
+          # pod hangs Pending (observed: mssql/spire-server/vault on node-5b2dfa).
+          resources: ["pods"]
+          verbs: ["create", "delete"]
+        - apiGroups: [""]
           resources: ["events"]
           verbs: ["create", "patch"]
         - apiGroups: ["storage.k8s.io"]


### PR DESCRIPTION
The earlier helperPod fix enabled local-path-provisioner v0.0.30's helper-pod model but didn't grant the SA RBAC to **create** the helper pod (only get/list/watch). So every `zeta-local-path` PVC failed to provision and every stateful workload (mssql, spire-server, vault) hung Pending on node-5b2dfa. Adds `pods: create/delete`. Patched live → mssql-0 Bound+Running, SQL Server 2022 queryable. Durable for fresh installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)