### PR TITLE
feat(darkhall): model CHIP9 arcade cabinets

### DIFF
--- a/src/Core/Arcade.fs
+++ b/src/Core/Arcade.fs
@@ -3,73 +3,204 @@ namespace Zeta.Core
 open System.Threading.Tasks
 
 /// Arcade — the **door** on the *darkhall* landmark (Aaron 2026-06-10, shadow*: "darkhall next — give the
-/// arcade its door"). Named `Arcade` because `DarkHall` (`DarkHall.fs`) is already the clean-room CHIP-8
-/// emulator *cell* — it's a **cabinet**, not the door. The landmark is "darkhall"; its door module is
-/// `Arcade` (the place's nature). (Rename if you'd rather flip them.)
+/// arcade its door"). `DarkHall` is the room: the place that owns cabinets. `Arcade` is the navigable
+/// door that lists the cabinets and exposes live entrances into their machines.
 ///
 /// The darkhall is the dim hall of cabinets — the **emulator / VM / games** landmark, where (Aaron +
 /// Max 2026-06-10) **programs are decompiled down to MIPS-like primitives** and **rooms are the CPU's
 /// micro-operations**: a room/cell is a μop, the program decompiles into rooms, and the soft layer does
 /// **branch detection in real time** (the only soft fork is on unknown future input). This door gathers
-/// the arcade's cabinets under one name and gives **live entrances** — `play` (a ROM on the soft
-/// scheduler) and `host` (the clean-room `DarkHall` CPU) — so you can walk in and run a cabinet.
+/// the Dark Hall's cabinets under one name and gives **live entrances** — `play` (a ROM on the soft
+/// scheduler), `playMetaCabinet` (a capability-gated multi-cart cabinet), and `host` (the clean-room
+/// `DarkHall` CPU) — so you can walk in and run a cabinet.
 [<RequireQualifiedAccess>]
 module Arcade =
 
-    /// A cabinet in the arcade — one named offering.
-    type Cabinet =
-        { Name: string
-          Does: string
-          Verb: string option
-          Module: string
-          Live: bool }
+    type MachineCore = DarkHall.MachineCore
+    type Machine = DarkHall.Machine
+    type Cabinet = DarkHall.Cabinet
+    type Room = DarkHall.Room
 
-    /// The arcade's cabinets — the emulator/VM/game fittings gathered under one door.
+    let private noCapabilities: Set<Chip9Capabilities.Capability> = Set.empty
+
+    let private softScheduler =
+        DarkHall.machine
+            "soft-chip8"
+            MachineCore.SoftChip8Scheduler
+            "run a CHIP-8 ROM on the soft IScheduler for N 60Hz frames"
+            "src/Core/SoftChip8Scheduler.fs"
+            true
+            noCapabilities
+
+    let private chip9Color =
+        DarkHall.machine
+            "chip9-color"
+            MachineCore.Chip9ColorPlanes
+            "CHIP-9 color-plane extension, guarded by an explicit room capability"
+            "src/Core/Chip9Capabilities.fs + src/Core/Chip8Cow.fs"
+            true
+            (Set.singleton Chip9Capabilities.Capability.ColorPlanes)
+
+    let private metaCartHost =
+        DarkHall.machine
+            "meta-cart-host"
+            MachineCore.MetaCartHost
+            "host-assisted cart-that-can-play-carts boundary, with typed refusals and heat"
+            "src/Core/MetaCart.fs"
+            true
+            (Set.singleton Chip9Capabilities.Capability.HostAssistedChildLaunch)
+
+    let private darkHallCpu =
+        DarkHall.machine
+            "darkhall-cpu"
+            MachineCore.DarkHallCpu
+            "clean-room minimal CHIP-8-subset CPU, deterministic and DST-replayable"
+            "src/Core/DarkHall.fs"
+            true
+            noCapabilities
+
+    let private cowStepper =
+        DarkHall.machine
+            "chip8-cow-step"
+            MachineCore.Chip8Cow
+            "one pure CHIP-8 instruction transition; parent frame untouched"
+            "src/Core/Chip8Cow.fs"
+            true
+            noCapabilities
+
+    let private predictor =
+        DarkHall.machine
+            "soft-chip8-predictor"
+            MachineCore.SoftChip8Predictor
+            "real-time branch detection and funded look-ahead"
+            "src/Core/SoftChip8.fs + src/Core/SoftChip8Flux.fs"
+            true
+            noCapabilities
+
+    let private fingerprint =
+        DarkHall.machine
+            "game-fingerprint"
+            MachineCore.FingerprintPrism
+            "hard exact key plus soft game recognition"
+            "src/Core/GameFingerprint.fs + src/Core/FingerprintPrism.fs"
+            true
+            noCapabilities
+
+    let private catalog =
+        DarkHall.machine
+            "game-catalog"
+            MachineCore.GameCatalog
+            "per-game soft state keyed by fingerprint"
+            "src/Core/GamePortfolio.fs + src/Core/GameCatalog.fs"
+            false
+            noCapabilities
+
+    let private simLoop =
+        DarkHall.machine
+            "sim-loop"
+            MachineCore.SimLoop
+            "the deterministic edge tick the cabinets lift"
+            "src/Core/Sim.fs"
+            true
+            noCapabilities
+
+    /// The Dark Hall's cabinets — emulator fittings gathered under one door.
+    /// The `play` cabinet is intentionally multi-machine: classic CHIP-8,
+    /// CHIP-9 color, and host-assisted child-cart launch share one cabinet
+    /// boundary the way a multi-cart arcade board shares one cabinet shell.
     let cabinets: Cabinet list =
-        [ { Name = "play"
-            Does = "run a CHIP-8 ROM on the soft IScheduler for N 60Hz frames (the soft cabinet)"
-            Verb = Some "sim"
-            Module = "src/Core/SoftChip8Scheduler.fs"
-            Live = true }
-          { Name = "host"
-            Does = "the clean-room minimal CHIP-8-subset CPU cell — deterministic, DST-replayable"
-            Verb = Some "sim"
-            Module = "src/Core/DarkHall.fs"
-            Live = true }
-          { Name = "step"
-            Does = "one pure CHIP-8 instruction (the COW transition; parent untouched)"
-            Verb = None
-            Module = "src/Core/Chip8Cow.fs"
-            Live = true }
-          { Name = "predict"
-            Does = "real-time BRANCH DETECTION — the only soft fork is on unknown future input; batch look-ahead between branches (play∥predict)"
-            Verb = None
-            Module = "src/Core/SoftChip8.fs"
-            Live = true }
-          { Name = "fingerprint"
-            Does = "identify the game — hard exact key (SHA-256) + soft recognition (FingerprintPrism)"
-            Verb = None
-            Module = "src/Core/GameFingerprint.fs + src/Core/FingerprintPrism.fs"
-            Live = true }
-          { Name = "catalog"
-            Does = "per-game soft state keyed by fingerprint (switch games staying soft)"
-            Verb = Some "cla"
-            Module = "src/Core/GamePortfolio.fs + src/Core/GameCatalog.fs"
-            Live = false }
-          { Name = "sim"
-            Does = "the ephemeral void run (the deterministic edge tick the cabinets lift)"
-            Verb = Some "sim"
-            Module = "src/Core/Sim.fs"
-            Live = true } ]
+        [ DarkHall.cabinet
+              "play"
+              "multi-machine CHIP-8/CHIP-9 cabinet: soft scheduler, color-plane extension, and host-assisted child carts"
+              (Some "sim")
+              "src/Core/SoftChip8Scheduler.fs + src/Core/Chip9Capabilities.fs + src/Core/MetaCart.fs"
+              true
+              [ softScheduler; chip9Color; metaCartHost ]
+          DarkHall.cabinet
+              "host"
+              "the clean-room minimal CHIP-8-subset CPU cell — deterministic, DST-replayable"
+              (Some "sim")
+              "src/Core/DarkHall.fs"
+              true
+              [ darkHallCpu ]
+          DarkHall.cabinet
+              "step"
+              "one pure CHIP-8 instruction (the COW transition; parent untouched)"
+              None
+              "src/Core/Chip8Cow.fs"
+              true
+              [ cowStepper ]
+          DarkHall.cabinet
+              "predict"
+              "real-time BRANCH DETECTION — the only soft fork is on unknown future input; batch look-ahead between branches (play∥predict)"
+              None
+              "src/Core/SoftChip8.fs"
+              true
+              [ predictor ]
+          DarkHall.cabinet
+              "fingerprint"
+              "identify the game — hard exact key (SHA-256) + soft recognition (FingerprintPrism)"
+              None
+              "src/Core/GameFingerprint.fs + src/Core/FingerprintPrism.fs"
+              true
+              [ fingerprint ]
+          DarkHall.cabinet
+              "catalog"
+              "per-game soft state keyed by fingerprint (switch games staying soft)"
+              (Some "cla")
+              "src/Core/GamePortfolio.fs + src/Core/GameCatalog.fs"
+              false
+              [ catalog ]
+          DarkHall.cabinet
+              "sim"
+              "the ephemeral void run (the deterministic edge tick the cabinets lift)"
+              (Some "sim")
+              "src/Core/Sim.fs"
+              true
+              [ simLoop ] ]
 
     /// The arcade's name and what work happens here (the signage).
-    let name = "darkhall"
-    let does = "the arcade — emulators / VMs / games; decompile programs to MIPS-like μops; rooms = micro-ops; real-time branch detection"
+    let private signage =
+        "the arcade — emulators / VMs / games; decompile programs to MIPS-like μops; rooms = micro-ops; real-time branch detection"
+
+    let room: Room = DarkHall.createRoom signage cabinets
+
+    let name = room.Name
+    let does = room.Does
+
+    let machines: Machine list = DarkHall.machines room
+    let liveMachines: Machine list = DarkHall.liveMachines room
+
+    let machinesRequiring (capability: Chip9Capabilities.Capability) : Machine list =
+        DarkHall.machinesRequiring capability room
 
     /// Live entrance: `play` — run a CHIP-8 ROM on the soft scheduler for `frames` 60Hz ticks (delegates
     /// to the working `SoftChip8Scheduler`).
     let play (seed: uint64) (rom: byte[]) (frames: int) : Task<Result<Chip8Cow.Frame, InterruptFeedback>> =
         SoftChip8Scheduler.run seed rom frames
+
+    /// Live entrance: `playMetaCabinet` — run the Dark Hall's multi-cart
+    /// cabinet. The parent machine chooses; the room/cabinet capabilities
+    /// decide whether the selected child can cross the host boundary.
+    let playMetaCabinet
+        (source: string)
+        (sink: IHeatSink)
+        (goal: int)
+        (seed: uint64)
+        (parentCapabilities: Chip9Capabilities.Manifest)
+        (childCapabilitiesBySha: Map<string, Chip9Capabilities.Manifest>)
+        (children: Cart.Cart list)
+        (parent: Chip8Cow.Frame)
+        : Result<MetaCart.ReflectedPlayResult, MetaCart.Feedback> =
+        MetaCart.playChosenCarriedWithCapabilities
+            source
+            sink
+            goal
+            seed
+            parentCapabilities
+            childCapabilitiesBySha
+            children
+            parent
 
     /// Live entrance: `host` — run a program on the clean-room `DarkHall` CPU to halt or `budget` steps
     /// (deterministic, DST-replayable). The hard cabinet.

--- a/src/Core/DarkHall.fs
+++ b/src/Core/DarkHall.fs
@@ -14,6 +14,96 @@ module DarkHall =
 
     open ZetaCli
 
+    /// Emulator/device cores hosted inside the Dark Hall. This is deliberately
+    /// MAME-shaped at the boundary: a room contains cabinets, and cabinets
+    /// contain one or more machines/devices. The cores stay Zeta-owned.
+    [<RequireQualifiedAccess>]
+    type MachineCore =
+        | DarkHallCpu
+        | Chip8Cow
+        | SoftChip8Scheduler
+        | SoftChip8Predictor
+        | Chip9ColorPlanes
+        | MetaCartHost
+        | FingerprintPrism
+        | GameCatalog
+        | SimLoop
+
+    /// One emulator/device mounted inside a cabinet.
+    type Machine =
+        { Name: string
+          Core: MachineCore
+          Does: string
+          Module: string
+          Live: bool
+          RequiredCapabilities: Set<Chip9Capabilities.Capability> }
+
+    /// A cabinet is a durable host object in the Dark Hall. Some cabinets carry
+    /// a single hard machine; others are multi-machine cabinets like a
+    /// cartridge board plus display/input/audio devices.
+    type Cabinet =
+        { Name: string
+          Does: string
+          Verb: string option
+          Module: string
+          Live: bool
+          Machines: Machine list }
+
+    /// The Dark Hall room: the place that owns cabinets. Door modules can
+    /// expose entrances, but the room is the stable substrate.
+    type Room =
+        { Name: string
+          Does: string
+          Cabinets: Cabinet list }
+
+    let machine
+        (name: string)
+        (core: MachineCore)
+        (does: string)
+        (modulePath: string)
+        (live: bool)
+        (requiredCapabilities: Set<Chip9Capabilities.Capability>)
+        : Machine =
+        { Name = name
+          Core = core
+          Does = does
+          Module = modulePath
+          Live = live
+          RequiredCapabilities = requiredCapabilities }
+
+    let cabinet
+        (name: string)
+        (does: string)
+        (verb: string option)
+        (modulePath: string)
+        (live: bool)
+        (machines: Machine list)
+        : Cabinet =
+        { Name = name
+          Does = does
+          Verb = verb
+          Module = modulePath
+          Live = live
+          Machines = machines }
+
+    let createRoom (does: string) (cabinets: Cabinet list) : Room =
+        { Name = "darkhall"
+          Does = does
+          Cabinets = cabinets }
+
+    let machines (room: Room) : Machine list =
+        room.Cabinets |> List.collect (fun cabinet -> cabinet.Machines)
+
+    let liveMachines (room: Room) : Machine list =
+        machines room |> List.filter (fun machine -> machine.Live)
+
+    let machinesRequiring
+        (capability: Chip9Capabilities.Capability)
+        (room: Room)
+        : Machine list =
+        machines room
+        |> List.filter (fun machine -> machine.RequiredCapabilities |> Set.contains capability)
+
     /// Emulator CPU state. Immutable (functional step) ⇒ every run replays identically.
     type EmuState =
         { V: int[]      // 16 registers, byte-valued (0..255); VF is the carry/flag register

--- a/tests/Tests.FSharp/Arcade.Tests.fs
+++ b/tests/Tests.FSharp/Arcade.Tests.fs
@@ -15,6 +15,31 @@ let ``the arcade door gathers its cabinets (incl. the existing DarkHall + soft s
     Assert.True(Arcade.cabinets |> List.forall (fun c -> c.Module.Length > 0))
 
 [<Fact>]
+let ``DarkHall is the room and Arcade is its door over cabinets`` () =
+    Assert.Equal("darkhall", Arcade.room.Name)
+    Assert.Equal(Arcade.name, Arcade.room.Name)
+    Assert.Equal<string list>(Arcade.cabinets |> List.map (fun c -> c.Name), Arcade.room.Cabinets |> List.map (fun c -> c.Name))
+    Assert.True(Arcade.machines.Length > Arcade.cabinets.Length)
+
+[<Fact>]
+let ``play cabinet is a multi-machine CHIP8 CHIP9 meta-cart cabinet`` () =
+    let playCabinet = Arcade.cabinets |> List.find (fun c -> c.Name = "play")
+    let machines = playCabinet.Machines |> List.map (fun m -> m.Name)
+
+    Assert.Contains("soft-chip8", machines)
+    Assert.Contains("chip9-color", machines)
+    Assert.Contains("meta-cart-host", machines)
+    Assert.True(playCabinet.Live)
+
+[<Fact>]
+let ``machine capabilities surface room-level CHIP9 grants`` () =
+    let colorMachines = Arcade.machinesRequiring Chip9Capabilities.Capability.ColorPlanes |> List.map (fun m -> m.Name)
+    let hostMachines = Arcade.machinesRequiring Chip9Capabilities.Capability.HostAssistedChildLaunch |> List.map (fun m -> m.Name)
+
+    Assert.Equal<string list>([ "chip9-color" ], colorMachines)
+    Assert.Equal<string list>([ "meta-cart-host" ], hostMachines)
+
+[<Fact>]
 let ``the arcade signage names the emulator/decompile-to-micro-ops work`` () =
     Assert.Equal("darkhall", Arcade.name)
     Assert.Contains("MIPS-like", Arcade.does)
@@ -28,6 +53,59 @@ let ``live entrance: play runs a ROM on the soft scheduler (CPU steps, sets V[A]
         | Ok f -> Assert.Equal(0x0Cuy, f.V.[0xA])
         | Error e -> Assert.Fail(sprintf "play errored: %A" e)
     }
+
+[<Fact>]
+let ``live entrance: meta cabinet emits heat when parent lacks launch grant`` () =
+    let sink = RecordingHeatSink()
+    let loop = CartFixtures.cart CartFixtures.loop
+    let inputFork = CartFixtures.cart CartFixtures.inputFork
+
+    let caps =
+        MetaCart.capabilityMap
+            [ loop, CartFixtures.loop.Capabilities
+              inputFork, CartFixtures.inputFork.Capabilities ]
+
+    match
+        Arcade.playMetaCabinet
+            "darkhall"
+            (sink :> IHeatSink)
+            10
+            1UL
+            Chip9Capabilities.chip8Default
+            caps
+            [ loop; inputFork ]
+            (Chip8Cow.create 1UL)
+    with
+    | Error(MetaCart.Feedback.HostDenied(denied, reason)) ->
+        Assert.Equal(MetaCart.slotOfCart inputFork, denied)
+        Assert.Contains("meta-cart.host-child-launch", reason)
+        Assert.Equal(1, sink.Signatures.Count)
+        Assert.Equal("meta-cart.denied", sink.Signatures.[0].Kind)
+    | other -> Assert.True(false, sprintf "expected launch denial, got %A" other)
+
+[<Fact>]
+let ``live entrance: meta cabinet runs a granted CHIP9 child`` () =
+    let sink = RecordingHeatSink()
+    let child = CartFixtures.cart CartFixtures.chip9GreenDot
+    let caps = MetaCart.capabilityMap [ child, CartFixtures.chip9GreenDot.Capabilities ]
+
+    match
+        Arcade.playMetaCabinet
+            "darkhall"
+            (sink :> IHeatSink)
+            3
+            1UL
+            Chip9Capabilities.chip9MetaHost
+            caps
+            [ child ]
+            (Chip8Cow.create 1UL)
+    with
+    | Ok result ->
+        Assert.Equal(MetaCart.slotOfCart child, result.Play.Slot)
+        Assert.Equal(2uy, result.Play.FinalFrame.Plane)
+        Assert.Equal(2uy, Chip8Cow.colorAt 0 0 result.Play.FinalFrame)
+        Assert.Equal(0, sink.Signatures.Count)
+    | Error feedback -> Assert.True(false, sprintf "expected granted CHIP9 child, got %A" feedback)
 
 [<Fact>]
 let ``live entrance: host runs the clean-room DarkHall CPU deterministically`` () =


### PR DESCRIPTION
feat(darkhall): model CHIP9 arcade cabinets

Make DarkHall the room-level owner of arcade cabinets and emulator machines. The new room vocabulary keeps the MAME-like shape local and Zeta-owned: a DarkHall room contains cabinets, and cabinets contain one or more machines/devices with explicit capability requirements.

Wire Arcade onto that room model. The play cabinet is now a multi-machine cabinet carrying the soft CHIP-8 scheduler, CHIP-9 color-plane machine, and host-assisted meta-cart machine. Arcade also exposes a playMetaCabinet entrance that routes through the capability-aware MetaCart path, so denied launch/color asks still return typed feedback and emit heat.

Verification:
- dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter "FullyQualifiedName~ArcadeTests|FullyQualifiedName~DarkHallTests|FullyQualifiedName~MetaCartTests|FullyQualifiedName~Chip9CapabilitiesTests" --no-build
- dotnet format --verify-no-changes
- git diff --check
- dotnet build -c Release
- dotnet test Zeta.sln -c Release

Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: OpenAI Codex
Agent-Model: gpt-5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: explicit
Human-Review-Evidence: chat
Action-Mode: human-directed
Task: none
Co-Authored-By: Codex <noreply@openai.com>

