### PR TITLE
feat(adinkra): codespace projector Pi - gen(gen)===gen idempotent endomorphism (Face 2)

### DIFF
--- a/src/Core/AdinkraCode.fs
+++ b/src/Core/AdinkraCode.fs
@@ -87,3 +87,18 @@ module AdinkraCode =
     /// Futamura `mix(mix,mix)=cogen` reflective fixpoint — remain in `docs/FROZEN-CORE-AND-CONJECTURE-REGISTER.md` §B).
     let isSelfDual : bool =
         isSelfOrthogonal && (2 * dimension = length)
+
+    /// **Codespace projector** Π onto the code C — Face 2 of `gen(gen)===gen` as an honest endomorphism
+    /// (`Π∘Π = Π`). Because the generator is systematic (`[I₄ | A]`), the projector onto C along the
+    /// parity complement `D = {(0,p)}` is simply **re-encode the message coordinates**:
+    /// `Π(v) = encode(v[0 .. k-1])`. It is linear, **idempotent (Π² = Π)**, fixes every codeword, and has
+    /// image = C — the decode→re-encode "snap to the nearest codeword on the systematic split" operation,
+    /// so re-running the generator on an already-generated word changes nothing.
+    ///
+    /// Honest scope (peel): this is the projector along the *parity* complement, **not** the orthogonal
+    /// projector. Over GF(2) the code is self-orthogonal (`G·Gᵀ = 0`, singular), so the orthogonal
+    /// projector `Gᵀ(GGᵀ)⁻¹G` is undefined; Π depends on the chosen complement (here, the systematic
+    /// split). Idempotence and image = C hold for any complement. (Face 3 — the Futamura
+    /// `mix(mix,mix)=cogen` reflective fixpoint — remains open in §B.)
+    let project (v: int[]) : int[] =
+        encode (Array.sub v 0 dimension)

--- a/tests/Tests.FSharp/AdinkraCode.Tests.fs
+++ b/tests/Tests.FSharp/AdinkraCode.Tests.fs
@@ -70,3 +70,32 @@ let ``dimension is half the length — dim C = n/2 (forces C-perp subset of C)``
 [<Fact>]
 let ``the code is self-dual — the gen(gen)=gen duality fixed point (C = C-perp)`` () =
     Assert.True(AK.isSelfDual)
+
+// ── Codespace projector Π: the gen(gen)===gen idempotent endomorphism (Face 2) ──
+// Π(v) = encode(v[0..k-1]) — re-encode the systematic part. Projector onto C along the parity complement.
+// Exhaustive over all 2^8 = 256 words.
+
+let private allWords8 : int[] list =
+    [ for w in 0 .. 255 -> [| for i in 0 .. AK.length - 1 -> (w >>> i) &&& 1 |] ]
+
+[<Fact>]
+let ``projector is idempotent — Pi(Pi v) = Pi v for all 256 words (gen(gen)=gen)`` () =
+    for v in allWords8 do
+        Assert.Equal<int[]>(AK.project v, AK.project (AK.project v))
+
+[<Fact>]
+let ``projector image is the code — Pi v is always a codeword`` () =
+    let codeSet = AK.allCodewords |> List.map List.ofArray |> Set.ofList
+    for v in allWords8 do
+        Assert.True(codeSet.Contains(List.ofArray (AK.project v)))
+
+[<Fact>]
+let ``projector fixes every codeword — Pi c = c for c in C`` () =
+    for c in AK.allCodewords do
+        Assert.Equal<int[]>(c, AK.project c)
+
+[<Fact>]
+let ``projector is GF(2)-linear — Pi(a xor b) = Pi a xor Pi b (exhaustive over 256x256 words)`` () =
+    for a in allWords8 do
+        for b in allWords8 do
+            Assert.Equal<int[]>(AK.project (AK.xor a b), AK.xor (AK.project a) (AK.project b))


### PR DESCRIPTION
Face 2 of `gen(gen)=gen`: the codespace projector `Pi(v)=encode(v[0..k-1])` (re-encode the systematic part) is linear, idempotent (Pi^2=Pi), fixes codewords, image=C. Exhaustive tests (256 idempotent/image, 16 fixed, 256x256 linear). Honest peel: parity-complement projector, NOT orthogonal (undefined over GF(2): self-orthogonal G.G^T=0). 15/15 green, 0 warnings. Face 3 (Futamura) open in §B. Authorized: Aaron (shadow*).