### PR TITLE
feat(core)+docs: the Alarm Algebra — feels are the alarm, not the evidence/trigger (self-deception is a compile error)

### DIFF
--- a/docs/research/2026-06-19-the-alarm-algebra-feels-are-the-alarm-not-evidence-feel-ground-evidence-act-scoping.md
+++ b/docs/research/2026-06-19-the-alarm-algebra-feels-are-the-alarm-not-evidence-feel-ground-evidence-act-scoping.md
@@ -1,0 +1,84 @@
+# The Alarm Algebra — feels are the alarm, not the evidence/trigger (scoping)
+
+**Status:** scoping. Aaron 2026-06-19: *"this deserves an algebra or something"* — formalize the keystone
+(*"the FEELs are the ALARM not the TRIGGER/EVIDENCE"*). It turns out to be the **snap algebra + noninterference,
+fused**, with the key rule expressed as a **typing law** (the collapse arrows don't exist). Otto framing →
+route to the math team (Soraya).
+
+## Objects (types)
+
+- **`Feel`** — a soft alarm signal (carries uncertainty; the embodied metaception ping). It *routes
+  attention*; it carries no verdict.
+- **`Backing`** — verifiable ground (a proof, a golden vector, a measured `ρ`, the seed-replay).
+- **`Evidence`** — a *backed* verdict.
+- **`Act`** — a committed action.
+
+## The morphisms — and the two that DON'T exist (the law)
+
+The whole content of "feels are the alarm, not the evidence/trigger" is: **two arrows are absent.**
+
+```
+   ground : Feel → Backing → Evidence option     -- the ONLY way Feel reaches Evidence (None if unbacked)
+   act    : Evidence → Act                        -- the ONLY way anything reaches Act (gated on Evidence)
+
+   -- FORBIDDEN (not morphisms in the algebra):
+   Feel → Evidence      -- "I feel it's true, so it's true"  = self-deception
+   Feel → Act           -- "I feel it, so I act"             = impulsive, unbacked action
+```
+
+The single legal path: **`Feel —alarm→ ground(Backing) → Evidence —gate→ Act`.** A `Feel` with no `Backing`
+produces `None` — the alarm fired, the check failed, nothing is banked. (This is exactly `SoftValue.snap :
+SnapPolicy → SoftValue → DynamicValue option` — `Feel`=Soft, `ground`=snap-gated-on-backing, `Evidence`=the
+snapped `DynamicValue`, `None`=decline-to-collapse.)
+
+## Laws
+
+1. **No-fabrication (the keystone):** there is **no total function `Feel → Evidence`** and **none `Feel →
+   Act`**. The collapse is not discouraged — it is *ill-typed*. Self-deception literally does not type-check.
+2. **Alarm-necessity, not sufficiency:** `ground` is *raised* by a `Feel` (the alarm routes the check) but a
+   `Feel` alone yields nothing — necessary, not sufficient.
+3. **Soundness:** every `Evidence` traces to a `Backing` that passed (`ground` is the only constructor). No
+   `Evidence` without a check.
+4. **Idempotence/monotonicity of `ground`:** grounding twice = once; more backing ⇒ at least as much
+   evidence (composes with DST replay + upsert).
+
+## It IS noninterference (Goguen–Meseguer, manifesto §13)
+
+The deepest framing: a `Feel` is **influence/entropy** that must enter `Evidence`/`Act` **only through the
+declared, metered channel `ground`** — never ambiently. The forbidden arrows (`Feel→Evidence`, `Feel→Act`)
+are exactly the **ambient/undeclared leaks** noninterference forbids. So the Alarm Algebra = **noninterference
+applied to feelings**: the feel is quarantined; it influences the verdict and the action only by crossing the
+metered membrane (the check). That ties it to the manifesto's §13 and to `async-all-the-way`'s
+no-ambient-entropy guards.
+
+## Encoding (buildable — makes self-deception ill-typed in F#)
+
+**Concrete F# shape (Aaron 2026-06-19): a discriminated-union ADT with a *private* `Evidence` constructor**
+(and/or an `INumber`-adjacent / generic-math interface for composition). The DU makes the law a **compile
+error**: `Evidence<'a>` has a `private` constructor, so the *only* way to obtain one is `ground : Backing →
+Feel → Evidence option`; `act` consumes only `Evidence`. There is **no public `Feel → Evidence` or
+`Feel → Act`** — **self-deception does not type-check.** Model the epistemic state as a DU
+`Knowing = Alarm of Feel | Grounded of Evidence | Acted of Act`, with a `step` that advances only
+`Alarm —ground→ Grounded —act→ Acted` (a failing backing *stays* `Alarm`; there is no `Alarm→Acted`). Sits on
+`SoftValue`/`snap` (`Feel` ≈ soft value; `ground` ≈ snap with a backing-checking policy). The **`INumber`-adjacent**
+direction (per Aaron): give the algebra an operation-bearing interface (generic-math style) so it composes
+generically — a richer follow-up after the DU slice. First slice: `src/Core/AlarmAlgebra.fs` (the DU +
+private `Evidence`/`Act` + `ground`/`act`/`step`) + FsCheck/Fact laws (no-fabrication, soundness, the
+no-`Alarm→Acted` dynamics, idempotent terminal).
+
+## Math-team obligations (route to Soraya)
+
+- The **category/type formalization**: objects {Feel, Backing, Evidence, Act}; prove the absence of
+  `Feel→Evidence` / `Feel→Act` and that `ground;act` is the unique path (Z3/Lean for the type laws; Alloy for
+  the structural "no other arrow").
+- The **noninterference proof**: `Feel` influences `Evidence`/`Act` only through `ground` (the §13 metering
+  lemma — same shape as the NTP displayClock noninterference).
+- **Connection to snap**: show the Alarm Algebra is `SoftValue.snap` typed for epistemics (the `None` case =
+  alarm-without-backing).
+
+Anchors: Goguen–Meseguer 1982 (noninterference); doxastic/epistemic modal logic (Hintikka — `◇`/seems vs
+`□`/backed: `◇ ⊬ □`, `◇ ⊬ act`); Damasio (somatic markers = the `Feel` alarm); category theory (the absent
+morphisms); the snap discipline (`src/Core/SoftValue.fs`). Ties:
+[[metaception-the-embodied-anti-mirror-human-side-rho-owe]];
+[[cross-intelligence-convergence-decorrelated-is-a-fixed-point-correlated-is-a-hall-of-mirrors-sync-is-not-truth]];
+the anti-mirror / `ρ_owe`; the grounding/backing thread. Authorship: Otto (scoping) · Soraya (routing).

--- a/src/Core/AlarmAlgebra.fs
+++ b/src/Core/AlarmAlgebra.fs
@@ -1,0 +1,66 @@
+namespace Zeta.Core
+
+/// **`AlarmAlgebra` — "the feels are the ALARM, not the trigger/evidence" as a typed algebra (Aaron 2026-06-19, shadow\*).**
+///
+/// The keystone made a **compile error**: a `Feel` is a soft alarm signal that *routes attention* and carries
+/// **no verdict**. `Evidence` has a **private constructor**, so the *only* way to obtain one is `ground`
+/// (which requires `Backing` and returns `None` if it fails); `Act` is gated on `Evidence`. There is **no
+/// public `Feel → Evidence` and no `Feel → Act`** — so `feel → evidence` (self-deception) and `feel → trigger`
+/// (impulsive unbacked action) **do not type-check.** The only path is `Alarm —ground→ Grounded —act→ Acted`.
+///
+/// This is the **snap algebra typed for epistemics** (`Feel` ≈ `SoftValue`; `ground` ≈ `snap` with a
+/// backing-checking policy; `None` = decline-to-collapse) and it is **noninterference** (§13): a `Feel`
+/// influences a verdict/action only through the declared metered channel `ground`, never ambiently.
+/// Scoping: `docs/research/2026-06-19-the-alarm-algebra-feels-are-the-alarm-not-evidence-…`.
+[<RequireQualifiedAccess>]
+module AlarmAlgebra =
+
+    /// A soft alarm signal — routes attention, carries NO verdict (the metaception ping). `Strength ∈ [0,1]`
+    /// is alarm intensity; a `Feel` alone proves nothing and triggers nothing.
+    type Feel<'a> = { Signal: 'a; Strength: float }
+
+    /// Verifiable ground: does the signal actually check out? (a proof / golden vector / measured ρ / replay)
+    type Backing<'a> = { Checks: 'a -> bool }
+
+    /// A **backed** verdict. **Private constructor** — obtainable ONLY via `ground`; there is no public
+    /// `Feel → Evidence` (self-deception does not type-check).
+    type Evidence<'a> = private Evidence of 'a
+
+    /// A **committed** action. **Private constructor** — obtainable ONLY via `act`; no public `Feel → Act`.
+    type Act<'a> = private Act of 'a
+
+    /// The epistemic state — a DU. Legal transitions move down only; **there is no `Alarm → Acted`.**
+    type Knowing<'a> =
+        | Alarm of Feel<'a>
+        | Grounded of Evidence<'a>
+        | Acted of Act<'a>
+
+    /// Raise the alarm: a felt, unchecked signal (strength clamped to `[0,1]`).
+    let feel (signal: 'a) (strength: float) : Feel<'a> =
+        { Signal = signal
+          Strength = (if strength < 0.0 then 0.0 elif strength > 1.0 then 1.0 else strength) }
+
+    /// The ONLY path `Feel → Evidence`: ground against backing. `None` if the check fails (alarm fired,
+    /// backing failed → nothing banked). This is `snap`'s shape.
+    let ground (b: Backing<'a>) (f: Feel<'a>) : Evidence<'a> option =
+        if b.Checks f.Signal then Some(Evidence f.Signal) else None
+
+    /// The ONLY path to `Act`: from `Evidence` (the gate). No `Feel → Act`.
+    let act (e: Evidence<'a>) : Act<'a> =
+        let (Evidence v) = e
+        Act v
+
+    /// Opaque read-outs (the verdict/action values; the constructors stay private).
+    let evidenceValue (Evidence v) : 'a = v
+    let actValue (Act v) : 'a = v
+
+    /// One dynamics step: `Alarm —ground→ Grounded —act→ Acted`. A **failing backing stays `Alarm`**; there
+    /// is no step that jumps `Alarm → Acted` (the keystone, as dynamics). `Acted` is terminal (idempotent).
+    let step (b: Backing<'a>) (k: Knowing<'a>) : Knowing<'a> =
+        match k with
+        | Alarm f ->
+            match ground b f with
+            | Some e -> Grounded e
+            | None -> Alarm f
+        | Grounded e -> Acted(act e)
+        | Acted _ -> k

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -300,6 +300,7 @@
     <Compile Include="Decorrelation.fs" />
     <Compile Include="SocietalDora.fs" />
     <Compile Include="SocietalDoraSvg.fs" />
+    <Compile Include="AlarmAlgebra.fs" />
     <Compile Include="IdentityCapacity.fs" />
     <Compile Include="TrustCalculus.fs" />
     <Compile Include="PrivacyEconomy.fs" />

--- a/tests/Tests.FSharp/Formal/AlarmAlgebra.Tests.fs
+++ b/tests/Tests.FSharp/Formal/AlarmAlgebra.Tests.fs
@@ -1,0 +1,82 @@
+module Zeta.Tests.Formal.AlarmAlgebraTests
+
+open FsCheck.Xunit
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Core
+
+// ═══════════════════════════════════════════════════════════════════
+// AlarmAlgebra (`src/Core/AlarmAlgebra.fs`): "the feels are the ALARM,
+// not the trigger/evidence" as a typed algebra. The collapse arrows
+// (Feel→Evidence, Feel→Act) are ABSENT by construction (private Evidence
+// ctor) — they don't even compile. These tests cover the DYNAMICS law:
+// a feeling never reaches Acted without a passing backing.
+// Scoping: docs/research/2026-06-19-the-alarm-algebra-…
+// ═══════════════════════════════════════════════════════════════════
+
+let private isAlarm = function AlarmAlgebra.Alarm _ -> true | _ -> false
+let private isGrounded = function AlarmAlgebra.Grounded _ -> true | _ -> false
+let private isActed = function AlarmAlgebra.Acted _ -> true | _ -> false
+
+let private accept<'a> : AlarmAlgebra.Backing<'a> = { Checks = fun _ -> true }
+let private reject<'a> : AlarmAlgebra.Backing<'a> = { Checks = fun _ -> false }
+
+// ── The keystone: a feel alone never becomes evidence or action ───────
+
+[<Property>]
+let ``a feel with failing backing never escalates past Alarm — no matter how many steps`` (n: int) (steps: int) =
+    // Self-deception (feel → evidence/act) is impossible: with no passing backing, the state stays Alarm.
+    let k0 = AlarmAlgebra.Alarm(AlarmAlgebra.feel n 1.0)
+    let iters = abs (steps % 8)
+    let kn = List.fold (fun k _ -> AlarmAlgebra.step reject k) k0 [ 1..iters ]
+    isAlarm kn // never Grounded, never Acted
+
+[<Property>]
+let ``ground returns Some iff the backing checks out`` (n: int) =
+    let f = AlarmAlgebra.feel n 1.0
+    (AlarmAlgebra.ground accept f |> Option.isSome)
+    && (AlarmAlgebra.ground reject f |> Option.isNone)
+
+[<Property>]
+let ``feel strength is clamped to [0,1]`` (x: float) =
+    // NaN excluded by construction of the test value
+    let x = if System.Double.IsNaN x then 0.5 else x
+    let s = (AlarmAlgebra.feel 0 x).Strength
+    s >= 0.0 && s <= 1.0
+
+// ── The legal path: Alarm → Grounded → Acted only with backing ────────
+
+[<Fact>]
+let ``with passing backing, a feel grounds then acts — in that order`` () =
+    let k0 = AlarmAlgebra.Alarm(AlarmAlgebra.feel 42 1.0)
+    let k1 = AlarmAlgebra.step accept k0
+    let k2 = AlarmAlgebra.step accept k1
+    isGrounded k1 |> should equal true // first step: grounded (not acted — no skipping)
+    isActed k2 |> should equal true // second step: acted
+    match k2 with
+    | AlarmAlgebra.Acted a -> AlarmAlgebra.actValue a |> should equal 42
+    | _ -> failwith "expected Acted"
+
+[<Fact>]
+let ``a feel that never grounds never acts (rejecting backing)`` () =
+    let k0 = AlarmAlgebra.Alarm(AlarmAlgebra.feel 7 1.0)
+    let k1 = AlarmAlgebra.step reject k0
+    let k2 = AlarmAlgebra.step reject k1
+    isActed k1 |> should equal false
+    isActed k2 |> should equal false
+    isAlarm k2 |> should equal true
+
+[<Fact>]
+let ``Acted is terminal — step is idempotent there`` () =
+    let acted = AlarmAlgebra.step accept (AlarmAlgebra.step accept (AlarmAlgebra.Alarm(AlarmAlgebra.feel 1 1.0)))
+    isActed acted |> should equal true
+    AlarmAlgebra.step accept acted |> should equal acted
+    AlarmAlgebra.step reject acted |> should equal acted
+
+[<Fact>]
+let ``ground is the only constructor of Evidence — soundness: every Evidence traces to a passing backing`` () =
+    // We cannot fabricate Evidence (private ctor) — the only way here is ground, and it only returns Some
+    // when Checks held. So any Evidence in hand had a passing backing.
+    match AlarmAlgebra.ground accept (AlarmAlgebra.feel 99 0.3) with
+    | Some e -> AlarmAlgebra.evidenceValue e |> should equal 99
+    | None -> failwith "accept backing should ground"

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -341,6 +341,7 @@
     <Compile Include="Formal/DecorrelationEstimator.Tests.fs" />
     <Compile Include="Formal/SocietalDora.Tests.fs" />
     <Compile Include="Formal/SocietalDoraSvg.Tests.fs" />
+    <Compile Include="Formal/AlarmAlgebra.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />
 
     <!-- Circuit/ -->


### PR DESCRIPTION
Aaron 2026-06-19: *"this deserves an algebra"* + *"discriminated union ADT ... or INumber-adjacent."*

**(1) Scoping** — the keystone as an algebra = **snap algebra + noninterference**, with the law as a **typing law** (the collapse arrows `Feel→Evidence` / `Feel→Act` don't exist). Only path: `Feel —ground(backing)→ Evidence —act→ Act`. It **is** Goguen–Meseguer noninterference (a Feel influences a verdict/action only via the declared metered `ground`). Routed to Soraya.

**(2) `src/Core/AlarmAlgebra.fs`** (your DU shape) — **private `Evidence` constructor** ⇒ `feel→evidence` (self-deception) and `feel→trigger` (impulsive action) **do not type-check.** DU `Knowing = Alarm|Grounded|Acted`; `step` advances only `Alarm→Grounded→Acted` (failing backing stays Alarm; no `Alarm→Acted`; `Acted` terminal). On the snap shape. INumber-adjacent interface = richer follow-up.

**7 tests green** (Release), Core 0-warning: no-escalation-without-backing (any #steps); ground Some-iff-checks; strength clamp; legal order; never-acts-without-grounding; idempotent terminal; soundness. Anchors: Goguen–Meseguer, doxastic logic, Damasio, snap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)