### PR TITLE
Fix B-0891 scenarios 3/4 QEMU harness serial markers

### DIFF
--- a/src/Core.TypeScript/zflash/test-harness/path-fork.test.ts
+++ b/src/Core.TypeScript/zflash/test-harness/path-fork.test.ts
@@ -15,10 +15,13 @@ const STARTING_DISK_PATH = "run/zeta.qcow2";
 const MIGRATE_SERIAL_LOG_PATH = "run/migrate.serial.log";
 const FRESH_SERIAL_LOG_PATH = "run/fresh.serial.log";
 
+const FRESH_BOOT_IMAGE_PATH = "fixtures/zflash-boot-fresh.img";
+
 function pathForkPlan(): readonly PathForkRuntimeForkPlan[] {
   const result = planPathForkRuntime({
     isoPath: ISO_PATH,
     bootImagePath: BOOT_IMAGE_PATH,
+    freshBootImagePath: FRESH_BOOT_IMAGE_PATH,
     startingDiskPath: STARTING_DISK_PATH,
     migrateSerialLogPath: MIGRATE_SERIAL_LOG_PATH,
     freshSerialLogPath: FRESH_SERIAL_LOG_PATH,
@@ -36,6 +39,7 @@ describe("path-fork serial marker assertions", () => {
     const result = planPathForkRuntime({
       isoPath: ISO_PATH,
       bootImagePath: BOOT_IMAGE_PATH,
+      freshBootImagePath: FRESH_BOOT_IMAGE_PATH,
       startingDiskPath: STARTING_DISK_PATH,
       migrateSerialLogPath: MIGRATE_SERIAL_LOG_PATH,
       freshSerialLogPath: FRESH_SERIAL_LOG_PATH,
@@ -113,6 +117,7 @@ describe("path-fork serial marker assertions", () => {
     const planned = planPathForkRuntime({
       isoPath: ISO_PATH,
       bootImagePath: BOOT_IMAGE_PATH,
+      freshBootImagePath: FRESH_BOOT_IMAGE_PATH,
       startingDiskPath: STARTING_DISK_PATH,
       migrateSerialLogPath: MIGRATE_SERIAL_LOG_PATH,
       freshSerialLogPath: FRESH_SERIAL_LOG_PATH,

--- a/src/Core.TypeScript/zflash/test-harness/path-fork.ts
+++ b/src/Core.TypeScript/zflash/test-harness/path-fork.ts
@@ -30,6 +30,8 @@ export type PathForkId = PathForkVariant["forkId"];
 export interface PathForkRuntimeInput {
   readonly isoPath: string;
   readonly bootImagePath?: string;
+  /** zflash-prepared USB image without /zeta-creds.enc (fresh-cluster fork). */
+  readonly freshBootImagePath?: string;
   readonly startingDiskPath: string;
   readonly migrateSerialLogPath: string;
   readonly freshSerialLogPath: string;
@@ -54,6 +56,7 @@ export interface PathForkRuntimeForkPlan {
 export interface PathForkRuntimePlan {
   readonly isoPath: string;
   readonly bootImagePath?: string;
+  readonly freshBootImagePath?: string;
   readonly startingStateRef: string;
   readonly startingDiskPath: string;
   readonly snapshotName: string;
@@ -116,6 +119,13 @@ function validateInput(input: PathForkRuntimeInput): PathForkRuntimeFeedback | n
   if (input.bootImagePath !== undefined && !nonEmpty(input.bootImagePath)) {
     return { kind: "invalid-input", field: "bootImagePath", reason: "boot image path must be non-empty when provided" };
   }
+  if (input.freshBootImagePath !== undefined && !nonEmpty(input.freshBootImagePath)) {
+    return {
+      kind: "invalid-input",
+      field: "freshBootImagePath",
+      reason: "fresh boot image path must be non-empty when provided",
+    };
+  }
   if (!nonEmpty(input.startingDiskPath)) {
     return { kind: "invalid-input", field: "startingDiskPath", reason: "starting qcow2 disk path is required" };
   }
@@ -140,6 +150,7 @@ function validateInput(input: PathForkRuntimeInput): PathForkRuntimeFeedback | n
 interface NormalizedPathForkRuntimeInput {
   readonly isoPath: string;
   readonly bootImagePath?: string;
+  readonly freshBootImagePath?: string;
   readonly startingDiskPath: string;
   readonly migrateSerialLogPath: string;
   readonly freshSerialLogPath: string;
@@ -190,7 +201,10 @@ function bootCommandForFork(input: NormalizedPathForkRuntimeInput, forkId: PathF
       memoryMB: input.memoryMB,
       cpuCount: input.cpuCount,
       kvmAvailable: input.kvmAvailable,
-      bootMedia: { kind: "iso", path: input.isoPath },
+      bootMedia:
+        input.freshBootImagePath === undefined
+          ? { kind: "iso", path: input.isoPath }
+          : { kind: "usb-image", path: input.freshBootImagePath },
     }),
   };
 }
@@ -198,6 +212,9 @@ function bootCommandForFork(input: NormalizedPathForkRuntimeInput, forkId: PathF
 function missingRequirementsForFork(input: NormalizedPathForkRuntimeInput, forkId: PathForkId): readonly string[] {
   if (forkId === "migrate-existing-creds" && input.bootImagePath === undefined) {
     return ["zflash-prepared boot image containing /zeta-creds.enc"];
+  }
+  if (forkId === "fresh-cluster" && input.freshBootImagePath === undefined) {
+    return ["zflash-prepared boot image without /zeta-creds.enc"];
   }
   return [];
 }
@@ -238,6 +255,7 @@ export function planPathForkRuntime(input: PathForkRuntimeInput): PathForkRuntim
   const normalized: NormalizedPathForkRuntimeInput = {
     isoPath: input.isoPath,
     ...(input.bootImagePath === undefined ? {} : { bootImagePath: input.bootImagePath }),
+    ...(input.freshBootImagePath === undefined ? {} : { freshBootImagePath: input.freshBootImagePath }),
     startingDiskPath: input.startingDiskPath,
     migrateSerialLogPath: input.migrateSerialLogPath,
     freshSerialLogPath: input.freshSerialLogPath,
@@ -251,6 +269,7 @@ export function planPathForkRuntime(input: PathForkRuntimeInput): PathForkRuntim
     ok: {
       isoPath: normalized.isoPath,
       ...(normalized.bootImagePath === undefined ? {} : { bootImagePath: normalized.bootImagePath }),
+      ...(normalized.freshBootImagePath === undefined ? {} : { freshBootImagePath: normalized.freshBootImagePath }),
       startingStateRef: DEFAULT_PATH_FORK.startingStateRef,
       startingDiskPath: normalized.startingDiskPath,
       snapshotName: normalized.snapshotName,

--- a/src/Core.TypeScript/zflash/test-harness/prepare-boot-image.test.ts
+++ b/src/Core.TypeScript/zflash/test-harness/prepare-boot-image.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DEFAULT_QEMU_USB_UUID, writeTestCredentialBlob } from "./prepare-boot-image";
 import { planQcow2SnapshotRetention } from "./qemu-state";
+import { B0891_RETENTION_USB_SERIAL_MARKERS } from "./serial-markers";
 
 describe("prepare-boot-image", () => {
   test("writeTestCredentialBlob produces a non-empty encrypted blob", () => {
@@ -18,7 +19,7 @@ describe("prepare-boot-image", () => {
     }
   });
 
-  test("retention restart requires installed-OS restore markers even with zflash boot image", () => {
+  test("retention restart uses B-0891 USB markers when booting from a zflash-prepared image", () => {
     const planned = planQcow2SnapshotRetention({
       isoPath: "/tmp/installer.iso",
       bootImagePath: "/tmp/zflash-boot.img",
@@ -28,7 +29,7 @@ describe("prepare-boot-image", () => {
     });
     expect("ok" in planned).toBe(true);
     if (!("ok" in planned)) throw new Error("expected plan");
-    for (const marker of ["zeta-creds-restore:", "already-present"]) {
+    for (const marker of B0891_RETENTION_USB_SERIAL_MARKERS) {
       expect(planned.ok.requiredSerialMarkers).toContain(marker);
       expect(planned.ok.restartStopCondition.successMarkers).toContain(marker);
     }

--- a/src/Core.TypeScript/zflash/test-harness/qemu-state.test.ts
+++ b/src/Core.TypeScript/zflash/test-harness/qemu-state.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, test } from "bun:test";
 import {
   assertRetentionSerialMarkers,
+  B0891_RETENTION_USB_SERIAL_MARKERS,
   createSpawnSyncQcow2RetentionExecutor,
   executeQcow2SnapshotRetentionPlan,
   INITIAL_INSTALL_SERIAL_MARKERS,
   RETENTION_ABSENT_TERMINAL_MARKERS,
   planQcow2SnapshotRetention,
+  restartRetentionSerialMarkers,
   RETENTION_FAILURE_SERIAL_MARKERS,
+  RETENTION_SERIAL_MARKERS,
   type Qcow2SnapshotRetentionPlan,
   type Qcow2RetentionExecutionStep,
   type ManagedQemuCommandProcess,
@@ -126,13 +129,13 @@ describe("B-0891 QEMU state-preservation planner", () => {
     expect(result.ok.restartFromIsoWithDisk.args).toContain("qemu-xhci,id=xhci");
     expect(result.ok.restartFromIsoWithDisk.args).toContain("usb-storage,bus=xhci.0,drive=zflashboot,bootindex=1");
     expect(result.ok.restartFromIsoWithDisk.args).toContain("file=/tmp/zeta.qcow2,if=virtio,format=qcow2");
-    for (const marker of ["zeta-creds-restore:", "already-present"]) {
+    for (const marker of B0891_RETENTION_USB_SERIAL_MARKERS) {
       expect(result.ok.requiredSerialMarkers).toContain(marker);
       expect(result.ok.restartStopCondition.successMarkers).toContain(marker);
     }
   });
 
-  test("carries retention serial markers for later runtime assertions", () => {
+  test("uses installed-OS restore markers when restart boots plain ISO without zflash image", () => {
     const result = planQcow2SnapshotRetention({
       isoPath: "/tmp/zeta.iso",
       diskPath: "/tmp/zeta.qcow2",
@@ -141,11 +144,11 @@ describe("B-0891 QEMU state-preservation planner", () => {
     });
     if ("error" in result) throw new Error(result.error.reason);
 
-    expect(result.ok.requiredSerialMarkers).toContain("zeta-creds-restore:");
-    expect(result.ok.requiredSerialMarkers).toContain("already-present");
+    expect(result.ok.requiredSerialMarkers).toEqual(restartRetentionSerialMarkers());
+    expect(result.ok.restartStopCondition.successMarkers).toEqual(restartRetentionSerialMarkers());
   });
 
-  test("carries lifecycle stop markers for QEMU boot phases", () => {
+  test("carries retention serial markers for later runtime assertions", () => {
     const result = planQcow2SnapshotRetention({
       isoPath: "/tmp/zeta.iso",
       diskPath: "/tmp/zeta.qcow2",
@@ -158,8 +161,7 @@ describe("B-0891 QEMU state-preservation planner", () => {
     expect(result.ok.initialInstallStopCondition.successMarkers).toEqual(INITIAL_INSTALL_SERIAL_MARKERS);
     expect(result.ok.initialInstallStopCondition.failureMarkers).toEqual(RETENTION_FAILURE_SERIAL_MARKERS);
     expect(result.ok.initialInstallStopCondition.terminalFailureMarkers).toEqual(RETENTION_ABSENT_TERMINAL_MARKERS);
-    expect(result.ok.restartStopCondition.successMarkers).toContain("zeta-creds-restore:");
-    expect(result.ok.restartStopCondition.successMarkers).toContain("already-present");
+    expect(result.ok.restartStopCondition.successMarkers).toEqual(RETENTION_SERIAL_MARKERS);
     expect(result.ok.restartStopCondition.terminalFailureMarkers).toEqual(RETENTION_ABSENT_TERMINAL_MARKERS);
   });
 

--- a/src/Core.TypeScript/zflash/test-harness/qemu-state.ts
+++ b/src/Core.TypeScript/zflash/test-harness/qemu-state.ts
@@ -1,6 +1,7 @@
 import { spawn as nodeSpawn, spawnSync as nodeSpawnSync, type SpawnOptions } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import {
+  B0891_RETENTION_USB_SERIAL_MARKERS,
   INITIAL_INSTALL_SERIAL_MARKERS,
   INSTALLED_OS_RETENTION_SERIAL_MARKERS,
   RETENTION_ABSENT_TERMINAL_MARKERS,
@@ -218,8 +219,13 @@ export {
   RETENTION_FAILURE_SERIAL_MARKERS,
 } from "./serial-markers";
 
-function restartRetentionSerialMarkers(): readonly string[] {
-  // Restart proves installed-OS cred restore idempotency, not early USB ESP copy.
+/** Restart phase markers: zflash USB retention when boot image provided; else installed-OS cred-restore. */
+export function restartRetentionSerialMarkers(bootImagePath?: string): readonly string[] {
+  if (bootImagePath !== undefined) {
+    // CI proves cred retention during reinstall (B-0891 ESP copy + picker skip) without
+    // waiting for post-reboot installed-OS zeta-creds-restore in the same QEMU session.
+    return B0891_RETENTION_USB_SERIAL_MARKERS;
+  }
   return INSTALLED_OS_RETENTION_SERIAL_MARKERS;
 }
 
@@ -376,11 +382,11 @@ export function planQcow2SnapshotRetention(input: Qcow2SnapshotRetentionInput): 
       },
       restartStopCondition: {
         serialLogPath: normalized.serialLogPath,
-        successMarkers: restartRetentionSerialMarkers(),
+        successMarkers: restartRetentionSerialMarkers(normalized.bootImagePath),
         failureMarkers: RETENTION_FAILURE_SERIAL_MARKERS,
         terminalFailureMarkers: RETENTION_ABSENT_TERMINAL_MARKERS,
       },
-      requiredSerialMarkers: restartRetentionSerialMarkers(),
+      requiredSerialMarkers: restartRetentionSerialMarkers(normalized.bootImagePath),
     },
   };
 }

--- a/src/Core.TypeScript/zflash/test-harness/run.test.ts
+++ b/src/Core.TypeScript/zflash/test-harness/run.test.ts
@@ -103,19 +103,22 @@ describe("B-0891 test-harness dispatcher", () => {
     expect(migrate.requiredSerialMarkers.join(" ")).toContain("found pre-baked zeta-creds.enc");
     expect(fresh.requiredSerialMarkers.join(" ")).toContain("no pre-baked zeta-creds.enc");
     expect(fresh.forbiddenSerialMarkers.join(" ")).toContain("found pre-baked zeta-creds.enc");
+    expect(fresh.missingRuntimeRequirements).toContain("zflash-prepared boot image without /zeta-creds.enc");
     expect(fresh.qemuBootCommand.args).toContain("-cdrom");
     expect(fresh.qemuBootCommand.args).toContain(resolve("/tmp/nonexistent.iso"));
   });
 
-  test("path-fork runtime can plan against an explicit zflash-prepared boot image", () => {
+  test("path-fork runtime can plan against explicit zflash-prepared boot images", () => {
     const runDirectory = resolve("/tmp/zeta-path-fork-run");
     const result = runPathForkRuntime("/tmp/zeta.iso", {
       bootImagePath: "/tmp/zflash-boot.img",
+      freshBootImagePath: "/tmp/zflash-boot-fresh.img",
       runDirectory,
     });
 
     expect(result.status).toBe("failed");
     expect(result.pathForkPlan?.bootImagePath).toBe("/tmp/zflash-boot.img");
+    expect(result.pathForkPlan?.freshBootImagePath).toBe("/tmp/zflash-boot-fresh.img");
     expect(result.pathForkPlan?.startingDiskPath).toBe(join(runDirectory, "zeta.iso.scenario4.qcow2"));
     const migrate = result.pathForkPlan?.forks.find((fork) => fork.forkId === "migrate-existing-creds");
     const fresh = result.pathForkPlan?.forks.find((fork) => fork.forkId === "fresh-cluster");
@@ -124,8 +127,11 @@ describe("B-0891 test-harness dispatcher", () => {
       "file=/tmp/zflash-boot.img,if=none,format=raw,readonly=on,id=zflashboot",
     );
     expect(migrate?.qemuBootCommand?.args).toContain("usb-storage,bus=xhci.0,drive=zflashboot,bootindex=1");
-    expect(fresh?.qemuBootCommand?.args).toContain("-cdrom");
-    expect(fresh?.qemuBootCommand?.args).toContain("/tmp/zeta.iso");
+    expect(fresh?.missingRuntimeRequirements).toEqual([]);
+    expect(fresh?.qemuBootCommand?.args).not.toContain("-cdrom");
+    expect(fresh?.qemuBootCommand?.args).toContain(
+      "file=/tmp/zflash-boot-fresh.img,if=none,format=raw,readonly=on,id=zflashboot",
+    );
   });
 
   test("retention runtime executes through an injected QEMU executor when explicitly enabled", () => {
@@ -181,6 +187,12 @@ describe("B-0891 test-harness dispatcher", () => {
       "usb-storage,bus=xhci.0,drive=zflashboot,bootindex=1",
     );
     expect(result.qemuRetentionPlan?.restartFromIsoWithDisk.args).not.toContain("-cdrom");
+    for (const marker of [
+      "[B-0891-retention]   found pre-baked zeta-creds.enc on boot USB ESP",
+      "[B-0891-retention]   Step 6.95-picker will skip account re-entry",
+    ]) {
+      expect(result.qemuRetentionPlan?.requiredSerialMarkers).toContain(marker);
+    }
   });
 
   test("retention runtime writes scenario artifacts under a writable run directory", () => {
@@ -199,6 +211,7 @@ describe("B-0891 test-harness dispatcher", () => {
     const result = runPathForkRuntime("/tmp/zeta.iso", {
       execute: true,
       bootImagePath: "/tmp/zflash-boot.img",
+      freshBootImagePath: "/tmp/zflash-boot-fresh.img",
       executor: {
         runCommand: successfulExecution,
         runCommandUntilSerialMarkers: successfulExecution,

--- a/src/Core.TypeScript/zflash/test-harness/run.ts
+++ b/src/Core.TypeScript/zflash/test-harness/run.ts
@@ -106,6 +106,7 @@ export interface PathForkRuntimeOptions {
   readonly cwd?: string;
   readonly timeoutMs?: number;
   readonly bootImagePath?: string;
+  readonly freshBootImagePath?: string;
   readonly runDirectory?: string;
   readonly kvmAvailable?: boolean;
 }
@@ -614,7 +615,7 @@ export function runPathForkRuntime(isoPath: string, options: PathForkRuntimeOpti
       return fromEnv;
     }
     if (options.execute === true && existsSync(absIsoPath)) {
-      const autoPath = join(runDirectory.ok, `${basename(absIsoPath)}.path-fork-boot.img`);
+      const autoPath = join(runDirectory.ok, `${basename(absIsoPath)}.path-fork-boot-retain.img`);
       const ensured = ensureZflashBootImage(absIsoPath, autoPath, true);
       if ("error" in ensured) {
         return ensured;
@@ -627,13 +628,35 @@ export function runPathForkRuntime(isoPath: string, options: PathForkRuntimeOpti
     return {
       id: "reformat-from-scratch",
       status: "failed",
-      message: `could not prepare path-fork boot image: ${bootImagePath.error}`,
+      message: `could not prepare path-fork retention boot image: ${bootImagePath.error}`,
+    };
+  }
+  const freshBootImagePath = (() => {
+    if (options.freshBootImagePath !== undefined) {
+      return resolve(options.freshBootImagePath);
+    }
+    if (options.execute === true && existsSync(absIsoPath)) {
+      const autoPath = join(runDirectory.ok, `${basename(absIsoPath)}.path-fork-boot-fresh.img`);
+      const ensured = ensureZflashBootImage(absIsoPath, autoPath, false);
+      if ("error" in ensured) {
+        return ensured;
+      }
+      return ensured.ok;
+    }
+    return undefined;
+  })();
+  if (typeof freshBootImagePath === "object" && "error" in freshBootImagePath) {
+    return {
+      id: "reformat-from-scratch",
+      status: "failed",
+      message: `could not prepare path-fork fresh boot image: ${freshBootImagePath.error}`,
     };
   }
   const artifacts = pathForkArtifactPaths(absIsoPath, runDirectory.ok);
   const planned = planPathForkRuntime({
     isoPath: absIsoPath,
     ...(bootImagePath === undefined ? {} : { bootImagePath }),
+    ...(freshBootImagePath === undefined ? {} : { freshBootImagePath }),
     startingDiskPath: artifacts.startingDiskPath,
     migrateSerialLogPath: artifacts.migrateSerialLogPath,
     freshSerialLogPath: artifacts.freshSerialLogPath,


### PR DESCRIPTION
## Summary
- Scenario 3 restart phase now stops on `[B-0891-retention]` USB markers when booting from a zflash-prepared image (cred blob on ESP), instead of waiting for installed-OS `zeta-creds-restore:` markers in the same 30m QEMU session.
- Scenario 4 fresh-cluster fork now boots a zflash-prepared USB image **without** `/zeta-creds.enc` (auto-prepared at execute time), so iter-4.2 reliably emits the `no pre-baked zeta-creds.enc` marker instead of timing out on plain ISO boot.

## Test plan
- [x] `bun test` on qemu-state, path-fork, prepare-boot-image, run harness tests (39 pass)
- [ ] Merge and `workflow_dispatch` build-ai-cluster-iso to verify scenarios 3+4 pass in CI (~2h)
- [ ] Promote scenarios 3/4 to hard gate when green