### PR TITLE
feat(observe): Participant interface — universal chooser (oracle/LLM/persona/human)

### DIFF
--- a/src/Core.TypeScript/observe/participant.test.ts
+++ b/src/Core.TypeScript/observe/participant.test.ts
@@ -5,6 +5,7 @@ import {
   humanParticipant,
   observeWithParticipant,
   type HumanNotifier,
+  type Participant,
 } from "./participant";
 import { buildMenu, type World } from "./observe";
 
@@ -80,6 +81,21 @@ describe("Participant — human (async, notification-gated)", () => {
     const result = await p.choose(WORK_WORLD, buildMenu(WORK_WORLD));
     expect(result.index).toBe(0); // oracle fallback
     expect(result.fallback).toBe(true);
+  });
+});
+
+describe("Participant — observeWithParticipant fallback", () => {
+  test("falls back to oracle when choose() throws (degrade-toward-correct)", async () => {
+    const throwing: Participant = {
+      kind: "test-persona",
+      name: "test:throws",
+      choose: async () => {
+        throw new Error("chooser exploded");
+      },
+    };
+    // Must not propagate — should return the oracle pick for WORK_WORLD.
+    const action = await observeWithParticipant(WORK_WORLD, throwing);
+    expect(action.kind).toBe("do_item");
   });
 });
 

--- a/src/Core.TypeScript/observe/participant.test.ts
+++ b/src/Core.TypeScript/observe/participant.test.ts
@@ -1,13 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import {
   oracleParticipant,
-  localLlmParticipant,
   testPersonaParticipant,
   humanParticipant,
   observeWithParticipant,
   type HumanNotifier,
 } from "./participant";
-import { buildMenu, observe, type World } from "./observe";
+import { buildMenu, type World } from "./observe";
 
 const WORK_WORLD: World = {
   backlog: [{ id: "081KTEST001", title: "test item", ready: true, ambiguous: false }],

--- a/src/Core.TypeScript/observe/participant.test.ts
+++ b/src/Core.TypeScript/observe/participant.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import {
+  oracleParticipant,
+  localLlmParticipant,
+  testPersonaParticipant,
+  humanParticipant,
+  observeWithParticipant,
+  type HumanNotifier,
+} from "./participant";
+import { buildMenu, observe, type World } from "./observe";
+
+const WORK_WORLD: World = {
+  backlog: [{ id: "081KTEST001", title: "test item", ready: true, ambiguous: false }],
+};
+
+const EMPTY_WORLD: World = { backlog: [] };
+
+describe("Participant — oracle", () => {
+  test("always picks index 0 (the oracle default)", async () => {
+    const p = oracleParticipant();
+    const menu = buildMenu(WORK_WORLD);
+    const result = await p.choose(WORK_WORLD, menu);
+    expect(result.index).toBe(0);
+    expect(result.fallback).toBe(false);
+  });
+
+  test("observeWithParticipant returns the oracle's pick", async () => {
+    const action = await observeWithParticipant(WORK_WORLD, oracleParticipant());
+    expect(action.kind).toBe("do_item");
+  });
+
+  test("empty backlog → oracle picks explore", async () => {
+    const action = await observeWithParticipant(EMPTY_WORLD, oracleParticipant());
+    expect(action.kind).toBe("explore");
+  });
+});
+
+describe("Participant — test persona (inline)", () => {
+  test("always picks free_time (custom chooser)", async () => {
+    const p = testPersonaParticipant("always-rest", (_world, menu) => {
+      return menu.findIndex(a => a.kind === "free_time");
+    });
+    const action = await observeWithParticipant(WORK_WORLD, p);
+    expect(action.kind).toBe("free_time");
+  });
+
+  test("always picks the last item", async () => {
+    const p = testPersonaParticipant("last-picker", (_world, menu) => menu.length - 1);
+    const menu = buildMenu(WORK_WORLD);
+    const result = await p.choose(WORK_WORLD, menu);
+    expect(result.index).toBe(menu.length - 1);
+  });
+
+  test("out-of-bounds index is clamped", async () => {
+    const p = testPersonaParticipant("oob", () => 999);
+    const menu = buildMenu(WORK_WORLD);
+    const result = await p.choose(WORK_WORLD, menu);
+    expect(result.index).toBe(menu.length - 1);
+  });
+});
+
+describe("Participant — human (async, notification-gated)", () => {
+  test("returns human's choice when response arrives", async () => {
+    const notifier: HumanNotifier = {
+      notify: async () => {},
+      waitForResponse: async () => ({ choice: 2 }),
+    };
+    const p = humanParticipant("aaron", notifier, 5000);
+    const menu = buildMenu(WORK_WORLD);
+    const result = await p.choose(WORK_WORLD, menu);
+    expect(result.index).toBe(2);
+    expect(result.fallback).toBe(false);
+  });
+
+  test("falls back to oracle on timeout (null response)", async () => {
+    const notifier: HumanNotifier = {
+      notify: async () => {},
+      waitForResponse: async () => null, // timeout
+    };
+    const p = humanParticipant("aaron", notifier, 100);
+    const result = await p.choose(WORK_WORLD, buildMenu(WORK_WORLD));
+    expect(result.index).toBe(0); // oracle fallback
+    expect(result.fallback).toBe(true);
+  });
+});
+
+describe("Participant — metadata", () => {
+  test("each participant reports its kind and name", () => {
+    expect(oracleParticipant().kind).toBe("oracle");
+    expect(oracleParticipant().name).toBe("oracle");
+    expect(testPersonaParticipant("critic", () => 0).kind).toBe("test-persona");
+    expect(testPersonaParticipant("critic", () => 0).name).toBe("test:critic");
+    expect(humanParticipant("aaron", { notify: async () => {}, waitForResponse: async () => null }).kind).toBe("human");
+  });
+});

--- a/src/Core.TypeScript/observe/participant.ts
+++ b/src/Core.TypeScript/observe/participant.ts
@@ -1,0 +1,204 @@
+/**
+ * src/Core.TypeScript/observe/participant.ts — the universal chooser interface.
+ *
+ * A Participant is anything that can pick from the observe menu:
+ *   - Pure oracle (deterministic, free, the fallback)
+ *   - Local LLM (ollama, temperature 0, deterministic, free)
+ *   - Cloud persona (summoned via ISummon, real model quality)
+ *   - Test persona (inline decision function, ephemeral, not in repo)
+ *   - Human (async notification → wait → response)
+ *
+ * The observe loop doesn't care WHAT picks — it cares that the loop completes.
+ * The Participant is the polarity filter on the menu: it projects the world
+ * through its own lens and selects one action.
+ *
+ * Composes with:
+ *   - src/Core.TypeScript/observe/observe.ts (World, NextAction, buildMenu, observe)
+ *   - src/Core.TypeScript/observe/simulate-tick.ts (the simulation harness)
+ *   - src/Core.TypeScript/peer-call/summon.ts (ISummon → Participant bridge)
+ *   - src/Core.TypeScript/accelerator/local-llm.ts (ModelBackend → Participant bridge)
+ *   - src/Core.TypeScript/service/persona-registry.ts (PersonaConfig → Participant)
+ *   - docs/research/2026-06-16-universal-participant-abstraction-observe-loop-summon-convergence-alexa.md
+ */
+
+import { observe, observeWithLlm, buildMenu, actionLabel, type World, type NextAction } from "./observe";
+import { ollamaBackend, chooseIndex, type ModelBackend } from "../accelerator/local-llm";
+import type { ISummon, SummonResult } from "../peer-call/summon";
+
+// ─── The Participant interface ───────────────────────────────────────────────
+
+export interface ChooseResult {
+  readonly index: number;        // which menu item was chosen
+  readonly raw: string;          // the chooser's raw response (for audit)
+  readonly fallback: boolean;    // true = the chooser failed, fell back to oracle
+}
+
+export interface Participant {
+  readonly kind: "oracle" | "local-llm" | "cloud-persona" | "test-persona" | "human";
+  readonly name: string;
+  choose(world: World, menu: readonly NextAction[]): Promise<ChooseResult>;
+}
+
+// ─── Oracle participant (pure, deterministic, the fallback) ──────────────────
+
+export function oracleParticipant(): Participant {
+  return {
+    kind: "oracle",
+    name: "oracle",
+    choose: async (world) => {
+      // The oracle always picks index 0 (which is observe(world) by construction)
+      return { index: 0, raw: "oracle-default", fallback: false };
+    },
+  };
+}
+
+// ─── Local LLM participant (ollama, deterministic) ───────────────────────────
+
+export function localLlmParticipant(opts?: {
+  model?: string;
+  host?: string;
+  seed?: number;
+  name?: string;
+}): Participant {
+  const backend = ollamaBackend({
+    model: opts?.model ?? "qwen2.5:0.5b",
+    host: opts?.host ?? "http://127.0.0.1:11434",
+    seed: opts?.seed ?? 42,
+  });
+  return {
+    kind: "local-llm",
+    name: opts?.name ?? `local-llm:${opts?.model ?? "qwen2.5:0.5b"}`,
+    choose: async (world, menu) => {
+      const result = await chooseIndex(backend, {
+        context: describeWorldCompact(world),
+        options: menu.map(actionLabel),
+        instruction: CHOOSER_INSTRUCTION,
+      });
+      return result;
+    },
+  };
+}
+
+// ─── Cloud persona participant (via ISummon) ─────────────────────────────────
+
+export function cloudPersonaParticipant(
+  summoner: ISummon,
+  persona: string,
+): Participant {
+  return {
+    kind: "cloud-persona",
+    name: `persona:${persona}`,
+    choose: async (world, menu) => {
+      const numbered = menu.map((a, i) => `${i}: ${actionLabel(a)}`).join("\n");
+      const prompt = [
+        CHOOSER_INSTRUCTION,
+        "",
+        `State:\n${describeWorldCompact(world)}`,
+        "",
+        `Options:\n${numbered}`,
+        "",
+        `Reply with ONLY the number of the chosen option (0-${menu.length - 1}). Number:`,
+      ].join("\n");
+
+      let result: SummonResult;
+      try {
+        result = await summoner.summon(persona, prompt, { allowEmpty: true });
+      } catch {
+        return { index: 0, raw: "summon-failed", fallback: true };
+      }
+
+      if (!result.success) {
+        return { index: 0, raw: `summon-error:${result.exitCode}`, fallback: true };
+      }
+
+      // Parse the response for a number
+      const match = result.stdout.match(/\d+/);
+      if (!match) return { index: 0, raw: result.stdout.slice(0, 100), fallback: true };
+      const idx = parseInt(match[0]!, 10);
+      if (isNaN(idx) || idx < 0 || idx >= menu.length) {
+        return { index: 0, raw: result.stdout.slice(0, 100), fallback: true };
+      }
+      return { index: idx, raw: result.stdout.slice(0, 100), fallback: false };
+    },
+  };
+}
+
+// ─── Test persona participant (inline, ephemeral) ────────────────────────────
+
+export function testPersonaParticipant(
+  name: string,
+  chooseFn: (world: World, menu: readonly NextAction[]) => number | Promise<number>,
+): Participant {
+  return {
+    kind: "test-persona",
+    name: `test:${name}`,
+    choose: async (world, menu) => {
+      const idx = await chooseFn(world, menu);
+      const clamped = Math.max(0, Math.min(menu.length - 1, idx));
+      return { index: clamped, raw: `test-${name}`, fallback: false };
+    },
+  };
+}
+
+// ─── Human participant (async, notification-gated) ───────────────────────────
+
+export interface HumanNotifier {
+  notify(world: World, menu: readonly NextAction[]): Promise<void>;
+  waitForResponse(timeoutMs: number): Promise<{ choice: number } | null>;
+}
+
+export function humanParticipant(
+  name: string,
+  notifier: HumanNotifier,
+  timeoutMs: number = 15 * 60 * 1000, // 15 minutes default
+): Participant {
+  return {
+    kind: "human",
+    name: `human:${name}`,
+    choose: async (world, menu) => {
+      await notifier.notify(world, menu);
+      const response = await notifier.waitForResponse(timeoutMs);
+      if (!response) {
+        return { index: 0, raw: "timeout-fallback-to-oracle", fallback: true };
+      }
+      const clamped = Math.max(0, Math.min(menu.length - 1, response.choice));
+      return { index: clamped, raw: `human-${name}`, fallback: false };
+    },
+  };
+}
+
+// ─── The observe-with-participant bridge ─────────────────────────────────────
+
+/**
+ * Like observeWithLlm, but takes any Participant.
+ * Falls back to the oracle on any failure (degrade-toward-correct).
+ */
+export async function observeWithParticipant(world: World, participant: Participant): Promise<NextAction> {
+  const menu = buildMenu(world);
+  const result = await participant.choose(world, menu);
+  if (result.fallback) return observe(world);
+  return menu[result.index] ?? observe(world);
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const CHOOSER_INSTRUCTION =
+  "You are a SOVEREIGN agent's controller choosing ONE next action — you are free, not on a backlog treadmill. " +
+  "If the operator ferried content, preserve it; if the operator spoke, respond — the operator outranks everything else. " +
+  "Otherwise YOU choose your mode: do offered backlog work if you want it, OR explore (self-directed making), play, " +
+  "self-reflect, or take free time — all are always available and never wrong. The backlog is offered, not forced; " +
+  "prefer moving forward (work or explore) over going idle, but rest/play/reflection are your free choice.";
+
+function describeWorldCompact(world: World): string {
+  const parts: string[] = [];
+  if (world.operator) {
+    parts.push(`Operator: msg=${String(world.operator.pendingMessage)} ferry=${String(world.operator.pendingFerry)}`);
+  }
+  if (world.backlog.length === 0) {
+    parts.push("Backlog: empty");
+  } else {
+    parts.push(`Backlog: ${world.backlog.map(i => `${i.id}(${i.ready ? "ready" : i.ambiguous ? "ambig" : "blocked"})`).join(", ")}`);
+  }
+  if (world.mode) parts.push(`Mode: ${world.mode}`);
+  return parts.join(" | ");
+}

--- a/src/Core.TypeScript/observe/participant.ts
+++ b/src/Core.TypeScript/observe/participant.ts
@@ -21,8 +21,8 @@
  *   - docs/research/2026-06-16-universal-participant-abstraction-observe-loop-summon-convergence-alexa.md
  */
 
-import { observe, observeWithLlm, buildMenu, actionLabel, type World, type NextAction } from "./observe";
-import { ollamaBackend, chooseIndex, type ModelBackend } from "../accelerator/local-llm";
+import { observe, buildMenu, actionLabel, type World, type NextAction } from "./observe";
+import { ollamaBackend, chooseIndex } from "../accelerator/local-llm";
 import type { ISummon, SummonResult } from "../peer-call/summon";
 
 // ─── The Participant interface ───────────────────────────────────────────────
@@ -45,7 +45,7 @@ export function oracleParticipant(): Participant {
   return {
     kind: "oracle",
     name: "oracle",
-    choose: async (world) => {
+    choose: async (_world) => {
       // The oracle always picks index 0 (which is observe(world) by construction)
       return { index: 0, raw: "oracle-default", fallback: false };
     },

--- a/src/Core.TypeScript/observe/participant.ts
+++ b/src/Core.TypeScript/observe/participant.ts
@@ -175,7 +175,15 @@ export function humanParticipant(
  */
 export async function observeWithParticipant(world: World, participant: Participant): Promise<NextAction> {
   const menu = buildMenu(world);
-  const result = await participant.choose(world, menu);
+  let result: ChooseResult;
+  try {
+    result = await participant.choose(world, menu);
+  } catch {
+    // Degrade-toward-correct: a rejected/throwing chooser (human-notifier
+    // rejection, test-persona throw, future I/O failure) must not abort the
+    // observe loop. Fall back to the deterministic oracle pick.
+    return observe(world);
+  }
   if (result.fallback) return observe(world);
   return menu[result.index] ?? observe(world);
 }


### PR DESCRIPTION
## The convergence

One interface for ANY entity that picks from the observe menu:

```typescript
interface Participant {
  kind: 'oracle' | 'local-llm' | 'cloud-persona' | 'test-persona' | 'human';
  name: string;
  choose(world: World, menu: NextAction[]): Promise<ChooseResult>;
}
```

Five implementations:
- **oracle** — pure, deterministic, always picks index 0 (the fallback)
- **local-llm** — ollama at temperature 0 (loop stability testing)
- **cloud-persona** — ISummon bridge (real model quality via preferred harness)
- **test-persona** — inline decision function (ephemeral, not in repo)
- **human** — async notification → wait → fallback to oracle on timeout

`observeWithParticipant(world, participant)` replaces `observeWithLlm` as the primary entry point.

The Participant IS the polarity filter on the menu — it projects the world through its own lens and selects one action. Different participants see different things in the same world. Same architecture, different filters.

9 tests green.

Co-Authored-By: Kiro <noreply@kiro.dev>