### PR TITLE
test(aurora): (b) BFT honest-count Z3 leg — quorum threshold soundness (QF_LIA)

### DIFF
--- a/docs/research/2026-06-16-aurora-immune-math-reconciliation-scoping-reground-on-proven-identity-primitive.md
+++ b/docs/research/2026-06-16-aurora-immune-math-reconciliation-scoping-reground-on-proven-identity-primitive.md
@@ -217,6 +217,30 @@ wiring are done. Only **(b)** remains, parked behind the open anti-Sybil-entropy
 row *"Aurora immune re-grounded on the proven identity primitive"* is now ready to promote toward §A
 (operator-by-operator, §C) — gated on the maintainer's sign-off (proof-lineage change).
 
+### (b) BFT honest-count — Z3 symbolic leg landed (2026-06-19, Otto)
+
+The symbolic (Z3) leg of Soraya's BP-16 routing for (b) — the BFT-threshold *arithmetic* over QF_LIA
+(N total proven-distinct identities, f Byzantine-faulty, quorum Q). 6 lemmas in
+`tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs` (5 UNSAT proofs + 1 SAT witness, 59 Z3 tests green):
+
+- **canonical quorum (N=3f+1, Q=2f+1) is safe ∧ live** (`2Q ≥ N+f+1` ∧ `Q ≤ N−f`); **honest
+  supermajority in any quorum** (honest ≥ f+1 > f); **honest quorum-intersection** (two quorums always
+  share ≥1 honest identity — the agreement crux).
+- **3f+1 is NECESSARY** — `N ≤ 3f` admits no quorum that is both safe and live (the classic BFT bound,
+  proven by UNSAT of the conjunction).
+- **fault-tolerance monotone** (tolerate f ⟹ tolerate any f′≤f) — mirrors CSLib FLP's
+  `Consensus.fault_mono`, the bridge to the eventual Lean lift.
+- **Sybil refusal witness:** a raw-node majority is *refused* when distinct-identity count falls short
+  (≥2 raw share 1 identity) — counting is over **proven-distinct identities** (rides §A
+  `NonRegisterCollapse`), the arithmetic shadow of the TLA+ `NoSybilRawMajorityRefusal`.
+
+**Honest scope (the binding seam):** this proves the threshold counting is sound **GIVEN distinctness**
+— it does **NOT** discharge **G3 anti-Sybil entropy** (§B, open). "Distinct" is only *enforced* if
+forging identities is costly; the full BFT-under-Sybil guarantee still inherits G3. So (b) now has its
+TLA+ leg (reachability, TLC-green) + this Z3 leg (threshold arithmetic), with the entropy premise
+named-and-open (see the CSLib FLP-lift scoping doc §4 G3). Anchors: Lamport–Shostak–Pease 1982;
+Castro–Liskov 1999 (PBFT).
+
 ## Composes with
 
 - `docs/research/aurora-immune-math-standardization-2026-04-26.md` — the math being re-grounded (Amara; Gemini; Otto rigor pass).

--- a/docs/trajectories/aurora-immune-reground/RESUME.md
+++ b/docs/trajectories/aurora-immune-reground/RESUME.md
@@ -60,11 +60,14 @@ theorems, not metaphor.
      `PermanentHarmHorizon.tla`, FsCheck asserts HarmFloor at every reachable state + 3 non-vacuity
      witnesses (accept / irrev-block / horizon-block). `tests/Tests.FSharp/Formal/PermanentHarmHorizonCrossVerify.Tests.fs`
      (4 green). Discharge: scoping doc §8(e).
-   - **(b) TODO:** the Z3 honest-count side (`honest > 2/3` over proven-distinct identities); note the
-     anti-Sybil-entropy §B dependency must sequence first (it's still open). **CSLib FLP-lift routing
-     scoped (2026-06-19):** `docs/research/2026-06-19-aurora-b-bft-sybil-lift-onto-cslib-flp-consensus-lean-scoping.md`
-     — maps (b) onto CSLib's Lean FLP framework (G1 crash→Byzantine, G2 identity-keyed quorum, G3
-     anti-Sybil entropy = the blocker); near-term win = the Z3 honest-count leg (no G3 needed).
+   - ✅ **(b) Z3 honest-count leg DONE (2026-06-19):** 6 QF_LIA lemmas — canonical quorum safe+live,
+     honest supermajority, 3f+1 necessity, fault-monotone (mirrors CSLib `Consensus.fault_mono`),
+     honest quorum-intersection, + Sybil raw-majority-refusal witness (counts proven-distinct
+     identities). `tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs` (59 Z3 green). Discharge: §8(b).
+     **Still open:** the TLA+ leg already exists; what remains is **G3 anti-Sybil entropy** (§B) — the
+     threshold arithmetic is sound GIVEN distinctness, not a discharge of the entropy premise.
+     **CSLib FLP-lift routing scoped:** `docs/research/2026-06-19-aurora-b-bft-sybil-lift-onto-cslib-flp-consensus-lean-scoping.md`
+     (G1 crash→Byzantine, G2 identity-keyed quorum, G3 anti-Sybil entropy = the blocker).
 3. **Authors:** (c)/(d)/(g) FsCheck/Z3 smalls.
    - ✅ **(g) DONE (2026-06-19):** Autoimmunity Flood / immune-memory decay (Test 4.5). Under flood
      (`Danger≈0`) Eq 10 → `n(t+1)=max(0,(1−δ)·n(t)−β·FP)`; FsCheck asserts decay→0, monotone,

--- a/tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs
+++ b/tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs
@@ -860,3 +860,83 @@ let ``Z3 witnesses a genuine ADMIT: a fully-covered non-empty requirement passes
         "(assert (= (bvand req (bvnot al)) " + bv0 + "))\n" + // fully covered ⇒ admitted
         "(check-sat)\n"
     z3ScriptHasModel "(d) genuine admit reachable" script
+
+
+// ═══════════════════════════════════════════════════════════════════
+// Aurora round (b) — BFT-threshold soundness under Sybil: the HONEST-COUNT side
+// (standardization §2 BFT threshold; the symbolic leg of Soraya's BP-16 routing for (b)).
+// Quorum arithmetic over QF_LIA: N total proven-distinct identities, f Byzantine-faulty, quorum Q.
+// Safety = two quorums intersect in an honest node (2Q ≥ N+f+1); liveness = a quorum forms from
+// non-faulty nodes (Q ≤ N−f). The canonical PBFT instance is N = 3f+1, Q = 2f+1.
+// SCOPE (honest, ties to the scoping doc): this is the THRESHOLD ARITHMETIC cross-check assuming
+// distinct identities — it does NOT discharge anti-Sybil entropy (G3, §B, open). "Distinct" is only
+// ENFORCED if forging identities is costly; here we prove the counting is sound GIVEN distinctness,
+// and (L6) that a raw-node majority sharing identities is refused by counting distinct, not raw.
+// Anchors: Lamport–Shostak–Pease 1982; Castro–Liskov 1999 (PBFT 3f+1 / 2f+1); rides §A NonRegisterCollapse.
+// ═══════════════════════════════════════════════════════════════════
+
+[<Fact>]
+let ``Z3 proves the canonical BFT quorum (N=3f+1, Q=2f+1) is both safe and live (b)`` () =
+    // safety: 2Q ≥ N+f+1 (two quorums share an honest node); liveness: Q ≤ N−f (a quorum can form).
+    let script =
+        "(declare-const f Int)(declare-const N Int)(declare-const Q Int)\n" +
+        "(assert (not (=> (and (>= f 0) (= N (+ (* 3 f) 1)) (= Q (+ (* 2 f) 1)))\n" +
+        "                 (and (>= (* 2 Q) (+ N f 1)) (<= Q (- N f))))))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "(b) canonical quorum safe+live" script
+
+[<Fact>]
+let ``Z3 proves a BFT quorum holds an honest supermajority (honest strictly outnumber faulty) (b)`` () =
+    // A quorum of Q=2f+1 with ≤ f faulty has honest ≥ f+1 > f — honest strictly outnumber faulty.
+    let script =
+        "(declare-const f Int)(declare-const Q Int)(declare-const faulty Int)\n" +
+        "(assert (not (=> (and (>= f 0) (= Q (+ (* 2 f) 1)) (>= faulty 0) (<= faulty f))\n" +
+        "                 (and (>= (- Q faulty) (+ f 1)) (> (- Q faulty) faulty)))))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "(b) honest supermajority in quorum" script
+
+[<Fact>]
+let ``Z3 proves N >= 3f+1 is NECESSARY — below it no quorum is both safe and live (b)`` () =
+    // The classic BFT bound: if N ≤ 3f, no Q satisfies both safety (2Q ≥ N+f+1) and liveness (Q ≤ N−f).
+    // Asserting the conjunction directly ⇒ UNSAT proves no such witness exists.
+    let script =
+        "(declare-const f Int)(declare-const N Int)(declare-const Q Int)\n" +
+        "(assert (and (>= f 0) (<= N (* 3 f)) (>= Q 0)\n" +
+        "             (>= (* 2 Q) (+ N f 1)) (<= Q (- N f))))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "(b) 3f+1 necessity (N<=3f has no safe+live quorum)" script
+
+[<Fact>]
+let ``Z3 proves BFT fault-tolerance is monotone: tolerate f implies tolerate any f' <= f (b)`` () =
+    // Mirrors CSLib FLP's Consensus.fault_mono — the bridge to the eventual Lean lift.
+    let script =
+        "(declare-const f Int)(declare-const fp Int)(declare-const N Int)\n" +
+        "(assert (not (=> (and (>= fp 0) (<= fp f) (>= N (+ (* 3 f) 1)))\n" +
+        "                 (>= N (+ (* 3 fp) 1)))))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "(b) fault-tolerance monotone" script
+
+[<Fact>]
+let ``Z3 proves two quorums always share at least one honest identity (the agreement crux) (b)`` () =
+    // intersection ≥ 2Q−N = f+1; minus ≤ f faulty ⇒ ≥ 1 honest in every quorum-intersection.
+    let script =
+        "(declare-const f Int)(declare-const N Int)(declare-const Q Int)(declare-const faulty Int)\n" +
+        "(assert (not (=> (and (>= f 0) (= N (+ (* 3 f) 1)) (= Q (+ (* 2 f) 1)) (>= faulty 0) (<= faulty f))\n" +
+        "                 (>= (- (- (* 2 Q) N) faulty) 1))))\n" +
+        "(check-sat)\n"
+    z3ScriptHolds "(b) honest quorum-intersection" script
+
+[<Fact>]
+let ``Z3 witnesses Sybil refusal: a raw-node majority is refused when distinct identities fall short (b)`` () =
+    // The (b)-specific link to §A NonRegisterCollapse + the TLA+ NoSybilRawMajorityRefusal witness:
+    // counting must be over PROVEN-DISTINCT identities, not raw nodes. A ring whose raw count meets the
+    // quorum but whose distinct-identity count does NOT (≥2 raw share 1 identity) is refused. SAT = the
+    // refusal is reachable (the quorum is keyed on identities, so raw majority ≠ admission).
+    let script =
+        "(declare-const Q Int)(declare-const rawInQ Int)(declare-const distinctInQ Int)\n" +
+        "(assert (> Q 0))\n" +
+        "(assert (>= rawInQ Q))\n" + // raw nodes meet the threshold count
+        "(assert (< distinctInQ Q))\n" + // distinct identities fall short ⇒ refused
+        "(assert (<= distinctInQ (- rawInQ 1)))\n" + // ≥2 raw nodes collapse to fewer distinct identities
+        "(check-sat)\n"
+    z3ScriptHasModel "(b) Sybil raw-majority refusal reachable" script


### PR DESCRIPTION
## What

The **symbolic (Z3) leg of round (b)** BFT-threshold-soundness-under-Sybil — the near-term win from the CSLib FLP-lift scoping (needs no G3, no dependency). Aaron authorized 2026-06-19 ("anything moving forward is good").

Quorum arithmetic over QF_LIA: `N` proven-distinct identities, `f` Byzantine-faulty, quorum `Q`; canonical PBFT instance `N=3f+1`, `Q=2f+1`.

## Lemmas (6 — 5 UNSAT proofs + 1 SAT witness; 59 Z3 tests green)

- **canonical quorum is safe ∧ live** (`2Q ≥ N+f+1` ∧ `Q ≤ N−f`)
- **honest supermajority in any quorum** (honest ≥ f+1 > f)
- **3f+1 is NECESSARY** — `N ≤ 3f` admits no safe+live quorum (the classic BFT bound, by UNSAT)
- **fault-tolerance monotone** (tolerate f ⟹ tolerate f′≤f) — mirrors CSLib FLP `Consensus.fault_mono`, the bridge to the eventual Lean lift
- **honest quorum-intersection** — two quorums always share ≥1 honest identity (the agreement crux)
- **Sybil refusal witness** — a raw-node majority is *refused* when distinct-identity count falls short (rides §A `NonRegisterCollapse`; the arithmetic shadow of the TLA+ `NoSybilRawMajorityRefusal`)

## Honest scope (the binding seam)

Proves the threshold counting is sound **GIVEN distinctness** — does **NOT** discharge **G3 anti-Sybil entropy** (§B, open). "Distinct" is only *enforced* if forging identities is costly. So (b) now has its TLA+ leg (reachability, TLC-green) + this Z3 leg (arithmetic), with the entropy premise named-and-open (CSLib scoping doc §4 G3).

## Gate

`dotnet build -c Release` → 0 warnings / 0 errors. Z3 suite **59 green**; full Formal suite **227 green**.

Files: `tests/Tests.FSharp/Formal/Z3.Laws.Tests.fs` (+6 lemmas); discharge §8(b) + RESUME. Anchors: Lamport–Shostak–Pease 1982; Castro–Liskov 1999 (PBFT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)