### PR TITLE
fix(opa): exempt zeta-platform + flowdent from Gatekeeper

### DIFF
--- a/full-ai-cluster/k8s/applications/open-policy-agent/Application.yaml
+++ b/full-ai-cluster/k8s/applications/open-policy-agent/Application.yaml
@@ -31,6 +31,8 @@ spec:
             - cilium
             - longhorn-system
             - argocd
+            - zeta-platform   # platform control plane (portal + controller); carries the gatekeeper ignore label
+            - flowdent        # tenant workload namespace (Flowdent services + db)
         # FAIL-OPEN, not fail-closed. With failurePolicy: Fail the validating
         # webhook intercepts EVERY write cluster-wide — including k3s's own
         # cluster-scoped CRD updates (e.g. addons.k3s.cattle.io). If gatekeeper


### PR DESCRIPTION
The platform namespace carries `admission.gatekeeper.sh/ignore=true` (it runs the control plane) but wasn't in gatekeeper's `exemptNamespaces` → the check-ignore-label webhook denied the namespace → the platform app went Degraded and portal+controller never deployed. Adds both namespaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)