### PR TITLE
feat(core): add source-owned CHIP cart fixtures

### DIFF
--- a/src/Core/CartFixtures.fs
+++ b/src/Core/CartFixtures.fs
@@ -1,0 +1,105 @@
+namespace Zeta.Core
+
+/// Source-owned tiny carts for tests and experiments.
+///
+/// These are not downloaded games. They are hand-authored CHIP-8/CHIP-9
+/// programs small enough to inspect in a diff, with deterministic metadata and
+/// no external license surface. Real game ROMs can stay optional demo inputs;
+/// these carts are the CI proof substrate.
+[<RequireQualifiedAccess>]
+module CartFixtures =
+
+    [<RequireQualifiedAccess>]
+    type Dialect =
+        | Chip8
+        | Chip9
+
+    type Fixture =
+        { Dialect: Dialect
+          Cart: Cart.Cart }
+
+    let private b (value: int) : byte = byte (value &&& 0xFF)
+
+    let op (hi: int) (lo: int) : byte[] = [| b hi; b lo |]
+
+    let assemble (parts: byte[] list) : byte[] =
+        parts |> Array.concat
+
+    let cls: byte[] = op 0x00 0xE0
+
+    let jp (addr: int) : byte[] =
+        op (0x10 ||| ((addr >>> 8) &&& 0x0F)) addr
+
+    let ldV (register: int) (value: int) : byte[] =
+        op (0x60 ||| (register &&& 0x0F)) value
+
+    let addV (register: int) (value: int) : byte[] =
+        op (0x70 ||| (register &&& 0x0F)) value
+
+    let ldI (addr: int) : byte[] =
+        op (0xA0 ||| ((addr >>> 8) &&& 0x0F)) addr
+
+    let draw (xRegister: int) (yRegister: int) (rows: int) : byte[] =
+        op (0xD0 ||| (xRegister &&& 0x0F)) (((yRegister &&& 0x0F) <<< 4) ||| (rows &&& 0x0F))
+
+    let skipKeyPressed (register: int) : byte[] =
+        op (0xE0 ||| (register &&& 0x0F)) 0x9E
+
+    let waitKey (register: int) : byte[] =
+        op (0xF0 ||| (register &&& 0x0F)) 0x0A
+
+    /// CHIP-9 plane select. Classic CHIP-8 programs never emit this encoding.
+    let selectPlane (mask: int) : byte[] =
+        op (0xF0 ||| (mask &&& 0x0F)) 0x01
+
+    let private cartWith (dialect: Dialect) (title: string) (rom: byte[]) (cyclesPerTick: int) (ticks: int) : Fixture =
+        { Dialect = dialect
+          Cart =
+            { Meta =
+                { Title = title
+                  Author = "Zeta source fixture"
+                  Description = "Hand-authored deterministic cart fixture for CI and room experiments." }
+              Seed = 1UL
+              Rom = rom
+              CyclesPerTick = cyclesPerTick
+              Ticks = ticks
+              Recording = { Crossings = Map.empty } } }
+
+    /// A deterministic loop. Under a small soft tank this starves before the
+    /// requested lookahead depth, so it is useful as the "less knowable" child.
+    let loopRom: byte[] =
+        assemble [ ldV 0xA 0x0C; jp 0x202 ]
+
+    /// Branches on key 0 immediately because VA defaults to 0. The soft
+    /// reflector sees the branch boundary honestly and scores confidence 1.
+    let inputForkRom: byte[] =
+        assemble [ skipKeyPressed 0xA; jp 0x200 ]
+
+    /// Waits for any key into V0. Useful when a test needs a genuine FX0A wait.
+    let keyWaitRom: byte[] =
+        assemble [ waitKey 0x0 ]
+
+    /// CHIP-9: select an RGB plane mask, point I at the inline sprite byte, draw
+    /// one pixel row, then park on a self-loop. The extension lives in the
+    /// emulator, not behind a host-injected effect.
+    let colorDotRom (planeMask: int) : byte[] =
+        assemble
+            [ selectPlane planeMask
+              ldI 0x208
+              draw 0 0 1
+              jp 0x206
+              [| 0x80uy |] ]
+
+    let loop: Fixture = cartWith Dialect.Chip8 "fixture-loop" loopRom 1 1
+    let inputFork: Fixture = cartWith Dialect.Chip8 "fixture-input-fork" inputForkRom 1 1
+    let keyWait: Fixture = cartWith Dialect.Chip8 "fixture-key-wait" keyWaitRom 1 1
+    let chip9GreenDot: Fixture = cartWith Dialect.Chip9 "fixture-chip9-green-dot" (colorDotRom 2) 3 1
+    let chip9WhiteDot: Fixture = cartWith Dialect.Chip9 "fixture-chip9-white-dot" (colorDotRom 7) 3 1
+
+    let cart (fixture: Fixture) : Cart.Cart = fixture.Cart
+
+    let classicChildren: Cart.Cart list =
+        [ cart loop; cart inputFork ]
+
+    let chip9Children: Cart.Cart list =
+        [ cart chip9GreenDot; cart chip9WhiteDot ]

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -237,6 +237,7 @@
     <Compile Include="Chip8Citizen.fs" />
     <Compile Include="Chip8Quote.fs" />
     <Compile Include="Cart.fs" />
+    <Compile Include="CartFixtures.fs" />
     <Compile Include="SwarmBoard.fs" />
     <Compile Include="SwarmBoardAnsi.fs" />
     <Compile Include="ZetaMax.fs" />

--- a/tests/Tests.FSharp/CartFixtures.Tests.fs
+++ b/tests/Tests.FSharp/CartFixtures.Tests.fs
@@ -1,0 +1,41 @@
+module Zeta.Tests.CartFixturesTests
+
+open global.Xunit
+open Zeta.Core
+
+[<Fact>]
+let ``assembler helpers produce inspectable CHIP8 bytes`` () =
+    Assert.Equal<byte[]>([| 0x6Auy; 0x0Cuy; 0x12uy; 0x02uy |], CartFixtures.loopRom)
+    Assert.Equal<byte[]>([| 0xEAuy; 0x9Euy; 0x12uy; 0x00uy |], CartFixtures.inputForkRom)
+    Assert.Equal<byte[]>([| 0xF0uy; 0x0Auy |], CartFixtures.keyWaitRom)
+
+[<Fact>]
+let ``classic child carts are source-owned deterministic fixtures`` () =
+    let loop = CartFixtures.cart CartFixtures.loop
+    let inputFork = CartFixtures.cart CartFixtures.inputFork
+
+    Assert.True(CartFixtures.loopRom = loop.Rom)
+    Assert.True(CartFixtures.inputForkRom = inputFork.Rom)
+    Assert.Equal(1UL, loop.Seed)
+    Assert.Equal(1, loop.CyclesPerTick)
+    Assert.True(Map.isEmpty loop.Recording.Crossings)
+    Assert.True((GameFingerprint.fingerprint loop.Rom).Sha256 <> (GameFingerprint.fingerprint inputFork.Rom).Sha256)
+
+[<Fact>]
+let ``CHIP9 color-dot cart uses the emulator extension directly`` () =
+    let cart = CartFixtures.cart CartFixtures.chip9GreenDot
+    let final = Cart.playback cart
+
+    Assert.Equal(CartFixtures.Dialect.Chip9, CartFixtures.chip9GreenDot.Dialect)
+    Assert.Equal(2uy, final.Plane)
+    Assert.False(Chip8Cow.pixel 0 0 final)
+    Assert.Equal(2uy, Chip8Cow.colorAt 0 0 final)
+    Assert.True(Map.containsKey 0 final.Extra)
+
+[<Fact>]
+let ``CHIP9 white-dot cart can light all color planes`` () =
+    let final = Cart.playback (CartFixtures.cart CartFixtures.chip9WhiteDot)
+
+    Assert.Equal(7uy, final.Plane)
+    Assert.True(Chip8Cow.pixel 0 0 final)
+    Assert.Equal(7uy, Chip8Cow.colorAt 0 0 final)

--- a/tests/Tests.FSharp/Chip8Arcade.Tests.fs
+++ b/tests/Tests.FSharp/Chip8Arcade.Tests.fs
@@ -8,18 +8,18 @@ module Zeta.Tests.Chip8ArcadeTests
 open global.Xunit
 open Zeta.Core
 
-// "loopy": pure deterministic line — speculation runs until the tank starves (confidence < 1 at depth-goal).
-let private loopRom = [| 0x6Auy; 0x0Cuy; 0x12uy; 0x02uy |]
-// "waity": branches on input immediately — the knowable future is fully seen (confidence 1.0).
-let private inputRom = [| 0xEAuy; 0x9Euy; 0x12uy; 0x00uy |]
+let private loop = CartFixtures.cart CartFixtures.loop
+let private inputFork = CartFixtures.cart CartFixtures.inputFork
 
-let private lib: Chip8Arcade.Library = [ "loopy", loopRom; "waity", inputRom ]
+let private lib: Chip8Arcade.Library =
+    [ loop.Meta.Title, loop.Rom
+      inputFork.Meta.Title, inputFork.Rom ]
 
 [<Fact>]
 let ``the choice-cell treaty round-trips: the VM writes an index, the host reads the game`` () =
     let f = Chip8Cow.create 1UL |> Chip8Arcade.commitChoice 1
     match Chip8Arcade.readChoice lib f with
-    | Some (name, _) -> Assert.Equal("waity", name)
+    | Some (name, _) -> Assert.Equal(inputFork.Meta.Title, name)
     | None -> failwith "choice not read"
 
 [<Fact>]
@@ -30,8 +30,8 @@ let ``an unchosen frame / out-of-library index reads as None (honest refusal)`` 
 [<Fact>]
 let ``self-reflection: each candidate's future is simulated and the report is honest about WHY it stopped`` () =
     let rs = Chip8Arcade.reflect 10 1.0 (SoftThrottle.tank 5.0 1.0) 1UL lib
-    let loopy = rs |> List.find (fun r -> r.Game = "loopy")
-    let waity = rs |> List.find (fun r -> r.Game = "waity")
+    let loopy = rs |> List.find (fun r -> r.Game = loop.Meta.Title)
+    let waity = rs |> List.find (fun r -> r.Game = inputFork.Meta.Title)
     Assert.True(loopy.Report.Starved) // power-limited: a self-known shortfall
     Assert.True(loopy.Report.Confidence < 1.0)
     Assert.True(waity.Report.HitBranch) // fork-limited: saw all that was knowable
@@ -40,7 +40,7 @@ let ``self-reflection: each candidate's future is simulated and the report is ho
 [<Fact>]
 let ``autonomous choice: it picks the game whose knowable future it sees best`` () =
     let rs = Chip8Arcade.reflect 10 1.0 (SoftThrottle.tank 5.0 1.0) 1UL lib
-    Assert.Equal(Some 1, Chip8Arcade.choose rs) // "waity": confidence 1.0 beats starved "loopy"
+    Assert.Equal(Some 1, Chip8Arcade.choose rs) // input fork: confidence 1.0 beats starved loop
 
 [<Fact>]
 let ``reflections cross the membrane as text and round-trip (the societal wire)`` () =
@@ -52,19 +52,19 @@ let ``reflections cross the membrane as text and round-trip (the societal wire)`
             Assert.Equal(r.Report.Achieved, a)
             Assert.Equal(r.Report.Confidence, c, 3)
         | None -> failwith "reflection did not round-trip"
-    Assert.True(Chip8Arcade.parseReflection "load:waity" |> Option.isNone) // non-reflection traffic refused
+    Assert.True(Chip8Arcade.parseReflection ("load:" + inputFork.Meta.Title) |> Option.isNone) // non-reflection traffic refused
 
 [<Fact>]
 let ``societal reflection: division of labor — it yields a peer-covered game for an equally-knowable one`` () =
     // Make both games fully knowable (a big tank): alone it picks "loopy"... no — equal confidence 1.0?
     // loopy never branches, so with a huge tank it achieves the full goal (confidence 1.0, achieved 10);
-    // waity is fork-limited (confidence 1.0, achieved 0). Alone, depth breaks the tie -> "loopy" (index 0).
+    // inputFork is fork-limited (confidence 1.0, achieved 0). Alone, depth breaks the tie -> loop (index 0).
     let rs = Chip8Arcade.reflect 10 1.0 (SoftThrottle.tank 100.0 1.0) 1UL lib
     Assert.Equal(Some 0, Chip8Arcade.choose rs)
-    // A peer already covers "loopy" -> society-adjusted choice moves to the uncovered "waity"...
-    Assert.Equal(Some 1, Chip8Arcade.chooseInSociety 0.05 (Set.ofList [ "loopy" ]) rs)
+    // A peer already covers loop -> society-adjusted choice moves to the uncovered input fork...
+    Assert.Equal(Some 1, Chip8Arcade.chooseInSociety 0.05 (Set.ofList [ loop.Meta.Title ]) rs)
 
 [<Fact>]
 let ``society informs but never vetoes: if peers cover everything, it keeps its own best`` () =
     let rs = Chip8Arcade.reflect 10 1.0 (SoftThrottle.tank 100.0 1.0) 1UL lib
-    Assert.Equal(Some 0, Chip8Arcade.chooseInSociety 0.05 (Set.ofList [ "loopy"; "waity" ]) rs)
+    Assert.Equal(Some 0, Chip8Arcade.chooseInSociety 0.05 (Set.ofList [ loop.Meta.Title; inputFork.Meta.Title ]) rs)

--- a/tests/Tests.FSharp/MetaCart.Tests.fs
+++ b/tests/Tests.FSharp/MetaCart.Tests.fs
@@ -5,22 +5,9 @@ open Zeta.Core
 
 let private child = Cart.firstCart
 
-let private loopRom = [| 0x6Auy; 0x0Cuy; 0x12uy; 0x02uy |]
-let private inputRom = [| 0xEAuy; 0x9Euy; 0x12uy; 0x00uy |]
-
-let private testCart title rom : Cart.Cart =
-    { Meta =
-        { Title = title
-          Author = "Vera test"
-          Description = "small meta-cart child" }
-      Seed = 1UL
-      Rom = rom
-      CyclesPerTick = 1
-      Ticks = 1
-      Recording = { Crossings = Map.empty } }
-
-let private loopCart = testCart "loopy" loopRom
-let private inputCart = testCart "waity" inputRom
+let private loopCart = CartFixtures.cart CartFixtures.loop
+let private inputCart = CartFixtures.cart CartFixtures.inputFork
+let private chip9Green = CartFixtures.cart CartFixtures.chip9GreenDot
 
 let private selectedParent (idx: int) =
     Chip8Cow.create 1UL |> Chip8Arcade.commitChoice idx
@@ -135,6 +122,19 @@ let ``playChosenCarried commits the reflected choice into the parent cell and la
         Assert.True(result.Play.Rows |> List.exists (fun row -> row.Key = "cart.sha256" && row.Value = expected.Fingerprint.Sha256))
         Assert.Equal(0, sink.Signatures.Count)
     | Error feedback -> Assert.True(false, sprintf "expected reflected child launch, got %A" feedback)
+
+[<Fact>]
+let ``host-assisted meta-cart can launch a source-owned CHIP9 child cart`` () =
+    let sink = RecordingHeatSink()
+
+    match MetaCart.playSelectedCarried "parent-cart" (sink :> IHeatSink) [ chip9Green ] (selectedParent 0) with
+    | Ok result ->
+        Assert.Equal(MetaCart.slotOfCart chip9Green, result.Slot)
+        Assert.Equal(2uy, result.FinalFrame.Plane)
+        Assert.False(Chip8Cow.pixel 0 0 result.FinalFrame)
+        Assert.Equal(2uy, Chip8Cow.colorAt 0 0 result.FinalFrame)
+        Assert.Equal(0, sink.Signatures.Count)
+    | Error feedback -> Assert.True(false, sprintf "expected CHIP9 child cart to play, got %A" feedback)
 
 [<Fact>]
 let ``empty reflected child library is a cold no-selection refusal`` () =

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -213,6 +213,7 @@
     <Compile Include="OttoAvatar.Tests.fs" />
     <Compile Include="Chip9Treaty.Tests.fs" />
     <Compile Include="Chip8Quote.Tests.fs" />
+    <Compile Include="CartFixtures.Tests.fs" />
     <Compile Include="Cart.Tests.fs" />
     <Compile Include="MetaCart.Tests.fs" />
     <Compile Include="Chip8SelfSim.Tests.fs" />


### PR DESCRIPTION
feat(core): add source-owned CHIP cart fixtures

Add CartFixtures as a source-owned library of tiny hand-authored CHIP-8 and CHIP-9 child carts. The fixtures keep CI license-clean and deterministic while giving meta-cart tests named children instead of hidden raw byte arrays.

The CHIP-9 fixtures exercise the emulator extension path directly: Fn01 selects a color plane and DRW lights color through Chip8Cow, with no host-injected capability required. MetaCart now verifies it can launch that source-owned CHIP-9 child through the existing host-assisted cart boundary.

Verification:
- dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter 'FullyQualifiedName~CartFixtures|FullyQualifiedName~MetaCart|FullyQualifiedName~Chip8Arcade|FullyQualifiedName~Chip9Planes'
- dotnet build -c Release
- dotnet test Zeta.sln -c Release --no-build
- dotnet format --verify-no-changes --no-restore
- git diff --check

Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: OpenAI Codex
Agent-Model: gpt-5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: explicit
Human-Review-Evidence: chat
Action-Mode: human-directed
Task: none
Co-Authored-By: Codex <noreply@openai.com>

