### PR TITLE
feat(core)+memory: TtlCache (soft-phase+UTC injected clock — respect the sites) + open-datasets/ZSet/schema-evolution scope

### DIFF
--- a/memory/project_imdb_wikipedia_fsharp_type_providers_reverse_mint_nfts_emergent_clusters_federations_kevin_bacon_2026_06_19.md
+++ b/memory/project_imdb_wikipedia_fsharp_type_providers_reverse_mint_nfts_emergent_clusters_federations_kevin_bacon_2026_06_19.md
@@ -69,3 +69,26 @@ data substrate**:
   description). Ties: `DynamicValue`; Roslyn source generators; the `nemerle-dotnet-support-macro-metaprogramming`
   backlog item; the 4-oracle byte-lock / `gen(gen)` lineage. This is *why* the type provider is the priority
   lever: build it once, harvest it in every oracle.
+
+## Caching · open datasets · reified-bounded-timeframe → ZSets / CE / zero-downtime schema-evolution (Aaron 2026-06-19)
+
+- **TTL cache — BUILT (`src/Core/TtlCache.fs`).** Cache the reified graphs keyed by source, valid for a TTL;
+  hit the source **only on miss/expiry** — *"don't always go to source; that's not respecting the sites."*
+  Injected clock (immutable `Map`, idempotent, DST). **The clock IS soft phase-spacetime generated time coupled
+  with UTC observables** (Aaron): since the sources are on Earth, **UTC ± uncertainty is the best Earth-time**,
+  captured as a correlated observation of the common-seed phase (the Zeta-NTP coupling — existing
+  code/math/backlog; [[project_zeta_ntp_phase_grounded_network_time_across_all_space_and_time_2026_06_19]]).
+- **Open datasets to bundle (Aaron):** prefer freely-licensed sources we can include or download-script:
+  **Wikidata** dumps (CC0 — bundleable), **DBpedia** (CC-BY-SA), **IMDb** non-commercial TSV
+  (personal/non-commercial — commit a *small sample fixture*; full set via a download script, not committed
+  wholesale). **TMDB/OMDb** = API ToS → *don't bundle*, cache with TTL. Land under `references/prior-art/`
+  (gitignored, explicit-target) or a download script; record per-source licensing honestly.
+- **Reified over a bounded timeframe + HKT → ZSets / graphs / CE / zero-downtime schema-evolution (Aaron):**
+  *"reified over some bounded timeframe with our HKT recursive type hacks we can plug this into our own ZSets,
+  graphs, computational expressions, and schema-evolution zero-downtime."* The reified (TTL-bounded) snapshot
+  becomes a **ZSet** (incremental / DBSP-delta-able) → composes via the **HKT recursive-type** machinery into
+  our **graphs** + **computational expressions** → and rides the **gset-expand / zset-contract zero-downtime
+  schema-evolution** when the external schema changes. So the external graph plugs *natively* into the Zeta
+  substrate and evolves without downtime. Ties: `TtlCache`; `ZSet`/`IndexedZSet` (DBSP); HKT-MDM /
+  recursive-HKT; `docs/research/2026-06-15-zero-downtime-schema-change-…` (gset-expand/zset-contract);
+  `CoEmpowerGraph` (the reverse-mint target).

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -305,6 +305,7 @@
     <Compile Include="CoEmpowerField.fs" />
     <Compile Include="CoEmpowerGraph.fs" />
     <Compile Include="ImdbDataset.fs" />
+    <Compile Include="TtlCache.fs" />
     <Compile Include="IdentityCapacity.fs" />
     <Compile Include="TrustCalculus.fs" />
     <Compile Include="PrivacyEconomy.fs" />

--- a/src/Core/TtlCache.fs
+++ b/src/Core/TtlCache.fs
@@ -1,0 +1,60 @@
+namespace Zeta.Core
+
+/// **`TtlCache` — a time-to-live cache with an INJECTED clock (Aaron 2026-06-19, shadow\*).**
+///
+/// The "don't re-source every time / respect the sites" mechanism for the IMDb/Wikipedia type provider: cache
+/// the **reified graphs** (e.g. `ImdbDataset.toCoEmpowerGraph`) keyed by source, valid for a TTL, so an
+/// external source is hit **only on a miss or after expiry** — respecting the source sites' ToS / rate limits.
+///
+/// **In discipline:** the clock is **injected** — `now` is passed in, never an ambient `DateTime.Now`
+/// (noninterference §13: entropy/time only through declared channels). Per the **Zeta-NTP** model, `now` is the
+/// **soft phase-spacetime generated time** (the common-seed phase tick — the canonical soft base) **coupled
+/// with UTC observables**: because these data sources are *on Earth*, **UTC (± uncertainty) is the best
+/// Earth-time we have**, captured as a *correlated observation* of the soft phase, not as the base itself.
+/// (The UTC ↔ common-seed-phase coupling has existing code/math/backlog —
+/// `memory/project_zeta_ntp_phase_grounded_…`.) The cache is an **immutable `Map`** ⇒ lock-free, **idempotent**
+/// (upsert by key), and **DST-replayable / byte-lockable** (same `now`/`ttl`/ops ⇒ same cache). "Bounded
+/// timeframe" = the TTL window (in phase-time, UTC-anchored) the data is reified over.
+[<RequireQualifiedAccess>]
+module TtlCache =
+
+    /// A cached value + the tick at which it expires (exclusive: live while `now < ExpiresAt`).
+    type Entry<'V> = { Value: 'V; ExpiresAt: int64 }
+
+    /// Immutable cache: key → entry.
+    type Cache<'K, 'V when 'K: comparison> = Map<'K, Entry<'V>>
+
+    let empty<'K, 'V when 'K: comparison> : Cache<'K, 'V> = Map.empty
+
+    /// Insert/refresh `key` with `value`, valid for `ttl` ticks from `now`. Idempotent (upsert by key).
+    let put (now: int64) (ttl: int64) (key: 'K) (value: 'V) (cache: Cache<'K, 'V>) : Cache<'K, 'V> =
+        Map.add key { Value = value; ExpiresAt = now + ttl } cache
+
+    /// Look up `key` as of `now`: `Some value` iff present **and** not expired (`now < ExpiresAt`); else `None`.
+    let tryGet (now: int64) (key: 'K) (cache: Cache<'K, 'V>) : 'V option =
+        match Map.tryFind key cache with
+        | Some e when now < e.ExpiresAt -> Some e.Value
+        | _ -> None
+
+    /// **Get-or-source:** return the cached value if live; else call `source` (the expensive / site-hitting
+    /// reifier — invoked **only** on miss/expiry, the rate-respecting path), cache it for `ttl`, and return both.
+    let getOrSource
+        (now: int64)
+        (ttl: int64)
+        (key: 'K)
+        (source: unit -> 'V)
+        (cache: Cache<'K, 'V>)
+        : 'V * Cache<'K, 'V> =
+        match tryGet now key cache with
+        | Some v -> v, cache
+        | None ->
+            let v = source ()
+            v, put now ttl key v cache
+
+    /// Drop expired entries (optional housekeeping; `tryGet` already treats expired as absent).
+    let evictExpired (now: int64) (cache: Cache<'K, 'V>) : Cache<'K, 'V> =
+        cache |> Map.filter (fun _ e -> now < e.ExpiresAt)
+
+    /// Count of live (non-expired) entries as of `now`.
+    let liveCount (now: int64) (cache: Cache<'K, 'V>) : int =
+        cache |> Map.filter (fun _ e -> now < e.ExpiresAt) |> Map.count

--- a/tests/Tests.FSharp/Formal/TtlCache.Tests.fs
+++ b/tests/Tests.FSharp/Formal/TtlCache.Tests.fs
@@ -1,0 +1,61 @@
+module Zeta.Tests.Formal.TtlCacheTests
+
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Core
+
+module C = Zeta.Core.TtlCache
+
+// ═══════════════════════════════════════════════════════════════════
+// TtlCache — injected-clock, immutable TTL cache (the "respect the
+// sites / don't re-source" mechanism). Deterministic: now is passed in.
+// ═══════════════════════════════════════════════════════════════════
+
+[<Fact>]
+let ``a value is live before expiry and gone after (now < ExpiresAt)`` () =
+    let cache = C.empty |> C.put 100L 10L "k" "v" // expires at 110
+    C.tryGet 105L "k" cache |> should equal (Some "v") // live
+    C.tryGet 109L "k" cache |> should equal (Some "v") // still live
+    C.tryGet 110L "k" cache |> should equal (None: string option) // expired (exclusive)
+    C.tryGet 200L "k" cache |> should equal (None: string option)
+
+[<Fact>]
+let ``getOrSource hits the source only on miss/expiry (rate-respect)`` () =
+    let mutable calls = 0
+    let source () = calls <- calls + 1; "graph"
+    let c0 = C.empty
+    // first call: miss → sources once
+    let v1, c1 = C.getOrSource 0L 50L "imdb" source c0
+    v1 |> should equal "graph"
+    calls |> should equal 1
+    // second call within TTL: hit → does NOT re-source
+    let v2, c2 = C.getOrSource 40L 50L "imdb" source c1
+    v2 |> should equal "graph"
+    calls |> should equal 1
+    // after expiry: miss → sources again
+    let v3, _ = C.getOrSource 60L 50L "imdb" source c2
+    v3 |> should equal "graph"
+    calls |> should equal 2
+
+[<Fact>]
+let ``put is idempotent — re-putting a key upserts (one entry, refreshed expiry)`` () =
+    let cache = C.empty |> C.put 0L 10L "k" "a" |> C.put 5L 10L "k" "b" // refresh at 5, expires 15
+    C.liveCount 6L cache |> should equal 1
+    C.tryGet 14L "k" cache |> should equal (Some "b") // refreshed value + window
+    C.tryGet 16L "k" cache |> should equal (None: string option)
+
+[<Fact>]
+let ``evictExpired drops only expired entries`` () =
+    let cache =
+        C.empty
+        |> C.put 0L 10L "old" "x" // expires 10
+        |> C.put 0L 100L "new" "y" // expires 100
+    let pruned = C.evictExpired 50L cache
+    C.tryGet 50L "old" pruned |> should equal (None: string option)
+    C.tryGet 50L "new" pruned |> should equal (Some "y")
+    C.liveCount 50L pruned |> should equal 1
+
+[<Fact>]
+let ``DST: same now/ttl/ops produce identical caches`` () =
+    let build () = C.empty |> C.put 10L 20L "a" 1 |> C.put 12L 20L "b" 2
+    (build ()) |> should equal (build ())

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -346,6 +346,7 @@
     <Compile Include="Formal/CoEmpowerField.Tests.fs" />
     <Compile Include="Formal/CoEmpowerGraph.Tests.fs" />
     <Compile Include="Formal/ImdbDataset.Tests.fs" />
+    <Compile Include="Formal/TtlCache.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />
 
     <!-- Circuit/ -->


### PR DESCRIPTION
Aaron 2026-06-19. The **"cache the graphs with TTL so we're not always going to source (respect the sites)"** mechanism, in discipline.

**`src/Core/TtlCache.fs`:** injected-clock, immutable-Map TTL cache. `getOrSource` hits the source **only on miss/expiry** (rate-respect); idempotent `put`; `evictExpired`; `liveCount`. **The clock is soft phase-spacetime generated time coupled with UTC observables** — Earth sources → UTC ± uncertainty is the best Earth-time, a correlated observation of the common-seed phase (Zeta-NTP). Noninterference-clean, DST-replayable. **5 tests green**, Core 0-warning.

**Memory captures:** (a) **open datasets** — Wikidata (CC0), DBpedia (CC-BY-SA), IMDb non-commercial TSV (sample fixture + download script), TMDB/OMDb (ToS → cache, don't bundle). (b) **reified-bounded-timeframe + HKT → ZSets/graphs/CE + gset-expand/zset-contract zero-downtime schema-evolution**: the TTL-bounded snapshot becomes a ZSet that plugs natively into the substrate and evolves without downtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)