### PR TITLE
fix(portal): URL-decode the resource path segment so logs/events/exec work

### DIFF
--- a/full-ai-cluster/portal/src/api.test.ts
+++ b/full-ai-cluster/portal/src/api.test.ts
@@ -6,8 +6,9 @@
 // paths pass through (null) for static serving.
 
 import { beforeEach, describe, expect, test } from "bun:test";
-import { encodeResource, handle } from "./api.ts";
+import { encodeResource, handle, type PlatformData } from "./api.ts";
 import { InMemoryPlatform } from "./data-memory.ts";
+import type { LogLine, ResourceOps } from "./ops.ts";
 import type { BlueprintCR, DeployableCR, RoomData } from "./viewmodel.ts";
 
 const BLUEPRINTS: BlueprintCR[] = [
@@ -146,5 +147,62 @@ describe("create Deployable (the deploy write path — a human deploys a service
     const noWrite = { listDeployables: async () => [], listBlueprints: async () => [], listRooms: async () => [], getRoom: async () => undefined, grant: async () => false };
     const r = await handle(new Request("http://x/api/deployables", { method: "POST", body: JSON.stringify({ name: "z", spec: { blueprint: "web" } }) }), noWrite as any);
     expect(r!.status).toBe(405);
+  });
+});
+
+describe("management plane: the :resource path segment is URL-decoded", () => {
+  // Regression for the live Logs/Events breakage: the web client builds the
+  // management URL by percent-encoding the resource id's slash (`ns/name` →
+  // `ns%2Fname`). URL.pathname keeps `%2F` literal, so the server MUST decode
+  // it before the ops layer — otherwise `K8sOps.split`'s `resource.split("/")`
+  // never splits and it builds `/namespaces/ns%2Fname/pods` → 403 → 500.
+
+  // A spy ops layer that captures the exact `resource` string each op receives,
+  // so we can assert the decoded `namespace/name` reaches the ops call.
+  const makeSpy = () => {
+    const seen: { logs?: string; events?: string } = {};
+    const ops = {
+      logs: async (resource: string): Promise<LogLine[]> => {
+        seen.logs = resource;
+        return [{ ts: "t", level: "info", text: "ok" }];
+      },
+      events: async (resource: string) => {
+        seen.events = resource;
+        return [];
+      },
+    } as unknown as ResourceOps;
+    const platform: PlatformData = {
+      listDeployables: async () => [],
+      listBlueprints: async () => [],
+      listRooms: async () => [],
+      getRoom: async () => undefined,
+      grant: async () => false,
+      ops,
+    };
+    return { platform, seen };
+  };
+
+  test("GET /api/resources/flowdent%2Fflowdent-webapp/logs → ns=flowdent name=flowdent-webapp", async () => {
+    const { platform, seen } = makeSpy();
+    const r = await handle(new Request("http://x/api/resources/flowdent%2Fflowdent-webapp/logs"), platform);
+    expect(r!.status).toBe(200);
+    // the decoded `namespace/name` (NOT the still-encoded `%2F`) reaches data.ops.logs,
+    // which is exactly what K8sOps.split needs to yield ["flowdent","flowdent-webapp"].
+    expect(seen.logs).toBe("flowdent/flowdent-webapp");
+    expect((seen.logs ?? "").split("/")).toEqual(["flowdent", "flowdent-webapp"]);
+  });
+
+  test("GET /api/resources/flowdent%2Fflowdent-webapp/events also decodes", async () => {
+    const { platform, seen } = makeSpy();
+    const r = await handle(new Request("http://x/api/resources/flowdent%2Fflowdent-webapp/events"), platform);
+    expect(r!.status).toBe(200);
+    expect(seen.events).toBe("flowdent/flowdent-webapp");
+  });
+
+  test("the canonical `~` separator still resolves (no double-decode regression)", async () => {
+    const { platform, seen } = makeSpy();
+    const r = await handle(new Request("http://x/api/resources/flowdent~flowdent-webapp/logs"), platform);
+    expect(r!.status).toBe(200);
+    expect(seen.logs).toBe("flowdent/flowdent-webapp");
   });
 });

--- a/full-ai-cluster/portal/src/api.ts
+++ b/full-ai-cluster/portal/src/api.ts
@@ -269,7 +269,28 @@ export async function handle(req: Request, data: PlatformData): Promise<Response
 export function encodeResource(namespace: string, name: string): string {
   return `${namespace}~${name}`;
 }
+/**
+ * Decode the `:resource` path segment back to its `namespace/name` id.
+ *
+ * The segment is URL-decoded FIRST: a web client that builds the URL with
+ * `encodeURIComponent("ns/name")` sends `ns%2Fname`, and `URL.pathname` keeps
+ * `%2F` literal (it never auto-decodes an encoded slash). Without this decode the
+ * still-encoded string reaches `K8sOps.split`, whose `resource.split("/")` finds
+ * no slash → it builds `/api/v1/namespaces/ns%2Fname/pods?...` → 403 → the
+ * endpoint 500s (the live Logs/Events breakage). Decoding ONLY this segment is
+ * safe: the op/sub-path (`logs`, `events`, …) is matched separately by the route
+ * regex and never passes through here, so there is no double-decode. After
+ * decoding we accept either the canonical `~` separator or a literal `/` (from a
+ * decoded `%2F`).
+ */
 function decodeResource(seg: string): string {
-  const [ns, name] = seg.split("~");
-  return name ? `${ns}/${name}` : seg;
+  let decoded = seg;
+  try {
+    decoded = decodeURIComponent(seg);
+  } catch {
+    // malformed %-escape — fall back to the raw segment rather than throwing
+  }
+  const [ns, name] = decoded.split("~");
+  if (name) return `${ns}/${name}`;
+  return decoded; // already `namespace/name` (decoded from `%2F`) or a bare id
 }


### PR DESCRIPTION
## The bug

The per-resource management-plane routes (`/api/resources/:resource/{logs,events,exec,config,lifecycle,files,...}`) passed the `:resource` path segment to the ops layer **still percent-encoded**.

A resource is addressed by its `<namespace>/<name>` id (e.g. `flowdent/flowdent-webapp`). When the slash is percent-encoded as `%2F`, `URL.pathname` keeps it **literal** — the URL spec never auto-decodes an encoded slash. So the still-encoded `flowdent%2Fflowdent-webapp` reached `K8sOps.split`, whose `resource.split("/")` found no slash and **never split** → it built:

```
/api/v1/namespaces/flowdent%2Fflowdent-webapp/pods?...  → 403 → endpoint 500s
```

Confirmed live: **Logs and Events tabs were broken for every resource.**

## The fix

Decode the `:resource` segment in `decodeResource` (`full-ai-cluster/portal/src/api.ts`) — the single funnel that **all** management-plane and room routes share — with `decodeURIComponent` **before** splitting:

```ts
function decodeResource(seg: string): string {
  let decoded = seg;
  try { decoded = decodeURIComponent(seg); } catch { /* malformed %-escape → raw */ }
  const [ns, name] = decoded.split("~");
  if (name) return `${ns}/${name}`;
  return decoded; // already `namespace/name` (decoded from %2F) or a bare id
}
```

`K8sOps.split` now yields `["flowdent", "flowdent-webapp"]`.

- **No double-decode:** the op/sub-path (`logs`, `events`, …) is matched separately by the route regex and never passes through `decodeResource`.
- **Belt-and-suspenders / round-trip safe:** decode handles both the `%2F` scheme (the live failure) **and** the canonical `~` separator the web client currently emits (decode is a no-op when there's no `%`). The web client is left unchanged — the server decode is the primary fix and covers both encodings.

## Tests

New focused block in `api.test.ts` proves a request to `/api/resources/flowdent%2Fflowdent-webapp/{logs,events}` resolves to namespace `flowdent` + name `flowdent-webapp` in the ops call (via a spy ops layer capturing the `resource` argument), plus a no-double-decode regression on the `~` separator.

- `bun test` — **99 pass / 0 fail**
- `bunx tsc --noEmit` (BFF) — clean
- `bun run build:web` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)