### PR TITLE
docs(aurora): discharge (a) — d_self identity axis grounded on NonRegisterCollapse

### DIFF
--- a/docs/research/2026-06-16-aurora-immune-math-reconciliation-scoping-reground-on-proven-identity-primitive.md
+++ b/docs/research/2026-06-16-aurora-immune-math-reconciliation-scoping-reground-on-proven-identity-primitive.md
@@ -82,6 +82,53 @@ Re-grounding does **not** upgrade Aurora's status: still (1) **NOT deployment-re
 - **Identity legs are about *non-collapse / privacy*, not liveness** — the immune system's *aliveness* leg leans on the §A aliveness proofs separately; don't conflate.
 - This is a **factoring of an open obligation into named dependencies**, not a closure — exactly the §C "one row, one discharge" shape.
 
+## 8. Discharge log
+
+### (a) `d_self` identity term — DISCHARGED on `NonRegisterCollapse` (2026-06-19, Otto)
+
+The wiring step (4b: "(a) is a wiring task", zero new tool). Aurora's `d_self` (§3.2 of the
+standardization doc) is a 5-axis distance `η_I·d_I + η_C·d_C + η_L·d_L + η_P·d_P + η_K·d_K`. Only
+the **identity** axis `d_I(IdentityFeatures(a), I_t)` is re-grounded here — it now stands on the
+proven `NonRegisterCollapse` (FROZEN-CORE §A; `src/Core.Lean4/Safety/NonRegisterCollapse.lean`,
+Lean+TLA, axiom-free):
+
+- **"Self" is no longer an undefined reference vector** — it is the traveler's **standing
+  register**. `distinctness_forces_standing` proves that any *persistent behavioral distinction*
+  between two travelers (after their shared commons converges under the CRDT join) MUST live in the
+  standing register. So "self ≠ non-self" on the identity axis ⟺ "distinct standing registers",
+  and that distinctness is **forced**, not assumed.
+- **The reference is non-forgeable by another party.** `non_collapse` proves consensus on the
+  shared commons CANNOT other-collapse two distinct standing registers into one (the merge leaves
+  each `= a.standing`, `= b.standing`). So the `I_t` that `d_I` measures distance against cannot be
+  collapsed away by a hostile peer — other-imposed collapse is impossible. The identity axis stands
+  on a theorem, not on the early metaphor.
+- **The register is necessary, not incidental.** `no_register_collapses` proves the necessity
+  direction: a traveler with NO standing register (`S := PUnit`) collapses every distinction once
+  the commons converges. The object grounding "self" is load-bearing.
+
+**Falsifier check (§5, leg 1) — PASSED.** Self/non-self on the identity axis expressed cleanly as
+identity-distinctness (standing-register distinctness) WITHOUT needing an extra undefined predicate.
+The metaphor did **not** survive on this axis — it grounds. Matches Soraya's table row (a): reuse,
+zero new tool.
+
+**Honest scope (razor — what this does NOT claim):**
+
+- Only `d_I` grounds. The other four axes — culture `d_C`, language `d_L`, provenance `d_P`,
+  capability `d_K` — remain **feature-space estimators**, NOT proven objects. Recording them as
+  grounded would be false-green — the same §4(f) discipline applied to (a). They stay §B / empirical.
+- Grounding the *self reference* does **not** change the *gate*. Amara's binding note holds: `d_self`
+  is NOT a trigger; foreignness ≠ pathology (`Danger(a) > θ_D` is the trigger; `d_self` only feeds the
+  Anomaly term). This discharge grounds *what "self" is*, not *when the immune system acts* — Otto-298
+  / don't-collapse preserved (foreign-but-useful and internal-but-compromised both still possible).
+- Guardrail held (§5, leg 4): no identity-based punishment introduced. `d_I` measures *distance
+  against a proven-distinct register*; it does not act on *who*. The act/trigger stays pattern-keyed
+  (Danger), blame-the-pattern intact, immune-absorbs-not-attacks intact.
+
+**Status move:** the (a) leg of the §B row now stands on a §A theorem (identity axis). Per §C
+"one row, one discharge", (a) is the first operator ready to promote toward §A. The four non-claims
+(§6) travel unchanged — this adds a proven foundation under the identity term, not deployment
+readiness.
+
 ## Composes with
 
 - `docs/research/aurora-immune-math-standardization-2026-04-26.md` — the math being re-grounded (Amara; Gemini; Otto rigor pass).

--- a/docs/research/aurora-immune-math-standardization-2026-04-26.md
+++ b/docs/research/aurora-immune-math-standardization-2026-04-26.md
@@ -261,6 +261,8 @@ d_self(a, S) = η_I · d_I(IdentityFeatures(a), I_t)
 
 **Critical Amara note:** `d_self` is NOT a trigger. Foreignness alone is not pathology. Trigger is `Danger(a) > θ_D`. `d_self` feeds the Anomaly term inside Danger; not a standalone gate. (Otto-298 / don't-collapse: foreign-but-useful work, internal-but-compromised agents, both possible.)
 
+> **Re-grounding (2026-06-19, Otto):** the **identity** axis `d_I` is now grounded on the proven `NonRegisterCollapse` (FROZEN-CORE §A) — "self" = the proven-distinct standing register. The other four axes (C/L/P/K) stay feature-space estimators. Discharge: `docs/research/2026-06-16-aurora-immune-math-reconciliation-scoping-reground-on-proven-identity-primitive.md` §8(a).
+
 ### 3.3 MI_H (theoretical) vs Legibility_H (operational estimator) — Round-2 Amara split
 
 ```text

--- a/docs/trajectories/aurora-immune-reground/RESUME.md
+++ b/docs/trajectories/aurora-immune-reground/RESUME.md
@@ -1,7 +1,7 @@
 # Trajectory — Aurora Immune System re-grounded on the proven identity primitive
 
-Status: **active — the 2 TLA+ rounds are AUTHORED, TLC-green, and Viktor/Kira RE-CONFIRMED (both PASS); formal round CLOSED. Next: the FsCheck/Z3 smalls + (a) d_self wiring → §A promotion.**
-Last refreshed: 2026-06-16
+Status: **active — the 2 TLA+ rounds are AUTHORED, TLC-green, and Viktor/Kira RE-CONFIRMED (both PASS); formal round CLOSED. (a) d_self identity-axis wiring DONE (grounded on `NonRegisterCollapse`, §8(a) of scoping doc, 2026-06-19). Next: the (b)/(e) FsCheck cross-checks + (c)/(d)/(g) FsCheck/Z3 smalls → §A promotion.**
+Last refreshed: 2026-06-19
 Parent trajectory: none (sibling of `anti-infection`, but this is *active formal work*, not the defensive posture)
 Grounding:
 
@@ -49,7 +49,12 @@ theorems, not metaphor.
 
 ## Next concrete steps (in order)
 
-1. **(a) wiring task:** point Aurora's `d_self` predicate at `NonRegisterCollapse` (no new proof).
+1. ✅ **(a) wiring task DONE (2026-06-19):** Aurora's `d_self` **identity** axis `d_I` grounded on
+   `NonRegisterCollapse` — "self" = the proven-distinct standing register; falsifier §5/leg-1 PASSED
+   (expressed as identity-distinctness with no extra undefined predicate). Honest scope: only `d_I`
+   grounds; the other four axes (C/L/P/K) stay feature-space estimators (no false-green); the gate is
+   unchanged (Amara: `d_self` is not a trigger). Discharge: scoping doc §8(a) + standardization §3.2
+   pointer. **(a) is the first operator ready to promote toward §A.**
 2. **(b)/(e) FsCheck cross-checks** (Soraya's BP-16): the Aurora §4.1 retraction sim (e) +
    the Z3 honest-count side (b).
 3. **Authors:** (c)/(d)/(g) FsCheck/Z3 smalls.


### PR DESCRIPTION
## What

The **(a) wiring leg** of the Aurora immune re-grounding trajectory (`docs/trajectories/aurora-immune-reground/`). Aaron authorized the slice 2026-06-19.

Aurora's `d_self` self-distance (§3.2 of the standardization doc) is a 5-axis distance. This grounds **only the identity axis** `d_I` on the proven `NonRegisterCollapse` (FROZEN-CORE §A; `src/Core.Lean4/Safety/NonRegisterCollapse.lean`, Lean+TLA, axiom-free):

- `distinctness_forces_standing` → "self ≠ non-self" ⟺ distinct **standing registers** (forced, not assumed).
- `non_collapse` → the self-reference can't be other-collapsed by a hostile peer (non-forgeable).
- `no_register_collapses` → the register grounding "self" is necessary.

**Falsifier §5/leg-1 PASSED:** expressed as identity-distinctness with no extra undefined predicate — the metaphor grounds on this axis. Reuse, zero new tool (Soraya's routing table row (a)).

## Honest scope (razor)

- **Only `d_I` grounds.** Culture / language / provenance / capability axes stay feature-space estimators, NOT proven (recording them as grounded = false-green — the §4(f) discipline).
- **The gate is unchanged.** Amara's binding note holds: `d_self` is *not* a trigger (`Danger > θ_D` is). This grounds *what "self" is*, not *when the immune system acts*.
- **No identity-based punishment** introduced — blame-the-pattern intact (§5/leg-4 guardrail).
- The four non-claims travel unchanged: proven foundation under the identity term, **not** deployment readiness.

## Changes

- `docs/research/2026-06-16-...-scoping-reground...md` — new §8(a) discharge log.
- `docs/research/aurora-immune-math-standardization-2026-04-26.md` — one-line forward-pointer under §3.2 (non-invasive; Amara's math untouched).
- `docs/trajectories/aurora-immune-reground/RESUME.md` — step 1 marked done; status + next-steps updated.

Docs-only. (a) is now the first operator ready to promote toward §A; promotion itself stays gated on Aaron's sign-off (proof-lineage change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)