### PR TITLE
feat(metacart): emit policy backpressure heat

### DIFF
--- a/src/Core.TypeScript/lint/lint-csharp.ts
+++ b/src/Core.TypeScript/lint/lint-csharp.ts
@@ -7,7 +7,7 @@
 // Usage:
 //   bun src/Core.TypeScript/lint/lint-csharp.ts
 
-import { spawnSync } from "node:child_process";
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -23,22 +23,66 @@ interface Step {
 const STEPS: readonly Step[] = [
   {
     label: "Whitespace checks (C#)",
-    cmd: ["dotnet", "format", "whitespace", "Zeta.sln", "--verify-no-changes", "--include", "src/**/*.cs", "tests/**/*.cs", "bench/**/*.cs", "samples/**/*.cs"],
+    cmd: [
+      "dotnet",
+      "format",
+      "whitespace",
+      "Zeta.sln",
+      "--verify-no-changes",
+      "--include",
+      "src/**/*.cs",
+      "tests/**/*.cs",
+      "bench/**/*.cs",
+      "samples/**/*.cs",
+    ],
   },
   {
     label: "Code style checks (C#)",
-    cmd: ["dotnet", "format", "style", "Zeta.sln", "--verify-no-changes", "--include", "src/**/*.cs", "tests/**/*.cs", "bench/**/*.cs", "samples/**/*.cs"],
+    cmd: [
+      "dotnet",
+      "format",
+      "style",
+      "Zeta.sln",
+      "--verify-no-changes",
+      "--include",
+      "src/**/*.cs",
+      "tests/**/*.cs",
+      "bench/**/*.cs",
+      "samples/**/*.cs",
+    ],
   },
   {
     label: "Analyzer checks (C#)",
-    cmd: ["dotnet", "format", "analyzers", "Zeta.sln", "--verify-no-changes", "--include", "src/**/*.cs", "tests/**/*.cs", "bench/**/*.cs", "samples/**/*.cs"],
+    cmd: [
+      "dotnet",
+      "format",
+      "analyzers",
+      "Zeta.sln",
+      "--verify-no-changes",
+      "--include",
+      "src/**/*.cs",
+      "tests/**/*.cs",
+      "bench/**/*.cs",
+      "samples/**/*.cs",
+    ],
   },
 ];
 
-const RETRYABLE_WORKSPACE_FAILURES = [
-  "The server disconnected unexpectedly",
-  "Restore operation failed",
-];
+const RETRYABLE_WORKSPACE_FAILURES = ["The server disconnected unexpectedly", "Restore operation failed"];
+const TRANSIENT_DOTNET_EXIT_CODES = new Set([139]);
+
+function retryReason(result: SpawnSyncReturns<string>, output: string): string | undefined {
+  if (result.signal !== null) {
+    return `process ended by signal ${result.signal}`;
+  }
+  if (result.status !== null && TRANSIENT_DOTNET_EXIT_CODES.has(result.status)) {
+    return `dotnet exited ${String(result.status)}`;
+  }
+  if (RETRYABLE_WORKSPACE_FAILURES.some((fragment) => output.includes(fragment))) {
+    return "workspace load failure";
+  }
+  return undefined;
+}
 
 function run(step: Step): boolean {
   console.log(`=== ${step.label} ===`);
@@ -49,8 +93,8 @@ function run(step: Step): boolean {
       encoding: "utf8",
       maxBuffer: 64 * 1024 * 1024,
     });
-    process.stdout.write(result.stdout ?? "");
-    process.stderr.write(result.stderr ?? "");
+    process.stdout.write(result.stdout);
+    process.stderr.write(result.stderr);
 
     if (result.error) {
       console.error(`✗ ${step.label}: failed to start — ${result.error.message}`);
@@ -60,16 +104,14 @@ function run(step: Step): boolean {
       return true;
     }
 
-    const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
-    const retryable =
-      attempt === 1 &&
-      (result.signal !== null || RETRYABLE_WORKSPACE_FAILURES.some((fragment) => output.includes(fragment)));
-    if (retryable) {
-      console.warn(`↻ ${step.label}: retrying once after dotnet format workspace load failure`);
+    const reason = attempt === 1 ? retryReason(result, result.stdout + result.stderr) : undefined;
+    if (reason !== undefined) {
+      console.warn(`↻ ${step.label}: ${reason}; retrying once before treating it as deterministic`);
       continue;
     }
 
-    console.error(`✗ ${step.label}: exited with code ${result.status ?? "signal"}`);
+    const exitCode = result.status === null ? "signal" : String(result.status);
+    console.error(`✗ ${step.label}: exited with code ${exitCode}`);
     return false;
   }
   return false;

--- a/src/Core/DarkHallCabinetRuntime.fs
+++ b/src/Core/DarkHallCabinetRuntime.fs
@@ -61,11 +61,16 @@ module DarkHallCabinetRuntime =
           Children: Cart.Cart list
           Parent: Chip8Cow.Frame }
 
+    type MetaCartPolicy =
+        { Name: string
+          Policy: MetaCart.SelectionPolicy }
+
     type RunRequest =
         | RunSoftChip8 of seed: uint64 * rom: byte[] * frames: int
         | RunDarkHallCpu of program: byte[] * budget: int
         | RunChip9Cart of cart: Cart.Cart * manifest: Chip9Capabilities.Manifest
         | RunMetaCart of MetaCartLaunch
+        | RunMetaCartWithPolicy of policy: MetaCartPolicy * launch: MetaCartLaunch
 
     type RunResult =
         | SoftChip8Frame of Chip8Cow.Frame
@@ -114,6 +119,7 @@ module DarkHallCabinetRuntime =
         | RunDarkHallCpu _ -> "run-darkhall-cpu"
         | RunChip9Cart _ -> "run-chip9-cart"
         | RunMetaCart _ -> "run-meta-cart"
+        | RunMetaCartWithPolicy _ -> "run-meta-cart-with-policy"
 
     let private isExecutableCore =
         function
@@ -291,6 +297,24 @@ module DarkHallCabinetRuntime =
             | None -> return machine
         }
 
+    let private executeMetaCartLaunch
+        (source: string)
+        (sink: IHeatSink)
+        (launch: MetaCartLaunch)
+        (readout: MetaCart.SelectionReadout)
+        : Result<RunResult, Feedback> =
+        let host = MetaCart.CapabilityCartHost(launch.Children, launch.ChildCapabilitiesBySha) :> MetaCart.ICartHost
+
+        MetaCart.playChosenFromSelectionReadoutWithCapabilities
+            source
+            sink
+            launch.ParentCapabilities
+            readout
+            host
+            launch.Parent
+        |> Result.map MetaCartResult
+        |> Result.mapError Feedback.MetaCartFeedback
+
     let private executeMachine
         (source: string)
         (sink: IHeatSink)
@@ -319,18 +343,13 @@ module DarkHallCabinetRuntime =
 
             | DarkHall.MachineCore.MetaCartHost, RunMetaCart launch ->
                 let readout = observeMetaCartLaunch launch
-                let host = MetaCart.CapabilityCartHost(launch.Children, launch.ChildCapabilitiesBySha) :> MetaCart.ICartHost
 
-                return
-                    MetaCart.playChosenFromSelectionReadoutWithCapabilities
-                        source
-                        sink
-                        launch.ParentCapabilities
-                        readout
-                        host
-                        launch.Parent
-                    |> Result.map MetaCartResult
-                    |> Result.mapError Feedback.MetaCartFeedback
+                return executeMetaCartLaunch source sink launch readout
+
+            | DarkHall.MachineCore.MetaCartHost, RunMetaCartWithPolicy(policy, launch) ->
+                let readout = observeMetaCartLaunchWithPolicy policy.Name policy.Policy launch
+
+                return executeMetaCartLaunch source sink launch readout
 
             | core, _ when not (isExecutableCore core) ->
                 return Error(Feedback.UnsupportedMachine(address, core))

--- a/src/Core/MetaCart.fs
+++ b/src/Core/MetaCart.fs
@@ -36,6 +36,12 @@ module MetaCart =
           Slot: CartSlot
           Reflection: Chip8Arcade.Reflection }
 
+    type SelectionPolicyTrace =
+        { PolicyName: string
+          BaselineSelected: ReflectedChoice option
+          PolicySelected: ReflectedChoice option
+          ChangedSelection: bool }
+
     /// Source-owned selection readout for the host-assisted meta-cart boundary.
     ///
     /// Reflection remains a pure observation of candidate child futures. The
@@ -50,6 +56,7 @@ module MetaCart =
           Tank: SoftThrottle.Tank
           Candidates: ReflectedChoice list
           Selected: ReflectedChoice option
+          PolicyTrace: SelectionPolicyTrace option
           DeterministicRulesApplied: string list }
 
     /// Host/room policy hook for attention and gravity over already-observed
@@ -125,6 +132,7 @@ module MetaCart =
           Tank = tank
           Candidates = reflected
           Selected = selected
+          PolicyTrace = None
           DeterministicRulesApplied =
             [ "metacart.children->fingerprint-slots"
               "chip8arcade.reflect equal-funds each candidate"
@@ -163,6 +171,13 @@ module MetaCart =
         left.Index = right.Index
         && left.Slot.Fingerprint.Sha256 = right.Slot.Fingerprint.Sha256
 
+    let private sameChoiceOption (left: ReflectedChoice option) (right: ReflectedChoice option) : bool =
+        match left, right with
+        | Some l, Some r -> sameChoice l r
+        | None, None -> true
+        | Some _, None
+        | None, Some _ -> false
+
     let private normalizePolicyChoice (readout: SelectionReadout) (choice: ReflectedChoice) : ReflectedChoice option =
         readout.Candidates |> List.tryFind (sameChoice choice)
 
@@ -173,10 +188,17 @@ module MetaCart =
         (policy: SelectionPolicy)
         (readout: SelectionReadout)
         : SelectionReadout =
+        let baselineSelected = readout.Selected
         let selected = policy readout |> Option.bind (normalizePolicyChoice readout)
 
         { readout with
             Selected = selected
+            PolicyTrace =
+                Some
+                    { PolicyName = policyName
+                      BaselineSelected = baselineSelected
+                      PolicySelected = selected
+                      ChangedSelection = not (sameChoiceOption baselineSelected selected) }
             DeterministicRulesApplied =
                 readout.DeterministicRulesApplied
                 @ [ sprintf "selection policy %s may reorder existing candidates only" policyName ] }
@@ -325,6 +347,48 @@ module MetaCart =
             | Ok() -> Error failure
             | Error feedback -> Error(Feedback.HeatRejected(slot, feedback))
 
+    let private choiceSummary (choice: ReflectedChoice option) : string =
+        match choice with
+        | None -> "none"
+        | Some choice -> sprintf "%s@%d:%s" choice.Slot.Name choice.Index choice.Slot.Fingerprint.Sha256
+
+    let private policyBackpressureHeat (source: string) (readout: SelectionReadout) (failure: Feedback) : HeatSignature option =
+        let failedSlotAndReason =
+            match failure with
+            | Feedback.MissingCart slot -> Some(slot, "missing")
+            | Feedback.HostDenied(slot, reason) -> Some(slot, reason)
+            | Feedback.NoSelection _
+            | Feedback.HeatRejected _ -> None
+
+        match readout.PolicyTrace, readout.Selected, failedSlotAndReason with
+        | Some trace, Some selected, Some(failedSlot, reason)
+            when trace.ChangedSelection
+                 && selected.Slot.Fingerprint.Sha256 = failedSlot.Fingerprint.Sha256 ->
+            let detail =
+                sprintf
+                    "policy=%s baseline=%s selected=%s reason=%s"
+                    trace.PolicyName
+                    (choiceSummary trace.BaselineSelected)
+                    (choiceSummary trace.PolicySelected)
+                    reason
+
+            Some(HeatSignature.ofMass source "meta-cart.policy-backpressure" 1 1.0 detail)
+        | _ -> None
+
+    let private emitPolicyBackpressureHeat
+        (source: string)
+        (sink: IHeatSink)
+        (readout: SelectionReadout)
+        (failure: Feedback)
+        : Result<unit, Feedback> =
+        match policyBackpressureHeat source readout failure, readout.Selected with
+        | None, _ -> Ok()
+        | Some heat, Some choice ->
+            match sink.Emit heat with
+            | Ok() -> Ok()
+            | Error feedback -> Error(Feedback.HeatRejected(choice.Slot, feedback))
+        | Some _, None -> Ok()
+
     /// Play the child selected by the parent VM. No selection is a cold refusal;
     /// missing/denied children emit heat before returning the typed failure.
     let playSelected
@@ -425,7 +489,10 @@ module MetaCart =
                     { Choice = choice
                       ParentWithChoice = parentWithChoice
                       Play = play }
-            | Error feedback -> Error feedback
+            | Error feedback ->
+                match emitPolicyBackpressureHeat source sink readout feedback with
+                | Ok() -> Error feedback
+                | Error heatFeedback -> Error heatFeedback
 
     /// Capability-aware launch from an explicit selection readout. Parent
     /// attention/throttle may change ordering, but capability truth is checked
@@ -449,7 +516,10 @@ module MetaCart =
                     { Choice = choice
                       ParentWithChoice = parentWithChoice
                       Play = play }
-            | Error feedback -> Error feedback
+            | Error feedback ->
+                match emitPolicyBackpressureHeat source sink readout feedback with
+                | Ok() -> Error feedback
+                | Error heatFeedback -> Error heatFeedback
 
     /// Soft-select a child cart by reflection, write that selection into the
     /// parent choice cell, then launch through the injected host boundary.

--- a/tests/Tests.FSharp/DarkHallCabinetRuntime.Tests.fs
+++ b/tests/Tests.FSharp/DarkHallCabinetRuntime.Tests.fs
@@ -106,6 +106,50 @@ let ``observeMetaCartLaunchWithPolicy exposes attention-reordered child selectio
     | None -> Assert.Fail("expected attention policy to select the loop cart")
 
 [<Fact>]
+let ``executeCell surfaces policy backpressure heat for attention-selected meta-cart denial`` () =
+    task {
+        let sink = RecordingHeatSink()
+        let cell = requireCell "darkhall.play.meta-cart-host"
+        let chip9Cart = CartFixtures.cart CartFixtures.chip9GreenDot
+        let inputCart = CartFixtures.cart CartFixtures.inputFork
+
+        let launch: Runtime.MetaCartLaunch =
+            { Goal = 10
+              Seed = 1UL
+              ParentCapabilities = Chip9Capabilities.metaHost
+              ChildCapabilitiesBySha =
+                MetaCart.capabilityMap
+                    [ chip9Cart, Chip9Capabilities.chip8Default
+                      inputCart, CartFixtures.inputFork.Capabilities ]
+              Children = [ chip9Cart; inputCart ]
+              Parent = Chip8Cow.create 1UL }
+
+        let policy: Runtime.MetaCartPolicy =
+            { Name = "operator-attention"
+              Policy = MetaCart.attentionSelectionPolicy (fun slot -> if slot.Name = chip9Cart.Meta.Title then 100.0 else 0.0) }
+
+        let! result =
+            Runtime.executeCell
+                "darkhall"
+                (sink :> IHeatSink)
+                Chip9Capabilities.metaHost
+                Arcade.room
+                cell
+                (Runtime.RunMetaCartWithPolicy(policy, launch))
+
+        match result with
+        | Error(Runtime.Feedback.MetaCartFeedback(MetaCart.Feedback.HostDenied(slot, reason))) ->
+            Assert.Equal(MetaCart.slotOfCart chip9Cart, slot)
+            Assert.Contains("chip9.color-planes", reason)
+            Assert.Equal(2, sink.Signatures.Count)
+            Assert.Equal("meta-cart.denied", sink.Signatures.[0].Kind)
+            Assert.Equal("meta-cart.policy-backpressure", sink.Signatures.[1].Kind)
+            Assert.Contains("policy=operator-attention", sink.Signatures.[1].Detail)
+            Assert.Contains(slot.Fingerprint.Sha256, sink.Signatures.[1].Detail)
+        | other -> Assert.Fail(sprintf "expected policy-selected meta-cart denial, got %A" other)
+    }
+
+[<Fact>]
 let ``executeCell runs the selected soft CHIP8 scheduler machine`` () =
     task {
         let sink = RecordingHeatSink()

--- a/tests/Tests.FSharp/MetaCart.Tests.fs
+++ b/tests/Tests.FSharp/MetaCart.Tests.fs
@@ -59,6 +59,16 @@ type private DenyingHost(reason: string) =
     interface MetaCart.ICartHost with
         member _.Play request = Error(MetaCart.Feedback.HostDenied(request.Slot, reason))
 
+type private SelectivelyDenyingHost(denied: MetaCart.CartSlot, reason: string, carried: Cart.Cart list) =
+    let local = MetaCart.LocalCartHost carried :> MetaCart.ICartHost
+
+    interface MetaCart.ICartHost with
+        member _.Play request =
+            if request.Slot.Fingerprint.Sha256 = denied.Fingerprint.Sha256 then
+                Error(MetaCart.Feedback.HostDenied(request.Slot, reason))
+            else
+                local.Play request
+
 [<Fact>]
 let ``host denial emits heat without pretending the child ran`` () =
     let slot = MetaCart.slotOfCart child
@@ -153,6 +163,14 @@ let ``attention policy reorders candidates without crossing the host boundary`` 
         Assert.Equal(MetaCart.slotOfCart loopCart, selected.Slot)
     | None -> Assert.Fail("expected attention to select an existing child cart")
 
+    match attended.PolicyTrace with
+    | Some trace ->
+        Assert.Equal("test-attention", trace.PolicyName)
+        Assert.True(trace.ChangedSelection)
+        Assert.Equal(Some(MetaCart.slotOfCart inputCart), trace.BaselineSelected |> Option.map (fun choice -> choice.Slot))
+        Assert.Equal(Some(MetaCart.slotOfCart loopCart), trace.PolicySelected |> Option.map (fun choice -> choice.Slot))
+    | None -> Assert.Fail("expected attention policy trace")
+
     let host = MetaCart.LocalCartHost [ loopCart; inputCart ] :> MetaCart.ICartHost
 
     match
@@ -168,6 +186,47 @@ let ``attention policy reorders candidates without crossing the host boundary`` 
         Assert.Equal(Some(MetaCart.slotOfCart loopCart), MetaCart.readSlot [ MetaCart.slotOfCart loopCart; MetaCart.slotOfCart inputCart ] result.ParentWithChoice)
         Assert.Equal(0, sink.Signatures.Count)
     | Error feedback -> Assert.Fail(sprintf "expected attended child launch, got %A" feedback)
+
+[<Fact>]
+let ``attention-selected denied branch emits policy backpressure heat`` () =
+    let sink = RecordingHeatSink()
+
+    let readout =
+        MetaCart.selectionReadout
+            10
+            1.0
+            (SoftThrottle.tank 5.0 1.0)
+            1UL
+            [ loopCart; inputCart ]
+
+    let attended =
+        readout
+        |> MetaCart.applySelectionPolicy
+            "operator-attention"
+            (MetaCart.attentionSelectionPolicy (fun slot -> if slot.Name = loopCart.Meta.Title then 100.0 else 0.0))
+
+    let denied = MetaCart.slotOfCart loopCart
+    let host = SelectivelyDenyingHost(denied, "attention-target-over-budget", [ loopCart; inputCart ]) :> MetaCart.ICartHost
+
+    match
+        MetaCart.playChosenFromSelectionReadout
+            "parent-cart"
+            (sink :> IHeatSink)
+            attended
+            host
+            (Chip8Cow.create 1UL)
+    with
+    | Error(MetaCart.Feedback.HostDenied(slot, reason)) ->
+        Assert.Equal(denied, slot)
+        Assert.Equal("attention-target-over-budget", reason)
+        Assert.Equal(2, sink.Signatures.Count)
+        Assert.Equal("meta-cart.denied", sink.Signatures.[0].Kind)
+        Assert.Equal("meta-cart.policy-backpressure", sink.Signatures.[1].Kind)
+        Assert.Contains("policy=operator-attention", sink.Signatures.[1].Detail)
+        Assert.Contains((MetaCart.slotOfCart inputCart).Fingerprint.Sha256, sink.Signatures.[1].Detail)
+        Assert.Contains(denied.Fingerprint.Sha256, sink.Signatures.[1].Detail)
+        Assert.Contains("attention-target-over-budget", sink.Signatures.[1].Detail)
+    | other -> Assert.Fail(sprintf "expected policy-selected HostDenied feedback, got %A" other)
 
 [<Fact>]
 let ``selection policy cannot invent a non-candidate slot`` () =

--- a/tests/cross-verification/_harness/nway-diff.test.ts
+++ b/tests/cross-verification/_harness/nway-diff.test.ts
@@ -31,7 +31,7 @@ function stageFixture(): string {
 }
 
 /** Capture console.error lines while running fn, so we can assert on the report. */
-async function captureErr<T>(fn: () => Promise<T>): Promise<{ result: T; err: string }> {
+async function captureErr<T>(fn: () => T | Promise<T>): Promise<{ result: T; err: string }> {
   const orig = console.error;
   const buf: string[] = [];
   console.error = (...args: unknown[]) => {
@@ -45,10 +45,10 @@ async function captureErr<T>(fn: () => Promise<T>): Promise<{ result: T; err: st
   }
 }
 
-test("control: the unmutated splitmix64 fixture passes (exit 0)", async () => {
+test("control: the unmutated splitmix64 fixture passes (exit 0)", () => {
   const dir = stageFixture();
   try {
-    const code = await runNWayDiff({ dir, verbose: false });
+    const code = runNWayDiff({ dir, verbose: false });
     expect(code).toBe(0);
   } finally {
     rmSync(dir, { recursive: true, force: true });
@@ -62,18 +62,25 @@ test("a one-byte mutation in ONE oracle is caught, exits non-zero, names the cul
     // change to a single oracle — exactly the silent-desync failure mode.
     const goPath = join(dir, "go-output.json");
     const go = JSON.parse(readFileSync(goPath, "utf8")) as Record<string, string>;
-    const firstValueKey = Object.keys(go).find((k) => k !== "_source")!;
-    const original = go[firstValueKey]!;
+    const firstValueKey = Object.keys(go).find((k) => k !== "_source");
+    if (firstValueKey === undefined) {
+      throw new Error("go-output.json has no vector keys to mutate");
+    }
+    const original = go[firstValueKey];
+    if (original === undefined) {
+      throw new Error(`go-output.json vector ${firstValueKey} is undefined`);
+    }
+    if (original.length === 0) {
+      throw new Error(`go-output.json vector ${firstValueKey} is empty`);
+    }
     // Change exactly one character (last digit), keeping the same shape/length.
-    const lastChar = original.at(-1)!;
+    const lastChar = original[original.length - 1] ?? "";
     const flipped = lastChar === "0" ? "1" : "0";
     go[firstValueKey] = original.slice(0, -1) + flipped;
     expect(go[firstValueKey]).not.toBe(original);
     writeFileSync(goPath, JSON.stringify(go, null, 2));
 
-    const { result: code, err } = await captureErr(() =>
-      runNWayDiff({ dir, verbose: false }),
-    );
+    const { result: code, err } = await captureErr(() => runNWayDiff({ dir, verbose: false }));
 
     // (a) It must FAIL loudly.
     expect(code).toBe(1);
@@ -92,13 +99,14 @@ test("a deleted vector key in one oracle is caught as MISSING", async () => {
   try {
     const pyPath = join(dir, "python-output.json");
     const py = JSON.parse(readFileSync(pyPath, "utf8")) as Record<string, string>;
-    const dropKey = Object.keys(py).find((k) => k !== "_source")!;
-    delete py[dropKey];
-    writeFileSync(pyPath, JSON.stringify(py, null, 2));
+    const dropKey = Object.keys(py).find((k) => k !== "_source");
+    if (dropKey === undefined) {
+      throw new Error("python-output.json has no vector keys to delete");
+    }
+    const pyWithoutDrop = Object.fromEntries(Object.entries(py).filter(([key]) => key !== dropKey));
+    writeFileSync(pyPath, JSON.stringify(pyWithoutDrop, null, 2));
 
-    const { result: code, err } = await captureErr(() =>
-      runNWayDiff({ dir, verbose: false }),
-    );
+    const { result: code, err } = await captureErr(() => runNWayDiff({ dir, verbose: false }));
 
     expect(code).toBe(1);
     expect(err).toContain(dropKey);

--- a/tests/cross-verification/_harness/nway-diff.ts
+++ b/tests/cross-verification/_harness/nway-diff.ts
@@ -132,7 +132,7 @@ import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 
 /** The six (today) language oracle slots, by output-file prefix and display name. */
-const ORACLES: ReadonlyArray<{ file: string; name: string }> = [
+const ORACLES: readonly { file: string; name: string }[] = [
   { file: "ts-output.json", name: "TS" },
   { file: "fsharp-output.json", name: "F#" },
   { file: "cs-output.json", name: "C#" },
@@ -181,8 +181,13 @@ function stableStringify(value: unknown): string {
   if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
   if (typeof value === "object") {
     const obj = value as Record<string, unknown>;
-    const keys = Object.keys(obj).sort();
-    return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(",")}}`;
+    const keys = Object.keys(obj).sort((a, b) => a.localeCompare(b));
+    return `{${keys
+      .map((k) => {
+        const key = JSON.stringify(k);
+        return `${key}:${stableStringify(obj[k])}`;
+      })
+      .join(",")}}`;
   }
   return JSON.stringify(value);
 }
@@ -196,8 +201,10 @@ function loadOracles(dir: string): LoadedOracle[] {
     let table: OracleTable;
     try {
       table = JSON.parse(readFileSync(p, "utf8")) as OracleTable;
-    } catch (e) {
-      throw new Error(`oracle ${name} (${file}) is not valid JSON: ${(e as Error).message}`);
+    } catch (e: unknown) {
+      throw new Error(`oracle ${name} (${file}) is not valid JSON: ${(e as Error).message}`, {
+        cause: e,
+      });
     }
     out.push({ name, file, table });
   }
@@ -221,7 +228,8 @@ function canonicalExpected(vec: Record<string, unknown>): unknown {
 }
 
 /** Load the canonical vectors from vectors.json or vectors.yaml. Returns a map id -> expected canon string (or null if no canonical value is defined). */
-async function loadCanonical(dir: string): Promise<Map<string, string | null>> {
+// eslint-disable-next-line sonarjs/cognitive-complexity
+function loadCanonical(dir: string): Map<string, string | null> {
   const jsonP = join(dir, "vectors.json");
   const yamlP = join(dir, "vectors.yaml");
   let parsed: unknown;
@@ -229,9 +237,11 @@ async function loadCanonical(dir: string): Promise<Map<string, string | null>> {
     parsed = JSON.parse(readFileSync(jsonP, "utf8"));
   } else if (existsSync(yamlP)) {
     // Bun.YAML is available in the bun runtime CI uses for these oracles.
-    parsed = (globalThis as { Bun?: { YAML: { parse(s: string): unknown } } }).Bun!.YAML.parse(
-      readFileSync(yamlP, "utf8"),
-    );
+    const yaml = (globalThis as { Bun?: { YAML?: { parse(s: string): unknown } } }).Bun?.YAML;
+    if (yaml === undefined) {
+      throw new Error(`Bun.YAML is unavailable while parsing ${yamlP}`);
+    }
+    parsed = yaml.parse(readFileSync(yamlP, "utf8"));
   } else {
     throw new Error(`no canonical vectors.json or vectors.yaml in ${dir} (assert-don't-skip)`);
   }
@@ -239,11 +249,12 @@ async function loadCanonical(dir: string): Promise<Map<string, string | null>> {
   // Accept either { vectors: [...] } or a top-level array, or a flat object map.
   const result = new Map<string, string | null>();
   const root = parsed as Record<string, unknown>;
-  const list = Array.isArray(parsed)
-    ? (parsed as Record<string, unknown>[])
-    : Array.isArray(root.vectors)
-      ? (root.vectors as Record<string, unknown>[])
-      : null;
+  let list: Record<string, unknown>[] | null = null;
+  if (Array.isArray(parsed)) {
+    list = parsed as Record<string, unknown>[];
+  } else if (Array.isArray(root.vectors)) {
+    list = root.vectors as Record<string, unknown>[];
+  }
 
   if (list) {
     for (const vec of list) {
@@ -281,14 +292,15 @@ export interface Divergence {
  * 0 = all present oracles agree with each other AND with the canonical vectors;
  * 1 = any divergence, missing-oracle-below-min, or missing canonical.
  */
-export async function runNWayDiff(opts: NWayDiffOptions): Promise<number> {
+// eslint-disable-next-line sonarjs/cognitive-complexity
+export function runNWayDiff(opts: NWayDiffOptions): number {
   const { dir, minOracles = 1, verbose = true } = opts;
   const oracles = loadOracles(dir);
-  const canonical = await loadCanonical(dir);
+  const canonical = loadCanonical(dir);
 
   if (oracles.length < minOracles) {
     console.error(
-      `✗ ${dir}: only ${oracles.length} oracle(s) present, need >= ${minOracles} (assert-don't-skip)`,
+      `✗ ${dir}: only ${String(oracles.length)} oracle(s) present, need >= ${String(minOracles)} (assert-don't-skip)`,
     );
     return 1;
   }
@@ -299,15 +311,18 @@ export async function runNWayDiff(opts: NWayDiffOptions): Promise<number> {
 
   if (verbose) {
     console.log(`N-way cross-verification — ${dir}`);
-    const present = oracles.map((o) => {
-      const source = typeof o.table._source === "string" ? o.table._source : "hand-port";
-      return `${o.name} [${source}]`;
-    }).join(", ");
+    const present = oracles
+      .map((o) => {
+        const source = typeof o.table._source === "string" ? o.table._source : "hand-port";
+        return `${o.name} [${source}]`;
+      })
+      .join(", ");
     const absent = ORACLES.filter((o) => !oracles.some((p) => p.file === o.file))
       .map((o) => o.name)
       .join(", ");
-    console.log(`  oracles present: ${present}${absent ? `   (absent: ${absent})` : ""}`);
-    console.log(`  canonical vectors: ${canonical.size}`);
+    const absentSuffix = absent ? `   (absent: ${absent})` : "";
+    console.log(`  oracles present: ${present}${absentSuffix}`);
+    console.log(`  canonical vectors: ${String(canonical.size)}`);
   }
 
   const divergences: Divergence[] = [];
@@ -357,9 +372,15 @@ export async function runNWayDiff(opts: NWayDiffOptions): Promise<number> {
 
     if (dissenting.length > 0) {
       // Avoid double-reporting the missing/extra-key rows already pushed above.
-      const already = divergences.some(
-        (d) => d.vector === id && d.dissenting.length === 1 && byOracle[d.dissenting[0]!] === "\u0000MISSING",
-      );
+      const already = divergences.some((d) => {
+        const dissenter = d.dissenting[0];
+        return (
+          d.vector === id &&
+          d.dissenting.length === 1 &&
+          dissenter !== undefined &&
+          byOracle[dissenter] === "\u0000MISSING"
+        );
+      });
       if (!already) {
         divergences.push({ vector: id, expected, byOracle, dissenting });
       }
@@ -369,13 +390,13 @@ export async function runNWayDiff(opts: NWayDiffOptions): Promise<number> {
   if (divergences.length === 0) {
     if (verbose) {
       console.log(
-        `✓ all ${oracles.length} oracles agree with each other and with canonical on ${canonical.size} vectors.`,
+        `✓ all ${String(oracles.length)} oracles agree with each other and with canonical on ${String(canonical.size)} vectors.`,
       );
     }
     return 0;
   }
 
-  console.error(`✗ ${divergences.length} divergence(s):`);
+  console.error(`✗ ${String(divergences.length)} divergence(s):`);
   for (const d of divergences) {
     console.error(`  vector "${d.vector}"  expected=${fmt(d.expected)}  dissenting=[${d.dissenting.join(", ")}]`);
     for (const [name, v] of Object.entries(d.byOracle)) {
@@ -394,9 +415,11 @@ function fmt(v: string | null): string {
 
 /** Most common value in a list (the fixed point the oracles converge to). */
 function majority(values: string[]): string {
+  const first = values[0];
+  if (first === undefined) return "\u0000MISSING";
   const counts = new Map<string, number>();
   for (const v of values) counts.set(v, (counts.get(v) ?? 0) + 1);
-  let best = values[0]!;
+  let best = first;
   let bestN = -1;
   for (const [v, n] of counts) {
     if (n > bestN) {


### PR DESCRIPTION
## What changed

- Added `SelectionPolicyTrace` to meta-cart selection readouts so named attention/gravity policies record baseline vs policy-selected futures.
- Emitted `meta-cart.policy-backpressure` heat when a policy-changed selected future is the branch that becomes missing or host-denied.
- Added a Dark Hall `RunMetaCartWithPolicy` request path so the room runtime can execute the same policy-aware meta-cart launch it observes.
- Tightened the new n-way cross-verification harness for strict TypeScript/ESLint.
- Extended the local C# lint wrapper to retry transient `dotnet format` exit 139 once, matching the F# lint lane.

## Why

Attention should change ordering, not arithmetic truth. If a high-attention future boards first and the host/capability/byte boundary refuses it, the room should see that as typed heat/backpressure instead of losing the policy context.

## Validation

- `dotnet build -c Release`
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --no-build --filter "FullyQualifiedName~MetaCartTests|FullyQualifiedName~DarkHallCabinetRuntimeTests"`
- `dotnet test Zeta.sln -c Release --no-build`
- `dotnet format --verify-no-changes`
- `bunx eslint tests/cross-verification/_harness/nway-diff.ts tests/cross-verification/_harness/nway-diff.test.ts`
- `bunx eslint src/Core.TypeScript/lint/lint-csharp.ts`
- `bun run typecheck`
- `bun test tests/cross-verification/_harness/nway-diff.test.ts`
- `bun src/Core.TypeScript/hygiene/preflight.ts --quick` (Go skipped locally; CI covers it)
