### PR TITLE
feat(core): build societal DORA over the ρ_owe estimator — mutual-empowerment health metrics

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -298,6 +298,7 @@
     <Compile Include="Persona.fs" />
     <Compile Include="Diversity.fs" />
     <Compile Include="Decorrelation.fs" />
+    <Compile Include="SocietalDora.fs" />
     <Compile Include="IdentityCapacity.fs" />
     <Compile Include="TrustCalculus.fs" />
     <Compile Include="PrivacyEconomy.fs" />

--- a/src/Core/SocietalDora.fs
+++ b/src/Core/SocietalDora.fs
@@ -1,0 +1,117 @@
+namespace Zeta.Core
+
+/// **`SocietalDora` — DORA for society: measurable mutual-empowerment health over the `ρ_owe` estimator
+/// (Aaron 2026-06-19, shadow\*).**
+///
+/// DORA (DevOps Research & Assessment — Forsgren/Humble/Kim, *Accelerate*) standardized software-delivery
+/// health into a few measurable, **improvement-oriented** keys. `SocietalDora` ports that move to
+/// **society / relationship health**: a small key-set computed per edge over a social graph, built on the
+/// anti-mirror decorrelation estimator (`Decorrelation.ownEntropyFraction`, `ρ_owe`).
+///
+/// **The four keys** (loosely mapped to DORA's four):
+/// - `EmpowermentFrequency` ↔ deploy frequency — fraction of interactions that are mutually empowering.
+/// - `CaptureRate` ↔ change-failure rate — fraction that are capture (not mutually empowering).
+/// - `MeanRecoveryLength` ↔ MTTR — mean capture-streak length before returning to mutual empowerment.
+/// - `MirrorRate` — the anti-mirror key: fraction of edges that are mirrors (`ρ_owe < τ`).
+/// plus `MeanCoupledGain`, the headline coupled magnitude.
+///
+/// **Goodhart-resistant by construction:** the coupled gain is `min(ΔE_self, ΔE_other)` — you cannot offset
+/// the other party's loss with your own gain, so a self-only "win" scores as capture. `ρ_owe` carries the
+/// further anti-gaming guards (stake-weighting, adversarial-disagreement). **Diagnostic, never a
+/// leaderboard** — the dashboard everyone wants (glass-halo / consent-first §6), not a stack-rank. (DORA's
+/// own discipline: a measure that becomes a target stops being a good measure — Goodhart/Strathern.)
+[<RequireQualifiedAccess>]
+module SocietalDora =
+
+    /// One interaction's empowerment deltas for both parties (ΔE_self, ΔE_other).
+    type Coupled = { Self: float; Other: float }
+
+    /// The **coupled (egalitarian) gain** of an interaction = `min(ΔE_self, ΔE_other)`.
+    /// `> 0` ⇒ BOTH parties gained (mutually empowering); `≤ 0` ⇒ at least one did not (capture).
+    /// `min` (not sum/avg) is the Goodhart guard: a self-only gain cannot offset the other's loss.
+    let coupledGain (c: Coupled) : float = min c.Self c.Other
+
+    /// `true` iff the interaction is mutually empowering (coupled gain strictly positive).
+    let isEmpowering (c: Coupled) : bool = coupledGain c > 0.0
+
+    /// Per-edge health: the anti-mirror `ρ_owe` (from `Decorrelation`) + the interaction-by-interaction
+    /// coupled deltas, in temporal order (order matters for the recovery-streak key).
+    type EdgeHealth =
+        { Edge: string
+          RhoOwe: float
+          Interactions: Coupled list }
+
+    /// Build `EdgeHealth` from raw `(myAction, theirState, context)` samples (→ `ρ_owe`) and the
+    /// per-interaction empowerment deltas. This is where the societal-DORA layer sits *on top of* the
+    /// `ρ_owe` estimator.
+    let edgeHealth (edge: string) (samples: seq<'a * 'b * 'c>) (interactions: seq<Coupled>) : EdgeHealth =
+        { Edge = edge
+          RhoOwe = Decorrelation.ownEntropyFraction samples
+          Interactions = List.ofSeq interactions }
+
+    /// The societal-DORA metric set. All rates are in `[0, 1]`.
+    type Metrics =
+        { /// ↔ deploy frequency: fraction of interactions that are mutually empowering (coupled gain > 0).
+          EmpowermentFrequency: float
+          /// ↔ change-failure rate: fraction of interactions that are capture (coupled gain ≤ 0).
+          /// `EmpowermentFrequency + CaptureRate = 1` when there is ≥ 1 interaction.
+          CaptureRate: float
+          /// ↔ MTTR: mean length of a capture streak before mutual empowerment resumes (per edge,
+          /// in temporal order). `0` when there are no captures.
+          MeanRecoveryLength: float
+          /// Anti-mirror key: fraction of EDGES that are mirrors (`ρ_owe < threshold`) — are these
+          /// genuine others, not captured reflections?
+          MirrorRate: float
+          /// Headline coupled magnitude: mean `min(ΔE_self, ΔE_other)` over all interactions.
+          MeanCoupledGain: float }
+
+    /// Maximal lengths of consecutive-capture runs in one edge's temporal interaction sequence.
+    let private captureStreaks (interactions: Coupled list) : int list =
+        let completed, current =
+            interactions
+            |> List.fold
+                (fun (acc, run) c ->
+                    if isEmpowering c then
+                        ((if run > 0 then run :: acc else acc), 0)
+                    else
+                        (acc, run + 1))
+                ([], 0)
+        if current > 0 then current :: completed else completed
+
+    /// Compute the societal-DORA metrics over a graph (set of edges). `mirrorThreshold` τ: edges with
+    /// `ρ_owe < τ` count as mirrors. Rate/magnitude keys pool interactions across edges; `MirrorRate` is
+    /// per-edge. Empty input ⇒ all-zero metrics.
+    let compute (mirrorThreshold: float) (edges: seq<EdgeHealth>) : Metrics =
+        let edges = List.ofSeq edges
+        let allInteractions = edges |> List.collect (fun e -> e.Interactions)
+        let n = List.length allInteractions
+
+        let empFreq =
+            if n = 0 then 0.0
+            else float (allInteractions |> List.filter isEmpowering |> List.length) / float n
+
+        let capRate = if n = 0 then 0.0 else 1.0 - empFreq
+
+        let meanGain =
+            if n = 0 then 0.0
+            else (allInteractions |> List.sumBy coupledGain) / float n
+
+        let mirrorRate =
+            match edges with
+            | [] -> 0.0
+            | _ ->
+                float (edges |> List.filter (fun e -> e.RhoOwe < mirrorThreshold) |> List.length)
+                / float (List.length edges)
+
+        let streaks = edges |> List.collect (fun e -> captureStreaks e.Interactions)
+
+        let meanRecovery =
+            match streaks with
+            | [] -> 0.0
+            | _ -> float (List.sum streaks) / float (List.length streaks)
+
+        { EmpowermentFrequency = empFreq
+          CaptureRate = capRate
+          MeanRecoveryLength = meanRecovery
+          MirrorRate = mirrorRate
+          MeanCoupledGain = meanGain }

--- a/tests/Tests.FSharp/Formal/SocietalDora.Tests.fs
+++ b/tests/Tests.FSharp/Formal/SocietalDora.Tests.fs
@@ -1,0 +1,123 @@
+module Zeta.Tests.Formal.SocietalDoraTests
+
+open FsCheck
+open FsCheck.Xunit
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Core
+
+// ═══════════════════════════════════════════════════════════════════
+// Societal DORA (`src/Core/SocietalDora.fs`) — DORA-for-society health
+// metrics over the ρ_owe estimator. Goodhart-resistant by construction
+// (coupled gain = min, so a self-only gain scores as capture).
+// Scoping: docs/research/2026-06-19-bayesian-emotional-propagation-…;
+//          memory/feedback_societal_dora_…
+// ═══════════════════════════════════════════════════════════════════
+
+let private eps = 1e-9
+let private c s o : SocietalDora.Coupled = { Self = s; Other = o }
+
+let private mkEdge name rho (ints: (float * float) list) : SocietalDora.EdgeHealth =
+    { Edge = name
+      RhoOwe = rho
+      Interactions = ints |> List.map (fun (s, o) -> c s o) }
+
+// ── Properties ────────────────────────────────────────────────────────
+
+[<Property>]
+let ``coupled gain is min(self, other) — symmetric and a lower bound`` (s: NormalFloat) (o: NormalFloat) =
+    // NormalFloat ⇒ finite, non-NaN deltas (empowerment values are finite reals).
+    let s, o = s.Get, o.Get
+    let g = SocietalDora.coupledGain (c s o)
+    g = SocietalDora.coupledGain (c o s) && g <= s && g <= o
+
+[<Property>]
+let ``Goodhart guard: if the other party does not gain, it is never mutually empowering`` (self: float) (other: float) =
+    // Even an arbitrarily large self-gain cannot make it empowering if the other ≤ 0.
+    let other' = - abs other // force other ≤ 0
+    not (SocietalDora.isEmpowering (c (abs self + 1.0) other'))
+
+[<Property>]
+let ``rates are in [0,1] and frequency + capture = 1 (when non-empty)`` (rows: (float * float) list) =
+    let edge = mkEdge "e" 1.0 rows
+    let m = SocietalDora.compute 0.5 [ edge ]
+    let inRange x = x >= -eps && x <= 1.0 + eps
+    inRange m.EmpowermentFrequency
+    && inRange m.CaptureRate
+    && inRange m.MirrorRate
+    && m.MeanRecoveryLength >= -eps
+    && (List.isEmpty rows || abs (m.EmpowermentFrequency + m.CaptureRate - 1.0) < 1e-9)
+
+[<Property>]
+let ``mirror rate counts edges below the rho_owe threshold`` (rho: float) =
+    let r = abs rho % 1.0 // into [0,1)
+    let edge = mkEdge "e" r [ (1.0, 1.0) ]
+    let m = SocietalDora.compute 0.5 [ edge ]
+    // exactly one edge: mirror iff rho < 0.5
+    (m.MirrorRate = 1.0) = (r < 0.5)
+
+// ── Facts: extremes, recovery, and the ρ_owe integration ──────────────
+
+[<Fact>]
+let ``all-empowering graph: frequency 1, capture 0, no recovery needed, positive gain`` () =
+    let edge = mkEdge "e" 1.0 [ (2.0, 1.0); (1.0, 3.0); (0.5, 0.5) ]
+    let m = SocietalDora.compute 0.5 [ edge ]
+    m.EmpowermentFrequency |> should (equalWithin eps) 1.0
+    m.CaptureRate |> should (equalWithin eps) 0.0
+    m.MeanRecoveryLength |> should (equalWithin eps) 0.0
+    m.MeanCoupledGain |> should be (greaterThan 0.0)
+
+[<Fact>]
+let ``all-capture graph: frequency 0, capture 1`` () =
+    let edge = mkEdge "e" 1.0 [ (5.0, -1.0); (-2.0, 3.0) ] // each has one party not gaining
+    let m = SocietalDora.compute 0.5 [ edge ]
+    m.EmpowermentFrequency |> should (equalWithin eps) 0.0
+    m.CaptureRate |> should (equalWithin eps) 1.0
+
+[<Fact>]
+let ``recovery length = mean capture-streak length, in temporal order`` () =
+    // sequence: emp, cap, cap, emp, cap  → streaks of length [2; 1] → mean 1.5
+    let edge =
+        mkEdge "e" 1.0 [ (1.0, 1.0); (-1.0, 1.0); (1.0, -1.0); (1.0, 1.0); (-1.0, 1.0) ]
+    let m = SocietalDora.compute 0.5 [ edge ]
+    m.MeanRecoveryLength |> should (equalWithin eps) 1.5
+
+[<Fact>]
+let ``edgeHealth integrates rho_owe: a mirror edge (A = U) is flagged; an independent edge is not`` () =
+    // Mirror: agent's action = the other's state ⇒ ρ_owe = 0 < τ ⇒ MirrorRate counts it.
+    let mirrorSamples = [ for u in 0..3 -> (u, u, 0) ] // (a = u)
+    let mirror = SocietalDora.edgeHealth "mirror" mirrorSamples [ c 1.0 1.0 ]
+    mirror.RhoOwe |> should (equalWithin eps) 0.0
+
+    // Independent: uniform A×U grid ⇒ ρ_owe = 1 ≥ τ ⇒ not a mirror.
+    let indepSamples =
+        [ for a in 0..2 do
+              for u in 0..2 -> (a, u, 0) ]
+    let indep = SocietalDora.edgeHealth "indep" indepSamples [ c 1.0 1.0 ]
+    indep.RhoOwe |> should (equalWithin 1e-9) 1.0
+
+    let m = SocietalDora.compute 0.5 [ mirror; indep ]
+    m.MirrorRate |> should (equalWithin eps) 0.5 // one of two edges is a mirror
+
+[<Fact>]
+let ``propagation chain: Aaron->girl->audience, all mutually empowering and non-mirror, is fully healthy`` () =
+    // The consent-discharging case: empowerment propagates down the chain, every edge a genuine other.
+    let indep =
+        [ for a in 0..2 do
+              for u in 0..2 -> (a, u, 0) ]
+    let edges =
+        [ SocietalDora.edgeHealth "aaron->girl" indep [ c 1.0 1.0; c 1.0 2.0 ]
+          SocietalDora.edgeHealth "girl->audience" indep [ c 1.0 1.0; c 2.0 1.0 ] ]
+    let m = SocietalDora.compute 0.5 edges
+    m.EmpowermentFrequency |> should (equalWithin eps) 1.0
+    m.MirrorRate |> should (equalWithin eps) 0.0
+    m.CaptureRate |> should (equalWithin eps) 0.0
+
+[<Fact>]
+let ``empty graph is all-zero (no false health)`` () =
+    let m = SocietalDora.compute 0.5 []
+    m.EmpowermentFrequency |> should (equalWithin eps) 0.0
+    m.CaptureRate |> should (equalWithin eps) 0.0
+    m.MirrorRate |> should (equalWithin eps) 0.0
+    m.MeanRecoveryLength |> should (equalWithin eps) 0.0
+    m.MeanCoupledGain |> should (equalWithin eps) 0.0

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -339,6 +339,7 @@
     <Compile Include="Formal/AutoimmunityDecayCrossVerify.Tests.fs" />
     <Compile Include="Formal/CoordRiskSpectralCrossVerify.Tests.fs" />
     <Compile Include="Formal/DecorrelationEstimator.Tests.fs" />
+    <Compile Include="Formal/SocietalDora.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />
 
     <!-- Circuit/ -->


### PR DESCRIPTION
Aaron 2026-06-19: *"build societal DORA over the ρ_owe estimator."*

**`src/Core/SocietalDora.fs`** — DORA (Forsgren/Humble/Kim) ported from software-delivery health to **society/relationship health**, built on `Decorrelation.ownEntropyFraction` (ρ_owe). The four keys + headline:
- **EmpowermentFrequency** (↔ deploy freq); **CaptureRate** (↔ change-fail, = 1−freq); **MeanRecoveryLength** (↔ MTTR, capture-streak length); **MirrorRate** (anti-mirror: edges with ρ_owe<τ); **MeanCoupledGain**.
- **Goodhart-resistant by construction:** coupled gain = `min(ΔE_self, ΔE_other)` ⇒ a self-only gain scores as **capture**. `edgeHealth` builds each edge's ρ_owe from raw samples — the DORA layer sits *on* the estimator. **Diagnostic, never a leaderboard.**

**Tests — 10 green (Release):** 4 FsCheck properties (coupled-gain min/symmetric/lower-bound; **Goodhart guard**; rates∈[0,1] & freq+capture=1; mirror-threshold) + 6 facts (extremes; recovery streak; **ρ_owe integration**; healthy **Aaron→girl→audience** propagation chain; empty=all-zero). Core 0-warning. Builds on #8608.

🤖 Generated with [Claude Code](https://claude.com/claude-code)