### PR TITLE
feat(core): project prediction inference into room horizon

### DIFF
--- a/src/Core.TypeScript/hygiene/audit-research-docs.test.ts
+++ b/src/Core.TypeScript/hygiene/audit-research-docs.test.ts
@@ -91,7 +91,7 @@ describe("auditResearchDocsInRoots", () => {
       ]);
       expect(result.memoryFiles).toEqual([
         "memory/MEMORY.md",
-        "memory/<persona>/CURRENT.md",
+        "memory/persona/CURRENT.md",
       ]);
       expect(result.referenced).toEqual([
         "docs/research/absolute.md",

--- a/src/Core/PredictionInference.fs
+++ b/src/Core/PredictionInference.fs
@@ -38,6 +38,11 @@ module PredictionInference =
         { Attention: PS.Rational
           Gravity: PS.Rational }
 
+    type RankedBranch<'S> =
+        { Scored: Scored<'S>
+          Priority: BranchPriority
+          BoardingWeight: PS.Rational }
+
     type Feedback =
         | EmptyCandidates
         | NegativePrior of label: string * value: PS.Rational
@@ -47,10 +52,6 @@ module PredictionInference =
         | AllCandidatesRefuted
         | VisionFeedback of Vision.GrowthFeedback
         | SoftValueRefuted
-
-    type private Prioritized<'S> =
-        { Scored: Scored<'S>
-          BoardingWeight: PS.Rational }
 
     let neutralPriority: BranchPriority =
         { Attention = PS.one
@@ -69,7 +70,7 @@ module PredictionInference =
         else
             String.CompareOrdinal(left.Candidate.Label, right.Candidate.Label)
 
-    let private comparePrioritized (left: Prioritized<'S>) (right: Prioritized<'S>) =
+    let private compareRankedBranch (left: RankedBranch<'S>) (right: RankedBranch<'S>) =
         let byPriority = PS.compare right.BoardingWeight left.BoardingWeight
         if byPriority <> 0 then
             byPriority
@@ -117,26 +118,15 @@ module PredictionInference =
             { Inference = inference
               Budget = report })
 
-    let predictWithPriority
+    let rankWithPriority
         (priorityOf: Scored<'S> -> BranchPriority)
-        (tank: SoftThrottle.Tank)
         (inference: Inference<'S>)
-        : Result<Prediction<'S>, Feedback> =
+        : Result<RankedBranch<'S> list, Feedback> =
         let rec collect acc rest =
             result {
                 match rest with
                 | [] ->
-                    let ordered =
-                        acc
-                        |> List.sortWith comparePrioritized
-                        |> List.map (fun prioritized -> prioritized.Scored.Branch)
-
-                    return!
-                        Vision.predictBranches ordered tank
-                        |> Result.mapError VisionFeedback
-                        |> Result.map (fun report ->
-                            { Inference = inference
-                              Budget = report })
+                    return acc |> List.sortWith compareRankedBranch
                 | scored :: tail ->
                     let priority = priorityOf scored
 
@@ -150,10 +140,34 @@ module PredictionInference =
                             |> PS.mul priority.Attention
                             |> PS.mul priority.Gravity
 
-                        return! collect ({ Scored = scored; BoardingWeight = boardingWeight } :: acc) tail
+                        return!
+                            collect
+                                ({ Scored = scored
+                                   Priority = priority
+                                   BoardingWeight = boardingWeight }
+                                 :: acc)
+                                tail
             }
 
         collect [] inference.Ranked
+
+    let predictWithPriority
+        (priorityOf: Scored<'S> -> BranchPriority)
+        (tank: SoftThrottle.Tank)
+        (inference: Inference<'S>)
+        : Result<Prediction<'S>, Feedback> =
+        result {
+            let! ranked = rankWithPriority priorityOf inference
+
+            return!
+                ranked
+                |> List.map _.Scored.Branch
+                |> fun branches -> Vision.predictBranches branches tank
+                |> Result.mapError VisionFeedback
+                |> Result.map (fun report ->
+                    { Inference = inference
+                      Budget = report })
+        }
 
     let inferAndPredict
         (tank: SoftThrottle.Tank)

--- a/src/Core/RoomHorizon.fs
+++ b/src/Core/RoomHorizon.fs
@@ -22,6 +22,7 @@ module RoomHorizon =
     type Feedback =
         | NegativeAttention of label: string * value: PS.Rational
         | NegativeGravity of label: string * value: PS.Rational
+        | InferenceFeedback of PredictionInference.Feedback
         | VisionFeedback of Vision.GrowthFeedback
         | HorizonFeedback of BoundedGSetError
 
@@ -35,6 +36,11 @@ module RoomHorizon =
           RejectedByHorizon: GSet<'K>
           EvictedByHorizon: GSet<'K>
           Prediction: Vision.PredictionReport<'S> }
+
+    type InferenceReport<'K, 'S when 'K : comparison> =
+        { Inference: PredictionInference.Inference<'S>
+          Ranked: PredictionInference.RankedBranch<'S> list
+          Horizon: Report<'K, 'S> }
 
     let private nonNegative (r: PS.Rational) : bool =
         PS.compare r PS.zero >= 0
@@ -103,16 +109,12 @@ module RoomHorizon =
 
         loop current GSet.empty GSet.empty GSet.empty boarded
 
-    /// Update an existing finite horizon with a newly ordered, byte-budgeted
-    /// set of candidate futures.
-    let update
+    let private reportFromOrdered
         (current: BoundedGSet<'K>)
         (tank: SoftThrottle.Tank)
-        (candidates: Candidate<'K, 'S> list)
+        (orderedCandidates: Candidate<'K, 'S> list)
         : Result<Report<'K, 'S>, Feedback> =
         result {
-            let! orderedCandidates = ordered candidates
-
             let! prediction =
                 orderedCandidates
                 |> List.map _.Branch
@@ -135,6 +137,18 @@ module RoomHorizon =
                   Prediction = prediction }
         }
 
+    /// Update an existing finite horizon with a newly ordered, byte-budgeted
+    /// set of candidate futures.
+    let update
+        (current: BoundedGSet<'K>)
+        (tank: SoftThrottle.Tank)
+        (candidates: Candidate<'K, 'S> list)
+        : Result<Report<'K, 'S>, Feedback> =
+        result {
+            let! orderedCandidates = ordered candidates
+            return! reportFromOrdered current tank orderedCandidates
+        }
+
     /// Start from an empty bounded horizon and admit the affordable visible
     /// prefix of candidates.
     let admit
@@ -148,4 +162,51 @@ module RoomHorizon =
                 |> Result.mapError HorizonFeedback
 
             return! update empty tank candidates
+        }
+
+    /// Project exact inference into a finite room view. Posterior truth stays
+    /// on the inference record; attention/gravity only decide the budgeted
+    /// boarding order, and the bounded G-set reports the finite exterior view.
+    let updateInference
+        (current: BoundedGSet<'K>)
+        (tank: SoftThrottle.Tank)
+        (keyOf: PredictionInference.Scored<'S> -> 'K)
+        (priorityOf: PredictionInference.Scored<'S> -> PredictionInference.BranchPriority)
+        (inference: PredictionInference.Inference<'S>)
+        : Result<InferenceReport<'K, 'S>, Feedback> =
+        result {
+            let! ranked =
+                PredictionInference.rankWithPriority priorityOf inference
+                |> Result.mapError InferenceFeedback
+
+            let orderedCandidates =
+                ranked
+                |> List.map (fun rankedBranch ->
+                    { Key = keyOf rankedBranch.Scored
+                      Branch = rankedBranch.Scored.Branch
+                      Priority = rankedBranch.Priority })
+
+            let! horizon = reportFromOrdered current tank orderedCandidates
+
+            return
+                { Inference = inference
+                  Ranked = ranked
+                  Horizon = horizon }
+        }
+
+    /// Start from an empty bounded room view and project exact inference into
+    /// the affordable visible prefix.
+    let admitInference
+        (config: BoundedGSetConfig)
+        (tank: SoftThrottle.Tank)
+        (keyOf: PredictionInference.Scored<'S> -> 'K)
+        (priorityOf: PredictionInference.Scored<'S> -> PredictionInference.BranchPriority)
+        (inference: PredictionInference.Inference<'S>)
+        : Result<InferenceReport<'K, 'S>, Feedback> =
+        result {
+            let! empty =
+                BoundedGSet.empty<'K> config
+                |> Result.mapError HorizonFeedback
+
+            return! updateInference empty tank keyOf priorityOf inference
         }

--- a/tests/Tests.FSharp/RoomHorizon.Tests.fs
+++ b/tests/Tests.FSharp/RoomHorizon.Tests.fs
@@ -5,6 +5,7 @@ open Zeta.Core
 
 module PS = ProbabilitySemiring
 module RH = RoomHorizon
+module PI = PredictionInference
 
 let private mustOk =
     function
@@ -30,6 +31,13 @@ let private candidate key label state attention gravity bytes : RH.Candidate<int
       Priority =
         { Attention = PS.rat attention 1L
           Gravity = PS.rat gravity 1L } }
+
+let private inferredCandidate label state prior likelihood bytes : PI.Candidate<string> =
+    { Label = label
+      State = state
+      Prior = PS.rat prior 1L
+      Likelihood = PS.rat likelihood 1L
+      Cost = cost bytes }
 
 [<Fact>]
 let ``attention and gravity change boarding order while byte cost stays honest`` () =
@@ -97,3 +105,54 @@ let ``negative attention is feedback not an ordering trick`` () =
     | Error(RH.NegativeAttention("bad", value)) ->
         Assert.Equal(0, PS.compare value (PS.rat -1L 1L))
     | other -> Assert.Fail(sprintf "expected NegativeAttention feedback, got %A" other)
+
+[<Fact>]
+let ``inference projection keeps posterior truth separate from attended boarding`` () =
+    let inference =
+        [ inferredCandidate "likely" "A" 3L 1L 6L
+          inferredCandidate "attended" "B" 1L 1L 6L ]
+        |> PI.infer
+        |> mustOk
+
+    let keyOf (scored: PI.Scored<string>) =
+        if scored.Candidate.Label = "attended" then 2 else 1
+
+    let priorityOf (scored: PI.Scored<string>) =
+        if scored.Candidate.Label = "attended" then
+            { PI.neutralPriority with Attention = PS.rat 10L 1L }
+        else
+            PI.neutralPriority
+
+    let report =
+        inference
+        |> RH.admitInference (config 2 BoundedGSetRetention.KeepHighest) (SoftThrottle.tank 6.0 0.0) keyOf priorityOf
+        |> mustOk
+
+    Assert.Equal("likely", report.Inference.Best.Candidate.Label)
+    Assert.Equal<string list>([ "attended"; "likely" ], report.Horizon.Ordered |> List.map _.Branch.Label)
+    Assert.Equal<string list>([ "attended" ], report.Horizon.Boarded |> List.map _.Branch.Label)
+    Assert.Equal<string list>([ "likely" ], report.Horizon.Deferred |> List.map _.Branch.Label)
+    Assert.Equal<int list>([ 2 ], report.Horizon.RetainedKeys |> GSet.toList)
+    Assert.Equal(Vision.PartiallyAdmitted, report.Horizon.Prediction.Outcome)
+
+[<Fact>]
+let ``inference projection reports finite horizon rejection after byte admission`` () =
+    let current =
+        BoundedGSet.ofSeq<int> (config 2 BoundedGSetRetention.KeepHighest) [ 2; 3 ]
+        |> mustOk
+
+    let inference =
+        [ inferredCandidate "older" "A" 1L 1L 1L ]
+        |> PI.infer
+        |> mustOk
+
+    let report =
+        inference
+        |> RH.updateInference current (SoftThrottle.tank 1.0 0.0) (fun _ -> 1) (fun _ -> PI.neutralPriority)
+        |> mustOk
+
+    Assert.Equal(Vision.Admitted, report.Horizon.Prediction.Outcome)
+    Assert.Equal<string list>([ "older" ], report.Horizon.Boarded |> List.map _.Branch.Label)
+    Assert.Equal<int list>([ 2; 3 ], report.Horizon.HorizonAfter |> BoundedGSet.toList)
+    Assert.Empty(report.Horizon.RetainedKeys |> GSet.toList)
+    Assert.Equal<int list>([ 1 ], report.Horizon.RejectedByHorizon |> GSet.toList)


### PR DESCRIPTION
## Summary
- Expose the source-owned `PredictionInference.rankWithPriority` order so downstream room code consumes the same posterior-plus-attention/gravity ordering that Vision budgets.
- Add `RoomHorizon.updateInference` / `RoomHorizon.admitInference` to project exact inference into a finite bounded-GSet room view.
- Add tests proving posterior truth stays separate from attention/gravity boarding and finite horizon rejection.
- Fix the research-doc hygiene fixture expectation so it matches the real `memory/persona/CURRENT.md` repo-relative path.

## Verification
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter "FullyQualifiedName~RoomHorizon|FullyQualifiedName~PredictionInference|FullyQualifiedName~PredictionScheduler|FullyQualifiedName~Vision"`
- `dotnet build -c Release`
- `dotnet format --verify-no-changes`
- `dotnet test Zeta.sln -c Release`
- `mise exec -- bun run preflight:quick`
- `mise exec -- bun test src/Core.TypeScript/hygiene/`

Agency-Signature-Version: 1
Agent: Vera
Agent-Runtime: OpenAI Codex
Agent-Model: GPT-5.5
Credential-Identity: AceHack
Credential-Mode: shared
Human-Review: explicit
Human-Review-Evidence: chat
Action-Mode: human-directed
Task: task-20260615
Co-Authored-By: Codex <noreply@openai.com>
