### PR TITLE
fix(memory): stop the persona-ferry main-red cluster — wire+broaden reindex hook, fix stale skip-glob

### DIFF
--- a/.claude/hooks/post-write-memory-reindex.ts
+++ b/.claude/hooks/post-write-memory-reindex.ts
@@ -2,15 +2,16 @@
 // post-write-memory-reindex.ts — PostToolUse hook: regenerates memory/MEMORY.md
 // after any Write or Edit to a memory heap file.
 //
-// Wired via .claude/settings.json PostToolUse matchers "Write" and "Edit".
+// Wired via .claude/settings.json PostToolUse matcher "Write|Edit".
 // Part of B-0259 (MEMORY.md drift enforcement).
 //
-// Trigger conditions (mirrors the generator's own exclusion list):
-//   - Path matches memory/*.md
-//   - Path is NOT memory/MEMORY.md   (the generated index itself)
-//   - Path is NOT memory/CURRENT-*.md (persona fast-path files)
-//   - Path is NOT memory/README.md   (convention doc)
-//   - Path is NOT memory/<persona>/**  (per-persona notebooks)
+// Trigger conditions (mirrors the generator's own exclusion list in
+// src/Core.TypeScript/memory/reindex-memory-md.ts collectEntriesRecursive):
+//   - Path matches memory/**/*.md  (RECURSIVE — the reindexer walks
+//     subdirectories incl. memory/<persona>/conversations/*.md)
+//   - Path is NOT a MEMORY.md   (generated index — root OR per-persona hub)
+//   - Path is NOT a CURRENT-*.md (persona fast-path files)
+//   - Path is NOT a README.md   (convention doc)
 //
 // When a trigger-qualifying path is written, runs:
 //   bun src/Core.TypeScript/memory/reindex-memory-md.ts
@@ -30,16 +31,20 @@ const EXCLUDED_FILENAMES = new Set(["MEMORY.md", "README.md"]);
 
 function isMemoryHeapFile(rawPath: string): boolean {
   // Resolve to absolute so relative paths from different CWDs work.
-  // Then recompute relative-to-cwd to match against memory/*.md pattern.
+  // Then recompute relative-to-cwd to match against memory/**/*.md.
   const abs = resolve(rawPath);
   const rel = relative(process.cwd(), abs);
 
-  // Must be directly under memory/ — not in a subdirectory.
+  // Must be anywhere under memory/ — INCLUDING subdirectories. The reindexer
+  // walks recursively (memory/<persona>/conversations/*.md etc.), so the hook
+  // must fire for those too or MEMORY.md drifts when a subtree file changes.
   const parts = rel.split("/");
-  if (parts.length !== 2) return false;
+  if (parts.length < 2) return false;
   if (parts[0] !== MEMORY_DIR) return false;
 
-  const filename = parts[1]!;
+  // Match on the basename, at any depth (mirrors the reindexer's per-file
+  // exclusions, which key off item.name regardless of directory).
+  const filename = parts[parts.length - 1]!;
   if (!filename.endsWith(".md")) return false;
   if (EXCLUDED_FILENAMES.has(filename)) return false;
   if (filename.startsWith("CURRENT-")) return false;

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,6 +34,15 @@
             "command": "bun \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/post-read-track.ts"
           }
         ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/post-write-memory-reindex.ts"
+          }
+        ]
       }
     ],
     "SessionStart": [

--- a/.github/workflows/memory-index-integrity.yml
+++ b/.github/workflows/memory-index-integrity.yml
@@ -101,11 +101,16 @@ jobs:
               memory/CURRENT-*.md)
                 :
                 ;;
-              memory/persona/*)
-                # Note: bash case `*` matches slashes (unlike
-                # pathname globbing). So this single pattern
-                # correctly covers ALL nested persona notebook
-                # paths including memory/persona/<name>/NOTEBOOK.md.
+              memory/*/*)
+                # Persona subtree: memory/<persona>/... (hubs, NOTEBOOK.md,
+                # OFFTIME.md, conversations/*.md, ferries). bash case `*`
+                # matches slashes, so this single pattern covers ALL nested
+                # persona paths at any depth. These are persona substrate —
+                # indexed opportunistically by the reindexer when they carry
+                # frontmatter, but NOT gated for frontmatter completeness here
+                # (matches the real layout memory/<persona>/, fixing the stale
+                # memory/persona/* pattern that matched nothing). Only the flat
+                # memory/*.md heap is gated.
                 :
                 ;;
               memory/*.md)


### PR DESCRIPTION
Aaron 2026-06-15 (shadow*): *"fix the skip-glob and reindex hook so this stops happening."*

Three coupled root causes behind the #8360/#8361/#8362 main-red cluster:

1. **The reindex hook was never wired.** `post-write-memory-reindex.ts` claimed to be registered for Write/Edit, but `.claude/settings.json` only had a `Read` matcher → **added `Write|Edit`**.
2. **The hook only fired at depth-2** (`memory/*.md`), but the reindexer walks **recursively** and indexes `memory/<persona>/conversations/*.md` → editing a subtree file drifted the index with no reindex → **broadened to `memory/**/*.md`**, mirroring the reindexer's exclusions (MEMORY.md/README.md/CURRENT-* by basename at any depth).
3. **The skip-glob `memory/persona/*` matched nothing** (real layout is `memory/<persona>/`) → persona ferries/hubs fell through to the frontmatter gate → **changed to `memory/*/*`** (persona subtree never gated; flat `memory/*.md` heap still gated).

**Validation:** settings.json parses; `isMemoryHeapFile` unit-checked over 9 paths; bash `case` simulated (persona hub+conversations → skip, flat heap → gate). actionlint runs in CI.

**Net:** agent Write/Edit to any memory file now auto-reindexes (no drift), and persona ferries no longer hit the frontmatter gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
