### PR TITLE
Fix OVMF 4M firmware paths for Ubuntu 24.04 CI

### DIFF
--- a/src/Core.TypeScript/ci/qemu-full-install-test.test.ts
+++ b/src/Core.TypeScript/ci/qemu-full-install-test.test.ts
@@ -3,6 +3,7 @@ import { validateSelfRegCiCoherent } from "./self-reg-serial.ts";
 import {
   detectUnexpectedControlPlaneLogin,
   extractGeneratedHostname,
+  OVMF_FIRMWARE_CANDIDATES,
 } from "./qemu-full-install-test.ts";
 
 describe("validateSelfRegCiCoherent", () => {
@@ -26,6 +27,15 @@ describe("qemu-full-install-test hostname extraction", () => {
 
   it("returns null when marker absent", () => {
     expect(extractGeneratedHostname("zeta-installer login:")).toBeNull();
+  });
+});
+
+describe("qemu-full-install-test OVMF firmware paths", () => {
+  it("prefers Ubuntu 24.04 4M OVMF pair before legacy 2M paths", () => {
+    expect(OVMF_FIRMWARE_CANDIDATES[0]).toEqual({
+      code: "/usr/share/OVMF/OVMF_CODE_4M.fd",
+      vars: "/usr/share/OVMF/OVMF_VARS_4M.fd",
+    });
   });
 });
 

--- a/src/Core.TypeScript/ci/qemu-full-install-test.ts
+++ b/src/Core.TypeScript/ci/qemu-full-install-test.ts
@@ -61,14 +61,14 @@ const CPU_COUNT = 2;
 const DISK_SIZE_GB = 20;
 const KVM_PATH = "/dev/kvm";
 
-const OVMF_CODE_CANDIDATES = [
-  "/usr/share/OVMF/OVMF_CODE.fd",
-  "/usr/share/qemu/OVMF_CODE.fd",
-] as const;
-
-const OVMF_VARS_TEMPLATE_CANDIDATES = [
-  "/usr/share/OVMF/OVMF_VARS.fd",
-  "/usr/share/qemu/OVMF_VARS.fd",
+/** Exported for unit tests. */
+export const OVMF_FIRMWARE_CANDIDATES = [
+  // Ubuntu 24.04+ / Debian 12+ (2MB images removed from ovmf package)
+  { code: "/usr/share/OVMF/OVMF_CODE_4M.fd", vars: "/usr/share/OVMF/OVMF_VARS_4M.fd" },
+  { code: "/usr/share/qemu/OVMF_CODE_4M.fd", vars: "/usr/share/qemu/OVMF_VARS_4M.fd" },
+  // Legacy 2MB images (older distros)
+  { code: "/usr/share/OVMF/OVMF_CODE.fd", vars: "/usr/share/OVMF/OVMF_VARS.fd" },
+  { code: "/usr/share/qemu/OVMF_CODE.fd", vars: "/usr/share/qemu/OVMF_VARS.fd" },
 ] as const;
 
 interface InstallResult {
@@ -129,12 +129,12 @@ function checkDependencies(): string | null {
 }
 
 function resolveOvmfFirmware(): { readonly code: string; readonly varsTemplate: string } | null {
-  const code = OVMF_CODE_CANDIDATES.find((candidate) => existsSync(candidate));
-  const varsTemplate = OVMF_VARS_TEMPLATE_CANDIDATES.find((candidate) => existsSync(candidate));
-  if (!code || !varsTemplate) {
-    return null;
+  for (const candidate of OVMF_FIRMWARE_CANDIDATES) {
+    if (existsSync(candidate.code) && existsSync(candidate.vars)) {
+      return { code: candidate.code, varsTemplate: candidate.vars };
+    }
   }
-  return { code, varsTemplate };
+  return null;
 }
 
 function prepareWritableOvmfVars(tmpDir: string, varsTemplate: string): string {


### PR DESCRIPTION
## Problem

Post-merge run #27588946713: scenario 2 failed immediately:

```
OVMF firmware not found; install via apt-get install -y ovmf
```

Ubuntu 24.04 `ovmf` package removed legacy `OVMF_CODE.fd` / `OVMF_VARS.fd`; only 4M variants exist (`OVMF_CODE_4M.fd`, `OVMF_VARS_4M.fd`).

## Fix

- Resolve **paired** CODE+VARS candidates (avoid mixing 2M/4M)
- Prefer 4M paths first for Noble runners; keep legacy fallback

## Test plan

- Unit test locks candidate order
- Merge and verify main `build-iso` scenario 2 phase 1+2