### PR TITLE
feat(core): LiveLegs — live TMDB + Wikidata legs behind an injected Fetch port (offline-tested, opt-in live edge)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -308,6 +308,7 @@
     <Compile Include="TtlCache.fs" />
     <Compile Include="CostarFederations.fs" />
     <Compile Include="CostarZSet.fs" />
+    <Compile Include="LiveLegs.fs" />
     <Compile Include="IdentityCapacity.fs" />
     <Compile Include="TrustCalculus.fs" />
     <Compile Include="PrivacyEconomy.fs" />

--- a/src/Core/LiveLegs.fs
+++ b/src/Core/LiveLegs.fs
@@ -1,0 +1,121 @@
+namespace Zeta.Core
+
+open System
+open System.Text.Json
+
+/// **`LiveLegs` — the live TMDB + Wikidata legs of the IMDb/Wikipedia type provider (Aaron 2026-06-19, shadow\*).**
+///
+/// The network-touching legs, built **in discipline**. The only door for network entropy is the **injected
+/// `Fetch` port** — a `string -> Async<string>` passed in, never an ambient `HttpClient` (noninterference §13:
+/// entropy/IO only through declared, metered channels). The leg *logic* (URL build → fetch via port → parse
+/// JSON → typed rows) is **pure w.r.t. the port**, so it is fully **offline-testable** and **DST-replayable**:
+/// a `recordedFetch` replays a captured `url → response` map deterministically (the record/replay membrane).
+///
+/// Results feed the SAME pipeline as `ImdbDataset` (the parsers emit `ImdbDataset.Principal`s → the co-star
+/// graph / `CostarZSet` / `CostarFederations`) and should be wrapped in `TtlCache` (respect the sites).
+///
+/// **Honest scope (peel):** `liveFetch` (the real `HttpClient` adapter) is the **opt-in network edge** — it is
+/// the *only* code here that touches the network, is **not exercised in CI** (determinism / noninterference),
+/// and carries the ToS caveat (TMDB needs an API key; Wikidata WDQS has rate limits — always `TtlCache` it).
+/// Same posture as the unverified-Q# lane: the capability is provided; the live call is opt-in. The parsers
+/// model the subset needed for the co-star / entity graph, not the full APIs.
+[<RequireQualifiedAccess>]
+module LiveLegs =
+
+    /// The injected network port — the single declared channel for external entropy. Inject a `recordedFetch`
+    /// (tests / DST replay) or `liveFetch` (the opt-in real edge).
+    type Fetch = string -> Async<string>
+
+    /// A deterministic, OFFLINE `Fetch` that replays a captured `url → response` map (DST record/replay). A
+    /// missing url is a replay-invariant violation (raised, not silently empty — no hidden gaps).
+    let recordedFetch (responses: Map<string, string>) : Fetch =
+        fun url ->
+            async {
+                match Map.tryFind url responses with
+                | Some r -> return r
+                | None -> return invalidOp (String.Concat("recordedFetch: no recording for ", url))
+            }
+
+    let private propString (el: JsonElement) (name: string) : string =
+        match el.TryGetProperty name with
+        | true, v ->
+            match v.ValueKind with
+            | JsonValueKind.String ->
+                match v.GetString() with
+                | null -> ""
+                | s -> s
+            | JsonValueKind.Null -> ""
+            | _ -> v.GetRawText()
+        | _ -> ""
+
+    /// ── TMDB leg ──────────────────────────────────────────────────────────────────────────────────────
+    [<RequireQualifiedAccess>]
+    module Tmdb =
+
+        /// `/movie/{id}/credits` URL (API key in the query — supply per call; never hard-code).
+        let creditsUrl (apiKey: string) (movieId: string) : string =
+            String.Concat("https://api.themoviedb.org/3/movie/", movieId, "/credits?api_key=", apiKey)
+
+        /// Parse a TMDB `credits` response into `ImdbDataset.Principal`s (one per cast member): the title is the
+        /// movie, the person is the cast id, namespaced `tmdb:` so TMDB and IMDb ids never collide.
+        let parseCredits (movieId: string) (json: string) : ImdbDataset.Principal list =
+            use doc = JsonDocument.Parse(json)
+
+            match doc.RootElement.TryGetProperty "cast" with
+            | true, cast when cast.ValueKind = JsonValueKind.Array ->
+                [ for el in cast.EnumerateArray() do
+                      match el.TryGetProperty "id" with
+                      | true, idEl ->
+                          yield
+                              ({ Tconst = String.Concat("tmdb:", movieId)
+                                 Nconst = String.Concat("tmdb:", idEl.GetRawText())
+                                 Category = "cast" }
+                              : ImdbDataset.Principal)
+                      | _ -> () ]
+            | _ -> []
+
+        /// Fetch + parse a movie's credits via the injected port.
+        let fetchCredits (fetch: Fetch) (apiKey: string) (movieId: string) : Async<ImdbDataset.Principal list> =
+            async {
+                let! json = fetch (creditsUrl apiKey movieId)
+                return parseCredits movieId json
+            }
+
+    /// ── Wikidata leg ──────────────────────────────────────────────────────────────────────────────────
+    [<RequireQualifiedAccess>]
+    module Wikidata =
+
+        /// The WDQS SPARQL endpoint URL for a query (JSON results; query percent-encoded).
+        let sparqlUrl (query: string) : string =
+            String.Concat("https://query.wikidata.org/sparql?format=json&query=", Uri.EscapeDataString query)
+
+        /// Parse a SPARQL-JSON results document into one `Map<var, value>` per binding row.
+        let parseBindings (json: string) : Map<string, string> list =
+            use doc = JsonDocument.Parse(json)
+
+            match doc.RootElement.TryGetProperty "results" with
+            | true, results ->
+                match results.TryGetProperty "bindings" with
+                | true, bindings when bindings.ValueKind = JsonValueKind.Array ->
+                    [ for row in bindings.EnumerateArray() ->
+                          [ for p in row.EnumerateObject() -> p.Name, propString p.Value "value" ] |> Map.ofList ]
+                | _ -> []
+            | _ -> []
+
+        /// Fetch + parse a SPARQL query via the injected port.
+        let fetchBindings (fetch: Fetch) (query: string) : Async<Map<string, string> list> =
+            async {
+                let! json = fetch (sparqlUrl query)
+                return parseBindings json
+            }
+
+    /// **The opt-in real network edge** (NOT exercised in CI). A shared `HttpClient` issuing the GET; this is the
+    /// only code here that touches the network — wire it explicitly (and `TtlCache` the results) when going live.
+    let private httpClient = lazy (new System.Net.Http.HttpClient())
+
+    let liveFetch: Fetch =
+        fun url ->
+            async {
+                let! body = httpClient.Value.GetStringAsync(url) |> Async.AwaitTask
+                return body
+            }

--- a/tests/Tests.FSharp/Formal/LiveLegs.Tests.fs
+++ b/tests/Tests.FSharp/Formal/LiveLegs.Tests.fs
@@ -1,0 +1,62 @@
+module Zeta.Tests.Formal.LiveLegsTests
+
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Core
+
+module L = Zeta.Core.LiveLegs
+module I = Zeta.Core.ImdbDataset
+
+// ═══════════════════════════════════════════════════════════════════
+// LiveLegs — TMDB + Wikidata legs behind the injected Fetch port. All
+// OFFLINE here: parsers on fixture JSON + recordedFetch (DST replay).
+// The live HttpClient edge is opt-in and not exercised in CI.
+// ═══════════════════════════════════════════════════════════════════
+
+let private tmdbCredits =
+    """{"id":603,"cast":[{"id":6384,"name":"Keanu Reeves","character":"Neo"},{"id":2975,"name":"Laurence Fishburne","character":"Morpheus"}]}"""
+
+let private sparqlJson =
+    """{"results":{"bindings":[{"item":{"value":"http://www.wikidata.org/entity/Q42"},"itemLabel":{"value":"Douglas Adams"}}]}}"""
+
+[<Fact>]
+let ``TMDB creditsUrl builds the documented endpoint`` () =
+    L.Tmdb.creditsUrl "KEY" "603"
+    |> should equal "https://api.themoviedb.org/3/movie/603/credits?api_key=KEY"
+
+[<Fact>]
+let ``TMDB parseCredits yields one namespaced principal per cast member`` () =
+    let ps = L.Tmdb.parseCredits "603" tmdbCredits
+    ps.Length |> should equal 2
+    ps.[0]
+    |> should equal ({ Tconst = "tmdb:603"; Nconst = "tmdb:6384"; Category = "cast" }: I.Principal)
+    ps.[1].Nconst |> should equal "tmdb:2975"
+
+[<Fact>]
+let ``TMDB fetchCredits goes through the injected (recorded) port — DST replay, no network`` () =
+    let url = L.Tmdb.creditsUrl "KEY" "603"
+    let fetch = L.recordedFetch (Map.ofList [ url, tmdbCredits ])
+    let ps = L.Tmdb.fetchCredits fetch "KEY" "603" |> Async.RunSynchronously
+    ps.Length |> should equal 2
+    // and it feeds the SAME pipeline: a 2-cast movie → one co-star link
+    let _, adj = I.coStarAdjacency ps
+    adj.[0] |> should equal [| 1 |]
+
+[<Fact>]
+let ``Wikidata sparqlUrl percent-encodes the query`` () =
+    let u = L.Wikidata.sparqlUrl "SELECT ?x WHERE {}"
+    u.StartsWith("https://query.wikidata.org/sparql?format=json&query=", System.StringComparison.Ordinal)
+    |> should equal true
+    u.Contains "%20" |> should equal true // spaces encoded
+
+[<Fact>]
+let ``Wikidata parseBindings yields var→value rows`` () =
+    let rows = L.Wikidata.parseBindings sparqlJson
+    rows.Length |> should equal 1
+    rows.[0].["itemLabel"] |> should equal "Douglas Adams"
+    rows.[0].["item"] |> should equal "http://www.wikidata.org/entity/Q42"
+
+[<Fact>]
+let ``recordedFetch replays a captured response (the DST membrane)`` () =
+    let fetch = L.recordedFetch (Map.ofList [ "u", "body" ])
+    (fetch "u" |> Async.RunSynchronously) |> should equal "body"

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -349,6 +349,7 @@
     <Compile Include="Formal/TtlCache.Tests.fs" />
     <Compile Include="Formal/CostarFederations.Tests.fs" />
     <Compile Include="Formal/CostarZSet.Tests.fs" />
+    <Compile Include="Formal/LiveLegs.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />
 
     <!-- Circuit/ -->


### PR DESCRIPTION
Aaron 2026-06-19 *"build the live TMDB/Wikidata legs."* The network legs **in discipline**: the only door for network entropy is the **injected `Fetch` port** (`string -> Async<string>`), never an ambient HttpClient (noninterference §13). Leg logic is pure w.r.t. the port → **offline-testable + DST-replayable** via `recordedFetch`.

**`src/Core/LiveLegs.fs`:** `Fetch` port; `recordedFetch` (DST membrane). **Tmdb**: `creditsUrl`, `parseCredits` (cast → `ImdbDataset.Principal`, `tmdb:`-namespaced — feeds the SAME co-star pipeline), `fetchCredits`. **Wikidata**: `sparqlUrl`, `parseBindings` (SPARQL-JSON rows), `fetchBindings`. JSON via System.Text.Json (in-framework).

**Honest scope:** `liveFetch` (real HttpClient) is the **opt-in network edge** — only network-touching code, **not in CI** (determinism/noninterference), ToS caveats (TMDB key; Wikidata rate limits → TtlCache). Design-time ProvidedTypes wrapper remains the follow-on. **6 tests green**, Core 0-warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)