### PR TITLE
feat(value-tree): ana (unfold/generator) + ana-fusion + hylo round-trip

### DIFF
--- a/src/Core/DynamicValueFold.fs
+++ b/src/Core/DynamicValueFold.fs
@@ -196,3 +196,75 @@ module DynamicValueFold =
           Bytes = fun _ -> 1
           Array = List.sum
           Object = fun kvs -> kvs |> List.sumBy snd }
+
+    // ───────────────────────── Anamorphism (the unfold / generator) ─────────────────────────
+    // `cata` is the fold (consume / infer); `ana` is its dual — the **unfold**: GENERATE a DynamicValue
+    // tree from a seed by a coalgebra `'s -> F 's`. This is the generator-direction (the "ana" Aaron
+    // names: unfold the cell from a codeword-seed). One layer of the functor `F` is `DvBase<'s>`.
+
+    /// One layer of the polynomial functor `F` with the recursive positions exposed as seeds `'s`. A
+    /// `DvCoalgebra<'s>` (= `'s -> DvBase<'s>`) decides, per seed, whether to stop (a leaf) or branch
+    /// (Array/Object with child-seeds). It is the dual of `DvAlgebra`.
+    type DvBase<'s> =
+        | NullF
+        | BoolF of bool
+        | IntF of int64
+        | FloatF of float
+        | StringF of string
+        | BytesF of ImmutableArray<byte>
+        | ArrayF of 's list
+        | ObjectF of (string * 's) list
+
+    /// A coalgebra: one unfolding step from a seed.
+    type DvCoalgebra<'s> = 's -> DvBase<'s>
+
+    /// The anamorphism: **unfold** a seed into a `DynamicValue` under `coalg` — the generator. Children
+    /// are produced by recursing on the child-seeds the coalgebra emits. Dual of `cata`.
+    let rec ana (coalg: DvCoalgebra<'s>) (seed: 's) : DynamicValue =
+        match coalg seed with
+        | NullF -> DynamicValue.Null
+        | BoolF b -> DynamicValue.Bool b
+        | IntF i -> DynamicValue.Int i
+        | FloatF f -> DynamicValue.Float f
+        | StringF s -> DynamicValue.String s
+        | BytesF b -> DynamicValue.Bytes b
+        | ArrayF seeds -> DynamicValue.Array(seeds |> List.map (ana coalg))
+        | ObjectF kvs -> DynamicValue.Object(kvs |> List.map (fun (k, s) -> (k, ana coalg s)))
+
+    /// The "expose one layer" coalgebra: seed IS a `DynamicValue`, emit its top layer with children as
+    /// seeds. Sanity anchor (the dual of `identityAlgebra`'s reflection law): `ana oneLayer dv = dv`.
+    let oneLayer: DvCoalgebra<DynamicValue> =
+        function
+        | DynamicValue.Null -> NullF
+        | DynamicValue.Bool b -> BoolF b
+        | DynamicValue.Int i -> IntF i
+        | DynamicValue.Float f -> FloatF f
+        | DynamicValue.String s -> StringF s
+        | DynamicValue.Bytes b -> BytesF b
+        | DynamicValue.Array xs -> ArrayF xs
+        | DynamicValue.Object kvs -> ObjectF kvs
+
+    /// Map the recursive positions of one functor-layer (the `F`-functor's `fmap`). Needed to state the
+    /// ana-fusion law (a coalgebra homomorphism precomposes a seed-map into the unfold).
+    let mapBase (h: 'a -> 'b) (layer: DvBase<'a>) : DvBase<'b> =
+        match layer with
+        | NullF -> NullF
+        | BoolF b -> BoolF b
+        | IntF i -> IntF i
+        | FloatF f -> FloatF f
+        | StringF s -> StringF s
+        | BytesF b -> BytesF b
+        | ArrayF seeds -> ArrayF(seeds |> List.map h)
+        | ObjectF kvs -> ObjectF(kvs |> List.map (fun (k, s) -> (k, h s)))
+
+    /// **Ana-fusion law** (the dual of cata-fusion). If `h : 'a -> 'b` is a *coalgebra* homomorphism —
+    /// `coalgB ∘ h = mapBase h ∘ coalgA` — then a seed-map precomposed with an unfold fuses into one
+    /// unfold: `ana coalgB (h s) = ana coalgA s`. The win is the same deforestation, on the generate
+    /// side: no intermediate `'b`-seed is materialised. Certifier (cf. `isHom`); law proven in tests.
+    let isCoalgHom
+        (h: 'a -> 'b)
+        (coalgA: DvCoalgebra<'a>)
+        (coalgB: DvCoalgebra<'b>)
+        (s: 'a)
+        : bool =
+        coalgB (h s) = mapBase h (coalgA s)

--- a/tests/Tests.FSharp/DynamicValueFold.Tests.fs
+++ b/tests/Tests.FSharp/DynamicValueFold.Tests.fs
@@ -155,3 +155,36 @@ let private sevenWeight: DynamicValueFold.DvAlgebra<int> =
 [<Property(Arbitrary = [| typeof<FoldDvArb> |])>]
 let ``fusion law (scaling): 7 * cata nodeCount dv = cata sevenWeight dv`` (dv: DynamicValue) =
     7 * DynamicValueFold.cata nodeCount dv = DynamicValueFold.cata sevenWeight dv
+
+// ── Anamorphism (unfold / generator): reconstruction + hylo round-trip + ana-fusion (dual of cata-fusion) ──
+//   (g) ana reconstruction:  ana oneLayer dv = dv          (dual of cata's reflection law)
+//   (h) hylo round-trip:     cata identityAlgebra (ana oneLayer dv) = dv   (generate then fold = id)
+//   (i) ana-fusion:          ana coalgB (h s) = ana coalgA s   when h is a coalgebra hom (seed-map fuses in)
+
+[<Property(Arbitrary = [| typeof<FoldDvArb> |])>]
+let ``ana reconstruction law: ana oneLayer dv = dv`` (dv: DynamicValue) =
+    DynamicValueFold.ana DynamicValueFold.oneLayer dv = dv
+
+[<Property(Arbitrary = [| typeof<FoldDvArb> |])>]
+let ``hylo round-trip: cata identityAlgebra (ana oneLayer dv) = dv`` (dv: DynamicValue) =
+    let regenerated = DynamicValueFold.ana DynamicValueFold.oneLayer dv
+    DynamicValueFold.cata DynamicValueFold.identityAlgebra regenerated = dv
+
+// countdownA n  unfolds to an n-deep nested Array ending in Null; countdownB works on doubled seeds.
+let private countdownA: DynamicValueFold.DvCoalgebra<int> =
+    fun n -> if n <= 0 then DynamicValueFold.NullF else DynamicValueFold.ArrayF [ n - 1 ]
+
+let private countdownB: DynamicValueFold.DvCoalgebra<int> =
+    fun m -> if m <= 0 then DynamicValueFold.NullF else DynamicValueFold.ArrayF [ m - 2 ]
+
+[<Fact>]
+let ``ana-fusion precondition: (*2) is a countdownA -> countdownB coalgebra homomorphism`` () =
+    for n in 0..6 do
+        Assert.True(DynamicValueFold.isCoalgHom (fun x -> x * 2) countdownA countdownB n)
+
+[<Fact>]
+let ``ana-fusion law: ana countdownB (2n) = ana countdownA n (seed-map fuses into the unfold)`` () =
+    for n in 0..6 do
+        Assert.Equal<DynamicValue>(
+            DynamicValueFold.ana countdownB (n * 2),
+            DynamicValueFold.ana countdownA n)


### PR DESCRIPTION
ana = the dual of cata (unfold/generate from a seed via a coalgebra). Adds DvBase/DvCoalgebra/ana, oneLayer + ana-reconstruction law, mapBase + isCoalgHom + ana-fusion law, and the hylo round-trip (cata∘ana=id). 10/10 green, 0 warnings. Meijer suite: cata/banana-split/cata-fusion/ana/ana-fusion/hylo = the generate(ana)/infer(cata) engine. Authorized: Aaron (shadow*).