### PR TITLE
feat(soft): SoftValue.combine + snap — soft banana-split/fuse in uncertainty space, policy-gated collapse

### DIFF
--- a/src/Core/SoftValue.fs
+++ b/src/Core/SoftValue.fs
@@ -82,3 +82,45 @@ module SoftValue =
     let resolve (threshold: float) (sv: SoftValue) : DynamicValue option =
         let best, p = sv.Candidates |> List.maxBy snd
         if p >= threshold then Some best else None
+
+    /// The weight `sv` assigns to candidate `d` (0 if `d` is absent from the support).
+    let weightOf (d: DynamicValue) (sv: SoftValue) : float =
+        sv.Candidates
+        |> List.tryPick (fun (c, w) -> if c = d then Some w else None)
+        |> Option.defaultValue 0.0
+
+    /// **combine — independent-evidence product of two soft values.** The commutative + associative
+    /// monoid that lets a soft fold **banana-split and fuse in uncertainty space** without ever
+    /// collapsing to a definite value: `combine a b ∝ aᵢ · bᵢ`, renormalized. `None` if their supports
+    /// are disjoint (a contradiction — no fabricated certainty, the same discipline as `observe`).
+    ///
+    /// It is literally `observe` with the other value as the likelihood, so it inherits `observe`'s
+    /// normalization and honesty. Because real multiplication commutes and associates, `combine` is a
+    /// commutative associative (partial) monoid — therefore folding a node's children with `combine`
+    /// is **order-independent** (the soft / NCI analogue of the eager `cata`-fusion law). The carrier
+    /// for a `DynamicValueFold.DvAlgebra<SoftValue>` is exactly this: soft cata/bananaSplit/fusion are
+    /// the generic schemes at `'r = SoftValue`, and `combine` is the order-free child-combiner.
+    let combine (a: SoftValue) (b: SoftValue) : SoftValue option =
+        observe (fun d -> weightOf d b) a
+
+    // ── Snap: the policy-gated soft → hard boundary ──
+    // The soft model runs entirely in uncertainty space (combine/observe, never collapsing); a *policy*
+    // is the one place it is allowed to leave that space and snap to a hard `DynamicValue` that
+    // represents the exact (math-provable) value. Bayesian is how we approximate; snap is how we commit.
+
+    /// A **snap policy**: the soft → hard decision. Collapse a soft value to a definite `DynamicValue`,
+    /// or hold (`None`) if the policy judges the collapse unwarranted. This is the *only* sanctioned exit
+    /// from uncertainty space — everything upstream of it stays soft.
+    type SnapPolicy = SoftValue -> DynamicValue option
+
+    /// Snap a soft value to a hard one under a policy. `snap (threshold t)` is calibration-gated (never
+    /// falsely certain); `snap best` always takes the argmax. `snap _ (certain dv) = Some dv` — with no
+    /// genuine uncertainty the soft layer reproduces exactly the hard value the math team proves.
+    let snap (policy: SnapPolicy) (sv: SoftValue) : DynamicValue option = policy sv
+
+    /// Policy: collapse iff confidence ≥ `t` (this is `resolve`, named as a policy).
+    let threshold (t: float) : SnapPolicy = resolve t
+
+    /// Policy: always collapse to the most-likely candidate (argmax); never holds.
+    let best: SnapPolicy =
+        fun sv -> sv.Candidates |> List.maxBy snd |> fst |> Some

--- a/tests/Tests.FSharp/SoftValue.Tests.fs
+++ b/tests/Tests.FSharp/SoftValue.Tests.fs
@@ -118,3 +118,49 @@ let ``SoftValue: independent-evidence Bayesian updates COMMUTE (order-independen
 let ``SoftValue: a refuting observation that zeroes all candidates returns None (no fabricated certainty)`` () =
     let sv = (SV.ofWeighted [ cand 0, 1.0; cand 1, 1.0 ]).Value
     Assert.Equal(None, SV.observe (fun _ -> 0.0) sv)
+
+// ═══════════════════════════════════════════════════════════════════
+// combine — the soft order-free child-combiner (soft banana-split / fuse in uncertainty space).
+// Commutative + associative (multiplication is) ⇒ reducing a node's children with `combine` is
+// order-independent: the soft / NCI analogue of the eager cata-fusion law. genSoft has full shared
+// support (cand 0/1/2 all positive) ⇒ every combine here is Some.
+// ═══════════════════════════════════════════════════════════════════
+
+[<Property(Arbitrary = [| typeof<SoftArb> |])>]
+let ``combine commutes`` (a: SV.SoftValue) (b: SV.SoftValue) =
+    match SV.combine a b, SV.combine b a with
+    | Some ab, Some ba -> sameDist ab ba
+    | None, None -> true
+    | _ -> false
+
+[<Property(Arbitrary = [| typeof<SoftArb> |])>]
+let ``combine associates`` (a: SV.SoftValue) (b: SV.SoftValue) (c: SV.SoftValue) =
+    let lhs = SV.combine a b |> Option.bind (fun ab -> SV.combine ab c)
+    let rhs = SV.combine b c |> Option.bind (fun bc -> SV.combine a bc)
+    match lhs, rhs with
+    | Some l, Some r -> sameDist l r
+    | None, None -> true
+    | _ -> false
+
+[<Property(Arbitrary = [| typeof<SoftArb> |])>]
+let ``combine reduce is order-independent (soft fold child-combine)`` (a: SV.SoftValue) (b: SV.SoftValue) (c: SV.SoftValue) =
+    let red xs = xs |> List.reduce (fun acc x -> (SV.combine acc x).Value) // shared support ⇒ Some
+    let r1 = red [ a; b; c ]
+    let r2 = red [ c; a; b ]
+    let r3 = red [ b; c; a ]
+    sameDist r1 r2 && sameDist r2 r3
+
+// ═══════════════════════════════════════════════════════════════════
+// snap — the policy-gated soft → hard boundary (the one sanctioned exit from uncertainty space).
+// ═══════════════════════════════════════════════════════════════════
+
+[<Fact>]
+let ``snap best of a certain value returns that exact value (soft reproduces hard when certain)`` () =
+    Assert.Equal(Some(cand 7), SV.snap SV.best (SV.certain (cand 7)))
+
+[<Fact>]
+let ``snap threshold holds below confidence and collapses above (calibration-gated)`` () =
+    let sv = (SV.ofWeighted [ cand 0, 0.6; cand 1, 0.4 ]).Value // confidence 0.6
+    Assert.Equal(None, SV.snap (SV.threshold 0.9) sv) // 0.6 < 0.9 → hold
+    Assert.Equal(Some(cand 0), SV.snap (SV.threshold 0.5) sv) // 0.6 ≥ 0.5 → snap argmax
+    Assert.Equal(Some(cand 0), SV.snap SV.best sv) // best always snaps to argmax


### PR DESCRIPTION
Soft recursion schemes = generic DynamicValueFold at 'r=SoftValue. New: combine (commutative+associative independent-evidence product ⇒ order-independent child fold = soft/NCI fusion analogue; stays in uncertainty space) + snap (SnapPolicy, the one sanctioned soft→hard exit; threshold/best; certain reproduces hard). 13/13 green, 0 warnings. Authorized: Aaron (shadow*).