### PR TITLE
Re-promote B-0891 scenario 2 hard gate

### DIFF
--- a/.github/workflows/build-ai-cluster-iso.yml
+++ b/.github/workflows/build-ai-cluster-iso.yml
@@ -274,16 +274,14 @@ jobs:
       # waits for `[iter-5.3]` marker in serial log to verify nixos-install
       # + iter-4.2 + iter-5.2 substrate completed.
       #
-      # Hard gate on push-to-main for scenario 1. Scenario 2 demoted back to
-      # advisory (2026-06-16): phase-2 login prompt still failing after OVMF +
-      # virtio-blk bootindex fixes — harness + install substrate iterating on
-      # initrd virtio root mount (run 27598982580). Re-promote when green.
+      # Hard gate on push-to-main for scenarios 1 + 2. Scenario 2 green on
+      # main after #8478 initrd virtio root fix (run 27602908527: phase-2
+      # reached node-XXXXXX login:).
       #
       # Security: no github.event.* interpolation; ISO path comes from
       # prior workflow step's filesystem find.
       - name: B-0891 scenario 2 — boot + install substrate (B-0831 Slice 1)
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        continue-on-error: true
         timeout-minutes: 90
         working-directory: full-ai-cluster
         env:

--- a/docs/trajectories/usb-zflash-installer/RESUME.md
+++ b/docs/trajectories/usb-zflash-installer/RESUME.md
@@ -4,8 +4,8 @@ Status: active — shipped + iterating; first surfaced as a trajectory 2026-05-2
 Last refreshed: 2026-06-16
 Type: workstream (current-focus) — a trajectory the operator is *actively powering*. Many trajectories can be tracked; only a few are workstreams at once (finite-focus / WIP-bounded — a workstream is a trajectory under sustained thrust, and thrust budget is finite, so most trajectories coast). (Genus = "trajectory"; "workstream" is the species: a trajectory under sustained thrust toward a deliverable, vs. emergent-posture trajectories like `anti-infection`. See [`factory-trajectory-surface`](../factory-trajectory-surface/RESUME.md) for the genus/species taxonomy.) One of the operator's three current cluster workstreams (encryption / usb-zflash / ts-workflow-engine).
 Eventual encoding (design-stage — the human maintainer 2026-05-23 genetic-ID substrate + Clifford/HKT): this trajectory's state is trackable as a 128-bit genetic-ID seed (discrete, reversible via parser-combinator ↔ generator-function) → Clifford-space path (continuous, eventual). Mirrors the three-lane I8-lattice / I9-manifold split.
-Current blocker: B-0891 scenario 2 phase-2 disk boot — initrd virtio root fix (#8478) on main; verifying on build-iso run 27602908527. Scenario 2 advisory while iterating.
-Next concrete action: confirm phase-2 reaches `node-XXXXXX login:` post-#8478; re-promote scenario 2 hard gate when green
+Current blocker: none for scenario 2 — green on main (run 27602908527: phase-2 `node-071392 login:` after #8478 initrd virtio fix). Scenario 2 re-promoted hard gate.
+Next concrete action: promote scenarios 3/4 via workflow_dispatch when ready; physical WiFi confirmation out-of-band
 
 ## Why This Exists
 
@@ -40,7 +40,7 @@ Grounding backlog:
 
 - [`B-0844`](../../backlog/P1/081KSGS9H0008QG0R001EZKNCB-zflash-agent-mode-native-implementation-close-doc-vs-impleme.md) — zflash agent-mode native implementation (**closed** — `--agent` in `cli.ts`)
 - Workitem `081KV1PY2H308QG0R00347547K` — `zeta flash` MCP router (**done** #8104)
-- [`B-0831`](../../backlog/P1/081KSGS9H0008QG0R0011BC7T2-ci-cascade-6-full-install-plus-cluster-auto-join-eliminate-r.md) — CI cascade-6: slices 1–3 landed (#8126, #8129, #8139); scenario 1 hard gate; scenario 2 advisory (phase-2 login iterating — OVMF/virtio stack #8335–#8461 on main)
+- [`B-0831`](../../backlog/P1/081KSGS9H0008QG0R0011BC7T2-ci-cascade-6-full-install-plus-cluster-auto-join-eliminate-r.md) — CI cascade-6: slices 1–3 landed (#8126, #8129, #8139); scenarios 1 + 2 hard gate (scenario 2 green run 27602908527 after #8478 initrd virtio)
 - [`B-0835`](../../backlog/P1/B-0835-installer-config-bugs-cluster-hostname-not-unique-gh-auth-not-respected-banner-password-disclosure-empirical-aaron-2026-05-26.md) — installer config bugs (hostname-not-unique, gh-auth, banner)
 - [`B-0792`](../../backlog/P1/B-0792-iter5-wifi-credentials-injection-via-usb-esp-for-zero-typing-cluster-bringup-without-ethernet-load-bearing-for-homelab-persona-aaron-2026-05-26.md) — iter-5 WiFi-credentials injection via USB ESP (zero-typing bringup without ethernet)
 - [`B-0789`](../../backlog/P1/B-0789-iter4-ssh-key-and-hashedpassword-substrate-for-cluster-bringup-2026-05-26.md) — iter-4 SSH-key + hashedPassword substrate (shared seam with encryption)
@@ -59,4 +59,4 @@ bringup.
 
 ## Current Next Action
 
-Merge initrd virtio + `hardware-configuration.nix` copy-at-install fix (#8478); verify scenario 2 phase-2 reaches `node-XXXXXX login:` on build-iso, then re-promote hard gate. Serial-log artifact preserves phase-1 install output for CI diagnosis.
+Scenario 2 hard gate restored. Next: workflow_dispatch scenarios 3/4 promotion; B-0835 installer bugs; physical WiFi path.


### PR DESCRIPTION
## Summary
Scenario 2 green on main (run 27602908527): phase-2 UEFI disk boot reached `node-071392 login:` after #8478 initrd virtio fix. Removes `continue-on-error: true` from the QEMU full-install step.

## Test plan
- [x] Prior run 27602908527 scenario 2 passed
- [ ] Next push build-iso fails job if scenario 2 regresses