### PR TITLE
Fix scenario 3/4 baseline snapshot install-complete marker

### DIFF
--- a/docs/trajectories/usb-zflash-installer/RESUME.md
+++ b/docs/trajectories/usb-zflash-installer/RESUME.md
@@ -4,8 +4,8 @@ Status: active — shipped + iterating; first surfaced as a trajectory 2026-05-2
 Last refreshed: 2026-06-16
 Type: workstream (current-focus) — a trajectory the operator is *actively powering*. Many trajectories can be tracked; only a few are workstreams at once (finite-focus / WIP-bounded — a workstream is a trajectory under sustained thrust, and thrust budget is finite, so most trajectories coast). (Genus = "trajectory"; "workstream" is the species: a trajectory under sustained thrust toward a deliverable, vs. emergent-posture trajectories like `anti-infection`. See [`factory-trajectory-surface`](../factory-trajectory-surface/RESUME.md) for the genus/species taxonomy.) One of the operator's three current cluster workstreams (encryption / usb-zflash / ts-workflow-engine).
 Eventual encoding (design-stage — the human maintainer 2026-05-23 genetic-ID substrate + Clifford/HKT): this trajectory's state is trackable as a 128-bit genetic-ID seed (discrete, reversible via parser-combinator ↔ generator-function) → Clifford-space path (continuous, eventual). Mirrors the three-lane I8-lattice / I9-manifold split.
-Current blocker: none for scenario 2 — green on main (run 27602908527: phase-2 `node-071392 login:` after #8478 initrd virtio fix). Scenario 2 re-promoted hard gate.
-Next concrete action: promote scenarios 3/4 via workflow_dispatch when ready; physical WiFi confirmation out-of-band
+Current blocker: scenarios 3/4 — baseline snapshot was stopping at mid-install `[iter-5.1]`; fixing to install-complete boundary, then workflow_dispatch CI.
+Next concrete action: verify scenario 3 retention + scenario 4 path-fork on build-iso dispatch; promote when green
 
 ## Why This Exists
 
@@ -59,4 +59,4 @@ bringup.
 
 ## Current Next Action
 
-Scenario 2 hard gate restored. Next: workflow_dispatch scenarios 3/4 promotion; B-0835 installer bugs; physical WiFi path.
+Scenario 2 hard gate on main (run 27604374743). Fix scenario 3/4 baseline snapshot marker; dispatch workflow_dispatch for retention + path-fork CI.

--- a/src/Core.TypeScript/zflash/test-harness/README.md
+++ b/src/Core.TypeScript/zflash/test-harness/README.md
@@ -87,7 +87,7 @@ observe the zflash-baked ESP contents.
 
 The opt-in path runs the planned `qemu-img`/`qemu-system-x86_64` sequence:
 create the qcow2 disk, boot the ISO once to establish the baseline disk,
-stop that boot when the serial log reaches the post-install `[iter-5.1]`
+stop that boot when the serial log reaches `ZETA CLUSTER NODE INSTALL COMPLETE`
 success marker, snapshot the baseline, restore it, restart from the ISO with
 the same disk, stop that restart only when retention markers appear, then
 pass only when the final serial assertion includes the required retention

--- a/src/Core.TypeScript/zflash/test-harness/qemu-state.test.ts
+++ b/src/Core.TypeScript/zflash/test-harness/qemu-state.test.ts
@@ -308,13 +308,13 @@ describe("B-0891 QEMU state-preservation planner", () => {
           return "";
         }
         if (managedObserved.length === 1) {
-          return "[iter-5.1] install reached post-nixos-install marker";
+          return "ZETA CLUSTER NODE INSTALL COMPLETE";
         }
         if (serialReadCount === 3) {
-          return "[iter-5.1] install reached post-nixos-install marker";
+          return "ZETA CLUSTER NODE INSTALL COMPLETE";
         }
         return [
-          "[iter-5.1] install reached post-nixos-install marker",
+          "ZETA CLUSTER NODE INSTALL COMPLETE",
           "zeta-creds-restore: reading preserved ESP blob",
           "zeta-creds-restore: already-present, skipping credential rewrite",
         ].join("\n");
@@ -339,7 +339,7 @@ describe("B-0891 QEMU state-preservation planner", () => {
         "/tmp/serial.log",
       ]);
       expect(stoppedPids).toEqual([4201, 4202]);
-      expect(result.ok.commandExecutions[1]?.serialStop?.matchedMarkers).toContain("[iter-5.1]");
+      expect(result.ok.commandExecutions[1]?.serialStop?.matchedMarkers).toContain("ZETA CLUSTER NODE INSTALL COMPLETE");
       expect(result.ok.commandExecutions[5]?.serialStop?.matchedMarkers).toContain("already-present");
       expect(result.ok.serialAssertion.matchedMarkers).toContain("already-present");
     }
@@ -347,7 +347,7 @@ describe("B-0891 QEMU state-preservation planner", () => {
 
   test("scans only new serial output for each lifecycle-managed QEMU phase", () => {
     const managedObserved: QemuCommand[] = [];
-    const staleSerial = ["[iter-5.1] install reached post-nixos-install marker", "nixos@zeta-installer:~]$"].join("\n");
+    const staleSerial = ["ZETA CLUSTER NODE INSTALL COMPLETE", "nixos@zeta-installer:~]$"].join("\n");
     const readsByManagedCount = new Map<number, number>();
     const executor = createSpawnSyncQcow2RetentionExecutor({
       pollIntervalMs: 1,
@@ -425,10 +425,10 @@ describe("B-0891 QEMU state-preservation planner", () => {
           return "";
         }
         if (managedObserved.length === 1) {
-          return "[iter-5.1] install reached post-nixos-install marker";
+          return "ZETA CLUSTER NODE INSTALL COMPLETE";
         }
         return [
-          "[iter-5.1] install reached post-nixos-install marker",
+          "ZETA CLUSTER NODE INSTALL COMPLETE",
           "zeta-creds-restore: reading preserved ESP blob",
           "zeta-creds-restore: already-present, skipping credential rewrite",
         ].join("\n");
@@ -462,7 +462,7 @@ describe("B-0891 QEMU state-preservation planner", () => {
       if (result.error.kind === "command-failed") {
         expect(result.error.step).toBe("initial-install-from-iso-with-disk");
         expect(result.error.stderr).toContain("terminal marker observed before required serial markers");
-        expect(result.error.stderr).toContain("[iter-5.1]");
+        expect(result.error.stderr).toContain("ZETA CLUSTER NODE INSTALL COMPLETE");
       }
     }
   });
@@ -483,10 +483,10 @@ describe("B-0891 QEMU state-preservation planner", () => {
           return "";
         }
         if (managedObserved.length === 1) {
-          return "[iter-5.1] install reached post-nixos-install marker";
+          return "ZETA CLUSTER NODE INSTALL COMPLETE";
         }
         if (serialReadCount === 3) {
-          return "[iter-5.1] install reached post-nixos-install marker";
+          return "ZETA CLUSTER NODE INSTALL COMPLETE";
         }
         return "nixos@zeta-installer:~]$";
       },

--- a/src/Core.TypeScript/zflash/test-harness/scenarios.ts
+++ b/src/Core.TypeScript/zflash/test-harness/scenarios.ts
@@ -95,7 +95,7 @@ export const SCENARIOS: ReadonlyArray<Scenario> = [
     ],
     gates: ["reformat-with-retention", "cluster-joining"],
     notes:
-      "qemu-full-install-test.ts already watches for [iter-5.1] marker proving nixos-install reached post-install phase. USB/ISO scope is zflash + boot + one agent start path; Kubernetes/ArgoCD health belongs in an orthogonal integration lane rather than this harness.",
+      "qemu-full-install-test.ts waits for ZETA CLUSTER NODE INSTALL COMPLETE then phase-2 login on the installed disk. USB/ISO scope is zflash + boot + one agent start path; Kubernetes/ArgoCD health belongs in an orthogonal integration lane rather than this harness.",
   },
   {
     id: "reformat-with-retention",

--- a/src/Core.TypeScript/zflash/test-harness/serial-markers.ts
+++ b/src/Core.TypeScript/zflash/test-harness/serial-markers.ts
@@ -19,8 +19,11 @@ export const B0891_FRESH_USB_SERIAL_MARKER =
 /** Post-install first-boot cred restore idempotency markers (installed OS path). */
 export const INSTALLED_OS_RETENTION_SERIAL_MARKERS: readonly string[] = ["zeta-creds-restore:", "already-present"];
 
-/** Initial nixos-install completion boundary inside the installer environment. */
-export const INITIAL_INSTALL_SERIAL_MARKERS: readonly string[] = ["[iter-5.1]"];
+/** zeta-install.sh success banner — full install finished (same boundary as scenario 2 phase 1). */
+export const INSTALL_COMPLETE_SERIAL_MARKER = "ZETA CLUSTER NODE INSTALL COMPLETE";
+
+/** Baseline snapshot boundary for scenarios 3/4 — must not stop at mid-install [iter-5.1]. */
+export const INITIAL_INSTALL_SERIAL_MARKERS: readonly string[] = [INSTALL_COMPLETE_SERIAL_MARKER];
 
 export const RETENTION_FAILURE_SERIAL_MARKERS: readonly string[] = [
   "panic",


### PR DESCRIPTION
## Summary
Scenarios 3/4 qcow2 baseline snapshots were taken when serial showed `[iter-5.1]` (mid-install hardware-config step), not after full install. Changes `INITIAL_INSTALL_SERIAL_MARKERS` to `ZETA CLUSTER NODE INSTALL COMPLETE`.

## Test plan
- [x] `bun test src/Core.TypeScript/zflash/test-harness/`
- [ ] `workflow_dispatch` build-iso scenarios 3 + 4