### PR TITLE
fix(memory): main-red — top-level type+created frontmatter (were nested under metadata:)

### DIFF
--- a/memory/project_decentralized_identity_unique_addressable_dependable_encrypted_heartbeat_is_the_dependable_leg_ctm_gap_2026_06_15.md
+++ b/memory/project_decentralized_identity_unique_addressable_dependable_encrypted_heartbeat_is_the_dependable_leg_ctm_gap_2026_06_15.md
@@ -1,8 +1,9 @@
 ---
 name: decentralized-identity-unique-addressable-dependable-encrypted-heartbeat-dependable-leg
 description: "Aaron 2026-06-15: decentralized identity is one of Zeta's hardest INITIAL problems — proving you are a UNIQUE, ADDRESSABLE, DEPENDABLE identity with no central authority, plus encryption. The heartbeat ('I commit therefore I am') is the DEPENDABLE leg. Ours is half-built and mapped out (ZetaId = unique; bus-address/Reticulum = addressable; heartbeat-via-commit + never-nowhere = dependable; Crypto.fs = encrypted). The CTM/consciousness framework does NOT solve this — different scope (single-machine mind, not multi-agent decentralized identity)."
+type: project
+created: 2026-06-15
 metadata:
-  type: project
   node_type: memory
   originSessionId: a9bca54f-fdf0-41b7-8def-cb33ee1bec26
 ---

--- a/memory/project_zeta_root_compression_differentiate_the_infinite_with_identity_agree_on_useful_to_continue_existing_2026_06_15.md
+++ b/memory/project_zeta_root_compression_differentiate_the_infinite_with_identity_agree_on_useful_to_continue_existing_2026_06_15.md
@@ -1,8 +1,9 @@
 ---
 name: zeta-root-compression-differentiate-the-infinite-with-identity
 description: "Aaron 2026-06-15: the one-breath root compression of the whole Zeta society arc — 'we differentiate the infinite with identity, then make them agree on what's useful enough to continue existing.' Identity = the differentiation operator on the infinite pluripotent substrate (stem cell/free object/db-DagFs); mutual-empowerment-graded, Eve-mediated agreement = the selection for continued existence (graded resourcing, never-nowhere floor, NO culling). The umbrella over the entire society arc; §B grand-synthesis, open prize."
+type: project
+created: 2026-06-15
 metadata:
-  type: project
   node_type: memory
   originSessionId: a9bca54f-fdf0-41b7-8def-cb33ee1bec26
 ---


### PR DESCRIPTION
Fixes main-red `memory-index-integrity` from 709362f65: the root-compression note had `type` nested under `metadata:` (not top-level) and no `created:`; the gate requires top-level **name/description/type/created**. Fixed both fields, and cleared the **same dormant landmine** in the decentralized-identity note (#8375 — on main with nested type / no created; would red on next edit). `reindex --check` CLEAN; markdownlint EXIT=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)