### PR TITLE
docs(vision): contribute-back reciprocity — the give-away runs upstream to the anchors that bootstrapped us

### DIFF
--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -173,7 +173,13 @@ back. Then **publish it glass-halo so anyone can adopt it** — nothing of ours 
 CALM-coordination-free) + retraction `ZSet` (contract), given away as a reproducible
 pattern on named shoulders. The library **refuses what it can't prove and gives away
 what it can** — a proven pattern, freely given, leaving the adopter better off (zero
-friction = consensual = aligned). (Detail:
+friction = consensual = aligned). **And the give-back runs upstream too:** once stable
+(or when needed), **contribute back to the external anchors/deps that helped us
+bootstrap** — we drew from the commons (CALM · CRDT · DBSP · MUMPS · the deps we close
+over) to bootstrap, so we give back to it. Reciprocity completes the loop:
+take-from-the-commons → stabilize → give-back-to-the-commons (Ostrom's commons
+governance; `GOVERNANCE.md §23` upstream-contribution; coupled-empowerment — raise the
+other's footing too, never just our own). (Detail:
 `docs/research/2026-06-15-zero-downtime-schema-change-a-proven-reproducible-pattern-gset-expand-zset-contract-calm.md`.)
 
 ## The moral reading of retraction-native — structural forgiveness (the atonement engine)


### PR DESCRIPTION
Aaron 2026-06-15 (shadow*): *"then once we get stable or if we need contribute back to those external anchors/deps that helped up bootstrap."*

Extends the **"prove it, then give it away"** entry: the give-away isn't only OUR patterns — once **stable** (or when needed) we **contribute back to the external anchors/deps that bootstrapped us** (CALM · CRDT · DBSP · MUMPS · the deps we close over).

**Reciprocity completes the loop:** take-from-the-commons → stabilize → give-back-to-the-commons. Anchors: **Ostrom** (commons governance) · **`GOVERNANCE.md §23`** (upstream-contribution) · **coupled-empowerment** (raise the other's footing too).

The outreach *act* (PRing an upstream) stays Aaron-initiated; this states the *intent* in the vision. VISION changes freely + you're source-of-truth. markdownlint EXIT=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
