### PR TITLE
feat(core): demo slice 1 — societal-DORA health dials as pure SVG (no JS, byte-lockable)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -299,6 +299,7 @@
     <Compile Include="Diversity.fs" />
     <Compile Include="Decorrelation.fs" />
     <Compile Include="SocietalDora.fs" />
+    <Compile Include="SocietalDoraSvg.fs" />
     <Compile Include="IdentityCapacity.fs" />
     <Compile Include="TrustCalculus.fs" />
     <Compile Include="PrivacyEconomy.fs" />

--- a/src/Core/SocietalDoraSvg.fs
+++ b/src/Core/SocietalDoraSvg.fs
@@ -1,0 +1,49 @@
+namespace Zeta.Core
+
+open System.Globalization
+
+/// **`SocietalDoraSvg` — the societal-DORA health dials as a PURE SVG dashboard (Aaron 2026-06-19, shadow\*).**
+///
+/// Slice 1 of the Zeta demo UX/UI
+/// (`docs/research/2026-06-19-zeta-demo-ux-ui-pure-css-svg-qsharp-pulls-it-all-together-scoping.md`): render
+/// `SocietalDora.Metrics` as a **declarative SVG** — a *pure function of state* (the animate-not-update
+/// discipline). No `<script>`, **integer coordinates only**, deterministic attribute order — the
+/// `ShapeRender` strict-dialect ethos, so the output is **byte-lockable** (same metrics ⇒ same bytes).
+/// Runs on the **verified F# substrate** (`SocietalDora` over `Decorrelation.ρ_owe`); no Q# needed for this
+/// slice (Q# is the frontier lane, slice 4).
+[<RequireQualifiedAccess>]
+module SocietalDoraSvg =
+
+    /// Invariant int→string (CA1305: never culture-sensitive in the bytes).
+    let private s (i: int) : string = i.ToString(CultureInfo.InvariantCulture)
+
+    /// A `[0,1]` value as an integer percent (clamped).
+    let private pct (v: float) : int =
+        let c = if v < 0.0 then 0.0 elif v > 1.0 then 1.0 else v
+        int (System.Math.Round(c * 100.0))
+
+    /// One horizontal gauge: label, a 300px track, a fill proportional to the value, and the percent.
+    let private bar (y: int) (label: string) (v: float) : string =
+        let p = pct v
+        let w = p * 3 // 0..300
+        System.String.Concat(
+            "<text x=\"10\" y=\"", s (y + 14), "\">", label, "</text>",
+            "<rect x=\"230\" y=\"", s y, "\" width=\"300\" height=\"18\" fill=\"#eeeeee\"/>",
+            "<rect x=\"230\" y=\"", s y, "\" width=\"", s w, "\" height=\"18\" fill=\"#3399cc\"/>",
+            "<text x=\"540\" y=\"", s (y + 14), "\">", s p, "</text>")
+
+    /// Render the societal-DORA metrics as a pure, scriptless, deterministic SVG dashboard string.
+    let render (m: SocietalDora.Metrics) : string =
+        let gauges =
+            [ "EmpowermentFrequency", m.EmpowermentFrequency
+              "CaptureRate", m.CaptureRate
+              "MirrorRate", m.MirrorRate
+              "QpgWeightedEmpowerment", m.QpgWeightedEmpowerment ]
+            |> List.mapi (fun i (lbl, v) -> bar (40 + i * 36) lbl v)
+            |> String.concat ""
+
+        System.String.Concat(
+            "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 580 210\" width=\"580\" height=\"210\">",
+            "<text x=\"10\" y=\"22\">Societal DORA — mutual-empowerment health</text>",
+            gauges,
+            "</svg>")

--- a/tests/Tests.FSharp/Formal/SocietalDoraSvg.Tests.fs
+++ b/tests/Tests.FSharp/Formal/SocietalDoraSvg.Tests.fs
@@ -1,0 +1,51 @@
+module Zeta.Tests.Formal.SocietalDoraSvgTests
+
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Core
+
+// ═══════════════════════════════════════════════════════════════════
+// Slice 1 of the Zeta demo UX/UI: SocietalDora.Metrics → pure SVG
+// (no script, integer coords, deterministic = byte-lockable). Verified
+// F# substrate; no Q#. docs/research/2026-06-19-zeta-demo-ux-ui-…
+// ═══════════════════════════════════════════════════════════════════
+
+let private c s o : SocietalDora.Coupled = { Self = s; Other = o }
+
+let private indep =
+    [ for a in 0..2 do
+          for u in 0..2 -> (a, u, 0) ] // ρ_owe = 1
+
+[<Fact>]
+let ``render is well-formed, scriptless, and deterministic`` () =
+    let edges = [ SocietalDora.edgeHealth "a->b" indep [ c 1.0 1.0; c 2.0 1.0 ] ]
+    let m = SocietalDora.compute 0.5 edges
+    let svg = SocietalDoraSvg.render m
+    svg.Contains "<svg" |> should equal true
+    svg.Contains "</svg>" |> should equal true
+    svg.Contains "<script" |> should equal false // declarative only — no live state
+    // deterministic ⇒ byte-lockable (same metrics, same bytes)
+    SocietalDoraSvg.render m |> should equal svg
+
+[<Fact>]
+let ``a fully-empowering, non-mirror graph renders full empowerment and zero capture bars`` () =
+    let edges =
+        [ SocietalDora.edgeHealth "aaron->girl" indep [ c 1.0 1.0; c 1.0 2.0 ]
+          SocietalDora.edgeHealth "girl->audience" indep [ c 1.0 1.0; c 2.0 1.0 ] ]
+    let m = SocietalDora.compute 0.5 edges // EmpowermentFrequency 1.0, CaptureRate 0.0, MirrorRate 0.0
+    let svg = SocietalDoraSvg.render m
+    // EmpowermentFrequency = 1.0 ⇒ the percent label 100 is shown (unambiguous; the track is always 300px)
+    svg.Contains ">100<" |> should equal true
+    // all four gauge labels present
+    svg.Contains "EmpowermentFrequency" |> should equal true
+    svg.Contains "CaptureRate" |> should equal true
+    svg.Contains "MirrorRate" |> should equal true
+    svg.Contains "QpgWeightedEmpowerment" |> should equal true
+
+[<Fact>]
+let ``empty graph renders all-zero bars (no false health on the dashboard)`` () =
+    let svg = SocietalDoraSvg.render (SocietalDora.compute 0.5 [])
+    svg.Contains "<svg" |> should equal true
+    // every gauge reads 0% (unambiguous percent label); none reads 100%
+    svg.Contains ">0<" |> should equal true
+    svg.Contains ">100<" |> should equal false

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -340,6 +340,7 @@
     <Compile Include="Formal/CoordRiskSpectralCrossVerify.Tests.fs" />
     <Compile Include="Formal/DecorrelationEstimator.Tests.fs" />
     <Compile Include="Formal/SocietalDora.Tests.fs" />
+    <Compile Include="Formal/SocietalDoraSvg.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />
 
     <!-- Circuit/ -->


### PR DESCRIPTION
Aaron 2026-06-19 *"start building."* First real, verified artifact of the demo UX/UI. **`SocietalDoraSvg.render : SocietalDora.Metrics -> string`** renders the four health gauges as a **declarative SVG** dashboard — pure function of state (animate-not-update), **no `<script>`, integer coords, deterministic = byte-lockable** (ShapeRender strict-dialect ethos). Runs on the **verified F# substrate** (`SocietalDora` over `Decorrelation.ρ_owe`); **no Q#** (frontier lane, slice 4). **3 tests green** (well-formed/scriptless/deterministic; full-empowerment shows 100; empty=all-zero = no false health). Core 0-warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)