### PR TITLE
Re-promote B-0891 scenarios 3/4 to hard gate

### DIFF
--- a/.github/workflows/build-ai-cluster-iso.yml
+++ b/.github/workflows/build-ai-cluster-iso.yml
@@ -300,7 +300,6 @@ jobs:
 
       - name: B-0891 scenario 3 — reformat with retention (workflow_dispatch only)
         if: github.event_name == 'workflow_dispatch'
-        continue-on-error: true
         timeout-minutes: 90
         working-directory: full-ai-cluster
         env:
@@ -321,7 +320,6 @@ jobs:
 
       - name: B-0891 scenario 4 — path-fork migrate vs fresh (workflow_dispatch only)
         if: github.event_name == 'workflow_dispatch'
-        continue-on-error: true
         timeout-minutes: 90
         working-directory: full-ai-cluster
         env:

--- a/docs/trajectories/usb-zflash-installer/RESUME.md
+++ b/docs/trajectories/usb-zflash-installer/RESUME.md
@@ -1,11 +1,11 @@
 # Trajectory - USB / zflash Installer
 
 Status: active — shipped + iterating; first surfaced as a trajectory 2026-05-29 from substrate inventory (the flashing mechanism works on `origin/main`; this surface was missing, so the workstream lived head-only)
-Last refreshed: 2026-06-16
+Last refreshed: 2026-06-20
 Type: workstream (current-focus) — a trajectory the operator is *actively powering*. Many trajectories can be tracked; only a few are workstreams at once (finite-focus / WIP-bounded — a workstream is a trajectory under sustained thrust, and thrust budget is finite, so most trajectories coast). (Genus = "trajectory"; "workstream" is the species: a trajectory under sustained thrust toward a deliverable, vs. emergent-posture trajectories like `anti-infection`. See [`factory-trajectory-surface`](../factory-trajectory-surface/RESUME.md) for the genus/species taxonomy.) One of the operator's three current cluster workstreams (encryption / usb-zflash / ts-workflow-engine).
 Eventual encoding (design-stage — the human maintainer 2026-05-23 genetic-ID substrate + Clifford/HKT): this trajectory's state is trackable as a 128-bit genetic-ID seed (discrete, reversible via parser-combinator ↔ generator-function) → Clifford-space path (continuous, eventual). Mirrors the three-lane I8-lattice / I9-manifold split.
-Current blocker: scenarios 3/4 — baseline snapshot was stopping at mid-install `[iter-5.1]`; fixing to install-complete boundary, then workflow_dispatch CI.
-Next concrete action: verify scenario 3 retention + scenario 4 path-fork on build-iso dispatch; promote when green
+Current blocker: none for QEMU scenarios 1–4 — green on workflow_dispatch [run 27854227014](https://github.com/Lucent-Financial-Group/Zeta/actions/runs/27854227014) after harness fix #8588.
+Next concrete action: merge hard-gate promotion for scenarios 3+4; physical WiFi confirmation out-of-band
 
 ## Why This Exists
 
@@ -59,4 +59,4 @@ bringup.
 
 ## Current Next Action
 
-Scenario 2 hard gate on main (run 27604374743). Fix scenario 3/4 baseline snapshot marker; dispatch workflow_dispatch for retention + path-fork CI.
+Scenarios 1–4 green on workflow_dispatch run 27854227014; promoting 3+4 to hard gate (PR in flight).


### PR DESCRIPTION
## Summary
- Remove `continue-on-error: true` from scenarios 3 (retention) and 4 (path-fork) in `build-ai-cluster-iso.yml`.
- Evidence: [workflow_dispatch run 27854227014](https://github.com/Lucent-Financial-Group/Zeta/actions/runs/27854227014) — all four harness scenarios `passed: 1`.

## Test plan
- [x] Dispatch run 27854227014 scenarios 1–4 green
- [ ] Merge; next `workflow_dispatch` fails workflow if 3 or 4 regress