### PR TITLE
feat(soft): multi-objective snap — sensor-fusion commit (society/self-aware, DI-externalized)

### DIFF
--- a/src/Core/SoftValue.fs
+++ b/src/Core/SoftValue.fs
@@ -124,3 +124,50 @@ module SoftValue =
     /// Policy: always collapse to the most-likely candidate (argmax); never holds.
     let best: SnapPolicy =
         fun sv -> sv.Candidates |> List.maxBy snd |> fst |> Some
+
+    // ── Multi-objective snap: the commit-decision for sensor fusion ──
+    // Snap is where a *sensor-fusion* loop commits, so a single threshold is not enough: many sensors
+    // (the interrupt handler is one of them, an ISR arrow) each impose an objective. `combine` is the
+    // fusion (it folds the sensor distributions into one belief, order-independently); the multi-objective
+    // policy is how that fused belief is committed. All pure — no wall clock — so it drops onto the
+    // existing wall-clock-free substrate (IScheduler / FerryThrottler / CHIP-8) and stays DST-replayable.
+
+    /// One objective scoring a candidate (higher = better). It may read the fused belief `SoftValue`
+    /// (e.g. `posterior`) or be purely value-driven (a sensor's cost/risk/urgency over the candidate).
+    ///
+    /// Objectives can be **self-aware** (the agent's own state — its flux tank, its uncertainty, its
+    /// interrupt-handler-as-sensor) and **society-aware** (the commons / the decorrelated ensemble /
+    /// collective bargaining). Both reach self-, society-, and history-state ONLY through an **injected
+    /// DI interface** (the single declared, metered door — noninterference), so the objective is built
+    /// by *closing over* that injected context and is then a **pure** `SoftValue -> DynamicValue -> float`:
+    /// no ambient clock, no resident history (it's externalized behind the DI, e.g. MCP→git), DST-replayable.
+    /// The CHIP-8/9 emu runs this the same way — self/society aware, history externalized via the DI.
+    type Objective = SoftValue -> DynamicValue -> float
+
+    /// The fused belief itself as an objective — the Bayesian posterior weight of a candidate.
+    let posterior: Objective = fun sv d -> weightOf d sv
+
+    /// **Weighted multi-objective policy** — scalarize the objectives by a weighted sum and snap to the
+    /// argmax over the belief's support. The support (what `combine` left positive) gates the candidate
+    /// set; the objectives rank within it. `weighted [posterior, 1.0]` reduces to `best`.
+    let weighted (objectives: (Objective * float) list) : SnapPolicy =
+        fun sv ->
+            match sv.Candidates with
+            | [] -> None
+            | cands ->
+                cands
+                |> List.map fst
+                |> List.maxBy (fun d -> objectives |> List.sumBy (fun (o, w) -> w * o sv d))
+                |> Some
+
+    /// **Pareto front** — the candidates not strictly dominated on the objectives (`d'` dominates `d`
+    /// iff `d'` is ≥ on every objective and `>` on at least one). The *weight-free* multi-objective read:
+    /// no objective is coerced above another (NCI-flavoured), so it returns the whole non-dominated set
+    /// rather than imposing a scalarization. A downstream tie-break (e.g. `weighted`) commits one.
+    let paretoFront (objectives: Objective list) (sv: SoftValue) : DynamicValue list =
+        let cands = sv.Candidates |> List.map fst
+        let scores d = objectives |> List.map (fun o -> o sv d)
+        let dominates d' d =
+            let sd', sd = scores d', scores d
+            List.forall2 (>=) sd' sd && List.exists2 (>) sd' sd
+        cands |> List.filter (fun d -> not (cands |> List.exists (fun d' -> d' <> d && dominates d' d)))

--- a/tests/Tests.FSharp/SoftValue.Tests.fs
+++ b/tests/Tests.FSharp/SoftValue.Tests.fs
@@ -164,3 +164,51 @@ let ``snap threshold holds below confidence and collapses above (calibration-gat
     Assert.Equal(None, SV.snap (SV.threshold 0.9) sv) // 0.6 < 0.9 → hold
     Assert.Equal(Some(cand 0), SV.snap (SV.threshold 0.5) sv) // 0.6 ≥ 0.5 → snap argmax
     Assert.Equal(Some(cand 0), SV.snap SV.best sv) // best always snaps to argmax
+
+// ═══════════════════════════════════════════════════════════════════
+// Multi-objective snap — the commit-decision for sensor fusion. `combine` fuses the sensors;
+// the multi-objective policy commits the fused belief. `valueObj` is a stand-in "sensor objective"
+// (prefer larger candidate values); `posterior` is the fused belief as an objective.
+// ═══════════════════════════════════════════════════════════════════
+
+let private valueObj: SV.Objective =
+    fun _ d ->
+        match d with
+        | DynamicValue.Int n -> float n
+        | _ -> 0.0
+
+[<Fact>]
+let ``weighted [posterior,1] reduces to best (argmax of the fused belief)`` () =
+    let sv = (SV.ofWeighted [ cand 0, 0.5; cand 1, 0.3; cand 5, 0.2 ]).Value
+    Assert.Equal(SV.snap SV.best sv, SV.snap (SV.weighted [ SV.posterior, 1.0 ]) sv)
+    Assert.Equal(Some(cand 0), SV.snap (SV.weighted [ SV.posterior, 1.0 ]) sv)
+
+[<Fact>]
+let ``weighted picks by the objective, and weights shift the winner (posterior vs value)`` () =
+    let sv = (SV.ofWeighted [ cand 0, 0.5; cand 1, 0.3; cand 5, 0.2 ]).Value
+    // value objective alone → the largest candidate
+    Assert.Equal(Some(cand 5), SV.snap (SV.weighted [ valueObj, 1.0 ]) sv)
+    // posterior-heavy → cand 0 (0.5); value-heavy → cand 5
+    Assert.Equal(Some(cand 0), SV.snap (SV.weighted [ SV.posterior, 10.0; valueObj, 0.01 ]) sv)
+    Assert.Equal(Some(cand 5), SV.snap (SV.weighted [ SV.posterior, 0.01; valueObj, 10.0 ]) sv)
+
+[<Fact>]
+let ``paretoFront drops dominated candidates, keeps the non-dominated set`` () =
+    let sv = (SV.ofWeighted [ cand 0, 0.5; cand 1, 0.3; cand 5, 0.15; cand 2, 0.05 ]).Value
+    // objectives: (posterior, value). cand 2 (post .05, val 2) is dominated by cand 5 (post .15, val 5).
+    // cand 0 (highest post), cand 1 (middle), cand 5 (highest value) are each non-dominated.
+    Assert.Equal<DynamicValue list>(
+        [ cand 0; cand 1; cand 5 ],
+        SV.paretoFront [ SV.posterior; valueObj ] sv)
+
+[<Fact>]
+let ``paretoFront of a single objective is its maximizer`` () =
+    let sv = (SV.ofWeighted [ cand 0, 0.5; cand 1, 0.3; cand 5, 0.2 ]).Value
+    Assert.Equal<DynamicValue list>([ cand 5 ], SV.paretoFront [ valueObj ] sv)
+
+[<Fact>]
+let ``sensor fusion: combine two sensors then multi-objective snap`` () =
+    let s1 = (SV.ofWeighted [ cand 0, 0.7; cand 1, 0.3 ]).Value
+    let s2 = (SV.ofWeighted [ cand 0, 0.4; cand 1, 0.6 ]).Value
+    let fused = (SV.combine s1 s2).Value // ∝ (0.28, 0.18) → cand 0 wins the fused belief
+    Assert.Equal(Some(cand 0), SV.snap (SV.weighted [ SV.posterior, 1.0 ]) fused)


### PR DESCRIPTION
Generalizes snap to multi-objective for sensor fusion: Objective + posterior + weighted (scalarization) + paretoFront (weight-free non-dominated set). Objectives may be self-aware (interrupt-as-sensor) / society-aware (commons), reaching self/society/history only via an injected DI interface (noninterference) → pure, wall-clock-free, DST. combine fuses; policy commits. 18/18 green, 0 warnings. Authorized: Aaron (shadow*).