### PR TITLE
fix(ci): guard qemu hostname regression

### DIFF
--- a/src/Core.TypeScript/ci/qemu-full-install-test.test.ts
+++ b/src/Core.TypeScript/ci/qemu-full-install-test.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import { validateSelfRegCiCoherent } from "./self-reg-serial.ts";
-import { extractGeneratedHostname } from "./qemu-full-install-test.ts";
+import {
+  detectUnexpectedControlPlaneLogin,
+  extractGeneratedHostname,
+} from "./qemu-full-install-test.ts";
 
 describe("validateSelfRegCiCoherent", () => {
   it("accepts matching maintainer/node/tree-path lines", () => {
@@ -23,5 +26,22 @@ describe("qemu-full-install-test hostname extraction", () => {
 
   it("returns null when marker absent", () => {
     expect(extractGeneratedHostname("zeta-installer login:")).toBeNull();
+  });
+});
+
+describe("qemu-full-install-test B-0835 hostname regression guard", () => {
+  it("fails when generated node identity was expected but control-plane login appears", () => {
+    const reason = detectUnexpectedControlPlaneLogin(
+      "booting...\ncontrol-plane login:",
+      "zeta-a1b2c3",
+    );
+
+    expect(reason).toContain("B-0835 Bug 1 regression");
+    expect(reason).toContain("zeta-a1b2c3");
+  });
+
+  it("allows control-plane when no generated hostname was expected", () => {
+    expect(detectUnexpectedControlPlaneLogin("control-plane login:", null)).toBeNull();
+    expect(detectUnexpectedControlPlaneLogin("control-plane login:", "control-plane")).toBeNull();
   });
 });

--- a/src/Core.TypeScript/ci/qemu-full-install-test.ts
+++ b/src/Core.TypeScript/ci/qemu-full-install-test.ts
@@ -46,6 +46,7 @@ const FAILURE_MARKERS: readonly string[] = [
 ];
 
 const IDLE_INSTALLER_SHELL_MARKER = "nixos@zeta-installer:~";
+const CONTROL_PLANE_LOGIN_PROMPT = "control-plane login:";
 
 const CONSOLE_MIRROR_HINT =
   "serial log shows idle installer shell without install progress — " +
@@ -72,6 +73,21 @@ interface InstallResult {
 export function extractGeneratedHostname(serialOutput: string): string | null {
   const match = serialOutput.match(/\[iter-5\.2\.2\]\s+generated:\s+([a-z0-9-]+)/i);
   return match?.[1] ?? null;
+}
+
+/** Exported for unit tests. */
+export function detectUnexpectedControlPlaneLogin(
+  serialOutput: string,
+  expectedHostname: string | null,
+): string | null {
+  if (
+    expectedHostname &&
+    expectedHostname !== "control-plane" &&
+    serialOutput.includes(CONTROL_PLANE_LOGIN_PROMPT)
+  ) {
+    return `phase 2 FAILURE — B-0835 Bug 1 regression: saw "${CONTROL_PLANE_LOGIN_PROMPT}" but expected "${expectedHostname}"`;
+  }
+  return null;
 }
 
 function usage(): never {
@@ -266,6 +282,16 @@ async function waitForInstalledLogin(
         serialLogTail: content.slice(-1500),
         elapsedSeconds: elapsedSec,
         ...(expectedHostname !== null ? { hostname: expectedHostname } : {}),
+      };
+    }
+
+    const unexpectedControlPlaneReason = detectUnexpectedControlPlaneLogin(content, expectedHostname);
+    if (unexpectedControlPlaneReason) {
+      return {
+        exitCode: 1,
+        reason: unexpectedControlPlaneReason,
+        serialLogTail: content.slice(-2000),
+        elapsedSeconds: elapsedSec,
       };
     }
 


### PR DESCRIPTION
## Summary

- Salvages the still-live B-0835 QEMU hostname regression guard from stale PR #8170 onto current main.
- Adds `detectUnexpectedControlPlaneLogin` as a pure, unit-tested detector.
- Wires the phase-2 installed-disk poller to fail fast when the generated node hostname was expected but `control-plane login:` appears.

## Verification

- `mise exec -- bun test src/Core.TypeScript/ci/qemu-full-install-test.test.ts`
- `mise exec -- bun src/Core.TypeScript/lint/lint-typescript.ts`
- `git diff --check`

## PR Board Note

This replaces the useful slice from stale red PR #8170 without carrying its obsolete generated backlog/index state or pre-#8173 zset-merkle formatter/cross-verify drift.

Agency-Signature-Version: 1
Agent: Vera
Agent-Runtime: OpenAI Codex
Agent-Model: GPT-5.5
Credential-Identity: AceHack
Credential-Mode: shared
Human-Review: explicit
Human-Review-Evidence: chat
Action-Mode: human-directed
Task: B-0835
Co-Authored-By: Codex <noreply@openai.com>
