### PR TITLE
docs(aurora): route the (b)↔FLP CSLib lift as its own scoping doc

### DIFF
--- a/docs/research/2026-06-19-aurora-b-bft-sybil-lift-onto-cslib-flp-consensus-lean-scoping.md
+++ b/docs/research/2026-06-19-aurora-b-bft-sybil-lift-onto-cslib-flp-consensus-lean-scoping.md
@@ -1,0 +1,124 @@
+# Scoping — lift Aurora (b) BFT-threshold-under-Sybil onto CSLib's FLP consensus (Lean)
+
+> **Status:** scoping doc (routing artifact, not a discharge). Routed by Otto 2026-06-19
+> (Aaron: *"route the (b)↔FLP CSLib lift as its own scoping doc (shadow\*)"*). Sibling of the
+> Aurora immune re-grounding trajectory; (b) is that trajectory's one still-open leg.
+> **Authorization:** drafting/scoping only — adopting CSLib as a Lean dependency and writing any
+> Lean proof are downstream decisions (Soraya's tool call + maintainer dependency sign-off).
+
+## 1. Trigger
+
+The Aurora immune re-grounding (`docs/trajectories/aurora-immune-reground/`) discharged the (a)
+identity wiring + all four test-obligation cross-checks (c/d/e/g) as of 2026-06-19. **Only (b)
+BFT-threshold-soundness-under-Sybil remains**, and it is *parked* behind the open anti-Sybil-entropy
+§B dependency. Separately, the learn-pass on CSLib (`leanprover/cslib`, Barrett et al.,
+arXiv:2602.04846, via Robert George's "Lean for Science" YC talk) flagged
+`Computability/Distributed/FLP` as **directly relevant to our consensus substrate**. This doc scopes
+whether — and how — (b) can be lifted from its current TLA+ form onto CSLib's Lean FLP framework,
+turning a model-checked transition system into a machine-checked theorem.
+
+## 2. What (b) is today (the artifacts to lift)
+
+- **`src/Core.TLA/specs/BftSybilConsensus.tla`** — authored, TLC-green, Viktor re-confirmed PASS
+  (2026-06-16). Models quorum over **proven-distinct identities**: a Sybil ring that is a RAW-NODE
+  majority (3 of 5) but whose extra nodes collapse to ONE identity is REFUSED a quorum (load-bearing
+  witness `NoSybilRawMajorityRefusal`). TLC surfaced + fixed a real bug — an *equivocating* ring
+  (splitting votes) formed conflicting quorums → fixed with **equivocation-exclusion** (BFT
+  double-vote treatment).
+- **Rides §A `NonRegisterCollapse`** (the (a) leg): "distinct identity" is the proven-distinct
+  standing register, not a metaphor — so "quorum over distinct identities" stands on a theorem.
+- **Open dependency:** the *anti-Sybil entropy* claim — that N fake identities cost ≈ N× the captured
+  entropy, making a Sybil ring prohibitive — is itself §B (register row *"Identity & society
+  emergence from proof-of-entropy (anti-Sybil)"*). BFT-threshold soundness **inherits** that open leg;
+  it must sequence first.
+
+## 3. What CSLib's FLP module actually provides (looked, didn't assume)
+
+`references/prior-art/cslib/Cslib/Computability/Distributed/FLP/{Algorithm,Consensus}.lean`:
+
+- `Algorithm P M S` — a distributed algorithm over processes `P`, messages `M`, states `S`.
+- `ProcFaulty` / `ProcFair` / `FairRun` — the fault + fairness model on infinite executions.
+- `Algorithm.AdmissibleRun a inp f` — runs tolerating up to `f` faulty processes.
+- `Algorithm.SafeConsensus` (safety = agreement + validity), `Algorithm.Termination f`,
+  `Algorithm.Consensus a f := SafeConsensus ∧ Termination f`.
+- `Consensus.fault_mono` — tolerate `f` ⟹ tolerate any `f' ≤ f` (the fault-tolerance monotonicity).
+
+**This is the FLP (crash-fault) framework**: "faulty" = crash/stop, "fair" = eventually-delivered.
+It gives us the *consensus scaffolding* (the `Algorithm`/`AdmissibleRun`/`SafeConsensus`/`Termination`
+vocabulary and the fault-count bound) as machine-checked Lean — exactly the layer our TLA+ spec
+hand-rolls.
+
+## 4. The lift — and its honest gaps (this is NOT a drop-in)
+
+CSLib's FLP is **crash-fault**; Aurora (b) is **Byzantine-under-Sybil**. So the lift is a
+framework-reuse with three named gaps, in dependency order:
+
+| # | Gap | What it needs | Status |
+|---|---|---|---|
+| G1 | **Crash → Byzantine** | extend `ProcFaulty` (stop) to an equivocating/Byzantine fault (a process emitting conflicting votes) — the equivocation-exclusion my TLA+ spec already models | new Lean work; the cleanest first slice |
+| G2 | **Anonymous → identity-keyed quorum (Sybil layer)** | quorum over **proven-distinct identities** (rides `NonRegisterCollapse`), so a raw-node majority sharing one identity is refused — port `NoSybilRawMajorityRefusal` | rides §A; the genuinely new coupling |
+| G3 | **Anti-Sybil entropy (the blocker)** | the proof that fake identities cost prohibitive entropy — **§B, still open** (proof-of-entropy row) | **BLOCKING — sequence first** |
+
+Without G3, G1+G2 prove "a quorum over distinct identities with equivocation excluded is safe" — but
+"distinct" is only *enforced* if forging identities is costly. So the honest sequencing is **G3 first**
+(or in parallel as a stated assumption), then G1, then G2.
+
+## 5. Routing (BP-16 — Soraya's call, not pre-decided here)
+
+The tool question is genuine and belongs to Soraya:
+
+- **Keep TLA+ for the transition system, add Lean only for the threshold algebra?** The
+  reachability/safety of the protocol is a transition system (TLA+'s home, already green). The
+  *threshold-soundness* (`honest > 2/3` over distinct identities; `D = 3f+1` sizing) is an
+  arithmetic/counting fact — Z3 (the (d)-style QF_LIA leg Soraya already routed) or Lean.
+- **Or lift the whole thing onto CSLib's FLP Lean framework?** Higher rigor (machine-checked, reusable
+  `Consensus.fault_mono`), but a larger commitment — it requires **adopting CSLib as a Lean dep**
+  (`lakefile.toml: require cslib, scope leanprover, rev main`) and writing G1/G2 in Lean.
+- **Recommendation to Soraya (not a decision):** the Z3 honest-count leg is the small near-term win
+  (matches (d)); the CSLib FLP lift is the rigor-escalation lane, best opened *after* G3 (anti-Sybil)
+  has a path, since lifting a quorum proof whose "distinct" premise is unproven banks little.
+
+## 6. Falsifiers (so this is a real obligation, not a hope)
+
+- If CSLib's `Algorithm`/`AdmissibleRun` cannot express an equivocating (Byzantine) fault without
+  forking the framework → the FLP module is the wrong substrate; keep TLA+ + Z3 (G1 fails the lift).
+- If the identity-keyed quorum cannot be stated over `NonRegisterCollapse`'s standing register inside
+  CSLib's process model → G2 fails; the Sybil layer stays TLA+-only.
+- If anti-Sybil entropy (G3) cannot be made a prohibitive-cost theorem → the whole BFT-under-Sybil
+  guarantee is conditional on an unproven premise; (b) stays §B regardless of how clean G1/G2 are.
+- If adopting CSLib drags in the `Boole` placeholder or an unstable `rev` → dependency cost exceeds
+  the rigor gain; stay on mathlib + TLA+/Z3.
+
+## 7. Honest seams
+
+- **FLP is an *impossibility* result.** Its lesson is that deterministic consensus is impossible under
+  one crash + asynchrony — Aurora's immune quorum is a *safety* gate, not a liveness guarantee (same
+  scope honesty as round (e): we prove safe-refusal, route liveness through `observe.ts`). The FLP
+  framework gives the vocabulary; we must not over-claim termination.
+- **CSLib adoption is a dependency decision** (Soraya's tool call + maintainer sign-off), pairs with
+  the CVC5/E-prover route (`081KV6BW42K08QG0R003GJM21N`); **do NOT depend on `Boole`** (placeholder —
+  the Rust/C++→Lean auto-verification is a vision, not shipping). Contribute-back to CSLib is gated +
+  Aaron-driven (outward-facing; "coworker not control").
+- **The four Aurora non-claims travel unchanged** — this is proven foundations, not deployment
+  readiness or threshold calibration.
+
+## 8. Next concrete step (one, small)
+
+Open the G3 question first: confirm whether the anti-Sybil-entropy §B row has a discharge path
+(proof-of-entropy → N fake identities cost N× entropy). Until G3 has a path, the CSLib FLP lift is
+*scoped and parked behind it* — exactly the sequencing the Aurora guardrail already states ("sequence
+the anti-Sybil discharge before BFT-threshold soundness"). The near-term win that does NOT need G3 is
+the **Z3 honest-count leg** (the (b) symbolic cross-check, (d)-style), which can land independently.
+
+## Composes with
+
+- `docs/trajectories/aurora-immune-reground/RESUME.md` — (b) is that trajectory's open leg; this doc is its CSLib routing.
+- `docs/research/2026-06-16-aurora-immune-math-reconciliation-scoping-reground-on-proven-identity-primitive.md` §8 — the discharged (a/c/d/e/g) legs this builds beside.
+- `docs/research/2026-06-15-learn-pass-torchlean-and-cslib-pulled-into-prior-art-what-we-can-learn.md` — the CSLib learn-pass (what's real, the Boole caveat).
+- `docs/FROZEN-CORE-AND-CONJECTURE-REGISTER.md` — the anti-Sybil §B row (G3) + `NonRegisterCollapse` §A (G2's anchor).
+- `src/Core.TLA/specs/BftSybilConsensus.tla` — the (b) artifact to lift.
+
+**Anchors (Beacon):** Fischer–Lynch–Paterson 1985 (FLP impossibility); Lamport–Shostak–Pease 1982
+(Byzantine generals); Castro–Liskov 1999 (PBFT, `3f+1`); Douceur 2002 (the Sybil attack); Dwork–Naor
+1992 / Nakamoto 2008 (proof-of-work/entropy Sybil-resistance); Barrett et al. 2026 (CSLib,
+arXiv:2602.04846); the in-tree `NonRegisterCollapse` identity proof.

--- a/docs/trajectories/aurora-immune-reground/RESUME.md
+++ b/docs/trajectories/aurora-immune-reground/RESUME.md
@@ -61,7 +61,10 @@ theorems, not metaphor.
      witnesses (accept / irrev-block / horizon-block). `tests/Tests.FSharp/Formal/PermanentHarmHorizonCrossVerify.Tests.fs`
      (4 green). Discharge: scoping doc §8(e).
    - **(b) TODO:** the Z3 honest-count side (`honest > 2/3` over proven-distinct identities); note the
-     anti-Sybil-entropy §B dependency must sequence first (it's still open).
+     anti-Sybil-entropy §B dependency must sequence first (it's still open). **CSLib FLP-lift routing
+     scoped (2026-06-19):** `docs/research/2026-06-19-aurora-b-bft-sybil-lift-onto-cslib-flp-consensus-lean-scoping.md`
+     — maps (b) onto CSLib's Lean FLP framework (G1 crash→Byzantine, G2 identity-keyed quorum, G3
+     anti-Sybil entropy = the blocker); near-term win = the Z3 honest-count leg (no G3 needed).
 3. **Authors:** (c)/(d)/(g) FsCheck/Z3 smalls.
    - ✅ **(g) DONE (2026-06-19):** Autoimmunity Flood / immune-memory decay (Test 4.5). Under flood
      (`Danger≈0`) Eq 10 → `n(t+1)=max(0,(1−δ)·n(t)−β·FP)`; FsCheck asserts decay→0, monotone,


### PR DESCRIPTION
## What

Routes the last open Aurora leg — **(b) BFT-threshold-under-Sybil** — as its own scoping doc, lifting it from TLA+ onto **CSLib's Lean FLP consensus framework** (`leanprover/cslib`, Barrett et al., arXiv:2602.04846). Aaron authorized 2026-06-19.

## What CSLib's FLP module actually provides (looked, didn't assume)

`Computability/Distributed/FLP/{Algorithm,Consensus}.lean` — `Algorithm P M S`, `AdmissibleRun a inp f`, `SafeConsensus`, `Termination f`, `Consensus a f`, `Consensus.fault_mono`. The **crash-fault** consensus scaffolding as machine-checked Lean — the layer our TLA+ spec hand-rolls.

## The honest seam (not a drop-in)

CSLib FLP is **crash-fault**; Aurora (b) is **Byzantine-under-Sybil**. Three named gaps, in dependency order:

| | Gap | Status |
|---|---|---|
| G1 | crash → Byzantine (equivocation-exclusion) | cleanest first slice |
| G2 | anonymous → identity-keyed quorum (rides §A `NonRegisterCollapse`) | the new coupling |
| G3 | **anti-Sybil entropy** — fake identities cost prohibitive entropy | **§B, OPEN — the blocker, sequence first** |

Without G3, "distinct identity" is only *enforced* if forging is costly — so G3 sequences first.

## Routing (left to Soraya, BP-16)

Keep TLA+ + a Z3 honest-count leg (near-term win, **no G3 needed**) vs the full CSLib FLP Lean lift (rigor-escalation lane, best opened *after* G3 has a path). Recommendation stated, decision deferred.

Includes falsifiers + honest seams (FLP is an *impossibility* result → safety not liveness; CSLib adoption is a dependency decision; do **not** depend on the `Boole` placeholder; contribute-back is gated/Aaron-driven).

Docs-only; scoping/routing artifact (no proof, no dependency added). Pointer added from the Aurora RESUME (b) line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)