### PR TITLE
fix(cilium): enable l2announcements so LoadBalancer IPs are reachable

### DIFF
--- a/full-ai-cluster/k8s/applications/cilium/Application.yaml
+++ b/full-ai-cluster/k8s/applications/cilium/Application.yaml
@@ -39,6 +39,18 @@ spec:
         ipv4NativeRoutingCIDR: "10.42.0.0/16"
         autoDirectNodeRoutes: true
 
+        # L2 announcements: ARP-advertise LoadBalancer/externalIP addresses on the
+        # LAN so type=LoadBalancer services (from cilium-lb-ipam) are actually
+        # reachable. The CiliumL2AnnouncementPolicy (zeta-l2-announce) is inert
+        # without this flag — LB IPs were assigned but unreachable on node-5b2dfa.
+        l2announcements:
+          enabled: true
+        # L2 leader-election leases are API-heavy; raise the client rate limit
+        # (Cilium docs recommendation when l2announcements is on).
+        k8sClientRateLimit:
+          qps: 50
+          burst: 100
+
         # Hubble (observability + Hubble Relay + Hubble UI).
         hubble:
           enabled: true


### PR DESCRIPTION
The `zeta-l2-announce` policy is inert without `l2announcements.enabled` — LB IPs were assigned but never ARP-advertised, so type=LoadBalancer services (the portal at 192.168.1.243) were unreachable on the LAN. Enables it + raises k8sClientRateLimit per Cilium docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)