### PR TITLE
docs(society): correct the 'tradeoff' framing — instantaneous global agreement is a toy model; simulating it causes coercion

### DIFF
--- a/docs/FROZEN-CORE-AND-CONJECTURE-REGISTER.md
+++ b/docs/FROZEN-CORE-AND-CONJECTURE-REGISTER.md
@@ -68,11 +68,15 @@ So the move is **theorem over axiom**: the CTM *posits* global convergence; Zeta
 (§A #1 + #8), which is **why the relativistic/decentralized §B rows below need no global axiom**
 — their convergence rides closed §A theorems, not an open posit. (Zeta also makes **no
 unitary-experience axiom at all** — checkable existence, *"I commit therefore I am"*, substitutes
-for the asserted feeling.) **Honest scope:** CALM/#8 give **eventual, causal** convergence to the
-common frame (a real overlap window where frames differ — reconciled by the §9h heartbeat + Eve +
-0-downtime expand-contract), **not** instantaneous global agreement; that eventual-causal price is
-the relativistic cost of having no center. *This note is §A-grounded method, not a new conjecture
-— it explains why several §B rows (relativistic society, self-regen, root-compression,
+for the asserted feeling.) **Not a tradeoff (Aaron 2026-06-15):** instantaneous global agreement
+is a **toy model, not physical reality** (relativity forbids it) — so "giving it up" gives up a
+**fiction**; and **simulating** that fiction **causes coercion** (forcing genuinely-distinct
+causal frames to one state = NCI violation = **register-collapse §8** = killing decorrelation).
+So CALM/#8's **eventual, causal, per-frame** convergence (overlap window reconciled by §9h
+heartbeat + Eve + 0-downtime expand-contract) is **not a price** — it is **physical reality AND
+non-coercive AND decorrelation-preserving**; the CTM's global axiom is *non-physical*,
+*coercive-to-pursue*, **and** *register-collapsing*. *This note is §A-grounded method, not a new
+conjecture — it explains why several §B rows (relativistic society, self-regen, root-compression,
 terraform-into-cell) can assume no-global without an axiom.* Detail: consolidated society note §9h.
 
 ## B. THE CONJECTURE REGISTER (open — frontier, NOT floor; nothing in §A depends on these)

--- a/docs/research/2026-06-15-the-zeta-society-architecture-consolidated-md-interface-isociety-eve-game-self-regeneration.md
+++ b/docs/research/2026-06-15-the-zeta-society-architecture-consolidated-md-interface-isociety-eve-game-self-regeneration.md
@@ -584,14 +584,24 @@ a **theorem, not a posit**:
   agreement). We build on provable laws (measure), play with feelings (sim) — never axiomatize
   the feeling.
 
-*The honest tradeoff:* the CTM's global broadcast buys **instantaneous global unitary state** —
-at the price of **needing "global"** (a central frame/bus). CALM buys **decentralization +
-relativity + scale-free** — at the price of **eventual** (not instantaneous) **causal**
-convergence: a real **overlap window** where frames legitimately disagree (the relativistic
-gap; reconciled by §9h heartbeat + Eve, and by the 0-downtime expand-contract). So we didn't
-trade one global axiom for another — **we traded the global *axiom* for a coordination-free
-*theorem* (CALM) plus a checkable existence claim**, accepting eventual-causal convergence as
-the relativistic price of having no center.
+*Not a tradeoff — there was nothing real to give up (Aaron 2026-06-15).* **Instantaneous
+global agreement is a *toy model*, not physical reality** — relativity forbids it (no global
+"now", finite information speed, relative simultaneity; only-math-and-physics-tell-truth says
+*no*). So "giving it up" gives up **a fiction**, not a capability. Worse: **trying to *simulate*
+that fiction *causes coercion*** — to fake one global state across agents that genuinely have
+their own causal frames, you must **force** them to a shared state, overriding their frames.
+That forcing **is coercion (NCI violation)**, and it is exactly **register-collapse (§8)** —
+collapsing distinct registers into one **kills the decorrelation** the society's intelligence
+needs. So the scorecard inverts: **eventual, causal, per-frame convergence (CALM/#8) is not a
+*price* — it is physical reality AND the non-coercive AND the decorrelation-preserving option,
+all at once.** The CTM's global axiom is therefore *non-physical*, *coercive-to-pursue*, **and**
+*register-collapsing*; Zeta's relativistic convergence (proven, §A #1+#8) is the only one that's
+physical and non-coercive. (The **overlap window** — frames legitimately differing until they
+causally converge, reconciled by §9h heartbeat + Eve + 0-downtime expand-contract — is not a
+defect; it *is* what having genuine independent frames looks like.) *Peel:* within one trusting,
+low-latency cluster, consensus (Paxos/Raft) approximates "global" cheaply — the coercion bites
+in proportion to how **genuinely sovereign/decorrelated** the frames are; forcing agreement is
+coercive exactly when the frame-differences are real (which, across a real society, they are).
 
 - **The fair competition = our default game = the aliveness core (partly PROVEN).** Liveness/
   aliveness is specced and proven, not just conjectured — `docs/MATH-SPEC-TESTS.md`,


### PR DESCRIPTION
Aaron 2026-06-15 (shadow*): *"instantaneous global agreement is a toy model anyways, it's not physical reality, and trying to simulate it causes coercion."*

Corrects Otto's too-generous **"honest tradeoff / relativistic price"** framing (§9h + register A-method note): **there was nothing real to give up** — instantaneous global agreement is **non-physical** (relativity forbids it), so "giving it up" gives up a **fiction**; and **simulating** it **causes coercion** (forcing genuinely-distinct causal frames to one state = NCI violation = **register-collapse §8** = killing decorrelation). So CALM/#8's eventual/causal/per-frame convergence is **not a price** — it's **physical reality AND non-coercive AND decorrelation-preserving**; the CTM's global axiom is *non-physical*, *coercive-to-pursue*, **and** *register-collapsing*. **Peel:** within one trusting low-latency cluster, consensus approximates global cheaply — coercion bites in proportion to how genuinely sovereign the frames are. markdownlint EXIT=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)