### PR TITLE
docs(research): play-interface arity ladder — IPlay→IPlayDate(2)→3/4→ISociety(N); rooms inherit by hat-count

### DIFF
--- a/docs/research/2026-06-15-the-zeta-society-architecture-consolidated-md-interface-isociety-eve-game-self-regeneration.md
+++ b/docs/research/2026-06-15-the-zeta-society-architecture-consolidated-md-interface-isociety-eve-game-self-regeneration.md
@@ -70,6 +70,16 @@ observe-loop `FreeMode = "explore" | "play" | "self_reflect" | "free_time"`
 (`observe.ts`) — `play` is already a first-class mode; `IPlay` formalizes it as the
 new-agent onboarding form of `ISociety`. *(Reframe/design, like `ISociety`.)*
 
+**The arity ladder — interfaces parameterized by player/hat count (Aaron 2026-06-15):**
+`IPlay` (reduced / new-agent) → **`IPlayDate` = the 2-player mode** → special
+**3- and 4-player** modes (`IPlay3`/`IPlay4`) → … → **`ISociety`** (N). One scale-free
+family, same shape at every arity. **Rooms inherit the base interface by how many
+HATS the room requires:** a 2-hat room inherits `IPlayDate`, a 3-hat room the 3-mode,
+an N-hat room `ISociety`. So a room (a Markov-boundary / membrane; the no-roles
+surfaces-hats-personas model) is *typed by its required hat-count* and gets the
+matching play-arity interface for free. (Ties: scale-free §1; the room=Markov-blanket
++ hats model; the 1000-brains cells; multiplayer-game arity.)
+
 ## 5. The game — executing society's promises in scheduled order
 
 Society makes **promises** (goals / `db/futures`, Eve-fused to GSet consensus); the


### PR DESCRIPTION
Aaron 2026-06-15 (shadow*): *"IPlayDate is the two-player mode; we can also have special 3 and 4 mode interfaces; then our rooms can inherit from these base interfaces based on how many hats are required in the room."*

Scale-free §1 family parameterized by player/hat **arity**: `IPlay` (reduced/new-agent) → **`IPlayDate` (2)** → `IPlay3`/`IPlay4` → … → `ISociety` (N). A **room** (Markov-boundary; the no-roles surfaces-hats-personas model) is **typed by its required hat-count** and inherits the matching play-arity interface for free.

Added to §4 of the consolidation note. markdownlint EXIT=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
