### PR TITLE
feat(core): soft-select meta-carts by reflection

### DIFF
--- a/src/Core/MetaCart.fs
+++ b/src/Core/MetaCart.fs
@@ -31,6 +31,16 @@ module MetaCart =
           FinalFrame: Chip8Cow.Frame
           Rows: ObservableRow list }
 
+    type ReflectedChoice =
+        { Index: int
+          Slot: CartSlot
+          Reflection: Chip8Arcade.Reflection }
+
+    type ReflectedPlayResult =
+        { Choice: ReflectedChoice
+          ParentWithChoice: Chip8Cow.Frame
+          Play: PlayResult }
+
     [<RequireQualifiedAccess>]
     type Feedback =
         | NoSelection of source: string
@@ -51,6 +61,41 @@ module MetaCart =
           Fingerprint = fingerprint }
 
     let slotsOfCarts (carts: Cart.Cart list) : CartSlot list = carts |> List.map slotOfCart
+
+    let private libraryOfCarts (carts: Cart.Cart list) : Chip8Arcade.Library =
+        carts |> List.map (fun cart -> (slotOfCart cart).Name, cart.Rom)
+
+    /// Run the existing soft arcade self-reflection over child carts and attach
+    /// each report to the fingerprint slot it would launch.
+    let reflectChildren
+        (goal: int)
+        (costPerStep: float)
+        (tank: SoftThrottle.Tank)
+        (seed: uint64)
+        (children: Cart.Cart list)
+        : ReflectedChoice list =
+        let slots = slotsOfCarts children
+
+        Chip8Arcade.reflect goal costPerStep tank seed (libraryOfCarts children)
+        |> List.mapi (fun index reflection ->
+            { Index = index
+              Slot = slots.[index]
+              Reflection = reflection })
+
+    /// Choose the child cart whose knowable future scores best under the
+    /// existing CHIP-8 arcade reflection policy.
+    let chooseSlot
+        (goal: int)
+        (costPerStep: float)
+        (tank: SoftThrottle.Tank)
+        (seed: uint64)
+        (children: Cart.Cart list)
+        : ReflectedChoice option =
+        let reflected = reflectChildren goal costPerStep tank seed children
+        let reflections = reflected |> List.map (fun item -> item.Reflection)
+
+        Chip8Arcade.choose reflections
+        |> Option.bind (fun index -> reflected |> List.tryItem index)
 
     /// Read the parent VM's choice using the same one-byte treaty as
     /// `Chip8Arcade.readChoice`, but return the fingerprint slot rather than
@@ -159,3 +204,52 @@ module MetaCart =
         let slots = slotsOfCarts children
         let host = LocalCartHost children :> ICartHost
         playSelected source sink slots host parent
+
+    /// Commit a reflected choice into the parent VM's existing choice cell.
+    /// This keeps the meta-cart ABI identical to `Chip8Arcade`: host-side
+    /// reflection can assist, but the selected child still crosses the
+    /// one-byte choice boundary.
+    let commitChoice (choice: ReflectedChoice) (parent: Chip8Cow.Frame) : Chip8Cow.Frame =
+        Chip8Arcade.commitChoice choice.Index parent
+
+    /// Soft-select a child cart by reflection, write that selection into the
+    /// parent choice cell, then launch through the injected host boundary.
+    let playChosenByReflection
+        (source: string)
+        (sink: IHeatSink)
+        (goal: int)
+        (costPerStep: float)
+        (tank: SoftThrottle.Tank)
+        (seed: uint64)
+        (children: Cart.Cart list)
+        (host: ICartHost)
+        (parent: Chip8Cow.Frame)
+        : Result<ReflectedPlayResult, Feedback> =
+        match chooseSlot goal costPerStep tank seed children with
+        | None -> Error(Feedback.NoSelection source)
+        | Some choice ->
+            let slots = slotsOfCarts children
+            let parentWithChoice = commitChoice choice parent
+
+            match playSelected source sink slots host parentWithChoice with
+            | Ok play ->
+                Ok
+                    { Choice = choice
+                      ParentWithChoice = parentWithChoice
+                      Play = play }
+            | Error feedback -> Error feedback
+
+    /// Convenience for the common carried-cart mode: reflect over the bundled
+    /// children and resolve the selected child from the same bundle.
+    let playChosenCarried
+        (source: string)
+        (sink: IHeatSink)
+        (goal: int)
+        (costPerStep: float)
+        (tank: SoftThrottle.Tank)
+        (seed: uint64)
+        (children: Cart.Cart list)
+        (parent: Chip8Cow.Frame)
+        : Result<ReflectedPlayResult, Feedback> =
+        let host = LocalCartHost children :> ICartHost
+        playChosenByReflection source sink goal costPerStep tank seed children host parent

--- a/tests/Tests.FSharp/MetaCart.Tests.fs
+++ b/tests/Tests.FSharp/MetaCart.Tests.fs
@@ -5,6 +5,23 @@ open Zeta.Core
 
 let private child = Cart.firstCart
 
+let private loopRom = [| 0x6Auy; 0x0Cuy; 0x12uy; 0x02uy |]
+let private inputRom = [| 0xEAuy; 0x9Euy; 0x12uy; 0x00uy |]
+
+let private testCart title rom : Cart.Cart =
+    { Meta =
+        { Title = title
+          Author = "Vera test"
+          Description = "small meta-cart child" }
+      Seed = 1UL
+      Rom = rom
+      CyclesPerTick = 1
+      Ticks = 1
+      Recording = { Crossings = Map.empty } }
+
+let private loopCart = testCart "loopy" loopRom
+let private inputCart = testCart "waity" inputRom
+
 let private selectedParent (idx: int) =
     Chip8Cow.create 1UL |> Chip8Arcade.commitChoice idx
 
@@ -74,3 +91,94 @@ let ``no selected child is a cold refusal and does not spend heat`` () =
         Assert.Equal("parent-cart", source)
         Assert.Equal(0, sink.Signatures.Count)
     | other -> Assert.True(false, sprintf "expected NoSelection feedback, got %A" other)
+
+[<Fact>]
+let ``chooseSlot reuses arcade reflection and picks the most knowable child`` () =
+    let choice =
+        MetaCart.chooseSlot
+            10
+            1.0
+            (SoftThrottle.tank 5.0 1.0)
+            1UL
+            [ loopCart; inputCart ]
+
+    match choice with
+    | Some c ->
+        let expected = MetaCart.slotOfCart inputCart
+        Assert.Equal(1, c.Index)
+        Assert.Equal(expected, c.Slot)
+        Assert.True(c.Reflection.Report.HitBranch)
+        Assert.Equal(1.0, c.Reflection.Report.Confidence, 12)
+        Assert.Equal((GameFingerprint.fingerprint inputCart.Rom).Sha256, c.Slot.Fingerprint.Sha256)
+    | None -> Assert.True(false, "expected a reflected child choice")
+
+[<Fact>]
+let ``playChosenCarried commits the reflected choice into the parent cell and launches the child`` () =
+    let sink = RecordingHeatSink()
+
+    match
+        MetaCart.playChosenCarried
+            "parent-cart"
+            (sink :> IHeatSink)
+            10
+            1.0
+            (SoftThrottle.tank 5.0 1.0)
+            1UL
+            [ loopCart; inputCart ]
+            (Chip8Cow.create 1UL)
+    with
+    | Ok result ->
+        let expected = MetaCart.slotOfCart inputCart
+        Assert.Equal(expected, result.Choice.Slot)
+        Assert.Equal(Some expected, MetaCart.readSlot [ MetaCart.slotOfCart loopCart; expected ] result.ParentWithChoice)
+        Assert.Equal<Chip8Cow.Frame>(Cart.playback inputCart, result.Play.FinalFrame)
+        Assert.True(result.Play.Rows |> List.exists (fun row -> row.Key = "cart.sha256" && row.Value = expected.Fingerprint.Sha256))
+        Assert.Equal(0, sink.Signatures.Count)
+    | Error feedback -> Assert.True(false, sprintf "expected reflected child launch, got %A" feedback)
+
+[<Fact>]
+let ``empty reflected child library is a cold no-selection refusal`` () =
+    let sink = RecordingHeatSink()
+    let host = MetaCart.LocalCartHost [] :> MetaCart.ICartHost
+
+    match
+        MetaCart.playChosenByReflection
+            "parent-cart"
+            (sink :> IHeatSink)
+            10
+            1.0
+            (SoftThrottle.tank 5.0 1.0)
+            1UL
+            []
+            host
+            (Chip8Cow.create 1UL)
+    with
+    | Error(MetaCart.Feedback.NoSelection source) ->
+        Assert.Equal("parent-cart", source)
+        Assert.Equal(0, sink.Signatures.Count)
+    | other -> Assert.True(false, sprintf "expected reflected NoSelection feedback, got %A" other)
+
+[<Fact>]
+let ``missing reflected child emits heat after the soft selector chooses it`` () =
+    let sink = RecordingHeatSink()
+    let host = MetaCart.LocalCartHost [ loopCart ] :> MetaCart.ICartHost
+
+    match
+        MetaCart.playChosenByReflection
+            "parent-cart"
+            (sink :> IHeatSink)
+            10
+            1.0
+            (SoftThrottle.tank 5.0 1.0)
+            1UL
+            [ loopCart; inputCart ]
+            host
+            (Chip8Cow.create 1UL)
+    with
+    | Error(MetaCart.Feedback.MissingCart missing) ->
+        let expected = MetaCart.slotOfCart inputCart
+        Assert.Equal(expected, missing)
+        Assert.Equal(1, sink.Signatures.Count)
+        Assert.Equal("meta-cart.missing", sink.Signatures.[0].Kind)
+        Assert.Contains(expected.Fingerprint.Sha256, sink.Signatures.[0].Detail)
+    | other -> Assert.True(false, sprintf "expected reflected MissingCart feedback, got %A" other)


### PR DESCRIPTION
feat(core): soft-select meta-carts by reflection

Teach MetaCart to reuse the existing CHIP-8 arcade reflection policy when a parent cart carries multiple child carts. The reflected choice stays host-assisted, but the selected index is committed through the same one-byte choice cell before launch so the ABI stays stable.

Missing reflected children still emit meta-cart heat, while an empty child library remains a cold no-selection refusal.

Verification:
- dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter 'FullyQualifiedName~MetaCart|FullyQualifiedName~Cart|FullyQualifiedName~Chip8Arcade'
- dotnet build -c Release
- dotnet test Zeta.sln -c Release --no-build
- dotnet format --verify-no-changes --no-restore
- git diff --check

Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: OpenAI Codex
Agent-Model: gpt-5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: explicit
Human-Review-Evidence: chat
Action-Mode: human-directed
Task: none
Co-Authored-By: Codex <noreply@openai.com>

