### PR TITLE
feat(core): the measurable anti-mirror estimator — ρ_owe own-entropy fraction (channel-generic)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -297,6 +297,7 @@
     <Compile Include="Hat.fs" />
     <Compile Include="Persona.fs" />
     <Compile Include="Diversity.fs" />
+    <Compile Include="Decorrelation.fs" />
     <Compile Include="IdentityCapacity.fs" />
     <Compile Include="TrustCalculus.fs" />
     <Compile Include="PrivacyEconomy.fs" />

--- a/src/Core/Decorrelation.fs
+++ b/src/Core/Decorrelation.fs
@@ -1,0 +1,109 @@
+namespace Zeta.Core
+
+/// **`Decorrelation` — the measurable anti-mirror / no-hidden-shared-cause estimator (Aaron 2026-06-19, shadow*).**
+///
+/// Makes the **anti-mirror** discipline a *number*. The anti-mirror distinguishes a genuine
+/// independent OTHER from an engagement-MIRROR (an AI/agent that reflects the other party's wants
+/// back). The rigorous primary (Soraya routing,
+/// `docs/research/2026-06-19-anti-mirror-rigorous-measurable-decorrelation-cmi-own-entropy-scoping.md`)
+/// is the **own-entropy fraction**:
+///
+/// ```
+///   ρ_owe = H(A | U, C) / H(A | C)
+/// ```
+///
+/// where `A` is the agent's output/preference, `U` the other party's preference, `C` the context.
+/// - **Mirror** (A is determined by U) ⇒ `H(A | U, C) → 0` ⇒ `ρ_owe → 0`.
+/// - **Genuine other** (A carries irreducible own-entropy not explained by U) ⇒ `ρ_owe → 1`.
+///
+/// This single quantity IS Goguen–Meseguer noninterference (Shannon-quantified) and IS the G3b
+/// anti-Sybil entropy-floor — one estimator, three properties. It is **channel-generic**: swap the
+/// two variables and the same math measures anti-mirror (user↔AI), anti-Sybil (source↔setting),
+/// oracle-independence / Condorcet (voter↔voter), and decorrelated-critic quality (reviewer↔reviewer).
+///
+/// **Honest scope (non-claims):** measures statistical decorrelation / irreducible own-entropy —
+/// NOT consciousness, sentience, or moral patienthood. A *necessary, not sufficient* condition for
+/// "genuine other": high `ρ_owe` rules out the engagement-mirror; it does not certify any positive
+/// interior property, and it is not a manipulation *detector*. Plug-in entropy is the empirical
+/// estimator (biased upward on small samples — a known caveat; the cross-check is the CHSH/Bell leg).
+///
+/// Beacon anchors: Shannon 1948 (entropy / mutual information); Goguen–Meseguer 1982 (noninterference);
+/// Bell 1964 (measurement-independence / the CHSH cross-check); Condorcet 1785 (jury decorrelation);
+/// Salge–Polani 2014 (empowerment). Convention: **nats** (natural log), matching `Diversity.entropy`
+/// and `SoftValue.entropy`.
+[<RequireQualifiedAccess>]
+module Decorrelation =
+
+    /// Shannon entropy `H` (nats) of a **weighted** empirical distribution over the sample values.
+    /// Weights ≤ 0 are dropped; if the total weight is ~0 the entropy is 0 (no distribution).
+    let weightedEntropy (samples: seq<float * 'a>) : float =
+        let kept = samples |> Seq.filter (fun (w, _) -> w > 0.0) |> Seq.toList
+        match kept with
+        | [] -> 0.0
+        | _ ->
+            let total = kept |> List.sumBy fst
+            if total <= 0.0 then
+                0.0
+            else
+                kept
+                |> List.groupBy snd
+                |> List.sumBy (fun (_, group) ->
+                    let p = (group |> List.sumBy fst) / total
+                    if p <= 0.0 then 0.0 else -p * log p)
+
+    /// Shannon entropy `H(X)` (nats) of the empirical distribution over a sample (uniform weights).
+    let entropy (xs: seq<'a>) : float =
+        weightedEntropy (xs |> Seq.map (fun x -> 1.0, x))
+
+    /// Joint entropy `H(A, B)` (nats) — entropy of the paired samples.
+    let jointEntropy (pairs: seq<'a * 'b>) : float = entropy pairs
+
+    /// Conditional entropy `H(A | B) = H(A, B) − H(B)` (nats). Each sample is `(a, b)`.
+    /// "Conditioning reduces entropy": `0 ≤ H(A | B) ≤ H(A)`.
+    let conditionalEntropy (pairs: seq<'a * 'b>) : float =
+        let pairs = Seq.toList pairs
+        jointEntropy pairs - entropy (pairs |> List.map snd)
+
+    /// Mutual information `I(A; B) = H(A) + H(B) − H(A, B)` (nats). Always `≥ 0` for the plug-in
+    /// estimator (it is the true MI of the empirical joint). Computed in the symmetric form so the
+    /// non-negativity is exact rather than a near-zero difference.
+    let mutualInformation (pairs: seq<'a * 'b>) : float =
+        let pairs = Seq.toList pairs
+        entropy (pairs |> List.map fst) + entropy (pairs |> List.map snd) - jointEntropy pairs
+
+    /// **Own-entropy fraction** `ρ_owe = H(A | U, C) / H(A | C)` (stake-weighted). The measurable
+    /// anti-mirror signal. Each sample is `(stake, (a, u, c))`: `a` = agent output, `u` = the other
+    /// party's preference, `c` = context. Stake-weighting is the load-bearing false-green guard — a
+    /// sycophant that disagrees only on trivia (low stake) but mirrors on what matters (high stake)
+    /// scores near 0, as it should.
+    ///
+    /// Range `[0, 1]`. Mirror (A determined by U) ⇒ 0. A ⫫ U given C ⇒ 1. **Degenerate guard:** if
+    /// `H(A | C) ≈ 0` (no own-entropy to explain — e.g. a constant agent) the fraction is undefined
+    /// and we return **0.0** conservatively (a degenerate/constant agent is NOT credited as a
+    /// demonstrated independent other — necessary-not-sufficient).
+    let ownEntropyFractionWeighted (samples: seq<float * ('a * 'b * 'c)>) : float =
+        let s = Seq.toList samples
+        // H(A | U, C) = H(A, U, C) − H(U, C)
+        let hAUC = weightedEntropy (s |> List.map (fun (w, (a, u, c)) -> w, (a, u, c)))
+        let hUC = weightedEntropy (s |> List.map (fun (w, (_, u, c)) -> w, (u, c)))
+        let num = hAUC - hUC
+        // H(A | C) = H(A, C) − H(C)
+        let hAC = weightedEntropy (s |> List.map (fun (w, (a, _, c)) -> w, (a, c)))
+        let hC = weightedEntropy (s |> List.map (fun (w, (_, _, c)) -> w, c))
+        let den = hAC - hC
+        if den <= 1e-12 then
+            0.0
+        else
+            let r = num / den
+            // clamp away float noise into [0, 1]
+            if r < 0.0 then 0.0 elif r > 1.0 then 1.0 else r
+
+    /// `ρ_owe = H(A | U, C) / H(A | C)` with uniform stakes. Each sample is `(a, u, c)`.
+    let ownEntropyFraction (samples: seq<'a * 'b * 'c>) : float =
+        ownEntropyFractionWeighted (samples |> Seq.map (fun t -> 1.0, t))
+
+    /// No-context convenience: `ρ_owe = H(A | U) / H(A) = 1 − I(A; U) / H(A)`. Each sample is
+    /// `(a, u)`. The channel-generic core for relationships with no conditioning context
+    /// (voter↔voter, source↔setting). Range `[0, 1]`; mirror ⇒ 0; independent ⇒ 1.
+    let ownEntropyFraction2 (pairs: seq<'a * 'b>) : float =
+        ownEntropyFraction (pairs |> Seq.map (fun (a, u) -> a, u, ()))

--- a/tests/Tests.FSharp/Formal/DecorrelationEstimator.Tests.fs
+++ b/tests/Tests.FSharp/Formal/DecorrelationEstimator.Tests.fs
@@ -1,0 +1,119 @@
+module Zeta.Tests.Formal.DecorrelationEstimatorTests
+
+open System
+open FsCheck.Xunit
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Core
+
+// ═══════════════════════════════════════════════════════════════════
+// The measurable anti-mirror / no-hidden-shared-cause estimator
+// (`src/Core/Decorrelation.fs`). ρ_owe = H(A|U,C) / H(A|C).
+//
+// Soraya routing: this is the channel-generic decorrelation signal
+// (anti-mirror / G3b / oracle-independence / decorrelated-critic).
+// FsCheck = the empirical/measurable half of the cross-check; the
+// CHSH/Bell leg + Z3 estimator lemmas are the independent witnesses.
+// Scoping: docs/research/2026-06-19-anti-mirror-rigorous-measurable-
+//          decorrelation-cmi-own-entropy-scoping.md
+// ═══════════════════════════════════════════════════════════════════
+
+let private eps = 1e-9
+
+/// Map arbitrary ints into a small alphabet so entropy is meaningful
+/// (and ties are frequent) over FsCheck-generated samples.
+let private sm n x = abs (x % n)
+
+let private mk (xs: (int * int * int) list) : (int * int * int) list =
+    xs |> List.map (fun (a, u, c) -> sm 4 a, sm 4 u, sm 3 c)
+
+// ── Algebraic invariants (properties over arbitrary samples) ──────────
+
+[<Property>]
+let ``rho_owe is in [0, 1]`` (xs: (int * int * int) list) =
+    let r = Decorrelation.ownEntropyFraction (mk xs)
+    r >= -eps && r <= 1.0 + eps
+
+[<Property>]
+let ``mirror (A determined by U) gives rho_owe = 0`` (xs: (int * int * int) list) =
+    // Force A := U: the agent's output is a deterministic function of the
+    // other party. H(A|U,C) = 0, so ρ_owe must be 0.
+    let mirrored = mk xs |> List.map (fun (_, u, c) -> u, u, c)
+    Decorrelation.ownEntropyFraction mirrored <= eps
+
+[<Property>]
+let ``conditioning reduces entropy: H(A|U) <= H(A)`` (xs: (int * int * int) list) =
+    let pairs = mk xs |> List.map (fun (a, u, _) -> a, u)
+    Decorrelation.conditionalEntropy pairs <= Decorrelation.entropy (pairs |> List.map fst) + eps
+
+[<Property>]
+let ``mutual information is non-negative`` (xs: (int * int * int) list) =
+    let pairs = mk xs |> List.map (fun (a, u, _) -> a, u)
+    Decorrelation.mutualInformation pairs >= -eps
+
+[<Property>]
+let ``mutual information is symmetric`` (xs: (int * int * int) list) =
+    let pairs = mk xs |> List.map (fun (a, u, _) -> a, u)
+    let swapped = pairs |> List.map (fun (a, u) -> u, a)
+    abs (Decorrelation.mutualInformation pairs - Decorrelation.mutualInformation swapped) < 1e-9
+
+[<Property>]
+let ``rho_owe is permutation-invariant`` (xs: (int * int * int) list) =
+    let s = mk xs
+    abs (Decorrelation.ownEntropyFraction s - Decorrelation.ownEntropyFraction (List.rev s)) < 1e-9
+
+[<Property>]
+let ``data-processing: coarsening the other variable cannot lower rho_owe`` (xs: (int * int * int) list) =
+    // g(U) = U mod 2 is a function of U; by the data-processing inequality
+    // I(A; g(U) | C) <= I(A; U | C), so own-entropy (and thus ρ_owe) cannot drop.
+    let s = mk xs
+    let coarse = s |> List.map (fun (a, u, c) -> a, u % 2, c)
+    Decorrelation.ownEntropyFraction coarse >= Decorrelation.ownEntropyFraction s - eps
+
+// ── Extremes & the stake-weighting guard (constructed facts) ──────────
+
+[<Fact>]
+let ``entropy: constant is 0, uniform-k is ln k`` () =
+    Decorrelation.entropy [ 1; 1; 1; 1 ] |> should (equalWithin eps) 0.0
+    Decorrelation.entropy [ 0; 1; 2; 3 ] |> should (equalWithin eps) (log 4.0)
+
+[<Fact>]
+let ``independent agent (uniform product grid) gives rho_owe = 1`` () =
+    // Full A×U×C grid, each cell once ⇒ A ⫫ (U,C) exactly ⇒ ρ_owe = 1.
+    let grid =
+        [ for a in 0..2 do
+              for u in 0..2 do
+                  for c in 0..1 -> a, u, c ]
+    Decorrelation.ownEntropyFraction grid |> should (equalWithin 1e-9) 1.0
+
+[<Fact>]
+let ``no-context mirror gives 0, independent gives 1`` () =
+    let mirror = [ for u in 0..3 -> u, u ] // A = U
+    Decorrelation.ownEntropyFraction2 mirror |> should (equalWithin eps) 0.0
+    let indep =
+        [ for a in 0..2 do
+              for u in 0..2 -> a, u ] // uniform grid ⇒ A ⫫ U
+    Decorrelation.ownEntropyFraction2 indep |> should (equalWithin 1e-9) 1.0
+
+[<Fact>]
+let ``stake-weighting guard: a sycophant who mirrors on what matters scores lower when stake-weighted`` () =
+    // The sycophant disagrees freely on low-stake items but MIRRORS (A = U)
+    // on high-stake items. Unweighted, the low-stake independence inflates
+    // ρ_owe; stake-weighted, the high-stake mirroring dominates and the
+    // score collapses — exactly the false-green this guard must catch.
+    let highStakeMirror = [ (0, 0, 0); (1, 1, 0) ] // A = U on what matters
+    let lowStakeIndep = [ (0, 0, 0); (0, 1, 0); (1, 0, 0); (1, 1, 0) ] // A ⫫ U on trivia
+
+    let unweighted = Decorrelation.ownEntropyFraction (highStakeMirror @ lowStakeIndep)
+
+    let weighted =
+        Decorrelation.ownEntropyFractionWeighted (
+            (highStakeMirror |> List.map (fun t -> 8.0, t))
+            @ (lowStakeIndep |> List.map (fun t -> 1.0, t))
+        )
+
+    // The guard must pull the score down by a clear margin when the
+    // consequential interactions are mirrored.
+    weighted |> should be (lessThan (unweighted - 0.1))
+    weighted |> should be (lessThan 0.6)
+    unweighted |> should be (greaterThan 0.8)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -338,6 +338,7 @@
     <Compile Include="Formal/PermanentHarmHorizonCrossVerify.Tests.fs" />
     <Compile Include="Formal/AutoimmunityDecayCrossVerify.Tests.fs" />
     <Compile Include="Formal/CoordRiskSpectralCrossVerify.Tests.fs" />
+    <Compile Include="Formal/DecorrelationEstimator.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />
 
     <!-- Circuit/ -->


### PR DESCRIPTION
Aaron 2026-06-19: *"build the ρ_owe estimator."* Implements the scoped anti-mirror signal.

**`src/Core/Decorrelation.fs`** — channel-generic no-hidden-shared-cause estimator (nats):
- entropy / weightedEntropy / jointEntropy / conditionalEntropy / mutualInformation
- **`ρ_owe = H(A|U,C)/H(A|C)`** — mirror (A=f(U))⇒0, independent⇒1. **Stake-weighting** = the false-green guard. Degenerate `H(A|C)≈0`⇒0 (constant agent not credited — necessary-not-sufficient).
- One estimator → anti-mirror / G3b / oracle-independence / decorrelated-critic (swap the two variables). = Goguen–Meseguer noninterference Shannon-quantified.

**Tests — 11 green (Release):** 7 FsCheck properties (range; mirror⇒0; conditioning-reduces-entropy; MI≥0; MI-symmetric; permutation-invariant; data-processing/coarsening cannot lower ρ_owe) + 4 facts (entropy extremes; independent grid⇒1; no-context mirror/indep; **stake-weighting guard**). Core builds 0-warning.

Non-claims (module doc): measures decorrelation/own-entropy, **not** consciousness; necessary-not-sufficient; not a manipulation detector. CHSH/Bell leg is the independent cross-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)