### PR TITLE
fix(observe): restore main-green TS lint — clear 11 tsc errors from the schema-evolution merges (#8458/#8487)

### DIFF
--- a/src/Core.TypeScript/observe/schema-cdc.ts
+++ b/src/Core.TypeScript/observe/schema-cdc.ts
@@ -86,7 +86,7 @@ export function emitSchemaEvent(
     type: "schema.evolved",
     specversion: "1.0",
     time: new Date(now()).toISOString(),
-    subject: opts.subject,
+    ...(opts.subject !== undefined ? { subject: opts.subject } : {}),
     datacontenttype: "application/json",
     data: {
       before,

--- a/src/Core.TypeScript/observe/schema-evolution-demo.test.ts
+++ b/src/Core.TypeScript/observe/schema-evolution-demo.test.ts
@@ -19,7 +19,6 @@ import {
   deltaFromSchemas,
   currentSchema,
   resolveField,
-  consolidate,
   FS_METADATA_SCHEMA_V1,
   FS_METADATA_SCHEMA_V2,
 } from "./schema-zset";
@@ -32,7 +31,6 @@ import {
   overlapStatus,
   tryConsolidate,
   migrateReader,
-  registerReader,
   type SchemaReader,
 } from "./schema-overlap";
 
@@ -103,7 +101,7 @@ describe("schema evolution worked example: FS metadata v1 → v2", () => {
   test("lifecycle with field REMOVAL (the harder case)", () => {
     // Remove "modified" field — this creates a real overlap window
     let schema = schemaZSet(FS_METADATA_SCHEMA_V1);
-    let readers: SchemaReader[] = [
+    let readers: readonly SchemaReader[] = [
       { id: "otto", migrated: false },
       { id: "alexa", migrated: false },
     ];

--- a/src/Core.TypeScript/observe/schema-golden-vectors.ts
+++ b/src/Core.TypeScript/observe/schema-golden-vectors.ts
@@ -23,10 +23,8 @@ import {
   applyDelta,
   currentSchema,
   consolidate,
-  deltaFromSchemas,
   type SchemaField,
   type SchemaEvolutionDelta,
-  type SchemaZSet as SchemaZSetType,
 } from "./schema-zset";
 
 // ─── The canonical scenario ──────────────────────────────────────────────────

--- a/src/Core.TypeScript/observe/schema-overlap.test.ts
+++ b/src/Core.TypeScript/observe/schema-overlap.test.ts
@@ -53,10 +53,6 @@ describe("schema-overlap — state machine", () => {
 
   test("readers_migrating when some (not all) readers migrated", () => {
     const schema = schemaZSet(FS_METADATA_SCHEMA_V1);
-    const delta: SchemaEvolutionDelta = {
-      retract: [{ name: "modified", type: "string", required: false }],
-      insert: [],
-    };
     const evolved = [...schema, { field: { name: "modified", type: "string" as const, required: false }, weight: -1 }];
 
     const partiallyMigrated = migrateReader(READERS, "otto");

--- a/src/Core.TypeScript/observe/schema-overlap.ts
+++ b/src/Core.TypeScript/observe/schema-overlap.ts
@@ -14,7 +14,7 @@
  *   - docs/specs/zero-downtime-schema-evolution/design.md (the spec)
  */
 
-import { type SchemaZSet, type SchemaField, currentSchema, isInOverlap, consolidate } from "./schema-zset";
+import { type SchemaZSet, currentSchema, isInOverlap, consolidate } from "./schema-zset";
 
 // ─── State machine ───────────────────────────────────────────────────────────
 

--- a/src/Core.TypeScript/observe/schema-rx-join.test.ts
+++ b/src/Core.TypeScript/observe/schema-rx-join.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { SchemaAwareJoin, deltasCommute, type SchemaView } from "./schema-rx-join";
-import { schemaZSet, FS_METADATA_SCHEMA_V1, type SchemaEvolutionDelta, type SchemaZSet as SchemaZSetType } from "./schema-zset";
+import { schemaZSet, FS_METADATA_SCHEMA_V1, type SchemaEvolutionDelta } from "./schema-zset";
 
 // A simple view that projects specific fields from the schema
 const fileInfoView: SchemaView<string[]> = {

--- a/src/Core.TypeScript/service/persona-health.test.ts
+++ b/src/Core.TypeScript/service/persona-health.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { listPersonas, type PersonaConfig } from "./persona-registry";
+import { listPersonas } from "./persona-registry";
 
 const personas = listPersonas();
 


### PR DESCRIPTION
The `lint (TS)` gate went **red on main** (commit 4b593a8b6): #8458/#8487 (observe schema-evolution Task 9) + a stray `service/` test landed **11 tsc errors** (unused imports/locals, a `readonly`→mutable assignment, an `exactOptionalPropertyTypes` mismatch). Main was sitting red — cleared it (CI-steward).

**Minimal, behavior-preserving:**
- `schema-cdc.ts`: `subject` is optional under `exactOptionalPropertyTypes` → conditional spread (TS2375).
- `schema-evolution-demo.test.ts`: drop unused `consolidate`/`registerReader` imports (TS6133); the 2nd `readers` decl → `readonly SchemaReader[]` (TS4104).
- `schema-golden-vectors.ts` / `schema-overlap.ts` / `schema-rx-join.test.ts` / `persona-health.test.ts`: remove unused imports.
- `schema-overlap.test.ts`: remove an unused `const delta`.

**Verified** with the exact gate command (`bun src/Core.TypeScript/lint/lint-typescript.ts`): *"TypeScript, Prettier, and style checks passed successfully!"* No behavior changed. cc the observe author — this completes the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
