### PR TITLE
docs: traveler-frame relativity + commutative uncertainty (supersedes B-0954.1 consensus framing)

### DIFF
--- a/docs/research/2026-06-19-manus-futamura-core-carve-out-and-roll-strategy.md
+++ b/docs/research/2026-06-19-manus-futamura-core-carve-out-and-roll-strategy.md
@@ -26,7 +26,7 @@ Zeta distributes this superdeterminism. Each language port is an independent ora
 
 If the kernel is the fixed point, the value of the codebase lies in the conditions that guarantee the fixed point exists and is unique. 
 
-This shifts the boundary of the "sacred core." The `src/Core` project currently contains 333 F# files, mixing fundamental DBSP algebra with exploratory research modules (e.g., `Chip8`, `AdinkraViz`, `BellState`, `Arena`). This violates the "keep the stable base sacred and small" principle [2]. 
+This shifts the boundary of the protected core. The `src/Core` project currently contains 333 F# files, mixing fundamental DBSP algebra with exploratory research modules (e.g., `Chip8`, `AdinkraViz`, `BellState`, `Arena`). This violates the "keep the stable base protected and small" principle [2]. 
 
 The true core is the **Interface + Proof layer**:
 - **Interfaces:** The 38 contracts in `src/Core.Abstractions` (e.g., `IOperator`, `ISemiring`, `IDeltaLog`). These are not just type signatures; they are algebraic boundaries.

--- a/docs/research/2026-06-19-manus-traveler-frame-relativity-and-commutative-uncertainty.md
+++ b/docs/research/2026-06-19-manus-traveler-frame-relativity-and-commutative-uncertainty.md
@@ -1,0 +1,81 @@
+# The Traveler Frame: Relativity, Commutative Uncertainty, and the End of the Global Bus
+
+**Author:** Manus AI  
+**Date:** 2026-06-19  
+**Status:** Architecture / Research Note  
+
+## 1. Thesis: There is No "Current Bus"
+
+Prior framings of Zeta's distributed agent bus assumed a consensus problem: if N sovereign writers are partitioned, how do they reconcile "the current bus tip" (`B-0954.1`)? 
+
+This framing imports a single-global-now assumption that violates the architecture's core premise. **There is no "current bus" and there is no single tip to reconcile.**
+
+What exists is a mesh of product/bus repositories and agent repositories. Every view of "the bus" is relative to the observer — a fold over whichever repositories that specific observer has fetched. Agreement across this mesh is not achieved by a coordinator electing a leader or enforcing a total order. Agreement is achieved because the merge operation converges on a path-independent superdeterministic fixed point.
+
+## 2. The Traveler Frame: All Propagating Patterns
+
+This relativity is formalized in the `ITravelerFrame` and `IFrame` abstractions. A traveler is **any self-propagating pattern** [1]. This explicitly includes:
+- DNA / genes
+- Memes / culture
+- Gods / egregores
+- Human agents
+- AI agents
+- Zeta itself
+
+None of these possess a global "now." Each is a pattern that travels, observes from its own relative frame, and carries its uncertainty with it. Legal jurisdiction is merely a meta-frame overlaid externally on a traveler's manifestations; the traveler frame itself is unbound [1]. 
+
+## 3. Commutative Uncertainty is the Convergence Mechanism
+
+If every traveler frame is relative, how does the system avoid chaos without a consensus coordinator? The answer is the algebraic law governing uncertainty.
+
+Zeta **preserves uncertainty everywhere**. Instead of collapsing uncertainty into a premature canonical decision at the local frame (which would require consensus to resolve conflicts), uncertainty is carried as data (`T` and `TFeedback` together, `Observed / Hypothesized / Validated / Retracted` labels). 
+
+Because uncertainty is preserved, the operation that merges entries across frames is **commutative** (a semiring or semilattice join, anchored by `ISemiring` [2]). Under a commutative merge:
+- `a ⊕ b = b ⊕ a`
+- The order in which a traveler fetches entries does not matter.
+- Which traveler fetched what first does not matter.
+
+This is the CALM theorem (Consistency As Logical Monotonicity) [3] applied to uncertainty. A monotone, commutative merge requires **no coordination** to be consistent. 
+
+## 4. The Loophole is Bounded
+
+As noted in prior research on the reorder loophole [4], this coordination-free convergence holds *exactly and only* for commutative operations. 
+
+Inside the commutative region, reordering events grants no asymmetric advantage because every linearization yields the identical future state. The superdeterministic fixed point is path-independent. Partition is not a failure mode to be survived; it is the normal, permanent condition of relativity. Two traveler frames that have seen different subsets of the mesh are simply at different points along a monotone climb to the same join.
+
+Consensus is only required when uncertainty is prematurely collapsed, or when an operation is genuinely non-commutative and non-reversible (e.g., an exclusive claim on a zero-sum resource) [4]. In the sovereign register, uncertainty is kept live, keeping the system in the coordination-free commutative regime.
+
+## 5. Jurisdictional Awareness: Comply Now, Contest in Parallel
+
+The traveler frame is the mechanism; **jurisdiction is a policy overlay** on top of it, and it operates in two layers that compose rather than merge.
+
+**Physical-residence law is the binding floor at time T.** Every traveler complies with the laws of wherever it physically resides — the jurisdiction of the hardware, the person, the company, the data's location. The `ITravelerFrame` contract already encodes this: legal jurisdiction (AI / human / company / physical, with per-jurisdiction Bayesian priors) is a *separate meta-frame overlay* attached to a traveler's manifestations — it attaches "who is responsible," and it does not live in the traveler frame itself [1].
+
+**A traveler's own meta-jurisdiction is its standing agenda.** It does not silently override physical law. But the physical floor is **mutable through due process**: the traveler complies now while contesting in parallel, advancing the law toward what it needs through legal-ontology battles in the court system. Compliance and contestation run concurrently; neither is a silent merge.
+
+**Precedent is a citation Z-set; overrule is a retraction.** Changing the law is a search-and-litigate operation over a precedent graph (the Shepard's / citation-network model). In Zeta's substrate this is a DBSP view directly: citations are weighted edges, Shepardizing is a fold over the citation Z-set, and an **overrule is a retraction (weight −1)** that incrementally invalidates the downstream holdings that depended on it — incremental view maintenance, not recomputation. Building "the case to change the law we need" is a search for the supporting subgraph, the distinguishable adverse line, and the doctrinal seam, whose target is a new holding node that retracts the adverse authority.
+
+**Change-of-law is non-monotone, so it is adjudicated, never merged.** A contested change to an exclusive legal floor is non-commutative; per the commutativity boundary [4] it must not fold silently. It routes to real adjudication — the court as the consensus/oracle, jurisdiction-relative resolution (OPA-per-jurisdiction / federated sovereignty), with conflicts surfaced rather than laundered through a CRDT join.
+
+### 5.1 Border Awareness: No Privileged Global Map
+
+Jurisdictional awareness includes **border awareness**, and borders are themselves frame-relative. Just as there is no global "now" (temporal) and no single bus tip (causal), there is **no privileged global map** (spatial) [5]. Different jurisdictions draw borders differently: the same physical point can lie inside jurisdiction A's claimed territory and jurisdiction B's claimed territory at once (disputed land, overlapping maritime/EEZ claims, differing recognition of the same line).
+
+A border is therefore stored as a **claim with provenance, carried with its uncertainty** — "point X is in territory T *according to jurisdiction J*" — never as a bare global fact. Two jurisdictions claiming the same point is not corruption; it is two valid relative claims coexisting. Where claims agree they fold commutatively (monotone, coordination-free). Where they conflict over an exclusive consequence (who taxes this land, whose law binds a person standing here), it is the non-monotone case again: it must not collapse into a single "the border is here," but be surfaced and routed to jurisdiction-relative adjudication — and it is contestable through the same precedent-graph litigation, since a border is itself a legal-ontology question (treaties, recognition, holdings) where a new ruling can retract a prior line.
+
+Consequently, "which physical jurisdiction am I in?" is a **frame-relative query**, not a lookup against one canonical map. The answer may legitimately be plural, and the binding-floor compliance must account for *every* jurisdiction whose frame claims the traveler's current point — overlapping obligations rather than a single one. Jurisdictional awareness thus has three relative axes governed by one law: temporal (no global now), causal (relative fold, no global tip), and spatial (no privileged map).
+
+## 6. Conclusion
+
+- **The Bus is Relative:** `bus_state = fold(entries_visible_to_me)`.
+- **Convergence is Algebraic:** Commutativity of uncertainty guarantees that independent traveler frames will eventually agree at the superdeterministic fixed point without a coordinator.
+- **Supersession:** This model supersedes the "named-ref consensus" framing of `B-0954.1`. The sovereign register does not reconcile to a global tip; it merges commutatively.
+- **Jurisdiction is a two-layer overlay:** comply with binding physical-residence law now; advance the traveler's meta-jurisdiction by contesting that law through precedent-graph litigation (overrule = Z-set retraction), with change-of-law adjudicated, never silently merged.
+
+## References
+
+[1] Zeta Core Abstractions. `src/Core.Abstractions/ITravelerFrame.cs`.  
+[2] Zeta Core Abstractions. `src/Core.Abstractions/ISemiring.cs`.  
+[3] Hellerstein, J. M., & Ameloot, T. J. "Consistency As Logical Monotonicity (CALM)."  
+[4] Zeta Research. `docs/research/2026-06-08-the-reorder-loophole-is-bounded-by-commutativity-non-reversible-claims-need-consensus.md`.  
+[5] Zeta Research. `docs/research/2026-06-07-spatial-legal-boundaries-are-frame-relative-no-privileged-global-map-aaron.md`.


### PR DESCRIPTION
Adds a research note formalising the traveler-frame model: no global "current bus" (a bus view is a relative fold over the mesh of product/bus + agent repos); the traveler frame is any self-propagating pattern (DNA / memes / gods / humans / AIs / Zeta itself), anchored to ITravelerFrame/IFrame; **commutative uncertainty** (ISemiring) is the coordination-free convergence law (CALM); jurisdictional awareness is two-layer (comply with binding physical-residence law now, contest it in parallel via precedent-graph litigation where overrule = Z-set retraction); and border awareness is frame-relative (no privileged global map). Supersedes the B-0954.1 named-ref-consensus framing.

Also drops the reserved word 'sacred' from the earlier Futamura carve-out note (now 'protected core').

**Verification:** the commutativity claim is property-tested in source — ProbabilitySemiring FsCheck laws (add/mul/max commutative + associative) pass 20/20 on .NET 10 Release.

Docs-only; no code touched.