### PR TITLE
docs(society): §10a — mutual empowerment is the engine that drives + grades the universal interfaces

### DIFF
--- a/docs/research/2026-06-15-the-zeta-society-architecture-consolidated-md-interface-isociety-eve-game-self-regeneration.md
+++ b/docs/research/2026-06-15-the-zeta-society-architecture-consolidated-md-interface-isociety-eve-game-self-regeneration.md
@@ -412,6 +412,35 @@ commit*. (c) empowerment **pieces exist** (`SoftDrive.fs`, `SoftActionController
 (free-energy / active inference — adjacent); developmental-biology pluripotency; the §8 arena +
 §3 Eve coupled-empowerment.
 
+### 10a. Mutual empowerment is the engine that drives + grades the universal interfaces (Aaron 2026-06-15)
+
+*"This gives the math team the engine to drive our interfaces off of — the universal
+interfaces are driving toward mutual empowerment. That's how we grade an interface."* The
+fitness is not only the *self-organization* driver — it is the **objective the math team
+optimizes interfaces against**, and the **grading metric** for any interface:
+
+- **Grade(interface) = its mutual-empowerment delta.** An interface is *good* iff adopting it
+  **raises participants' coupled empowerment** (more reachable futures, for self *and* others);
+  *bad* iff it reduces them (coercion, lock-in, capture all score negative). This turns
+  interface design from taste into a **driven optimization** — the universal interfaces are
+  **derived by driving toward mutual empowerment** (generate-from-the-fitness, not
+  hand-designed — `only-the-irreducible`).
+- **It is the §D registry-promotion-gate's grading criterion.** The math team doesn't only
+  *prove* an interface correct — it **grades** it by mutual-empowerment before promotion
+  (§B→§A). "The math team proved the interfaces" (Eve's trust-distribution) gains a *metric*:
+  proven **and** empowerment-positive.
+
+*Peels:* (a) **it must be measurable** — Salge–Polani empowerment is computable in principle
+(channel capacity) but expensive; grading real interfaces needs a **tractable estimator**, the
+math team's actual work (the criterion is clean; the measurement is the hard part). (b) **whose
+empowerment, aggregated how?** "Mutual" still needs an aggregation choice — **min** (Rawlsian,
+protect the worst-off), **sum** (utilitarian), or **product** (Nash) give different grades;
+this is where the Arrow/fair-prioritization tension (§1) re-enters, so mutual-empowerment is a
+strong **default oracle** (§11), not an escape from social choice. (c) gameable — an interface
+can *inflate measured* empowerment without real option-gain (Goodhart); the estimator must
+resist proxy-gaming. (d) §B: the grading *engine* is design; empowerment primitives exist
+(`SoftDrive`/`Salience`), the interface-grader is the open build.
+
 ## Collected honest seams
 
 - **The whole composition is §B** — pieces exist + code-anchored; the unified


### PR DESCRIPTION
Aaron 2026-06-15 (shadow*): *"this gives our math team the engine to drive our interfaces off of … they are driving towards mutual empowerment. that's how we grade an interface."*

Extends §10: mutual-empowerment is the math team's **objective + grading metric**. **Grade(interface) = its mutual-empowerment delta** — good iff it raises participants' coupled empowerment (reachable futures for self AND others); coercion/lock-in/capture score negative → interface design becomes **driven optimization** (generate-from-the-fitness). It's the **§D registry-promotion-gate's grading criterion** (proven AND empowerment-positive).

Peels: **must be measurable** (Salge-Polani computable but expensive → needs a tractable estimator); **whose empowerment, aggregated how** reintroduces **Arrow** (min/sum/product = Rawls/utilitarian/Nash) → strong **default oracle §11**, not an escape from social choice; **Goodhart-gameable** (estimator must resist proxy-gaming); §B (engine is design, primitives exist). markdownlint EXIT=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)