### PR TITLE
feat(core): WikidataGraph — the entity-graph leg (SPARQL → entity graph → CoEmpowerGraph) + MerkleFS persistence scope

### DIFF
--- a/memory/project_imdb_wikipedia_fsharp_type_providers_reverse_mint_nfts_emergent_clusters_federations_kevin_bacon_2026_06_19.md
+++ b/memory/project_imdb_wikipedia_fsharp_type_providers_reverse_mint_nfts_emergent_clusters_federations_kevin_bacon_2026_06_19.md
@@ -92,3 +92,20 @@ data substrate**:
   substrate and evolves without downtime. Ties: `TtlCache`; `ZSet`/`IndexedZSet` (DBSP); HKT-MDM /
   recursive-HKT; `docs/research/2026-06-15-zero-downtime-schema-change-…` (gset-expand/zset-contract);
   `CoEmpowerGraph` (the reverse-mint target).
+
+## Persisting the reified graphs — git-native / MerkleFS columnar formats (Aaron 2026-06-19)
+
+*"SPARQL-JSON is cool, and maybe some of our Arrow or other columnar or HDF5/CDF or DynamicValue or Parquet
+files — we have many options that are git-native, zetadb-native, MerkleFS-friendly."* The reified snapshots
+(the TTL-bounded co-star / entity graphs) don't have to stay in-memory — they persist in our **content-addressed
+MerkleFS** in whichever format fits:
+
+- **Wire-in:** SPARQL-JSON / TMDB-JSON (parsed by `LiveLegs` via `System.Text.Json`).
+- **Persist-as (options, all in-tree):** **Arrow** (`DynamicValue.Arrow`), **Parquet**, **CBOR**
+  (`DynamicValue` CBOR golden-vector path), **`DynamicValue`** itself, columnar / HDF5-style — content-addressed
+  in **`CasStore` / `DagFs` / `Merkle`** (MerkleFS), so a snapshot is **hash-addressed, dedup'd, diffable-by-root,
+  git-native + zetadb-native**.
+- **Discipline caveat:** these are **DATA snapshots, not proofs** — binary columnar (Arrow/Parquet) is fine
+  here; `no-binary-in-proof-lineage` applies only to *verification golden vectors* (those stay text hex-in-JSON).
+  So: graph snapshots = binary columnar in MerkleFS (data); byte-locks = text (proof). Ties: `DynamicValue.Arrow`;
+  `Merkle`/`CasStore`/`DagFs`; `TtlCache` (in-memory) → persisted snapshot; `no-binary-in-proof-lineage`.

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -309,6 +309,7 @@
     <Compile Include="CostarFederations.fs" />
     <Compile Include="CostarZSet.fs" />
     <Compile Include="LiveLegs.fs" />
+    <Compile Include="WikidataGraph.fs" />
     <Compile Include="IdentityCapacity.fs" />
     <Compile Include="TrustCalculus.fs" />
     <Compile Include="PrivacyEconomy.fs" />

--- a/src/Core/WikidataGraph.fs
+++ b/src/Core/WikidataGraph.fs
@@ -1,0 +1,66 @@
+namespace Zeta.Core
+
+open System
+
+/// **`WikidataGraph` — the entity-graph leg (Aaron 2026-06-19, shadow\*).**
+///
+/// The Wikipedia/Wikidata half of *"everything grows from IMDb and Wikipedia."* `LiveLegs.Wikidata` yields
+/// SPARQL `var → value` rows; this projects them into an **entity-relation graph** — entities (Q-ids) as nodes,
+/// relations as edges — **parallel to `ImdbDataset`'s co-star graph**, so the entity graph flows into the *same*
+/// `CoEmpowerGraph` / federation-characterization machinery. Pure (consumes parsed bindings), offline-testable,
+/// DST-deterministic.
+[<RequireQualifiedAccess>]
+module WikidataGraph =
+
+    /// A directed relation edge between two entities (Q-ids).
+    type Triple = { Subject: string; Object: string }
+
+    /// The Q-id (last path segment) of a Wikidata entity URI; pass-through if already bare.
+    let qid (uri: string) : string =
+        let i = uri.LastIndexOf('/')
+        if i >= 0 && i < uri.Length - 1 then uri.Substring(i + 1) else uri
+
+    /// Extract relation edges from SPARQL bindings given the subject/object variable names (rows missing either
+    /// var are skipped). Q-ids extracted; distinct.
+    let edges (subjectVar: string) (objectVar: string) (bindings: Map<string, string> list) : Triple list =
+        [ for row in bindings do
+              match Map.tryFind subjectVar row, Map.tryFind objectVar row with
+              | Some s, Some o when s <> "" && o <> "" -> { Subject = qid s; Object = qid o }
+              | _ -> () ]
+        |> List.distinct
+
+    /// Entity labels (`Q-id → label`) from an id var + a label var.
+    let labels (idVar: string) (labelVar: string) (bindings: Map<string, string> list) : Map<string, string> =
+        [ for row in bindings do
+              match Map.tryFind idVar row, Map.tryFind labelVar row with
+              | Some i, Some l when i <> "" -> qid i, l
+              | _ -> () ]
+        |> Map.ofList
+
+    /// Entity nodes (ordinal-sorted) + undirected adjacency from the relation edges (related entities = linked).
+    let adjacency (triples: Triple list) : string[] * int[][] =
+        let entities =
+            triples
+            |> List.collect (fun t -> [ t.Subject; t.Object ])
+            |> List.distinct
+            |> List.sortWith (fun a b -> String.CompareOrdinal(a, b))
+            |> List.toArray
+
+        let idx = entities |> Array.mapi (fun i e -> e, i) |> Map.ofArray
+        let adj = Array.init entities.Length (fun _ -> System.Collections.Generic.SortedSet<int>())
+
+        for t in triples do
+            match Map.tryFind t.Subject idx, Map.tryFind t.Object idx with
+            | Some a, Some b when a <> b ->
+                adj.[a].Add(b) |> ignore
+                adj.[b].Add(a) |> ignore
+            | _ -> ()
+
+        entities, adj |> Array.map Seq.toArray
+
+    /// Project the entity graph into a `CoEmpowerGraph` (all `Audience` by default; the federation machinery then
+    /// characterizes the entity clusters). Identities seeded deterministically.
+    let toCoEmpowerGraph (kinds: int) (seed: int) (triples: Triple list) : string[] * CoEmpowerGraph.Graph =
+        let entities, adj = adjacency triples
+        let roles = Array.create entities.Length CoEmpowerGraph.Audience
+        entities, CoEmpowerGraph.seed kinds seed adj roles

--- a/tests/Tests.FSharp/Formal/WikidataGraph.Tests.fs
+++ b/tests/Tests.FSharp/Formal/WikidataGraph.Tests.fs
@@ -1,0 +1,69 @@
+module Zeta.Tests.Formal.WikidataGraphTests
+
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Core
+
+module W = Zeta.Core.WikidataGraph
+module L = Zeta.Core.LiveLegs
+
+// ═══════════════════════════════════════════════════════════════════
+// WikidataGraph — SPARQL bindings → entity-relation graph (parallel to
+// ImdbDataset's co-star graph). Fixture chain: Q42 – Q5 – Q1.
+// ═══════════════════════════════════════════════════════════════════
+
+let private bindings =
+    [ Map.ofList
+          [ "item", "http://www.wikidata.org/entity/Q42"
+            "related", "http://www.wikidata.org/entity/Q5"
+            "itemLabel", "Douglas Adams" ]
+      Map.ofList
+          [ "item", "http://www.wikidata.org/entity/Q5"
+            "related", "http://www.wikidata.org/entity/Q1" ] ]
+
+[<Fact>]
+let ``qid extracts the Q-id from a Wikidata URI (and passes bare ids through)`` () =
+    W.qid "http://www.wikidata.org/entity/Q42" |> should equal "Q42"
+    W.qid "Q5" |> should equal "Q5"
+
+[<Fact>]
+let ``edges extracts qid relation triples from the chosen subject/object vars`` () =
+    let es = W.edges "item" "related" bindings
+    es
+    |> should
+        equal
+        [ { W.Subject = "Q42"; W.Object = "Q5" }
+          { W.Subject = "Q5"; W.Object = "Q1" } ]
+
+[<Fact>]
+let ``labels maps Q-id to label`` () =
+    let ls = W.labels "item" "itemLabel" bindings
+    ls.["Q42"] |> should equal "Douglas Adams"
+
+[<Fact>]
+let ``adjacency builds the undirected entity graph (Q42–Q5–Q1)`` () =
+    let entities, adj = W.adjacency (W.edges "item" "related" bindings)
+    entities |> should equal [| "Q1"; "Q42"; "Q5" |] // ordinal-sorted
+    adj.[0] |> should equal [| 2 |] // Q1 — Q5
+    adj.[1] |> should equal [| 2 |] // Q42 — Q5
+    adj.[2] |> should equal [| 0; 1 |] // Q5 — Q1, Q42
+
+[<Fact>]
+let ``toCoEmpowerGraph projects entities to an all-Audience CoEmpowerGraph, deterministically`` () =
+    let _, g1 = W.toCoEmpowerGraph 4 7 (W.edges "item" "related" bindings)
+    let entities, g2 = W.toCoEmpowerGraph 4 7 (W.edges "item" "related" bindings)
+    g1.Identity |> should equal g2.Identity
+    g2.N |> should equal 3
+    entities |> should equal [| "Q1"; "Q42"; "Q5" |]
+    g2.Role |> Array.forall (fun r -> r = CoEmpowerGraph.Audience) |> should equal true
+
+[<Fact>]
+let ``the full Wikidata leg: recorded SPARQL fetch → bindings → entity graph (DST, no network)`` () =
+    let query = "SELECT ?item ?related WHERE {}"
+    let url = L.Wikidata.sparqlUrl query
+    let json =
+        """{"results":{"bindings":[{"item":{"value":"http://www.wikidata.org/entity/Q42"},"related":{"value":"http://www.wikidata.org/entity/Q5"}}]}}"""
+    let fetch = L.recordedFetch (Map.ofList [ url, json ])
+    let rows = L.Wikidata.fetchBindings fetch query |> Async.RunSynchronously
+    let entities, _ = W.adjacency (W.edges "item" "related" rows)
+    entities |> should equal [| "Q42"; "Q5" |]

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -350,6 +350,7 @@
     <Compile Include="Formal/CostarFederations.Tests.fs" />
     <Compile Include="Formal/CostarZSet.Tests.fs" />
     <Compile Include="Formal/LiveLegs.Tests.fs" />
+    <Compile Include="Formal/WikidataGraph.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />
 
     <!-- Circuit/ -->


### PR DESCRIPTION
Aaron 2026-06-19 *"ready for the entity-graph leg."* The Wikipedia/Wikidata half: `LiveLegs.Wikidata` yields SPARQL var→value rows; **`WikidataGraph`** projects them into an entity-relation graph (Q-id nodes, relation edges) **parallel to `ImdbDataset`'s co-star graph** → the same CoEmpowerGraph/federation machinery.

**`src/Core/WikidataGraph.fs`:** `Triple`; `qid`; `edges`; `labels`; `adjacency`; `toCoEmpowerGraph`. Pure, offline, DST. **6 tests green**, Core 0-warning incl. the **full leg** (recorded SPARQL fetch → bindings → entity graph, no network).

**Memory capture:** persist reified snapshots in **git-native/MerkleFS columnar** formats — Arrow/Parquet/CBOR/DynamicValue — content-addressed via CasStore/DagFs/Merkle. Caveat: data snapshots may be binary; `no-binary-in-proof-lineage` applies only to verification golden vectors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)