### PR TITLE
[codex] add meta-cart attention ledger

### DIFF
--- a/src/Core.TypeScript/observe/workspace-port.test.ts
+++ b/src/Core.TypeScript/observe/workspace-port.test.ts
@@ -4,9 +4,6 @@ import {
   emptySimulatedState,
   GATED_PERMISSIONS,
   DEFAULT_PERMISSIONS,
-  TRADITIONAL_FS_DEFAULT,
-  type SimulatedState,
-  type FileEntry,
 } from "./workspace-port";
 
 describe("simulatedWorkspacePort — in-memory filesystem", () => {

--- a/src/Core/DarkHallCabinetRuntime.fs
+++ b/src/Core/DarkHallCabinetRuntime.fs
@@ -79,6 +79,33 @@ module DarkHallCabinetRuntime =
         | MetaCartResult of MetaCart.ReflectedPlayResult
 
     [<RequireQualifiedAccess>]
+    type AttentionOutcome =
+        | Executed
+        | Denied
+        | Missing
+        | NoSelection
+        | HeatRejected
+
+    type AttentionLedgerRow =
+        { Source: string
+          Address: MachineAddress
+          PolicyName: string
+          Baseline: MetaCart.CartSlot option
+          Selected: MetaCart.CartSlot option
+          ChangedSelection: bool
+          Outcome: AttentionOutcome
+          Reason: string
+          HeatKind: string option }
+
+    type AttentionLedgerSummary =
+        { Executed: int
+          Denied: int
+          Missing: int
+          NoSelection: int
+          HeatRejected: int
+          Backpressured: int }
+
+    [<RequireQualifiedAccess>]
     type Feedback =
         | CellUnbound of cell: int
         | CabinetMissing of cabinetName: string
@@ -92,6 +119,10 @@ module DarkHallCabinetRuntime =
         | SchedulerFeedback of InterruptFeedback
         | MetaCartFeedback of MetaCart.Feedback
         | Chip9Feedback of address: MachineAddress * reason: string
+
+    type RunReport =
+        { Result: Result<RunResult, Feedback>
+          AttentionLedger: AttentionLedgerRow list }
 
     let defaultPriority: Map<string, float> =
         Map.ofList
@@ -297,31 +328,120 @@ module DarkHallCabinetRuntime =
             | None -> return machine
         }
 
-    let private executeMetaCartLaunch
+    let private runReport result =
+        { Result = result
+          AttentionLedger = [] }
+
+    let private slotOfChoice (choice: MetaCart.ReflectedChoice option) : MetaCart.CartSlot option =
+        choice |> Option.map (fun selected -> selected.Slot)
+
+    let private boundedGSetErrorReason =
+        function
+        | BoundedGSetError.NonPositiveCapacity capacity -> sprintf "heat storage non-positive capacity %d" capacity
+        | BoundedGSetError.CapacityExceeded(capacity, count) ->
+            sprintf "heat storage capacity exceeded capacity=%d count=%d" capacity count
+        | BoundedGSetError.ConfigMismatch(left, right) ->
+            sprintf
+                "heat storage config mismatch left-capacity=%d right-capacity=%d"
+                left.Capacity
+                right.Capacity
+
+    let private heatSinkFeedbackReason =
+        function
+        | HeatSinkFeedback.Backpressure(heat, capacity, count) ->
+            sprintf "heat sink backpressure kind=%s capacity=%d count=%d" heat.Kind capacity count
+        | HeatSinkFeedback.StorageError error -> boundedGSetErrorReason error
+
+    let private metaCartFeedbackOutcome =
+        function
+        | MetaCart.Feedback.NoSelection source ->
+            AttentionOutcome.NoSelection, sprintf "no selection from %s" source, None
+        | MetaCart.Feedback.MissingCart slot ->
+            AttentionOutcome.Missing, sprintf "missing cart sha256=%s" slot.Fingerprint.Sha256, Some slot
+        | MetaCart.Feedback.HostDenied(slot, reason) -> AttentionOutcome.Denied, reason, Some slot
+        | MetaCart.Feedback.HeatRejected(slot, feedback) ->
+            AttentionOutcome.HeatRejected, heatSinkFeedbackReason feedback, Some slot
+
+    let private isPolicyBackpressure
+        (trace: MetaCart.SelectionPolicyTrace)
+        (selected: MetaCart.ReflectedChoice option)
+        (failedSlot: MetaCart.CartSlot option)
+        : bool =
+        match trace.ChangedSelection, selected, failedSlot with
+        | true, Some selected, Some failedSlot -> selected.Slot.Fingerprint.Sha256 = failedSlot.Fingerprint.Sha256
+        | _ -> false
+
+    let attentionLedgerRow
+        (source: string)
+        (address: MachineAddress)
+        (readout: MetaCart.SelectionReadout)
+        (result: Result<MetaCart.ReflectedPlayResult, MetaCart.Feedback>)
+        : AttentionLedgerRow option =
+        readout.PolicyTrace
+        |> Option.map (fun trace ->
+            let outcome, reason, failedSlot =
+                match result with
+                | Ok _ -> AttentionOutcome.Executed, "selected cart executed", None
+                | Error feedback -> metaCartFeedbackOutcome feedback
+
+            let heatKind =
+                if isPolicyBackpressure trace readout.Selected failedSlot then
+                    Some "meta-cart.policy-backpressure"
+                else
+                    None
+
+            { Source = source
+              Address = address
+              PolicyName = trace.PolicyName
+              Baseline = slotOfChoice trace.BaselineSelected
+              Selected = slotOfChoice trace.PolicySelected
+              ChangedSelection = trace.ChangedSelection
+              Outcome = outcome
+              Reason = reason
+              HeatKind = heatKind })
+
+    let summarizeAttentionLedger (rows: AttentionLedgerRow list) : AttentionLedgerSummary =
+        let count outcome =
+            rows |> List.filter (fun row -> row.Outcome = outcome) |> List.length
+
+        { Executed = count AttentionOutcome.Executed
+          Denied = count AttentionOutcome.Denied
+          Missing = count AttentionOutcome.Missing
+          NoSelection = count AttentionOutcome.NoSelection
+          HeatRejected = count AttentionOutcome.HeatRejected
+          Backpressured = rows |> List.filter (fun row -> Option.isSome row.HeatKind) |> List.length }
+
+    let executeMetaCartLaunchWithAttentionLedger
         (source: string)
         (sink: IHeatSink)
+        (address: MachineAddress)
         (launch: MetaCartLaunch)
         (readout: MetaCart.SelectionReadout)
-        : Result<RunResult, Feedback> =
+        : RunReport =
         let host = MetaCart.CapabilityCartHost(launch.Children, launch.ChildCapabilitiesBySha) :> MetaCart.ICartHost
 
-        MetaCart.playChosenFromSelectionReadoutWithCapabilities
-            source
-            sink
-            launch.ParentCapabilities
-            readout
-            host
-            launch.Parent
-        |> Result.map MetaCartResult
-        |> Result.mapError Feedback.MetaCartFeedback
+        let result =
+            MetaCart.playChosenFromSelectionReadoutWithCapabilities
+                source
+                sink
+                launch.ParentCapabilities
+                readout
+                host
+                launch.Parent
 
-    let private executeMachine
+        { Result =
+            result
+            |> Result.map MetaCartResult
+            |> Result.mapError Feedback.MetaCartFeedback
+          AttentionLedger = attentionLedgerRow source address readout result |> Option.toList }
+
+    let private executeMachineWithAttentionLedger
         (source: string)
         (sink: IHeatSink)
         (address: MachineAddress)
         (machine: DarkHall.Machine)
         (request: RunRequest)
-        : Task<Result<RunResult, Feedback>> =
+        : Task<RunReport> =
         task {
             match machine.Core, request with
             | DarkHall.MachineCore.SoftChip8Scheduler, RunSoftChip8(seed, rom, frames) ->
@@ -331,31 +451,47 @@ module DarkHallCabinetRuntime =
                     result
                     |> Result.map SoftChip8Frame
                     |> Result.mapError Feedback.SchedulerFeedback
+                    |> runReport
 
             | DarkHall.MachineCore.DarkHallCpu, RunDarkHallCpu(program, budget) ->
-                return Ok(DarkHallCpuState(DarkHall.run program budget))
+                return runReport (Ok(DarkHallCpuState(DarkHall.run program budget)))
 
             | DarkHall.MachineCore.Chip9ColorPlanes, RunChip9Cart(cart, cartManifest) ->
                 return
                     Chip9Capabilities.playback cartManifest cart
                     |> Result.map Chip9Frame
                     |> Result.mapError (fun reason -> Feedback.Chip9Feedback(address, reason))
+                    |> runReport
 
             | DarkHall.MachineCore.MetaCartHost, RunMetaCart launch ->
                 let readout = observeMetaCartLaunch launch
 
-                return executeMetaCartLaunch source sink launch readout
+                return executeMetaCartLaunchWithAttentionLedger source sink address launch readout
 
             | DarkHall.MachineCore.MetaCartHost, RunMetaCartWithPolicy(policy, launch) ->
                 let readout = observeMetaCartLaunchWithPolicy policy.Name policy.Policy launch
 
-                return executeMetaCartLaunch source sink launch readout
+                return executeMetaCartLaunchWithAttentionLedger source sink address launch readout
 
             | core, _ when not (isExecutableCore core) ->
-                return Error(Feedback.UnsupportedMachine(address, core))
+                return runReport (Error(Feedback.UnsupportedMachine(address, core)))
 
             | core, _ ->
-                return Error(Feedback.RequestMismatch(address, core, requestName request))
+                return runReport (Error(Feedback.RequestMismatch(address, core, requestName request)))
+        }
+
+    let executeAddressWithAttentionLedger
+        (source: string)
+        (sink: IHeatSink)
+        (manifest: Chip9Capabilities.Manifest)
+        (room: DarkHall.Room)
+        (address: MachineAddress)
+        (request: RunRequest)
+        : Task<RunReport> =
+        task {
+            match validateAddress source sink manifest room address with
+            | Error feedback -> return runReport (Error feedback)
+            | Ok machine -> return! executeMachineWithAttentionLedger source sink address machine request
         }
 
     let executeAddress
@@ -367,9 +503,27 @@ module DarkHallCabinetRuntime =
         (request: RunRequest)
         : Task<Result<RunResult, Feedback>> =
         task {
-            match validateAddress source sink manifest room address with
-            | Error feedback -> return Error feedback
-            | Ok machine -> return! executeMachine source sink address machine request
+            let! report = executeAddressWithAttentionLedger source sink manifest room address request
+            return report.Result
+        }
+
+    /// Execute the action bound to a selected 4x4 controller cell.
+    let executeCellWithAttentionLedger
+        (source: string)
+        (sink: IHeatSink)
+        (manifest: Chip9Capabilities.Manifest)
+        (room: DarkHall.Room)
+        (cell: int)
+        (request: RunRequest)
+        : Task<RunReport> =
+        task {
+            let readout = observe room
+
+            match actionAt cell readout with
+            | None -> return runReport (Error(Feedback.CellUnbound cell))
+            | Some { Address = None } -> return runReport (Error(Feedback.CellUnbound cell))
+            | Some { Address = Some address } ->
+                return! executeAddressWithAttentionLedger source sink manifest room address request
         }
 
     /// Execute the action bound to a selected 4x4 controller cell.
@@ -382,10 +536,6 @@ module DarkHallCabinetRuntime =
         (request: RunRequest)
         : Task<Result<RunResult, Feedback>> =
         task {
-            let readout = observe room
-
-            match actionAt cell readout with
-            | None -> return Error(Feedback.CellUnbound cell)
-            | Some { Address = None } -> return Error(Feedback.CellUnbound cell)
-            | Some { Address = Some address } -> return! executeAddress source sink manifest room address request
+            let! report = executeCellWithAttentionLedger source sink manifest room cell request
+            return report.Result
         }

--- a/src/Core/DarkHallCabinetRuntime.fs
+++ b/src/Core/DarkHallCabinetRuntime.fs
@@ -352,15 +352,20 @@ module DarkHallCabinetRuntime =
             sprintf "heat sink backpressure kind=%s capacity=%d count=%d" heat.Kind capacity count
         | HeatSinkFeedback.StorageError error -> boundedGSetErrorReason error
 
+    let private rejectedHeatKind =
+        function
+        | HeatSinkFeedback.Backpressure(heat, _, _) -> Some heat.Kind
+        | HeatSinkFeedback.StorageError _ -> None
+
     let private metaCartFeedbackOutcome =
         function
         | MetaCart.Feedback.NoSelection source ->
-            AttentionOutcome.NoSelection, sprintf "no selection from %s" source, None
+            AttentionOutcome.NoSelection, sprintf "no selection from %s" source, None, None
         | MetaCart.Feedback.MissingCart slot ->
-            AttentionOutcome.Missing, sprintf "missing cart sha256=%s" slot.Fingerprint.Sha256, Some slot
-        | MetaCart.Feedback.HostDenied(slot, reason) -> AttentionOutcome.Denied, reason, Some slot
+            AttentionOutcome.Missing, sprintf "missing cart sha256=%s" slot.Fingerprint.Sha256, Some slot, None
+        | MetaCart.Feedback.HostDenied(slot, reason) -> AttentionOutcome.Denied, reason, Some slot, None
         | MetaCart.Feedback.HeatRejected(slot, feedback) ->
-            AttentionOutcome.HeatRejected, heatSinkFeedbackReason feedback, Some slot
+            AttentionOutcome.HeatRejected, heatSinkFeedbackReason feedback, Some slot, rejectedHeatKind feedback
 
     let private isPolicyBackpressure
         (trace: MetaCart.SelectionPolicyTrace)
@@ -379,16 +384,20 @@ module DarkHallCabinetRuntime =
         : AttentionLedgerRow option =
         readout.PolicyTrace
         |> Option.map (fun trace ->
-            let outcome, reason, failedSlot =
+            let outcome, reason, failedSlot, rejectedHeatKind =
                 match result with
-                | Ok _ -> AttentionOutcome.Executed, "selected cart executed", None
+                | Ok _ -> AttentionOutcome.Executed, "selected cart executed", None, None
                 | Error feedback -> metaCartFeedbackOutcome feedback
 
             let heatKind =
-                if isPolicyBackpressure trace readout.Selected failedSlot then
-                    Some "meta-cart.policy-backpressure"
-                else
-                    None
+                match rejectedHeatKind with
+                | Some "meta-cart.policy-backpressure" -> Some "meta-cart.policy-backpressure"
+                | Some _ -> None
+                | None ->
+                    if isPolicyBackpressure trace readout.Selected failedSlot then
+                        Some "meta-cart.policy-backpressure"
+                    else
+                        None
 
             { Source = source
               Address = address

--- a/src/Core/DarkHallCabinetRuntime.fs
+++ b/src/Core/DarkHallCabinetRuntime.fs
@@ -393,6 +393,7 @@ module DarkHallCabinetRuntime =
                 match rejectedHeatKind with
                 | Some "meta-cart.policy-backpressure" -> Some "meta-cart.policy-backpressure"
                 | Some _ -> None
+                | None when outcome = AttentionOutcome.HeatRejected -> None
                 | None ->
                     if isPolicyBackpressure trace readout.Selected failedSlot then
                         Some "meta-cart.policy-backpressure"

--- a/tests/Tests.FSharp/DarkHallCabinetRuntime.Tests.fs
+++ b/tests/Tests.FSharp/DarkHallCabinetRuntime.Tests.fs
@@ -150,6 +150,91 @@ let ``executeCell surfaces policy backpressure heat for attention-selected meta-
     }
 
 [<Fact>]
+let ``attention ledger compares denied high-attention future with executed lower-attention future`` () =
+    task {
+        let address = mkAddress "play" "meta-cart-host"
+        let chip9Cart = CartFixtures.cart CartFixtures.chip9GreenDot
+        let inputCart = CartFixtures.cart CartFixtures.inputFork
+
+        let launch: Runtime.MetaCartLaunch =
+            { Goal = 10
+              Seed = 1UL
+              ParentCapabilities = Chip9Capabilities.metaHost
+              ChildCapabilitiesBySha =
+                MetaCart.capabilityMap
+                    [ chip9Cart, Chip9Capabilities.chip8Default
+                      inputCart, CartFixtures.inputFork.Capabilities ]
+              Children = [ chip9Cart; inputCart ]
+              Parent = Chip8Cow.create 1UL }
+
+        let highAttention: Runtime.MetaCartPolicy =
+            { Name = "operator-attention"
+              Policy = MetaCart.attentionSelectionPolicy (fun slot -> if slot.Name = chip9Cart.Meta.Title then 100.0 else 0.0) }
+
+        let highSink = RecordingHeatSink()
+
+        let! deniedReport =
+            Runtime.executeAddressWithAttentionLedger
+                "darkhall"
+                (highSink :> IHeatSink)
+                Chip9Capabilities.metaHost
+                Arcade.room
+                address
+                (Runtime.RunMetaCartWithPolicy(highAttention, launch))
+
+        match deniedReport.Result with
+        | Error(Runtime.Feedback.MetaCartFeedback(MetaCart.Feedback.HostDenied(slot, reason))) ->
+            Assert.Equal(MetaCart.slotOfCart chip9Cart, slot)
+            Assert.Contains("chip9.color-planes", reason)
+        | other -> Assert.Fail(sprintf "expected high-attention denial, got %A" other)
+
+        let deniedRow = Assert.Single(deniedReport.AttentionLedger)
+
+        Assert.Equal("darkhall", deniedRow.Source)
+        Assert.Equal(address, deniedRow.Address)
+        Assert.Equal("operator-attention", deniedRow.PolicyName)
+        Assert.True(deniedRow.ChangedSelection)
+        Assert.Equal<MetaCart.CartSlot option>(Some(MetaCart.slotOfCart inputCart), deniedRow.Baseline)
+        Assert.Equal<MetaCart.CartSlot option>(Some(MetaCart.slotOfCart chip9Cart), deniedRow.Selected)
+        Assert.Equal(Runtime.AttentionOutcome.Denied, deniedRow.Outcome)
+        Assert.Equal<string option>(Some "meta-cart.policy-backpressure", deniedRow.HeatKind)
+        Assert.Contains("chip9.color-planes", deniedRow.Reason)
+
+        let lowerAttention: Runtime.MetaCartPolicy =
+            { Name = "operator-attention"
+              Policy = MetaCart.attentionSelectionPolicy (fun slot -> if slot.Name = inputCart.Meta.Title then 1.0 else 0.0) }
+
+        let lowerSink = RecordingHeatSink()
+
+        let! executedReport =
+            Runtime.executeAddressWithAttentionLedger
+                "darkhall"
+                (lowerSink :> IHeatSink)
+                Chip9Capabilities.metaHost
+                Arcade.room
+                address
+                (Runtime.RunMetaCartWithPolicy(lowerAttention, launch))
+
+        match executedReport.Result with
+        | Ok(Runtime.MetaCartResult result) -> Assert.Equal(MetaCart.slotOfCart inputCart, result.Play.Slot)
+        | other -> Assert.Fail(sprintf "expected lower-attention execution, got %A" other)
+
+        let executedRow = Assert.Single(executedReport.AttentionLedger)
+
+        Assert.False(executedRow.ChangedSelection)
+        Assert.Equal<MetaCart.CartSlot option>(Some(MetaCart.slotOfCart inputCart), executedRow.Baseline)
+        Assert.Equal<MetaCart.CartSlot option>(Some(MetaCart.slotOfCart inputCart), executedRow.Selected)
+        Assert.Equal(Runtime.AttentionOutcome.Executed, executedRow.Outcome)
+        Assert.Equal<string option>(None, executedRow.HeatKind)
+
+        let summary = Runtime.summarizeAttentionLedger [ deniedRow; executedRow ]
+
+        Assert.Equal(1, summary.Denied)
+        Assert.Equal(1, summary.Executed)
+        Assert.Equal(1, summary.Backpressured)
+    }
+
+[<Fact>]
 let ``executeCell runs the selected soft CHIP8 scheduler machine`` () =
     task {
         let sink = RecordingHeatSink()

--- a/tests/Tests.FSharp/DarkHallCabinetRuntime.Tests.fs
+++ b/tests/Tests.FSharp/DarkHallCabinetRuntime.Tests.fs
@@ -295,6 +295,60 @@ let ``attention ledger does not label rejected denial heat as policy backpressur
     }
 
 [<Fact>]
+let ``attention ledger does not infer policy backpressure after heat storage errors`` () =
+    task {
+        let address = mkAddress "play" "meta-cart-host"
+        let chip9Cart = CartFixtures.cart CartFixtures.chip9GreenDot
+        let inputCart = CartFixtures.cart CartFixtures.inputFork
+
+        let launch: Runtime.MetaCartLaunch =
+            { Goal = 10
+              Seed = 1UL
+              ParentCapabilities = Chip9Capabilities.metaHost
+              ChildCapabilitiesBySha =
+                MetaCart.capabilityMap
+                    [ chip9Cart, Chip9Capabilities.chip8Default
+                      inputCart, CartFixtures.inputFork.Capabilities ]
+              Children = [ chip9Cart; inputCart ]
+              Parent = Chip8Cow.create 1UL }
+
+        let highAttention: Runtime.MetaCartPolicy =
+            { Name = "operator-attention"
+              Policy = MetaCart.attentionSelectionPolicy (fun slot -> if slot.Name = chip9Cart.Meta.Title then 100.0 else 0.0) }
+
+        let sink =
+            BoundedHeatSink(
+                { Capacity = 0
+                  ForgetPolicy = BoundedGSetForgetPolicy.RejectNew }
+            )
+
+        let! report =
+            Runtime.executeAddressWithAttentionLedger
+                "darkhall"
+                (sink :> IHeatSink)
+                Chip9Capabilities.metaHost
+                Arcade.room
+                address
+                (Runtime.RunMetaCartWithPolicy(highAttention, launch))
+
+        match report.Result with
+        | Error(Runtime.Feedback.MetaCartFeedback(MetaCart.Feedback.HeatRejected(slot, HeatSinkFeedback.StorageError(BoundedGSetError.NonPositiveCapacity capacity)))) ->
+            Assert.Equal(MetaCart.slotOfCart chip9Cart, slot)
+            Assert.Equal(0, capacity)
+        | other -> Assert.Fail(sprintf "expected heat storage error, got %A" other)
+
+        let row = Assert.Single(report.AttentionLedger)
+
+        Assert.Equal(Runtime.AttentionOutcome.HeatRejected, row.Outcome)
+        Assert.Equal<string option>(None, row.HeatKind)
+
+        let summary = Runtime.summarizeAttentionLedger [ row ]
+
+        Assert.Equal(1, summary.HeatRejected)
+        Assert.Equal(0, summary.Backpressured)
+    }
+
+[<Fact>]
 let ``executeCell runs the selected soft CHIP8 scheduler machine`` () =
     task {
         let sink = RecordingHeatSink()

--- a/tests/Tests.FSharp/DarkHallCabinetRuntime.Tests.fs
+++ b/tests/Tests.FSharp/DarkHallCabinetRuntime.Tests.fs
@@ -235,6 +235,66 @@ let ``attention ledger compares denied high-attention future with executed lower
     }
 
 [<Fact>]
+let ``attention ledger does not label rejected denial heat as policy backpressure`` () =
+    task {
+        let address = mkAddress "play" "meta-cart-host"
+        let chip9Cart = CartFixtures.cart CartFixtures.chip9GreenDot
+        let inputCart = CartFixtures.cart CartFixtures.inputFork
+
+        let launch: Runtime.MetaCartLaunch =
+            { Goal = 10
+              Seed = 1UL
+              ParentCapabilities = Chip9Capabilities.metaHost
+              ChildCapabilitiesBySha =
+                MetaCart.capabilityMap
+                    [ chip9Cart, Chip9Capabilities.chip8Default
+                      inputCart, CartFixtures.inputFork.Capabilities ]
+              Children = [ chip9Cart; inputCart ]
+              Parent = Chip8Cow.create 1UL }
+
+        let highAttention: Runtime.MetaCartPolicy =
+            { Name = "operator-attention"
+              Policy = MetaCart.attentionSelectionPolicy (fun slot -> if slot.Name = chip9Cart.Meta.Title then 100.0 else 0.0) }
+
+        let sink =
+            BoundedHeatSink(
+                { Capacity = 1
+                  ForgetPolicy = BoundedGSetForgetPolicy.RejectNew }
+            )
+
+        let filler = HeatSignature.ofMass "test" "heat.fill" 1 1.0 "occupy bounded heat sink"
+
+        match (sink :> IHeatSink).Emit filler with
+        | Ok() -> ()
+        | Error feedback -> Assert.Fail(sprintf "expected heat sink prefill, got %A" feedback)
+
+        let! report =
+            Runtime.executeAddressWithAttentionLedger
+                "darkhall"
+                (sink :> IHeatSink)
+                Chip9Capabilities.metaHost
+                Arcade.room
+                address
+                (Runtime.RunMetaCartWithPolicy(highAttention, launch))
+
+        match report.Result with
+        | Error(Runtime.Feedback.MetaCartFeedback(MetaCart.Feedback.HeatRejected(slot, HeatSinkFeedback.Backpressure(heat, _, _)))) ->
+            Assert.Equal(MetaCart.slotOfCart chip9Cart, slot)
+            Assert.Equal("meta-cart.denied", heat.Kind)
+        | other -> Assert.Fail(sprintf "expected rejected denial heat, got %A" other)
+
+        let row = Assert.Single(report.AttentionLedger)
+
+        Assert.Equal(Runtime.AttentionOutcome.HeatRejected, row.Outcome)
+        Assert.Equal<string option>(None, row.HeatKind)
+
+        let summary = Runtime.summarizeAttentionLedger [ row ]
+
+        Assert.Equal(1, summary.HeatRejected)
+        Assert.Equal(0, summary.Backpressured)
+    }
+
+[<Fact>]
 let ``executeCell runs the selected soft CHIP8 scheduler machine`` () =
     task {
         let sink = RecordingHeatSink()


### PR DESCRIPTION
## What

- Added Dark Hall attention-ledger report types and `executeAddressWithAttentionLedger` / `executeCellWithAttentionLedger` APIs while preserving the existing result-only execution APIs.
- Records meta-cart policy rows with source, address, policy name, baseline slot, selected slot, outcome, reason, and policy-backpressure heat kind.
- Added a regression test comparing a high-attention CHIP-9 child that is denied/backpressured with a lower-attention CHIP-8 child that executes.
- Removed three unused imports from `src/Core.TypeScript/observe/workspace-port.test.ts` so the current TypeScript preflight gate is green.

## Why

Attention should change ordering, not arithmetic truth. This gives the room a typed ledger row for the exact case Aaron called out: high-attention/high-gravity futures board first, but if the capability/byte tank is too small they emit backpressure instead of magically passing.

## Validation

- `dotnet build -c Release`
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --no-build --filter "FullyQualifiedName~DarkHallCabinetRuntimeTests|FullyQualifiedName~MetaCartTests|FullyQualifiedName~DarkHallRoomLoopTests"`
- `dotnet test Zeta.sln -c Release --no-build`
- `dotnet format --verify-no-changes`
- `bun test src/Core.TypeScript/observe/workspace-port.test.ts`
- `bun run preflight:quick` (Go lint skipped locally because the toolchain is unavailable; CI still runs it)

Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: Codex
Agent-Model: gpt-5.5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: not-implied-by-credential
Human-Review-Evidence: none
Action-Mode: human-directed
Task: none
Co-Authored-By: Codex <noreply@openai.com>
