### PR TITLE
[codex] fix TtlCache determinism lint doc token

### DIFF
--- a/src/Core/TtlCache.fs
+++ b/src/Core/TtlCache.fs
@@ -6,7 +6,7 @@ namespace Zeta.Core
 /// the **reified graphs** (e.g. `ImdbDataset.toCoEmpowerGraph`) keyed by source, valid for a TTL, so an
 /// external source is hit **only on a miss or after expiry** — respecting the source sites' ToS / rate limits.
 ///
-/// **In discipline:** the clock is **injected** — `now` is passed in, never an ambient `DateTime.Now`
+/// **In discipline:** the clock is **injected** — `now` is passed in, never an ambient local wall-clock read
 /// (noninterference §13: entropy/time only through declared channels). Per the **Zeta-NTP** model, `now` is the
 /// **soft phase-spacetime generated time** (the common-seed phase tick — the canonical soft base) **coupled
 /// with UTC observables**: because these data sources are *on Earth*, **UTC (± uncertainty) is the best


### PR DESCRIPTION
## What

- Reworded the `TtlCache` injected-clock doc comment to avoid spelling a banned ambient wall-clock token.

## Why

The implementation was already deterministic and injected-clock only, but the determinism lint intentionally scans comments. The ARM CI runner caught the literal token in the doc comment, so this keeps the source text inside the lint contract without weakening the rule or adding an allowlist row.

## Validation

- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter "FullyQualifiedName~DeterminismLintTests"`
- `dotnet build -c Release`
- `dotnet format --verify-no-changes`
- `bun run preflight:quick` (Go lint skipped locally because the toolchain is unavailable; CI still runs it)

Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: Codex
Agent-Model: gpt-5.5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: not-implied-by-credential
Human-Review-Evidence: none
Action-Mode: human-directed
Task: none
Co-Authored-By: Codex <noreply@openai.com>
