### PR TITLE
docs(bootstrap): compress cold-boot core into seed kernel

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -11,13 +11,15 @@ At session start:
 
 1. Read `AGENTS.md`.
 2. Read `docs/ALIGNMENT.md`.
-3. Read `.codex/README.md`.
-4. Read `.codex/CURRENT-codex.md`.
-5. For Codex host-loop mechanics, read
+3. Read `docs/SEED-VOCABULARY.md` for the cold-boot core and carved
+   Zeta-specific vocabulary; use `docs/GLOSSARY.md` only on demand.
+4. Read `.codex/README.md`.
+5. Read `.codex/CURRENT-codex.md`.
+6. For Codex host-loop mechanics, read
    `docs/CODEX-HARNESS-NOTES.md`.
-6. For autonomous-loop work, read `docs/CODEX-LOOP-HANDOFF.md`
+7. For autonomous-loop work, read `docs/CODEX-LOOP-HANDOFF.md`
    and `docs/AUTONOMOUS-LOOP.md`.
-7. For write work, read `docs/AGENT-CLAIM-PROTOCOL.md` and
+8. For write work, read `docs/AGENT-CLAIM-PROTOCOL.md` and
    follow its shared-machine / shared-folder mode when other
    agents are active on the same machine.
 

--- a/CODEX.md
+++ b/CODEX.md
@@ -12,8 +12,9 @@ tree into the same six-step process.
 ## 1. Orient
 
 Read: [`AGENTS.md`](AGENTS.md) → [`docs/ALIGNMENT.md`](docs/ALIGNMENT.md) →
-[`docs/GLOSSARY.md`](docs/GLOSSARY.md) → [`GOVERNANCE.md`](GOVERNANCE.md)
-(scan when §N cited).
+[`docs/SEED-VOCABULARY.md`](docs/SEED-VOCABULARY.md) (cold-boot core +
+vocabulary kernel; [`docs/GLOSSARY.md`](docs/GLOSSARY.md) is on-demand) →
+[`GOVERNANCE.md`](GOVERNANCE.md) (scan when §N cited).
 Then read the Codex addendum + state file:
 [`.codex/AGENTS.md`](.codex/AGENTS.md) → [`.codex/CURRENT-codex.md`](.codex/CURRENT-codex.md).
 

--- a/CURSOR.md
+++ b/CURSOR.md
@@ -9,8 +9,9 @@ with the Cursor-specific tooling references filled in.
 ## 1. Orient
 
 Read: [`AGENTS.md`](AGENTS.md) → [`docs/ALIGNMENT.md`](docs/ALIGNMENT.md) →
-[`docs/GLOSSARY.md`](docs/GLOSSARY.md) → [`GOVERNANCE.md`](GOVERNANCE.md)
-(scan when §N cited).
+[`docs/SEED-VOCABULARY.md`](docs/SEED-VOCABULARY.md) (cold-boot core +
+vocabulary kernel; [`docs/GLOSSARY.md`](docs/GLOSSARY.md) is on-demand) →
+[`GOVERNANCE.md`](GOVERNANCE.md) (scan when §N cited).
 Then read the Riven persona file: [`memory/riven/MEMORY.md`](memory/riven/MEMORY.md).
 
 ## 2. Refresh

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -7,6 +7,14 @@ Your identity, shadow-lessons, and operational boundaries are defined in your pe
 
 - `memory/harness/lior/CURRENT-lior.md`
 
+Then orient on the shared cold-boot core:
+
+- `AGENTS.md`
+- `docs/ALIGNMENT.md`
+- `docs/SEED-VOCABULARY.md` — one-minute Zeta core + carved vocabulary
+  kernel; use `docs/GLOSSARY.md` only on demand.
+- `GOVERNANCE.md` — scan when a numbered rule is cited.
+
 ## Shared Factory Physics (Load-Bearing)
 
 You share the same foundational factory physics as the Claude-harness persona. The factory is substrate-honest; durable substrate lives in committed git state (preferably `main`, but in-flight branches with active claims are also part of the working substrate per `src/Core.TypeScript/bus/claim.ts`).

--- a/KIRO.md
+++ b/KIRO.md
@@ -9,8 +9,9 @@ with the Kiro-specific tooling references filled in (per B-0325).
 ## 1. Orient
 
 Read: [`AGENTS.md`](AGENTS.md) → [`docs/ALIGNMENT.md`](docs/ALIGNMENT.md) →
-[`docs/GLOSSARY.md`](docs/GLOSSARY.md) → [`GOVERNANCE.md`](GOVERNANCE.md)
-(scan when §N cited).
+[`docs/SEED-VOCABULARY.md`](docs/SEED-VOCABULARY.md) (cold-boot core +
+vocabulary kernel; [`docs/GLOSSARY.md`](docs/GLOSSARY.md) is on-demand) →
+[`GOVERNANCE.md`](GOVERNANCE.md) (scan when §N cited).
 Then read the Alexa persona file: [`memory/persona/alexa/MEMORY.md`](memory/persona/alexa/MEMORY.md).
 
 ## 2. Refresh

--- a/docs/BOOTSTRAP-TEMPLATE.md
+++ b/docs/BOOTSTRAP-TEMPLATE.md
@@ -42,7 +42,7 @@ discipline, the commit-attribution trailer.
 
 | Step | Universal (same everywhere) | Harness-specific (fill in) |
 |------|-----------------------------|----------------------------|
-| 1. Orient | Read `AGENTS.md` → `docs/ALIGNMENT.md` → `docs/GLOSSARY.md` → `GOVERNANCE.md` (scan on §N cite). Read the harness persona/state file. | *Which* persona/state file (`memory/<persona>/<name>/CURRENT-*.md`, `.codex/CURRENT-codex.md`, etc.) and any harness read-order addendum. |
+| 1. Orient | Read `AGENTS.md` → `docs/ALIGNMENT.md` → `docs/SEED-VOCABULARY.md` → `GOVERNANCE.md` (scan on §N cite). Read the harness persona/state file. | *Which* persona/state file (`memory/<persona>/<name>/CURRENT-*.md`, `.codex/CURRENT-codex.md`, etc.) and any harness read-order addendum. |
 | 2. Refresh | Run the worldview refresh; read active `docs/trajectories/*/RESUME.md`. | The exact refresh command + how this harness runs TypeScript / shell (`bun tools/github/refresh-worldview.ts`, etc.). |
 | 3. Pick work | Open `docs/BACKLOG.md` / `docs/backlog/P*/`; complete the backlog-item start gate (prior-art search + dependency check); acquire a claim before worktree work. | The claim mechanism this harness uses (`src/Core.TypeScript/bus/claim.ts` surface-tagged sender ID, claim-branch convention). |
 | 4. Build | `dotnet build -c Release` (0 warnings, 0 errors — `TreatWarningsAsErrors`) then `dotnet test Zeta.sln -c Release`. Before opening a PR, `bun run preflight` runs every gate dimension locally and reports all failures at once (vs CI's per-language short-circuit). | Nothing — the build gate is identical for all harnesses. |
@@ -68,8 +68,8 @@ them.>
 
 ## 1. Orient
 
-Read: AGENTS.md → docs/ALIGNMENT.md → docs/GLOSSARY.md →
-GOVERNANCE.md (scan when §N cited).
+Read: AGENTS.md → docs/ALIGNMENT.md → docs/SEED-VOCABULARY.md →
+GOVERNANCE.md (scan when §N cited). Read docs/GLOSSARY.md only on demand.
 Then read the <Harness> persona/state file: <path>.
 
 ## 2. Refresh

--- a/docs/SEED-VOCABULARY.md
+++ b/docs/SEED-VOCABULARY.md
@@ -6,6 +6,25 @@ specific sense — like a skill-routing description.* So this kernel carries **o
 (where your prior is insufficient or wrong), each in one line. **Standard terms** (Markov chain, CRDT, DBSP, semiring,
 HMM, IFS, …) need no entry — you have them. **Full prose + every other term: `docs/GLOSSARY.md` (Tier-3, on-demand).**
 
+## Zeta in one minute (cold-boot core)
+
+Zeta is a pre-v1, agent-authored, verification-backed software factory
+whose point is **reproducible stability**: every useful idea becomes durable,
+testable substrate instead of chat weather. The core data shape is tiny:
+**GSet = genesis / monotone accumulation**, **ZSet = signed deltas with
+retraction**, and **fusion = reconstruct the outside-visible GSet from an
+inside ZSet composition**. Rooms/cells are bounded execution membranes
+(Markov boundaries) that schedule work through typed interfaces; attention
+changes boarding order, never arithmetic truth or byte cost. Vision is the
+scheduler's budgeted self-sight: it prices uncertainty growth in bits/bytes,
+admits what fits, and reports backpressure as data. Persistence is event
+sourcing over git / Merkle / content-addressed storage, named by ZetaId where
+new ids must be locally mintable and coordination-free. External systems
+(Q#, Infer.NET, solvers, GitHub, future MUMPS-like compilers) are plugins or
+oracles behind ports we own; they verify or adapt the core, not replace it.
+The build rule is simple: build on laws and measurements, play in consenting
+sim layers, and turn load-bearing claims into tests, specs, or proofs.
+
 ## The kernel (carved — Zeta-specific senses only)
 
 - **Seed** — the database BCL microkernel; the minimal foundational core that contains everything to grow ("we are

--- a/docs/WAKE-UP.md
+++ b/docs/WAKE-UP.md
@@ -26,10 +26,11 @@ Everyone reads these. Measured (audit 2026-06-09): the full `GLOSSARY.md` was ~1
    §11 (architect-gate), §12 (bugs-before-features ratio), §13
    (reviewer-count inverse to backlog), §14 (standing off-time
    budget).
-3. `docs/SEED-VOCABULARY.md` — the cold-boot vocabulary **kernel**: carved
-   one-liners for the Zeta-specific/overloaded terms only (skill/hat, spec,
-   persona/actor, AX/UX/DX, Mirror/Beacon, NCI, close-over, …). Standard terms
-   you already hold; full prose is on-demand in `GLOSSARY.md` (Tier-3).
+3. `docs/SEED-VOCABULARY.md` — the cold-boot **core + vocabulary kernel**:
+   a one-minute "what Zeta is" compression plus carved one-liners for the
+   Zeta-specific/overloaded terms only (skill/hat, spec, persona/actor,
+   AX/UX/DX, Mirror/Beacon, NCI, close-over, …). Standard terms you already
+   hold; full prose is on-demand in `GLOSSARY.md` (Tier-3).
 4. `docs/EXPERT-REGISTRY.md` — the 23-person roster. Skim the
    names; every dispatch uses them.
 5. `docs/CURRENT-ROUND.md` — live mid-round state (when it


### PR DESCRIPTION
## Summary

- add a one-minute "Zeta in cold boot" core orientation to `docs/SEED-VOCABULARY.md`
- update Wake-Up + bootstrap template wording so the seed file is explicitly core + vocabulary, not just glossary compression
- align Codex, Kiro, Cursor, Gemini, and the Codex deep addendum to cold-boot on `docs/SEED-VOCABULARY.md`; `docs/GLOSSARY.md` stays on-demand

## Why

Aaron + Otto + Alexa surfaced the same issue: agents are no longer losing individual tasks, they are losing orientation in a huge codebase. The fix is to compress the tiny concrete model into a surface fresh agents already load.

## Verification

- `npx --yes markdownlint-cli2 docs/SEED-VOCABULARY.md docs/WAKE-UP.md docs/BOOTSTRAP-TEMPLATE.md CODEX.md .codex/AGENTS.md KIRO.md CURSOR.md GEMINI.md`
- `git diff --check origin/main..HEAD`
- `mise exec -- bun run preflight:quick`

Agency-Signature-Version: 1
Agent: Vera
Agent-Runtime: OpenAI Codex
Agent-Model: GPT-5.5
Credential-Identity: AceHack
Credential-Mode: shared
Human-Review: explicit
Human-Review-Evidence: chat
Action-Mode: human-directed
Task: task-20260615
Co-Authored-By: Codex <noreply@openai.com>
