### PR TITLE
feat(core): CostarZSet — co-star link-set as a DBSP ZSet (reverse-mint = a fold; incremental deltas; schema-evolution-ready)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -307,6 +307,7 @@
     <Compile Include="ImdbDataset.fs" />
     <Compile Include="TtlCache.fs" />
     <Compile Include="CostarFederations.fs" />
+    <Compile Include="CostarZSet.fs" />
     <Compile Include="IdentityCapacity.fs" />
     <Compile Include="TrustCalculus.fs" />
     <Compile Include="PrivacyEconomy.fs" />

--- a/src/Core/CostarZSet.fs
+++ b/src/Core/CostarZSet.fs
@@ -1,0 +1,61 @@
+namespace Zeta.Core
+
+open System
+
+/// **`CostarZSet` — the co-star link-set as a DBSP `ZSet` (Aaron 2026-06-19, shadow\*).**
+///
+/// The "reified over a bounded timeframe → plug into our own **ZSets** / **schema-evolution zero-downtime**"
+/// leg. The co-star links of `ImdbDataset` become a **`ZSet<Link>`** where the **weight is the shared-title
+/// count** — so **reverse-mint *is* a ZSet fold** (sum of per-title deltas), and the objective link rating
+/// (`SharedTitles`) is just the accumulated weight.
+///
+/// Because it is a ZSet, the graph is **DBSP-incremental**: adding a title is a `+` delta (`addTitle`), and
+/// removing one is the **Z-set antiparticle** (`removeTitle`, `−1` weights) — `add then remove = identity`,
+/// and an incremental add equals a full recompute (IVM correctness). The link's **`DynamicValue`** form rides
+/// **`SchemaEvolution`** for **zero-downtime** schema change (additive expand is forward/back compatible;
+/// non-destructive contract via the dump).
+[<RequireQualifiedAccess>]
+module CostarZSet =
+
+    /// A co-star link as a ZSet key: the unordered pair, stored ordinal `A ≤ B`. The ZSet **weight** carries the
+    /// shared-title count, so the key is just the pair.
+    type Link = { A: string; B: string }
+
+    /// Canonical (ordinal-ordered) link for an unordered pair.
+    let link (a: string) (b: string) : Link =
+        if String.CompareOrdinal(a, b) <= 0 then { A = a; B = b } else { A = b; B = a }
+
+    /// The co-star pairs contributed by ONE title, each at weight `+1` (the title's ZSet delta).
+    let titleDelta (persons: string seq) : ZSet<Link> =
+        let arr =
+            persons |> Seq.distinct |> Seq.sortWith (fun a b -> String.CompareOrdinal(a, b)) |> Seq.toArray
+
+        ZSet.ofSeq
+            [ for i in 0 .. arr.Length - 1 do
+                  for j in i + 1 .. arr.Length - 1 -> link arr.[i] arr.[j], 1L ]
+
+    /// The accumulated co-star ZSet — **reverse-mint AS a ZSet fold** (sum of per-title deltas). Each link's
+    /// weight = the number of shared titles (the objective rating).
+    let ofPrincipals (principals: ImdbDataset.Principal list) : ZSet<Link> =
+        principals
+        |> List.groupBy (fun p -> p.Tconst)
+        |> List.map (fun (_, ps) -> titleDelta (ps |> List.map (fun p -> p.Nconst)))
+        |> ZSet.sum
+
+    /// **Incremental add** of a title (DBSP delta): `z + titleDelta`. Equals a full recompute (IVM correctness).
+    let addTitle (persons: string seq) (z: ZSet<Link>) : ZSet<Link> = ZSet.add z (titleDelta persons)
+
+    /// **Incremental retraction** of a title (the Z-set antiparticle, `−1` weights): `add` then `remove` = identity.
+    let removeTitle (persons: string seq) (z: ZSet<Link>) : ZSet<Link> =
+        ZSet.add z (ZSet.scale -1L (titleDelta persons))
+
+    /// Shared-title count (the rating) of a pair = the link's ZSet weight (`0` if absent).
+    let sharedTitles (a: string) (b: string) (z: ZSet<Link>) : int64 = z.[link a b]
+
+    /// A link + its rating as a `DynamicValue` record — the bridge to `SchemaEvolution` (zero-downtime schema
+    /// change on the link shape).
+    let toDynamicValue (rating: int64) (l: Link) : DynamicValue =
+        DynamicValue.Object
+            [ "a", DynamicValue.String l.A
+              "b", DynamicValue.String l.B
+              "sharedTitles", DynamicValue.Int rating ]

--- a/tests/Tests.FSharp/Formal/CostarZSet.Tests.fs
+++ b/tests/Tests.FSharp/Formal/CostarZSet.Tests.fs
@@ -1,0 +1,56 @@
+module Zeta.Tests.Formal.CostarZSetTests
+
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Core
+
+module Z = Zeta.Core.CostarZSet
+module I = Zeta.Core.ImdbDataset
+
+// ═══════════════════════════════════════════════════════════════════
+// CostarZSet — the co-star link-set as a DBSP ZSet: reverse-mint = a
+// ZSet fold (weight = shared-title count); add/remove-title = deltas
+// (IVM correctness + Z-set antiparticle); link DynamicValue rides
+// SchemaEvolution for zero-downtime schema change.
+// ═══════════════════════════════════════════════════════════════════
+
+let private baseLines =
+    [ "tconst\tordering\tnconst\tcategory\tjob\tcharacters"
+      "tt001\t1\tnm0001\tactor\t\\N\t\\N"
+      "tt001\t2\tnm0002\tactress\t\\N\t\\N"
+      "tt002\t1\tnm0002\tactress\t\\N\t\\N"
+      "tt002\t2\tnm0003\tactor\t\\N\t\\N" ]
+
+let private tt003 = [ "tt003\t1\tnm0003\tactor\t\\N\t\\N"; "tt003\t2\tnm0004\tactor\t\\N\t\\N" ]
+
+[<Fact>]
+let ``reverse-mint AS a ZSet: a link's weight is its shared-title count`` () =
+    let withRepeat =
+        I.parsePrincipals (
+            baseLines
+            @ [ "tt004\t1\tnm0001\tactor\t\\N\t\\N"; "tt004\t2\tnm0002\tactress\t\\N\t\\N" ]
+        ) // a SECOND nm0001–nm0002 title
+    let z = Z.ofPrincipals withRepeat
+    Z.sharedTitles "nm0001" "nm0002" z |> should equal 2L // tt001 + tt004
+    Z.sharedTitles "nm0002" "nm0003" z |> should equal 1L
+    Z.sharedTitles "nm0001" "nm9999" z |> should equal 0L // absent → 0
+
+[<Fact>]
+let ``incremental addTitle equals a full recompute (DBSP IVM correctness)`` () =
+    let incremental = Z.ofPrincipals (I.parsePrincipals baseLines) |> Z.addTitle [ "nm0003"; "nm0004" ]
+    let full = Z.ofPrincipals (I.parsePrincipals (baseLines @ tt003))
+    incremental |> should equal full
+
+[<Fact>]
+let ``removeTitle retracts (the Z-set antiparticle): add then remove = identity`` () =
+    let baseZ = Z.ofPrincipals (I.parsePrincipals baseLines)
+    let roundTrip = baseZ |> Z.addTitle [ "nm0003"; "nm0004" ] |> Z.removeTitle [ "nm0003"; "nm0004" ]
+    roundTrip |> should equal baseZ
+
+[<Fact>]
+let ``the link DynamicValue rides SchemaEvolution: additive expand then contract round-trips (zero-downtime)`` () =
+    let dv = Z.toDynamicValue 2L ({ A = "nm0001"; B = "nm0002" }: Z.Link)
+    let expanded = SchemaEvolution.addField "medium" (DynamicValue.String "film") dv
+    expanded |> should not' (equal dv) // the new field is present (expand)
+    let contracted = SchemaEvolution.removeField "medium" expanded
+    contracted |> should equal dv // expand → contract is identity on the core (no data loss)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -348,6 +348,7 @@
     <Compile Include="Formal/ImdbDataset.Tests.fs" />
     <Compile Include="Formal/TtlCache.Tests.fs" />
     <Compile Include="Formal/CostarFederations.Tests.fs" />
+    <Compile Include="Formal/CostarZSet.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />
 
     <!-- Circuit/ -->


### PR DESCRIPTION
Aaron 2026-06-19 (picked the ZSet/schema-evolution plug-in). The **"reified → plug into our own ZSets / schema-evolution zero-downtime"** leg.

**`src/Core/CostarZSet.fs`:** the co-star links become a **`ZSet<Link>`** with **weight = shared-title count** — so **reverse-mint *is* a ZSet fold** (sum of per-title deltas) and the rating = the accumulated weight. DBSP-incremental: **`addTitle`** = a `+` delta (== full recompute, IVM correctness); **`removeTitle`** = the Z-set antiparticle (`−1`; add-then-remove = identity). The link's **`DynamicValue`** rides **`SchemaEvolution`** for zero-downtime schema change.

**4 tests green**, Core 0-warning: reverse-mint-as-ZSet (Bacon–B weight 2); incremental == full recompute; retraction identity; DynamicValue expand→contract round-trip. Ties: ZSet (DBSP); SchemaEvolution; ImdbDataset/CostarFederations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)