### PR TITLE
feat(core): Clifford→E8 bridge — stitch Cl(3,0) to the E8 root lattice (the middle of the adinkra unfold)

### DIFF
--- a/src/Core/CliffordE8Bridge.fs
+++ b/src/Core/CliffordE8Bridge.fs
@@ -1,0 +1,58 @@
+namespace Zeta.Core
+
+open System.Numerics
+
+/// **`CliffordE8Bridge` — the middle of the adinkra → Clifford → E8 unfold (Aaron 2026-06-19, shadow\*).**
+///
+/// The ends of the ladder are already proven in code: `AdinkraCode` (octonion → Fano → [8,4] doubly-even
+/// self-dual code) and `E8Lattice` (Construction A over that code → the 240 E8 roots). `Cl3` (Clifford
+/// `Cl(3,0)`) existed but sat **isolated**. This module **stitches `Cl3` to `E8Lattice`**, the step Aaron's
+/// note (`E8Lattice.fs:5`) flagged as belief-not-theorem.
+///
+/// **The bridge (what it IS):** `Cl(3,0)` is 8-dimensional with basis blades indexed by a 3-bit mask `0..7`
+/// (`Cl3` field order `[S; E1; E2; E12; E3; E13; E23; E123]` = masks `0..7`). E8's roots are length-8 integer
+/// vectors whose coordinates `0..7` are the 8 positions of the same `[8,4]` code. So **coordinate `i` ↔ blade
+/// mask `i`** is a natural bijection that makes the two 8-dim spaces *one object*. It is a **linear isometry**:
+/// it preserves addition and the Euclidean norm² (so every E8 root maps to a Cl(3,0) multivector of the same
+/// norm² = 4), and it endows each E8 coordinate with a **Clifford grade** = `popcount(i)` — partitioning the 8
+/// coordinates into the graded `1 + 3 + 3 + 1` (scalar · vectors · bivectors · pseudoscalar).
+///
+/// **Honest scope (peel):** this is the **basis / metric** bridge — an isometric identification of E8's ambient
+/// ℝ⁸ with `Cl(3,0)`'s blade space, plus the grade labeling. It does **NOT** claim the Clifford **geometric
+/// product** alone *generates* the E8 root system (the deeper "unfold" — that GA dynamics produce the 240 roots
+/// — remains open/aspirational, `FROZEN-CORE §B`). What is proven here: the 8↔8 linear isometry, the
+/// root↔multivector bijection preserving norm², and the grade partition.
+///
+/// Anchors: W. K. Clifford (geometric algebra); Conway–Sloane (E8 Construction A); Gates (adinkra doubly-even
+/// self-dual ECC). Ties: `docs/research/2026-06-19-adinkra-clifford-e8-unfold-status-…`.
+[<RequireQualifiedAccess>]
+module CliffordE8Bridge =
+
+    /// The Clifford grade (blade rank) of E8 coordinate `i` = popcount of its 3-bit blade mask.
+    /// Grades: `0`→scalar, `1/2/4`→vectors (grade 1), `3/5/6`→bivectors (grade 2), `7`→pseudoscalar (grade 3).
+    let gradeOfCoord (i: int) : int = BitOperations.PopCount(uint (i &&& 0b111))
+
+    /// Express an E8 root (length-8 integer vector; coordinate `i` = blade mask `i`) as a `Cl(3,0)` multivector.
+    let rootToMv (x: int[]) : Cl3.Mv =
+        { Cl3.S = float x.[0]
+          Cl3.E1 = float x.[1]
+          Cl3.E2 = float x.[2]
+          Cl3.E12 = float x.[3]
+          Cl3.E3 = float x.[4]
+          Cl3.E13 = float x.[5]
+          Cl3.E23 = float x.[6]
+          Cl3.E123 = float x.[7] }
+
+    /// Inverse: a multivector with (near-)integer coefficients back to an 8-int vector (round-to-nearest).
+    let mvToRoot (m: Cl3.Mv) : int[] =
+        [| int (round m.S)
+           int (round m.E1)
+           int (round m.E2)
+           int (round m.E12)
+           int (round m.E3)
+           int (round m.E13)
+           int (round m.E23)
+           int (round m.E123) |]
+
+    /// The 240 E8 roots, carried into `Cl(3,0)` as multivectors (the unfold, realized at the basis/metric level).
+    let rootMvs : Cl3.Mv list = E8Lattice.roots |> List.map rootToMv

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -27,6 +27,7 @@
     <Compile Include="Orbit.fs" />
     <Compile Include="AdinkraCode.fs" />
     <Compile Include="E8Lattice.fs" />
+    <Compile Include="CliffordE8Bridge.fs" />
     <Compile Include="Tsirelson.fs" />
     <Compile Include="HexCore.fs" />
     <Compile Include="Semiring.fs" />

--- a/tests/Tests.FSharp/Formal/CliffordE8Bridge.Tests.fs
+++ b/tests/Tests.FSharp/Formal/CliffordE8Bridge.Tests.fs
@@ -1,0 +1,51 @@
+module Zeta.Tests.Formal.CliffordE8BridgeTests
+
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Core
+
+// ═══════════════════════════════════════════════════════════════════
+// CliffordE8Bridge (`src/Core/CliffordE8Bridge.fs`) — the middle of the
+// adinkra → Clifford → E8 unfold. The map E8-coordinate ↔ Cl(3,0) blade
+// (both 3-bit-mask indexed) is a LINEAR ISOMETRY: it preserves addition
+// and norm², carries the 240 roots to 240 distinct multivectors of norm²
+// = 4, and grades the 8 coordinates into 1+3+3+1. (It does NOT claim the
+// geometric product generates the root system — that stays open.)
+// ═══════════════════════════════════════════════════════════════════
+
+[<Fact>]
+let ``root↔multivector round-trips for all 240 E8 roots`` () =
+    for r in E8Lattice.roots do
+        Assert.Equal<int[]>(r, CliffordE8Bridge.mvToRoot (CliffordE8Bridge.rootToMv r))
+
+[<Fact>]
+let ``the bridge is an ISOMETRY — Cl(3,0) norm² equals the E8 integer norm² (both 4) for every root`` () =
+    for r in E8Lattice.roots do
+        let lhs = Cl3.normSq (CliffordE8Bridge.rootToMv r)
+        Assert.True(abs (lhs - float (E8Lattice.normSq r)) < 1e-9)
+        Assert.True(abs (lhs - 4.0) < 1e-9) // every E8 root has norm² 4
+
+[<Fact>]
+let ``the 240 roots map to 240 distinct multivectors`` () =
+    let distinct = CliffordE8Bridge.rootMvs |> List.distinct
+    Assert.Equal(240, List.length CliffordE8Bridge.rootMvs)
+    Assert.Equal(240, List.length distinct)
+
+[<Fact>]
+let ``the bridge is LINEAR — rootToMv(a+b) = rootToMv a + rootToMv b`` () =
+    // exhaustive over a representative cross-section: every root against the first 8 roots
+    let roots = List.toArray E8Lattice.roots
+    for a in roots do
+        for b in Array.truncate 8 roots do
+            let sum = Array.map2 (+) a b
+            let viaSum = CliffordE8Bridge.rootToMv sum
+            let viaParts = Cl3.add (CliffordE8Bridge.rootToMv a) (CliffordE8Bridge.rootToMv b)
+            Assert.True(Cl3.normSq (Cl3.sub viaSum viaParts) < 1e-9)
+
+[<Fact>]
+let ``the grade labeling partitions the 8 coordinates into 1 + 3 + 3 + 1 (scalar·vectors·bivectors·pseudoscalar)`` () =
+    let counts =
+        [ 0 .. 7 ]
+        |> List.countBy CliffordE8Bridge.gradeOfCoord
+        |> List.sortBy fst
+    Assert.Equal<(int * int) list>([ (0, 1); (1, 3); (2, 3); (3, 1) ], counts)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -319,6 +319,7 @@
     <Compile Include="Curve.Serializer.Tests.fs" />
     <Compile Include="BeliefConvergence.Tests.fs" />
     <Compile Include="AdinkraCode.Tests.fs" />
+    <Compile Include="Formal/CliffordE8Bridge.Tests.fs" />
     <Compile Include="CayleyDicksonAdinkra.Tests.fs" />
     <Compile Include="Evolution.Tests.fs" />
     <Compile Include="MediatorUnit.Tests.fs" />


### PR DESCRIPTION
Aaron 2026-06-19 picked this as the next front. The ladder's ends were proven (AdinkraCode: octonion→Fano→[8,4]; E8Lattice: 240 roots); **Cl3 sat isolated** — this stitches them (the step your E8Lattice.fs:5 note flagged as belief).

**`src/Core/CliffordE8Bridge.fs`:** E8's 8 coordinates ↔ Cl(3,0)'s 8 blades are both 3-bit-mask indexed, so coordinate i ↔ blade mask i is a **linear isometry** — preserves addition + norm² (every root → a multivector of norm² 4) and grades the 8 coords into **1+3+3+1**. API: `gradeOfCoord`, `rootToMv`, `mvToRoot`, `rootMvs`.

**Honest scope:** basis/metric bridge (isometry + grade labeling); does **not** claim the geometric product alone generates the 240 roots (that stays open, §B). **5 tests green**, Core 0-warning: round-trip (240); isometry (Cl norm²=E8 norm²=4); 240 distinct; linearity; grade partition 1+3+3+1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)