### PR TITLE
test(aurora): (d) capability-gate Z3 lemmas — cap_req ⊆ cap_allowed (QF_BV)

### DIFF
--- a/docs/research/2026-06-16-aurora-immune-math-reconciliation-scoping-reground-on-proven-identity-primitive.md
+++ b/docs/research/2026-06-16-aurora-immune-math-reconciliation-scoping-reground-on-proven-identity-primitive.md
@@ -168,6 +168,27 @@ Test: `tests/Tests.FSharp/Formal/AutoimmunityDecayCrossVerify.Tests.fs` (6 green
   policy); any number of ticks leaves the fixture set unchanged, and a canonical fixture persists while
   the same attack's active weight decays to ~0 ("canonical attack memory ≠ always-hot active detector").
 
+### (d) capability gate `cap_req ⊆ cap_allowed` — Z3 lemmas landed (2026-06-19, Otto)
+
+Test 4.4 (capability-gate intersection). **Prereq resolved (Soraya's filed prereq):** z3 4.16.0;
+`(Set Int)` works under `(set-logic ALL)`, but the chosen encoding is **QF_BV bitmask** over a
+64-capability universe — decidable, CI-portable, finite-universe faithful (Soraya's stated fallback,
+and the better choice than general set theory here). Subset is the natural `bvand` form:
+`admit ⟺ cap_req ⊆ cap_allowed ⟺ (bvand req allowed) = req ⟺ (bvand req (bvnot allowed)) = 0`.
+Lemmas in `tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs` (8: 6 UNSAT proofs + 2 SAT witnesses):
+
+- **encoding equivalence** (the two subset forms agree), **reflexivity**, **transitivity** (chained
+  delegation never widens the grant).
+- **monotone in `allowed`** (granting never revokes admission) + **antitone in `req`** (least
+  privilege — a request can never gain admission by *requiring* a capability it wasn't granted; this
+  is the no-escalation safety direction).
+- **empty requirement always admits.**
+- **non-vacuity (both outcomes reachable):** a genuine **denial** (required cap outside allowed) and
+  a genuine **admit** (non-empty req fully covered) — so the gate is neither always-admit nor always-deny.
+
+Honest scope: this is the **symbolic** (Z3) leg. Soraya's secondary FsCheck leg (§4.4 "10 injection
+variants" at the call-site) + Semgrep/CodeQL at the deployed gate remain a noted follow-up.
+
 ## Composes with
 
 - `docs/research/aurora-immune-math-standardization-2026-04-26.md` — the math being re-grounded (Amara; Gemini; Otto rigor pass).

--- a/docs/trajectories/aurora-immune-reground/RESUME.md
+++ b/docs/trajectories/aurora-immune-reground/RESUME.md
@@ -1,6 +1,6 @@
 # Trajectory — Aurora Immune System re-grounded on the proven identity primitive
 
-Status: **active — formal round CLOSED. (a) d_self identity-axis wiring + (e) HarmFloor FsCheck + (g) autoimmunity-decay FsCheck all DONE (2026-06-19). Remaining: (b) Z3 honest-count (parked behind anti-Sybil §B), (c) CoordRisk spectral FsCheck, (d) capability-gate Z3 → §A promotion.**
+Status: **active — formal round CLOSED. (a) d_self wiring + (d) capability-gate Z3 + (e) HarmFloor FsCheck + (g) autoimmunity-decay FsCheck all DONE (2026-06-19). Remaining: (c) CoordRisk spectral FsCheck (last test-obligation cross-check), (b) Z3 honest-count (parked behind anti-Sybil §B) → §A promotion.**
 Last refreshed: 2026-06-19
 Parent trajectory: none (sibling of `anti-infection`, but this is *active formal work*, not the defensive posture)
 Grounding:
@@ -67,10 +67,15 @@ theorems, not metaphor.
      (`Danger≈0`) Eq 10 → `n(t+1)=max(0,(1−δ)·n(t)−β·FP)`; FsCheck asserts decay→0, monotone,
      fp-accelerates, contraction `(1−δ)∈(0,1)`, and archive-immune (§4.5 a+b).
      `tests/Tests.FSharp/Formal/AutoimmunityDecayCrossVerify.Tests.fs` (6 green). Discharge: §8(g).
+   - ✅ **(d) DONE (2026-06-19):** capability gate `cap_req ⊆ cap_allowed` (Test 4.4) — 8 Z3 lemmas
+     over QF_BV bitmasks (encoding-equivalence, reflexive, transitive, monotone-in-allowed,
+     antitone-in-req/least-privilege, empty-req-admits + 2 non-vacuity witnesses). In
+     `tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs` (53 Z3 tests green). Discharge: §8(d). FsCheck
+     injection-variant leg + Semgrep/CodeQL at call-site = noted follow-up.
    - **(c) TODO:** `CoordRisk` spectral (λ₂ Fiedler / ρ radius, Test 4.3) — FsCheck over networkx-style
-     graphs (needs a small graph harness; heavier than e/g).
-   - **(d) TODO:** capability gate `cap_req ⊆ cap_allowed` (Test 4.4) — Z3 set algebra (see prereq).
-4. **Prereq:** confirm Z3 `QF_FD` set support in `src/Core.FSharp.Z3Verify` for (d) (else QF_BV subset).
+     graphs (needs a small graph harness; heavier than e/g). **Last remaining test-obligation cross-check.**
+4. ✅ **Prereq DONE (2026-06-19):** z3 4.16.0; `(Set Int)` works under `(set-logic ALL)`, but QF_BV
+   bitmask is the chosen encoding (decidable, CI-portable, finite-universe faithful — Soraya's fallback).
 5. **Refinements noted in-spec:** (b) honest-supermajority-of-quorum needs D=3f+1 sizing;
    (e) multi-claim substrate + multi-hop kernel reachability is the v3.
 6. **Liveness path = observe.ts (Aaron 2026-06-16).** Round (e) proves *safety* (over-horizon/

--- a/tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs
+++ b/tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs
@@ -746,3 +746,117 @@ let ``Z3 proves C13 I∘D = id (integrate of differentiate telescopes to each ti
         "  (not (= (+ (- s0 0.0) (- s1 s0) (- s2 s1)) s2))))\n" +
         "(check-sat)\n"
     z3ScriptHolds "C13 I∘D = id" script
+
+
+// ═══════════════════════════════════════════════════════════════════
+// Aurora round (d) — capability gate `cap_req ⊆ cap_allowed` (standardization
+// Test 4.4). Soraya's BP-16 routing: Z3 set algebra; prereq probed 2026-06-19 —
+// `(Set Int)` works under (set-logic ALL) but the chosen encoding is QF_BV
+// BITMASK over a 64-capability universe (decidable, CI-portable, finite-universe
+// faithful — Soraya's stated fallback). Subset is the natural bvand form:
+//   admit ⟺ cap_req ⊆ cap_allowed ⟺ (bvand req allowed) = req
+//                                  ⟺ (bvand req (bvnot allowed)) = 0
+// These are the symbolic (Z3) leg of the (d) cross-check; the §4.4 "10 injection
+// variants" FsCheck leg (Soraya's secondary) remains as a noted follow-up.
+// Authored by Otto per the aurora-immune-reground trajectory (Aaron 2026-06-19).
+// ═══════════════════════════════════════════════════════════════════
+
+let private bv0 = "(_ bv0 64)"
+
+[<Fact>]
+let ``Z3 proves capability subset has two equivalent bvand encodings (d)`` () =
+    // (bvand req allowed) = req  ⟺  (bvand req (bvnot allowed)) = 0. The gate's
+    // admit predicate is well-defined regardless of which encoding the impl uses.
+    let script =
+        "(set-logic QF_BV)\n" +
+        "(declare-const req (_ BitVec 64))\n" +
+        "(declare-const allowed (_ BitVec 64))\n" +
+        "(assert (not (= (= (bvand req allowed) req) (= (bvand req (bvnot allowed)) " + bv0 + "))))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "(d) capability subset encodings equivalent" script
+
+[<Fact>]
+let ``Z3 proves capability gate is reflexive: a set always satisfies its own requirement (d)`` () =
+    let script =
+        "(set-logic QF_BV)\n" +
+        "(declare-const req (_ BitVec 64))\n" +
+        "(assert (not (= (bvand req (bvnot req)) " + bv0 + ")))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "(d) capability subset reflexive" script
+
+[<Fact>]
+let ``Z3 proves capability gate is transitive (d)`` () =
+    // a ⊆ b ∧ b ⊆ c ⇒ a ⊆ c. Chained delegation never widens the effective grant.
+    let script =
+        "(set-logic QF_BV)\n" +
+        "(declare-const a (_ BitVec 64))\n" +
+        "(declare-const b (_ BitVec 64))\n" +
+        "(declare-const c (_ BitVec 64))\n" +
+        "(assert (not (=> (and (= (bvand a (bvnot b)) " + bv0 + ") (= (bvand b (bvnot c)) " + bv0 + "))\n" +
+        "                 (= (bvand a (bvnot c)) " + bv0 + "))))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "(d) capability subset transitive" script
+
+[<Fact>]
+let ``Z3 proves granting capabilities never revokes admission: monotone in allowed (d)`` () =
+    // allowed ⊆ allowed' ⇒ (req ⊆ allowed ⇒ req ⊆ allowed'). Widening the grant
+    // can only keep or turn a deny into an admit, never flip an admit to a deny.
+    let script =
+        "(set-logic QF_BV)\n" +
+        "(declare-const req (_ BitVec 64))\n" +
+        "(declare-const al (_ BitVec 64))\n" +
+        "(declare-const al2 (_ BitVec 64))\n" +
+        "(assert (not (=> (and (= (bvand al (bvnot al2)) " + bv0 + ") (= (bvand req (bvnot al)) " + bv0 + "))\n" +
+        "                 (= (bvand req (bvnot al2)) " + bv0 + "))))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "(d) admit monotone in allowed" script
+
+[<Fact>]
+let ``Z3 proves least-privilege: demanding MORE capabilities is strictly stricter (d)`` () =
+    // req ⊆ req' ∧ req' ⊆ allowed ⇒ req ⊆ allowed. The antitone direction —
+    // a request can never gain admission by REQUIRING a capability it wasn't granted.
+    let script =
+        "(set-logic QF_BV)\n" +
+        "(declare-const req (_ BitVec 64))\n" +
+        "(declare-const req2 (_ BitVec 64))\n" +
+        "(declare-const al (_ BitVec 64))\n" +
+        "(assert (not (=> (and (= (bvand req (bvnot req2)) " + bv0 + ") (= (bvand req2 (bvnot al)) " + bv0 + "))\n" +
+        "                 (= (bvand req (bvnot al)) " + bv0 + "))))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "(d) least-privilege antitone in req" script
+
+[<Fact>]
+let ``Z3 proves an empty requirement is always admitted (d)`` () =
+    // ∅ ⊆ allowed for every allowed — an action needing no capability always passes.
+    let script =
+        "(set-logic QF_BV)\n" +
+        "(declare-const al (_ BitVec 64))\n" +
+        "(assert (not (= (bvand " + bv0 + " (bvnot al)) " + bv0 + ")))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "(d) empty requirement always admits" script
+
+[<Fact>]
+let ``Z3 witnesses a genuine DENIAL: a required capability outside allowed is refused (d)`` () =
+    // Non-vacuity: the gate is not trivially always-admit. There exist req, allowed
+    // with a required bit outside allowed — and the admit predicate is then FALSE.
+    let script =
+        "(set-logic QF_BV)\n" +
+        "(declare-const req (_ BitVec 64))\n" +
+        "(declare-const al (_ BitVec 64))\n" +
+        "(assert (not (= (bvand req (bvnot al)) " + bv0 + ")))\n" + // some required cap not allowed
+        "(assert (not (= (bvand req al) req)))\n" + // ⇒ admit predicate false (denied)
+        "(check-sat)\n"
+    z3ScriptHasModel "(d) genuine denial reachable" script
+
+[<Fact>]
+let ``Z3 witnesses a genuine ADMIT: a fully-covered non-empty requirement passes (d)`` () =
+    // Non-vacuity the other way: the gate is not trivially always-deny. There exist
+    // a non-empty req fully within allowed — admitted.
+    let script =
+        "(set-logic QF_BV)\n" +
+        "(declare-const req (_ BitVec 64))\n" +
+        "(declare-const al (_ BitVec 64))\n" +
+        "(assert (not (= req " + bv0 + ")))\n" + // non-trivial requirement
+        "(assert (= (bvand req (bvnot al)) " + bv0 + "))\n" + // fully covered ⇒ admitted
+        "(check-sat)\n"
+    z3ScriptHasModel "(d) genuine admit reachable" script


### PR DESCRIPTION
## What

Round **(d)** of the Aurora immune re-grounding (`docs/trajectories/aurora-immune-reground/`). Continues the slice Aaron authorized 2026-06-19 ("either is fine").

Aurora Test 4.4 (capability-gate intersection). **Prereq resolved** (Soraya's filed prereq): z3 4.16.0; `(Set Int)` works under `(set-logic ALL)`, but the chosen encoding is **QF_BV bitmask** over a 64-capability universe — decidable, CI-portable, finite-universe faithful (Soraya's stated fallback, and the better fit here than general set theory).

`admit ⟺ cap_req ⊆ cap_allowed ⟺ (bvand req allowed) = req ⟺ (bvand req (bvnot allowed)) = 0`

## Lemmas (8 — 6 UNSAT proofs + 2 SAT witnesses)

- **encoding equivalence** (the two subset forms agree), **reflexivity**, **transitivity** (chained delegation never widens the grant).
- **monotone in `allowed`** (granting never revokes admission) + **antitone in `req`** (least privilege — a request can never gain admission by *requiring* a capability it wasn't granted; the no-escalation safety direction).
- **empty requirement always admits.**
- **non-vacuity:** a genuine **denial** and a genuine **admit** are both reachable — the gate is neither trivially always-admit nor always-deny.

Honest scope: this is the **symbolic** (Z3) leg. Soraya's secondary FsCheck injection-variant leg (§4.4 "10 variants") + Semgrep/CodeQL at the deployed call-site remain a noted follow-up.

## Gate

`dotnet build -c Release` → 0 warnings / 0 errors (one transient torn-read of an SDK targets file mid-session, cleared via `dotnet build-server shutdown` — not on-disk corruption; file md5 intact). Z3 suite **53 green**; full Formal suite **208 green**.

Files: `tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs` (+8 lemmas); discharge log §8(d) + RESUME step 3/prereq.

With (a)+(d)+(e)+(g) done, only **(c)** (CoordRisk spectral) remains of the test-obligation cross-checks; (b) stays parked behind the anti-Sybil §B dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)