### PR TITLE
feat(core): ImdbDataset — typed offline binding over IMDb non-commercial datasets (type-provider slice 1: co-star graph + Bacon number)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -304,6 +304,7 @@
     <Compile Include="AlarmAlgebra.fs" />
     <Compile Include="CoEmpowerField.fs" />
     <Compile Include="CoEmpowerGraph.fs" />
+    <Compile Include="ImdbDataset.fs" />
     <Compile Include="IdentityCapacity.fs" />
     <Compile Include="TrustCalculus.fs" />
     <Compile Include="PrivacyEconomy.fs" />

--- a/src/Core/ImdbDataset.fs
+++ b/src/Core/ImdbDataset.fs
@@ -1,0 +1,108 @@
+namespace Zeta.Core
+
+open System
+
+/// **`ImdbDataset` — typed, OFFLINE, deterministic binding over the IMDb non-commercial datasets (Aaron 2026-06-19, shadow\*).**
+///
+/// The first slice of the **IMDb/Wikipedia type provider** — the external **grounding** for NFT links + the
+/// `network<>creator<>audience` graph. It parses the public **IMDb non-commercial TSV dumps** (`name.basics`,
+/// `title.principals`) into typed records, projects the **co-star graph** (persons linked by a shared title —
+/// the *remembered links between travelers*), computes the **Bacon number** (six-degrees), and projects into a
+/// `CoEmpowerGraph.Graph` so the reverse-mint → cluster/federation pipeline runs on real public data.
+///
+/// **Why offline / dataset (not a live-API design-time provider):** a type provider that hit IMDb/TMDB at
+/// *compile time* would inject **ambient network entropy** (violates noninterference §13 — entropy only through
+/// declared metered channels) and would not be **DST-replayable**. So this slice consumes **declared, local
+/// dataset text** — deterministic, byte-lockable, replayable. IMDb has no free official API (licensed); the
+/// non-commercial TSV datasets are the sanctioned source.
+///
+/// **Honest scope (peel):** this is the **typed binding + graph projection** a provider surfaces — parsing the
+/// dataset shape, not the design-time `ProvidedTypes` wrapper (a follow-on slice), nor live **TMDB/OMDb** /
+/// **Wikidata/DBpedia** (the other legs). It deliberately models only the co-star subset (`name.basics` +
+/// `title.principals`) needed for the Kevin-Bacon demo. Anchors: IMDb non-commercial datasets; Oracle of Bacon
+/// (Tjaden); Milgram six-degrees; Erdős number. Ties: `CoEmpowerGraph`, the NFT-grounding / reverse-mint scope.
+[<RequireQualifiedAccess>]
+module ImdbDataset =
+
+    /// A person row (subset of `name.basics.tsv`).
+    type Name = { Nconst: string; PrimaryName: string }
+
+    /// A credited contribution (subset of `title.principals.tsv`): person `Nconst` on title `Tconst`.
+    type Principal =
+        { Tconst: string
+          Nconst: string
+          Category: string }
+
+    let private cols (line: string) : string[] = line.Split('\t')
+
+    /// IMDb encodes a missing field as the literal `\N`; normalize it to empty.
+    let private denull (s: string) : string =
+        if String.Equals(s, "\\N", StringComparison.Ordinal) then "" else s
+
+    /// Parse `name.basics.tsv` lines (header auto-skipped). Columns: nconst, primaryName, …
+    let parseNames (lines: string seq) : Name list =
+        [ for line in lines do
+              let c = cols line
+              if c.Length >= 2 && not (String.Equals(c.[0], "nconst", StringComparison.Ordinal)) then
+                  yield { Nconst = c.[0]; PrimaryName = denull c.[1] } ]
+
+    /// Parse `title.principals.tsv` lines (header auto-skipped). Columns: tconst, ordering, nconst, category, …
+    let parsePrincipals (lines: string seq) : Principal list =
+        [ for line in lines do
+              let c = cols line
+              if c.Length >= 4 && not (String.Equals(c.[0], "tconst", StringComparison.Ordinal)) then
+                  yield
+                      { Tconst = c.[0]
+                        Nconst = c.[2]
+                        Category = denull c.[3] } ]
+
+    /// The **co-star graph**: distinct persons (nconst, ordinal-sorted) + undirected adjacency where two persons
+    /// share at least one title. Deterministic (ordinal sort + sorted neighbor lists).
+    let coStarAdjacency (principals: Principal list) : string[] * int[][] =
+        let persons =
+            principals
+            |> List.map (fun p -> p.Nconst)
+            |> List.distinct
+            |> List.sortWith (fun a b -> String.CompareOrdinal(a, b))
+            |> List.toArray
+
+        let idx = persons |> Array.mapi (fun i n -> n, i) |> Map.ofArray
+        let adj = Array.init persons.Length (fun _ -> System.Collections.Generic.SortedSet<int>())
+
+        principals
+        |> List.groupBy (fun p -> p.Tconst)
+        |> List.iter (fun (_, ps) ->
+            let ids = ps |> List.map (fun p -> idx.[p.Nconst]) |> List.distinct
+            for a in ids do
+                for b in ids do
+                    if a <> b then adj.[a].Add(b) |> ignore)
+
+        persons, adj |> Array.map Seq.toArray
+
+    /// **Bacon number:** BFS shortest-hop distance from `source` (an nconst) to every person; `-1` if
+    /// unreachable, empty map if the source is absent.
+    let baconNumber (persons: string[]) (adjacency: int[][]) (source: string) : Map<string, int> =
+        match persons |> Array.tryFindIndex (fun n -> String.Equals(n, source, StringComparison.Ordinal)) with
+        | None -> Map.empty
+        | Some s ->
+            let dist = Array.create persons.Length -1
+            dist.[s] <- 0
+            let q = System.Collections.Generic.Queue<int>()
+            q.Enqueue s
+
+            while q.Count > 0 do
+                let u = q.Dequeue()
+                for v in adjacency.[u] do
+                    if dist.[v] < 0 then
+                        dist.[v] <- dist.[u] + 1
+                        q.Enqueue v
+
+            persons |> Array.mapi (fun i n -> n, dist.[i]) |> Map.ofArray
+
+    /// Project the co-star graph into a `CoEmpowerGraph.Graph` (for reverse-mint → cluster/federation). Identities
+    /// are seeded deterministically; every person is a **Creator** (IMDb persons are creators; the *audience* is
+    /// the social-media layer, a separate provider leg). Returns the person index (`nconst` per node) + the graph.
+    let toCoEmpowerGraph (kinds: int) (seed: int) (principals: Principal list) : string[] * CoEmpowerGraph.Graph =
+        let persons, adjacency = coStarAdjacency principals
+        let roles = Array.create persons.Length CoEmpowerGraph.Creator
+        persons, CoEmpowerGraph.seed kinds seed adjacency roles

--- a/tests/Tests.FSharp/Formal/ImdbDataset.Tests.fs
+++ b/tests/Tests.FSharp/Formal/ImdbDataset.Tests.fs
@@ -1,0 +1,75 @@
+module Zeta.Tests.Formal.ImdbDatasetTests
+
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Core
+
+module I = Zeta.Core.ImdbDataset
+
+// ═══════════════════════════════════════════════════════════════════
+// ImdbDataset — typed offline binding over the IMDb non-commercial TSV
+// datasets: parse → co-star graph → Bacon number → CoEmpowerGraph.
+// Fixture: a Bacon chain  nm0001(Bacon)–nm0002–nm0003–nm0004  via three
+// shared titles. Deterministic, offline, byte-lockable.
+// ═══════════════════════════════════════════════════════════════════
+
+// name.basics.tsv (header + 4 persons; \N = missing)
+let private nameLines =
+    [ "nconst\tprimaryName\tbirthYear\tdeathYear\tprimaryProfession\tknownForTitles"
+      "nm0001\tKevin Bacon\t1958\t\\N\tactor\ttt001"
+      "nm0002\tActor B\t\\N\t\\N\tactress\ttt001"
+      "nm0003\tActor C\t\\N\t\\N\tactor\ttt002"
+      "nm0004\tActor D\t\\N\t\\N\tactor\ttt003" ]
+
+// title.principals.tsv (header + a Bacon chain: tt001 {Bacon,B}, tt002 {B,C}, tt003 {C,D})
+let private principalLines =
+    [ "tconst\tordering\tnconst\tcategory\tjob\tcharacters"
+      "tt001\t1\tnm0001\tactor\t\\N\t[\"Ren\"]"
+      "tt001\t2\tnm0002\tactress\t\\N\t\\N"
+      "tt002\t1\tnm0002\tactress\t\\N\t\\N"
+      "tt002\t2\tnm0003\tactor\t\\N\t\\N"
+      "tt003\t1\tnm0003\tactor\t\\N\t\\N"
+      "tt003\t2\tnm0004\tactor\t\\N\t\\N" ]
+
+[<Fact>]
+let ``parseNames skips the header, parses nconst+primaryName, and normalizes \N`` () =
+    let names = I.parseNames nameLines
+    names.Length |> should equal 4
+    names.[0] |> should equal { I.Nconst = "nm0001"; I.PrimaryName = "Kevin Bacon" }
+    names |> List.map (fun n -> n.Nconst) |> should equal [ "nm0001"; "nm0002"; "nm0003"; "nm0004" ]
+
+[<Fact>]
+let ``parsePrincipals skips the header and parses tconst/nconst/category`` () =
+    let ps = I.parsePrincipals principalLines
+    ps.Length |> should equal 6
+    ps.[0] |> should equal ({ Tconst = "tt001"; Nconst = "nm0001"; Category = "actor" }: I.Principal)
+
+[<Fact>]
+let ``the co-star graph links persons who share a title (the Bacon chain)`` () =
+    let persons, adj = I.coStarAdjacency (I.parsePrincipals principalLines)
+    // persons ordinal-sorted: nm0001..nm0004 → indices 0..3
+    persons |> should equal [| "nm0001"; "nm0002"; "nm0003"; "nm0004" |]
+    adj.[0] |> should equal [| 1 |] // Bacon — B
+    adj.[1] |> should equal [| 0; 2 |] // B — Bacon, C
+    adj.[2] |> should equal [| 1; 3 |] // C — B, D
+    adj.[3] |> should equal [| 2 |] // D — C
+
+[<Fact>]
+let ``Bacon number is the six-degrees BFS distance from Kevin Bacon`` () =
+    let persons, adj = I.coStarAdjacency (I.parsePrincipals principalLines)
+    let bn = I.baconNumber persons adj "nm0001"
+    bn.["nm0001"] |> should equal 0
+    bn.["nm0002"] |> should equal 1
+    bn.["nm0003"] |> should equal 2
+    bn.["nm0004"] |> should equal 3
+
+[<Fact>]
+let ``projection to CoEmpowerGraph is deterministic, all-Creator, adjacency-faithful`` () =
+    let ps = I.parsePrincipals principalLines
+    let _, g1 = I.toCoEmpowerGraph 4 7 ps
+    let persons, g2 = I.toCoEmpowerGraph 4 7 ps
+    g1.Identity |> should equal g2.Identity // DST: same args → same graph
+    g2.N |> should equal 4
+    persons |> should equal [| "nm0001"; "nm0002"; "nm0003"; "nm0004" |]
+    g2.Role |> Array.forall (fun r -> r = CoEmpowerGraph.Creator) |> should equal true
+    g2.Adjacency.[1] |> should equal [| 0; 2 |] // the co-star adjacency carried through

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -345,6 +345,7 @@
     <Compile Include="Formal/AlarmAlgebra.Tests.fs" />
     <Compile Include="Formal/CoEmpowerField.Tests.fs" />
     <Compile Include="Formal/CoEmpowerGraph.Tests.fs" />
+    <Compile Include="Formal/ImdbDataset.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />
 
     <!-- Circuit/ -->


### PR DESCRIPTION
Aaron 2026-06-19 *"build the IMDb/Wikipedia type provider."* First slice, **in discipline**: a live-API design-time provider would inject ambient network entropy (violates noninterference §13) and isn't DST-replayable — so this consumes **declared, local dataset text** (deterministic, byte-lockable). IMDb has no free API; the non-commercial TSV dumps are the sanctioned source.

**`src/Core/ImdbDataset.fs`:** typed `Name`/`Principal` over name.basics/title.principals; `parseNames`/`parsePrincipals` (TSV, \N-null, header-skip); **`coStarAdjacency`** (shared-title links = remembered links between travelers); **`baconNumber`** (six-degrees BFS); **`toCoEmpowerGraph`** (project into CoEmpowerGraph for reverse-mint → cluster/federation).

**Honest scope:** the typed binding + graph projection (co-star subset for the Kevin-Bacon demo) — not the design-time ProvidedTypes wrapper nor live TMDB/Wikidata (follow-ons). **5 tests green**, Core 0-warning. Anchors: IMDb non-commercial datasets; Oracle of Bacon; Milgram; Erdős.

🤖 Generated with [Claude Code](https://claude.com/claude-code)