### PR TITLE
docs(cslib): G1 reconnaissance — toolchain gap is the real first step (v4.30.0-rc1 → v4.31.0)

### DIFF
--- a/docs/research/2026-06-19-aurora-b-bft-sybil-lift-onto-cslib-flp-consensus-lean-scoping.md
+++ b/docs/research/2026-06-19-aurora-b-bft-sybil-lift-onto-cslib-flp-consensus-lean-scoping.md
@@ -131,6 +131,35 @@ CSLib adoption + contribute-back is now a standing GO (§7). Sequenced, smallest
 Each external PR still gets a look before it goes out (GOVERNANCE §23 upstream-contribution workflow),
 but the *direction* is decided: Zeta is an early shaper of CSLib, not just a consumer.
 
+## 10. Adoption prerequisite — TOOLCHAIN GAP (reconnaissance 2026-06-19, Otto)
+
+Before any `require cslib`, a real blocker surfaced from the toolchain files (not assumed):
+
+| | our `src/Core.Lean4/` | CSLib (`references/prior-art/cslib/lean-toolchain`) |
+|---|---|---|
+| Lean | **`leanprover/lean4:v4.30.0-rc1`** | **`leanprover/lean4:v4.31.0`** |
+| mathlib | `leanprover-community v4.30.0-rc1` (pinned in `lakefile.toml` + `lake-manifest.json`) | tracks v4.31.0 |
+
+So **step (1) "adopt as a Lean dep" is actually a toolchain + mathlib BUMP** (`v4.30.0-rc1 → v4.31.0`),
+not a one-line `require`. A mathlib major bump churns API and **can break existing proofs** — and our
+proof lineage is **load-bearing**: `Safety/NonRegisterCollapse.lean` is the §A theorem the Aurora **(a)**
+leg *rides*, plus `Safety/ChildFloor.lean` (the child-floor cross-check) and `Privacy/IdentityForcesPrivacy.lean`.
+There is a real CI Lean gate (`.github/workflows/lean-proof.yml`) that would catch breakage — but a
+bump that reds the gate would block the whole fleet.
+
+**This is a proof-lineage-risking change → surfaced, not done blind.** Safe sequence:
+
+1. **Bump first, in isolation:** `v4.30.0-rc1 → v4.31.0` Lean + matching mathlib rev; `lake build` the
+   existing `Lean4` lib; **confirm `NonRegisterCollapse` / `ChildFloor` / `IdentityForcesPrivacy` all
+   still compile sorry-free** and `lean-proof.yml` stays green. *No cslib yet.* (Also moves us off an
+   `-rc1` onto a stable release — independently worth it.)
+2. **Then** `require cslib` (pinned rev) and confirm it resolves + builds.
+3. **Then** G1 (the Byzantine-fault extension).
+
+Routing note for Soraya: the bump is the gating cost of the Lean-on-CSLib vehicle. If it proves
+expensive/destabilizing, the FsCheck-leg alternatives for G1/G2 (no Lean dep) are the fallback. The
+bump should be its own verified PR (proof-lineage), maintainer-visible — **not** bundled into a feature.
+
 ## Composes with
 
 - `docs/trajectories/aurora-immune-reground/RESUME.md` — (b) is that trajectory's open leg; this doc is its CSLib routing.


### PR DESCRIPTION
## What

Starting **CSLib G1** (per Aaron's 1-3-2 order). Reconnaissance *before* mutating the build surfaced a load-bearing blocker.

**The gap:** our `src/Core.Lean4/` is on Lean `v4.30.0-rc1` + mathlib `v4.30.0-rc1`; **CSLib needs `v4.31.0`.** So "adopt as a Lean dep" is actually a **toolchain + mathlib bump**, not a one-line `require` — and a mathlib major bump churns API and can break existing proofs.

**Why this is handled carefully:** our proof lineage is load-bearing — `NonRegisterCollapse` (the §A theorem the Aurora **(a)** leg *rides*), `ChildFloor`, `IdentityForcesPrivacy` — and there's a real `lean-proof.yml` CI gate. A bump that reds it blocks the fleet. So it's proof-lineage-risking → **surfaced, not done blind.**

**Safe sequence (scoping doc §10):**
1. Bump `v4.30.0-rc1 → v4.31.0` (Lean + mathlib) in isolation; confirm the three proofs still compile sorry-free + gate green (no cslib yet; also gets us off an RC).
2. `require cslib` (pinned); confirm it resolves + builds.
3. G1 (Byzantine-fault extension).

The bump is its own verified, maintainer-visible PR — never bundled into a feature. FsCheck-leg fallback if the bump destabilizes. Docs/scoping only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)