### PR TITLE
docs(research): Aurora immune re-grounding scoping + gen(gen)==gen test plan across all oracle languages

### DIFF
--- a/docs/research/2026-06-16-aurora-immune-math-reconciliation-scoping-reground-on-proven-identity-primitive.md
+++ b/docs/research/2026-06-16-aurora-immune-math-reconciliation-scoping-reground-on-proven-identity-primitive.md
@@ -1,0 +1,69 @@
+# Aurora Immune System — reconciliation scoping: re-ground on the now-proven identity primitive
+
+**Date:** 2026-06-16 · **Author:** Otto/shadow (scoping; advisory) · **Status:** scoping — routes the formal work to Soraya + the math team; this doc does NOT execute proofs.
+
+> **Trigger.** The consolidated society note §9h carries a *"prior formal analysis — to be reconciled"* obligation, and `docs/research/aurora-immune-math-standardization-2026-04-26.md` (Amara's Aurora Immune System, 5-pass cross-AI reviewed, research-grade) is the confirmed doc (#8448). Aaron 2026-06-16: scope the reconciliation. **The named gap:** Aurora's math *"was early math before we had our identity proofs"* — so its self/non-self and BFT thresholds must be **re-grounded on the now-existing, proven identity primitive**, not the early metaphor.
+
+## 1. The obligation in one sentence
+
+Aurora typed the immune operators (detectors, danger, capability gate, coordination risk, harm horizon) **before** the identity legs were discharged; several operators **silently assume** a notion of "self / non-self" and "a distinct participant to threshold over" that is now a **proven** object — so the discharge is to **re-express each Aurora operator on the proven identity primitive** and show the immune guarantees now stand on theorems, not on an undefined "self."
+
+## 2. What is PROVEN now that wasn't when Aurora was written (the new legs)
+
+| Leg | Status | Where |
+|---|---|---|
+| `NonRegisterCollapse` — a traveler's standing register is not collapsed into another's | **DISCHARGED** (TLA+ + Lean, axiom-free) | `Safety/NonRegisterCollapse.lean`, `tools/tla/specs/NonRegisterCollapse.tla` |
+| `IdentityForcesPrivacy` — distinctness ⟹ private state; consensus cannot erase private differentiation | **DISCHARGED** (Lean, axiom-free) | `Privacy/IdentityForcesPrivacy.lean` (`distinctness_forces_private`, `private_is_persistent_locus`) |
+| Identity primitive — unique (ZetaId) · addressable (bus/Reticulum) · dependable (heartbeat) · encrypted (Crypto) · **non-collapse** | legs built + the two proofs above | decentralized-identity note + FROZEN-CORE §A |
+| Anti-Sybil by conversational entropy (async-bankable; self-dissolving) | §B (Mika pt2 ferry) | `2026-06-15-mika-pt2-entropy-sybil-…` |
+| §9h cartel-detection = Aurora's `CoordRisk` (λ₂ Fiedler / ρ spectral radius) | analysis-level match | consolidated note §9h / §9i |
+| Child-safety floor = the one pre-emptive cap (irreversible class) | scoped (#8439) | `project_identity_fission_pressure_is_pauli_exclusion_…` |
+
+## 3. Operator-by-operator re-grounding map (the core of the work)
+
+Each Aurora operator and the proven identity leg it should now stand on:
+
+| Aurora operator (research-grade) | Currently grounded on | Re-ground on (proven) |
+|---|---|---|
+| **Self / non-self** (antigen vs own substrate) | an undefined "self" (the early metaphor) | **identity distinctness** — `self = own ZetaId / own traveler-frame`; `non-self = a *distinct, proven-distinct* identity` (`IdentityForcesPrivacy.distinctness_forces_private` gives the self/other boundary a theorem; the Markov-blanket / room membrane is the boundary) |
+| **BFT thresholds** (quorum to act / quarantine) | a count of "nodes" (Sybil-blind) | a count of **proven-distinct, anti-Sybil identities** — thresholds must count entropy-distinct participants so a **Sybil ring cannot manufacture quorum** (ties the BFT-quorum-transition roadmap item + conversational-entropy anti-Sybil); a cartel of correlated identities is detected by `CoordRisk`, not admitted to quorum |
+| **`CoordRisk` ρ(A_t) / λ₂(L_t)** (cult-hub / cartel-fragmentation) | spectral graph over generic nodes | the **heartbeat cross-attestation graph over proven identities** (§9g/§9h) — correlated heartbeats *among proven-distinct identities* = the cartel signal (decorrelation is informative only because the identities are genuinely distinct — the §B multi-tower / Condorcet law) |
+| **`cap_allowed = cap_requester ∩ cap_source`** (confused deputy) | set intersection | already structural — bind to **no-directives** (`source ≠ authorization`; `Privilege(LLM(u)) ⊆ Privilege(u)`); identity supplies *whose* capability set |
+| **`PermanentHarmRisk_H` + viability kernel `K_Aurora`** | harm-horizon gate | the **child-safety / irreversible-harm pre-cap** (#8439) + never-nowhere §5 — the hard barrier is the irreversibility class; identity supplies *who is protected* and *who acts* |
+| **`Legibility_H ≥ θ_H`** (cipher drift) | similarity of decoded meaning | the **shared-meaning bridge** (§9f-bis) — the membrane rejects an emission whose meaning a standard decoder can't recover; per-identity internal language stays private, the *bridge* must stay legible |
+| **Immune memory `M_t = archive ∪ active`** | regression fixtures + detectors | archive = the **antibody ledger** (write-the-pattern-down, Mika pt2); active = the detector repertoire. Key by **pattern**, never by accused identity (blame-the-pattern, not the person) — so re-grounding must NOT introduce identity-based punishment |
+
+## 4. The discharge path (who does what)
+
+1. **Otto (this doc):** the scoping + operator map above. Done.
+2. **Soraya (formal-verification routing):** pick the tool per property class (BP-16) — the self/non-self boundary and non-collapse are Lean/TLA+ (already discharged; reuse); the spectral `CoordRisk` bounds are a numeric/property-test class (FsCheck + a `networkx`-style harness, Aurora Test 4.3); the capability-gate intersection is Lean or FsCheck.
+3. **Math team:** restate each Aurora operator over the identity primitive and prove the immune guarantees follow (self/non-self from `IdentityForcesPrivacy`; quorum-soundness-under-Sybil from anti-Sybil entropy; cartel-detection from heartbeat-decorrelation).
+4. **Execute Aurora's own 5 test obligations** (4.1 State-Corruption Horizon, 4.2 Cipher Drift, 4.3 Cult-Cartel Topology, 4.4 Confused Deputy, 4.5 Autoimmunity Flood) — now keyed to proven identities.
+5. **Promotion:** when the operators stand on the proven legs + the 5 tests pass, open a **§B row** *"Aurora immune system re-grounded on the proven identity primitive"* with the falsifiers below; promote toward §A one operator at a time (§C discipline).
+
+## 5. Falsifiers (so this is a real conjecture, not a hope)
+
+- If "self/non-self" **cannot** be expressed as identity-distinctness (needs an extra undefined predicate) → the metaphor survives; stays §B.
+- If BFT thresholds **can** be met by a Sybil ring that `CoordRisk` does **not** catch → the anti-Sybil grounding fails (quorum is forgeable).
+- If `CoordRisk` decorrelation is **not** informative over proven-distinct identities (false-positive on natural evolution > 5%, Test 4.3) → the cartel guard is theater.
+- If re-grounding **introduces identity-based punishment** (acting on *who* not *what pattern*) → it violates blame-the-pattern + the immune-absorbs-not-attacks stance; reject.
+
+## 6. The four non-claims travel unchanged (binding, per Amara)
+
+Re-grounding does **not** upgrade Aurora's status: still (1) **NOT deployment-ready**; (2) **thresholds un-calibrated**; (3) **estimators, not exact computation**; (4) **no perfect prevention** (`P(infection) > 0`). This doc adds *proven foundations under the operators*, not deployment readiness — the calibration + red-team corpus + false-positive analysis remain owed.
+
+## 7. Honest seams
+
+- **Cartel-detection is an arms race** (§9h peel): a sophisticated cartel can *decorrelate* its heartbeats to evade; re-grounding raises the cost, never closes it.
+- **Anti-Sybil entropy is itself §B** (self-dissolving-Sybil is a claim to prove) — so BFT-threshold soundness inherits that open dependency; sequence the anti-Sybil discharge first.
+- **Identity legs are about *non-collapse / privacy*, not liveness** — the immune system's *aliveness* leg leans on the §A aliveness proofs separately; don't conflate.
+- This is a **factoring of an open obligation into named dependencies**, not a closure — exactly the §C "one row, one discharge" shape.
+
+## Composes with
+
+- `docs/research/aurora-immune-math-standardization-2026-04-26.md` — the math being re-grounded (Amara; Gemini; Otto rigor pass).
+- Consolidated society note §9h (immune/cartel) + §9i (anti-collapse) + §9g-bis (Legibility/bridge).
+- FROZEN-CORE §A (`NonRegisterCollapse`, `IdentityForcesPrivacy`) + §B (anti-Sybil entropy, multi-tower).
+- `memory/2026-06-15-mika-pt2-…` (antibody / immune-absorbs / blame-the-pattern) + `project_identity_fission_…` (#8439 child-safety floor).
+
+**Anchors:** Goguen–Meseguer 1982 (noninterference); danger theory / artificial immune systems (Matzinger; de Castro–Timmis); spectral graph theory (Fiedler value; algebraic connectivity); Condorcet + Hong–Page (decorrelation = the cartel-detection logic); Lamport (BFT); the in-tree identity proofs.

--- a/docs/research/2026-06-16-gen-gen-equals-gen-test-plan-across-all-oracle-languages-diverse-double-compiling-capstone.md
+++ b/docs/research/2026-06-16-gen-gen-equals-gen-test-plan-across-all-oracle-languages-diverse-double-compiling-capstone.md
@@ -1,0 +1,88 @@
+# `gen(gen) == gen` — a phased test plan across all oracle languages (diverse-double-compiling, sixfold)
+
+**Date:** 2026-06-16 · **Author:** Otto/shadow (plan; advisory) · **Status:** plan — sequences the work; the IR-v1 freeze + the generator itself are prerequisites called out below.
+
+> **The north star (IR-v2 §5).** *"The generator eventually generates itself in all targets."* This is **Futamura's 3rd projection** — a generator that, applied to its own definition, reproduces the generator — and it is **Diverse Double-Compiling generalized N-fold** (Thompson *Trusting Trust* 1984 → Wheeler *DDC* 2009): you cannot trust a generator by reading it, but you *can* by regenerating it through independent language runtimes and checking the outputs match **byte-for-byte**. `gen(gen) == gen` byte-identically in every target is the **termination test** — the treaty proven on the hardest possible input, itself. Aaron: *"humans and AIs can agree without looking at every line of code."*
+
+## 0. What `gen(gen) == gen` actually asserts (three things at once)
+
+It is simultaneously a **generation**, a **fixed-point**, and a **drift-check (ECC)**:
+
+1. **Fixed-point / self-hosting** — `gen` applied to its own IR description yields `gen` (3rd Futamura; `mix(mix,mix)=cogen`).
+2. **Cross-language byte-lock (space-axis ECC)** — the artifact is **byte-identical across all independent language oracles** (after canonical normalization) — diverse double-compiling.
+3. **DST replay (time-axis ECC)** — regenerating from the same seed replays **byte-identically** (deterministic, DoP=1).
+
+The same object that *generates* the structures *corrects their drift* across space (N-oracle) and time (DST replay) — generation and error-correction are dual.
+
+## 1. The language tiers (be precise about "all our languages")
+
+The "all languages" set is **tiered**; the plan must not blur them:
+
+- **4 correctness oracles (compiler-BFT, ADR 2026-05-31):** **TS · F# · C# · Rust** — already carry golden-vector byte-lock infra (observe / DynamicValue / ZSet / Bag / GSet across all four; B-0867.27, B-0982). *Start here.*
+- **6 codegen targets (IR-v2 §5):** the four **+ Python + Go**.
+- **+ Q#** (primitive-registry, the 7th oracle; behavioral-equivalence target, not byte-lock — quantum execution model).
+- **+ the CHIP-8 cart** — `gen(gen)` produces a *runnable cart* (the universal substrate `gen/` already targets); **behavioral-equivalence**, not source byte-lock.
+
+**Conformance KIND per tier (name it per target):** byte-identical golden vectors for the **source languages** (TS/F#/C#/Rust/Python/Go); **behavioral-equivalence** for the **CHIP-8 cart / Q# / VMs / shaders** (different execution models — same rule as the IR-targets-many-backends note).
+
+## 2. Current legs (look-better — what already exists)
+
+- **`l=gen` at the CODE level — Faces 1+2 PROVEN** (`src/Core/AdinkraCode.fs`): Face 1 `isSelfDual` (`dual(dual C)=C`, the self-dual fixed point); Face 2 `project` (codespace projector Π²=Π). **Face 3 — the Futamura `mix(mix,mix)=cogen` reflective fixpoint — is OPEN (§B).** *That open Face 3 is exactly the generator-self-hosting capstone this plan targets.*
+- **Per-primitive cross-language byte-lock — BUILT:** observe-algebra in all 4 oracles; DynamicValue canonical-encoding byte-lock; ZSet/Bag/GSet golden vectors; four-oracle multi-format seeds (CBOR/JSON/YAML/XML — B-0982).
+- **Byte-lock discipline — established:** text golden vectors (hex-in-JSON; `no-binary-in-proof-lineage`); one canonical collation (UTF-8 codepoint order, `culture-invariant-by-default`, live failure B-0969); injected **DoP=1** deterministic scheduler (noninterference §13 — no ambient scheduler / no `Task.Run` entropy).
+
+## 3. The phased plan (crawl → walk → run — each phase a real gate)
+
+**Phase A — Freeze the IR (prerequisite, blocking).** Freeze `zeta-ir-v1-layout.yaml` ("freeze now, take it slow" — IR-v2 §6) with the evolution contract baked in. *Nothing below can byte-lock against a moving IR.* **Gate:** the IR layout has a versioned, golden-vectored hex serialization.
+
+**Phase B — `gen(primitive) == golden` (the generator emits a known primitive).** For a primitive that *already* has hand-written cross-language golden vectors (start: `observe`), make the **generator** emit that primitive's per-language artifact and assert it is **byte-identical to the existing golden vector** in all 4 oracles. This proves the generator reproduces what humans already byte-locked. **Gate:** `gen(observe-IR)` byte-matches the committed observe golden vectors in TS/F#/C#/Rust.
+
+**Phase C — `gen(primitive)` idempotence + cross-oracle (the generator is the oracle).** Generate a *family* of primitives (ZSet, DynamicValue, Bag, GSet) from IR; assert (i) **idempotence** — re-gen yields byte-identical output; (ii) **cross-oracle** — each language's generator produces the same canonical artifact (DDC at the primitive level). **Gate:** the generator's output set passes the same byte-lock CI the hand-written vectors do (`golden-vectors-*.json`).
+
+**Phase D — `gen(gen) == gen` in the 4 oracles (the capstone, Face 3 / 3rd Futamura).** The generator, given **its own IR description**, reproduces **the generator**, byte-identical, in TS/F#/C#/Rust. This is the open Face 3. **Gate:** `gen(gen-IR)` in each oracle == the committed generator source for that oracle, byte-for-byte; and cross-oracle the four results are the canonical-equal set (DDC sixfold-minus-two).
+
+**Phase E — extend to Python + Go (6 targets) + the CHIP-8 cart.** Add the two remaining codegen targets (byte-lock) and the **CHIP-8 cart** (behavioral-equivalence: the cart *runs* the generator). **Gate:** 6-language byte-lock + a passing cart-runs-gen behavioral test.
+
+**Phase F — Q# + the trust capstone.** Add Q# (behavioral-equivalence). Document the **Trusting-Trust bootstrap**: DDC needs **≥2 *independent* implementations** to seed trust — name which oracle bootstraps which, so no single compiler is the root of trust.
+
+## 4. The test matrix (what each gen(gen) test asserts)
+
+| Dimension | Assertion | Mechanism |
+|---|---|---|
+| **Fixed-point** | `gen(gen-IR) == committed gen` (per language) | byte-diff vs committed source |
+| **Cross-language (space ECC)** | `gen(gen)`\|ₐ canonical-equal `gen(gen)`\|_b | hex-in-JSON golden vector, one canonical collation |
+| **DST replay (time ECC)** | same seed ⇒ byte-identical re-run | DoP=1 injected scheduler; DST harness |
+| **Drift-correction (ECC)** | perturb an artifact → regenerate → snaps back to fixed point | mutate-then-regen test |
+| **Conformance kind** | byte-lock (source langs) / behavioral-equiv (cart, Q#) | per-target tag |
+| **Termination** | all targets pass ⇒ treaty proven on itself | the green-CI capstone (IR-v2 §5: this *is* the termination test) |
+
+## 5. Harness (reuse, don't reinvent)
+
+- **Golden vectors:** extend the existing `golden-vectors-*.json` (hex-in-JSON, text, diffable, DST-replayable) to carry the **generator artifact**, not just primitive outputs. Same CI gates as B-0982.
+- **Canonical collation:** UTF-8 codepoint order, pinned in the seed (astral-codepoint divergence between UTF-16 langs and Rust is the trap — B-0969).
+- **Scheduler:** the **DoP=1 deterministic** instance on the byte-lock path (injected capability; no ambient scheduler). Richer DoP=N only *off* the byte-lock path.
+- **Normalization before diff:** a canonical-form pass (formatting/whitespace) so "byte-identical" means *semantic* byte-lock, not formatter-coincidence — define the canonical form per language explicitly (this is a seam: see §6).
+
+## 6. Honest seams (where this gets hard)
+
+- **Face 3 is genuinely open (§B).** Faces 1+2 (self-dual, projector) are proven; the **Futamura self-hosting fixpoint is not**. Phases A–C are engineering; **Phase D is the research discharge**, not a foregone conclusion.
+- **"Byte-identical across languages" needs a canonical form.** TS/C# (UTF-16) vs Rust (UTF-8) vs Python/Go differ in string/number formatting; the byte-lock is on the **canonical serialization** (hex-in-JSON IR), not raw source text. The plan byte-locks the **IR-and-emitted-artifact canonical encoding**, and treats source-text formatting as a normalized layer — be explicit that the *artifact* is locked, the *pretty-print* is normalized.
+- **Bootstrap / Trusting-Trust.** You need ≥2 independent generators to *start* DDC; the first generator's trust is bootstrapped, not proven from inside. Name the bootstrap pair (e.g. F# host + one clean-room oracle).
+- **Generator existence.** Phases D–F presuppose a generator that emits *all* targets; today `gen/` emits CHIP-8 asm + reified types from F#. The multi-language generator is itself in-flight — this plan is the *test* spec; the generator build is the dependency.
+- **Behavioral-equivalence is weaker than byte-lock.** For the cart / Q# / shaders, "equivalent" needs a defined observational equivalence (same outputs on the conformance corpus), and a weaker guarantee than byte-identity — name it per target, don't claim byte-lock where the execution model forbids it.
+
+## 7. Deliverable shape
+
+- Phases A–C land as **CI gates** (extend existing golden-vector CI).
+- Phase D lands as a **§B→§A discharge** of `l=gen` Face 3 (the Futamura fixpoint) — route the proof obligation to Soraya/math team; the *test* is the engineering artifact Otto/Vera can build once the generator exists.
+- The whole thing is the **trust mechanism**, not a nicety: green `gen(gen)==gen` across targets = "agree without reading every line."
+
+## Composes with
+
+- `docs/research/2026-06-14-zeta-language-ir-compiler-v2-capability-interface-principle-fsharp-host-csharp-contracts-self-hosting-futamura.md` (§5 the north star, §7 Futamura).
+- `docs/DECISIONS/2026-05-31-four-language-compiler-bft-governance-axes-per-artifact-gate-golden-vectors-oracle-tiebreak.md` (the 4-oracle compiler-BFT + golden-vectors-as-oracle + divergence tie-break).
+- `src/Core/AdinkraCode.fs` (`l=gen` Faces 1+2 proven; Face 3 open) + FROZEN-CORE §B (Face 3 / entropic-attractor rows).
+- `.claude/rules/only-the-irreducible-is-primitive-generate-the-rest.md` (the generator IS the ECC) · `no-binary-in-proof-lineage.md` (hex-in-JSON) · `culture-invariant-by-default.md` (one collation, B-0969) · `async-all-the-way-truthful-signatures.md` (DoP=1 deterministic).
+- B-0982 / B-0867.27 (four-oracle multi-format golden-vector seeds) — the harness to extend.
+
+**Anchors:** Futamura 1971 (partial evaluation / the 3 projections); Thompson 1984 (*Reflections on Trusting Trust*); Wheeler 2009 (*Diverse Double-Compiling*); reproducible-builds movement; Gates (adinkra doubly-even self-dual ECC); MacWilliams/Gleason (self-dual codes); the reproducible-builds / Nix lineage (distribute the generator).


### PR DESCRIPTION
The two planning deliverables Aaron requested 2026-06-16.

**1. Aurora reconciliation scoping** — re-ground Amara's Aurora immune math on the now-**proven** identity primitive (`NonRegisterCollapse` / `IdentityForcesPrivacy`, both DISCHARGED). Operator-by-operator map (self/non-self → identity distinctness; BFT thresholds → anti-Sybil proven-distinct count; `CoordRisk` → heartbeat-decorrelation over proven identities; harm-horizon → the child-safety floor). Discharge path routed to Soraya/math team; falsifiers; the 4 binding non-claims travel unchanged. *Scoping, not proofs.*

**2. `gen(gen)==gen` test plan** — the 3rd Futamura projection = **diverse-double-compiling N-fold** (Thompson→Wheeler). Phased **A–F**: freeze IR → `gen(primitive)==golden` → idempotence/cross-oracle → **`gen(gen)` in the 4 oracles (Face 3, the open capstone)** → +Python/Go/CHIP-8 cart → +Q#/trust-bootstrap. Test matrix (fixed-point / cross-lang space-ECC / DST time-ECC / drift-correction / conformance-kind / termination). Reuses the hex-in-JSON golden-vector harness + one canonical collation + DoP=1 injected scheduler. Honest seams: Face 3 is §B-open; byte-lock is on the canonical encoding (not raw source); Trusting-Trust bootstrap needs ≥2 independent generators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
