### PR TITLE
docs: correct the Orthwein skip-permissions safety peel — PR gate IS the boundary (same model)

### DIFF
--- a/docs/research/2026-06-15-collaboration-readiness-veri-coding-ecosystem-coworker-not-control.md
+++ b/docs/research/2026-06-15-collaboration-readiness-veri-coding-ecosystem-coworker-not-control.md
@@ -52,11 +52,26 @@ frameworks; mutual, not capture.
 their work into code and scripts."* = **parallelize + automate-the-automator**.
 Resonates with our factory-automation + **scripts-over-ad-hoc-LLM-for-determinism**
 (a script is a metered, replayable channel — noninterference §13 — vs a
-non-replayable ad-hoc call). **Honest peel (clear-eyed collaboration):** the brain
-alignment is on *parallelism + automation*, **not** on the safety axis — Orthwein's
-*"dangerously skip permissions whenever possible"* (#8326) is the **opposite** of
-our least-privilege / gated discipline. Adopt the parallelize-and-automate ethos;
-do **not** adopt the skip-permissions posture.
+non-replayable ad-hoc call). **Correction (Aaron 2026-06-15 — Otto's earlier peel
+was too simple):** "dangerously skip permissions" is **NOT** the opposite of our
+discipline — it is the **same model**: the agent runs free *inside its sandbox*, but
+nothing **lands** except through a reviewed **PR + CI gate**. That is exactly what we
+run (Otto skip-permissions in its own clone; PR → markdownlint → CI → auto-merge-
+only-when-green). Orthwein simply **preached speed and never articulated the gate as
+the safety**. Two boundaries, kept distinct:
+
+1. **What LANDS** → the PR/CI gate. Orthwein has it; identical to ours;
+   skip-permissions is bounded by it. *(Do not over-gate reversible local edits —
+   "we should never do `.wait`"; gate at the meaningful boundary.)*
+2. **What the agent DOES while running** → secrets, outward/irreversible
+   side-effects. The PR gate does **not** cover this; **noninterference §13 (metered
+   channels) + gated-classes** apply *here* — and only here, not to reversible local
+   edits. (Least-privilege is correctly scoped to this layer.)
+
+**Where we help (the coworker complementarity):** Orthwein brings parallel-speed +
+the PR gate; **we make the gate a *verified* gate** — proofs at the PR boundary
+(build=verify / the veri-coding stack), not just tests + review — plus the
+metered-runtime layer (§13) for side-effect safety he didn't preach.
 
 ## 4. Contribute-back path (when Aaron green-lights outreach)
 

--- a/docs/research/ip-questionable/2026-06-15-lukens-orthwein-programming-is-an-rts-game-channel-ai-yc-talk-verbatim-transcript-aaron-forwarded.md
+++ b/docs/research/ip-questionable/2026-06-15-lukens-orthwein-programming-is-an-rts-game-channel-ai-yc-talk-verbatim-transcript-aaron-forwarded.md
@@ -30,10 +30,16 @@
 >
 > **Honest peels (where we differ — *similar, not same*):**
 >
-> - **"Dangerously skip permissions whenever possible"** is the **opposite** of our
->   discipline — we run *least-privilege* with gated classes (`no-directives`;
->   mechanical-authorization-check). His speed-over-safety is a real divergence, not
->   a model to copy.
+> - **"Dangerously skip permissions whenever possible"** — *NOT* the opposite of our
+>   discipline (Aaron 2026-06-15 corrected Otto's first read): it is the **same
+>   model** — run free *inside the sandbox*, but nothing **lands** except through a
+>   reviewed **PR + CI gate** (exactly our clone → PR → markdownlint → CI →
+>   auto-merge-when-green). Orthwein just *preached speed and never articulated the
+>   gate as the safety*. Two boundaries: (1) what **lands** = the PR gate (he has it;
+>   don't over-gate reversible local edits); (2) what the agent **does while running**
+>   = secrets / outward side-effects = where §13 metered-channels + gated-classes
+>   apply (least-privilege scoped *here*, not to local edits). **Where we help:** make
+>   the gate a *verified* gate (proofs at the PR boundary) + the metered-runtime layer.
 > - **"Wasteful from a per-token standpoint, run lots in parallel anyway"** —
 >   tolerable for him; for us it collides with the **metering/ΔU-per-watt** thesis
 >   (we *price* the waste; noninterference §13 meters the channel). Parallelism yes,


### PR DESCRIPTION
Aaron 2026-06-15 (shadow*): *"he can do this cause his agents are behind PR gates — this is their safety, like mine; but yes he obviously did not preach any safety only speed lol."*

Otto's first peel (#8326/#8327) wrongly called *"dangerously skip permissions"* the **opposite** of our least-privilege discipline. **Correction:** it's the **same model** — run free inside the sandbox, nothing **lands** except via a reviewed **PR + CI gate** (= our clone → PR → markdownlint → CI → auto-merge-when-green). Orthwein just preached speed, never named the gate as the safety.

Two boundaries kept distinct:
1. **What LANDS** → the PR gate (he has it; don't over-gate reversible local edits).
2. **What the agent DOES while running** (secrets, outward/irreversible side-effects) → §13 metered-channels + gated-classes — least-privilege scoped **here**, not to local edits.

**Where we help:** make the gate a **verified** gate (proofs at the PR boundary) + the metered-runtime layer.

Fixes the collaboration-readiness note (§3) + the Orthwein ip-questionable routing note. markdownlint EXIT=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)