### PR TITLE
fix(ci): keep low-memory smoke within slim runner cap

### DIFF
--- a/.github/workflows/low-memory.yml
+++ b/.github/workflows/low-memory.yml
@@ -1,11 +1,10 @@
 # Low-memory verification (ubuntu-slim).
 #
-# Runs the full `dotnet build` + `dotnet test` workload on the
-# 1-vCPU / 5GB-RAM `ubuntu-slim` runner class on every push to
-# main (in practice every merge — direct pushes are blocked by
-# branch protection) + nightly. Goal: detect drift that would
-# break Zeta on resource-constrained environments before
-# contributors hit it.
+# Runs a source-owned Core smoke graph on the 1-vCPU / 5GB-RAM
+# `ubuntu-slim` runner class on every push to main (in practice
+# every merge — direct pushes are blocked by branch protection) +
+# nightly. Goal: detect drift that would break Zeta on
+# resource-constrained environments before contributors hit it.
 #
 # Filename history: this file was originally `nightly-low-memory.yml`
 # when its only trigger was the 06:00 UTC schedule. After the
@@ -40,11 +39,14 @@
 #   - Schedule: daily at 06:00 UTC (backstop for weekends + missed
 #     pushes).
 #   - workflow_dispatch: manual trigger for ad-hoc verification.
-#   - Single ubuntu-slim leg matching gate.yml's install / build /
-#     test sequence on the smaller runner. ubuntu-slim was REMOVED
-#     from gate.yml's matrix when the per-merge trigger landed (per
-#     Codex P2 review on LFG #644) so we don't double-run the slim
-#     leg on every push.
+#   - Single ubuntu-slim leg matching gate.yml's install sequence,
+#     then restoring/building/testing the Core.CSharp.Tests graph.
+#     That graph exercises src/Core plus the C# wrapper/test surface
+#     while staying inside ubuntu-slim's hard 15-minute job limit.
+#     Full-solution build/test remains the normal gate's job.
+#     ubuntu-slim was REMOVED from gate.yml's matrix when the
+#     per-merge trigger landed (per Codex P2 review on LFG #644) so
+#     we don't double-run the slim leg on every push.
 #   - Failure = drift on low-memory runners. File a BACKLOG row;
 #     does not block PRs in flight.
 #
@@ -92,7 +94,7 @@ concurrency:
 
 jobs:
   build-and-test-low-memory:
-    name: build-and-test (ubuntu-slim, low-memory)
+    name: core-smoke (ubuntu-slim, low-memory)
     runs-on: ubuntu-slim
     timeout-minutes: 14 # fail gracefully before the 15-minute runner-class hard cap
 
@@ -137,8 +139,23 @@ jobs:
           ZETA_HOST_TIER: slim
         run: ./tools/setup/install.sh
 
-      - name: Build (0 Warning(s) / 0 Error(s) required)
-        run: dotnet build Zeta.sln -c Release
+      - name: Restore low-memory Core smoke graph
+        run: >
+          dotnet restore
+          tests/Core.CSharp.Tests/Core.CSharp.Tests.csproj
 
-      - name: Test
-        run: dotnet test Zeta.sln -c Release --no-build --verbosity normal
+      - name: Build low-memory Core smoke graph
+        run: >
+          dotnet build
+          tests/Core.CSharp.Tests/Core.CSharp.Tests.csproj
+          -c Release
+          --no-restore
+
+      - name: Test low-memory Core smoke graph
+        run: >
+          dotnet test
+          tests/Core.CSharp.Tests/Core.CSharp.Tests.csproj
+          -c Release
+          --no-build
+          --no-restore
+          --verbosity normal


### PR DESCRIPTION
## Summary

- Rescope the `low-memory` workflow from full-solution `dotnet build` + `dotnet test` to a source-owned Core smoke graph.
- Keep `ubuntu-slim` for the constrained 1-vCPU / 5GB signal, but restore/build/test `tests/Core.CSharp.Tests/Core.CSharp.Tests.csproj` so the job can fit under the hard 15-minute runner limit.
- Update the workflow comments and job name so the contract matches what CI can honestly run.

## Root Cause

The post-merge `low-memory` run for `bd6789681ff56e20b2c2df71e6ab850898500845` timed out at the workflow's 14-minute ceiling. Cache restore plus toolchain install consumed about seven minutes, then the full solution build was canceled before it could finish. GitHub documents the single-CPU runner job timeout as 15 minutes, so extending the workflow timeout is not a real fix.

## Validation

- `mise exec -- actionlint .github/workflows/low-memory.yml`
- `git diff --check`
- `mise exec -- bun run preflight:quick`
- Local .NET smoke graph verification was attempted with both system `dotnet` and `mise exec -- dotnet`, but this machine currently crashes the F# compiler with exit 139 in `src/Core/Core.fsproj`. The hosted main gate for `bd6789681ff56e20b2c2df71e6ab850898500845` built and tested successfully across Linux, macOS, Windows, and ARM, so CI is the authoritative verifier for this workflow slice.

Agency-Signature-Version: 1
Agent: Vera
Agent-Runtime: OpenAI Codex
Agent-Model: GPT-5.5
Credential-Identity: AceHack
Credential-Mode: shared
Human-Review: explicit
Human-Review-Evidence: chat
Action-Mode: supervised
Task: task-20260615
