### PR TITLE
feat(core): CostarFederations — the end-to-end IMDb through-line (reverse-mint → federation health → cached)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -306,6 +306,7 @@
     <Compile Include="CoEmpowerGraph.fs" />
     <Compile Include="ImdbDataset.fs" />
     <Compile Include="TtlCache.fs" />
+    <Compile Include="CostarFederations.fs" />
     <Compile Include="IdentityCapacity.fs" />
     <Compile Include="TrustCalculus.fs" />
     <Compile Include="PrivacyEconomy.fs" />

--- a/src/Core/CostarFederations.fs
+++ b/src/Core/CostarFederations.fs
@@ -1,0 +1,81 @@
+namespace Zeta.Core
+
+open System
+
+/// **`CostarFederations` — the end-to-end IMDb pipeline (Aaron 2026-06-19, shadow\*).**
+///
+/// Ties the three slices into the through-line: **`ImdbDataset`** (co-star graph) → **reverse-mint** the
+/// co-star links (objectively rated) → **`CoEmpowerGraph`** (characterize emergent clusters/federations) →
+/// **`TtlCache`** (cache the reified graph on the soft-phase + UTC clock; source only on miss/expiry).
+///
+/// This realizes, on real public data, the carved thesis: an **NFT = an objectively-rateable remembered link
+/// between travelers** (here, a co-star link rated by the number of titles two people share — the QPG analogue
+/// from the actual record), and **reverse-mint → emergent federations** (neutral clusters, *characterized* by
+/// the co-empowerment / diversity health, never hunted). Deterministic (DST), offline.
+[<RequireQualifiedAccess>]
+module CostarFederations =
+
+    /// A reverse-minted co-star link — a *remembered link between two travelers* — objectively rated by the
+    /// number of titles they share (`SharedTitles`: the link's quality on the real record). `A < B` (ordinal).
+    type MintedLink =
+        { A: string
+          B: string
+          SharedTitles: int }
+
+    /// **Reverse-mint** every co-star link from the principals: each pair sharing ≥ 1 title becomes a
+    /// `MintedLink` rated by its shared-title count. Deterministic (ordinal-sorted by `(A, B)`).
+    let reverseMint (principals: ImdbDataset.Principal list) : MintedLink list =
+        let pairCounts = System.Collections.Generic.Dictionary<struct (string * string), int>()
+
+        principals
+        |> List.groupBy (fun p -> p.Tconst)
+        |> List.iter (fun (_, ps) ->
+            let persons =
+                ps
+                |> List.map (fun p -> p.Nconst)
+                |> List.distinct
+                |> List.sortWith (fun a b -> String.CompareOrdinal(a, b))
+                |> List.toArray
+
+            for i in 0 .. persons.Length - 1 do
+                for j in i + 1 .. persons.Length - 1 do
+                    let key = struct (persons.[i], persons.[j])
+                    let prev =
+                        match pairCounts.TryGetValue key with
+                        | true, v -> v
+                        | _ -> 0
+                    pairCounts.[key] <- prev + 1)
+
+        [ for kv in pairCounts ->
+              let struct (a, b) = kv.Key
+              { A = a; B = b; SharedTitles = kv.Value } ]
+        |> List.sortWith (fun x y ->
+            let c = String.CompareOrdinal(x.A, y.A)
+            if c <> 0 then c else String.CompareOrdinal(x.B, y.B))
+
+    /// The full characterization: the minted links, the emergent-federation health, and Bacon numbers from a
+    /// chosen source person.
+    type Report =
+        { Links: MintedLink list
+          Health: CoEmpowerGraph.Health
+          BaconFrom: Map<string, int> }
+
+    let report (kinds: int) (seed: int) (baconSource: string) (principals: ImdbDataset.Principal list) : Report =
+        let persons, adjacency = ImdbDataset.coStarAdjacency principals
+        let _, graph = ImdbDataset.toCoEmpowerGraph kinds seed principals
+        { Links = reverseMint principals
+          Health = CoEmpowerGraph.health graph
+          BaconFrom = ImdbDataset.baconNumber persons adjacency baconSource }
+
+    /// Cache the reified co-star graph via `TtlCache` (injected soft-phase + UTC `now`): the reifier runs **only**
+    /// on miss/expiry — respecting the source site. Returns the graph + the updated cache.
+    let cachedGraph
+        (now: int64)
+        (ttl: int64)
+        (sourceId: string)
+        (kinds: int)
+        (seed: int)
+        (principals: ImdbDataset.Principal list)
+        (cache: TtlCache.Cache<string, CoEmpowerGraph.Graph>)
+        : CoEmpowerGraph.Graph * TtlCache.Cache<string, CoEmpowerGraph.Graph> =
+        TtlCache.getOrSource now ttl sourceId (fun () -> snd (ImdbDataset.toCoEmpowerGraph kinds seed principals)) cache

--- a/tests/Tests.FSharp/Formal/CostarFederations.Tests.fs
+++ b/tests/Tests.FSharp/Formal/CostarFederations.Tests.fs
@@ -1,0 +1,61 @@
+module Zeta.Tests.Formal.CostarFederationsTests
+
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Core
+
+module F = Zeta.Core.CostarFederations
+module I = Zeta.Core.ImdbDataset
+
+// ═══════════════════════════════════════════════════════════════════
+// CostarFederations — the end-to-end IMDb through-line: reverse-mint
+// co-star links (rated by shared titles) → federation health → cached
+// reified graph. Fixture: Bacon chain + a repeat title (tt004) so the
+// Bacon↔B link is rated 2 (objective rating varies).
+// ═══════════════════════════════════════════════════════════════════
+
+let private principals =
+    I.parsePrincipals
+        [ "tconst\tordering\tnconst\tcategory\tjob\tcharacters"
+          "tt001\t1\tnm0001\tactor\t\\N\t\\N"
+          "tt001\t2\tnm0002\tactress\t\\N\t\\N"
+          "tt002\t1\tnm0002\tactress\t\\N\t\\N"
+          "tt002\t2\tnm0003\tactor\t\\N\t\\N"
+          "tt003\t1\tnm0003\tactor\t\\N\t\\N"
+          "tt003\t2\tnm0004\tactor\t\\N\t\\N"
+          "tt004\t1\tnm0001\tactor\t\\N\t\\N" // a SECOND Bacon–B title
+          "tt004\t2\tnm0002\tactress\t\\N\t\\N" ]
+
+[<Fact>]
+let ``reverse-mint produces the co-star links, objectively rated by shared-title count`` () =
+    let links = F.reverseMint principals
+    links
+    |> should
+        equal
+        [ { F.A = "nm0001"; F.B = "nm0002"; F.SharedTitles = 2 } // Bacon–B share tt001 + tt004
+          { F.A = "nm0002"; F.B = "nm0003"; F.SharedTitles = 1 }
+          { F.A = "nm0003"; F.B = "nm0004"; F.SharedTitles = 1 } ]
+
+[<Fact>]
+let ``report carries federation health + Bacon numbers`` () =
+    let r = F.report 4 7 "nm0001" principals
+    r.Links.Length |> should equal 3
+    r.BaconFrom.["nm0001"] |> should equal 0
+    r.BaconFrom.["nm0004"] |> should equal 3
+    r.Health.Diversity |> should be (greaterThanOrEqualTo 1)
+
+[<Fact>]
+let ``cachedGraph sources on miss, then serves from cache within TTL (respects the source)`` () =
+    let c0 = TtlCache.empty
+    let g1, c1 = F.cachedGraph 1000L 500L "imdb:costar" 4 7 principals c0
+    TtlCache.liveCount 1000L c1 |> should equal 1 // populated
+    let g2, _ = F.cachedGraph 1200L 500L "imdb:costar" 4 7 principals c1 // within TTL → cache hit
+    g1.Identity |> should equal g2.Identity
+    g2.N |> should equal 4
+
+[<Fact>]
+let ``the pipeline is deterministic (DST) — same principals/seed → same report`` () =
+    let a = F.report 4 7 "nm0001" principals
+    let b = F.report 4 7 "nm0001" principals
+    a.Links |> should equal b.Links
+    a.Health |> should equal b.Health

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -347,6 +347,7 @@
     <Compile Include="Formal/CoEmpowerGraph.Tests.fs" />
     <Compile Include="Formal/ImdbDataset.Tests.fs" />
     <Compile Include="Formal/TtlCache.Tests.fs" />
+    <Compile Include="Formal/CostarFederations.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />
 
     <!-- Circuit/ -->


### PR DESCRIPTION
Aaron 2026-06-19 *"let's do it."* Ties the three slices into the working pipeline: **ImdbDataset** (co-star graph) → **reverse-mint** the links (objectively rated) → **CoEmpowerGraph** (emergent federation health) → **TtlCache** (cache the reified graph on the soft-phase+UTC clock; source only on miss/expiry).

Realizes the thesis on real public data: an **NFT = objectively-rateable remembered link between travelers** (co-star link rated by `SharedTitles` — the QPG analogue from the record); **reverse-mint → emergent federations** (characterized, not hunted).

**`src/Core/CostarFederations.fs`:** `MintedLink`; `reverseMint`; `Report{Links;Health;BaconFrom}`; `report`; `cachedGraph`. **4 tests green**, Core 0-warning: rating (Bacon–B rated 2); report (federation health + Bacon numbers); cachedGraph (miss-sources/hit-serves); DST determinism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)