### PR TITLE
feat(core): adinkra mirror, layer one — the [8,4,4] doubly-even self-dual code (generator IS the ECC)

### DIFF
--- a/src/Core/AdinkraMirror.fs
+++ b/src/Core/AdinkraMirror.fs
@@ -1,0 +1,83 @@
+namespace Zeta.Core
+
+open System.Numerics
+
+/// **`AdinkraMirror` — layer one of the adinkra unfold: the [8,4,4] doubly-even self-dual code (Aaron 2026-06-19, shadow\*).**
+///
+/// The irreducible root of the cohomoiconic unfold (adinkra → Clifford → Cayley–Dickson → memetics), built
+/// "one onion/egg layer at a time." This is **layer one: the adinkra MIRROR** — the **[8,4,4] extended-Hamming
+/// code**, the smallest **doubly-even self-dual** binary code (the one Gates' adinkras carry as their ECC):
+///
+/// - **SELF-DUAL (the mirror):** `C = C⊥` — the code is *its own dual*. It reflects itself; that is what makes
+///   it "the mirror" and why it's the root (nothing more primitive to reduce to — it is its own check).
+/// - **DOUBLY-EVEN:** every codeword's Hamming weight ≡ 0 (mod 4).
+/// - **THE GENERATOR *IS* THE ECC:** the same generator matrix both **generates** the 16 codewords *and*
+///   **corrects** errors (syndrome = `G·x`, since `H = G` for a self-dual code). Generation and
+///   error-correction are **dual** — exactly `only-the-irreducible-is-primitive` ("the generator IS the ECC;
+///   regenerating from the irreducible IS the correction").
+///
+/// Anchors: S. James Gates Jr. (adinkras / doubly-even self-dual codes); the extended Hamming [8,4,4] /
+/// `e8` lineage; the in-tree adinkra→Clifford→E8 research (ferry-26) + unfolding-as-the-common-seed (ferry-37).
+[<RequireQualifiedAccess>]
+module AdinkraMirror =
+
+    /// Block length (bits) of the code.
+    let n = 8
+
+    /// The four generators of the [8,4,4] extended-Hamming doubly-even self-dual code (systematic `[I₄ | A]`).
+    /// Each is weight-4 (doubly-even) and the rows are mutually orthogonal mod 2 (⇒ self-dual).
+    let generators : int[] =
+        [| 0b10000111; 0b01001011; 0b00101101; 0b00011110 |]
+
+    /// Hamming weight (popcount).
+    let weight (x: int) : int = BitOperations.PopCount(uint x)
+
+    /// All 16 codewords — the **generation**: XOR-unfold every subset of the generators.
+    let codewords : int[] =
+        [| for m in 0..15 ->
+               let mutable c = 0
+               for i in 0..3 do
+                   if (m >>> i) &&& 1 = 1 then c <- c ^^^ generators.[i]
+               c |]
+
+    /// Inner product mod 2.
+    let private dot (a: int) (b: int) : int = weight (a &&& b) % 2
+
+    /// **Syndrome** `= G·x` (mod 2), packed into 4 bits. `H = G` because the code is self-dual, so a word is a
+    /// codeword **iff** its syndrome is `0`. (This is the generator acting AS the error-detector.)
+    let syndrome (x: int) : int =
+        let mutable s = 0
+        for i in 0..3 do
+            if dot generators.[i] x = 1 then s <- s ||| (1 <<< i)
+        s
+
+    /// `true` iff `x` is a codeword (syndrome `0`).
+    let isCodeword (x: int) : bool = syndrome x = 0
+
+    /// **Correct** a single-bit error (the code is `d=4`, so `t=1`): `Some` the unique codeword reachable by
+    /// flipping ≤ 1 bit; `None` if uncorrectable (≥ 2 errors detected). Same generator that *made* the code
+    /// now *repairs* it — generation = correction.
+    let correct (x: int) : int option =
+        if isCodeword x then
+            Some x
+        else
+            let fixes = [ for p in 0 .. n - 1 do
+                              let y = x ^^^ (1 <<< p)
+                              if isCodeword y then yield y ]
+            match fixes with
+            | [ y ] -> Some y
+            | _ -> None
+
+    /// Minimum distance = the smallest nonzero codeword weight (the ECC distance; here 4).
+    let minDistance : int =
+        codewords |> Array.filter (fun c -> c <> 0) |> Array.map weight |> Array.min
+
+    /// **Doubly-even:** every codeword's weight ≡ 0 (mod 4).
+    let isDoublyEven : bool = codewords |> Array.forall (fun c -> weight c % 4 = 0)
+
+    /// **Self-orthogonal:** every pair (including each with itself) is orthogonal mod 2.
+    let isSelfOrthogonal : bool =
+        codewords |> Array.forall (fun a -> codewords |> Array.forall (fun b -> dot a b = 0))
+
+    /// **Self-dual (the mirror):** self-orthogonal **and** `|C| = 2^(n/2)` — i.e. `C = C⊥`.
+    let isSelfDual : bool = isSelfOrthogonal && codewords.Length = (1 <<< (n / 2))

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -302,6 +302,7 @@
     <Compile Include="SocietalDoraSvg.fs" />
     <Compile Include="AlarmAlgebra.fs" />
     <Compile Include="CoEmpowerField.fs" />
+    <Compile Include="AdinkraMirror.fs" />
     <Compile Include="IdentityCapacity.fs" />
     <Compile Include="TrustCalculus.fs" />
     <Compile Include="PrivacyEconomy.fs" />

--- a/tests/Tests.FSharp/Formal/AdinkraMirror.Tests.fs
+++ b/tests/Tests.FSharp/Formal/AdinkraMirror.Tests.fs
@@ -1,0 +1,49 @@
+module Zeta.Tests.Formal.AdinkraMirrorTests
+
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Core
+
+// ═══════════════════════════════════════════════════════════════════
+// AdinkraMirror (`src/Core/AdinkraMirror.fs`) — layer one of the adinkra
+// unfold: the [8,4,4] doubly-even self-dual code. The MIRROR (C = C⊥),
+// doubly-even, and the generator IS the ECC (generation = correction).
+// Anchors: Gates adinkras / doubly-even self-dual codes; ext. Hamming.
+// ═══════════════════════════════════════════════════════════════════
+
+[<Fact>]
+let ``the code has 16 distinct codewords, including zero`` () =
+    AdinkraMirror.codewords.Length |> should equal 16
+    (AdinkraMirror.codewords |> Array.distinct |> Array.length) |> should equal 16
+    AdinkraMirror.codewords |> Array.contains 0 |> should equal true
+
+[<Fact>]
+let ``doubly-even — every codeword weight is a multiple of 4`` () =
+    AdinkraMirror.isDoublyEven |> should equal true
+    AdinkraMirror.codewords
+    |> Array.iter (fun c -> (AdinkraMirror.weight c % 4) |> should equal 0)
+
+[<Fact>]
+let ``self-dual — the MIRROR: the code is its own dual (C = C⊥)`` () =
+    AdinkraMirror.isSelfOrthogonal |> should equal true
+    AdinkraMirror.isSelfDual |> should equal true
+
+[<Fact>]
+let ``minimum distance is 4`` () =
+    AdinkraMirror.minDistance |> should equal 4
+
+[<Fact>]
+let ``the generator IS the ECC: codewords have zero syndrome; a single-bit error does not`` () =
+    AdinkraMirror.codewords |> Array.iter (fun c -> AdinkraMirror.isCodeword c |> should equal true)
+    // flip one bit of a codeword ⇒ no longer a codeword (the generator detects it)
+    let c = AdinkraMirror.codewords.[5]
+    AdinkraMirror.isCodeword (c ^^^ 0b1) |> should equal false
+
+[<Fact>]
+let ``single-error correction recovers every codeword (generation = correction)`` () =
+    for c in AdinkraMirror.codewords do
+        for p in 0 .. AdinkraMirror.n - 1 do
+            AdinkraMirror.correct (c ^^^ (1 <<< p)) |> should equal (Some c)
+    // a clean codeword corrects to itself
+    let c3 = AdinkraMirror.codewords.[3]
+    AdinkraMirror.correct c3 |> should equal (Some c3)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -343,6 +343,7 @@
     <Compile Include="Formal/SocietalDoraSvg.Tests.fs" />
     <Compile Include="Formal/AlarmAlgebra.Tests.fs" />
     <Compile Include="Formal/CoEmpowerField.Tests.fs" />
+    <Compile Include="Formal/AdinkraMirror.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />
 
     <!-- Circuit/ -->


### PR DESCRIPTION
Aaron 2026-06-19 *"build the adinkra mirror layer one."* The irreducible root of the cohomoiconic unfold, one layer at a time. **`src/Core/AdinkraMirror.fs`** — the **[8,4,4] doubly-even self-dual** code (the code Gates' adinkras carry): **self-dual** (C=C⊥, *the mirror*), **doubly-even** (weights ≡0 mod4), and **the generator IS the ECC** (the same generator both **generates** the 16 codewords and **corrects** errors via syndrome=G·x since H=G — generation = correction, dual).

**6 tests green**, Core 0-warning: 16 distinct codewords; doubly-even; **self-dual/self-orthogonal** (the mirror); min distance 4; generator-IS-ECC (zero-syndrome codewords, error detected); **single-error correction recovers every codeword**. Anchors: Gates (adinkras); ext. Hamming [8,4,4] / e8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)