### PR TITLE
feat(adinkra): self-dual fixpoint check — code-level gen(gen)===gen (Face 1)

### DIFF
--- a/src/Core/AdinkraCode.fs
+++ b/src/Core/AdinkraCode.fs
@@ -62,3 +62,28 @@ module AdinkraCode =
     /// Bitwise GF(2) XOR of two equal-length words (the linear-combination operation).
     let xor (a: int[]) (b: int[]) : int[] =
         Array.map2 (^^^) a b
+
+    /// GF(2) inner product of two equal-length words: (Σ aᵢ·bᵢ) mod 2. The bilinear form whose
+    /// fixed point (C = C⊥) is self-duality.
+    let dot (a: int[]) (b: int[]) : int =
+        let mutable acc = 0
+        for i in 0 .. (min a.Length b.Length) - 1 do
+            acc <- acc ^^^ (a.[i] &&& b.[i])
+        acc
+
+    /// **Self-orthogonal**: every pair of generator rows is orthogonal under `dot` (and each row is
+    /// orthogonal to itself, i.e. has even weight). By bilinearity this extends to all codewords, so
+    /// `C ⊆ C⊥`. (Doubly-even ⇒ even weight ⇒ self-orthogonal on the diagonal; checked here directly.)
+    let isSelfOrthogonal : bool =
+        generator
+        |> Array.forall (fun gi -> generator |> Array.forall (fun gj -> dot gi gj = 0))
+
+    /// **Self-dual** — the `gen(gen) === gen` fixed point at the code level. The dual map `C ↦ C⊥` is an
+    /// involution (`dual(dual C) = C` always); a *self-dual* code is its **fixed point** (`dual C = C`).
+    /// A linear code is self-dual iff it is self-orthogonal (`C ⊆ C⊥`) **and** `dim C = n/2` (forcing
+    /// `C⊥ ⊆ C`, hence equality). The [8,4] extended Hamming code satisfies both — it is the e8 code, the
+    /// unique doubly-even self-dual binary code of length 8 — so the generator already sits on the
+    /// duality fixed point (Face 1 of `gen(gen)=gen`; Faces 2/3 — the codespace projector Π²=Π and the
+    /// Futamura `mix(mix,mix)=cogen` reflective fixpoint — remain in `docs/FROZEN-CORE-AND-CONJECTURE-REGISTER.md` §B).
+    let isSelfDual : bool =
+        isSelfOrthogonal && (2 * dimension = length)

--- a/tests/Tests.FSharp/AdinkraCode.Tests.fs
+++ b/tests/Tests.FSharp/AdinkraCode.Tests.fs
@@ -52,3 +52,21 @@ let ``xor of two codewords stays doubly-even`` (i: int) (j: int) =
     let a = AK.allCodewords.[((i % n) + n) % n]
     let b = AK.allCodewords.[((j % n) + n) % n]
     AK.weight (AK.xor a b) % 4 = 0
+
+// ── Self-duality: the gen(gen)===gen fixed point at the code level (Face 1) ──
+// The dual map C ↦ C⊥ is an involution; a self-dual code is its fixed point (dual C = C). Proven via
+// the standard criterion: self-orthogonal (C ⊆ C⊥) AND dim C = n/2 ⇒ C = C⊥.
+
+[<Fact>]
+let ``code is self-orthogonal — every pair of codewords is GF(2)-orthogonal (C subset of C-perp)`` () =
+    for a in AK.allCodewords do
+        for b in AK.allCodewords do
+            Assert.Equal(0, AK.dot a b)
+
+[<Fact>]
+let ``dimension is half the length — dim C = n/2 (forces C-perp subset of C)`` () =
+    Assert.Equal(AK.length, 2 * AK.dimension)
+
+[<Fact>]
+let ``the code is self-dual — the gen(gen)=gen duality fixed point (C = C-perp)`` () =
+    Assert.True(AK.isSelfDual)


### PR DESCRIPTION
Face 1 of `gen(gen)=gen`: the dual map C↦C⊥ is an involution; a self-dual code is its fixed point. The [8,4] extended Hamming generator (e8 code) already sits there — now proven, not asserted. Adds `dot`/`isSelfOrthogonal`/`isSelfDual` + exhaustive tests (16×16 self-orthogonality, dim=n/2, self-dual). 11/11 green, 0 warnings. Faces 2 (projector Π²=Π) and 3 (Futamura mix(mix,mix)=cogen) stay open in §B. Authorized: Aaron (shadow*).