### PR TITLE
feat(peer-call): local-LLM harness type + runtime persona registration for ISummon

### DIFF
--- a/src/Core.TypeScript/peer-call/summon.ts
+++ b/src/Core.TypeScript/peer-call/summon.ts
@@ -163,6 +163,11 @@ export class PersonaSummoner implements ISummon {
     const outputFile = options.outputFile ?? `/tmp/peer-call-output/${ts}-${persona}.md`;
     ensureParentDir(outputFile);
 
+    // ─── Local-LLM path: call ollama directly (no external CLI) ──────
+    if (personaConfig.harness.type === "local-llm") {
+      return this.summonViaLocalLlm(personaConfig, fullPrompt, outputFile);
+    }
+
     const { harness } = personaConfig;
     // Replace prompt template
     const execArgs = harness.args.map(arg => arg.replace("{{PROMPT}}", fullPrompt));
@@ -213,6 +218,83 @@ export class PersonaSummoner implements ISummon {
       stdout,
       stderr,
     };
+  }
+
+  /**
+   * Local-LLM path: call ollama directly (no external CLI required).
+   * Temperature 0 + fixed seed = deterministic, DST-compatible.
+   * No account, no API key, no network (localhost only).
+   */
+  private async summonViaLocalLlm(
+    config: import("../service/persona-registry").PersonaConfig,
+    fullPrompt: string,
+    outputFile: string,
+  ): Promise<SummonResult> {
+    const { harness } = config;
+    const model = harness.model ?? "qwen2.5:0.5b";
+    const host = harness.host ?? "http://127.0.0.1:11434";
+
+    try {
+      const ctrl = new AbortController();
+      const timer = setTimeout(() => ctrl.abort(), (config.gateTimeout || 60) * 1000);
+
+      const systemPrompt = harness.systemPrompt ?? `You are ${config.name}.`;
+
+      const res = await fetch(`${host}/api/generate`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model,
+          system: systemPrompt,
+          prompt: fullPrompt,
+          stream: false,
+          options: {
+            temperature: 0,
+            seed: 42,
+            num_predict: 2048,
+          },
+        }),
+        signal: ctrl.signal,
+      });
+
+      clearTimeout(timer);
+
+      if (!res.ok) {
+        return {
+          success: false,
+          exitCode: 2,
+          outputFile,
+          stdout: "",
+          stderr: `local-llm: ollama HTTP ${res.status} (model=${model}, host=${host})\n`,
+        };
+      }
+
+      const data = (await res.json()) as { response?: string };
+      const stdout = data.response ?? "";
+
+      try {
+        writeFileSync(outputFile, stdout);
+      } catch {
+        // best-effort output file
+      }
+
+      return {
+        success: true,
+        exitCode: 0,
+        outputFile,
+        stdout,
+        stderr: "",
+      };
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      return {
+        success: false,
+        exitCode: 2,
+        outputFile,
+        stdout: "",
+        stderr: `local-llm: ${reason} (model=${model}, host=${host})\n`,
+      };
+    }
   }
 
   private buildPreamble(persona: string): string {

--- a/src/Core.TypeScript/service/persona-registry.ts
+++ b/src/Core.TypeScript/service/persona-registry.ts
@@ -22,6 +22,19 @@ export interface HarnessConfig {
   readonly args: readonly string[];
   /** If true, the tick runs in an IDE terminal (not launchd). No agent gate by default. */
   readonly ideNative?: boolean;
+  /**
+   * Harness type: "cli" (default, shells out to command) or "local-llm"
+   * (calls ollama/local model directly, no external CLI required).
+   * "local-llm" uses the accelerator/local-llm module at temperature 0
+   * for deterministic, free, no-account-required operation.
+   */
+  readonly type?: "cli" | "local-llm";
+  /** For local-llm type: the model name (default: "qwen2.5:0.5b"). */
+  readonly model?: string;
+  /** For local-llm type: ollama host (default: "http://127.0.0.1:11434"). */
+  readonly host?: string;
+  /** For local-llm type: system prompt / persona preamble. */
+  readonly systemPrompt?: string;
 }
 
 export const PERSONAS: readonly PersonaConfig[] = [
@@ -57,14 +70,60 @@ export const PERSONAS: readonly PersonaConfig[] = [
   },
 ];
 
+/** Mutable runtime registry — starts with the static PERSONAS, can be extended at runtime. */
+const registry: PersonaConfig[] = [...PERSONAS];
+
 export function getPersona(name: string): PersonaConfig | undefined {
-  return PERSONAS.find((p) => p.name === name);
+  return registry.find((p) => p.name === name);
 }
 
 export function listPersonas(): readonly PersonaConfig[] {
-  return PERSONAS;
+  return registry;
 }
 
 export function listPersonaNames(): readonly string[] {
-  return PERSONAS.map((p) => p.name);
+  return registry.map((p) => p.name);
+}
+
+/**
+ * Register a persona at runtime (ephemeral — not persisted to disk).
+ * Use for test personas, local-LLM personas, or personas that don't
+ * need a permanent entry in the static array.
+ *
+ * If a persona with the same name already exists, it is replaced.
+ */
+export function registerPersona(config: PersonaConfig): void {
+  const idx = registry.findIndex((p) => p.name === config.name);
+  if (idx >= 0) {
+    registry[idx] = config;
+  } else {
+    registry.push(config);
+  }
+}
+
+/**
+ * Create a local-LLM persona config (convenience helper).
+ * No external CLI required — calls ollama directly.
+ */
+export function localLlmPersona(name: string, opts?: {
+  model?: string;
+  systemPrompt?: string;
+  host?: string;
+}): PersonaConfig {
+  return {
+    name,
+    label: `local-llm-${name}`,
+    scheduleInterval: 0,
+    gateInterval: 0,
+    gateTimeout: 60,
+    defaultRef: "main",
+    harness: {
+      type: "local-llm",
+      command: "ollama", // not actually shelled out — marker only
+      args: [],
+      model: opts?.model ?? "qwen2.5:0.5b",
+      host: opts?.host ?? "http://127.0.0.1:11434",
+      systemPrompt: opts?.systemPrompt ?? `You are ${name}, a local test persona. Respond concisely.`,
+    },
+  };
 }


### PR DESCRIPTION
## What

Extends Lior's ISummon interface to support local-LLM personas — no external CLI, no account, no API key required.

### New capabilities

1. **`type: 'local-llm'` in HarnessConfig** — calls ollama directly instead of shelling out to a CLI
2. **`registerPersona(config)`** — add personas at runtime (test personas that don't need a repo entry)
3. **`localLlmPersona(name, opts)`** — one-liner convenience to create a local-LLM persona
4. **`PersonaSummoner.summonViaLocalLlm`** — the execution path (temperature 0, seed 42, deterministic)

### Usage

```typescript
import { registerPersona, localLlmPersona } from '../service/persona-registry';
import { PersonaSummoner } from './summon';

registerPersona(localLlmPersona('test-critic', {
  systemPrompt: 'You are a skeptical reviewer. Respond concisely.'
}));

const summoner = new PersonaSummoner();
const result = await summoner.summon('test-critic', 'Is this design sound?');
// → calls ollama locally, temperature 0, deterministic
```

### Why

- **Loop stability testing**: summon any persona without needing external CLIs installed
- **Test personas**: ephemeral personas that don't pollute the repo (not in PERSONAS array)
- **DST-compatible**: temperature 0 + seed 42 = same input → same output, reproducibly
- **Connects observe loop to summon protocol**: `simulateTick` can now summon a local persona as the chooser

### Verified

- 45 existing smoke tests pass
- Live test: `registerPersona(localLlmPersona('test-critic')))` → `summon('test-critic', prompt)` → ollama responds ✅

Co-Authored-By: Kiro <noreply@kiro.dev>