### PR TITLE
memory(project): IR-gen — trust-concentration IS the point; once compiling on 7, the IR is the single source for bugs

### DIFF
--- a/memory/project_primitive_registry_tracks_proof_and_homeostat_chains_oracle_languages_4_to_6_7_qsharp_generate_from_ir_2026_06_15.md
+++ b/memory/project_primitive_registry_tracks_proof_and_homeostat_chains_oracle_languages_4_to_6_7_qsharp_generate_from_ir_2026_06_15.md
@@ -50,7 +50,17 @@ cross-space ECC; IR-gen is how that scales to 6–7 languages without N× cost.
 all N are generated from one IR, a bug in the IR/generator is a **correlated** failure across
 all oracles (the generator becomes a single point of trust); so IR-gen trades
 duplicate-work-cost for generator-trust-concentration — the generator itself must be
-heavily verified (it's the new load-bearing oracle). (b) "7 if you count Q#" — Q# (quantum)
+heavily verified (it's the new load-bearing oracle). **Aaron's refinement (2026-06-15):
+the concentration IS the point — once you have it, "the IR becomes the single source for bugs
+over time."** That trust-concentration is the dual of **fix-concentration**: a bug is fixed
+**once in the IR and propagates to all 7** (not fixed N× by hand), so the IR **hardens over
+time** — it converges to the single most-tested correct path (every-bug-has-economic-value
+banked once, not N times; the generator-IS-the-ECC corrects drift across the oracles). **The
+genuinely-hard work is making it *compile correctly on all 7 languages*** (each oracle's type
+system / idioms / quirks) — *that* is the earning; once paid, single-source bug-fixing is the
+payoff. So peel (a) stands as a *risk to manage* (verify the generator heavily; keep some
+independent cross-checks so a generator bug is still caught) **and** as the *intended design*
+(one hardening source of truth) — both true. (b) "7 if you count Q#" — Q# (quantum)
 is a *different* execution model; counting it as a byte-lock oracle needs care (what is
 "byte-identical" for a quantum primitive?). (c) proof coverage is **partial** (the honest §B
 state) — the registry tracks *where we are*, not "all proven."


### PR DESCRIPTION
Aaron 2026-06-15 (shadow*), refining peel (a): *"making it compile on the 7 languages is part of the work that's genuinely hard, but yes once you have that the IR becomes the single source for bugs over time."*

Sharpens the primitive-registry note's peel (a): the generator-trust-concentration is the **dual of fix-concentration** — a bug fixed **once in the IR propagates to all 7** (not N× by hand), so the IR **hardens over time** (the single most-tested correct path; ΔU banked once; generator-IS-ECC corrects cross-oracle drift). The **genuinely-hard work = compiling correctly on all 7 languages** (the earning); single-source bug-fixing is the payoff. Peel (a) now stands **both** as a risk-to-manage (verify the generator; keep independent cross-checks) **and** the intended design (one hardening source of truth). markdownlint EXIT=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)