### PR TITLE
Fix scenario 2 phase 2: serial console on installed cluster nodes

### DIFF
--- a/full-ai-cluster/nixos/modules/common.nix
+++ b/full-ai-cluster/nixos/modules/common.nix
@@ -87,17 +87,13 @@
   # B-0831 slice 1 phase-2 / B-0891 scenario 2: qemu-full-install-test boots
   # the installed disk with -serial file: and polls for "<hostname> login:".
   # Installer ISO has these params (PR #5324); installed nodes must mirror them
-  # or phase-2 serial capture is empty and the harness times out.
+  # or phase-2 serial capture is empty and the harness times out. systemd
+  # getty-generator spawns serial-getty@ from console= kernel params.
   boot.kernelParams = [
     "console=ttyS0,115200n8"
     "console=ttyAMA0,115200n8"
     "console=tty1"
   ];
-
-  services.getty.serial = {
-    enable = true;
-    speed = 115200;
-  };
 
   nix.settings = {
     experimental-features = [ "nix-command" "flakes" ];

--- a/full-ai-cluster/nixos/modules/common.nix
+++ b/full-ai-cluster/nixos/modules/common.nix
@@ -84,6 +84,21 @@
   # auth back. Idempotent; per-host opt-out: zeta.selfRegister.enable = false;
   zeta.selfRegister.enable = lib.mkDefault true;
 
+  # B-0831 slice 1 phase-2 / B-0891 scenario 2: qemu-full-install-test boots
+  # the installed disk with -serial file: and polls for "<hostname> login:".
+  # Installer ISO has these params (PR #5324); installed nodes must mirror them
+  # or phase-2 serial capture is empty and the harness times out.
+  boot.kernelParams = [
+    "console=ttyS0,115200n8"
+    "console=ttyAMA0,115200n8"
+    "console=tty1"
+  ];
+
+  services.getty.serial = {
+    enable = true;
+    speed = 115200;
+  };
+
   nix.settings = {
     experimental-features = [ "nix-command" "flakes" ];
     auto-optimise-store = true;


### PR DESCRIPTION
## Summary
- Run 402: iter-5.3 fix worked (phase 1 green in ~8m) but phase 2 timed out waiting for node login on serial.
- Root cause: installer ISO has console=ttyS0 (PR #5324); installed nodes in common.nix did not — QEMU phase-2 serial log was 172 bytes.
- Mirror installer kernelParams + enable services.getty.serial on all cluster hosts.

## Test plan
- Merge and verify build-ai-cluster-iso scenario 2 passes phase 1 + phase 2
- Re-dispatch workflow for scenarios 3/4