### PR TITLE
feat(core): name CHIP9 cart capabilities

### DIFF
--- a/src/Core/CartFixtures.fs
+++ b/src/Core/CartFixtures.fs
@@ -16,6 +16,7 @@ module CartFixtures =
 
     type Fixture =
         { Dialect: Dialect
+          Capabilities: Chip9Capabilities.Manifest
           Cart: Cart.Cart }
 
     let private b (value: int) : byte = byte (value &&& 0xFF)
@@ -52,8 +53,16 @@ module CartFixtures =
     let selectPlane (mask: int) : byte[] =
         op (0xF0 ||| (mask &&& 0x0F)) 0x01
 
-    let private cartWith (dialect: Dialect) (title: string) (rom: byte[]) (cyclesPerTick: int) (ticks: int) : Fixture =
+    let private cartWith
+        (dialect: Dialect)
+        (capabilities: Chip9Capabilities.Manifest)
+        (title: string)
+        (rom: byte[])
+        (cyclesPerTick: int)
+        (ticks: int)
+        : Fixture =
         { Dialect = dialect
+          Capabilities = capabilities
           Cart =
             { Meta =
                 { Title = title
@@ -90,11 +99,19 @@ module CartFixtures =
               jp 0x206
               [| 0x80uy |] ]
 
-    let loop: Fixture = cartWith Dialect.Chip8 "fixture-loop" loopRom 1 1
-    let inputFork: Fixture = cartWith Dialect.Chip8 "fixture-input-fork" inputForkRom 1 1
-    let keyWait: Fixture = cartWith Dialect.Chip8 "fixture-key-wait" keyWaitRom 1 1
-    let chip9GreenDot: Fixture = cartWith Dialect.Chip9 "fixture-chip9-green-dot" (colorDotRom 2) 3 1
-    let chip9WhiteDot: Fixture = cartWith Dialect.Chip9 "fixture-chip9-white-dot" (colorDotRom 7) 3 1
+    let loop: Fixture = cartWith Dialect.Chip8 Chip9Capabilities.chip8Default "fixture-loop" loopRom 1 1
+
+    let inputFork: Fixture =
+        cartWith Dialect.Chip8 Chip9Capabilities.chip8Default "fixture-input-fork" inputForkRom 1 1
+
+    let keyWait: Fixture =
+        cartWith Dialect.Chip8 Chip9Capabilities.chip8Default "fixture-key-wait" keyWaitRom 1 1
+
+    let chip9GreenDot: Fixture =
+        cartWith Dialect.Chip9 Chip9Capabilities.chip9ColorUnthrottled "fixture-chip9-green-dot" (colorDotRom 2) 3 1
+
+    let chip9WhiteDot: Fixture =
+        cartWith Dialect.Chip9 Chip9Capabilities.chip9ColorUnthrottled "fixture-chip9-white-dot" (colorDotRom 7) 3 1
 
     let cart (fixture: Fixture) : Cart.Cart = fixture.Cart
 

--- a/src/Core/Chip9Capabilities.fs
+++ b/src/Core/Chip9Capabilities.fs
@@ -1,0 +1,101 @@
+namespace Zeta.Core
+
+/// Named capability surface for carts that intentionally step beyond classic CHIP-8.
+///
+/// CHIP-8 stays the tiny zero case. CHIP-9 is the same emulator core with explicit
+/// extensions: color planes live in `Chip8Cow.step`, throttle policy is a manifest
+/// choice, and launching child carts is a host boundary the parent must be granted.
+[<RequireQualifiedAccess>]
+module Chip9Capabilities =
+
+    [<RequireQualifiedAccess>]
+    type Capability =
+        | ColorPlanes
+        | UnthrottledExecution
+        | HostAssistedChildLaunch
+
+    [<RequireQualifiedAccess>]
+    type ThrottlePolicy =
+        | Metered of costPerStep: float * tank: SoftThrottle.Tank
+        | Unthrottled
+
+    type Manifest =
+        { Name: string
+          Capabilities: Set<Capability>
+          Throttle: ThrottlePolicy }
+
+    let capabilityName =
+        function
+        | Capability.ColorPlanes -> "chip9.color-planes"
+        | Capability.UnthrottledExecution -> "chip9.unthrottled-execution"
+        | Capability.HostAssistedChildLaunch -> "meta-cart.host-child-launch"
+
+    let grants (capability: Capability) (manifest: Manifest) : bool =
+        manifest.Capabilities |> Set.contains capability
+
+    let grant (capability: Capability) (manifest: Manifest) : Manifest =
+        { manifest with Capabilities = Set.add capability manifest.Capabilities }
+
+    let withThrottle (throttle: ThrottlePolicy) (manifest: Manifest) : Manifest =
+        { manifest with Throttle = throttle }
+
+    let denied (capability: Capability) : string =
+        sprintf "capability-not-granted:%s" (capabilityName capability)
+
+    let chip8Metered (costPerStep: float) (tank: SoftThrottle.Tank) : Manifest =
+        { Name = "chip8-metered"
+          Capabilities = Set.empty
+          Throttle = ThrottlePolicy.Metered(costPerStep, tank) }
+
+    let chip8Default: Manifest =
+        chip8Metered 1.0 (SoftThrottle.tank 5.0 1.0)
+
+    let chip9ColorUnthrottled: Manifest =
+        { Name = "chip9-color-unthrottled"
+          Capabilities = Set.ofList [ Capability.ColorPlanes; Capability.UnthrottledExecution ]
+          Throttle = ThrottlePolicy.Unthrottled }
+
+    let metaHost: Manifest =
+        chip8Default |> grant Capability.HostAssistedChildLaunch
+
+    let chip9MetaHost: Manifest =
+        chip9ColorUnthrottled |> grant Capability.HostAssistedChildLaunch
+
+    let private romOps (rom: byte[]) : int seq =
+        seq {
+            for i in 0 .. 2 .. rom.Length - 2 do
+                yield (int rom.[i] <<< 8) ||| int rom.[i + 1]
+        }
+
+    /// Conservative static scan for the CHIP-9 `Fn01` plane-select opcode.
+    /// Sprite/data bytes that look like an opcode still require the capability;
+    /// this is a manifest guard, not a verifier for arbitrary ROM control flow.
+    let requiresColorPlanes (rom: byte[]) : bool =
+        romOps rom |> Seq.exists (fun op -> (op &&& 0xF0FF) = 0xF001)
+
+    let requiredByRom (rom: byte[]) : Set<Capability> =
+        if requiresColorPlanes rom then
+            Set.singleton Capability.ColorPlanes
+        else
+            Set.empty
+
+    let missingForRom (manifest: Manifest) (rom: byte[]) : Capability list =
+        requiredByRom rom
+        |> Set.toList
+        |> List.filter (fun capability -> not (grants capability manifest))
+
+    let validateRom (manifest: Manifest) (rom: byte[]) : Result<unit, string> =
+        match missingForRom manifest rom with
+        | [] -> Ok()
+        | capability :: _ -> Error(denied capability)
+
+    let playback (manifest: Manifest) (cart: Cart.Cart) : Result<Chip8Cow.Frame, string> =
+        validateRom manifest cart.Rom |> Result.map (fun () -> Cart.playback cart)
+
+    /// Turn the manifest throttle policy into the existing speculation arguments.
+    /// Unthrottled means each step costs zero flux: the emulator still runs the
+    /// same deterministic transition, but the policy stops metering this branch.
+    let reflectionBudget (goal: int) (manifest: Manifest) : int * float * SoftThrottle.Tank =
+        match manifest.Throttle with
+        | ThrottlePolicy.Metered(costPerStep, tank) -> goal, costPerStep, tank
+        | ThrottlePolicy.Unthrottled -> goal, 0.0, SoftThrottle.tank 0.0 0.0

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -237,6 +237,7 @@
     <Compile Include="Chip8Citizen.fs" />
     <Compile Include="Chip8Quote.fs" />
     <Compile Include="Cart.fs" />
+    <Compile Include="Chip9Capabilities.fs" />
     <Compile Include="CartFixtures.fs" />
     <Compile Include="SwarmBoard.fs" />
     <Compile Include="SwarmBoardAnsi.fs" />

--- a/src/Core/MetaCart.fs
+++ b/src/Core/MetaCart.fs
@@ -146,6 +146,37 @@ module MetaCart =
                           FinalFrame = finalFrame
                           Rows = observableRows request.Slot finalFrame }
 
+    /// Capability-aware local host: carried children still resolve by content
+    /// fingerprint, but each child runs through its declared CHIP-9 capability
+    /// manifest before playback. Missing capability is a host denial, not a VM
+    /// exception and not silent downgrading.
+    [<Sealed>]
+    type CapabilityCartHost(carried: Cart.Cart list, capabilitiesBySha: Map<string, Chip9Capabilities.Manifest>) =
+        let bySha =
+            carried
+            |> List.map (fun cart ->
+                let slot = slotOfCart cart
+                slot.Fingerprint.Sha256, cart)
+            |> Map.ofList
+
+        interface ICartHost with
+            member _.Play request =
+                match Map.tryFind request.Slot.Fingerprint.Sha256 bySha with
+                | None -> Error(Feedback.MissingCart request.Slot)
+                | Some cart ->
+                    let manifest =
+                        capabilitiesBySha
+                        |> Map.tryFind request.Slot.Fingerprint.Sha256
+                        |> Option.defaultValue Chip9Capabilities.chip8Default
+
+                    match Chip9Capabilities.playback manifest cart with
+                    | Error reason -> Error(Feedback.HostDenied(request.Slot, reason))
+                    | Ok finalFrame ->
+                        Ok
+                            { Slot = request.Slot
+                              FinalFrame = finalFrame
+                              Rows = observableRows request.Slot finalFrame }
+
     let private feedbackHeat (source: string) (feedback: Feedback) : HeatSignature option =
         match feedback with
         | Feedback.MissingCart slot ->
@@ -193,6 +224,26 @@ module MetaCart =
             | Ok result -> Ok result
             | Error failure -> failWithHeat source sink slot failure
 
+    /// Play the selected child only if the parent cart has the host-child-launch
+    /// capability. The child host may still deny its own capabilities separately.
+    let playSelectedWithCapabilities
+        (source: string)
+        (sink: IHeatSink)
+        (parentCapabilities: Chip9Capabilities.Manifest)
+        (slots: CartSlot list)
+        (host: ICartHost)
+        (parent: Chip8Cow.Frame)
+        : Result<PlayResult, Feedback> =
+        match readSlot slots parent with
+        | None -> Error(Feedback.NoSelection source)
+        | Some slot when not (Chip9Capabilities.grants Chip9Capabilities.Capability.HostAssistedChildLaunch parentCapabilities) ->
+            failWithHeat
+                source
+                sink
+                slot
+                (Feedback.HostDenied(slot, Chip9Capabilities.denied Chip9Capabilities.Capability.HostAssistedChildLaunch))
+        | Some _ -> playSelected source sink slots host parent
+
     /// Convenience for the carried-cart mode: the parent bundle includes the
     /// child carts, so the local host can resolve the selected slot directly.
     let playSelectedCarried
@@ -204,6 +255,27 @@ module MetaCart =
         let slots = slotsOfCarts children
         let host = LocalCartHost children :> ICartHost
         playSelected source sink slots host parent
+
+    /// Capability-aware carried-cart mode. Parent launch permission and child
+    /// execution requirements are both explicit manifests.
+    let playSelectedCarriedWithCapabilities
+        (source: string)
+        (sink: IHeatSink)
+        (parentCapabilities: Chip9Capabilities.Manifest)
+        (childCapabilitiesBySha: Map<string, Chip9Capabilities.Manifest>)
+        (children: Cart.Cart list)
+        (parent: Chip8Cow.Frame)
+        : Result<PlayResult, Feedback> =
+        let slots = slotsOfCarts children
+        let host = CapabilityCartHost(children, childCapabilitiesBySha) :> ICartHost
+        playSelectedWithCapabilities source sink parentCapabilities slots host parent
+
+    let capabilityMap (items: (Cart.Cart * Chip9Capabilities.Manifest) list) : Map<string, Chip9Capabilities.Manifest> =
+        items
+        |> List.map (fun (cart, manifest) ->
+            let slot = slotOfCart cart
+            slot.Fingerprint.Sha256, manifest)
+        |> Map.ofList
 
     /// Commit a reflected choice into the parent VM's existing choice cell.
     /// This keeps the meta-cart ABI identical to `Chip8Arcade`: host-side

--- a/tests/Tests.FSharp/Chip9Capabilities.Tests.fs
+++ b/tests/Tests.FSharp/Chip9Capabilities.Tests.fs
@@ -1,0 +1,115 @@
+module Zeta.Tests.Chip9CapabilitiesTests
+
+open global.Xunit
+open Zeta.Core
+
+let private selectedParent (idx: int) =
+    Chip8Cow.create 1UL |> Chip8Arcade.commitChoice idx
+
+let private capabilityMap (fixture: CartFixtures.Fixture) =
+    MetaCart.capabilityMap [ CartFixtures.cart fixture, fixture.Capabilities ]
+
+[<Fact>]
+let ``classic CHIP8 manifest rejects CHIP9 color-plane opcodes`` () =
+    let cart = CartFixtures.cart CartFixtures.chip9GreenDot
+
+    Assert.True(Chip9Capabilities.requiresColorPlanes cart.Rom)
+
+    match Chip9Capabilities.playback Chip9Capabilities.chip8Default cart with
+    | Error reason -> Assert.Equal("capability-not-granted:chip9.color-planes", reason)
+    | Ok _ -> Assert.True(false, "classic CHIP8 manifest should not run a color-plane cart")
+
+[<Fact>]
+let ``CHIP9 color manifest runs the emulator-native plane extension`` () =
+    let manifest = CartFixtures.chip9GreenDot.Capabilities
+    let cart = CartFixtures.cart CartFixtures.chip9GreenDot
+
+    Assert.True(Chip9Capabilities.grants Chip9Capabilities.Capability.ColorPlanes manifest)
+    Assert.True(Chip9Capabilities.grants Chip9Capabilities.Capability.UnthrottledExecution manifest)
+
+    match Chip9Capabilities.playback manifest cart with
+    | Ok final ->
+        Assert.Equal(2uy, final.Plane)
+        Assert.False(Chip8Cow.pixel 0 0 final)
+        Assert.Equal(2uy, Chip8Cow.colorAt 0 0 final)
+    | Error reason -> Assert.True(false, sprintf "expected CHIP9 cart to run, got %s" reason)
+
+[<Fact>]
+let ``unthrottled manifest makes self-reflection cost zero flux`` () =
+    let goal = 10
+    let start = Chip8Arcade.boot 1UL CartFixtures.loopRom
+    let _, metered, _ = SoftChip8Flux.speculateToward goal 1.0 (SoftThrottle.tank 2.0 0.0) start
+    let reflectedGoal, costPerStep, tank = Chip9Capabilities.reflectionBudget goal CartFixtures.chip9GreenDot.Capabilities
+    let _, unthrottled, _ = SoftChip8Flux.speculateToward reflectedGoal costPerStep tank start
+
+    Assert.True(metered.Starved)
+    Assert.True(metered.Achieved < goal)
+    Assert.Equal(0.0, costPerStep)
+    Assert.False(unthrottled.Starved)
+    Assert.Equal(goal, unthrottled.Achieved)
+
+[<Fact>]
+let ``parent manifest gates host-assisted child launch`` () =
+    let child = CartFixtures.cart CartFixtures.chip9GreenDot
+    let sink = RecordingHeatSink()
+
+    match
+        MetaCart.playSelectedCarriedWithCapabilities
+            "parent-cart"
+            (sink :> IHeatSink)
+            Chip9Capabilities.chip8Default
+            (capabilityMap CartFixtures.chip9GreenDot)
+            [ child ]
+            (selectedParent 0)
+    with
+    | Error(MetaCart.Feedback.HostDenied(slot, reason)) ->
+        Assert.Equal(MetaCart.slotOfCart child, slot)
+        Assert.Contains("meta-cart.host-child-launch", reason)
+        Assert.Equal(1, sink.Signatures.Count)
+        Assert.Equal("meta-cart.denied", sink.Signatures.[0].Kind)
+        Assert.Contains(reason, sink.Signatures.[0].Detail)
+    | other -> Assert.True(false, sprintf "expected host-child-launch denial, got %A" other)
+
+[<Fact>]
+let ``parent and child manifests launch a CHIP9 color child`` () =
+    let child = CartFixtures.cart CartFixtures.chip9GreenDot
+    let sink = RecordingHeatSink()
+
+    match
+        MetaCart.playSelectedCarriedWithCapabilities
+            "parent-cart"
+            (sink :> IHeatSink)
+            Chip9Capabilities.metaHost
+            (capabilityMap CartFixtures.chip9GreenDot)
+            [ child ]
+            (selectedParent 0)
+    with
+    | Ok result ->
+        Assert.Equal(MetaCart.slotOfCart child, result.Slot)
+        Assert.Equal(2uy, result.FinalFrame.Plane)
+        Assert.Equal(2uy, Chip8Cow.colorAt 0 0 result.FinalFrame)
+        Assert.Equal(0, sink.Signatures.Count)
+    | Error feedback -> Assert.True(false, sprintf "expected capability-granted launch, got %A" feedback)
+
+[<Fact>]
+let ``child manifest gates CHIP9 color execution after parent launch is granted`` () =
+    let child = CartFixtures.cart CartFixtures.chip9GreenDot
+    let sink = RecordingHeatSink()
+    let childCaps = MetaCart.capabilityMap [ child, Chip9Capabilities.chip8Default ]
+
+    match
+        MetaCart.playSelectedCarriedWithCapabilities
+            "parent-cart"
+            (sink :> IHeatSink)
+            Chip9Capabilities.metaHost
+            childCaps
+            [ child ]
+            (selectedParent 0)
+    with
+    | Error(MetaCart.Feedback.HostDenied(slot, reason)) ->
+        Assert.Equal(MetaCart.slotOfCart child, slot)
+        Assert.Contains("chip9.color-planes", reason)
+        Assert.Equal(1, sink.Signatures.Count)
+        Assert.Equal("meta-cart.denied", sink.Signatures.[0].Kind)
+        Assert.Contains(reason, sink.Signatures.[0].Detail)
+    | other -> Assert.True(false, sprintf "expected child color capability denial, got %A" other)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -212,6 +212,7 @@
     <Compile Include="SpectralPivot.Tests.fs" />
     <Compile Include="OttoAvatar.Tests.fs" />
     <Compile Include="Chip9Treaty.Tests.fs" />
+    <Compile Include="Chip9Capabilities.Tests.fs" />
     <Compile Include="Chip8Quote.Tests.fs" />
     <Compile Include="CartFixtures.Tests.fs" />
     <Compile Include="Cart.Tests.fs" />


### PR DESCRIPTION
feat(core): name CHIP9 cart capabilities

Add Chip9Capabilities as the source-owned manifest for carts that intentionally step beyond classic CHIP-8. The zero case stays CHIP-8; CHIP-9 color planes, unthrottled execution, and host-assisted child launch are explicit named grants.

Wire CartFixtures to carry capability manifests, add a capability-aware MetaCart host, and expose carried-cart launch that checks both the parent launch capability and the child execution capability before playback. Denials stay typed and emit the existing meta-cart heat signatures.

Add focused tests for classic CHIP-8 rejecting Fn01 color opcodes, CHIP-9 running the emulator-native color plane extension, zero-flux unthrottled reflection, parent host-launch gating, successful CHIP-9 child launch, and child color-capability denial.

Verification:

- dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter 'FullyQualifiedName~Chip9Capabilities|FullyQualifiedName~CartFixtures|FullyQualifiedName~MetaCart'

- dotnet build -c Release

- dotnet test Zeta.sln -c Release --no-build

- dotnet format --verify-no-changes --no-restore

- git diff --check

Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: OpenAI Codex
Agent-Model: gpt-5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: explicit
Human-Review-Evidence: chat
Action-Mode: human-directed
Task: none
Co-Authored-By: Codex <noreply@openai.com>

