### PR TITLE
feat(darkhall): expose meta-cart selection readout

### DIFF
--- a/src/Core/DarkHallCabinetRuntime.fs
+++ b/src/Core/DarkHallCabinetRuntime.fs
@@ -212,6 +212,16 @@ module DarkHallCabinetRuntime =
     let actionAt (cell: int) (readout: ControllerReadout) : CabinetAction option =
         GridBinding.labelAt cell readout.Grid
 
+    /// Sub-readout for the host-assisted meta-cart machine. The Dark Hall
+    /// controller observes the cabinet action; this readout observes the child
+    /// cart selection inside that action before the host boundary executes.
+    let observeMetaCartLaunch (launch: MetaCartLaunch) : MetaCart.SelectionReadout =
+        MetaCart.selectionReadoutWithCapabilities
+            launch.Goal
+            launch.ParentCapabilities
+            launch.Seed
+            launch.Children
+
     let private findCabinet (room: DarkHall.Room) (cabinetName: string) =
         room.Cabinets |> List.tryFind (fun cabinet -> cabinet.Name = cabinetName)
 
@@ -299,15 +309,16 @@ module DarkHallCabinetRuntime =
                     |> Result.mapError (fun reason -> Feedback.Chip9Feedback(address, reason))
 
             | DarkHall.MachineCore.MetaCartHost, RunMetaCart launch ->
+                let readout = observeMetaCartLaunch launch
+                let host = MetaCart.CapabilityCartHost(launch.Children, launch.ChildCapabilitiesBySha) :> MetaCart.ICartHost
+
                 return
-                    MetaCart.playChosenCarriedWithCapabilities
+                    MetaCart.playChosenFromSelectionReadoutWithCapabilities
                         source
                         sink
-                        launch.Goal
-                        launch.Seed
                         launch.ParentCapabilities
-                        launch.ChildCapabilitiesBySha
-                        launch.Children
+                        readout
+                        host
                         launch.Parent
                     |> Result.map MetaCartResult
                     |> Result.mapError Feedback.MetaCartFeedback

--- a/src/Core/MetaCart.fs
+++ b/src/Core/MetaCart.fs
@@ -36,6 +36,22 @@ module MetaCart =
           Slot: CartSlot
           Reflection: Chip8Arcade.Reflection }
 
+    /// Source-owned selection readout for the host-assisted meta-cart boundary.
+    ///
+    /// Reflection remains a pure observation of candidate child futures. The
+    /// selected child is only an ordering decision over those observations; the
+    /// launch still crosses the one-byte CHIP-8 choice cell plus the injected
+    /// `ICartHost` capability boundary.
+    type SelectionReadout =
+        { Goal: int
+          ReflectedGoal: int
+          Seed: uint64
+          CostPerStep: float
+          Tank: SoftThrottle.Tank
+          Candidates: ReflectedChoice list
+          Selected: ReflectedChoice option
+          DeterministicRulesApplied: string list }
+
     type ReflectedPlayResult =
         { Choice: ReflectedChoice
           ParentWithChoice: Chip8Cow.Frame
@@ -82,6 +98,35 @@ module MetaCart =
               Slot = slots.[index]
               Reflection = reflection })
 
+    let selectionReadout
+        (goal: int)
+        (costPerStep: float)
+        (tank: SoftThrottle.Tank)
+        (seed: uint64)
+        (children: Cart.Cart list)
+        : SelectionReadout =
+        let reflected = reflectChildren goal costPerStep tank seed children
+
+        let selected =
+            reflected
+            |> List.map (fun item -> item.Reflection)
+            |> Chip8Arcade.choose
+            |> Option.bind (fun index -> reflected |> List.tryItem index)
+
+        { Goal = goal
+          ReflectedGoal = goal
+          Seed = seed
+          CostPerStep = costPerStep
+          Tank = tank
+          Candidates = reflected
+          Selected = selected
+          DeterministicRulesApplied =
+            [ "metacart.children->fingerprint-slots"
+              "chip8arcade.reflect equal-funds each candidate"
+              "chip8arcade.choose max confidence, depth, then library order"
+              "selection orders candidates only; launch still crosses choice-cell 0x1FF"
+              "host capability gate remains authoritative" ] }
+
     /// Choose the child cart whose knowable future scores best under the
     /// existing CHIP-8 arcade reflection policy.
     let chooseSlot
@@ -91,11 +136,23 @@ module MetaCart =
         (seed: uint64)
         (children: Cart.Cart list)
         : ReflectedChoice option =
-        let reflected = reflectChildren goal costPerStep tank seed children
-        let reflections = reflected |> List.map (fun item -> item.Reflection)
+        (selectionReadout goal costPerStep tank seed children).Selected
 
-        Chip8Arcade.choose reflections
-        |> Option.bind (fun index -> reflected |> List.tryItem index)
+    let selectionReadoutWithCapabilities
+        (goal: int)
+        (parentCapabilities: Chip9Capabilities.Manifest)
+        (seed: uint64)
+        (children: Cart.Cart list)
+        : SelectionReadout =
+        let reflectedGoal, costPerStep, tank = Chip9Capabilities.reflectionBudget goal parentCapabilities
+        let readout = selectionReadout reflectedGoal costPerStep tank seed children
+
+        { readout with
+            Goal = goal
+            ReflectedGoal = reflectedGoal
+            DeterministicRulesApplied =
+                readout.DeterministicRulesApplied
+                @ [ sprintf "parent manifest %s supplies reflection budget" parentCapabilities.Name ] }
 
     /// Choose under the parent room's declared CHIP-9 policy. The manifest
     /// does not change arithmetic truth: it only decides how much flux funds
@@ -106,8 +163,7 @@ module MetaCart =
         (seed: uint64)
         (children: Cart.Cart list)
         : ReflectedChoice option =
-        let reflectedGoal, costPerStep, tank = Chip9Capabilities.reflectionBudget goal parentCapabilities
-        chooseSlot reflectedGoal costPerStep tank seed children
+        (selectionReadoutWithCapabilities goal parentCapabilities seed children).Selected
 
     /// Read the parent VM's choice using the same one-byte treaty as
     /// `Chip8Arcade.readChoice`, but return the fingerprint slot rather than
@@ -296,6 +352,56 @@ module MetaCart =
     let commitChoice (choice: ReflectedChoice) (parent: Chip8Cow.Frame) : Chip8Cow.Frame =
         Chip8Arcade.commitChoice choice.Index parent
 
+    let private slotsOfReadout (readout: SelectionReadout) : CartSlot list =
+        readout.Candidates |> List.map (fun candidate -> candidate.Slot)
+
+    /// Launch from an explicit selection readout. This is the testable
+    /// observe/choose/execute boundary: callers may inspect or replace the
+    /// readout before any child crosses the injected host.
+    let playChosenFromSelectionReadout
+        (source: string)
+        (sink: IHeatSink)
+        (readout: SelectionReadout)
+        (host: ICartHost)
+        (parent: Chip8Cow.Frame)
+        : Result<ReflectedPlayResult, Feedback> =
+        match readout.Selected with
+        | None -> Error(Feedback.NoSelection source)
+        | Some choice ->
+            let parentWithChoice = commitChoice choice parent
+
+            match playSelected source sink (slotsOfReadout readout) host parentWithChoice with
+            | Ok play ->
+                Ok
+                    { Choice = choice
+                      ParentWithChoice = parentWithChoice
+                      Play = play }
+            | Error feedback -> Error feedback
+
+    /// Capability-aware launch from an explicit selection readout. Parent
+    /// attention/throttle may change ordering, but capability truth is checked
+    /// here at the host boundary and still returns typed feedback/heat.
+    let playChosenFromSelectionReadoutWithCapabilities
+        (source: string)
+        (sink: IHeatSink)
+        (parentCapabilities: Chip9Capabilities.Manifest)
+        (readout: SelectionReadout)
+        (host: ICartHost)
+        (parent: Chip8Cow.Frame)
+        : Result<ReflectedPlayResult, Feedback> =
+        match readout.Selected with
+        | None -> Error(Feedback.NoSelection source)
+        | Some choice ->
+            let parentWithChoice = commitChoice choice parent
+
+            match playSelectedWithCapabilities source sink parentCapabilities (slotsOfReadout readout) host parentWithChoice with
+            | Ok play ->
+                Ok
+                    { Choice = choice
+                      ParentWithChoice = parentWithChoice
+                      Play = play }
+            | Error feedback -> Error feedback
+
     /// Soft-select a child cart by reflection, write that selection into the
     /// parent choice cell, then launch through the injected host boundary.
     let playChosenByReflection
@@ -309,19 +415,7 @@ module MetaCart =
         (host: ICartHost)
         (parent: Chip8Cow.Frame)
         : Result<ReflectedPlayResult, Feedback> =
-        match chooseSlot goal costPerStep tank seed children with
-        | None -> Error(Feedback.NoSelection source)
-        | Some choice ->
-            let slots = slotsOfCarts children
-            let parentWithChoice = commitChoice choice parent
-
-            match playSelected source sink slots host parentWithChoice with
-            | Ok play ->
-                Ok
-                    { Choice = choice
-                      ParentWithChoice = parentWithChoice
-                      Play = play }
-            | Error feedback -> Error feedback
+        playChosenFromSelectionReadout source sink (selectionReadout goal costPerStep tank seed children) host parent
 
     /// Capability-aware reflection path. The parent manifest funds the
     /// lookahead and gates host-child-launch; the child manifest gates the
@@ -336,20 +430,9 @@ module MetaCart =
         (children: Cart.Cart list)
         (parent: Chip8Cow.Frame)
         : Result<ReflectedPlayResult, Feedback> =
-        match chooseSlotWithCapabilities goal parentCapabilities seed children with
-        | None -> Error(Feedback.NoSelection source)
-        | Some choice ->
-            let slots = slotsOfCarts children
-            let host = CapabilityCartHost(children, childCapabilitiesBySha) :> ICartHost
-            let parentWithChoice = commitChoice choice parent
-
-            match playSelectedWithCapabilities source sink parentCapabilities slots host parentWithChoice with
-            | Ok play ->
-                Ok
-                    { Choice = choice
-                      ParentWithChoice = parentWithChoice
-                      Play = play }
-            | Error feedback -> Error feedback
+        let readout = selectionReadoutWithCapabilities goal parentCapabilities seed children
+        let host = CapabilityCartHost(children, childCapabilitiesBySha) :> ICartHost
+        playChosenFromSelectionReadoutWithCapabilities source sink parentCapabilities readout host parent
 
     /// Convenience for the common carried-cart mode: reflect over the bundled
     /// children and resolve the selected child from the same bundle.

--- a/tests/Tests.FSharp/DarkHallCabinetRuntime.Tests.fs
+++ b/tests/Tests.FSharp/DarkHallCabinetRuntime.Tests.fs
@@ -48,6 +48,33 @@ let ``machine action declares workflow-style DU metadata`` () =
     Assert.Equal(Some(mkAddress "play" "meta-cart-host"), action.Address)
 
 [<Fact>]
+let ``observeMetaCartLaunch exposes the child-cart selection readout`` () =
+    let loopCart = CartFixtures.cart CartFixtures.loop
+    let inputCart = CartFixtures.cart CartFixtures.inputFork
+
+    let launch: Runtime.MetaCartLaunch =
+        { Goal = 10
+          Seed = 1UL
+          ParentCapabilities = Chip9Capabilities.metaHost
+          ChildCapabilitiesBySha =
+            MetaCart.capabilityMap
+                [ loopCart, CartFixtures.loop.Capabilities
+                  inputCart, CartFixtures.inputFork.Capabilities ]
+          Children = [ loopCart; inputCart ]
+          Parent = Chip8Cow.create 1UL }
+
+    let readout = Runtime.observeMetaCartLaunch launch
+
+    Assert.Equal(2, readout.Candidates.Length)
+    Assert.Contains("chip8arcade.choose", System.String.Join(" ", readout.DeterministicRulesApplied))
+
+    match readout.Selected with
+    | Some selected ->
+        Assert.Equal(1, selected.Index)
+        Assert.Equal(MetaCart.slotOfCart inputCart, selected.Slot)
+    | None -> Assert.Fail("expected selected child cart")
+
+[<Fact>]
 let ``executeCell runs the selected soft CHIP8 scheduler machine`` () =
     task {
         let sink = RecordingHeatSink()

--- a/tests/Tests.FSharp/MetaCart.Tests.fs
+++ b/tests/Tests.FSharp/MetaCart.Tests.fs
@@ -106,6 +106,57 @@ let ``chooseSlot reuses arcade reflection and picks the most knowable child`` ()
     | None -> Assert.True(false, "expected a reflected child choice")
 
 [<Fact>]
+let ``selectionReadout exposes reflected candidates and the selected slot before launch`` () =
+    let readout =
+        MetaCart.selectionReadoutWithCapabilities
+            10
+            Chip9Capabilities.metaHost
+            1UL
+            [ loopCart; inputCart ]
+
+    Assert.Equal(10, readout.Goal)
+    Assert.Equal(10, readout.ReflectedGoal)
+    Assert.Equal(2, readout.Candidates.Length)
+    Assert.Contains("choice-cell 0x1FF", System.String.Join(" ", readout.DeterministicRulesApplied))
+
+    match readout.Selected with
+    | Some selected ->
+        let expected = MetaCart.slotOfCart inputCart
+        Assert.Equal(1, selected.Index)
+        Assert.Equal(expected, selected.Slot)
+        Assert.Equal(expected.Fingerprint.Sha256, selected.Slot.Fingerprint.Sha256)
+    | None -> Assert.True(false, "expected a selected child in the readout")
+
+[<Fact>]
+let ``playChosenFromSelectionReadout launches through the injected host boundary`` () =
+    let sink = RecordingHeatSink()
+    let readout =
+        MetaCart.selectionReadout
+            10
+            1.0
+            (SoftThrottle.tank 5.0 1.0)
+            1UL
+            [ loopCart; inputCart ]
+
+    let host = MetaCart.LocalCartHost [ loopCart; inputCart ] :> MetaCart.ICartHost
+
+    match
+        MetaCart.playChosenFromSelectionReadout
+            "parent-cart"
+            (sink :> IHeatSink)
+            readout
+            host
+            (Chip8Cow.create 1UL)
+    with
+    | Ok result ->
+        let expected = MetaCart.slotOfCart inputCart
+        Assert.Equal(expected, result.Choice.Slot)
+        Assert.Equal(expected, result.Play.Slot)
+        Assert.Equal(Some expected, MetaCart.readSlot [ MetaCart.slotOfCart loopCart; expected ] result.ParentWithChoice)
+        Assert.Equal(0, sink.Signatures.Count)
+    | Error feedback -> Assert.True(false, sprintf "expected reflected child launch, got %A" feedback)
+
+[<Fact>]
 let ``playChosenCarried commits the reflected choice into the parent cell and launches the child`` () =
     let sink = RecordingHeatSink()
 


### PR DESCRIPTION
## What changed

- Added `MetaCart.SelectionReadout` so reflected child-cart candidates, the selected slot, and the deterministic selection rules are observable before launch.
- Routed existing reflected meta-cart launches through explicit readout-based helpers while keeping the injected `ICartHost` and capability checks as the execution boundary.
- Added `DarkHallCabinetRuntime.observeMetaCartLaunch` so the Dark Hall controller can observe the child-cart sub-selection inside the meta-cart cabinet action.
- Added F# tests for the selection readout and runtime sub-readout.

## Why

The Dark Hall room loop already has the right observe/choose/execute shape at the cabinet level. This exposes the same shape one layer lower for meta-carts, without renaming `GridBinding` or making the 4x4 placement primitive carry controller semantics it should not own.

## Validation

- `dotnet build -c Release` passed after rerunning a transient F# compiler `exit 139` seen in `Core.FSharp.Blake3`.
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --no-restore --filter "FullyQualifiedName~MetaCartTests|FullyQualifiedName~DarkHallCabinetRuntimeTests|FullyQualifiedName~DarkHallRoomLoopTests"` passed: 27/27.
- `dotnet test Zeta.sln -c Release --no-build` passed: 3290 F# + 307 C# + other assemblies green, 4 existing skips.
- `dotnet format --verify-no-changes` passed.
- `bun run preflight:quick` passed on rerun; first run hit transient F# analyzer `exit 139`, isolated `bun src/Core.TypeScript/lint/lint-fsharp.ts` passed.
