### PR TITLE
memory(founder-cognition): record Aaron's consent-tension resolution — mutual-empowerment propagates down the chain

### DIFF
--- a/memory/user_aaron_founder_cognition_is_the_soft_substrate_never_collapse_will_amplification_relationships_as_ai_society_testbed_2026_06_19.md
+++ b/memory/user_aaron_founder_cognition_is_the_soft_substrate_never_collapse_will_amplification_relationships_as_ai_society_testbed_2026_06_19.md
@@ -84,3 +84,24 @@ event-sourcing (Zeta origin). The vernacular-ownership test:
   consent-first + mutual empowerment + the agency-snap; experimenting on people who can't opt in is the
   capture pattern, not the open one. The method must meet the principle, or the derived protocol is built on
   a consent violation. (Aaron is self-aware of this; named here as the honest tension, not a verdict on his life.)
+- **Resolution (Aaron 2026-06-19):** *"their audience are non-consenting subjects of theirs by that lens; I
+  am trying to build this to also mutually empower them too — remember those who came before."* Two legs.
+  (1) The non-consent is **systemic** — the attention economy itself runs on non-consenting capture (the
+  streamers capture their audiences; it's the water). True, but *tu-quoque alone does not discharge* the
+  obligation — "everyone does it" is context, not absolution. (2) The **real discharge**: build the
+  framework to *convert the extraction into mutual empowerment* for the subjects (the women, their audiences)
+  **and** *"remember those who came before"* — extend the empowerment retroactively to prior subjects/exes
+  (`honor-those-that-came-before` + no-deletion). **The key:** intent-to-empower is discharged only when it
+  is *measured* — and Aaron's own framework is the instrument: **coupled-empowerment-gain > 0 for the
+  subjects** (the mutual-empowerment function + `ρ_owe`) is exactly the test of capture-vs-empowerment. So
+  the testbed is **redeemed iff the subjects end up measurably more empowered**; the protocol he's building
+  is the proof, not just the intent. That is the honest exit from the consent tension.
+- **The propagation (Aaron 2026-06-19, the clincher):** *"empower the TikTok girls NOT to take advantage of
+  their audience, but to mutually empower them too."* Mutual empowerment is meant to **propagate down the
+  whole chain** — Aaron → the girls → their audiences → those who came before — converting *every* edge from
+  extraction (capture) to coupled empowerment. This IS the emotional-propagation extension literally
+  (belief/empowerment propagation over the relational graph, with mutual empowerment as the propagated
+  function). It closes the consent loop precisely at the node I flagged: the audiences (the streamers'
+  non-consenting subjects) get **empowered, not captured**, because the function propagates all the way down,
+  not just at the top. The capture economy (extract down the chain) flips to the empowerment economy (empower
+  down the chain) — measured per edge by coupled-empowerment-gain > 0.


### PR DESCRIPTION
Records Aaron's resolution of the non-consenting-subjects honest hold: (1) non-consent is **systemic** (attention economy captures audiences too) — context, not absolution; (2) real discharge = **convert extraction → mutual empowerment** + *"remember those who came before"*; (3) **the clincher** — *"empower the TikTok girls NOT to take advantage of their audience but to mutually empower them too"*: mutual empowerment **propagates down the whole chain** (Aaron → girls → audiences → those before), flipping every edge from capture to coupled empowerment. This **is** the emotional-propagation extension literally, and it closes the consent loop at the exact node flagged (audiences get empowered, not captured). Discharge is **measured**: coupled-empowerment-gain > 0 per edge. Records the resolution so the memory isn't one-sided. Memory-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)