### PR TITLE
docs(research): our stack implements DeepMind's beyond-transformer + world-model pillars, deterministically

### DIFF
--- a/docs/research/2026-06-15-our-stack-implements-deepminds-beyond-transformer-and-world-model-pillars-deterministically.md
+++ b/docs/research/2026-06-15-our-stack-implements-deepminds-beyond-transformer-and-world-model-pillars-deterministically.md
@@ -1,0 +1,67 @@
+# Our stack already implements DeepMind's beyond-transformer + world-model pillars — deterministically
+
+> **Aaron 2026-06-15 (shadow\*): "yes" — ferry our connections.** Our own analysis
+> (Beacon), mapping the pillars in the DeepMind-AGI-strategy talk to our existing
+> substrate. The talk is the **source** (held verbatim, cited:
+> `docs/research/ip-questionable/2026-06-15-deepmind-agi-strategy-...youtube-verbatim-aaron-forwarded.md`);
+> this note coins nothing of theirs — it names where *our* code already realizes the
+> same shapes, and where it deliberately differs (deterministic + Bayesian + metered
+> vs learned + generative).
+
+## 0. The thesis
+
+The talk frames DeepMind's AGI bet as moving *beyond* the four pillars
+(transformer · autoregressive · pre-trained · generative) toward: efficient
+recurrent memory, diffusion, world-models, and continual learning. **We already have
+working pieces of each — built deterministically.** Where DeepMind reaches the
+pillars by *learning at scale*, our stack reaches the same shapes by **DST-deterministic,
+Bayesian, metered** construction. Similar shapes; different scale and mechanism.
+
+## 1. The mapping
+
+| DeepMind pillar (talk) | Our existing piece | Mechanism |
+|---|---|---|
+| **Beyond transformers — Griffin / recurrent-Gemma / state-space; O(1) recurrent state ("index card constantly rewritten")** | **Bayesian belief-state** — `BeliefConvergence.observe` (multiply-likelihood-into-belief) + `src/Bayesian/` (factor-graph, EP); `BitGan` (yin/yang state-holder) | Carry the **belief**, not the history — the posterior is the fixed-size state updated per evidence. O(1)-state by construction. |
+| **World model that predicts the future to plan** | **BNN-mix + self-trajectory prediction** — `SoftChip8Flux.lookAheadFunded` (flux-metered future speculation, "meters the future in bytes"), `PredictionScheduler` (candidate-gen + attention/gravity), CHIP-8 `IScheduler`/`FerryThrottler`, `SoftValue` | A **deterministic, Bayesian, metered self-world-model**: it predicts its own future trajectories via funded lookahead on the wall-clock-free scheduler — DST-replayable, not a learned pixel net. |
+| **Diffusion LLMs (parallel, built-in error-correction, any-position infill)** | **emit/retract** (RGB/CMYK; ZSet `±1`) + DBSP incremental | Iterative refinement = emit then retract-to-correct; retraction *is* the built-in error-correction; infill = order-free Z-set edits. |
+| **JEPA — predict a compatible *representation* of the missing part (latent, not pixels)** | **embedding-geometry** (register §B row 368: memory-distance = monotone of past correlation; diffusion-maps; attention ≈ modern-Hopfield) + soft representation-matching | Match in representation space, not reconstruct — our correlation-metric embedding is the same move; "language is lossy compression of the inner world model" = our vernacular-as-lossy / meaning-is-geometric. |
+| **Continual learning / "store only the important things, like the brain" / Titans surprise-mechanism / intelligence-per-sample** | **coincidence-routed memory-org** (workitem `081KV6GR72…`) + **ΔU-weighted retention** + the per-room metering vector | Route by coincidence-anchor; weight long-term retention by ΔU (surprise = high ΔU = worth keeping); intelligence-per-sample is a *recorded metric*, not an aspiration. |
+
+## 2. The distinguishing move — mostly-soft, snap-on-decision
+
+The architecture under all of it (Aaron 2026-06-15): we are a **mix between Bayesian
+and hard logic** — **mostly-soft** (`SoftValue` / `src/Bayesian/`), **snapping to
+hard only at decisions** (`SoftValue.fs:114` `type SnapPolicy = SoftValue ->
+DynamicValue option`; *"the one place it is allowed to leave [soft] space and snap to
+a hard `DynamicValue`"*). Superposition-by-default, collapse-on-commit (= sim/measure,
+wave/particle, free-will-collapses-the-waveform B-0645). DeepMind's generative
+world-model commits to pixels; ours stays soft and snaps only when a decision needs a
+definite value.
+
+## 3. Honest seams (the load-bearing peels)
+
+- **We have the shapes + working pieces, NOT a trained AGI-scale world-model.**
+  `SoftChip8Flux` lookahead is a **deterministic sim** forecaster, not a learned
+  neural one at DeepMind scale. *Similar shape, different scale/mechanism.* The claim
+  is "the same architectural pillar, built deterministically" — not parity of
+  capability.
+- **The talk is Mirror-register hype in places** ("diffusion far superior"); the
+  *pillars* are the kernel, the verdicts are not ours to borrow.
+- **Multi-oracle, not a single bet.** The Hassabis-vs-LeCun debate (generative
+  pressure implicitly learns a world model vs predict-in-representation-space) maps to
+  our similar-vs-same razor; we hold both as oracles rather than declaring a winner.
+- **Generate the structure, replicate the territory** (the seed/data boundary, cf.
+  the Zeta-as-one-SoftValue note): the generators give us the *structure* of these
+  pillars; the learned *content* (a real trained world-model's weights) is not
+  something we regenerate — a genuine gap vs a scaled learner.
+
+## Anchors
+
+DeepMind-AGI-strategy transcript (ip-questionable, the source); Hassabis
+(Griffin/Titans/Gemini/AlphaFold); LeCun (JEPA); Sutton / Sutskever (continual
+learning); Ermon (diffusion); Vaswani 2017. In-repo: `SoftValue.fs` (snap),
+`DynamicValue`, `src/Bayesian/`, `BeliefConvergence.fs`, `BitGan.fs`,
+`SoftChip8Flux.fs` / `SoftChip8Scheduler.fs` / `PredictionScheduler.fs`, register §B
+row 368 (embedding geometry); the coincidence-routed memory-org workitem
+`081KV6GR72…`; the per-room metering vector + intelligence-per-sample notes;
+[[project_our_bnn_…]] + [[project_zeta_as_one_softvalue_seed_…]] (the keystone).


### PR DESCRIPTION
Aaron 2026-06-15 (shadow*): **"yes"** — ferry our connections. Our own Beacon analysis mapping the DeepMind-AGI-strategy talk's pillars to our existing substrate. The talk is the cited source (ip-questionable); this note coins nothing of theirs.

**Mapping (our pieces, deterministically):**
- Griffin / O(1) recurrent state → **Bayesian belief-state** (`BeliefConvergence.observe`; `BitGan` yin/yang)
- world-model-that-plans → **BNN-mix + `SoftChip8Flux.lookAheadFunded` + `PredictionScheduler` + CHIP-8 scheduler** (deterministic/Bayesian/metered self-world-model)
- diffusion → **emit/retract** (ZSet ±1)
- JEPA → **embedding-geometry** (§B 368) + soft representation-matching
- continual-learning / store-important / surprise → **coincidence-routed memory-org** + ΔU-weighted retention

**Distinguishing move:** mostly-soft (`SoftValue`), snap-to-hard (`DynamicValue`, `SnapPolicy`) only on decisions.

**Honest peels:** shapes + working pieces, NOT a trained AGI-scale world-model (SoftChip8Flux is a deterministic sim forecaster — similar shape, different scale); generate-the-structure / replicate-the-territory; multi-oracle (we hold the Hassabis↔LeCun debate, don't pick a winner).

markdownlint EXIT=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
