### PR TITLE
feat(toffoli): implement Z-set join circuit model and verify reversibility laws

### DIFF
--- a/docs/backlog/P1/081KR50HA0008QG0R0002PGV1N-2-toffoli-circuit-zset-join-formal-model.md
+++ b/docs/backlog/P1/081KR50HA0008QG0R0002PGV1N-2-toffoli-circuit-zset-join-formal-model.md
@@ -2,11 +2,13 @@
 id: B-0366.2
 zetaid: 081KR50HA0008QG0R0002PGV1N
 priority: P1
-status: open
+status: closed
 title: "Toffoli circuit for Z-set join — formal gate-network model"
 effort: M
 created: 2026-05-09
-last_updated: 2026-05-11
+last_updated: 2026-06-19
+resolved: 2026-06-19
+resolved_by: "lior/proof-yaml-locks"
 depends_on: [081KR50HA0008QG0R0021B5J87]
 parent: 081KR50HA0008QG0R003T5MZAC
 classification: buildable-now

--- a/docs/backlog/P1/081KRA5AR0008QG0R000CYY9ZN-2.3-reversibility-laws-fscheck-properties.md
+++ b/docs/backlog/P1/081KRA5AR0008QG0R000CYY9ZN-2.3-reversibility-laws-fscheck-properties.md
@@ -2,11 +2,13 @@
 id: B-0366.2.3
 zetaid: 081KRA5AR0008QG0R000CYY9ZN
 priority: P1
-status: open
+status: closed
 title: "Reversibility laws + FsCheck properties for Toffoli Z-set join model (final slice of B-0366.2)"
 effort: S
 created: 2026-05-11
-last_updated: 2026-05-11
+last_updated: 2026-06-19
+resolved: 2026-06-19
+resolved_by: "lior/proof-yaml-locks"
 depends_on: [081KR50HA0008QG0R0002PGV1N.1, 081KR50HA0008QG0R0002PGV1N.2]
 parent: 081KR50HA0008QG0R0002PGV1N
 classification: buildable-now

--- a/docs/backlog/P1/081KRA5AR0008QG0R001GQSVWE-2.2-join-weight-multiplication-encoding.md
+++ b/docs/backlog/P1/081KRA5AR0008QG0R001GQSVWE-2.2-join-weight-multiplication-encoding.md
@@ -2,11 +2,13 @@
 id: B-0366.2.2
 zetaid: 081KRA5AR0008QG0R001GQSVWE
 priority: P1
-status: open
+status: closed
 title: "Z-set join weight multiplication as reversible Toffoli encoding (slice of B-0366.2)"
 effort: S
 created: 2026-05-11
-last_updated: 2026-05-11
+last_updated: 2026-06-19
+resolved: 2026-06-19
+resolved_by: "lior/proof-yaml-locks"
 depends_on: [081KR50HA0008QG0R0002PGV1N.1]
 parent: 081KR50HA0008QG0R0002PGV1N
 classification: buildable-now

--- a/src/Core/ToffoliGate.fs
+++ b/src/Core/ToffoliGate.fs
@@ -286,3 +286,72 @@ module ToffoliGate =
           IntermediateWires = intermediateWires
           CarryWires = carryWires |> Seq.toList
           PeresChains = peresChains }
+
+    /// Model a Z-set join as a Toffoli-gate network.
+    ///
+    /// The join of two Z-sets A and B on equal keys computes:
+    ///   join(A, B) = { (key) -> w_A(key) * w_B(key) }
+    ///
+    /// For each key present in both A and B, we allocate a weight multiplication
+    /// fragment using `modelWeightMul w_A w_B`.
+    ///
+    /// Wires from different fragments are mapped to disjoint global wire IDs.
+    /// The total Ancilla capacity of the circuit is the sum of the capacities of all fragments.
+    let modelJoinCircuit<'K when 'K : comparison> (a: ZSet<'K>) (b: ZSet<'K>) : ToffoliCircuit =
+        let sa = a.AsSpan()
+        let sb = b.AsSpan()
+        if sa.IsEmpty || sb.IsEmpty then
+            emptyCircuit
+        else
+            let cmp = KeyComparerCache<'K>.Instance
+            let mutable i = 0
+            let mutable j = 0
+            let fragments = ResizeArray<ToffoliCircuitFragment>()
+            while i < sa.Length && j < sb.Length do
+                let c = cmp.Compare(sa.[i].Key, sb.[j].Key)
+                if c < 0 then
+                    i <- i + 1
+                elif c > 0 then
+                    j <- j + 1
+                else
+                    let wA = sa.[i].Weight
+                    let wB = sb.[j].Weight
+                    let frag = modelWeightMul wA wB
+                    fragments.Add frag
+                    i <- i + 1
+                    j <- j + 1
+
+            if fragments.Count = 0 then
+                emptyCircuit
+            else
+                let mutable globalGates = []
+                let mutable globalWires = Map.empty
+                let mutable offset = 0
+
+                for frag in fragments do
+                    // Shift the gate wire IDs
+                    let shiftedGates =
+                        frag.Circuit.Gates
+                        |> List.map (fun step ->
+                            { ControlA = step.ControlA + offset
+                              ControlB = step.ControlB + offset
+                              Target = step.Target + offset })
+
+                    // Shift the wire map keys
+                    let shiftedWires =
+                        frag.Circuit.Wires
+                        |> Map.toSeq
+                        |> Seq.map (fun (wireId, bitValue) -> (wireId + offset, bitValue))
+                        |> Map.ofSeq
+
+                    globalGates <- globalGates @ shiftedGates
+
+                    // Merge wires
+                    for KeyValue(wireId, bitValue) in shiftedWires do
+                        globalWires <- Map.add wireId bitValue globalWires
+
+                    offset <- offset + frag.Circuit.Ancilla
+
+                { Gates = globalGates
+                  Wires = globalWires
+                  Ancilla = offset }

--- a/tests/Tests.FSharp/Formal/ToffoliGate.Laws.Tests.fs
+++ b/tests/Tests.FSharp/Formal/ToffoliGate.Laws.Tests.fs
@@ -348,3 +348,52 @@ let ``Weight multiplication fragment Landauer accounting reports zero erased bit
     && erasedWireCount initial afterForward = 0
     && erasedWireCount afterForward afterReverse = 0
     && erasedWireCount initial afterReverse = 0
+
+
+// ── Reversible Z-set join circuit laws (B-0366.2.3) ──────────────────────────
+
+let private smallZSet : Arbitrary<ZSet<int>> =
+    let g =
+        Gen.sized (fun size ->
+            let n = min size 8
+            Gen.zip (Gen.choose (-5, 5)) (Gen.choose (-3, 3) |> Gen.map int64)
+            |> Gen.listOfLength n
+            |> Gen.map ZSet.ofSeq)
+    Arb.fromGen g
+
+type SmallZSetArb() =
+    static member ZSet() = smallZSet
+
+
+[<FsCheck.Xunit.Property(Arbitrary = [| typeof<SmallZSetArb> |], MaxTest = 64)>]
+let ``Join circuit forward then reverse restores all wires`` (a: ZSet<int>) (b: ZSet<int>) =
+    let circuit = ToffoliGate.modelJoinCircuit a b
+    let initial = circuit.Wires
+    let afterForward = applySteps circuit.Gates initial
+    let afterReverse = applySteps (List.rev circuit.Gates) afterForward
+    afterReverse = initial
+
+
+[<FsCheck.Xunit.Property(Arbitrary = [| typeof<SmallZSetArb> |], MaxTest = 64)>]
+let ``Join circuit forward execution never erases wires`` (a: ZSet<int>) (b: ZSet<int>) =
+    let circuit = ToffoliGate.modelJoinCircuit a b
+    let initial = circuit.Wires
+    let initialKeys = wireKeySet initial
+
+    executionStates circuit.Gates initial
+    |> List.forall (fun state ->
+        Map.count state = Map.count initial
+        && wireKeySet state = initialKeys)
+
+
+[<FsCheck.Xunit.Property(Arbitrary = [| typeof<SmallZSetArb> |], MaxTest = 64)>]
+let ``Join circuit Landauer accounting reports zero erased bits`` (a: ZSet<int>) (b: ZSet<int>) =
+    let circuit = ToffoliGate.modelJoinCircuit a b
+    let initial = circuit.Wires
+    let afterForward = applySteps circuit.Gates initial
+    let afterReverse = applySteps (List.rev circuit.Gates) afterForward
+
+    circuit.Ancilla = Map.count initial
+    && erasedWireCount initial afterForward = 0
+    && erasedWireCount afterForward afterReverse = 0
+    && erasedWireCount initial afterReverse = 0


### PR DESCRIPTION
Why: To complete B-0366.2 and B-0366.2.3, we need to model a symbolic Z-set join as a Toffoli gate network and prove its logical reversibility and Landauer thermodynamic preservation using property-based FsCheck tests.

- Add modelJoinCircuit in src/Core/ToffoliGate.fs to join two Z-sets using a two-pointer merge and Peres weight multiplication fragments.
- Add SmallZSetArb generator in ToffoliGate.Laws.Tests.fs.
- Add FsCheck properties for reversibility, wire retention, and Landauer accounting on the joint circuit.
- Close backlog rows B-0366.2, B-0366.2.2, and B-0366.2.3.