### PR TITLE
docs(prior-art): register TorchLean + CSLib (json + reading list + learn-pass); fix stale 'upstreams' misnomer

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -154,7 +154,7 @@ wear the same procedure if the round-table grew.
 - `docs/CONFLICT-RESOLUTION.md` — conflict protocol
 - `docs/GLOSSARY.md` — shared vocabulary (glossary-police home)
 - `docs/AGENT-BEST-PRACTICES.md` — BP-01 .. BP-16 plus
-  the "Operational standing rules" section (upstreams
+  the "Operational standing rules" section (prior-art
   exclusion on every file-iteration command; no name
   attribution in code / docs / skills)
 - `docs/ROUND-HISTORY.md` — where the round narrative lands

--- a/.claude/rules.bak/references-prior-art-not-our-code-search-excludes.md
+++ b/.claude/rules.bak/references-prior-art-not-our-code-search-excludes.md
@@ -11,7 +11,7 @@ Carved sentence:
 > with patterns that match in protobuf docs, gRPC tests, Redis
 > manifests, etc. **Default to ripgrep** (`rg`) which respects
 > `.gitignore` automatically. For plain `grep -r`, use
-> `--exclude-dir=upstreams` (basename glob, NOT a path) or an
+> `--exclude-dir=prior-art` (basename glob, NOT a path) or an
 > explicit allowlist (`memory/ docs/ .claude/ tools/`). For
 > `find`, use `-not -path './references/prior-art/*'` (the `find`
 > command does NOT support `--exclude-dir`).
@@ -70,13 +70,13 @@ rg "pattern" docs/ memory/  # explicit allowlist
 
 ```bash
 # GNU grep --exclude-dir takes a BASENAME glob, not a path —
-# so --exclude-dir=upstreams excludes any directory named
-# 'upstreams' anywhere in the tree (currently only references/prior-art/).
-# If a second 'upstreams/' ever appears that we DO want to search,
+# so --exclude-dir=prior-art excludes any directory named
+# 'prior-art' anywhere in the tree (currently only references/prior-art/).
+# If a second 'prior-art/' ever appears that we DO want to search,
 # this approach overreaches and we need the explicit-allowlist
 # approach below instead.
 grep -rn "pattern" \
-  --exclude-dir=upstreams \
+  --exclude-dir=prior-art \
   --exclude-dir=node_modules \
   --exclude-dir=.git \
   --exclude-dir=bin --exclude-dir=obj \
@@ -86,7 +86,7 @@ grep -rn "pattern" \
 **Caveat**: GNU `grep`'s `--exclude-dir=GLOB` matches directory
 *names* (basename), NOT slash-delimited paths. So
 `--exclude-dir=references/prior-art` does NOT work (silently
-matches nothing). Use the basename `upstreams` instead, OR use
+matches nothing). Use the basename `prior-art` instead, OR use
 explicit-allowlist sub-paths (`memory/ docs/ .claude/ tools/`)
 which sidestep the issue entirely.
 
@@ -155,7 +155,7 @@ upstream(s) is encouraged and composes with
 | Mode | Pattern | Treatment |
 |---|---|---|
 | **Backlog prior-art research** (explicit-target) | `rg "pattern" references/prior-art/postgres/` | Encouraged; one of the curated prior-art surfaces; log queries on the backlog row |
-| **Unconstrained repo scan with plain `grep -r`** or `find . \| xargs grep` | (`grep -rn "pattern" .`) | MUST exclude `--exclude-dir=upstreams`; otherwise runaway-scan failure mode |
+| **Unconstrained repo scan with plain `grep -r`** or `find . \| xargs grep` | (`grep -rn "pattern" .`) | MUST exclude `--exclude-dir=prior-art`; otherwise runaway-scan failure mode |
 | **Unconstrained repo scan with ripgrep** | `rg "pattern" .` | Safe-by-default — ripgrep respects `.gitignore`, and `references/prior-art/*` is already gitignored |
 
 Other legitimate explicit-target reasons:

--- a/.dockerignore
+++ b/.dockerignore
@@ -12,7 +12,7 @@
 # root sends gigabytes of references/prior-art/ even if the Dockerfile
 # only needs MB of tools/setup/.
 
-# Curated prior-art / mirrors (per references-upstreams-* rule)
+# Curated prior-art / mirrors (per references-prior-art-* rule)
 references/prior-art/
 
 # Node deps (npm + bun caches)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,7 +45,7 @@
 #      Running the full suite on every PR would slow feedback
 #      and explode the alert queue.
 #   5. A config file (.github/codeql/codeql-config.yml) carries
-#      paths-ignore for vendored upstreams, bench harness, and
+#      paths-ignore for vendored prior-art mirrors, bench harness, and
 #      external-tool trees where any C# is incidental.
 #   6. `concurrency: cancel-in-progress` cuts stale runs on
 #      force-push; 30-minute timeout caps the CodeQL DB-build

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   // Shape mirrors SQLSharp's `.vscode/settings.json` so
   // contributors get consistent editor behaviour around Zeta's
-  // build outputs + vendored upstreams.
+  // build outputs + vendored prior-art mirrors.
   "dotnet.defaultSolution": "Zeta.sln",
 
   "files.exclude": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ See [`docs/CONFLICT-RESOLUTION.md`](docs/CONFLICT-RESOLUTION.md). On deadlock, t
   `feedback_*.md` logs; CURRENT files win on conflict with older raw memories.
 - **`references/prior-art/` — explicit-target searches ONLY; NOT our code.** Gitignored, gigabytes,
   mirror of other repos; a naive `grep -r .` is a 2-hour runaway. Explicit-target `rg` encouraged
-  (check `docs/PRIOR-ART-LIST.md` first); unconstrained `grep -r` needs `--exclude-dir=upstreams`.
+  (check `docs/PRIOR-ART-LIST.md` first); unconstrained `grep -r` needs `--exclude-dir=prior-art`.
   Full: `.claude/rules.bak/references-prior-art-not-our-code-search-excludes.md`.
 - **Thoughts free, actions razored** — journal to `memory/` freely; CLAUDE.md additions
   are razored (cooling-period, disposition-shaping bar). Full: `memory/feedback_thoughts_free_actions_razored_*`.

--- a/docs/FACTORY-HYGIENE.md
+++ b/docs/FACTORY-HYGIENE.md
@@ -57,7 +57,7 @@ is never destructive; retiring one requires an ADR in
 | 12 | Memory frontmatter discipline | Every memory write | Memory authoring agent | factory | `name` / `description` / `type` / `originSessionId` present + accurate | Memory-linter flag | `CLAUDE.md` auto-memory section |
 | 13 | Persona-notebook invisible-char lint | Every notebook edit + pre-commit | Prompt-Protector | factory | Same BP-10 charset as source | Notebook edit blocked | `.claude/skills/prompt-protector/SKILL.md` |
 | 14 | `.github/copilot-instructions.md` audit | Same cadence as SKILL.md files (5-10 rounds) | Aarav | both | Factory-managed contract, BP-NN citations | Finding in notebook | GOVERNANCE.md §31 |
-| 15 | Upstream-sync cadence | Every round close | Architect | project | `docs/PRIOR-ART-LIST.md` — what's new in tracked upstreams | Round-history row | GOVERNANCE.md §23 |
+| 15 | Prior-art-sync cadence | Every round close | Architect | project | `docs/PRIOR-ART-LIST.md` — what's new in tracked prior-art repos | Round-history row | GOVERNANCE.md §23 |
 | 16 | Verification-drift audit | Round cadence (in-progress) | verification-drift-auditor skill | project | Lean / TLA+ / Z3 / FsCheck spec alignment with code | Finding in notebook | `project_verification_drift_auditor.md` |
 | 17 | Public-API review | Every public-surface change | Ilyana (public-api-designer) | project | Internal→public flips + new public members | Finding / ADR | `feedback_public_api_review.md` |
 | 18 | BP-NN promotion cadence | Round cadence | Architect | factory | Stable rules vs. scratchpad findings; ADR-gated promotion | ADR under `docs/DECISIONS/` | `docs/AGENT-BEST-PRACTICES.md` |

--- a/docs/PRIOR-ART-LIST.md
+++ b/docs/PRIOR-ART-LIST.md
@@ -214,6 +214,27 @@ with a ⭐ below and add a row there.
   2008-2012); the historical F#-native refinement-type checker.
   Dormant (download artefact dated 2012). Listed for lineage;
   not a live dependency.
+- **CSLib — The Lean Computer Science Library** — `leanprover/cslib`;
+  Barrett et al., arXiv:2602.04846 (Feb 2026). "Mathlib for computer
+  science." Real modules: `Computability/Distributed/FLP`, `Automata`
+  (Büchi), `MachineLearning/PACLearning` (VC dimension, version space),
+  `Probability/PMF`, `Crypto`, `Logics`, `CombinatoryLogic`. PACLearning +
+  Probability are candidate Lean substrate for the **ΔU-aggregation /
+  generalized-Condorcet** proof (workitem `081KV6B1MBM`); FLP anchors our
+  consensus/decorrelated-society work. Addable as a Lean dep (`lakefile.toml`
+  `require cslib`). **CAVEAT:** the `Boole` sub-language is a *placeholder* —
+  the Rust/C++→Lean auto-verification is a vision, not shipping. Surfaced via
+  Robert George's YC "Lean for Science" talk. (Pairs with CVC5/E-prover route
+  `081KV6BW42K`.)
+- **TorchLean — Formalizing Neural Networks in Lean** — `lean-dojo/TorchLean`;
+  arXiv:2602.22631 (2026). Lean 4 framework for NN spec/execution/verification:
+  typed tensors, op-tagged SSA/DAG IR, IEEE finite-precision + interval/affine
+  scalar semantics, autograd, **certificate checkers (IBP/CROWN/α,β-CROWN =
+  certified robustness)**, explicit CUDA trust boundary (untrusted). Its
+  **spec-level flash-attention ≡ standard-attention** proof is the template for
+  our **cross-oracle byte-lock** equivalence (the `E8Lattice.fs` F#-side parity
+  seam); interval/affine bounds = the pattern for `SoftValue`/`UniversalNumber`
+  certified bounds. (From Robert George / Max Tegmark "veri coding"; study-not-copy.)
 - **Boost (C++)** — deep, composable primitive collection; the
   "C++ Boost for any language" prior-art for our cross-language
   primitive effort (study the design, not the C++ — ideas-not-code;

--- a/docs/research/2026-06-15-learn-pass-torchlean-and-cslib-pulled-into-prior-art-what-we-can-learn.md
+++ b/docs/research/2026-06-15-learn-pass-torchlean-and-cslib-pulled-into-prior-art-what-we-can-learn.md
@@ -1,0 +1,85 @@
+# Learn-pass: TorchLean + CSLib pulled into prior art — what we can actually learn
+
+> **Aaron 2026-06-15 (shadow\*): "put their code in our prior art and pull it and
+> see if there is anything we can learn."** Both repos cloned into the gitignored
+> mirror `references/prior-art/` (TorchLean, cslib) and skimmed. This is a
+> **first-pass (repo-structure + paper) learn note**, not a deep code audit — the
+> code-level pass is the follow-up.
+
+## The honest correction first
+
+**Boole is a placeholder.** Aaron's "now our Rust code can be formally verified
+directly" (from the talk's framing that Boole auto-translates Rust/C++ → Lean) is
+**not real today**: `Cslib/Languages/Boole/README.md` reads verbatim *"Placeholder
+for the Boole language."* So Boole is a **vision/roadmap stub**, not a shipping
+Rust→Lean verifier. The *direction* (mainstream code → Lean at scale) is real and
+worth tracking; the *capability* does not exist yet. (Same look-better discipline
+as the UniversalNumber/E8 corrections — here the territory is *less* than the
+slide, not more. Verify before depending.)
+
+## TorchLean (`github.com/lean-dojo/TorchLean`, arXiv:2602.22631) — what's real
+
+A Lean 4 framework for writing/running/**verifying** neural networks. Builds on
+`leanprover/lean4:v4.30.0`. Confirmed in-repo: typed tensors, an op-tagged
+**SSA/DAG graph IR**, IEEE-style finite-precision (`Float32`) **and** interval/
+affine scalar semantics, autograd, **certificate checkers**, a CUDA boundary
+explicitly marked *not a trusted proof boundary* (`TRUST_BOUNDARIES.md`), and
+`lake exe verify -- torchlean-ibp` (**IBP / interval-bound-propagation = certified
+robustness**; the `leanx` fork adds CROWN / α,β-CROWN).
+
+**What we can learn:**
+
+- **The certified-bounds pattern** (interval / affine scalar semantics +
+  certificate checking) is directly applicable to our **`SoftValue` / `UniversalNumber`**
+  precision layer — robustness certificates are *bounds proofs*, the same shape as
+  our resolution-accounting (`BitsUsed`) + the ECC-Bayesian-growth bounds.
+- **Spec-level equivalence** (their flash-attention ≡ standard-attention proof) is
+  the **template for our cross-oracle byte-lock** — proving two implementations of
+  one op equal at the spec level (the open `E8Lattice.fs` F#-vs-other-oracles parity
+  seam). Their op-tagged IR ≈ our IR-compiler trajectory (`zeta-language-ir-compiler`).
+- **Explicit trust boundaries** (CUDA is untrusted; only the Lean path is the proof)
+  = our noninterference §13 (the metered channel is the only trusted door).
+
+## CSLib (`github.com/leanprover/cslib`, arXiv:2602.04846) — what's real
+
+Official `leanprover` library, "Mathlib for computer science." Addable as a Lean
+dependency (`lakefile.toml`: `require cslib, scope leanprover, rev main`). Real
+modules skimmed: `Algorithms`, `Computability/{Automata (Büchi), Distributed/FLP,
+Languages/OmegaLanguage}`, `Crypto`, `Foundations`, `Languages/{CombinatoryLogic,
+Boole(placeholder)}`, `Logics`, `MachineLearning/PACLearning/{Defs, VCDimension,
+VersionSpace}`, `Probability/PMF`.
+
+**What we can learn / directly use:**
+
+- **`MachineLearning/PACLearning` (VC dimension, version space) + `Probability/PMF`
+  could support the routed ΔU-aggregation workitem** (`081KV6B1MBM08QG0R000RZK4WY`).
+  The "competence > threshold" precondition of the generalized-Condorcet claim is a
+  **capacity/learnability bound** — exactly PAC/VC territory; PMF gives the discrete
+  distributions to state the jury aggregation over. *Candidate Lean substrate for
+  that proof* (Soraya's call; still partial — `Probability` is just `PMF.lean` today).
+- **`Computability/Distributed/FLP`** (the FLP impossibility theorem, formalized) is
+  directly relevant to our **consensus / decorrelated-society** substrate
+  (`Reconcile.fs`, the society-emergence row) — a checkable anchor for what
+  consensus can/can't guarantee.
+- **CSLib as the CS-side `Mathlib`** to build our Lean proofs on (we currently lean
+  on mathlib only). Adopting it as a dep is the natural next step — pairs with the
+  CVC5/E-prover route (`081KV6BW42K08QG0R003GJM21N`).
+
+## Net + next steps
+
+- **Adopt-candidate:** CSLib as a Lean dependency (low-risk, official, composes with
+  our existing Lean proofs) — Soraya's call; route alongside the CVC5/E workitem.
+- **Template-to-copy:** TorchLean's spec-level equivalence + certificate-checking for
+  our cross-oracle parity and `SoftValue`/`UniversalNumber` bounds.
+- **Do NOT depend on Boole** (placeholder) — track only.
+- **Collaboration / contribute-back is gated** (outward-facing, Aaron-driven;
+  GOVERNANCE.md §23). This note is the readiness substrate, not an outreach.
+
+## Anchors
+
+TorchLean (lean-dojo; arXiv:2602.22631) · CSLib (Barrett et al.; arXiv:2602.04846;
+`leanprover/cslib`) · the "vericoding" benchmark (arXiv:2509.22908) · Robert George
+(YC talk, ip-questionable transcript) · Max Tegmark ("veri coding") · in-repo:
+`SoftValue`, `UniversalNumber`, `E8Lattice.fs` (cross-oracle parity seam),
+`Reconcile.fs`, the routed workitems `081KV6B1MBM…` (ΔU-aggregation) +
+`081KV6BW42K…` (CVC5/E), `docs/PRIOR-ART-LIST.md`.

--- a/references/reference-sources.json
+++ b/references/reference-sources.json
@@ -817,5 +817,21 @@
     "path": "references/prior-art/chip8-roms",
     "categories": ["emulator", "chip8", "roms", "reference-corpus"],
     "notes": "CHIP-8/SuperChip/MegaChip8 program collection (games/demos/tests; curated by Revival Studios, 2011) — ROM corpus for the DarkHall cell emulator (#6986) and the rom: ZetaId-pointer scheme (#6987). LICENSE CAVEAT: informal — README says 'can be freely distributed in its original form'; NO formal OSS license, modification/commercial rights not granted, individual-ROM copyright varies. LOCAL reference/study mirror only (references/prior-art is gitignored, read-only — NOT redistributed by us); for actually running, use freely-distributable/PD entries or the user's own legal copies, verified by signature (reference-not-copy, #6925/#6987). Many CHIP-8 programs are PD/freeware (cleaner than copyrighted console ROMs)."
+  },
+  {
+    "name": "TorchLean",
+    "url": "https://github.com/lean-dojo/TorchLean.git",
+    "branch": "main",
+    "path": "references/prior-art/TorchLean",
+    "categories": ["formal-verification", "lean4", "neural-network-verification", "certified-robustness"],
+    "notes": "Lean 4 framework for NN spec/execution/verification (lean-dojo; arXiv:2602.22631). Typed tensors, op-tagged SSA/DAG graph IR, IEEE finite-precision + interval/affine scalar semantics, autograd, certificate checkers (IBP/CROWN/α,β-CROWN = certified robustness), explicit CUDA trust boundary (untrusted). Spec-level flash-attn ≡ standard-attn = the template for OUR cross-oracle byte-lock equivalence (the E8Lattice.fs F#-side parity seam). Surfaced via Robert George's YC talk; study-not-copy."
+  },
+  {
+    "name": "cslib",
+    "url": "https://github.com/leanprover/cslib.git",
+    "branch": "main",
+    "path": "references/prior-art/cslib",
+    "categories": ["formal-verification", "lean4", "computer-science-library"],
+    "notes": "Official leanprover 'Mathlib for computer science' (Barrett et al.; arXiv:2602.04846). Real modules: Computability/Distributed/FLP, Automata(Büchi), MachineLearning/PACLearning (VC dimension, version space), Probability/PMF, Crypto, Logics, CombinatoryLogic. PACLearning + Probability are candidate Lean substrate for the ΔU-aggregation proof (workitem 081KV6B1MBM); FLP anchors consensus. CAVEAT: the Boole sub-language is a PLACEHOLDER ('Placeholder for the Boole language') — the Rust/C++→Lean auto-verification is a VISION, not shipping. Addable as a Lean dep (lakefile.toml require cslib scope leanprover); study + potential dependency."
   }
 ]

--- a/workitems/081KV6D1B3T08QG0R000QCTMXN-sweep-remaining-stale-upstreams-prior-art-mirror-dir-misnome.md
+++ b/workitems/081KV6D1B3T08QG0R000QCTMXN-sweep-remaining-stale-upstreams-prior-art-mirror-dir-misnome.md
@@ -1,0 +1,50 @@
+---
+id: 081KV6D1B3T08QG0R000QCTMXN
+type: task
+state: backlog
+priority: P3
+slug: sweep-remaining-stale-upstreams-prior-art-mirror-dir-misnome
+title: "Sweep remaining stale 'upstreams' -> 'prior-art' mirror-dir misnomer in active docs/backlog (keep legit OSS-upstream usage; leave dated historical snapshots)"
+created: 2026-06-15T19:44:48.250Z
+depends_on: []
+composes_with: []
+---
+
+# Sweep remaining stale 'upstreams' -> 'prior-art' mirror-dir misnomer in active docs/backlog (keep legit OSS-upstream usage; leave dated historical snapshots)
+
+<!-- Work-item body. ZetaId-keyed (conflict-free, time-sortable). "Backlog" is a
+     STATE = this folder; completion moves the file to workitems/done/YYYY/MM/.
+     Identity is the zetaid prefix — resolve cross-refs by `081KV6D1B3T08QG0R000QCTMXN-*.md` glob. -->
+
+**Context (Aaron 2026-06-15):** "I had called it upstreams when we first created
+the project but then renamed it [to `references/prior-art/`]; it probably has
+upstreams language left over places." Otto fixed the **live surfaces** in PR (the
+prior-art-add PR): `CLAUDE.md` guard (`--exclude-dir=upstreams` → `prior-art` — was
+*wrong*, no such dir), `.claude/rules.bak/references-prior-art-not-our-code-search-excludes.md`,
+`.claude/agents/architect.md`, `docs/FACTORY-HYGIENE.md`, and comments in
+`.dockerignore` / `.github/workflows/codeql.yml` / `.vscode/settings.json`.
+
+## Remaining (this item) — classify each, then fix/keep/leave
+
+**FIX (stale mirror-dir refs in *active* docs/backlog — `references/upstreams/` →
+`references/prior-art/`):** several `docs/backlog/P*/…` items carry stale
+`-not -path "*/references/upstreams/*"` find-excludes + `tools/setup/common/sync-upstreams.sh`
+naming; `docs/aurora/2026-04-23-…` scan-scope comment. These are wrong (the dir is
+`prior-art`) and could mis-guide a copy-paste.
+
+**KEEP (legitimate "OSS upstream" usage — do NOT change):**
+`.claude/skills/workflows/blueprints/fork-pr-workflow.md` ("direct PRs to OSS
+upstreams"); `docs/PRIMITIVE-REGISTRY.md` ("push to all upstreams" = git distros);
+GOVERNANCE.md §23 upstream-contribution.
+
+**LEAVE (dated historical snapshots — do not rewrite history):**
+`docs/DECISIONS/2026-04-20-tools-scripting-language.md`, `docs/MISSED-ITEMS-AUDIT.md`,
+`docs/ROUND-HISTORY.md` entries — records of what was true when the dir was named
+`upstreams`.
+
+## Done
+
+`git grep "upstreams"` over *active, non-historical* surfaces returns only the
+legitimate-OSS-upstream usages; the prior-art mirror is never called "upstreams" in
+any live guidance. Low priority (cosmetic + minor copy-paste footgun); no code path
+depends on it.


### PR DESCRIPTION
Aaron 2026-06-15 (shadow*): *"put their code in our prior art and pull it and see if there is anything we can learn"* + *"did you add them to the json list"* + *"upstreams language left over places."*

**Prior-art registration:**
- `references/reference-sources.json` (the tracked sync manifest the install script clones from): **+ TorchLean** (lean-dojo; arXiv:2602.22631) **+ cslib** (leanprover; arXiv:2602.04846). Both cloned into `references/prior-art/` (gitignored). JSON re-validated (103 entries).
- `docs/PRIOR-ART-LIST.md`: reading-list entries (formal-verification cluster).
- **Learn-pass note:** CSLib `PACLearning`(VC) + `Probability/PMF` as candidate substrate for the ΔU-aggregation proof (`081KV6B1MBM`); `Distributed/FLP` for consensus; TorchLean spec-level flash-attn≡attn = the **cross-oracle byte-lock** template; certified robustness (IBP/CROWN) = the `SoftValue`/`UniversalNumber` bounds pattern. **Honest correction:** CSLib's `Boole` is a *placeholder* — "Rust→Lean directly" is a vision, not shipping.

**Upstreams misnomer** (legacy from the `references/upstreams` → `references/prior-art` rename) fixed on **live surfaces only**:
- `CLAUDE.md`: `--exclude-dir=upstreams` → `prior-art` (was **wrong** — excluded a nonexistent dir).
- rules.bak guard, `architect.md`, `FACTORY-HYGIENE.md`, comments in `.dockerignore`/`codeql.yml`/`.vscode`.
- Kept legit OSS-upstream usage; left dated historical snapshots; long-tail tracked in `081KV6D1B3T` (P3).

No functional ignore-path **values** changed. markdownlint EXIT=0; frontmatter OK; JSON valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)