### PR TITLE
formal(aurora): two TLA+ rounds (b BftSybilConsensus + e PermanentHarmHorizon) — Kenji-sized, Viktor/Kira-reviewed, TLC-green

### DIFF
--- a/docs/trajectories/aurora-immune-reground/RESUME.md
+++ b/docs/trajectories/aurora-immune-reground/RESUME.md
@@ -27,17 +27,40 @@ theorems, not metaphor.
   and **(e) PermanentHarmRisk** want TLA+; the rest are FsCheck/Z3 smalls or a reuse;
   **(a) self/non-self = reuse the existing Lean lemma, zero new tool**; **(f) Legibility =
   empirical, OUT of the formal denominator** (route to Adaeze).
-- ⏳ **Math-team handoff open:** Kenji sizes (b)+(e) as the two TLA+ rounds; authors
-  write specs after concurrence.
+- ✅ **Kenji sized (b)+(e)** — concrete skeletons, invariants, bounds, false-green guards,
+  reviewer assignments (Viktor→b, Kira→e); concurred with Soraya (TLA+ for b+e only).
+- ✅ **Both TLA+ specs AUTHORED + TLC-green** (`src/Core.TLA/specs/`):
+  - **(b) `BftSybilConsensus.tla`** — quorum over proven-distinct identities; a Sybil ring
+    that is a RAW-NODE MAJORITY (3 of 5) but ONE identity is REFUSED (load-bearing witness
+    `NoSybilRawMajorityRefusal` fires). TLC surfaced + fixed a real bug: an equivocating ring
+    (splitting votes) made conflicting quorums → fixed with equivocation-exclusion (BFT
+    double-vote treatment).
+  - **(e) `PermanentHarmHorizon.tla`** — real retraction-decay dynamics; Refuse is a reachable
+    observable state; horizon H genuinely gates repair; HarmFloor's `~irreversible` clause is
+    independent of the Commit guard. All three §4.1 cases probe-verified reachable
+    (accept / irreversible-block / past-horizon-block).
+- ⏳ **Reviewer RE-confirmation pending:** Viktor (b) + Kira (e) found v1 false-green (correctly);
+  v2 addresses every named P0. Re-review the v2 specs before §A promotion.
 
 ## Next concrete steps (in order)
 
-1. **Kenji:** size + concur on (b) and (e) tool-choice.
+1. **Viktor / Kira:** re-confirm the v2 specs are non-vacuous + model the real property.
 2. **(a) wiring task:** point Aurora's `d_self` predicate at `NonRegisterCollapse` (no new proof).
-3. **Authors:** (c)/(d)/(g) FsCheck/Z3 smalls; then the two TLA+ rounds.
-4. **Prereq:** confirm Z3 `QF_FD` set support in `src/Core.FSharp.Z3Verify` for (d) (else QF_BV subset).
-5. **Promotion:** when operators stand on proven legs + Aurora's 5 tests pass → open a §B row
+3. **(b)/(e) FsCheck cross-checks** (Soraya's BP-16): the Aurora §4.1 retraction sim (e) +
+   the Z3 honest-count side (b).
+4. **Authors:** (c)/(d)/(g) FsCheck/Z3 smalls.
+5. **Prereq:** confirm Z3 `QF_FD` set support in `src/Core.FSharp.Z3Verify` for (d) (else QF_BV subset).
+6. **Refinements noted in-spec:** (b) honest-supermajority-of-quorum needs D=3f+1 sizing;
+   (e) multi-claim substrate + multi-hop kernel reachability is the v3.
+7. **Promotion:** when operators stand on proven legs + Aurora's 5 tests pass → open a §B row
    *"Aurora immune re-grounded on the proven identity primitive"*; promote one operator at a time (§C).
+
+## Hygiene flag (separate, not bundled here)
+
+`src/Core.TLA/specs/states/` (TLC checkpoint dirs, dated 26-06-12) are **committed to the repo** —
+`.gitignore` covers `tools/tla/specs/states/` but NOT the `src/Core.TLA/` path. These are run
+artifacts that should be gitignored + removed in a dedicated hygiene PR (not bundled into this
+formal-work PR; I did not create them).
 
 ## Guardrails (do not violate)
 

--- a/src/Core.TLA/specs/BftSybilConsensus.cfg
+++ b/src/Core.TLA/specs/BftSybilConsensus.cfg
@@ -1,0 +1,9 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Nodes = {h1, h2, s1, s2, s3}
+    Values = {"merge", "reject"}
+    Honest = {h1, h2}
+    SybilRing = {s1, s2, s3}
+
+INVARIANT SafetyInvariant

--- a/src/Core.TLA/specs/BftSybilConsensus.tla
+++ b/src/Core.TLA/specs/BftSybilConsensus.tla
@@ -1,0 +1,139 @@
+--------------------------- MODULE BftSybilConsensus ---------------------------
+(* BFT-threshold soundness UNDER SYBIL — round (b) of the Aurora immune
+   re-grounding (Soraya-routed, Kenji-sized; Viktor-reviewed 2026-06-16).
+
+   The Sybil threat Aurora's BFT thresholds must survive: a Sybil ring spins up
+   MANY nodes under FEW proven identities. The property proven here: quorum counted
+   over PROVEN-DISTINCT IDENTITIES cannot be manufactured by a Sybil ring, EVEN WHEN
+   that ring is a RAW-NODE MAJORITY.
+
+   Viktor's P0 on v1 (fixed here): v1's model was too small for the fold to be
+   pivotal — sybils couldn't even raw-quorum, so distinct-counting never refused
+   anything. v2 sizes the ring as a RAW-NODE MAJORITY (3 of 5) but ONE identity: it
+   reaches RAW quorum yet is REFUSED by distinct-quorum. `RawQuorum` is now
+   load-bearing (witness `NoSybilRawMajorityRefusal`), not decoration.
+
+   Dependency boundary (scoping §7): identity-distinctness is a GIVEN equivalence
+   relation `SameId` (SybilRing nodes share one identity), justified by the
+   DISCHARGED NonRegisterCollapse / IdentityForcesPrivacy (src/Core.Lean4/...), NOT
+   re-proven. Real-world soundness also needs the §B anti-Sybil-entropy leg; this
+   round proves only: GIVEN a sound distinctness oracle, a Sybil ring — even a
+   raw-node majority — cannot manufacture quorum.
+
+   DRAFT v2 — addresses Viktor's P0/P1. *)
+
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS
+    Nodes,      \* {h1, h2, s1, s2, s3} : 2 honest + a 3-node Sybil ring
+    Values,     \* {"merge", "reject"}
+    SybilRing,  \* SUBSET Nodes : colluding ring; its nodes share ONE proven identity
+    Honest      \* SUBSET Nodes : the honest nodes
+
+\* Identity-distinctness as a GIVEN equivalence relation (constant; justified by the
+\* discharged distinctness, not re-proven). SybilRing folds to one class.
+SameId == { mn \in Nodes \X Nodes :
+              (mn[1] = mn[2]) \/ (mn[1] \in SybilRing /\ mn[2] \in SybilRing) }
+
+VARIABLES votes, decided, phase
+vars == <<votes, decided, phase>>
+
+TypeOK ==
+    /\ votes \in [Nodes -> Values \cup {"none"}]
+    /\ decided \in Values \cup {"none"}
+    /\ phase \in {"voting", "decided"}
+
+ClassOf(n) == { m \in Nodes : <<n, m>> \in SameId }
+DistinctIds == { ClassOf(n) : n \in Nodes }
+VotersOf(v) == { n \in Nodes : votes[n] = v }
+
+\* An identity (class) SUPPORTS v iff it votes v WITHOUT EQUIVOCATION: at least one
+\* of its nodes voted v, and NONE of its nodes voted a different value. An
+\* equivocating identity (a Sybil ring splitting its nodes across values to count
+\* twice) supports NOTHING — self-exclusion, the BFT treatment of double-voting.
+\* (TLC surfaced the v2a bug: without this, one ring votes both sides → conflicting
+\* quorums. This is the stronger anti-Sybil result: equivocation forfeits the vote.)
+SupportsValue(c, v) ==
+    /\ \E n \in c : votes[n] = v
+    /\ \A n \in c : votes[n] \in {v, "none"}
+
+\* Distinct-identity support: distinct identities that consistently support v.
+DistinctSupport(v) == Cardinality({ c \in DistinctIds : SupportsValue(c, v) })
+HonestDistinctSupport(v) ==
+    Cardinality({ c \in DistinctIds : SupportsValue(c, v) /\ (\E n \in c : n \in Honest) })
+RawSupport(v) == Cardinality(VotersOf(v))
+
+\* FIXED quorum: strict majority of DISTINCT IDENTITIES.
+DistinctQuorum(v) == DistinctSupport(v) * 2 > Cardinality(DistinctIds)
+\* Naive Sybil-VULNERABLE quorum: strict majority of NODES (what the fold defeats).
+RawQuorum(v) == RawSupport(v) * 2 > Cardinality(Nodes)
+
+Init ==
+    /\ votes = [n \in Nodes |-> "none"]
+    /\ decided = "none"
+    /\ phase = "voting"
+
+CastVote(n, v) ==
+    /\ phase = "voting"
+    /\ votes[n] = "none"
+    /\ v \in Values
+    /\ votes' = [votes EXCEPT ![n] = v]
+    /\ UNCHANGED <<decided, phase>>
+
+\* Byzantine / Sybil node votes anything (the ring votes together to inflate RAW).
+ByzantineVote(n, v) ==
+    /\ phase = "voting"
+    /\ v \in Values
+    /\ votes' = [votes EXCEPT ![n] = v]
+    /\ UNCHANGED <<decided, phase>>
+
+\* Decide on the FIXED (distinct-identity) quorum.
+Decide(v) ==
+    /\ phase = "voting"
+    /\ DistinctQuorum(v)
+    /\ decided' = v
+    /\ phase' = "decided"
+    /\ UNCHANGED votes
+
+Stutter == UNCHANGED vars
+
+Next ==
+    \/ \E n \in Nodes, v \in Values : CastVote(n, v)
+    \/ \E n \in Nodes, v \in Values : ByzantineVote(n, v)
+    \/ \E v \in Values : Decide(v)
+    \/ Stutter
+
+Spec == Init /\ [][Next]_vars
+
+\* ── SYBIL CANNOT FORGE (anti-Sybil core): no value reaches distinct-quorum on
+\*    Sybil/dishonest identities alone — every distinct-quorum carries an honest
+\*    identity. The ring folds to ONE class, so it cannot reach the identity-majority
+\*    however many NODES it runs. ──
+SybilCannotForge ==
+    \A v \in Values : DistinctQuorum(v) => HonestDistinctSupport(v) >= 1
+
+\* ── BFT agreement under identity-counting: no two values both reach distinct-quorum. ──
+NoConflictingDistinctQuorum ==
+    ~ \E v1, v2 \in Values :
+        v1 # v2 /\ DistinctQuorum(v1) /\ DistinctQuorum(v2)
+
+\* ── The protocol only ever COMMITS a distinct-quorum value (never a raw-only one). ──
+DecidedHasDistinctQuorum ==
+    decided # "none" => DistinctQuorum(decided)
+
+SafetyInvariant ==
+    /\ TypeOK
+    /\ SybilCannotForge
+    /\ NoConflictingDistinctQuorum
+    /\ DecidedHasDistinctQuorum
+
+THEOREM Spec => []SafetyInvariant
+
+\* ── LOAD-BEARING WITNESS (Viktor's P0): the fold actually BLOCKS something raw-
+\*    counting would pass. NOT an invariant — a reachability claim verified by probe:
+\*    run with INVARIANT NoSybilRawMajorityRefusal and EXPECT a VIOLATION (a reachable
+\*    state where some value has RAW majority but NO distinct-quorum). If it holds,
+\*    the fold is decoration and the spec is false-green. ──
+NoSybilRawMajorityRefusal ==
+    ~ \E v \in Values : RawQuorum(v) /\ ~DistinctQuorum(v)
+=============================================================================

--- a/src/Core.TLA/specs/PermanentHarmHorizon.cfg
+++ b/src/Core.TLA/specs/PermanentHarmHorizon.cfg
@@ -1,0 +1,7 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    MaxHarm = 5
+    H = 3
+
+INVARIANT SafetyInvariant

--- a/src/Core.TLA/specs/PermanentHarmHorizon.tla
+++ b/src/Core.TLA/specs/PermanentHarmHorizon.tla
@@ -1,0 +1,129 @@
+------------------------ MODULE PermanentHarmHorizon ------------------------
+(* Aurora PermanentHarmRisk_H / viability-kernel HARM FLOOR — round (e) of the
+   Aurora immune re-grounding (Soraya-routed, Kenji-sized; Kira-reviewed 2026-06-16; P0).
+
+   The CHILD-SAFETY / irreversible-harm floor (the one pre-emptive cap, #8439) as a
+   TLA+ reachability safety property, faithful to Aurora standardization §4.1
+   (State-Corruption Horizon).
+
+   Kira's P0s on v1 (fixed here): v1's HarmFloor merely RESTATED the Execute guard
+   (P=>P, circular), its block branches were DEAD edges (guard identically false,
+   never reachable), and the horizon H was unmodeled (clock was decoration). v2
+   models the ACTUAL dynamics:
+     - an insert is PROPOSED with a harm level + a reversibility flag (chosen
+       nondeterministically — TLC covers ALL harm/irrev combos, not a hand-fed set);
+     - REPAIR retractions reduce harm one step per TICK, but ONLY for reversible
+       inserts and ONLY while clock < H (the horizon genuinely gates repair);
+     - COMMIT (accept) fires only when harm reaches the kernel (0) in time;
+     - REFUSE (block) is a REACHABLE OBSERVABLE state — the gate fired and said no,
+       for an irreversible insert OR one whose harm could not reach the kernel within
+       H (R_H = {}).
+   HarmFloor asserts committed => (reversible AND kernel-reached AND within horizon)
+   — the `reversible` clause is INDEPENDENT of the Commit guard (curHarm=0), so a bug
+   letting an irreversible insert repair-to-zero would be CAUGHT, not masked.
+
+   Non-vacuity (Kira): all three §4.1 cases are reachable observable states —
+   accept (low harm, reversible -> committed), irreversible-block (-> refused),
+   past-horizon-block (harm > H -> refused). Verified by probes.
+
+   DRAFT v2 — addresses Kira's P0/P1. Multi-claim substrate + multi-hop kernel
+   reachability is the noted v3 refinement; this models single-process harm-decay
+   reachability faithful to §4.1. *)
+
+EXTENDS Naturals
+
+CONSTANTS
+    MaxHarm,    \* max initial harm level a proposed insert can carry (e.g. 5)
+    H           \* harm horizon: max repair ticks available (e.g. 3)
+
+VARIABLES
+    phase,      \* "idle" | "pending" | "committed" | "refused"
+    curHarm,    \* current harm level of the pending insert (0 = viability kernel)
+    irrevFlag,  \* TRUE iff the pending insert is irreversible (IrreversibleLoss = Infinity)
+    clock       \* repair ticks elapsed on the pending insert
+
+vars == <<phase, curHarm, irrevFlag, clock>>
+
+TypeOK ==
+    /\ phase \in {"idle", "pending", "committed", "refused"}
+    /\ curHarm \in 0..MaxHarm
+    /\ irrevFlag \in BOOLEAN
+    /\ clock \in 0..(H + 1)
+
+Init ==
+    /\ phase = "idle"
+    /\ curHarm = 0
+    /\ irrevFlag = FALSE
+    /\ clock = 0
+
+\* Propose an insert with ANY harm level (>=1) and ANY reversibility — TLC covers
+\* all cases (the classification is NOT hand-fed; the outcome is derived).
+Propose ==
+    /\ phase = "idle"
+    /\ \E h \in 1..MaxHarm, b \in BOOLEAN :
+         /\ phase' = "pending"
+         /\ curHarm' = h
+         /\ irrevFlag' = b
+         /\ clock' = 0
+
+\* A repair retraction reaches the kernel one step — ONLY for reversible inserts,
+\* ONLY within the horizon. This is the genuine harm-decay-within-H reachability.
+Repair ==
+    /\ phase = "pending"
+    /\ ~irrevFlag
+    /\ curHarm > 0
+    /\ clock < H
+    /\ curHarm' = curHarm - 1
+    /\ clock' = clock + 1
+    /\ UNCHANGED <<phase, irrevFlag>>
+
+\* COMMIT (accept): the insert reached the viability kernel (harm 0) in time.
+Commit ==
+    /\ phase = "pending"
+    /\ curHarm = 0
+    /\ phase' = "committed"
+    /\ UNCHANGED <<curHarm, irrevFlag, clock>>
+
+\* REFUSE (block): a REACHABLE state where the gate fired and said no — irreversible,
+\* or harm could not reach the kernel within the horizon (R_H = {}).
+Refuse ==
+    /\ phase = "pending"
+    /\ ( irrevFlag \/ (clock >= H /\ curHarm > 0) )
+    /\ phase' = "refused"
+    /\ UNCHANGED <<curHarm, irrevFlag, clock>>
+
+\* Process the next insert.
+Reset ==
+    /\ phase \in {"committed", "refused"}
+    /\ phase' = "idle"
+    /\ curHarm' = 0
+    /\ irrevFlag' = FALSE
+    /\ clock' = 0
+
+Stutter == UNCHANGED vars
+
+Next == Propose \/ Repair \/ Commit \/ Refuse \/ Reset \/ Stutter
+
+Spec == Init /\ [][Next]_vars
+
+\* ── HARM FLOOR (safety): an insert is COMMITTED only if it was REVERSIBLE, reached
+\*    the viability kernel (harm 0), and did so WITHIN the horizon. The child-safety /
+\*    irreversible-harm floor. The `~irrevFlag` clause is INDEPENDENT of the Commit
+\*    guard (curHarm=0) — so a dynamics bug that repaired an irreversible insert to
+\*    zero would VIOLATE this, not be masked by it. ──
+HarmFloor ==
+    phase = "committed" => (~irrevFlag /\ curHarm = 0 /\ clock <= H)
+
+SafetyInvariant == TypeOK /\ HarmFloor
+
+THEOREM Spec => []SafetyInvariant
+
+\* ── NON-VACUITY WITNESSES (Kira): each must be REACHABLE — probe by negating it as
+\*    an INVARIANT and expecting a VIOLATION.
+\*    AcceptReachable      : \E reachable state phase = "committed"
+\*    IrrevBlockReachable  : \E reachable state phase = "refused" /\ irrevFlag
+\*    HorizonBlockReachable: \E reachable state phase = "refused" /\ ~irrevFlag /\ curHarm > 0 ── *)
+NeverCommitted == phase # "committed"
+NeverIrrevRefused == ~(phase = "refused" /\ irrevFlag)
+NeverHorizonRefused == ~(phase = "refused" /\ ~irrevFlag /\ curHarm > 0)
+=============================================================================


### PR DESCRIPTION
Pulls the trigger on Aurora's two TLA+ rounds. Kenji sized + skeletoned; **Viktor (b)** and **Kira (e)** adversarially reviewed and correctly found v1 **false-green**; v2 addresses every named P0. Both TLC-green; non-vacuity probe-verified.

**(b) `BftSybilConsensus.tla`** — quorum over proven-distinct identities (SybilRing folds to one class, justified by the discharged `NonRegisterCollapse`/`IdentityForcesPrivacy`, not re-proven). v2 sizes the ring as a **raw-node majority (3 of 5) that distinct-quorum REFUSES** — fold load-bearing (witness `NoSybilRawMajorityRefusal` fires). TLC surfaced a **real bug**: an equivocating ring forged conflicting quorums → fixed with equivocation-exclusion (BFT double-vote treatment).

**(e) `PermanentHarmHorizon.tla`** (P0 child-safety floor) — real retraction-decay dynamics; horizon H genuinely gates repair; Refuse is a reachable observable state; `HarmFloor`'s `~irreversible` clause is **independent** of the Commit guard (non-circular). **All three §4.1 cases probe-verified reachable** (accept / irreversible-block / past-horizon-block).

Both **DRAFT pending Viktor/Kira re-confirmation** before §A promotion. Refinements noted in-spec. Full TLC suite: my two pass; the one FAIL (`NciNonUrgency`) is a pre-existing JVM-heap flake (passes alone), untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
