### PR TITLE
feat(core): add host-assisted meta-cart launch

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -325,6 +325,7 @@
     <Compile Include="ConformalGA.fs" />
     <Compile Include="Salon.fs" />
     <Compile Include="GameCatalog.fs" />
+    <Compile Include="MetaCart.fs" />
     <Compile Include="ControlMerge.fs" />
     <Compile Include="PolarityFilter.fs" />
     <Compile Include="ZetaExec.fs" />

--- a/src/Core/MetaCart.fs
+++ b/src/Core/MetaCart.fs
@@ -1,0 +1,161 @@
+namespace Zeta.Core
+
+/// Host-assisted cart hosting for the first "cart that can play carts" slice.
+///
+/// The parent CHIP-8 room still chooses from inside the VM by writing the
+/// existing `Chip8Arcade.choiceCell`. The host owns the bytes and execution
+/// boundary: the parent selects an ordered `CartSlot`, the injected `ICartHost`
+/// resolves and plays it, and any refusal emits heat through the injected
+/// `IHeatSink`.
+[<RequireQualifiedAccess>]
+module MetaCart =
+
+    let private inv = System.Globalization.CultureInfo.InvariantCulture
+
+    /// The tiny ABI visible to the parent cart: a stable name and the child
+    /// ROM's content fingerprint. Carrying vs referencing is a host concern.
+    type CartSlot =
+        { Name: string
+          Fingerprint: GameFingerprint.Fingerprint }
+
+    /// Host-visible rows returned from a child play. These are deliberately
+    /// small observables, not a second serialized savestate format.
+    type ObservableRow = { Key: string; Value: string }
+
+    type PlayRequest =
+        { Source: string
+          Slot: CartSlot }
+
+    type PlayResult =
+        { Slot: CartSlot
+          FinalFrame: Chip8Cow.Frame
+          Rows: ObservableRow list }
+
+    [<RequireQualifiedAccess>]
+    type Feedback =
+        | NoSelection of source: string
+        | MissingCart of slot: CartSlot
+        | HostDenied of slot: CartSlot * reason: string
+        | HeatRejected of slot: CartSlot * feedback: HeatSinkFeedback
+
+    /// Injected host boundary for child-cart resolution/execution.
+    type ICartHost =
+        abstract Play: request: PlayRequest -> Result<PlayResult, Feedback>
+
+    let slotOfCart (cart: Cart.Cart) : CartSlot =
+        { Name = cart.Meta.Title
+          Fingerprint = GameFingerprint.fingerprint cart.Rom }
+
+    let reference (name: string) (fingerprint: GameFingerprint.Fingerprint) : CartSlot =
+        { Name = name
+          Fingerprint = fingerprint }
+
+    let slotsOfCarts (carts: Cart.Cart list) : CartSlot list = carts |> List.map slotOfCart
+
+    /// Read the parent VM's choice using the same one-byte treaty as
+    /// `Chip8Arcade.readChoice`, but return the fingerprint slot rather than
+    /// raw ROM bytes.
+    let readSlot (slots: CartSlot list) (frame: Chip8Cow.Frame) : CartSlot option =
+        Map.tryFind Chip8Arcade.choiceCell frame.Mem
+        |> Option.bind (fun idx -> List.tryItem (int idx) slots)
+
+    let private litPixels (frame: Chip8Cow.Frame) : int =
+        seq {
+            for y in 0 .. Chip8.DisplayH - 1 do
+                for x in 0 .. Chip8.DisplayW - 1 do
+                    if Chip8Cow.pixel x y frame then
+                        1
+        }
+        |> Seq.sum
+
+    let observableRows (slot: CartSlot) (frame: Chip8Cow.Frame) : ObservableRow list =
+        [ { Key = "cart.name"; Value = slot.Name }
+          { Key = "cart.sha256"; Value = slot.Fingerprint.Sha256 }
+          { Key = "cart.crc32"; Value = slot.Fingerprint.Crc32.ToString("x8", inv) }
+          { Key = "cart.size"; Value = slot.Fingerprint.Size.ToString(inv) }
+          { Key = "frame.pc"; Value = frame.PC.ToString(inv) }
+          { Key = "frame.i"; Value = frame.I.ToString(inv) }
+          { Key = "display.lit"; Value = (litPixels frame).ToString(inv) } ]
+
+    /// Local host: "carried" children are present in the parent bundle and
+    /// resolved by fingerprint. A referenced-but-absent cart returns
+    /// `MissingCart`; the caller decides how to surface that heat.
+    [<Sealed>]
+    type LocalCartHost(carried: Cart.Cart list) =
+        let bySha =
+            carried
+            |> List.map (fun cart ->
+                let slot = slotOfCart cart
+                slot.Fingerprint.Sha256, cart)
+            |> Map.ofList
+
+        interface ICartHost with
+            member _.Play request =
+                match Map.tryFind request.Slot.Fingerprint.Sha256 bySha with
+                | None -> Error(Feedback.MissingCart request.Slot)
+                | Some cart ->
+                    let finalFrame = Cart.playback cart
+
+                    Ok
+                        { Slot = request.Slot
+                          FinalFrame = finalFrame
+                          Rows = observableRows request.Slot finalFrame }
+
+    let private feedbackHeat (source: string) (feedback: Feedback) : HeatSignature option =
+        match feedback with
+        | Feedback.MissingCart slot ->
+            Some(
+                HeatSignature.ofMass
+                    source
+                    "meta-cart.missing"
+                    1
+                    1.0
+                    (sprintf "name=%s sha256=%s" slot.Name slot.Fingerprint.Sha256)
+            )
+        | Feedback.HostDenied(slot, reason) ->
+            Some(
+                HeatSignature.ofMass
+                    source
+                    "meta-cart.denied"
+                    1
+                    1.0
+                    (sprintf "name=%s sha256=%s reason=%s" slot.Name slot.Fingerprint.Sha256 reason)
+            )
+        | Feedback.NoSelection _
+        | Feedback.HeatRejected _ -> None
+
+    let private failWithHeat (source: string) (sink: IHeatSink) (slot: CartSlot) (failure: Feedback) =
+        match feedbackHeat source failure with
+        | None -> Error failure
+        | Some heat ->
+            match sink.Emit heat with
+            | Ok() -> Error failure
+            | Error feedback -> Error(Feedback.HeatRejected(slot, feedback))
+
+    /// Play the child selected by the parent VM. No selection is a cold refusal;
+    /// missing/denied children emit heat before returning the typed failure.
+    let playSelected
+        (source: string)
+        (sink: IHeatSink)
+        (slots: CartSlot list)
+        (host: ICartHost)
+        (parent: Chip8Cow.Frame)
+        : Result<PlayResult, Feedback> =
+        match readSlot slots parent with
+        | None -> Error(Feedback.NoSelection source)
+        | Some slot ->
+            match host.Play { Source = source; Slot = slot } with
+            | Ok result -> Ok result
+            | Error failure -> failWithHeat source sink slot failure
+
+    /// Convenience for the carried-cart mode: the parent bundle includes the
+    /// child carts, so the local host can resolve the selected slot directly.
+    let playSelectedCarried
+        (source: string)
+        (sink: IHeatSink)
+        (children: Cart.Cart list)
+        (parent: Chip8Cow.Frame)
+        : Result<PlayResult, Feedback> =
+        let slots = slotsOfCarts children
+        let host = LocalCartHost children :> ICartHost
+        playSelected source sink slots host parent

--- a/tests/Tests.FSharp/MetaCart.Tests.fs
+++ b/tests/Tests.FSharp/MetaCart.Tests.fs
@@ -1,0 +1,76 @@
+module Zeta.Tests.MetaCartTests
+
+open global.Xunit
+open Zeta.Core
+
+let private child = Cart.firstCart
+
+let private selectedParent (idx: int) =
+    Chip8Cow.create 1UL |> Chip8Arcade.commitChoice idx
+
+[<Fact>]
+let ``slotOfCart uses the child ROM fingerprint as the meta-cart address`` () =
+    let slot = MetaCart.slotOfCart child
+    let fp = GameFingerprint.fingerprint child.Rom
+    Assert.Equal(child.Meta.Title, slot.Name)
+    Assert.Equal(fp.Sha256, slot.Fingerprint.Sha256)
+    Assert.Equal(fp.Crc32, slot.Fingerprint.Crc32)
+    Assert.Equal(fp.Size, slot.Fingerprint.Size)
+
+[<Fact>]
+let ``host-assisted meta-cart plays the carried child selected by the CHIP8 choice cell`` () =
+    let sink = RecordingHeatSink()
+
+    match MetaCart.playSelectedCarried "parent-cart" (sink :> IHeatSink) [ child ] (selectedParent 0) with
+    | Ok result ->
+        Assert.Equal(MetaCart.slotOfCart child, result.Slot)
+        Assert.Equal<Chip8Cow.Frame>(Cart.playback child, result.FinalFrame)
+        Assert.True(result.Rows |> List.exists (fun row -> row.Key = "cart.sha256" && row.Value = result.Slot.Fingerprint.Sha256))
+        Assert.True(result.Rows |> List.exists (fun row -> row.Key = "display.lit"))
+        Assert.Equal(0, sink.Signatures.Count)
+    | Error feedback -> Assert.True(false, sprintf "expected child cart to play, got %A" feedback)
+
+[<Fact>]
+let ``referenced child missing from the injected host emits heat and returns typed feedback`` () =
+    let slot = MetaCart.reference "missing-child" (GameFingerprint.fingerprint [| 0x00uy; 0xE0uy |])
+    let sink = RecordingHeatSink()
+    let host = MetaCart.LocalCartHost [] :> MetaCart.ICartHost
+
+    match MetaCart.playSelected "parent-cart" (sink :> IHeatSink) [ slot ] host (selectedParent 0) with
+    | Error(MetaCart.Feedback.MissingCart missing) ->
+        Assert.Equal(slot, missing)
+        Assert.Equal(1, sink.Signatures.Count)
+        Assert.Equal("meta-cart.missing", sink.Signatures.[0].Kind)
+        Assert.Equal("parent-cart", sink.Signatures.[0].Source)
+        Assert.Contains(slot.Fingerprint.Sha256, sink.Signatures.[0].Detail)
+    | other -> Assert.True(false, sprintf "expected MissingCart feedback, got %A" other)
+
+type private DenyingHost(reason: string) =
+    interface MetaCart.ICartHost with
+        member _.Play request = Error(MetaCart.Feedback.HostDenied(request.Slot, reason))
+
+[<Fact>]
+let ``host denial emits heat without pretending the child ran`` () =
+    let slot = MetaCart.slotOfCart child
+    let sink = RecordingHeatSink()
+    let host = DenyingHost("capability-not-granted") :> MetaCart.ICartHost
+
+    match MetaCart.playSelected "parent-cart" (sink :> IHeatSink) [ slot ] host (selectedParent 0) with
+    | Error(MetaCart.Feedback.HostDenied(denied, reason)) ->
+        Assert.Equal(slot, denied)
+        Assert.Equal("capability-not-granted", reason)
+        Assert.Equal(1, sink.Signatures.Count)
+        Assert.Equal("meta-cart.denied", sink.Signatures.[0].Kind)
+        Assert.Contains("capability-not-granted", sink.Signatures.[0].Detail)
+    | other -> Assert.True(false, sprintf "expected HostDenied feedback, got %A" other)
+
+[<Fact>]
+let ``no selected child is a cold refusal and does not spend heat`` () =
+    let sink = RecordingHeatSink()
+    let host = MetaCart.LocalCartHost [ child ] :> MetaCart.ICartHost
+
+    match MetaCart.playSelected "parent-cart" (sink :> IHeatSink) [ MetaCart.slotOfCart child ] host (Chip8Cow.create 1UL) with
+    | Error(MetaCart.Feedback.NoSelection source) ->
+        Assert.Equal("parent-cart", source)
+        Assert.Equal(0, sink.Signatures.Count)
+    | other -> Assert.True(false, sprintf "expected NoSelection feedback, got %A" other)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -214,6 +214,7 @@
     <Compile Include="Chip9Treaty.Tests.fs" />
     <Compile Include="Chip8Quote.Tests.fs" />
     <Compile Include="Cart.Tests.fs" />
+    <Compile Include="MetaCart.Tests.fs" />
     <Compile Include="Chip8SelfSim.Tests.fs" />
     <Compile Include="SoftChip8Scheduler.Tests.fs" />
     <Compile Include="BitAdinkra.Tests.fs" />


### PR DESCRIPTION
feat(core): add host-assisted meta-cart launch

A cart can now select a child cart through the existing CHIP-8 choice-cell treaty without embedding a full nested interpreter in the tiny VM.

Adds MetaCart slots keyed by GameFingerprint, an injected ICartHost boundary, a local carried-cart host, observable child-play rows, and heat emission for missing or denied child carts. This keeps carrying and referencing isomorphic: carrying means the local host has the child bytes; referencing means the slot names a fingerprint the host may resolve or refuse.

Verification:

- dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter 'FullyQualifiedName~MetaCart|FullyQualifiedName~Cart|FullyQualifiedName~Chip8Arcade'
- dotnet build -c Release
- dotnet test Zeta.sln -c Release --no-build
- dotnet format --verify-no-changes --no-restore

Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: OpenAI Codex
Agent-Model: gpt-5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: explicit
Human-Review-Evidence: chat
Action-Mode: human-directed
Task: none
Co-Authored-By: Codex <noreply@openai.com>

