### PR TITLE
feat(darkhall): add observe-style room loop

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -335,6 +335,7 @@
     <Compile Include="DarkHall.fs" />
     <Compile Include="Arcade.fs" />
     <Compile Include="DarkHallCabinetRuntime.fs" />
+    <Compile Include="DarkHallRoomLoop.fs" />
     <Compile Include="ReticulumQuantum.fs" />
     <Compile Include="Skadium.fs" />
     <Compile Include="BowlingAlley.fs" />

--- a/src/Core/DarkHallCabinetRuntime.fs
+++ b/src/Core/DarkHallCabinetRuntime.fs
@@ -40,11 +40,18 @@ module DarkHallCabinetRuntime =
           FeedbackVariants: string list
           Address: MachineAddress option }
 
-    type Readout =
+    /// The Dark Hall's projection onto the universal controller surface.
+    ///
+    /// `Grid` is the 4x4 placement primitive (`GridBinding`). The readout is the
+    /// larger controller/menu observation: available action grammar entries,
+    /// deterministic construction rules, and the room being observed.
+    type ControllerReadout =
         { RoomName: string
           Grid: GridBinding.GridBinding<CabinetAction>
           Actions: CabinetAction list
           DeterministicRulesApplied: string list }
+
+    type Readout = ControllerReadout
 
     type MetaCartLaunch =
         { Goal: int
@@ -184,7 +191,7 @@ module DarkHallCabinetRuntime =
 
     /// observe.ts-shaped readout: reduce the whole room to the 4x4 controller
     /// labels plus the deterministic rules used to build that menu.
-    let observeWithPriority (priority: Map<string, float>) (room: DarkHall.Room) : Readout =
+    let observeWithPriority (priority: Map<string, float>) (room: DarkHall.Room) : ControllerReadout =
         let actions = machineActions priority room @ [ escapeHatch; editGrammar ]
 
         { RoomName = room.Name
@@ -195,12 +202,14 @@ module DarkHallCabinetRuntime =
               "salience.display top-14 machines"
               "escape-hatch always available"
               "grammar-extension always available"
+              "actiongrid 4x4 geometry"
+              "gridbinding labels controller cells"
               "gridbinding 4x4" ] }
 
-    let observe (room: DarkHall.Room) : Readout =
+    let observe (room: DarkHall.Room) : ControllerReadout =
         observeWithPriority defaultPriority room
 
-    let actionAt (cell: int) (readout: Readout) : CabinetAction option =
+    let actionAt (cell: int) (readout: ControllerReadout) : CabinetAction option =
         GridBinding.labelAt cell readout.Grid
 
     let private findCabinet (room: DarkHall.Room) (cabinetName: string) =

--- a/src/Core/DarkHallRoomLoop.fs
+++ b/src/Core/DarkHallRoomLoop.fs
@@ -1,0 +1,191 @@
+namespace Zeta.Core
+
+open System.Threading.Tasks
+
+/// Observe/choose/execute loop for Dark Hall cabinets.
+///
+/// This is the F# room-loop counterpart to `src/Core.TypeScript/observe/execute.ts`:
+/// observe the current room into a controller readout, choose one bound cell, run
+/// the selected effect through the owned cabinet runtime, and append a typed
+/// event to the room ledger. The 4x4 `GridBinding` remains only the controller
+/// placement view; this module owns the loop semantics.
+[<RequireQualifiedAccess>]
+module DarkHallRoomLoop =
+
+    module Runtime = DarkHallCabinetRuntime
+
+    [<RequireQualifiedAccess>]
+    type ChoiceTier =
+        | Oracle
+        | Composer
+        | Deliberator
+        | Operator
+
+    type ControllerChoice =
+        { Cell: int
+          Tier: ChoiceTier
+          Confidence: float
+          Reason: string }
+
+    type RequestResolver = Runtime.CabinetAction -> Runtime.RunRequest option
+
+    [<RequireQualifiedAccess>]
+    type TickFeedback =
+        | CellUnbound of cell: int
+        | ControllerActionSelected of cell: int * action: Runtime.CabinetAction
+        | RequestMissing of cell: int * action: Runtime.CabinetAction
+        | RuntimeFeedback of Runtime.Feedback
+
+    [<RequireQualifiedAccess>]
+    type LoopEvent =
+        | Observed of roomName: string * actionCount: int
+        | Chosen of choice: ControllerChoice * action: Runtime.CabinetAction
+        | Executed of choice: ControllerChoice * action: Runtime.CabinetAction * result: Runtime.RunResult
+        | Refused of choice: ControllerChoice option * action: Runtime.CabinetAction option * feedback: TickFeedback
+
+    type LoopState =
+        { Room: DarkHall.Room
+          Manifest: Chip9Capabilities.Manifest
+          EventsRev: LoopEvent list
+          LastReadout: Runtime.ControllerReadout option
+          LastResult: Runtime.RunResult option }
+
+    type TickOutcome =
+        { Readout: Runtime.ControllerReadout
+          Choice: ControllerChoice
+          Action: Runtime.CabinetAction option
+          Result: Result<Runtime.RunResult, TickFeedback>
+          State: LoopState }
+
+    type RunOutcome =
+        { Ticks: TickOutcome list
+          Final: LoopState }
+
+    let initial (room: DarkHall.Room) (manifest: Chip9Capabilities.Manifest) : LoopState =
+        { Room = room
+          Manifest = manifest
+          EventsRev = []
+          LastReadout = None
+          LastResult = None }
+
+    let events (state: LoopState) : LoopEvent list =
+        List.rev state.EventsRev
+
+    let private append (event: LoopEvent) (state: LoopState) : LoopState =
+        { state with EventsRev = event :: state.EventsRev }
+
+    let private complete
+        (readout: Runtime.ControllerReadout)
+        (choice: ControllerChoice)
+        (action: Runtime.CabinetAction option)
+        (result: Result<Runtime.RunResult, TickFeedback>)
+        (state: LoopState)
+        : TickOutcome =
+        { Readout = readout
+          Choice = choice
+          Action = action
+          Result = result
+          State = state }
+
+    let private cellForAction (action: Runtime.CabinetAction) (readout: Runtime.ControllerReadout) : int option =
+        GridBinding.bound readout.Grid
+        |> List.tryFind (fun (_, bound) -> bound.Id = action.Id)
+        |> Option.map fst
+
+    /// Cheap deterministic chooser: pick the first executable cabinet action in
+    /// the current controller readout. This is the room-loop oracle tier; richer
+    /// soft/dynamic policies can replace it without changing the tick boundary.
+    let chooseFirstExecutable (readout: Runtime.ControllerReadout) : ControllerChoice =
+        let cell =
+            readout.Actions
+            |> List.tryFind (fun action -> Option.isSome action.Address)
+            |> Option.bind (fun action -> cellForAction action readout)
+            |> Option.orElseWith (fun () -> GridBinding.bound readout.Grid |> List.tryHead |> Option.map fst)
+            |> Option.defaultValue 0
+
+        { Cell = cell
+          Tier = ChoiceTier.Oracle
+          Confidence = 1.0
+          Reason = "first executable cabinet action in the controller readout" }
+
+    /// One observe.ts-shaped tick: observe -> choose -> execute -> append.
+    let tick
+        (source: string)
+        (sink: IHeatSink)
+        (requestFor: RequestResolver)
+        (choose: Runtime.ControllerReadout -> ControllerChoice)
+        (state: LoopState)
+        : Task<TickOutcome> =
+        let readout = Runtime.observe state.Room
+
+        let observed =
+            { state with LastReadout = Some readout }
+            |> append (LoopEvent.Observed(readout.RoomName, readout.Actions.Length))
+
+        let choice = choose readout
+
+        match Runtime.actionAt choice.Cell readout with
+        | None ->
+            let feedback = TickFeedback.CellUnbound choice.Cell
+            let next = observed |> append (LoopEvent.Refused(Some choice, None, feedback))
+            Task.FromResult(complete readout choice None (Error feedback) next)
+
+        | Some action ->
+            let chosen = observed |> append (LoopEvent.Chosen(choice, action))
+
+            match action.Address with
+            | None ->
+                let feedback = TickFeedback.ControllerActionSelected(choice.Cell, action)
+                let next = chosen |> append (LoopEvent.Refused(Some choice, Some action, feedback))
+                Task.FromResult(complete readout choice (Some action) (Error feedback) next)
+
+            | Some _ ->
+                match requestFor action with
+                | None ->
+                    let feedback = TickFeedback.RequestMissing(choice.Cell, action)
+                    let next = chosen |> append (LoopEvent.Refused(Some choice, Some action, feedback))
+                    Task.FromResult(complete readout choice (Some action) (Error feedback) next)
+
+                | Some request ->
+                    task {
+                        let! result =
+                            Runtime.executeCell source sink state.Manifest state.Room choice.Cell request
+
+                        match result with
+                        | Ok runResult ->
+                            let next =
+                                { chosen with LastResult = Some runResult }
+                                |> append (LoopEvent.Executed(choice, action, runResult))
+
+                            return complete readout choice (Some action) (Ok runResult) next
+
+                        | Error runtimeFeedback ->
+                            let feedback = TickFeedback.RuntimeFeedback runtimeFeedback
+                            let next = chosen |> append (LoopEvent.Refused(Some choice, Some action, feedback))
+                            return complete readout choice (Some action) (Error feedback) next
+                    }
+
+    /// Bounded foreground room loop. Infinity happens by explicit continuation
+    /// scheduling outside this function; one call always runs a finite number of ticks.
+    let run
+        (source: string)
+        (sink: IHeatSink)
+        (requestFor: RequestResolver)
+        (choose: Runtime.ControllerReadout -> ControllerChoice)
+        (maxTicks: int)
+        (state: LoopState)
+        : Task<RunOutcome> =
+        task {
+            let tickCount = max 1 maxTicks
+            let mutable current = state
+            let mutable ticksRev = []
+
+            for _ in 1..tickCount do
+                let! outcome = tick source sink requestFor choose current
+                current <- outcome.State
+                ticksRev <- outcome :: ticksRev
+
+            return
+                { Ticks = List.rev ticksRev
+                  Final = current }
+        }

--- a/tests/Tests.FSharp/DarkHallRoomLoop.Tests.fs
+++ b/tests/Tests.FSharp/DarkHallRoomLoop.Tests.fs
@@ -1,0 +1,164 @@
+module Zeta.Tests.DarkHallRoomLoopTests
+
+open global.Xunit
+open Zeta.Core
+
+module Runtime = DarkHallCabinetRuntime
+module RoomLoop = DarkHallRoomLoop
+
+let private setRegRom = [| 0x6Auy; 0x0Cuy; 0x12uy; 0x02uy |]
+
+let private mkAddress cabinet machine : Runtime.MachineAddress =
+    { CabinetName = cabinet
+      MachineName = machine }
+
+let private chooseById id (readout: Runtime.ControllerReadout) : RoomLoop.ControllerChoice =
+    let cell =
+        GridBinding.bound readout.Grid
+        |> List.tryFind (fun (_, action) -> action.Id = id)
+        |> Option.map fst
+        |> Option.defaultValue -1
+
+    { Cell = cell
+      Tier = RoomLoop.ChoiceTier.Operator
+      Confidence = 1.0
+      Reason = "test-selected action id" }
+
+let private wait (task: System.Threading.Tasks.Task<'T>) : 'T =
+    task.GetAwaiter().GetResult()
+
+[<Fact>]
+let ``ControllerReadout names the controller projection while GridBinding stays the 4x4 placement`` () =
+    let readout = Runtime.observe Arcade.room
+
+    Assert.Equal("darkhall", readout.RoomName)
+    Assert.Contains("actiongrid 4x4 geometry", readout.DeterministicRulesApplied)
+    Assert.Contains("gridbinding labels controller cells", readout.DeterministicRulesApplied)
+    Assert.True(GridBinding.count readout.Grid <= GridBinding.Size)
+
+[<Fact>]
+let ``tick observes chooses executes and appends the cabinet event ledger`` () =
+    let sink = RecordingHeatSink()
+    let state = RoomLoop.initial Arcade.room Chip9Capabilities.chip8Default
+
+    let requestFor (action: Runtime.CabinetAction) =
+        if action.Id = "darkhall.play.soft-chip8" then
+            Some(Runtime.RunSoftChip8(1UL, setRegRom, 5))
+        else
+            None
+
+    let outcome =
+        RoomLoop.tick
+            "darkhall-room-loop"
+            (sink :> IHeatSink)
+            requestFor
+            (chooseById "darkhall.play.soft-chip8")
+            state
+        |> wait
+
+    match outcome.Result with
+    | Ok(Runtime.SoftChip8Frame frame) ->
+        Assert.Equal(0x0Cuy, frame.V.[0xA])
+        Assert.Equal(0, sink.Signatures.Count)
+        Assert.Equal(Some "darkhall.play.soft-chip8", outcome.Action |> Option.map (fun action -> action.Id))
+
+        match RoomLoop.events outcome.State with
+        | [ RoomLoop.LoopEvent.Observed("darkhall", _)
+            RoomLoop.LoopEvent.Chosen(_, chosen)
+            RoomLoop.LoopEvent.Executed(_, executed, Runtime.SoftChip8Frame _) ] ->
+            Assert.Equal("darkhall.play.soft-chip8", chosen.Id)
+            Assert.Equal("darkhall.play.soft-chip8", executed.Id)
+        | events -> Assert.Fail(sprintf "unexpected events: %A" events)
+    | other -> Assert.Fail(sprintf "expected soft CHIP8 execution, got %A" other)
+
+[<Fact>]
+let ``tick records controller-only grammar action as a typed refusal without heat`` () =
+    let sink = RecordingHeatSink()
+    let state = RoomLoop.initial Arcade.room Chip9Capabilities.chip8Default
+
+    let outcome =
+        RoomLoop.tick
+            "darkhall-room-loop"
+            (sink :> IHeatSink)
+            (fun _ -> None)
+            (chooseById "darkhall.edit-grammar")
+            state
+        |> wait
+
+    match outcome.Result with
+    | Error(RoomLoop.TickFeedback.ControllerActionSelected(_, action)) ->
+        Assert.Equal("darkhall.edit-grammar", action.Id)
+        Assert.Equal(0, sink.Signatures.Count)
+
+        match RoomLoop.events outcome.State |> List.rev |> List.tryHead with
+        | Some(RoomLoop.LoopEvent.Refused(_, Some refused, RoomLoop.TickFeedback.ControllerActionSelected _)) ->
+            Assert.Equal("darkhall.edit-grammar", refused.Id)
+        | other -> Assert.Fail(sprintf "expected controller refusal event, got %A" other)
+    | other -> Assert.Fail(sprintf "expected controller action refusal, got %A" other)
+
+[<Fact>]
+let ``tick appends runtime refusal and emits heat for denied cabinet capability`` () =
+    let sink = RecordingHeatSink()
+    let child = CartFixtures.cart CartFixtures.chip9GreenDot
+    let caps = MetaCart.capabilityMap [ child, CartFixtures.chip9GreenDot.Capabilities ]
+
+    let launch: Runtime.MetaCartLaunch =
+        { Goal = 3
+          Seed = 1UL
+          ParentCapabilities = Chip9Capabilities.chip8Default
+          ChildCapabilitiesBySha = caps
+          Children = [ child ]
+          Parent = Chip8Cow.create 1UL }
+
+    let requestFor (action: Runtime.CabinetAction) =
+        if action.Id = "darkhall.play.meta-cart-host" then
+            Some(Runtime.RunMetaCart launch)
+        else
+            None
+
+    let outcome =
+        RoomLoop.tick
+            "darkhall-room-loop"
+            (sink :> IHeatSink)
+            requestFor
+            (chooseById "darkhall.play.meta-cart-host")
+            (RoomLoop.initial Arcade.room Chip9Capabilities.chip8Default)
+        |> wait
+
+    match outcome.Result with
+    | Error(RoomLoop.TickFeedback.RuntimeFeedback(Runtime.Feedback.CapabilityDenied(address, capability))) ->
+        Assert.Equal(mkAddress "play" "meta-cart-host", address)
+        Assert.Equal(Chip9Capabilities.Capability.HostAssistedChildLaunch, capability)
+        Assert.Equal(1, sink.Signatures.Count)
+        Assert.Equal("darkhall.machine.denied", sink.Signatures.[0].Kind)
+
+        match RoomLoop.events outcome.State |> List.rev |> List.tryHead with
+        | Some(RoomLoop.LoopEvent.Refused(_, Some refused, RoomLoop.TickFeedback.RuntimeFeedback _)) ->
+            Assert.Equal("darkhall.play.meta-cart-host", refused.Id)
+        | other -> Assert.Fail(sprintf "expected runtime refusal event, got %A" other)
+    | other -> Assert.Fail(sprintf "expected denied capability, got %A" other)
+
+[<Fact>]
+let ``run is bounded and carries state through consecutive room ticks`` () =
+    let sink = RecordingHeatSink()
+    let state = RoomLoop.initial Arcade.room Chip9Capabilities.chip8Default
+
+    let requestFor (action: Runtime.CabinetAction) =
+        if action.Id = "darkhall.play.soft-chip8" then
+            Some(Runtime.RunSoftChip8(1UL, setRegRom, 5))
+        else
+            None
+
+    let run =
+        RoomLoop.run
+            "darkhall-room-loop"
+            (sink :> IHeatSink)
+            requestFor
+            (chooseById "darkhall.play.soft-chip8")
+            2
+            state
+        |> wait
+
+    Assert.Equal(2, run.Ticks.Length)
+    Assert.Equal(6, RoomLoop.events run.Final |> List.length)
+    Assert.Equal(0, sink.Signatures.Count)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -135,6 +135,7 @@
     <Compile Include="Salon.Tests.fs" />
     <Compile Include="Arcade.Tests.fs" />
     <Compile Include="DarkHallCabinetRuntime.Tests.fs" />
+    <Compile Include="DarkHallRoomLoop.Tests.fs" />
     <Compile Include="BowlingAlley.Tests.fs" />
     <Compile Include="Skadium.Tests.fs" />
     <Compile Include="DevRoom.Tests.fs" />


### PR DESCRIPTION
## Summary

- clarifies DarkHall controller naming: `ControllerReadout` is the room/controller projection, while `GridBinding` remains the 4x4 placement primitive
- adds `DarkHallRoomLoop` as an observe.ts-shaped loop: observe -> choose -> execute -> append typed event
- records observed/chosen/executed/refused events, supports typed controller-only refusals, and preserves heat emission on runtime capability denial
- covers the loop with focused F# tests for successful execution, grammar-action refusal, heat/refusal, and bounded multi-tick runs

## Verification

- `dotnet format --verify-no-changes`
- `dotnet build tests/Tests.FSharp/Tests.FSharp.fsproj -c Release -v:minimal`
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter "FullyQualifiedName~DarkHallRoomLoopTests|FullyQualifiedName~DarkHallCabinetRuntimeTests|FullyQualifiedName~ArcadeTests|FullyQualifiedName~DarkHallTests|FullyQualifiedName~MetaCartTests|FullyQualifiedName~Chip9CapabilitiesTests" --no-build`
- `dotnet build -c Release`
- `dotnet test Zeta.sln -c Release --no-build`

## Note

One local full-build attempt hit an intermittent F# compiler `exit 139` in `bench/Benchmarks/Benchmarks.fsproj`; the isolated project build passed twice, then the full release build and full solution tests passed cleanly.

Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: OpenAI Codex
Agent-Model: gpt-5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: explicit
Human-Review-Evidence: chat
Action-Mode: human-directed
Task: none
Co-Authored-By: Codex <noreply@openai.com>