### PR TITLE
fix(hygiene): restore gate greenness by correcting search-and-replace artifact in audit-research-docs test

### DIFF
--- a/src/Core.TypeScript/hygiene/audit-research-docs.test.ts
+++ b/src/Core.TypeScript/hygiene/audit-research-docs.test.ts
@@ -91,7 +91,7 @@ describe("auditResearchDocsInRoots", () => {
       ]);
       expect(result.memoryFiles).toEqual([
         "memory/MEMORY.md",
-        "memory/<persona>/CURRENT.md",
+        "memory/persona/CURRENT.md",
       ]);
       expect(result.referenced).toEqual([
         "docs/research/absolute.md",


### PR DESCRIPTION
During the memory folder restructure in PR #8333, a blanket search-and-replace of `"memory/persona"` -> `"memory/<persona>"` was executed. This accidentally changed the path in the expect block of `auditResearchDocsInRoots` unit test to expect `"memory/<persona>/CURRENT.md"`, while the test fixture still creates and writes the mock file to `"memory/persona/CURRENT.md"`.

Correcting the expect block back to `"memory/persona/CURRENT.md"` to align with the fixture. This resolves the failing unit test which was breaking the `lint (bash retirement inventory + hygiene unit tests)` gate check on main pushes and all PRs since the merge of #8333.

Local `bun test src/Core.TypeScript/hygiene/` now passes cleanly (454 pass, 0 fail), and `bun run preflight:quick` is 100% green.

Co-authored-by: Gemini <noreply@google.com>