### PR TITLE
feat(chip9): gate reflected meta-cart launch

### DIFF
--- a/src/Core/MetaCart.fs
+++ b/src/Core/MetaCart.fs
@@ -97,6 +97,18 @@ module MetaCart =
         Chip8Arcade.choose reflections
         |> Option.bind (fun index -> reflected |> List.tryItem index)
 
+    /// Choose under the parent room's declared CHIP-9 policy. The manifest
+    /// does not change arithmetic truth: it only decides how much flux funds
+    /// the reflection before the choice crosses the host boundary.
+    let chooseSlotWithCapabilities
+        (goal: int)
+        (parentCapabilities: Chip9Capabilities.Manifest)
+        (seed: uint64)
+        (children: Cart.Cart list)
+        : ReflectedChoice option =
+        let reflectedGoal, costPerStep, tank = Chip9Capabilities.reflectionBudget goal parentCapabilities
+        chooseSlot reflectedGoal costPerStep tank seed children
+
     /// Read the parent VM's choice using the same one-byte treaty as
     /// `Chip8Arcade.readChoice`, but return the fingerprint slot rather than
     /// raw ROM bytes.
@@ -311,6 +323,34 @@ module MetaCart =
                       Play = play }
             | Error feedback -> Error feedback
 
+    /// Capability-aware reflection path. The parent manifest funds the
+    /// lookahead and gates host-child-launch; the child manifest gates the
+    /// selected cart's own CHIP-9 extensions.
+    let playChosenByReflectionWithCapabilities
+        (source: string)
+        (sink: IHeatSink)
+        (goal: int)
+        (seed: uint64)
+        (parentCapabilities: Chip9Capabilities.Manifest)
+        (childCapabilitiesBySha: Map<string, Chip9Capabilities.Manifest>)
+        (children: Cart.Cart list)
+        (parent: Chip8Cow.Frame)
+        : Result<ReflectedPlayResult, Feedback> =
+        match chooseSlotWithCapabilities goal parentCapabilities seed children with
+        | None -> Error(Feedback.NoSelection source)
+        | Some choice ->
+            let slots = slotsOfCarts children
+            let host = CapabilityCartHost(children, childCapabilitiesBySha) :> ICartHost
+            let parentWithChoice = commitChoice choice parent
+
+            match playSelectedWithCapabilities source sink parentCapabilities slots host parentWithChoice with
+            | Ok play ->
+                Ok
+                    { Choice = choice
+                      ParentWithChoice = parentWithChoice
+                      Play = play }
+            | Error feedback -> Error feedback
+
     /// Convenience for the common carried-cart mode: reflect over the bundled
     /// children and resolve the selected child from the same bundle.
     let playChosenCarried
@@ -325,3 +365,26 @@ module MetaCart =
         : Result<ReflectedPlayResult, Feedback> =
         let host = LocalCartHost children :> ICartHost
         playChosenByReflection source sink goal costPerStep tank seed children host parent
+
+    /// Capability-aware carried-cart mode for the host-assisted meta-cart
+    /// experiment. This is the source-owned room boundary: no file IO, no
+    /// exceptions, and denied launch/extension asks become heat.
+    let playChosenCarriedWithCapabilities
+        (source: string)
+        (sink: IHeatSink)
+        (goal: int)
+        (seed: uint64)
+        (parentCapabilities: Chip9Capabilities.Manifest)
+        (childCapabilitiesBySha: Map<string, Chip9Capabilities.Manifest>)
+        (children: Cart.Cart list)
+        (parent: Chip8Cow.Frame)
+        : Result<ReflectedPlayResult, Feedback> =
+        playChosenByReflectionWithCapabilities
+            source
+            sink
+            goal
+            seed
+            parentCapabilities
+            childCapabilitiesBySha
+            children
+            parent

--- a/tests/Tests.FSharp/MetaCart.Tests.fs
+++ b/tests/Tests.FSharp/MetaCart.Tests.fs
@@ -8,6 +8,12 @@ let private child = Cart.firstCart
 let private loopCart = CartFixtures.cart CartFixtures.loop
 let private inputCart = CartFixtures.cart CartFixtures.inputFork
 let private chip9Green = CartFixtures.cart CartFixtures.chip9GreenDot
+let private classicCaps =
+    MetaCart.capabilityMap
+        [ loopCart, CartFixtures.loop.Capabilities
+          inputCart, CartFixtures.inputFork.Capabilities ]
+
+let private chip9Caps = MetaCart.capabilityMap [ chip9Green, CartFixtures.chip9GreenDot.Capabilities ]
 
 let private selectedParent (idx: int) =
     Chip8Cow.create 1UL |> Chip8Arcade.commitChoice idx
@@ -182,3 +188,76 @@ let ``missing reflected child emits heat after the soft selector chooses it`` ()
         Assert.Equal("meta-cart.missing", sink.Signatures.[0].Kind)
         Assert.Contains(expected.Fingerprint.Sha256, sink.Signatures.[0].Detail)
     | other -> Assert.True(false, sprintf "expected reflected MissingCart feedback, got %A" other)
+
+[<Fact>]
+let ``capability-aware reflected launch emits heat when parent lacks host launch`` () =
+    let sink = RecordingHeatSink()
+
+    match
+        MetaCart.playChosenCarriedWithCapabilities
+            "parent-cart"
+            (sink :> IHeatSink)
+            10
+            1UL
+            Chip9Capabilities.chip8Default
+            classicCaps
+            [ loopCart; inputCart ]
+            (Chip8Cow.create 1UL)
+    with
+    | Error(MetaCart.Feedback.HostDenied(denied, reason)) ->
+        let expected = MetaCart.slotOfCart inputCart
+        Assert.Equal(expected, denied)
+        Assert.Contains("meta-cart.host-child-launch", reason)
+        Assert.Equal(1, sink.Signatures.Count)
+        Assert.Equal("meta-cart.denied", sink.Signatures.[0].Kind)
+        Assert.Contains(expected.Fingerprint.Sha256, sink.Signatures.[0].Detail)
+        Assert.Contains(reason, sink.Signatures.[0].Detail)
+    | other -> Assert.True(false, sprintf "expected reflected host-child-launch denial, got %A" other)
+
+[<Fact>]
+let ``capability-aware reflected launch emits heat when child lacks CHIP9 color grant`` () =
+    let sink = RecordingHeatSink()
+    let childCaps = MetaCart.capabilityMap [ chip9Green, Chip9Capabilities.chip8Default ]
+
+    match
+        MetaCart.playChosenCarriedWithCapabilities
+            "parent-cart"
+            (sink :> IHeatSink)
+            3
+            1UL
+            Chip9Capabilities.metaHost
+            childCaps
+            [ chip9Green ]
+            (Chip8Cow.create 1UL)
+    with
+    | Error(MetaCart.Feedback.HostDenied(denied, reason)) ->
+        Assert.Equal(MetaCart.slotOfCart chip9Green, denied)
+        Assert.Contains("chip9.color-planes", reason)
+        Assert.Equal(1, sink.Signatures.Count)
+        Assert.Equal("meta-cart.denied", sink.Signatures.[0].Kind)
+        Assert.Contains(reason, sink.Signatures.[0].Detail)
+    | other -> Assert.True(false, sprintf "expected reflected child color denial, got %A" other)
+
+[<Fact>]
+let ``capability-aware reflected launch runs granted CHIP9 child`` () =
+    let sink = RecordingHeatSink()
+
+    match
+        MetaCart.playChosenCarriedWithCapabilities
+            "parent-cart"
+            (sink :> IHeatSink)
+            3
+            1UL
+            Chip9Capabilities.chip9MetaHost
+            chip9Caps
+            [ chip9Green ]
+            (Chip8Cow.create 1UL)
+    with
+    | Ok result ->
+        Assert.Equal(MetaCart.slotOfCart chip9Green, result.Choice.Slot)
+        Assert.Equal(MetaCart.slotOfCart chip9Green, result.Play.Slot)
+        Assert.Equal(Some(MetaCart.slotOfCart chip9Green), MetaCart.readSlot [ MetaCart.slotOfCart chip9Green ] result.ParentWithChoice)
+        Assert.Equal(2uy, result.Play.FinalFrame.Plane)
+        Assert.Equal(2uy, Chip8Cow.colorAt 0 0 result.Play.FinalFrame)
+        Assert.Equal(0, sink.Signatures.Count)
+    | Error feedback -> Assert.True(false, sprintf "expected granted reflected CHIP9 launch, got %A" feedback)


### PR DESCRIPTION
feat(chip9): gate reflected meta-cart launch

Add the capability-aware reflected meta-cart path so host-assisted cart selection uses the same manifest boundary as direct selection. The parent manifest funds reflection and gates host-child-launch; the child manifest gates CHIP-9 extensions before playback.

Denied parent launch and denied child extension asks now return typed feedback and emit heat through the injected sink. The granted path proves a CHIP-9 color child can still run through the reflected carried-cart helper without contaminating classic CHIP-8.

Verification:
- dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter "FullyQualifiedName~MetaCartTests|FullyQualifiedName~Chip9CapabilitiesTests"
- dotnet format --verify-no-changes
- git diff --check
- dotnet build -c Release
- dotnet test Zeta.sln -c Release

Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: OpenAI Codex
Agent-Model: gpt-5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: explicit
Human-Review-Evidence: chat
Action-Mode: human-directed
Task: none
Co-Authored-By: Codex <noreply@openai.com>

