### PR TITLE
fix(portal): logs tab 406 — pod-log API rejects Accept: text/plain

### DIFF
--- a/full-ai-cluster/portal/src/ops-k8s.ts
+++ b/full-ai-cluster/portal/src/ops-k8s.ts
@@ -100,7 +100,7 @@ export class K8sOps implements ResourceOps {
     const pod = list.items[0]?.metadata?.name;
     if (!pod) return [];
     const tail = opts?.tail ?? 200;
-    const r = await this.req("GET", `/api/v1/namespaces/${ns}/pods/${pod}/log?timestamps=true&tailLines=${tail}`, { accept: "text/plain" });
+    const r = await this.req("GET", `/api/v1/namespaces/${ns}/pods/${pod}/log?timestamps=true&tailLines=${tail}`, { accept: "*/*" });
     if (!r.ok) return [{ ts: "", level: "warn", text: `could not read logs: ${r.status}` }];
     return parseLogs(await r.text(), tail);
   }


### PR DESCRIPTION
## Problem
The resource console **Logs** tab showed `could not read logs: 406` in the browser.

## Root cause
k3s 1.34's API content-negotiation returns **406 Not Acceptable** when the pod `log` subresource is requested with an explicit `Accept: text/plain`. The decode fix in #8229 made the route resolve correctly (HTTP 200 envelope), exposing this deeper 406 in the log payload itself.

## Fix
Request `Accept: */*` for the pod-log read in `K8sOps.logs`.

## Verification (live, portal service account)
```
Accept=text/plain -> HTTP 406
Accept=*/*       -> HTTP 200
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)