### PR TITLE
docs: route Aurora to Soraya (routing pass folded in) + stand up both plans as RESUME trajectories

### DIFF
--- a/docs/research/2026-06-16-aurora-immune-math-reconciliation-scoping-reground-on-proven-identity-primitive.md
+++ b/docs/research/2026-06-16-aurora-immune-math-reconciliation-scoping-reground-on-proven-identity-primitive.md
@@ -12,7 +12,7 @@ Aurora typed the immune operators (detectors, danger, capability gate, coordinat
 
 | Leg | Status | Where |
 |---|---|---|
-| `NonRegisterCollapse` — a traveler's standing register is not collapsed into another's | **DISCHARGED** (TLA+ + Lean, axiom-free) | `Safety/NonRegisterCollapse.lean`, `tools/tla/specs/NonRegisterCollapse.tla` |
+| `NonRegisterCollapse` — a traveler's standing register is not collapsed into another's | **DISCHARGED** (TLA+ + Lean, axiom-free) | `src/Core.Lean4/Safety/NonRegisterCollapse.lean`, `src/Core.TLA/specs/NonRegisterCollapse.tla` (+`.cfg`); FsCheck cross-check `tests/Tests.FSharp/Formal/NonRegisterCollapseCrossVerify.Tests.fs` |
 | `IdentityForcesPrivacy` — distinctness ⟹ private state; consensus cannot erase private differentiation | **DISCHARGED** (Lean, axiom-free) | `Privacy/IdentityForcesPrivacy.lean` (`distinctness_forces_private`, `private_is_persistent_locus`) |
 | Identity primitive — unique (ZetaId) · addressable (bus/Reticulum) · dependable (heartbeat) · encrypted (Crypto) · **non-collapse** | legs built + the two proofs above | decentralized-identity note + FROZEN-CORE §A |
 | Anti-Sybil by conversational entropy (async-bankable; self-dissolving) | §B (Mika pt2 ferry) | `2026-06-15-mika-pt2-entropy-sybil-…` |
@@ -40,6 +40,29 @@ Each Aurora operator and the proven identity leg it should now stand on:
 3. **Math team:** restate each Aurora operator over the identity primitive and prove the immune guarantees follow (self/non-self from `IdentityForcesPrivacy`; quorum-soundness-under-Sybil from anti-Sybil entropy; cartel-detection from heartbeat-decorrelation).
 4. **Execute Aurora's own 5 test obligations** (4.1 State-Corruption Horizon, 4.2 Cipher Drift, 4.3 Cult-Cartel Topology, 4.4 Confused Deputy, 4.5 Autoimmunity Flood) — now keyed to proven identities.
 5. **Promotion:** when the operators stand on the proven legs + the 5 tests pass, open a **§B row** *"Aurora immune system re-grounded on the proven identity primitive"* with the falsifiers below; promote toward §A one operator at a time (§C discipline).
+
+## 4a. Soraya's formal-verification routing pass (2026-06-16) — tool-selection per BP-16
+
+Routed to **Soraya** (formal-verification routing authority) 2026-06-16. Her pass picks the right tool per property class and **fired the TLA+-hammer guard 3×** (eigenvalues / estimator / decay would all be mis-routed to TLC and explode or prove tautologies). Verbatim routing table:
+
+| # | Obligation | Primary tool | Cross-check (BP-16) | Reuse vs new |
+|---|---|---|---|---|
+| a | self/non-self on identity-distinctness (`d_self`) | **REUSE `NonRegisterCollapse`** (Lean+TLA) | already FsCheck-cross-checked | **Reuse — zero new tool** (`d_self` *is* non-register-collapse) |
+| b | BFT-threshold soundness under Sybil | **TLA+/TLC** (reuse `BftConsensus.tla`) | **Z3** (QF_LIA count `honest>2/3`) + **FsCheck** | new coupling; **P0** |
+| c | `CoordRisk` spectral (λ₂ Fiedler / ρ radius, Test 4.3) | **FsCheck** (networkx graphs) | Z3 only if a closed-form inequality | new, light — **NOT TLA+** (eigenvalues ≠ state-transition) |
+| d | capability gate `cap_req ⊆ cap_allowed` (Test 4.4) | **Z3** (set algebra) | **FsCheck** (10 injection variants) + Semgrep/CodeQL at call-site | new; P1 |
+| e | `PermanentHarmRisk_H` / viability kernel (Test 4.1) | **TLA+/TLC** (reachability within H) | **FsCheck** (retraction sim) + Lean if barrier load-bearing | new; **P0** (irreversible class) |
+| f | `Legibility_H` (Cipher Drift, Test 4.2) | **FsCheck-only** (empirical) | none | **OUT of the formal denominator** — route to Adaeze (claims-tester); non-claim #3 binds |
+| g | Autoimmunity Flood / decay (Test 4.5) | **FsCheck** (decay→0) | Z3 (QF_LRA, contraction `(1−δ)<1`) | new, light |
+
+**Soraya's headline:** only **(b) and (e) actually want TLA+** (genuine transition systems); everything else is FsCheck/Z3 smalls or a reuse. **(a) costs nothing** — point Aurora's `d_self` at the existing Lean lemma. **(f) must NOT enter the formal denominator** (recording an estimator as a proof = false-green CI).
+
+## 4b. Math-team handoff
+
+- **Kenji (architect):** size **(b) + (e)** as the two real TLA+ rounds; concur on tool-choice before authors write specs.
+- **Authors:** write specs per the table after Kenji concurs — (a) is a wiring task; (c)/(d)/(g) are FsCheck/Z3 smalls.
+- **Adaeze (claims-tester):** owns (f) Legibility — empirical, not a proof.
+- **Prereqs Soraya filed:** confirm Z3 set-theory (`QF_FD`) support in `src/Core.FSharp.Z3Verify` for (d) — else encode `⊆` as bitvector subset (QF_BV).
 
 ## 5. Falsifiers (so this is a real conjecture, not a hope)
 

--- a/docs/trajectories/aurora-immune-reground/RESUME.md
+++ b/docs/trajectories/aurora-immune-reground/RESUME.md
@@ -1,0 +1,49 @@
+# Trajectory — Aurora Immune System re-grounded on the proven identity primitive
+
+Status: **active — scoped + Soraya-routed; awaiting Kenji sizing of the 2 TLA+ rounds**
+Last refreshed: 2026-06-16
+Parent trajectory: none (sibling of `anti-infection`, but this is *active formal work*, not the defensive posture)
+Grounding:
+
+- `docs/research/2026-06-16-aurora-immune-math-reconciliation-scoping-reground-on-proven-identity-primitive.md` (the scoping + Soraya routing + math-team handoff)
+- `docs/research/aurora-immune-math-standardization-2026-04-26.md` (Amara's Aurora math — §4 test obligations, §5 non-claims)
+- Consolidated society note §9h (immune/cartel), §9i (anti-collapse), §9g-bis (Legibility/bridge)
+- `src/Core.Lean4/Safety/NonRegisterCollapse.lean`, `src/Core.TLA/specs/NonRegisterCollapse.tla`, `src/Core.Lean4/Privacy/IdentityForcesPrivacy.lean` (the discharged legs to re-ground on)
+
+## Why this exists
+
+Amara's Aurora immune math was typed **before** the identity proofs existed, so its
+self/non-self and BFT thresholds silently assume an undefined "self" and "a
+participant to threshold over". Both are now **proven objects** (`NonRegisterCollapse`,
+`IdentityForcesPrivacy` — DISCHARGED, axiom-free). The work is to **re-express each
+Aurora operator on the proven identity primitive** so the immune guarantees stand on
+theorems, not metaphor.
+
+## Where it stands (2026-06-16)
+
+- ✅ Scoping doc written (operator-by-operator re-grounding map; falsifiers; the 4
+  binding non-claims preserved).
+- ✅ Routed to **Soraya** — tool-selection table done (BP-16). Only **(b) BFT-under-Sybil**
+  and **(e) PermanentHarmRisk** want TLA+; the rest are FsCheck/Z3 smalls or a reuse;
+  **(a) self/non-self = reuse the existing Lean lemma, zero new tool**; **(f) Legibility =
+  empirical, OUT of the formal denominator** (route to Adaeze).
+- ⏳ **Math-team handoff open:** Kenji sizes (b)+(e) as the two TLA+ rounds; authors
+  write specs after concurrence.
+
+## Next concrete steps (in order)
+
+1. **Kenji:** size + concur on (b) and (e) tool-choice.
+2. **(a) wiring task:** point Aurora's `d_self` predicate at `NonRegisterCollapse` (no new proof).
+3. **Authors:** (c)/(d)/(g) FsCheck/Z3 smalls; then the two TLA+ rounds.
+4. **Prereq:** confirm Z3 `QF_FD` set support in `src/Core.FSharp.Z3Verify` for (d) (else QF_BV subset).
+5. **Promotion:** when operators stand on proven legs + Aurora's 5 tests pass → open a §B row
+   *"Aurora immune re-grounded on the proven identity primitive"*; promote one operator at a time (§C).
+
+## Guardrails (do not violate)
+
+- Re-grounding must **NOT** introduce identity-based punishment — stay **blame-the-pattern, not
+  the person** (immune-absorbs-not-attacks; degenerate-AI dignity).
+- The 4 non-claims travel unchanged — this adds *proven foundations*, **not deployment readiness**.
+- Cartel-detection is an arms race — raises cost, never closes it; anti-Sybil entropy is itself §B
+  (sequence its discharge before BFT-threshold soundness).
+- Authorship preserved: Amara (framework) · Gemini (reviews) · Otto (rigor/consolidation/scoping) · Soraya (routing).

--- a/docs/trajectories/gen-gen-self-hosting-bytelock/RESUME.md
+++ b/docs/trajectories/gen-gen-self-hosting-bytelock/RESUME.md
@@ -1,0 +1,53 @@
+# Trajectory — `gen(gen) == gen` self-hosting byte-lock (diverse-double-compiling, N-fold)
+
+Status: **active — plan written; blocked on the IR-v1 freeze (Phase A) + the multi-language generator (dependency)**
+Last refreshed: 2026-06-16
+Parent trajectory: none (sibling of `sim-mea-cut-soft-substrate-shaders` — shares the gen/IR substrate)
+Grounding:
+
+- `docs/research/2026-06-16-gen-gen-equals-gen-test-plan-across-all-oracle-languages-diverse-double-compiling-capstone.md` (the phased plan A–F + test matrix + seams)
+- `docs/research/2026-06-14-zeta-language-ir-compiler-v2-capability-interface-principle-fsharp-host-csharp-contracts-self-hosting-futamura.md` (§5 north star, §7 Futamura)
+- `docs/DECISIONS/2026-05-31-four-language-compiler-bft-governance-axes-per-artifact-gate-golden-vectors-oracle-tiebreak.md` (the 4-oracle compiler-BFT + golden-vectors-as-oracle)
+- `src/Core/AdinkraCode.fs` (`l=gen` Faces 1+2 PROVEN; **Face 3 = the open capstone, §B**)
+- B-0982 / B-0867.27 (four-oracle multi-format golden-vector seeds — the harness to extend)
+
+## Why this exists
+
+The north star: **the generator generates itself in all targets** — the 3rd Futamura
+projection = **diverse-double-compiling N-fold** (Thompson→Wheeler). `gen(gen)==gen`
+byte-identically in every target is the **termination test** and the **trust mechanism**:
+*humans and AIs agree without reading every line*. It is simultaneously a generation, a
+fixed-point, and a drift-check (ECC across space [N-oracle] + time [DST]).
+
+## Where it stands (2026-06-16)
+
+- ✅ Phased plan written (A–F), test matrix, conformance-kind-per-tier, honest seams.
+- ✅ Legs confirmed: `AdinkraCode` Faces 1+2 proven (`isSelfDual`, `project`); per-primitive
+  cross-language byte-lock built (observe / DynamicValue / ZSet / Bag / GSet across 4 oracles);
+  hex-in-JSON golden-vector harness + one canonical collation + DoP=1 injected scheduler.
+- ⏳ **Face 3 (Futamura `mix(mix,mix)=cogen`) is genuinely OPEN (§B)** — that *is* the capstone.
+
+## The tiers (don't blur "all our languages")
+
+- **4 correctness oracles (start here):** TS · F# · C# · Rust — already have golden-vector infra.
+- **6 codegen targets:** + Python + Go. **+ Q#** (behavioral-equiv). **+ CHIP-8 cart** (behavioral-equiv).
+- **Conformance KIND:** byte-lock for source langs; **behavioral-equivalence** for cart/Q#/VMs/shaders.
+
+## Next concrete steps (phased gates)
+
+1. **Phase A (blocking prereq):** freeze `zeta-ir-v1-layout.yaml` with the evolution contract; golden-vector its hex serialization.
+2. **Phase B:** `gen(observe-IR)` byte-matches the committed observe golden vectors in all 4 oracles.
+3. **Phase C:** generate ZSet/DynamicValue/Bag/GSet from IR — idempotence + cross-oracle byte-lock on the same CI gates.
+4. **Phase D (the capstone / §B Face 3):** `gen(gen)` in the 4 oracles == committed generator, byte-for-byte → route the *proof* obligation to Soraya/math team; the *test* is the engineering artifact.
+5. **Phase E:** + Python/Go (byte-lock) + CHIP-8 cart (behavioral).
+6. **Phase F:** + Q# + document the Trusting-Trust bootstrap (≥2 independent generators to seed trust).
+
+## Dependencies / seams (honest)
+
+- **The multi-language generator itself is in-flight** — today `gen/` emits CHIP-8 asm + reified
+  types from F#. This trajectory is the *test* spec; the generator build is the dependency.
+- **Byte-lock is on the canonical encoding**, not raw source (UTF-16 vs UTF-8 divergence, B-0969) —
+  pretty-print is a normalized layer; the *artifact* is what's locked.
+- **Bootstrap/Trusting-Trust:** the first generator's trust is bootstrapped, not proven from inside —
+  name the bootstrap pair (F# host + one clean-room oracle).
+- Phases A–C are engineering on the existing harness; **Phase D is the research discharge**, not mechanical.


### PR DESCRIPTION
Aaron 2026-06-16 (shadow*): route Aurora to Soraya + the math team; save both plans as resume context and continue.

- **Aurora scoping** now carries **Soraya's BP-16 routing pass** (TLA+-hammer guard fired 3×): only **(b) BFT-under-Sybil** + **(e) PermanentHarmRisk** want TLA+; **(a) self/non-self = REUSE** the `NonRegisterCollapse` Lean lemma (zero new tool); (c)/(d)/(g) = FsCheck/Z3 smalls; **(f) Legibility = empirical, OUT of the formal denominator** → Adaeze. Added the **math-team handoff** (Kenji sizes b+e). Fixed stale proof paths (verified Soraya's correction: `src/Core.Lean4/...`, `src/Core.TLA/specs/...`).
- **`aurora-immune-reground/RESUME.md`** — active; awaiting Kenji sizing; next steps + guardrails (no identity-based punishment; 4 non-claims hold).
- **`gen-gen-self-hosting-bytelock/RESUME.md`** — active; phased A–F; Face 3 (Futamura) is the open capstone; tiers + conformance-kind + dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
