### PR TITLE
fix(observe): resolve TS2322 compile errors on SCENARIOS

### DIFF
--- a/src/Core.TypeScript/observe/simulate-tick.ts
+++ b/src/Core.TypeScript/observe/simulate-tick.ts
@@ -28,7 +28,7 @@
  *   - src/Core.TypeScript/accelerator/local-llm.ts (ollamaBackend / chooseIndex)
  */
 
-import { observe, observeWithLlm, simulate, renderAction, type BacklogItem, type World, type NextAction } from "./observe";
+import { observe, observeWithLlm, renderAction, type BacklogItem, type World, type NextAction } from "./observe";
 import { execute, type EventSink, type AppendOutcome, type OperatorPort } from "./execute";
 import { fakeExecutor, type DoItemOptions, type RunOutcome } from "./do-item";
 import { ollamaBackend, type ModelBackend } from "../accelerator/local-llm";
@@ -39,7 +39,15 @@ function item(id: string, title: string, ready = true, ambiguous = false): Backl
   return { id, title, ready, ambiguous };
 }
 
-export const SCENARIOS: Record<string, World> = {
+export const SCENARIOS: Record<string, World> & {
+  readonly empty: World;
+  readonly work: World;
+  readonly ambiguous: World;
+  readonly mixed: World;
+  readonly operator: World;
+  readonly ferry: World;
+  readonly persisted_mode: World;
+} = {
   empty: { backlog: [] },
   work: { backlog: [item("081KSIM000000001", "test-item: prove loop stability")] },
   ambiguous: { backlog: [item("081KSIM000000002", "big-item: needs decomposition", false, true)] },


### PR DESCRIPTION
## Summary

This pull request fixes the TypeScript type compilation errors introduced in #8406 under `noUncheckedIndexedAccess`. 

## Changes

- Specify explicit types for scenarios in `SCENARIOS` in [simulate-tick.ts](file:///Users/acehack/Documents/src/repos/Zeta/src/Core.TypeScript/observe/simulate-tick.ts) so that property access is correctly inferred as `World` rather than `World | undefined`.
- Remove unused `simulate` import from `src/Core.TypeScript/observe/simulate-tick.ts` to satisfy `--noUnusedLocals` / `TS6133`.

## Verification

Ran TypeScript compilation locally in an isolated worktree:
```bash
bun x tsc --noEmit
```
Status: PASS (0 errors).

Co-authored-by: Gemini <noreply@google.com>
