### PR TITLE
memory(feedback): Beacon — Zeta's per-identity anti-Sybil fair-throttle extends the Itron throttler prior art

### DIFF
--- a/memory/feedback_ferries_bloat_context_externalize_state_to_resume_immediately_2026_06_16.md
+++ b/memory/feedback_ferries_bloat_context_externalize_state_to_resume_immediately_2026_06_16.md
@@ -65,7 +65,14 @@ a DDoS attempt."* This is *why* the decoupling is load-bearing, not just tidy:
 - **The ONLY legitimate throttle is resource / DDoS** — value-neutral *capacity backpressure* (the
   ferry-throttler's actual DoP/queue job: "the lane is saturated," not "I judge your message bad").
   And even that must be **fair** — per-identity rate limits riding the anti-Sybil forgery-cost floor,
-  so a DDoS can't be one entity faking many.
+  so a DDoS can't be one entity faking many. **Beacon — where Zeta extends the prior art (Aaron
+  2026-06-16):** the named prior art for the ferry-throttle is the maintainer's **Itron**
+  `Platform.DotNet Threading.Tasks.Throttling` (`MaxDegreeOfParallelism` / `MaxQueueSize`
+  backpressure; see `async-all-the-way-truthful-signatures`). Itron did capacity backpressure but
+  **NOT per-identity anti-Sybil fairness** (Aaron: *"mine from Itron didn't do that"*). Binding the
+  rate-share to **proven-distinct identities** (the `AntiSybil` forgery-cost floor: DistinctCount ≤
+  real sources) is the Zeta extension — the *same* ratio proof that stops quorum-forging (`SybilCannotForge`)
+  also stops lane-hogging-by-Sybil. *Honest peel: a design point, not yet load-tested at scale.*
 - **Morality acts at the ENDPOINTS, never on the wire:** consent-first §6 at the surface; the
   child-safety floor gates the *committed ACT* (the `PermanentHarmHorizon` viability-kernel gate on
   Execute), **not message transport** — a message may cross the bus while the harmful *action* it


### PR DESCRIPTION
Aaron 2026-06-16: *"mine from Itron didn't do that."* The named ferry-throttle prior art (Itron `Platform.DotNet Threading.Tasks.Throttling` — DoP/queue backpressure) did capacity backpressure but **not** per-identity anti-Sybil fairness. Zeta binds rate-share to **proven-distinct identities** (the `AntiSybil` forgery-cost floor); the same ratio proof that stops quorum-forging (`SybilCannotForge`) stops lane-hogging-by-Sybil. Honest peel: a design point, not yet load-tested at scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)