### PR TITLE
feat(core): route soft prune heat through sinks

### DIFF
--- a/src/Core/Injection.fs
+++ b/src/Core/Injection.fs
@@ -63,6 +63,109 @@ type IMetricsSink =
     abstract RecordAllocations: bytes: int64 -> unit
 
 
+/// A deterministic heat signature for information loss at a room boundary.
+///
+/// The emitting subsystem should keep the detailed lost payload locally only
+/// when it can afford to; this signature is the small host-facing smell:
+/// source, kind, units, and fixed-point mass. `MassPpm` is parts per million so
+/// cross-language tests can compare integers instead of float formatting.
+type HeatSignature =
+    { Source: string
+      Kind: string
+      Units: int
+      MassPpm: int64
+      Detail: string }
+
+
+[<RequireQualifiedAccess>]
+module HeatSignature =
+
+    let ofMass (source: string) (kind: string) (units: int) (mass: double) (detail: string) : HeatSignature =
+        let ppm =
+            if Double.IsNaN mass || Double.IsInfinity mass then
+                0L
+            else
+                int64 (Math.Round(max 0.0 mass * 1_000_000.0))
+
+        { Source = source
+          Kind = kind
+          Units = max 0 units
+          MassPpm = ppm
+          Detail = detail }
+
+
+/// Feedback from the injected heat sink. Heat is diagnostic output, but the
+/// sink still has a budget; if even the heat cannot fit, report backpressure
+/// rather than recursively losing the loss signal.
+[<RequireQualifiedAccess>]
+type HeatSinkFeedback =
+    | Backpressure of heat: HeatSignature * capacity: int * count: int
+    | StorageError of BoundedGSetError
+
+
+/// Injected IO port for heat. Production can export these signatures to host
+/// telemetry; tests can bind a recorder; tiny rooms can bind a bounded in-room
+/// store and learn when the heat channel itself saturates.
+type IHeatSink =
+    abstract Emit: heat: HeatSignature -> Result<unit, HeatSinkFeedback>
+
+
+[<Sealed>]
+type NullHeatSink() =
+    interface IHeatSink with
+        member _.Emit _ = Ok()
+
+
+[<Sealed>]
+type RecordingHeatSink() =
+    let signatures = List<HeatSignature>()
+    let lockObj = obj ()
+    member _.Signatures : IReadOnlyList<HeatSignature> = upcast signatures
+    interface IHeatSink with
+        member _.Emit heat =
+            lock lockObj (fun () -> signatures.Add heat)
+            Ok()
+
+
+/// Bounded in-room heat storage. Use `RejectNew` for the no-forget mode; use a
+/// forgetting policy only for experiments that explicitly measure heat-channel
+/// self-shedding via `StorageHeat`.
+[<Sealed>]
+type BoundedHeatSink(config: BoundedGSetConfig) =
+    let lockObj = obj ()
+    let mutable state = BoundedGSet.empty<HeatSignature> config
+    let mutable storageHeat = BoundedGSet.emptyHeat<HeatSignature>
+
+    member _.Stored : HeatSignature list =
+        lock lockObj (fun () ->
+            match state with
+            | Ok s -> BoundedGSet.toList s
+            | Error _ -> [])
+
+    member _.StorageHeat : BoundedGSetHeat<HeatSignature> =
+        lock lockObj (fun () -> storageHeat)
+
+    interface IHeatSink with
+        member _.Emit heat =
+            lock lockObj (fun () ->
+                match state with
+                | Error e -> Error(HeatSinkFeedback.StorageError e)
+                | Ok s ->
+                    match BoundedGSet.add heat s with
+                    | Error e -> Error(HeatSinkFeedback.StorageError e)
+                    | Ok added ->
+                        match added.Admission with
+                        | BoundedGSetAdmission.RejectedByBound ->
+                            Error(HeatSinkFeedback.Backpressure(heat, s.Capacity, s.Count + 1))
+                        | BoundedGSetAdmission.Admitted
+                        | BoundedGSetAdmission.AlreadyPresent ->
+                            state <- Ok added.State
+                            storageHeat <-
+                                { Forgotten = GSet.union storageHeat.Forgotten added.Heat.Forgotten
+                                  Units = storageHeat.Units + added.Heat.Units }
+                            Ok())
+
+
 /// Default sink routes to `DbspMetrics` (System.Diagnostics.Metrics).
 [<Sealed>]
 type DefaultMetricsSink() =

--- a/src/Core/SoftDrive.fs
+++ b/src/Core/SoftDrive.fs
@@ -33,6 +33,15 @@ module SoftDrive =
     let private actions: bool[] list =
         SoftController.none :: [ for k in 0..15 -> SoftController.singleKey k ]
 
+    let private collectResults (results: Result<'a, 'e> list) : Result<'a list, 'e> =
+        let rec loop acc rest =
+            match rest with
+            | [] -> Ok(List.rev acc)
+            | Ok value :: tail -> loop (value :: acc) tail
+            | Error e :: _ -> Error e
+
+        loop [] results
+
     /// **The planner:** the best immediate control input from the hard state `hard`, chosen by soft rollout.
     /// For each candidate action, commit it once, roll out `depth` soft steps (capped to `width`), and take the
     /// expected `value` over the resulting ensemble; return the action whose rollout scores highest.
@@ -78,11 +87,55 @@ module SoftDrive =
                 s <- SoftEmu.softFrame cyclesPerFrame s |> SoftEmu.prune width
             SoftEmu.expect value s)
 
+    /// Frame-aware planner with heat exported through an injected boundary.
+    /// Use a host sink to pass heat outside the tiny CHIP-8 room, or a
+    /// `BoundedHeatSink` to measure how much heat the room can carry before
+    /// the heat channel itself backpressures.
+    let bestFrameActionWithHeatSink
+        (source: string)
+        (sink: IHeatSink)
+        (value: Chip8Cow.Frame -> float)
+        (cyclesPerFrame: int)
+        (depth: int)
+        (width: int)
+        (hard: Chip8Cow.Frame)
+        : Result<bool[], HeatSinkFeedback> =
+
+        actions
+        |> List.map (fun keys ->
+            let started = Chip8Cow.frameStep cyclesPerFrame { hard with Keys = keys }
+            let mutable s = SoftEmu.pure1 started
+            let mutable error: HeatSinkFeedback option = None
+            for _ in 1 .. max 0 depth do
+                if Option.isNone error then
+                    match SoftEmu.softFrame cyclesPerFrame s |> SoftEmu.pruneWithHeatSink source sink width with
+                    | Ok report -> s <- report.State
+                    | Error e -> error <- Some e
+
+            match error with
+            | Some e -> Error e
+            | None -> Ok(keys, SoftEmu.expect value s))
+        |> collectResults
+        |> Result.map (List.maxBy snd >> fst)
+
     /// **One live control step:** plan the best action, commit it to one full `frameStep` (steps + tick). Unlike
     /// `controlStep` this keeps timers advancing, so delay-wait ROMs don't freeze.
     let frameControlStep (value: Chip8Cow.Frame -> float) (cyclesPerFrame: int) (depth: int) (width: int) (hard: Chip8Cow.Frame) : Chip8Cow.Frame =
         let keys = bestFrameAction value cyclesPerFrame depth width hard
         Chip8Cow.frameStep cyclesPerFrame { hard with Keys = keys }
+
+    /// One live control step with pruning heat routed through an injected sink.
+    let frameControlStepWithHeatSink
+        (source: string)
+        (sink: IHeatSink)
+        (value: Chip8Cow.Frame -> float)
+        (cyclesPerFrame: int)
+        (depth: int)
+        (width: int)
+        (hard: Chip8Cow.Frame)
+        : Result<Chip8Cow.Frame, HeatSinkFeedback> =
+        bestFrameActionWithHeatSink source sink value cyclesPerFrame depth width hard
+        |> Result.map (fun keys -> Chip8Cow.frameStep cyclesPerFrame { hard with Keys = keys })
 
     /// **Drive the hard emulator for `frames` live control frames** (the live receding-horizon loop). Deterministic.
     let driveFrames (value: Chip8Cow.Frame -> float) (cyclesPerFrame: int) (depth: int) (width: int) (frames: int) (hard: Chip8Cow.Frame) : Chip8Cow.Frame =
@@ -90,3 +143,28 @@ module SoftDrive =
         for _ in 1 .. max 0 frames do
             cur <- frameControlStep value cyclesPerFrame depth width cur
         cur
+
+    /// Drive live control frames while exporting pruning heat. A sink failure
+    /// stops the run with feedback instead of letting the tiny CHIP-8 room
+    /// pretend erased futures were free.
+    let driveFramesWithHeatSink
+        (source: string)
+        (sink: IHeatSink)
+        (value: Chip8Cow.Frame -> float)
+        (cyclesPerFrame: int)
+        (depth: int)
+        (width: int)
+        (frames: int)
+        (hard: Chip8Cow.Frame)
+        : Result<Chip8Cow.Frame, HeatSinkFeedback> =
+        let mutable cur = hard
+        let mutable error: HeatSinkFeedback option = None
+        for _ in 1 .. max 0 frames do
+            if Option.isNone error then
+                match frameControlStepWithHeatSink source sink value cyclesPerFrame depth width cur with
+                | Ok next -> cur <- next
+                | Error e -> error <- Some e
+
+        match error with
+        | Some e -> Error e
+        | None -> Ok cur

--- a/src/Core/SoftEmu.fs
+++ b/src/Core/SoftEmu.fs
@@ -1,5 +1,7 @@
 namespace Zeta.Core
 
+open System
+
 /// **`SoftEmu` — the WHOLE CHIP-8 emulator as one soft value (Aaron 2026-06-08, shadow*).**
 ///
 /// Aaron: *"we have a CAS-less, lockless, purely soft emulator — this is insane to have the whole emu soft."*
@@ -23,7 +25,9 @@ namespace Zeta.Core
 ///
 /// **Honest scope (peel):** branching doubles the ensemble at each input opcode → unbounded growth; `prune`
 /// (the throttle / `FerryThrottler` breadth knob) caps it by keeping the top-weighted members — a *lossy*
-/// truncation (the dropped tail is logged by `support` shrinking, not silently). No per-cell factoring here
+/// truncation. The typed pruning APIs report the dropped tail as heat: if the room cannot afford to keep
+/// all futures, that information loss must be visible instead of hiding inside a smaller support count.
+/// No per-cell factoring here
 /// (that is the further mean-field compression; this ensemble keeps correlations exact at the cost of width).
 /// Prior art anchors: symbolic execution (KLEE/angr — fork-on-branch), probabilistic-program semantics (Kozen),
 /// planning over emulator state (ALE/MuZero — take-every-branch-score-collapse). The *synthesis* (exact
@@ -35,7 +39,65 @@ module SoftEmu =
     /// weights > 0, weights sum to 1 after `normalize`). CAS-less (a plain list), lockless (immutable frames).
     type Soft = (Chip8Cow.Frame * float) list
 
+    /// How a finite soft room handles an ensemble wider than its support budget.
+    [<RequireQualifiedAccess>]
+    type SoftPrunePolicy =
+        /// Keep every current branch and report backpressure instead of erasing futures.
+        | RejectNew
+        /// Keep the highest-weight branches and report the dropped tail as heat.
+        | KeepHighestWeight
+
+    /// Feedback for cold/no-forget pruning.
+    [<RequireQualifiedAccess>]
+    type SoftPruneFeedback =
+        | SupportExceeded of limit: int * support: int
+
+    /// Heat emitted by lossy soft-ensemble pruning.
+    ///
+    /// `DroppedBranches` carries the pre-renormalization branch weights that no
+    /// longer participate in the ensemble. `DroppedMass` is the probability mass
+    /// that had to be redistributed over the retained branches.
+    type SoftEmuHeat =
+        { DroppedBranches: (Chip8Cow.Frame * float) list
+          DroppedSupport: int
+          DroppedMass: float
+          RenormalizationGain: float }
+
+    type SoftPruneReport =
+        { State: Soft
+          Heat: SoftEmuHeat }
+
     let private EPS = 1e-12
+
+    let emptyHeat =
+        { DroppedBranches = []
+          DroppedSupport = 0
+          DroppedMass = 0.0
+          RenormalizationGain = 1.0 }
+
+    let private heatOf (keptMass: float) (dropped: Soft) : SoftEmuHeat =
+        let droppedMass = dropped |> List.sumBy snd
+
+        { DroppedBranches = dropped
+          DroppedSupport = List.length dropped
+          DroppedMass = droppedMass
+          RenormalizationGain = if keptMass <= EPS then 0.0 else 1.0 / keptMass }
+
+    let private millionths (value: float) : int64 =
+        if Double.IsNaN value || Double.IsInfinity value then
+            0L
+        else
+            int64 (Math.Round(max 0.0 value * 1_000_000.0))
+
+    /// Compact host-facing heat signature for a lossy soft-ensemble prune.
+    let heatSignature (source: string) (heat: SoftEmuHeat) : HeatSignature =
+        let detail =
+            sprintf
+                "droppedSupport=%d;renormalizationGainPpm=%d"
+                heat.DroppedSupport
+                (millionths heat.RenormalizationGain)
+
+        HeatSignature.ofMass source "soft-emu.prune" heat.DroppedSupport heat.DroppedMass detail
 
     /// Renormalize weights to sum to 1 (drops non-positive). Empty input ⇒ empty (no fabricated certainty).
     let normalize (s: Soft) : Soft =
@@ -73,14 +135,80 @@ module SoftEmu =
             cur <- softStep cur
         cur
 
-    /// **The throttle / breadth knob:** keep at most `k` highest-weighted branches, renormalize. Lossy by
-    /// design — the dropped tail shows up as `support` no longer doubling (not silent). `k ≤ 0` ⇒ unchanged.
+    /// **The throttle / breadth knob with an explicit policy.**
+    ///
+    /// `RejectNew` is the cold/no-forget option: if the ensemble is too wide,
+    /// it returns typed backpressure and keeps the caller's state untouched.
+    /// `KeepHighestWeight` is lossy by design, but emits the dropped tail as
+    /// heat before renormalizing the retained branches.
+    let pruneWithPolicy (policy: SoftPrunePolicy) (k: int) (s: Soft) : Result<SoftPruneReport, SoftPruneFeedback> =
+        if k <= 0 || List.length s <= k then
+            Ok { State = s; Heat = emptyHeat }
+        else
+            match policy with
+            | SoftPrunePolicy.RejectNew -> Error(SoftPruneFeedback.SupportExceeded(k, List.length s))
+            | SoftPrunePolicy.KeepHighestWeight ->
+                let sorted = s |> List.sortByDescending snd
+                let kept = sorted |> List.truncate k
+                let dropped = sorted |> List.skip k
+                let keptMass = kept |> List.sumBy snd
+
+                Ok
+                    { State = normalize kept
+                      Heat = heatOf keptMass dropped }
+
+    /// Lossy pruning with a heat report.
+    let pruneWithHeat (k: int) (s: Soft) : SoftPruneReport =
+        match pruneWithPolicy SoftPrunePolicy.KeepHighestWeight k s with
+        | Ok report -> report
+        | Error _ -> { State = s; Heat = emptyHeat }
+
+    /// Emit pruning heat through an injected host/in-room IO port. No heat is
+    /// emitted for cold no-op prunes; sink backpressure stays on the feedback
+    /// channel so the CHIP-8 room never has to swallow its own lost futures.
+    let emitHeat (source: string) (sink: IHeatSink) (report: SoftPruneReport) : Result<SoftPruneReport, HeatSinkFeedback> =
+        if report.Heat.DroppedSupport = 0 then
+            Ok report
+        else
+            sink.Emit(heatSignature source report.Heat)
+            |> Result.map (fun () -> report)
+
+    /// Lossy prune and immediately export the heat signature through the
+    /// injected boundary.
+    let pruneWithHeatSink
+        (source: string)
+        (sink: IHeatSink)
+        (k: int)
+        (s: Soft)
+        : Result<SoftPruneReport, HeatSinkFeedback> =
+        pruneWithHeat k s |> emitHeat source sink
+
+    /// Cold/no-forget pruning: returns backpressure instead of erasing futures.
+    let pruneOrBackpressure (k: int) (s: Soft) : Result<SoftPruneReport, SoftPruneFeedback> =
+        pruneWithPolicy SoftPrunePolicy.RejectNew k s
+
+    /// Compatibility state projection. Prefer `pruneWithHeat` when a caller can
+    /// carry debugging heat forward.
     let prune (k: int) (s: Soft) : Soft =
-        if k <= 0 || List.length s <= k then s
-        else s |> List.sortByDescending snd |> List.truncate k |> normalize
+        (pruneWithHeat k s).State
 
     /// One throttled soft step: advance, then cap width to `k` (the `FerryThrottler` breadth budget per tick).
-    let throttledStep (k: int) (s: Soft) : Soft = softStep s |> prune k
+    let throttledStepWithHeat (k: int) (s: Soft) : SoftPruneReport =
+        softStep s |> pruneWithHeat k
+
+    /// One throttled step with heat exported through an injected boundary.
+    let throttledStepWithHeatSink
+        (source: string)
+        (sink: IHeatSink)
+        (k: int)
+        (s: Soft)
+        : Result<SoftPruneReport, HeatSinkFeedback> =
+        throttledStepWithHeat k s |> emitHeat source sink
+
+    /// One throttled soft step projected to state only. Prefer `throttledStepWithHeat`
+    /// when the dropped branch tail is diagnostically relevant.
+    let throttledStep (k: int) (s: Soft) : Soft =
+        (throttledStepWithHeat k s).State
 
     /// **Collapse — the ONE legitimate definite choice (never silent):** the single frame maximizing `value`
     /// (a fitness / empowerment fn). This is "take every branch, score, collapse to the best" (Aaron #7090).

--- a/tests/Tests.FSharp/SoftDrive.Tests.fs
+++ b/tests/Tests.FSharp/SoftDrive.Tests.fs
@@ -37,6 +37,9 @@ let ``a control step advances exactly one hard step (PC moves once)`` () =
 // delay-wait ROM: 6305 F315 F207 3200 1206 — step-based drive would freeze; frame-aware keeps it live
 let private delayWait = [| 0x63uy; 0x05uy; 0xF3uy; 0x15uy; 0xF2uy; 0x07uy; 0x32uy; 0x00uy; 0x12uy; 0x06uy |]
 
+// 6000 E09E 6001 — first frame reaches an input branch; the soft rollout then forks.
+let private inputAfterOne = [| 0x60uy; 0x00uy; 0xE0uy; 0x9Euy; 0x60uy; 0x01uy |]
+
 [<Fact>]
 let ``frame-aware driveFrames stays LIVE on a delay-wait ROM (ticks the timer down)`` () =
     let setup = Chip8Cow.run 2 (Chip8Cow.create 1UL |> Chip8Cow.loadRom delayWait) // delay = 5, in wait loop
@@ -54,3 +57,20 @@ let ``frame-aware drive is deterministic (DST)`` () =
 let ``bestFrameAction returns a valid 16-key vector`` () =
     let keys = SoftDrive.bestFrameAction SoftDashboard.sumMemory 8 2 4 (hard ())
     Assert.Equal(16, keys.Length)
+
+[<Fact>]
+let ``frame-aware driveFramesWithHeatSink exports prune heat to host`` () =
+    let setup = Chip8Cow.create 1UL |> Chip8Cow.loadRom inputAfterOne
+    let recorder = RecordingHeatSink()
+
+    match SoftDrive.driveFramesWithHeatSink "chip8-room" (recorder :> IHeatSink) SoftDashboard.sumMemory 1 1 1 1 setup with
+    | Error e -> Assert.True(false, sprintf "unexpected heat sink feedback: %A" e)
+    | Ok _ ->
+        let signatures = recorder.Signatures |> Seq.toList
+        Assert.NotEmpty signatures
+        Assert.All(
+            signatures,
+            fun heat ->
+                Assert.Equal("chip8-room", heat.Source)
+                Assert.Equal("soft-emu.prune", heat.Kind)
+                Assert.Equal(1, heat.Units))

--- a/tests/Tests.FSharp/SoftEmu.Tests.fs
+++ b/tests/Tests.FSharp/SoftEmu.Tests.fs
@@ -41,6 +41,73 @@ let ``prune caps ensemble width (the throttle breadth knob)`` () =
     Assert.Equal(1.0, capped |> List.sumBy snd, 9)
 
 [<Fact>]
+let ``pruneWithHeat emits dropped branch mass as heat`` () =
+    let grown = SoftEmu.softRun 1 (inputStart ())
+    let report = SoftEmu.pruneWithHeat 1 grown
+    Assert.Equal(1, SoftEmu.support report.State)
+    Assert.Equal(1, report.Heat.DroppedSupport)
+    Assert.Equal(0.5, report.Heat.DroppedMass, 9)
+    Assert.Equal(2.0, report.Heat.RenormalizationGain, 9)
+    Assert.Equal(1.0, report.State |> List.sumBy snd, 9)
+
+[<Fact>]
+let ``pruneOrBackpressure is the no-forget cold policy`` () =
+    let grown = SoftEmu.softRun 1 (inputStart ())
+    match SoftEmu.pruneOrBackpressure 1 grown with
+    | Ok _ -> Assert.True(false, "cold pruning must not silently drop a branch")
+    | Error(SoftEmu.SoftPruneFeedback.SupportExceeded(limit, support)) ->
+        Assert.Equal(1, limit)
+        Assert.Equal(2, support)
+
+[<Fact>]
+let ``throttledStepWithHeat reports branch pruning heat`` () =
+    let report = SoftEmu.throttledStepWithHeat 1 (inputStart ())
+    Assert.Equal(1, SoftEmu.support report.State)
+    Assert.Equal(1, report.Heat.DroppedSupport)
+    Assert.Equal(0.5, report.Heat.DroppedMass, 9)
+
+[<Fact>]
+let ``pruneWithHeatSink exports CHIP8 heat to an injected host port`` () =
+    let grown = SoftEmu.softRun 1 (inputStart ())
+    let recorder = RecordingHeatSink()
+
+    match SoftEmu.pruneWithHeatSink "chip8-room" (recorder :> IHeatSink) 1 grown with
+    | Error e -> Assert.True(false, sprintf "unexpected heat sink feedback: %A" e)
+    | Ok report ->
+        Assert.Equal(1, report.Heat.DroppedSupport)
+        let signatures = recorder.Signatures |> Seq.toList
+        Assert.Single signatures |> ignore
+        let heat = signatures.Head
+        Assert.Equal("chip8-room", heat.Source)
+        Assert.Equal("soft-emu.prune", heat.Kind)
+        Assert.Equal(1, heat.Units)
+        Assert.Equal(500000L, heat.MassPpm)
+
+[<Fact>]
+let ``bounded in-room heat sink backpressures instead of forgetting heat`` () =
+    let sink =
+        BoundedHeatSink
+            { Capacity = 1
+              ForgetPolicy = BoundedGSetForgetPolicy.RejectNew }
+
+    let port = sink :> IHeatSink
+    let first = HeatSignature.ofMass "chip8-a" "soft-emu.prune" 1 0.5 "a"
+    let second = HeatSignature.ofMass "chip8-b" "soft-emu.prune" 1 0.25 "b"
+
+    match port.Emit first with
+    | Error e -> Assert.True(false, sprintf "unexpected first heat feedback: %A" e)
+    | Ok () -> ()
+
+    match port.Emit second with
+    | Ok () -> Assert.True(false, "bounded heat sink must backpressure when full")
+    | Error(HeatSinkFeedback.Backpressure(heat, capacity, count)) ->
+        Assert.Equal(second, heat)
+        Assert.Equal(1, capacity)
+        Assert.Equal(2, count)
+        Assert.Equal<HeatSignature list>([ first ], sink.Stored)
+    | Error e -> Assert.True(false, sprintf "unexpected heat feedback: %A" e)
+
+[<Fact>]
 let ``entropy is zero for a point mass, positive once branched`` () =
     Assert.Equal(0.0, SoftEmu.entropy (start ()), 9)
     Assert.True(SoftEmu.entropy (SoftEmu.softRun 1 (inputStart ())) > 0.0)


### PR DESCRIPTION
feat(core): route soft prune heat through sinks

Information loss in tiny CHIP-8 rooms should cross an explicit boundary instead of hiding inside a smaller support count.

Adds a reusable HeatSignature/IHeatSink port with null, recording, and bounded in-room implementations. SoftEmu pruning now reports dropped branch support/mass, supports a no-forget backpressure policy, and can export heat through an injected sink. SoftDrive's live frame loop now has heat-sink variants so host export and bounded in-room measurement are both testable.

Verification:

- dotnet build -c Release

- dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter 'FullyQualifiedName~SoftEmu|FullyQualifiedName~SoftDrive'

- dotnet test Zeta.sln -c Release --no-build

Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: OpenAI Codex
Agent-Model: gpt-5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: explicit
Human-Review-Evidence: chat
Action-Mode: human-directed
Task: none
Co-Authored-By: Codex <noreply@openai.com>

