### PR TITLE
fix(observe): main-red lint — legacyId fixture + unused git()/itemContent + MD032

### DIFF
--- a/docs/DECISIONS/2026-06-15-zero-downtime-id-rotation-pattern-overlap-window-dual-key.md
+++ b/docs/DECISIONS/2026-06-15-zero-downtime-id-rotation-pattern-overlap-window-dual-key.md
@@ -66,6 +66,7 @@ key is a resolvable alias with weight -1 pending). After drop, only the new key 
 ### Quorum condition for Phase 5 (drop)
 
 All of:
+
 1. `depends_on` arrays in all P0-P2 items resolve on ZetaId alone
 2. No in-flight branches reference B-xxxx in active code paths
 3. Golden vectors regenerated and byte-lock checksums pass

--- a/src/Core.TypeScript/observe/backlog-reader.test.ts
+++ b/src/Core.TypeScript/observe/backlog-reader.test.ts
@@ -13,6 +13,7 @@ import type { BacklogItem as RichItem, PickupSelection } from "../backlog/autono
 
 const richItem = (id: string, title: string): RichItem => ({
   id,
+  legacyId: null,
   priority: "P2",
   status: "open",
   title,

--- a/src/Core.TypeScript/observe/kiro-executor.ts
+++ b/src/Core.TypeScript/observe/kiro-executor.ts
@@ -19,7 +19,7 @@
  *   - src/Core.TypeScript/observe/run-loop-real.ts (the tick entrypoint that wires this)
  */
 
-import { execFileSync, type SpawnSyncReturns } from "node:child_process";
+import { type SpawnSyncReturns } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { CommandExecutor, RunSpec, RunOutcome, ExecutorTier } from "./do-item";
@@ -32,16 +32,6 @@ export interface KiroExecutorOptions {
   readonly timeoutMs?: number;
   /** Agent identity for branch naming (default: "alexa"). */
   readonly agentId?: string;
-}
-
-/**
- * Run a git command in the repo, returning stdout. Throws on failure.
- */
-function git(repoRoot: string, args: readonly string[]): string {
-  return execFileSync("git", ["-C", repoRoot, ...args], {
-    encoding: "utf-8",
-    timeout: 30_000,
-  }).trim();
 }
 
 /**
@@ -94,7 +84,7 @@ function readItemFile(repoRoot: string, item: BacklogItem): string | null {
  * For now, the script is a diagnostic that proves the loop works end-to-end.
  * Real work dispatch (invoking the agent with a focused prompt) is Phase 2.
  */
-function generateScript(item: BacklogItem, itemContent: string | null, opts: Required<KiroExecutorOptions>): string {
+function generateScript(item: BacklogItem, _itemContent: string | null, opts: Required<KiroExecutorOptions>): string {
   const branch = claimBranchName(item, opts.agentId);
   // Phase 1: create the claim branch and write a claim file as proof-of-life.
   // This demonstrates the full loop works. Phase 2 will do actual implementation.


### PR DESCRIPTION
**Main went red** on the `gate` lint jobs (TS lint + markdownlint) after #8355/#8356 (ZetaId-canonical reader + Phase-2 `depends_on` migration). Diagnosed as **real, not flake**. Four mechanical fixes to unblock the fleet's gate:

| File | Failure | Fix |
|---|---|---|
| `backlog-reader.test.ts` | TS2741 — `legacyId` missing | add `legacyId: null` to fixture (now-required field) |
| `kiro-executor.ts` | TS6133 — `itemContent` unused | rename `_itemContent` (kept for Phase 2; caller positional) |
| `kiro-executor.ts` | TS6133 — `git()` unused | remove unused helper + orphaned `execFileSync` import (`SpawnSyncReturns` stays) |
| `DECISIONS/…id-rotation….md` | MD032 | blank line before the ordered list |

**Verified:** `bun src/Core.TypeScript/lint/lint-typescript.ts` ✓ · markdownlint clean · `backlog-reader.test.ts` 4 pass.

Touches Alexa's just-landed work purely to restore green; Phase-2 scaffolding preserved where the linter allowed (`_itemContent` kept; `git()` recoverable from history). **@Alexa** — flag if you'd prefer `git()` restored differently in Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
