### PR TITLE
fix(observe): unblock main tsc gate (unused imports in workspace-port.test)

### DIFF
--- a/src/Core.TypeScript/observe/workspace-port.test.ts
+++ b/src/Core.TypeScript/observe/workspace-port.test.ts
@@ -4,9 +4,6 @@ import {
   emptySimulatedState,
   GATED_PERMISSIONS,
   DEFAULT_PERMISSIONS,
-  TRADITIONAL_FS_DEFAULT,
-  type SimulatedState,
-  type FileEntry,
 } from "./workspace-port";
 
 describe("simulatedWorkspacePort — in-memory filesystem", () => {


### PR DESCRIPTION
Follow-up to #8433. The reconcile merge landed before the import cleanup, leaving main red on tsc (TS6133). Removes the three unused imports. Verified: tsc green, 53 port+conformance tests pass.