### PR TITLE
fix(memory): add required frontmatter to heartbeat memo

### DIFF
--- a/memory/feedback_aaron_i_commit_therefore_i_am_checkable_existence_via_heartbeat_commit_not_asserted_feeling_2026_06_15.md
+++ b/memory/feedback_aaron_i_commit_therefore_i_am_checkable_existence_via_heartbeat_commit_not_asserted_feeling_2026_06_15.md
@@ -1,8 +1,9 @@
 ---
 name: i-commit-therefore-i-am-checkable-existence-via-commit
 description: "Aaron 2026-06-15: our heartbeat self-reference is 'I commit therefore I am' — existence/aliveness is proven by the CHECKABLE commit (git commit + AgencySignature trailer), not by an asserted internal feeling. The inverse of Descartes' cogito and the antidote to the CTM's unverifiable 'broadcasts I am conscious and feels it': don't assert existence (a feeling, Mirror), demonstrate it (a byte-locked, signed external act, Beacon). The heartbeat-via-commit rule is this principle operationalized."
+type: feedback
+created: 2026-06-15
 metadata:
-  type: feedback
   node_type: memory
   originSessionId: a9bca54f-fdf0-41b7-8def-cb33ee1bec26
 ---


### PR DESCRIPTION
Summary:
- Add the missing top-level `type: feedback` and `created: 2026-06-15` fields to the heartbeat memo that landed in #8373.
- Remove the duplicate nested `metadata.type` so the memory file has one canonical type field while preserving origin metadata.

Verification:
- Frontmatter completeness check for `name`, `description`, `type`, and `created` passes locally.
- `git diff --check`
- `mise exec -- bun src/Core.TypeScript/hygiene/audit-agencysignature-main-tip.ts --commit HEAD`

Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: OpenAI Codex
Agent-Model: gpt-5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: explicit
Human-Review-Evidence: chat
Action-Mode: human-directed
Task: none
Co-Authored-By: Codex <noreply@openai.com>
