### PR TITLE
docs(aurora): note observe.ts is the liveness path (safety→liveness deferred there)

### DIFF
--- a/docs/trajectories/aurora-immune-reground/RESUME.md
+++ b/docs/trajectories/aurora-immune-reground/RESUME.md
@@ -56,7 +56,12 @@ theorems, not metaphor.
 4. **Prereq:** confirm Z3 `QF_FD` set support in `src/Core.FSharp.Z3Verify` for (d) (else QF_BV subset).
 5. **Refinements noted in-spec:** (b) honest-supermajority-of-quorum needs D=3f+1 sizing;
    (e) multi-claim substrate + multi-hop kernel reachability is the v3.
-6. **Promotion:** when operators stand on proven legs + Aurora's 5 tests pass → open a §B row
+6. **Liveness path = observe.ts (Aaron 2026-06-16).** Round (e) proves *safety* (over-horizon/
+   irreversible inserts are never **committed**), not *liveness* (that they **are** refused). The
+   route to liveness is **observe.ts** — the flushed-out hard-observe being unified with the soft
+   inference (observe⊕soft; observe WorkspacePort in active build, PRs #8458/#8433). Come back to
+   the liveness leg there, NOT by bolting `WF` onto the toy spec. Deferred + tracked.
+7. **Promotion:** when operators stand on proven legs + Aurora's 5 tests pass → open a §B row
    *"Aurora immune re-grounded on the proven identity primitive"*; promote one operator at a time (§C).
 
 ## Hygiene flag (separate, not bundled here)

--- a/src/Core.TLA/specs/PermanentHarmHorizon.tla
+++ b/src/Core.TLA/specs/PermanentHarmHorizon.tla
@@ -92,6 +92,11 @@ Commit ==
 \* (with Commit disabled), not *forced* to: absent fairness it may Stutter. §4.1 is a
 \* safety floor, so this is in-scope; banking "it IS refused" would need `WF_vars(Refuse)`
 \* + a `<>(phase # "pending")` liveness check (v3, alongside the multi-hop refinement).
+\* LIVENESS PATH (Aaron 2026-06-16): the route from this safety floor TO liveness is
+\* **observe.ts** — the flushed-out *hard*-observe being unified with the *soft* inference
+\* (the observe⊕soft unification; observe.ts WorkspacePort is in active build). Progress/
+\* fairness ("the over-horizon insert IS refused", not merely can-be) is reached there, not
+\* by bolting WF onto this toy. Deferred + tracked — come back to it once observe⊕soft lands.
 Refuse ==
     /\ phase = "pending"
     /\ ( irrevFlag \/ (clock >= H /\ curHarm > 0) )


### PR DESCRIPTION
Aaron 2026-06-16: round (e) proves **safety** (over-horizon/irreversible inserts never **committed**), not **liveness** (that they **are** refused). The route to liveness is **observe.ts** — the flushed-out hard-observe unified with the soft inference (observe⊕soft; observe WorkspacePort in active build, #8458/#8433). Note added to the spec's safety-only scope comment + the Aurora trajectory; deferred + tracked, come back to it there. Comment-only; TLC still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
