### PR TITLE
feat(core): make bounded GSet forgetting explicit heat

### DIFF
--- a/src/Core/BoundedGSet.fs
+++ b/src/Core/BoundedGSet.fs
@@ -2,25 +2,32 @@ namespace Zeta.Core
 
 open System.Collections.Immutable
 
-/// Which side of the canonical GSet order survives when a bounded view is full.
+/// How a bounded GSet decides what to forget when the finite room is full.
+///
+/// Forgetting is heat: every policy that evicts a materialized value reports it
+/// on the result. `RejectNew` is the cold policy: it preserves the existing
+/// view and backpressures instead of silently losing history.
 [<RequireQualifiedAccess>]
-type BoundedGSetRetention =
-    /// Keep the lowest-ranked values under the canonical comparison.
-    | KeepLowest
-    /// Keep the highest-ranked values under the canonical comparison.
+type BoundedGSetForgetPolicy =
+    /// Never evict a materialized value; reject new/out-of-window values.
+    | RejectNew
+    /// Forget the lowest-ranked values under canonical comparison.
     /// Use this for rolling logs when the key contains a monotone tick/sequence.
-    | KeepHighest
+    | ForgetLowest
+    /// Forget the highest-ranked values under canonical comparison.
+    | ForgetHighest
 
 /// Construction and merge feedback for bounded GSet views.
 [<RequireQualifiedAccess>]
 type BoundedGSetError =
     | NonPositiveCapacity of int
+    | CapacityExceeded of capacity: int * count: int
     | ConfigMismatch of left: BoundedGSetConfig * right: BoundedGSetConfig
 
 /// A deterministic capacity bound for a GSet projection.
 and BoundedGSetConfig =
     { Capacity: int
-      Retention: BoundedGSetRetention }
+      ForgetPolicy: BoundedGSetForgetPolicy }
 
 /// Admission result for adding one value to a bounded GSet view.
 [<RequireQualifiedAccess>]
@@ -29,18 +36,32 @@ type BoundedGSetAdmission =
     | AlreadyPresent
     | RejectedByBound
 
+/// Heat emitted by bounded GSet operations.
+///
+/// `Forgotten` is the materialized memory the operation had to drop to keep the
+/// room finite. A non-empty value is a smell worth investigating: maybe the
+/// room needs a larger bound, a colder policy, or a better key.
+type BoundedGSetHeat<'T when 'T : comparison> =
+    { Forgotten: GSet<'T>
+      Units: int }
+
+/// Result of projecting arbitrary input into a bounded GSet view.
+type BoundedGSetProjectionResult<'T when 'T : comparison> =
+    { State: BoundedGSet<'T>
+      Heat: BoundedGSetHeat<'T> }
+
 /// Result of a single bounded add.
-type BoundedGSetAddResult<'T when 'T : comparison> =
+and BoundedGSetAddResult<'T when 'T : comparison> =
     { State: BoundedGSet<'T>
       Admission: BoundedGSetAdmission
-      Evicted: GSet<'T> }
+      Heat: BoundedGSetHeat<'T> }
 
 /// A finite, deterministic projection of a grow-only set.
 ///
 /// This is intentionally not a replacement for `GSet<'T>`. A true GSet never
 /// forgets. `BoundedGSet<'T>` stores a materialized room-sized view of the GSet
 /// under a deterministic projection, so memory stays bounded and backpressure is
-/// visible as `RejectedByBound` or `Evicted`.
+/// visible as `RejectedByBound` or heat.
 and BoundedGSet<'T when 'T : comparison> =
     private
         { config: BoundedGSetConfig
@@ -49,7 +70,7 @@ and BoundedGSet<'T when 'T : comparison> =
     member this.Config = this.config
     member this.View = this.view
     member this.Capacity = this.config.Capacity
-    member this.Retention = this.config.Retention
+    member this.ForgetPolicy = this.config.ForgetPolicy
     member this.Count = GSet.count this.view
     member this.IsSaturated = this.Count >= this.config.Capacity
 
@@ -62,25 +83,47 @@ module BoundedGSet =
         else
             Ok config
 
-    let private keep (config: BoundedGSetConfig) (g: GSet<'T>) : GSet<'T> =
-        let items = GSet.toArray g
-        let keepCount = min config.Capacity items.Length
-
-        if keepCount = items.Length then
-            g
-        else
-            let offset =
-                match config.Retention with
-                | BoundedGSetRetention.KeepLowest -> 0
-                | BoundedGSetRetention.KeepHighest -> items.Length - keepCount
-
-            GSet<'T>(ImmutableArray.Create(items, offset, keepCount))
-
     let private difference (left: GSet<'T>) (right: GSet<'T>) : GSet<'T> =
         left
         |> GSet.toSeq
         |> Seq.filter (fun value -> not (GSet.contains value right))
         |> GSet.ofSeq
+
+    let private heatOf (forgotten: GSet<'T>) : BoundedGSetHeat<'T> =
+        { Forgotten = forgotten
+          Units = GSet.count forgotten }
+
+    let emptyHeat<'T when 'T : comparison> : BoundedGSetHeat<'T> =
+        heatOf GSet.empty<'T>
+
+    let private project
+        (config: BoundedGSetConfig)
+        (g: GSet<'T>)
+        : Result<BoundedGSetProjectionResult<'T>, BoundedGSetError> =
+        let items = GSet.toArray g
+        let keepCount = min config.Capacity items.Length
+
+        if keepCount = items.Length then
+            Ok
+                { State = { config = config; view = g }
+                  Heat = emptyHeat }
+        else
+            match config.ForgetPolicy with
+            | BoundedGSetForgetPolicy.RejectNew ->
+                Error(BoundedGSetError.CapacityExceeded(config.Capacity, items.Length))
+            | BoundedGSetForgetPolicy.ForgetHighest
+            | BoundedGSetForgetPolicy.ForgetLowest ->
+                let offset =
+                    match config.ForgetPolicy with
+                    | BoundedGSetForgetPolicy.ForgetHighest -> 0
+                    | BoundedGSetForgetPolicy.ForgetLowest -> items.Length - keepCount
+                    | BoundedGSetForgetPolicy.RejectNew -> 0
+
+                let kept = GSet<'T>(ImmutableArray.Create(items, offset, keepCount))
+
+                Ok
+                    { State = { config = config; view = kept }
+                      Heat = heatOf (difference g kept) }
 
     /// Build an empty bounded view. Invalid capacity stays on the feedback channel.
     let empty<'T when 'T : comparison>
@@ -95,11 +138,10 @@ module BoundedGSet =
     let ofSeq<'T when 'T : comparison>
         (config: BoundedGSetConfig)
         (values: seq<'T>)
-        : Result<BoundedGSet<'T>, BoundedGSetError> =
+        : Result<BoundedGSetProjectionResult<'T>, BoundedGSetError> =
         result {
             let! valid = validate config
-            let view = values |> GSet.ofSeq |> keep valid
-            return { config = valid; view = view }
+            return! values |> GSet.ofSeq |> project valid
         }
 
     /// The current finite exterior view.
@@ -122,14 +164,13 @@ module BoundedGSet =
     let union
         (left: BoundedGSet<'T>)
         (right: BoundedGSet<'T>)
-        : Result<BoundedGSet<'T>, BoundedGSetError> =
+        : Result<BoundedGSetProjectionResult<'T>, BoundedGSetError> =
         if left.Config <> right.Config then
             Error(BoundedGSetError.ConfigMismatch(left.Config, right.Config))
         else
             result {
                 let! valid = validate left.Config
-                let merged = GSet.union left.View right.View |> keep valid
-                return { config = valid; view = merged }
+                return! GSet.union left.View right.View |> project valid
             }
 
     /// Add one value to the bounded projection and report whether it survived.
@@ -140,18 +181,32 @@ module BoundedGSet =
         result {
             let! valid = validate bounded.Config
             let before = bounded.View
-            let after = GSet.add value before |> keep valid
+            let expanded = GSet.add value before
 
-            let admission =
-                if GSet.contains value before then
-                    BoundedGSetAdmission.AlreadyPresent
-                elif GSet.contains value after then
-                    BoundedGSetAdmission.Admitted
-                else
-                    BoundedGSetAdmission.RejectedByBound
+            if GSet.contains value before then
+                return
+                    { State = bounded
+                      Admission = BoundedGSetAdmission.AlreadyPresent
+                      Heat = emptyHeat }
+            else
+                match project valid expanded with
+                | Error(BoundedGSetError.CapacityExceeded _) ->
+                    return
+                        { State = bounded
+                          Admission = BoundedGSetAdmission.RejectedByBound
+                          Heat = emptyHeat }
+                | Error error ->
+                    return! Error error
+                | Ok projection ->
+                    let after = projection.State.View
+                    let admission =
+                        if GSet.contains value after then
+                            BoundedGSetAdmission.Admitted
+                        else
+                            BoundedGSetAdmission.RejectedByBound
 
-            return
-                { State = { config = valid; view = after }
-                  Admission = admission
-                  Evicted = difference before after }
+                    return
+                        { State = projection.State
+                          Admission = admission
+                          Heat = heatOf (difference before after) }
         }

--- a/src/Core/RoomHorizon.fs
+++ b/src/Core/RoomHorizon.fs
@@ -34,7 +34,7 @@ module RoomHorizon =
           Deferred: Candidate<'K, 'S> list
           RetainedKeys: GSet<'K>
           RejectedByHorizon: GSet<'K>
-          EvictedByHorizon: GSet<'K>
+          HorizonHeat: BoundedGSetHeat<'K>
           Prediction: Vision.PredictionReport<'S> }
 
     type InferenceReport<'K, 'S when 'K : comparison> =
@@ -81,11 +81,17 @@ module RoomHorizon =
     let private applyVisible
         (current: BoundedGSet<'K>)
         (boarded: Candidate<'K, 'S> list)
-        : Result<BoundedGSet<'K> * GSet<'K> * GSet<'K> * GSet<'K>, Feedback> =
-        let rec loop state retained rejected evicted rest =
+        : Result<BoundedGSet<'K> * GSet<'K> * GSet<'K> * BoundedGSetHeat<'K>, Feedback> =
+        let rec loop state retained rejected forgotten rest =
             result {
                 match rest with
-                | [] -> return state, retained, rejected, evicted
+                | [] ->
+                    return
+                        state,
+                        retained,
+                        rejected,
+                        { Forgotten = forgotten
+                          Units = GSet.count forgotten }
                 | candidate :: tail ->
                     let! addResult =
                         BoundedGSet.add candidate.Key state
@@ -103,8 +109,8 @@ module RoomHorizon =
                         | BoundedGSetAdmission.Admitted
                         | BoundedGSetAdmission.AlreadyPresent -> rejected
 
-                    let evicted' = GSet.union evicted addResult.Evicted
-                    return! loop addResult.State retained' rejected' evicted' tail
+                    let forgotten' = GSet.union forgotten addResult.Heat.Forgotten
+                    return! loop addResult.State retained' rejected' forgotten' tail
             }
 
         loop current GSet.empty GSet.empty GSet.empty boarded
@@ -123,7 +129,7 @@ module RoomHorizon =
 
             let boarded = orderedCandidates |> List.truncate prediction.Boarded.Length
             let deferred = orderedCandidates |> List.skip prediction.Boarded.Length
-            let! horizonAfter, retained, rejected, evicted = applyVisible current boarded
+            let! horizonAfter, retained, rejected, heat = applyVisible current boarded
 
             return
                 { HorizonBefore = current
@@ -133,7 +139,7 @@ module RoomHorizon =
                   Deferred = deferred
                   RetainedKeys = retained
                   RejectedByHorizon = rejected
-                  EvictedByHorizon = evicted
+                  HorizonHeat = heat
                   Prediction = prediction }
         }
 

--- a/tests/Tests.FSharp/Algebra/BoundedGSet.Tests.fs
+++ b/tests/Tests.FSharp/Algebra/BoundedGSet.Tests.fs
@@ -4,94 +4,131 @@ open FsUnit.Xunit
 open global.Xunit
 open Zeta.Core
 
-let private keepLowest3 =
+let private rejectNew3 =
     { Capacity = 3
-      Retention = BoundedGSetRetention.KeepLowest }
+      ForgetPolicy = BoundedGSetForgetPolicy.RejectNew }
 
-let private keepHighest3 =
+let private forgetHighest3 =
     { Capacity = 3
-      Retention = BoundedGSetRetention.KeepHighest }
+      ForgetPolicy = BoundedGSetForgetPolicy.ForgetHighest }
+
+let private forgetLowest3 =
+    { Capacity = 3
+      ForgetPolicy = BoundedGSetForgetPolicy.ForgetLowest }
 
 let private unwrap =
     function
     | Ok value -> value
     | Error error -> failwithf "unexpected bounded GSet error: %A" error
 
-let private ofInts config values =
+let private projectInts config values =
     BoundedGSet.ofSeq<int> config values |> unwrap
+
+let private ofInts config values =
+    (projectInts config values).State
 
 [<Fact>]
 let ``invalid capacity returns feedback instead of throwing`` () =
     let config =
         { Capacity = 0
-          Retention = BoundedGSetRetention.KeepHighest }
+          ForgetPolicy = BoundedGSetForgetPolicy.RejectNew }
 
     match BoundedGSet.empty<int> config with
     | Error(BoundedGSetError.NonPositiveCapacity 0) -> ()
     | other -> failwithf "expected NonPositiveCapacity feedback, got %A" other
 
 [<Fact>]
-let ``bounded projection keeps the configured side of canonical GSet order`` () =
-    let values = [ 5; 1; 4; 2; 3; 3 ]
-
-    ofInts keepLowest3 values
-    |> BoundedGSet.toList
-    |> should equal [ 1; 2; 3 ]
-
-    ofInts keepHighest3 values
-    |> BoundedGSet.toList
-    |> should equal [ 3; 4; 5 ]
+let ``reject-new policy backpressures instead of forgetting`` () =
+    match BoundedGSet.ofSeq<int> rejectNew3 [ 1; 2; 3; 4 ] with
+    | Error(BoundedGSetError.CapacityExceeded(capacity, count)) ->
+        capacity |> should equal 3
+        count |> should equal 4
+    | other -> failwithf "expected CapacityExceeded feedback, got %A" other
 
 [<Fact>]
-let ``rolling add reports admission rejection and eviction`` () =
-    let full = ofInts keepHighest3 [ 3; 4; 5 ]
+let ``forget policies keep the configured side and report heat`` () =
+    let values = [ 5; 1; 4; 2; 3; 3 ]
+
+    let keepLowest = projectInts forgetHighest3 values
+    keepLowest.State |> BoundedGSet.toList |> should equal [ 1; 2; 3 ]
+    keepLowest.Heat.Forgotten |> GSet.toList |> should equal [ 4; 5 ]
+    keepLowest.Heat.Units |> should equal 2
+
+    let keepHighest = projectInts forgetLowest3 values
+    keepHighest.State |> BoundedGSet.toList |> should equal [ 3; 4; 5 ]
+    keepHighest.Heat.Forgotten |> GSet.toList |> should equal [ 1; 2 ]
+    keepHighest.Heat.Units |> should equal 2
+
+[<Fact>]
+let ``cold add reports backpressure with no heat`` () =
+    let full = ofInts rejectNew3 [ 3; 4; 5 ]
+
+    let result = BoundedGSet.add 6 full |> unwrap
+    result.Admission |> should equal BoundedGSetAdmission.RejectedByBound
+    result.State |> BoundedGSet.toList |> should equal [ 3; 4; 5 ]
+    Assert.Empty(result.Heat.Forgotten |> GSet.toList)
+    result.Heat.Units |> should equal 0
+
+[<Fact>]
+let ``rolling add reports admission rejection and forgetting heat`` () =
+    let full = ofInts forgetLowest3 [ 3; 4; 5 ]
 
     let low = BoundedGSet.add 2 full |> unwrap
     low.Admission |> should equal BoundedGSetAdmission.RejectedByBound
     low.State |> BoundedGSet.toList |> should equal [ 3; 4; 5 ]
-    Assert.Equal<int list>([], GSet.toList low.Evicted)
+    Assert.Equal<int list>([], GSet.toList low.Heat.Forgotten)
+    low.Heat.Units |> should equal 0
 
     let high = BoundedGSet.add 6 full |> unwrap
     high.Admission |> should equal BoundedGSetAdmission.Admitted
     high.State |> BoundedGSet.toList |> should equal [ 4; 5; 6 ]
-    high.Evicted |> GSet.toList |> should equal [ 3 ]
+    high.Heat.Forgotten |> GSet.toList |> should equal [ 3 ]
+    high.Heat.Units |> should equal 1
 
     let duplicate = BoundedGSet.add 5 high.State |> unwrap
     duplicate.Admission |> should equal BoundedGSetAdmission.AlreadyPresent
     duplicate.State |> BoundedGSet.toList |> should equal [ 4; 5; 6 ]
-    Assert.Equal<int list>([], GSet.toList duplicate.Evicted)
+    Assert.Equal<int list>([], GSet.toList duplicate.Heat.Forgotten)
+    duplicate.Heat.Units |> should equal 0
 
 [<Fact>]
 let ``bounded union is idempotent and associative for one projection policy`` () =
-    let a = ofInts keepHighest3 [ 1; 5 ]
-    let b = ofInts keepHighest3 [ 2; 4 ]
-    let c = ofInts keepHighest3 [ 3; 6 ]
+    let a = ofInts forgetLowest3 [ 1; 5 ]
+    let b = ofInts forgetLowest3 [ 2; 4 ]
+    let c = ofInts forgetLowest3 [ 3; 6 ]
 
     BoundedGSet.union a a
     |> unwrap
+    |> fun projection -> projection.State
     |> should equal a
 
     let left =
         BoundedGSet.union a b
         |> unwrap
-        |> fun ab -> BoundedGSet.union ab c |> unwrap
+        |> fun ab ->
+            BoundedGSet.union ab.State c
+            |> unwrap
 
     let right =
         BoundedGSet.union b c
         |> unwrap
-        |> fun bc -> BoundedGSet.union a bc |> unwrap
+        |> fun bc ->
+            BoundedGSet.union a bc.State
+            |> unwrap
 
-    left |> BoundedGSet.toList |> should equal [ 4; 5; 6 ]
-    right |> BoundedGSet.toList |> should equal [ 4; 5; 6 ]
-    left |> should equal right
+    left.State |> BoundedGSet.toList |> should equal [ 4; 5; 6 ]
+    right.State |> BoundedGSet.toList |> should equal [ 4; 5; 6 ]
+    left.State |> should equal right.State
+    left.Heat.Units |> should equal 2
+    right.Heat.Units |> should equal 2
 
 [<Fact>]
 let ``bounded union rejects mismatched projection policies`` () =
-    let low = ofInts keepLowest3 [ 1; 2; 3 ]
-    let high = ofInts keepHighest3 [ 4; 5; 6 ]
+    let low = ofInts forgetHighest3 [ 1; 2; 3 ]
+    let high = ofInts forgetLowest3 [ 4; 5; 6 ]
 
     match BoundedGSet.union low high with
     | Error(BoundedGSetError.ConfigMismatch(left, right)) ->
-        left |> should equal keepLowest3
-        right |> should equal keepHighest3
+        left |> should equal forgetHighest3
+        right |> should equal forgetLowest3
     | other -> failwithf "expected ConfigMismatch feedback, got %A" other

--- a/tests/Tests.FSharp/RoomHorizon.Tests.fs
+++ b/tests/Tests.FSharp/RoomHorizon.Tests.fs
@@ -14,7 +14,7 @@ let private mustOk =
 
 let private config capacity retention =
     { Capacity = capacity
-      Retention = retention }
+      ForgetPolicy = retention }
 
 let private cost bytes : Vision.BranchCost =
     { SpaceBytes = bytes
@@ -44,7 +44,7 @@ let ``attention and gravity change boarding order while byte cost stays honest``
     let report =
         [ candidate 1 "likely" "A" 1L 1L 6L
           candidate 2 "attended" "B" 10L 2L 6L ]
-        |> RH.admit (config 2 BoundedGSetRetention.KeepHighest) (SoftThrottle.tank 6.0 0.0)
+        |> RH.admit (config 2 BoundedGSetForgetPolicy.ForgetLowest) (SoftThrottle.tank 6.0 0.0)
         |> mustOk
 
     Assert.Equal<string list>([ "attended"; "likely" ], report.Ordered |> List.map _.Branch.Label)
@@ -60,8 +60,9 @@ let ``attention and gravity change boarding order while byte cost stays honest``
 [<Fact>]
 let ``rolling horizon reports finite-view evictions separately from byte admission`` () =
     let current =
-        BoundedGSet.ofSeq<int> (config 2 BoundedGSetRetention.KeepHighest) [ 1; 2 ]
+        BoundedGSet.ofSeq<int> (config 2 BoundedGSetForgetPolicy.ForgetLowest) [ 1; 2 ]
         |> mustOk
+        |> fun projection -> projection.State
 
     let report =
         [ candidate 3 "newer" "C" 1L 1L 1L ]
@@ -72,14 +73,16 @@ let ``rolling horizon reports finite-view evictions separately from byte admissi
     Assert.Equal<string list>([ "newer" ], report.Boarded |> List.map _.Branch.Label)
     Assert.Equal<int list>([ 2; 3 ], report.HorizonAfter |> BoundedGSet.toList)
     Assert.Equal<int list>([ 3 ], report.RetainedKeys |> GSet.toList)
-    Assert.Equal<int list>([ 1 ], report.EvictedByHorizon |> GSet.toList)
+    Assert.Equal<int list>([ 1 ], report.HorizonHeat.Forgotten |> GSet.toList)
+    Assert.Equal(1, report.HorizonHeat.Units)
     Assert.Empty(report.RejectedByHorizon |> GSet.toList)
 
 [<Fact>]
 let ``paid branch can still be rejected by the finite horizon projection`` () =
     let current =
-        BoundedGSet.ofSeq<int> (config 2 BoundedGSetRetention.KeepHighest) [ 2; 3 ]
+        BoundedGSet.ofSeq<int> (config 2 BoundedGSetForgetPolicy.ForgetLowest) [ 2; 3 ]
         |> mustOk
+        |> fun projection -> projection.State
 
     let report =
         [ candidate 1 "older" "A" 1L 1L 1L ]
@@ -91,7 +94,8 @@ let ``paid branch can still be rejected by the finite horizon projection`` () =
     Assert.Equal<int list>([ 2; 3 ], report.HorizonAfter |> BoundedGSet.toList)
     Assert.Empty(report.RetainedKeys |> GSet.toList)
     Assert.Equal<int list>([ 1 ], report.RejectedByHorizon |> GSet.toList)
-    Assert.Empty(report.EvictedByHorizon |> GSet.toList)
+    Assert.Empty(report.HorizonHeat.Forgotten |> GSet.toList)
+    Assert.Equal(0, report.HorizonHeat.Units)
 
 [<Fact>]
 let ``negative attention is feedback not an ordering trick`` () =
@@ -101,7 +105,7 @@ let ``negative attention is feedback not an ordering trick`` () =
                 { Attention = PS.rat -1L 1L
                   Gravity = PS.one } }
 
-    match RH.admit (config 2 BoundedGSetRetention.KeepHighest) (SoftThrottle.tank 1.0 0.0) [ bad ] with
+    match RH.admit (config 2 BoundedGSetForgetPolicy.ForgetLowest) (SoftThrottle.tank 1.0 0.0) [ bad ] with
     | Error(RH.NegativeAttention("bad", value)) ->
         Assert.Equal(0, PS.compare value (PS.rat -1L 1L))
     | other -> Assert.Fail(sprintf "expected NegativeAttention feedback, got %A" other)
@@ -125,7 +129,7 @@ let ``inference projection keeps posterior truth separate from attended boarding
 
     let report =
         inference
-        |> RH.admitInference (config 2 BoundedGSetRetention.KeepHighest) (SoftThrottle.tank 6.0 0.0) keyOf priorityOf
+        |> RH.admitInference (config 2 BoundedGSetForgetPolicy.ForgetLowest) (SoftThrottle.tank 6.0 0.0) keyOf priorityOf
         |> mustOk
 
     Assert.Equal("likely", report.Inference.Best.Candidate.Label)
@@ -138,8 +142,9 @@ let ``inference projection keeps posterior truth separate from attended boarding
 [<Fact>]
 let ``inference projection reports finite horizon rejection after byte admission`` () =
     let current =
-        BoundedGSet.ofSeq<int> (config 2 BoundedGSetRetention.KeepHighest) [ 2; 3 ]
+        BoundedGSet.ofSeq<int> (config 2 BoundedGSetForgetPolicy.ForgetLowest) [ 2; 3 ]
         |> mustOk
+        |> fun projection -> projection.State
 
     let inference =
         [ inferredCandidate "older" "A" 1L 1L 1L ]


### PR DESCRIPTION
feat(core): make bounded GSet forgetting explicit heat

BoundedGSet now names the finite-room policy as ForgetPolicy: RejectNew for cold backpressure, ForgetLowest for rolling high-water views, and ForgetHighest for low-water views. Projection and union return heat-bearing results so any materialized forgetting is visible instead of being a silent capacity side effect.

RoomHorizon now propagates bounded-GSet forgetting as HorizonHeat while keeping byte admission and finite-view rejection as separate ledgers. Attention can still change ordering, but forgotten keys are observable heat for investigation.

Verification:

- dotnet build -c Release

- dotnet test Zeta.sln -c Release --no-build

- dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter 'FullyQualifiedName~BoundedGSet|FullyQualifiedName~RoomHorizon'

Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: OpenAI Codex
Agent-Model: gpt-5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: explicit
Human-Review-Evidence: chat
Action-Mode: human-directed
Task: none
Co-Authored-By: Codex <noreply@openai.com>