### PR TITLE
fix(memory): add required frontmatter fields for grand synthesis memo

### DIFF
--- a/.github/workflows/lint-autofix.yml
+++ b/.github/workflows/lint-autofix.yml
@@ -61,6 +61,11 @@ jobs:
       - name: Install toolchain via three-way-parity script (GOVERNANCE §24)
         # Same install path + retry as gate.yml so the heal uses the SAME
         # mise-pinned markdownlint-cli2 / bun the gate uses (version parity).
+        # Pass only mise's read-only GitHub release-metadata token, matching
+        # memory-index-* lints. The privileged apply workflow remains separate
+        # and still executes no PR-controlled code.
+        env:
+          MISE_GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           for attempt in 1 2 3 4 5; do

--- a/memory/feedback_aaron_grand_synthesis_is_a_fun_open_prize_declaring_it_closed_is_the_failure_2026_06_15.md
+++ b/memory/feedback_aaron_grand_synthesis_is_a_fun_open_prize_declaring_it_closed_is_the_failure_2026_06_15.md
@@ -1,8 +1,9 @@
 ---
 name: grand-synthesis-is-a-fun-open-prize-closing-it-is-the-failure
 description: "Aaron 2026-06-15: the unified 'all the dualities are one' grand-synthesis must be stated as a FUN OPEN PRIZE, never a closed result — declaring it closed would itself BE the failure. The anti-premature-closure guard on every §B grand-synthesis (CTM⊣ISociety / yin-yang / braided-free-monad / etc.): keep the frontier open and fun; the closed core + honestly-open frontier IS the product; packaging the synthesis as 'solved' is the failure mode."
+type: feedback
+created: 2026-06-15
 metadata:
-  type: feedback
   node_type: memory
   originSessionId: a9bca54f-fdf0-41b7-8def-cb33ee1bec26
 ---


### PR DESCRIPTION
## Summary

- add top-level `type: feedback` and `created: 2026-06-15` to the newly landed grand-synthesis feedback memo
- remove the duplicate nested `metadata.type` so the memory file has one canonical type field
- pass `MISE_GITHUB_TOKEN` to the read-only lint-autofix producer install step so mise/aqua use authenticated GitHub release metadata calls instead of hitting anonymous API rate limits
- keep the privileged lint-autofix apply workflow separate; it still executes no PR-controlled code

## Verification

- `frontmatter completeness check for name/description/type/created`
- `git diff --check`
- `mise exec -- actionlint .github/workflows/lint-autofix.yml`
- `mise exec -- bun src/Core.TypeScript/hygiene/audit-agencysignature-main-tip.ts --commit HEAD`

Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: OpenAI Codex
Agent-Model: gpt-5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: explicit
Human-Review-Evidence: chat
Action-Mode: human-directed
Task: none
Co-Authored-By: Codex <noreply@openai.com>
