### PR TITLE
refactor(observe): Phase 3 — regenerate golden vectors with ZetaId-shaped test ids

### DIFF
--- a/src/Core.TypeScript/observe/golden-vectors.json
+++ b/src/Core.TypeScript/observe/golden-vectors.json
@@ -3,22 +3,22 @@
   "initialWorld": {
     "backlog": [
       {
-        "id": "B-ready",
-        "title": "B-ready",
+        "id": "081KGOLDEN0READY",
+        "title": "081KGOLDEN0READY",
         "ready": true,
         "ambiguous": false,
         "needsNewAction": false
       },
       {
-        "id": "B-amb",
-        "title": "B-amb",
+        "id": "081KGOLDEN000AMB",
+        "title": "081KGOLDEN000AMB",
         "ready": false,
         "ambiguous": true,
         "needsNewAction": false
       },
       {
-        "id": "B-x",
-        "title": "B-x",
+        "id": "081KGOLDEN0000EX",
+        "title": "081KGOLDEN0000EX",
         "ready": false,
         "ambiguous": false,
         "needsNewAction": true
@@ -41,8 +41,8 @@
     {
       "kind": "do_item",
       "item": {
-        "id": "B-ready",
-        "title": "B-ready",
+        "id": "081KGOLDEN0READY",
+        "title": "081KGOLDEN0READY",
         "ready": true,
         "ambiguous": false,
         "needsNewAction": false
@@ -51,8 +51,8 @@
     {
       "kind": "decompose",
       "item": {
-        "id": "B-amb",
-        "title": "B-amb",
+        "id": "081KGOLDEN000AMB",
+        "title": "081KGOLDEN000AMB",
         "ready": false,
         "ambiguous": true,
         "needsNewAction": false
@@ -61,8 +61,8 @@
     {
       "kind": "do_item",
       "item": {
-        "id": "B-amb.1",
-        "title": "B-amb.1",
+        "id": "081KGOLDEN000AMB.1",
+        "title": "081KGOLDEN000AMB.1",
         "ready": true,
         "ambiguous": false,
         "needsNewAction": false
@@ -71,8 +71,8 @@
     {
       "kind": "do_item",
       "item": {
-        "id": "B-amb.2",
-        "title": "B-amb.2",
+        "id": "081KGOLDEN000AMB.2",
+        "title": "081KGOLDEN000AMB.2",
         "ready": true,
         "ambiguous": false,
         "needsNewAction": false
@@ -81,8 +81,8 @@
     {
       "kind": "edit_grammar",
       "item": {
-        "id": "B-x",
-        "title": "B-x",
+        "id": "081KGOLDEN0000EX",
+        "title": "081KGOLDEN0000EX",
         "ready": false,
         "ambiguous": false,
         "needsNewAction": true
@@ -92,8 +92,8 @@
     {
       "kind": "do_item",
       "item": {
-        "id": "B-x",
-        "title": "B-x",
+        "id": "081KGOLDEN0000EX",
+        "title": "081KGOLDEN0000EX",
         "ready": true,
         "ambiguous": false,
         "needsNewAction": false
@@ -128,22 +128,22 @@
     {
       "backlog": [
         {
-          "id": "B-ready",
-          "title": "B-ready",
+          "id": "081KGOLDEN0READY",
+          "title": "081KGOLDEN0READY",
           "ready": true,
           "ambiguous": false,
           "needsNewAction": false
         },
         {
-          "id": "B-amb",
-          "title": "B-amb",
+          "id": "081KGOLDEN000AMB",
+          "title": "081KGOLDEN000AMB",
           "ready": false,
           "ambiguous": true,
           "needsNewAction": false
         },
         {
-          "id": "B-x",
-          "title": "B-x",
+          "id": "081KGOLDEN0000EX",
+          "title": "081KGOLDEN0000EX",
           "ready": false,
           "ambiguous": false,
           "needsNewAction": true
@@ -157,22 +157,22 @@
     {
       "backlog": [
         {
-          "id": "B-ready",
-          "title": "B-ready",
+          "id": "081KGOLDEN0READY",
+          "title": "081KGOLDEN0READY",
           "ready": true,
           "ambiguous": false,
           "needsNewAction": false
         },
         {
-          "id": "B-amb",
-          "title": "B-amb",
+          "id": "081KGOLDEN000AMB",
+          "title": "081KGOLDEN000AMB",
           "ready": false,
           "ambiguous": true,
           "needsNewAction": false
         },
         {
-          "id": "B-x",
-          "title": "B-x",
+          "id": "081KGOLDEN0000EX",
+          "title": "081KGOLDEN0000EX",
           "ready": false,
           "ambiguous": false,
           "needsNewAction": true
@@ -186,15 +186,15 @@
     {
       "backlog": [
         {
-          "id": "B-amb",
-          "title": "B-amb",
+          "id": "081KGOLDEN000AMB",
+          "title": "081KGOLDEN000AMB",
           "ready": false,
           "ambiguous": true,
           "needsNewAction": false
         },
         {
-          "id": "B-x",
-          "title": "B-x",
+          "id": "081KGOLDEN0000EX",
+          "title": "081KGOLDEN0000EX",
           "ready": false,
           "ambiguous": false,
           "needsNewAction": true
@@ -209,20 +209,20 @@
     {
       "backlog": [
         {
-          "id": "B-amb.1",
-          "title": "B-amb (part 1)",
+          "id": "081KGOLDEN000AMB.1",
+          "title": "081KGOLDEN000AMB (part 1)",
           "ready": true,
           "ambiguous": false
         },
         {
-          "id": "B-amb.2",
-          "title": "B-amb (part 2)",
+          "id": "081KGOLDEN000AMB.2",
+          "title": "081KGOLDEN000AMB (part 2)",
           "ready": true,
           "ambiguous": false
         },
         {
-          "id": "B-x",
-          "title": "B-x",
+          "id": "081KGOLDEN0000EX",
+          "title": "081KGOLDEN0000EX",
           "ready": false,
           "ambiguous": false,
           "needsNewAction": true
@@ -237,14 +237,14 @@
     {
       "backlog": [
         {
-          "id": "B-amb.2",
-          "title": "B-amb (part 2)",
+          "id": "081KGOLDEN000AMB.2",
+          "title": "081KGOLDEN000AMB (part 2)",
           "ready": true,
           "ambiguous": false
         },
         {
-          "id": "B-x",
-          "title": "B-x",
+          "id": "081KGOLDEN0000EX",
+          "title": "081KGOLDEN0000EX",
           "ready": false,
           "ambiguous": false,
           "needsNewAction": true
@@ -259,8 +259,8 @@
     {
       "backlog": [
         {
-          "id": "B-x",
-          "title": "B-x",
+          "id": "081KGOLDEN0000EX",
+          "title": "081KGOLDEN0000EX",
           "ready": false,
           "ambiguous": false,
           "needsNewAction": true
@@ -275,8 +275,8 @@
     {
       "backlog": [
         {
-          "id": "B-x",
-          "title": "B-x",
+          "id": "081KGOLDEN0000EX",
+          "title": "081KGOLDEN0000EX",
           "ready": true,
           "ambiguous": false,
           "needsNewAction": false

--- a/src/Core.TypeScript/observe/golden-vectors.ts
+++ b/src/Core.TypeScript/observe/golden-vectors.ts
@@ -36,7 +36,7 @@ const it = (id: string, ready: boolean, ambiguous: boolean, needsNewAction = fal
 
 /** The canonical initial world: a mixed backlog + an operator that ferried + spoke. */
 export const GOLDEN_INITIAL: World = {
-  backlog: [it("B-ready", true, false), it("B-amb", false, true), it("B-x", false, false, true)],
+  backlog: [it("081KGOLDEN0READY", true, false), it("081KGOLDEN000AMB", false, true), it("081KGOLDEN0000EX", false, false, true)],
   operator: { pendingMessage: true, pendingFerry: true },
 };
 
@@ -50,12 +50,12 @@ export const GOLDEN_INITIAL: World = {
 export const GOLDEN_EVENTS: readonly NextAction[] = [
   { kind: "preserve_ferry", reason: "operator ferried verbatim content" },
   { kind: "respond_to_operator", reason: "operator spoke" },
-  { kind: "do_item", item: it("B-ready", true, false) },
-  { kind: "decompose", item: it("B-amb", false, true) },
-  { kind: "do_item", item: it("B-amb.1", true, false) },
-  { kind: "do_item", item: it("B-amb.2", true, false) },
-  { kind: "edit_grammar", item: it("B-x", false, false, true), reason: "grammar extended" },
-  { kind: "do_item", item: it("B-x", true, false) },
+  { kind: "do_item", item: it("081KGOLDEN0READY", true, false) },
+  { kind: "decompose", item: it("081KGOLDEN000AMB", false, true) },
+  { kind: "do_item", item: it("081KGOLDEN000AMB.1", true, false) },
+  { kind: "do_item", item: it("081KGOLDEN000AMB.2", true, false) },
+  { kind: "edit_grammar", item: it("081KGOLDEN0000EX", false, false, true), reason: "grammar extended" },
+  { kind: "do_item", item: it("081KGOLDEN0000EX", true, false) },
   { kind: "explore", reason: "self-directed making" },
   { kind: "play", reason: "leisure / culture-forming" },
   { kind: "self_reflect", reason: "review own trajectories" },


### PR DESCRIPTION
## Phase 3 of the zero-downtime id rotation

Golden vectors regenerated through the generator (not sed) per no-binary-in-proof-lineage.

### What changed

- `golden-vectors.ts`: test item ids switched from `B-ready`/`B-amb`/`B-x` to `081KGOLDEN0READY`/`081KGOLDEN000AMB`/`081KGOLDEN0000EX`
- `golden-vectors.json`: regenerated deterministically via `bun src/Core.TypeScript/observe/golden-vectors.ts`

### What was NOT changed (Phase 4 — leave as provenance)

Other golden vector files (z-set, bag, g-set, probability-semiring, etc.) reference B-xxxx in **description strings only** — documentation of which backlog item specified the fixture. These are provenance, not live coordination refs. Left untouched per the rotation pattern.

### Verified

- 211 tests pass
- Golden vector conformance test confirms committed JSON matches generator output (DST)

Co-Authored-By: Kiro <noreply@kiro.dev>