### PR TITLE
QEMU harness: phase-1 serial preservation + hw-config guards

### DIFF
--- a/docs/trajectories/usb-zflash-installer/RESUME.md
+++ b/docs/trajectories/usb-zflash-installer/RESUME.md
@@ -4,8 +4,8 @@ Status: active — shipped + iterating; first surfaced as a trajectory 2026-05-2
 Last refreshed: 2026-06-16
 Type: workstream (current-focus) — a trajectory the operator is *actively powering*. Many trajectories can be tracked; only a few are workstreams at once (finite-focus / WIP-bounded — a workstream is a trajectory under sustained thrust, and thrust budget is finite, so most trajectories coast). (Genus = "trajectory"; "workstream" is the species: a trajectory under sustained thrust toward a deliverable, vs. emergent-posture trajectories like `anti-infection`. See [`factory-trajectory-surface`](../factory-trajectory-surface/RESUME.md) for the genus/species taxonomy.) One of the operator's three current cluster workstreams (encryption / usb-zflash / ts-workflow-engine).
 Eventual encoding (design-stage — the human maintainer 2026-05-23 genetic-ID substrate + Clifford/HKT): this trajectory's state is trackable as a 128-bit genetic-ID seed (discrete, reversible via parser-combinator ↔ generator-function) → Clifford-space path (continuous, eventual). Mirrors the three-lane I8-lattice / I9-manifold split.
-Current blocker: B-0891 scenario 2 phase-2 disk boot — kernel reaches earlycon then hangs (likely initrd missing virtio_blk; stub hardware-configuration never replaced at install). Scenario 2 advisory again on main while iterating (#8461 stack merged: OVMF 4M, virtio-blk bootindex, no NIC).
-Next concrete action: merge initrd virtio + hardware-configuration copy fix; re-promote scenario 2 hard gate when login prompt green
+Current blocker: B-0891 scenario 2 phase-2 disk boot — initrd virtio root fix (#8478) on main; verifying on build-iso run 27602908527. Scenario 2 advisory while iterating.
+Next concrete action: confirm phase-2 reaches `node-XXXXXX login:` post-#8478; re-promote scenario 2 hard gate when green
 
 ## Why This Exists
 
@@ -59,4 +59,4 @@ bringup.
 
 ## Current Next Action
 
-Merge initrd virtio + `hardware-configuration.nix` copy-at-install fix; verify scenario 2 phase-2 reaches `node-XXXXXX login:` on build-iso, then re-promote hard gate. B-0835 installer bugs + scenarios 3/4 promotion follow.
+Merge initrd virtio + `hardware-configuration.nix` copy-at-install fix (#8478); verify scenario 2 phase-2 reaches `node-XXXXXX login:` on build-iso, then re-promote hard gate. Serial-log artifact preserves phase-1 install output for CI diagnosis.

--- a/src/Core.TypeScript/ci/audit-installer-substrate.ts
+++ b/src/Core.TypeScript/ci/audit-installer-substrate.ts
@@ -126,6 +126,9 @@ const REQUIRED_SENTINELS: readonly SentinelAssertion[] = [
       // iter-5.4.1 hardware-probe sentinels (catches MAC parsing regression from #5352).
       "/proc/cpuinfo", // CPU_MODEL extraction
       "link/ether", // MAC_ADDR parses field AFTER link/ether (not before)
+      // B-0891 phase-2: probe-generated hardware-configuration must land in flake host tree
+      "installing probe-generated hardware-configuration.nix",
+      'hosts/${HOST}/hardware-configuration.nix',
     ],
     rationale: "iter-4.2 + iter-5.1 + iter-5.2 + iter-5.2.2 + iter-5.4.0 + iter-5.4.1 (incl. B-0835 Bug 2a/2b fixes) substrate must be present in installer script",
   },
@@ -171,6 +174,24 @@ const REQUIRED_SENTINELS: readonly SentinelAssertion[] = [
       "ZETA_SELF_REGISTER_MARKER", // marker path exported to implementation
     ],
     rationale: "B-0855.2 service must be a post-install marker-gated oneshot (bash impl) ordered after network and credential restore surfaces",
+  },
+  {
+    path: "full-ai-cluster/nixos/hosts/control-plane/hardware-configuration.nix",
+    mustContain: [
+      "virtio_pci",
+      "virtio_blk",
+      "boot.initrd.kernelModules",
+    ],
+    rationale: "B-0891 QEMU phase-2 initrd floor: virtio modules in host stub until probe copy at install",
+  },
+  {
+    path: "full-ai-cluster/nixos/hosts/worker-gpu/hardware-configuration.nix",
+    mustContain: [
+      "virtio_pci",
+      "virtio_blk",
+      "boot.initrd.kernelModules",
+    ],
+    rationale: "B-0891 QEMU phase-2 initrd floor: virtio modules in worker stub until probe copy at install",
   },
   {
     path: "full-ai-cluster/nixos/modules/injected-hostname.nix",

--- a/src/Core.TypeScript/ci/qemu-full-install-test.test.ts
+++ b/src/Core.TypeScript/ci/qemu-full-install-test.test.ts
@@ -4,7 +4,9 @@ import {
   buildQemuDiskBootArgsPure,
   detectUnexpectedControlPlaneLogin,
   extractGeneratedHostname,
+  mergeFullInstallSerialLogs,
   OVMF_FIRMWARE_CANDIDATES,
+  PHASE2_SERIAL_SEPARATOR,
 } from "./qemu-full-install-test.ts";
 
 describe("validateSelfRegCiCoherent", () => {
@@ -55,6 +57,18 @@ describe("qemu-full-install-test phase 2 disk boot QEMU args", () => {
     expect(args.join(" ")).not.toContain("netdev");
     expect(args).toContain("-vga");
     expect(args).toContain("none");
+  });
+});
+
+describe("qemu-full-install-test serial log artifact merge", () => {
+  it("preserves phase 1 output when phase 2 QEMU truncates its serial file", () => {
+    const merged = mergeFullInstallSerialLogs(
+      "phase1: ZETA CLUSTER NODE INSTALL COMPLETE\n",
+      "phase2: node-abc123 login:",
+    );
+    expect(merged).toContain("ZETA CLUSTER NODE INSTALL COMPLETE");
+    expect(merged).toContain(PHASE2_SERIAL_SEPARATOR.trim());
+    expect(merged).toContain("node-abc123 login:");
   });
 });
 

--- a/src/Core.TypeScript/ci/qemu-full-install-test.ts
+++ b/src/Core.TypeScript/ci/qemu-full-install-test.ts
@@ -21,7 +21,7 @@
  */
 
 import { execFileSync, spawn } from "node:child_process";
-import { appendFileSync, existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { serialFirstBootInProgress } from "../zflash/test-harness/serial-markers";
@@ -60,6 +60,15 @@ const MEMORY_MB = 4096;
 const CPU_COUNT = 2;
 const DISK_SIZE_GB = 20;
 const KVM_PATH = "/dev/kvm";
+
+/** Separator between phase-1 installer serial and phase-2 disk-boot serial in artifacts. */
+export const PHASE2_SERIAL_SEPARATOR =
+  "\n\n=== PHASE 2: boot installed disk (no ISO) ===\n\n";
+
+/** Exported for unit tests. QEMU `-serial file:` truncates on each launch. */
+export function mergeFullInstallSerialLogs(phase1: string, phase2: string): string {
+  return phase1 + PHASE2_SERIAL_SEPARATOR + phase2;
+}
 
 /** Exported for unit tests. */
 export const OVMF_FIRMWARE_CANDIDATES = [
@@ -403,7 +412,7 @@ async function waitForInstalledLogin(
     content.trim().length === 0
       ? " (serial log empty — installed disk may need UEFI/OVMF boot or console=ttyS0 on the installed node)"
       : content.includes("EFI stub: Loaded initrd") && !content.includes("login:")
-        ? " (serial stopped after EFI initrd — check UEFI boot order / virtio-net PXE entry / console kernel params)"
+        ? " (serial stopped after EFI initrd — likely initrd cannot mount virtio root; verify hardware-configuration.nix copy at install + virtio_blk in initrd)"
         : "";
   return {
     exitCode: 1,
@@ -495,38 +504,44 @@ async function main(): Promise<never> {
 
   const tmpDir = mkdtempSync(join(tmpdir(), "zeta-qemu-full-install-test-"));
   const diskPath = join(tmpDir, "install-target.qcow2");
-  const serialLogPath = process.env.SERIAL_LOG_OUT_PATH ?? join(tmpDir, "serial.log");
+  const artifactSerialLogPath = process.env.SERIAL_LOG_OUT_PATH ?? join(tmpDir, "serial.log");
+  const phase1SerialLogPath = join(tmpDir, "phase1-serial.log");
+  const phase2SerialLogPath = join(tmpDir, "phase2-serial.log");
+
+  const writeArtifactSerialLog = (phase1: string, phase2: string): void => {
+    writeFileSync(artifactSerialLogPath, mergeFullInstallSerialLogs(phase1, phase2));
+  };
 
   console.log(`[qemu-full-install-test] ISO: ${isoPath}`);
   console.log(`[qemu-full-install-test] Virtual disk: ${diskPath}`);
-  console.log(`[qemu-full-install-test] Serial log: ${serialLogPath}`);
+  console.log(`[qemu-full-install-test] Serial log artifact: ${artifactSerialLogPath}`);
 
   createVirtualDisk(diskPath);
 
   const phase1 = await runQemuUntil(
-    buildQemuInstallArgs(isoPath, diskPath, serialLogPath),
-    serialLogPath,
-    () => waitForInstallComplete(serialLogPath),
+    buildQemuInstallArgs(isoPath, diskPath, phase1SerialLogPath),
+    phase1SerialLogPath,
+    () => waitForInstallComplete(phase1SerialLogPath),
     "phase 1 (ISO install)",
   );
+  const phase1Serial = readSerial(phase1SerialLogPath);
   if (phase1.exitCode !== 0) {
-    reportResult(phase1, serialLogPath);
+    writeArtifactSerialLog(phase1Serial, "");
+    reportResult(phase1, artifactSerialLogPath);
   }
 
-  const installSerial = readSerial(serialLogPath);
-  const hostname = phase1.hostname ?? extractGeneratedHostname(installSerial);
+  const hostname = phase1.hostname ?? extractGeneratedHostname(phase1Serial);
   console.log(`[qemu-full-install-test] phase 1 done; expected hostname: ${hostname ?? "(infer at login)"}`);
 
-  appendFileSync(serialLogPath, "\n\n=== PHASE 2: boot installed disk (no ISO) ===\n\n");
-
   const phase2 = await runQemuUntil(
-    buildQemuDiskBootArgs(diskPath, serialLogPath, tmpDir),
-    serialLogPath,
-    () => waitForInstalledLogin(serialLogPath, hostname),
+    buildQemuDiskBootArgs(diskPath, phase2SerialLogPath, tmpDir),
+    phase2SerialLogPath,
+    () => waitForInstalledLogin(phase2SerialLogPath, hostname),
     "phase 2 (disk boot)",
   );
 
-  reportResult(phase2, serialLogPath);
+  writeArtifactSerialLog(phase1Serial, readSerial(phase2SerialLogPath));
+  reportResult(phase2, artifactSerialLogPath);
 }
 
 if (import.meta.main) {

--- a/src/Core.TypeScript/ci/test-iter-54-install-flow.test.ts
+++ b/src/Core.TypeScript/ci/test-iter-54-install-flow.test.ts
@@ -346,3 +346,17 @@ describe("iter-5.4 substrate-honest framing (defense-in-depth assertions)", () =
     );
   });
 });
+
+describe("iter-5.1 hardware-configuration copy (B-0891 phase-2 initrd)", () => {
+  test("nixos-generate-config output is copied into flake host tree before nixos-install", () => {
+    const genIdx = SCRIPT.indexOf("nixos-generate-config --root /mnt");
+    const copyIdx = SCRIPT.indexOf("installing probe-generated hardware-configuration.nix");
+    const installIdx = SCRIPT.indexOf("nixos-install --flake");
+    expect(genIdx).toBeGreaterThan(0);
+    expect(copyIdx).toBeGreaterThan(genIdx);
+    expect(installIdx).toBeGreaterThan(copyIdx);
+    expect(SCRIPT).toContain(
+      'HW_DST="/mnt/etc/zeta/full-ai-cluster/nixos/hosts/${HOST}/hardware-configuration.nix"',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- **Serial log artifact**: phase 2 QEMU was truncating the shared serial file, so uploaded logs only showed ~4KB of phase-2 earlycon (run 27598982580). Phase 1 and phase 2 now use separate temp paths; artifact merges both with a separator.
- **Regression guards**: audit + structural test assert  output is copied to  before , and host stubs include virtio initrd modules.
- **Diagnostics**: phase-2 timeout hint names virtio root / hardware-configuration copy when serial stops after EFI initrd.

Composes with #8478 (initrd virtio fix on main). Does not change scenario 2 gate status.

## Test plan
- [x] bun test v1.3.13 (bf2e2cec)
- [ ] CI audit + structural-behavioral steps green
- [ ] Next build-iso scenario 2 artifact includes phase-1  line