### PR TITLE
docs+memory: type providers = high-leverage cross-oracle (Roslyn/Nemerle); Gates Garden Algebra = Clifford = braided-monoidal shadow + the cart

### DIFF
--- a/docs/research/2026-06-19-adinkra-clifford-e8-unfold-status-cogen-mix-mix-surface-rx-operator-on-soft-phase-spacetime-scoping.md
+++ b/docs/research/2026-06-19-adinkra-clifford-e8-unfold-status-cogen-mix-mix-surface-rx-operator-on-soft-phase-spacetime-scoping.md
@@ -69,6 +69,28 @@ Face 3 **and** the soft-phase unification.
 land. Routing: math team (Clifford→E8 bridge + Face 3; handoff row 10) · the `gen-gen-self-hosting-bytelock`
 trajectory (Face 3 capstone) · Vera (the generator).
 
+## "Garden Algebra" + braided-monoidal generality + the cart (Aaron 2026-06-19)
+
+Aaron: *"I think James Gates calls Clifford 'Garden' algebra; we concluded this is the geometric version of
+more general braided-monoid stuff — it's all related to our cart visualization on CHIP-8."* Three threads to
+keep:
+
+- **Gates' term.** Gates et al. name the adinkra SUSY structure the **"Garden Algebra"** (`GR(d, N)`) — the
+  algebra the adinkra graphs encode, closely tied to the Clifford / doubly-even-code picture. So our `Cl3` /
+  `AdinkraCode` line *is* the Garden-Algebra lineage under its published name (a Beacon anchor: Gates,
+  GR(d,N)).
+- **Clifford = the GEOMETRIC SHADOW of braided-monoidal.** Our conclusion: the Clifford/Garden algebra is the
+  **geometric instance** of the more general **braided monoidal** structure — i.e. the *free braided monoidal
+  category / operad* at the top, with Clifford as its geometric-algebra quotient (exactly
+  `only-the-irreducible-is-primitive`: the free monoidal/operad generator at the top, structured special cases
+  as earned quotients). The algebra ladder (Cayley–Dickson → Clifford → E8) is the geometric shadow of the
+  braided-monoidal generator.
+- **The cart connection.** It all ties to the **CHIP-8 cart visualization** (`ShapeRender` / the cart as one of
+  our common sources of meaning): the cart is the *rendered projection* of this structure — string-diagram /
+  braided-monoidal morphisms made visible as a cart. (Anchors for the generality: Joyal–Street braided
+  monoidal categories; Mac Lane monoidal categories; May operads — the same anchors as
+  `only-the-irreducible-is-primitive`.)
+
 ## External anchors for the DEEPER unfold (Clifford geometric product → E8 root system) — pass to math team
 
 The deeper claim — that the **Clifford geometric product / GA structure *generates* the E8 root system** (beyond

--- a/memory/project_imdb_wikipedia_fsharp_type_providers_reverse_mint_nfts_emergent_clusters_federations_kevin_bacon_2026_06_19.md
+++ b/memory/project_imdb_wikipedia_fsharp_type_providers_reverse_mint_nfts_emergent_clusters_federations_kevin_bacon_2026_06_19.md
@@ -51,3 +51,21 @@ NFT §0a (the backing); the grounding/children's-game thread; `CoEmpowerField` (
 the federation-health metric); `CoordRisk`/`CartelToy`/Aurora-immune (coercive-collapse case only);
 `anchor-to-human-prior-art`; HKT-MDM. Anchors: Six Degrees of Kevin Bacon / Oracle of Bacon; Watts–Strogatz
 small-world; Milgram six-degrees; Erdős number.
+
+## Why type providers are HIGH-LEVERAGE — cross-oracle (Aaron 2026-06-19)
+
+*"All reified F# type providers are high-leverage: they work in C# and our DynamicValue, and we should be able
+to cross-lang-oracle eventually with Roslyn and others for other langs — maybe a homoiconic meta-language like
+Nemerle."* The point: a type provider is **not an F#-only convenience** — it is the **high-leverage cross-oracle
+data substrate**:
+
+- **Reified ⇒ reusable across .NET oracles.** The provided types flow into **C#** and into our **`DynamicValue`**
+  (the universal self-describing payload) — one provider, every .NET consumer.
+- **Cross-language-oracle is the target.** Eventually generate the same typed bindings into the *other* oracles
+  via **Roslyn** source-gen (C#) + each lang's toolchain (TS/Rust/…) — the byte-lock / `gen(gen)` cross-oracle
+  discipline applied to *external-reference types*, so IMDb/Wikipedia bindings are identical across oracles.
+- **A homoiconic meta-language** (e.g. **Nemerle** — macro/metaprogramming .NET lang, already a P3 backlog item)
+  is the natural *generator* for those cross-lang bindings (code=data → emit per-oracle providers from one
+  description). Ties: `DynamicValue`; Roslyn source generators; the `nemerle-dotnet-support-macro-metaprogramming`
+  backlog item; the 4-oracle byte-lock / `gen(gen)` lineage. This is *why* the type provider is the priority
+  lever: build it once, harvest it in every oracle.


### PR DESCRIPTION
Aaron 2026-06-19, two captures:

**(1) Type providers are high-leverage = cross-oracle.** Reified F# type providers work in **C# AND DynamicValue**; target = **cross-language-oracle** via Roslyn (+ each lang toolchain) — byte-lock/gen(gen) applied to external-reference types — possibly generated from a **homoiconic meta-language (Nemerle, P3 backlog)**. Build the IMDb/Wikipedia provider once, harvest in every oracle.

**(2) Gates' "Garden Algebra" (GR(d,N))** = our Cl3/AdinkraCode line under its published name. Clifford = the **geometric shadow of more general braided-monoidal** structure (free braided monoidal category/operad at the top, Clifford an earned quotient — only-the-irreducible-is-primitive); ties to the **CHIP-8 cart** viz (the cart = the rendered string-diagram). Anchors: Gates (GR(d,N)); Joyal–Street; Mac Lane; May. Docs + memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)