### PR TITLE
feat(core): demo slice 1.5 — societal-DORA dashboard as a complete static HTML page (pure HTML/CSS, no JS)

### DIFF
--- a/src/Core/SocietalDoraSvg.fs
+++ b/src/Core/SocietalDoraSvg.fs
@@ -47,3 +47,23 @@ module SocietalDoraSvg =
             "<text x=\"10\" y=\"22\">Societal DORA — mutual-empowerment health</text>",
             gauges,
             "</svg>")
+
+    /// Wrap the dashboard SVG in a complete **static HTML page** — pure HTML + CSS, **no JavaScript** (the
+    /// `HtmlCssBinding` ethos). A viewable artifact: open the string as `.html` in any browser, no runtime.
+    /// Deterministic ⇒ byte-lockable. Slice 1.5 of the demo UX/UI.
+    let renderPage (m: SocietalDora.Metrics) : string =
+        System.String.Concat(
+            "<!DOCTYPE html>",
+            "<html lang=\"en\"><head><meta charset=\"utf-8\"/>",
+            "<title>Zeta — Societal DORA</title>",
+            "<style>",
+            "body{font-family:system-ui,sans-serif;background:#0f1115;color:#e6e6e6;margin:0;padding:32px}",
+            "main{max-width:640px;margin:0 auto}",
+            "h1{font-size:18px;font-weight:600;margin:0 0 4px}",
+            "p{color:#9aa0a6;margin:0 0 24px;font-size:13px}",
+            "svg text{fill:#e6e6e6;font-family:system-ui,sans-serif;font-size:13px}",
+            "</style></head><body><main>",
+            "<h1>Zeta — Societal DORA</h1>",
+            "<p>mutual-empowerment health, rendered declaratively (no JS). The feels are the alarm; the numbers are the backing.</p>",
+            render m,
+            "</main></body></html>")

--- a/tests/Tests.FSharp/Formal/SocietalDoraSvg.Tests.fs
+++ b/tests/Tests.FSharp/Formal/SocietalDoraSvg.Tests.fs
@@ -49,3 +49,13 @@ let ``empty graph renders all-zero bars (no false health on the dashboard)`` () 
     // every gauge reads 0% (unambiguous percent label); none reads 100%
     svg.Contains ">0<" |> should equal true
     svg.Contains ">100<" |> should equal false
+
+[<Fact>]
+let ``renderPage is a complete, scriptless, deterministic HTML document embedding the SVG`` () =
+    let m = SocietalDora.compute 0.5 [ SocietalDora.edgeHealth "a->b" indep [ c 1.0 1.0 ] ]
+    let page = SocietalDoraSvg.renderPage m
+    page.Contains "<!DOCTYPE html>" |> should equal true
+    page.Contains "</html>" |> should equal true
+    page.Contains "<svg" |> should equal true // the dashboard is embedded
+    page.Contains "<script" |> should equal false // pure HTML/CSS, no JS
+    SocietalDoraSvg.renderPage m |> should equal page // deterministic ⇒ byte-lockable


### PR DESCRIPTION
Aaron 2026-06-19 *"please push forward."* Extends `SocietalDoraSvg` with **`renderPage : SocietalDora.Metrics -> string`** — wraps the dashboard SVG in a complete **static HTML document (pure HTML+CSS, no JavaScript)**: open it as `.html` in any browser, no runtime. Deterministic ⇒ byte-lockable. The **viewable** artifact (slice 1 = SVG; this = page). 4 tests green, Core 0-warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)