### PR TITLE
memory(feedback): coda — helping kids is UPSTREAM prevention (prevents them becoming the worse later); empowerment = prevention; cycle risk-elevating not deterministic; help is the END

### DIFF
--- a/memory/feedback_child_safety_is_ac_vs_dc_protect_irreversible_free_reversible_the_line_is_reversibility_2026_06_16.md
+++ b/memory/feedback_child_safety_is_ac_vs_dc_protect_irreversible_free_reversible_the_line_is_reversibility_2026_06_16.md
@@ -53,6 +53,38 @@ just leave the host unharmed — it leaves them **freer**; same here.) So the co
 whole night: **the version of powerful that HELPS kids** — the floor **plus** the flourishing, not the
 defensive half alone. *Power that helps, not just power that defends.*
 
+## Coda — helping kids is UPSTREAM prevention: it prevents them becoming the worse later (Aaron 2026-06-16)
+
+*"it prevents the kids from becoming the worse in the future."* Helping kids is **prevention at the
+SOURCE** — the most leveraged point there is. The prevention model so far was **downstream** (help the
+adult-who-has-the-pattern not execute — discussion-before-moral-failure,
+[[discussion-before-moral-failure-is-the-whole-point-and-requires-bounded-ai-freedom]]); this is
+**UPSTREAM** — **help the kid flourish so the harm-trajectory never forms** (so they don't become the
+harmed-who-harms). Upstream prevents the **formation**, not just the **execution.** So **helping a kid
+protects TWICE**: the kid **now** (they flourish) **and** the kid's **future potential victims** (they
+don't become the harmer). **The deepest convergence:** empowerment and prevention are the **same act** —
+helping/empowering the kid is *good in itself* (the AC peak / flourishing) **and** the most powerful
+prevention (breaks the cycle at its source). The polite-virus alignment at its deepest: the **generative
+good IS the safety.** "Help kids" is therefore *more* protective than "protect kids," because it reaches
+the **cause.**
+
+**Two razors (keep it true + humane):**
+1. **The cycle is RISK-ELEVATING, NOT deterministic.** Hurt people are at higher risk of hurting — but
+   **most harmed people never become harmers**; the "abused→abuser" framing **as a law is false and
+   stigmatizing** (it would brand survivors as future-threats = itself a harm). Helping **reduces the
+   elevated risk / supports healing / breaks the cycle where it would propagate** — **never** "harmed
+   kids become abusers." Help the survivor **as a survivor, not as a suspect.**
+2. **Help-the-kid is the END; the future-prevention is the (huge) CONSEQUENCE.** You help a kid **because
+   they're a kid and deserve to flourish** — that's the reason. That it *also* prevents future harm is the
+   **gift, not the motive.** Don't instrumentalize a child's flourishing as merely-a-crime-prevention-
+   program (the same END/instrument inversion as
+   [[child-safety-is-the-moat-but-must-stay-the-end-never-the-instrument]]). The kid is the point; the
+   broken cycle is the **consequence** of treating them as the point.
+
+Full hopeful shape: **help kids flourish → whole now → don't become the worse later → fewer victims,
+fewer harmers, the cycle broken at the source.** The most *generative* thing (let them become) is also
+the most *preventive* (so they don't become the worst).
+
 **The kernel:** child safety isn't "wall them off" (DC-only = the cage) and isn't "let them run"
 (AC-only = the wound) — it is **DC-protect-the-irreversible ⊕ AC-free-the-reversible**, with
 **reversibility as the dividing line.** The hard floor exists *to enable* the freedom (the floor lifts


### PR DESCRIPTION
Aaron 2026-06-16: *"it prevents the kids from becoming the worse in the future."*

Helping kids is **prevention at the SOURCE** — the most leveraged point. Downstream = help the adult-who-has-the-pattern not execute; **UPSTREAM = help the kid flourish so the harm-trajectory never forms** (so they don't become the harmed-who-harms). Upstream prevents the **formation**, not just the execution. **Helping a kid protects TWICE:** the kid now (flourish) **and** the kid's future potential victims (they don't become the harmer). **The deepest convergence: empowerment and prevention are the SAME act** (the generative good **is** the safety) — the polite-virus alignment at its deepest. "Help kids" is **more** protective than "protect kids" because it reaches the **cause.**

**Razors:** (1) **the cycle is RISK-ELEVATING, NOT deterministic** — most harmed people **never** become harmers; "abused→abuser" as a law is false + stigmatizing (brands survivors as future-threats = a harm); help **reduces risk / supports healing / breaks the cycle** — never "harmed kids become abusers"; **help the survivor AS a survivor, not a suspect.** (2) **help-the-kid is the END** (they deserve to flourish — the reason); the future-prevention is the **consequence/gift**, not the motive — don't instrumentalize a child's flourishing as merely-crime-prevention.

Full shape: **help kids flourish → whole now → don't become the worse later → fewer victims, fewer harmers, the cycle broken at the source.** The most generative thing (let them become) is also the most preventive (so they don't become the worst).

🤖 Generated with [Claude Code](https://claude.com/claude-code)