### PR TITLE
fix(cross-verification): TS strict-null errors in the N-way harness (main was red)

### DIFF
--- a/tests/cross-verification/_harness/nway-diff.test.ts
+++ b/tests/cross-verification/_harness/nway-diff.test.ts
@@ -63,7 +63,7 @@ test("a one-byte mutation in ONE oracle is caught, exits non-zero, names the cul
     const goPath = join(dir, "go-output.json");
     const go = JSON.parse(readFileSync(goPath, "utf8")) as Record<string, string>;
     const firstValueKey = Object.keys(go).find((k) => k !== "_source")!;
-    const original = go[firstValueKey];
+    const original = go[firstValueKey]!;
     // Change exactly one character (last digit), keeping the same shape/length.
     const lastChar = original.at(-1)!;
     const flipped = lastChar === "0" ? "1" : "0";

--- a/tests/cross-verification/_harness/nway-diff.ts
+++ b/tests/cross-verification/_harness/nway-diff.ts
@@ -128,7 +128,7 @@
 // read from vectors.{yaml,json}: a scalar field (expected/expected_hex/result/value)
 // when present, else the vector object minus its `id`/`type` bookkeeping keys.
 
-import { readFileSync, existsSync, readdirSync } from "node:fs";
+import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 
 /** The six (today) language oracle slots, by output-file prefix and display name. */
@@ -358,7 +358,7 @@ export async function runNWayDiff(opts: NWayDiffOptions): Promise<number> {
     if (dissenting.length > 0) {
       // Avoid double-reporting the missing/extra-key rows already pushed above.
       const already = divergences.some(
-        (d) => d.vector === id && d.dissenting.length === 1 && byOracle[d.dissenting[0]] === "\u0000MISSING",
+        (d) => d.vector === id && d.dissenting.length === 1 && byOracle[d.dissenting[0]!] === "\u0000MISSING",
       );
       if (!already) {
         divergences.push({ vector: id, expected, byOracle, dissenting });
@@ -396,7 +396,7 @@ function fmt(v: string | null): string {
 function majority(values: string[]): string {
   const counts = new Map<string, number>();
   for (const v of values) counts.set(v, (counts.get(v) ?? 0) + 1);
-  let best = values[0];
+  let best = values[0]!;
   let bestN = -1;
   for (const [v, n] of counts) {
     if (n > bestN) {


### PR DESCRIPTION
## What

`gate` went **red on main** — full `tsc` caught 5 strict-null/unused TypeScript errors in the N-way oracle harness (#8585, Lumen) that the harness's own `bun test` didn't surface. Surgical type-safety fixes only (the harness's existing `!` convention); **no behavior change** (3 harness tests still pass, lint exit 0).

- `nway-diff.test.ts` — `go[firstValueKey]` is `string|undefined` → `!` (2× TS18048)
- `nway-diff.ts` — remove unused `readdirSync` import (TS6133)
- `nway-diff.ts` — `byOracle[d.dissenting[0]!]` array index possibly-undefined (TS2538)
- `nway-diff.ts` — `majority()` `values[0]!` so it returns `string` not `string|undefined` (TS2322)

CI-green steward fix on a teammate's merged code — main-green serves the whole fleet. Lumen notified to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)