### PR TITLE
feat(metacart): add attention selection policy

### DIFF
--- a/src/Core.TypeScript/lint/lint-fsharp.ts
+++ b/src/Core.TypeScript/lint/lint-fsharp.ts
@@ -7,7 +7,7 @@
 // Usage:
 //   bun src/Core.TypeScript/lint/lint-fsharp.ts
 
-import { spawnSync } from "node:child_process";
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -23,22 +23,69 @@ interface Step {
 const STEPS: readonly Step[] = [
   {
     label: "Whitespace checks (F#)",
-    cmd: ["dotnet", "format", "whitespace", "Zeta.sln", "--verify-no-changes", "--include", "src/**/*.fs", "tests/**/*.fs", "bench/**/*.fs", "samples/**/*.fs", "vocab/**/*.fs"],
+    cmd: [
+      "dotnet",
+      "format",
+      "whitespace",
+      "Zeta.sln",
+      "--verify-no-changes",
+      "--include",
+      "src/**/*.fs",
+      "tests/**/*.fs",
+      "bench/**/*.fs",
+      "samples/**/*.fs",
+      "vocab/**/*.fs",
+    ],
   },
   {
     label: "Code style checks (F#)",
-    cmd: ["dotnet", "format", "style", "Zeta.sln", "--verify-no-changes", "--include", "src/**/*.fs", "tests/**/*.fs", "bench/**/*.fs", "samples/**/*.fs", "vocab/**/*.fs"],
+    cmd: [
+      "dotnet",
+      "format",
+      "style",
+      "Zeta.sln",
+      "--verify-no-changes",
+      "--include",
+      "src/**/*.fs",
+      "tests/**/*.fs",
+      "bench/**/*.fs",
+      "samples/**/*.fs",
+      "vocab/**/*.fs",
+    ],
   },
   {
     label: "Analyzer checks (F#)",
-    cmd: ["dotnet", "format", "analyzers", "Zeta.sln", "--verify-no-changes", "--include", "src/**/*.fs", "tests/**/*.fs", "bench/**/*.fs", "samples/**/*.fs", "vocab/**/*.fs"],
+    cmd: [
+      "dotnet",
+      "format",
+      "analyzers",
+      "Zeta.sln",
+      "--verify-no-changes",
+      "--include",
+      "src/**/*.fs",
+      "tests/**/*.fs",
+      "bench/**/*.fs",
+      "samples/**/*.fs",
+      "vocab/**/*.fs",
+    ],
   },
 ];
 
-const RETRYABLE_WORKSPACE_FAILURES = [
-  "The server disconnected unexpectedly",
-  "Restore operation failed",
-];
+const RETRYABLE_WORKSPACE_FAILURES = ["The server disconnected unexpectedly", "Restore operation failed"];
+const TRANSIENT_DOTNET_EXIT_CODES = new Set([139]);
+
+function retryReason(result: SpawnSyncReturns<string>, output: string): string | undefined {
+  if (result.signal !== null) {
+    return `process ended by signal ${result.signal}`;
+  }
+  if (result.status !== null && TRANSIENT_DOTNET_EXIT_CODES.has(result.status)) {
+    return `dotnet exited ${String(result.status)}`;
+  }
+  if (RETRYABLE_WORKSPACE_FAILURES.some((fragment) => output.includes(fragment))) {
+    return "workspace load failure";
+  }
+  return undefined;
+}
 
 function run(step: Step): boolean {
   console.log(`=== ${step.label} ===`);
@@ -49,8 +96,8 @@ function run(step: Step): boolean {
       encoding: "utf8",
       maxBuffer: 64 * 1024 * 1024,
     });
-    process.stdout.write(result.stdout ?? "");
-    process.stderr.write(result.stderr ?? "");
+    process.stdout.write(result.stdout);
+    process.stderr.write(result.stderr);
 
     if (result.error) {
       console.error(`✗ ${step.label}: failed to start — ${result.error.message}`);
@@ -60,16 +107,14 @@ function run(step: Step): boolean {
       return true;
     }
 
-    const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
-    const retryable =
-      attempt === 1 &&
-      (result.signal !== null || RETRYABLE_WORKSPACE_FAILURES.some((fragment) => output.includes(fragment)));
-    if (retryable) {
-      console.warn(`↻ ${step.label}: retrying once after dotnet format workspace load failure`);
+    const reason = attempt === 1 ? retryReason(result, result.stdout + result.stderr) : undefined;
+    if (reason !== undefined) {
+      console.warn(`↻ ${step.label}: ${reason}; retrying once before treating it as deterministic`);
       continue;
     }
 
-    console.error(`✗ ${step.label}: exited with code ${result.status ?? "signal"}`);
+    const exitCode = result.status === null ? "signal" : String(result.status);
+    console.error(`✗ ${step.label}: exited with code ${exitCode}`);
     return false;
   }
   return false;

--- a/src/Core/DarkHallCabinetRuntime.fs
+++ b/src/Core/DarkHallCabinetRuntime.fs
@@ -222,6 +222,15 @@ module DarkHallCabinetRuntime =
             launch.Seed
             launch.Children
 
+    let observeMetaCartLaunchWithPolicy
+        (policyName: string)
+        (policy: MetaCart.SelectionPolicy)
+        (launch: MetaCartLaunch)
+        : MetaCart.SelectionReadout =
+        launch
+        |> observeMetaCartLaunch
+        |> MetaCart.applySelectionPolicy policyName policy
+
     let private findCabinet (room: DarkHall.Room) (cabinetName: string) =
         room.Cabinets |> List.tryFind (fun cabinet -> cabinet.Name = cabinetName)
 

--- a/src/Core/MetaCart.fs
+++ b/src/Core/MetaCart.fs
@@ -52,6 +52,11 @@ module MetaCart =
           Selected: ReflectedChoice option
           DeterministicRulesApplied: string list }
 
+    /// Host/room policy hook for attention and gravity over already-observed
+    /// child futures. Policies may reorder/select existing candidates only;
+    /// `applySelectionPolicy` rejects invented children before execution.
+    type SelectionPolicy = SelectionReadout -> ReflectedChoice option
+
     type ReflectedPlayResult =
         { Choice: ReflectedChoice
           ParentWithChoice: Chip8Cow.Frame
@@ -153,6 +158,50 @@ module MetaCart =
             DeterministicRulesApplied =
                 readout.DeterministicRulesApplied
                 @ [ sprintf "parent manifest %s supplies reflection budget" parentCapabilities.Name ] }
+
+    let private sameChoice (left: ReflectedChoice) (right: ReflectedChoice) : bool =
+        left.Index = right.Index
+        && left.Slot.Fingerprint.Sha256 = right.Slot.Fingerprint.Sha256
+
+    let private normalizePolicyChoice (readout: SelectionReadout) (choice: ReflectedChoice) : ReflectedChoice option =
+        readout.Candidates |> List.tryFind (sameChoice choice)
+
+    let defaultSelectionPolicy (readout: SelectionReadout) : ReflectedChoice option = readout.Selected
+
+    let applySelectionPolicy
+        (policyName: string)
+        (policy: SelectionPolicy)
+        (readout: SelectionReadout)
+        : SelectionReadout =
+        let selected = policy readout |> Option.bind (normalizePolicyChoice readout)
+
+        { readout with
+            Selected = selected
+            DeterministicRulesApplied =
+                readout.DeterministicRulesApplied
+                @ [ sprintf "selection policy %s may reorder existing candidates only" policyName ] }
+
+    let private finiteOrFloor (value: float) : float =
+        if System.Double.IsNaN value || System.Double.IsInfinity value then
+            System.Double.NegativeInfinity
+        else
+            value
+
+    /// Attention changes ordering, not arithmetic truth. The byte/flux cost
+    /// and host capability checks remain downstream; this only chooses which
+    /// already-reflected child future boards first.
+    let attentionSelectionPolicy (attention: CartSlot -> float) : SelectionPolicy =
+        fun readout ->
+            match readout.Candidates with
+            | [] -> None
+            | candidates ->
+                candidates
+                |> List.maxBy (fun choice ->
+                    finiteOrFloor (attention choice.Slot),
+                    choice.Reflection.Report.Confidence,
+                    choice.Reflection.Report.Achieved,
+                    -choice.Index)
+                |> Some
 
     /// Choose under the parent room's declared CHIP-9 policy. The manifest
     /// does not change arithmetic truth: it only decides how much flux funds

--- a/tests/Tests.FSharp/DarkHallCabinetRuntime.Tests.fs
+++ b/tests/Tests.FSharp/DarkHallCabinetRuntime.Tests.fs
@@ -75,6 +75,37 @@ let ``observeMetaCartLaunch exposes the child-cart selection readout`` () =
     | None -> Assert.Fail("expected selected child cart")
 
 [<Fact>]
+let ``observeMetaCartLaunchWithPolicy exposes attention-reordered child selection`` () =
+    let loopCart = CartFixtures.cart CartFixtures.loop
+    let inputCart = CartFixtures.cart CartFixtures.inputFork
+
+    let launch: Runtime.MetaCartLaunch =
+        { Goal = 10
+          Seed = 1UL
+          ParentCapabilities = Chip9Capabilities.metaHost
+          ChildCapabilitiesBySha =
+            MetaCart.capabilityMap
+                [ loopCart, CartFixtures.loop.Capabilities
+                  inputCart, CartFixtures.inputFork.Capabilities ]
+          Children = [ loopCart; inputCart ]
+          Parent = Chip8Cow.create 1UL }
+
+    let readout =
+        Runtime.observeMetaCartLaunchWithPolicy
+            "operator-attention"
+            (MetaCart.attentionSelectionPolicy (fun slot -> if slot.Name = loopCart.Meta.Title then 100.0 else 0.0))
+            launch
+
+    Assert.Equal(2, readout.Candidates.Length)
+    Assert.Contains("selection policy operator-attention", System.String.Join(" ", readout.DeterministicRulesApplied))
+
+    match readout.Selected with
+    | Some selected ->
+        Assert.Equal(0, selected.Index)
+        Assert.Equal(MetaCart.slotOfCart loopCart, selected.Slot)
+    | None -> Assert.Fail("expected attention policy to select the loop cart")
+
+[<Fact>]
 let ``executeCell runs the selected soft CHIP8 scheduler machine`` () =
     task {
         let sink = RecordingHeatSink()

--- a/tests/Tests.FSharp/MetaCart.Tests.fs
+++ b/tests/Tests.FSharp/MetaCart.Tests.fs
@@ -128,6 +128,87 @@ let ``selectionReadout exposes reflected candidates and the selected slot before
     | None -> Assert.True(false, "expected a selected child in the readout")
 
 [<Fact>]
+let ``attention policy reorders candidates without crossing the host boundary`` () =
+    let sink = RecordingHeatSink()
+
+    let readout =
+        MetaCart.selectionReadout
+            10
+            1.0
+            (SoftThrottle.tank 5.0 1.0)
+            1UL
+            [ loopCart; inputCart ]
+
+    let attended =
+        readout
+        |> MetaCart.applySelectionPolicy
+            "test-attention"
+            (MetaCart.attentionSelectionPolicy (fun slot -> if slot.Name = loopCart.Meta.Title then 10.0 else 0.0))
+
+    Assert.Contains("selection policy test-attention", System.String.Join(" ", attended.DeterministicRulesApplied))
+
+    match attended.Selected with
+    | Some selected ->
+        Assert.Equal(0, selected.Index)
+        Assert.Equal(MetaCart.slotOfCart loopCart, selected.Slot)
+    | None -> Assert.Fail("expected attention to select an existing child cart")
+
+    let host = MetaCart.LocalCartHost [ loopCart; inputCart ] :> MetaCart.ICartHost
+
+    match
+        MetaCart.playChosenFromSelectionReadout
+            "parent-cart"
+            (sink :> IHeatSink)
+            attended
+            host
+            (Chip8Cow.create 1UL)
+    with
+    | Ok result ->
+        Assert.Equal(MetaCart.slotOfCart loopCart, result.Play.Slot)
+        Assert.Equal(Some(MetaCart.slotOfCart loopCart), MetaCart.readSlot [ MetaCart.slotOfCart loopCart; MetaCart.slotOfCart inputCart ] result.ParentWithChoice)
+        Assert.Equal(0, sink.Signatures.Count)
+    | Error feedback -> Assert.Fail(sprintf "expected attended child launch, got %A" feedback)
+
+[<Fact>]
+let ``selection policy cannot invent a non-candidate slot`` () =
+    let sink = RecordingHeatSink()
+
+    let readout =
+        MetaCart.selectionReadout
+            10
+            1.0
+            (SoftThrottle.tank 5.0 1.0)
+            1UL
+            [ loopCart; inputCart ]
+
+    let fakeSlot = MetaCart.reference "invented-child" (GameFingerprint.fingerprint [| 0x00uy; 0xE0uy |])
+
+    let inventingPolicy (candidateReadout: MetaCart.SelectionReadout) =
+        candidateReadout.Selected
+        |> Option.map (fun selected -> { selected with Slot = fakeSlot })
+
+    let attended = readout |> MetaCart.applySelectionPolicy "inventing" inventingPolicy
+
+    match attended.Selected with
+    | Some selected -> Assert.Fail(sprintf "expected invented policy choice to be rejected, got %A" selected)
+    | None -> ()
+
+    let host = MetaCart.LocalCartHost [ loopCart; inputCart ] :> MetaCart.ICartHost
+
+    match
+        MetaCart.playChosenFromSelectionReadout
+            "parent-cart"
+            (sink :> IHeatSink)
+            attended
+            host
+            (Chip8Cow.create 1UL)
+    with
+    | Error(MetaCart.Feedback.NoSelection source) ->
+        Assert.Equal("parent-cart", source)
+        Assert.Equal(0, sink.Signatures.Count)
+    | other -> Assert.Fail(sprintf "expected cold NoSelection after invented policy choice, got %A" other)
+
+[<Fact>]
 let ``playChosenFromSelectionReadout launches through the injected host boundary`` () =
     let sink = RecordingHeatSink()
     let readout =


### PR DESCRIPTION
## What changed

- Added `MetaCart.SelectionPolicy` plus `applySelectionPolicy` so attention/gravity policies can reorder/select from observed child-cart candidates.
- Added `attentionSelectionPolicy`, which scores existing candidates by injected attention while preserving the downstream byte/flux and host capability gates.
- Exposed `DarkHallCabinetRuntime.observeMetaCartLaunchWithPolicy` for the observe.ts-shaped room/controller path.
- Hardened `src/Core.TypeScript/lint/lint-fsharp.ts` to retry `dotnet format` exit 139 once before classifying it as deterministic failure.

## Why

The meta-cart boundary needed the next small policy hook: attention changes ordering, not arithmetic truth. Policies may choose only from the already-reflected candidates; invented choices normalize to `NoSelection` rather than bypassing the host.

The local exit 139 symptom is a toolchain determinism smell at the F# compiler/analyzer boundary, not a Zeta DST/runtime smell. The lint wrapper now treats the first 139 like the existing transient workspace-load failures and retries once; a second failure still goes red.

## Validation

- `dotnet build -c Release`
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --no-build --filter "FullyQualifiedName~MetaCartTests|FullyQualifiedName~DarkHallCabinetRuntimeTests"`
- `dotnet test Zeta.sln -c Release --no-build`
- `bun src/Core.TypeScript/hygiene/preflight.ts --quick` (Go skipped locally; CI covers it)
- `bun src/Core.TypeScript/lint/lint-fsharp.ts`
- `bun src/Core.TypeScript/lint/lint-typescript.ts`
- `bunx prettier --check src/Core.TypeScript/lint/lint-fsharp.ts`
- `bunx eslint src/Core.TypeScript/lint/lint-fsharp.ts`
