### PR TITLE
feat(core): export room horizon heat

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -185,10 +185,10 @@
     <Compile Include="Vision.fs" />
     <Compile Include="PredictionInference.fs" />
     <Compile Include="PredictionScheduler.fs" />
+    <Compile Include="Heat.fs" />
     <Compile Include="RoomHorizon.fs" />
     <Compile Include="Query.fs" />
     <Compile Include="Injection.fs" />
-    <Compile Include="Heat.fs" />
     <Compile Include="InjectionExt.fs" />
     <Compile Include="SpeculativeWatermark.fs" />
     <Compile Include="Sink.fs" />

--- a/src/Core/RoomHorizon.fs
+++ b/src/Core/RoomHorizon.fs
@@ -42,6 +42,44 @@ module RoomHorizon =
           Ranked: PredictionInference.RankedBranch<'S> list
           Horizon: Report<'K, 'S> }
 
+    let private positiveSignature (source: string) (kind: string) (units: int) (detail: string) : HeatSignature option =
+        if units <= 0 then
+            None
+        else
+            Some(HeatSignature.ofMass source kind units (float units) detail)
+
+    /// Host-facing heat signatures for finite horizon pressure.
+    ///
+    /// Deferred futures are intentionally cold: the byte tank could not afford
+    /// them yet, so no information entered the room and nothing was erased.
+    /// Forgotten materialized keys are heat. Paid futures that still cannot fit
+    /// the finite exterior view are backpressure heat.
+    let heatSignatures (source: string) (report: Report<'K, 'S>) : HeatSignature list =
+        [ positiveSignature
+              source
+              "room-horizon.forgotten"
+              report.HorizonHeat.Units
+              "bounded horizon forgot materialized keys"
+          positiveSignature
+              source
+              "room-horizon.backpressure"
+              (GSet.count report.RejectedByHorizon)
+              "paid futures could not enter the finite horizon" ]
+        |> List.choose id
+
+    /// Emit finite horizon heat through an injected host/room boundary.
+    let emitHeat (sink: IHeatSink) (source: string) (report: Report<'K, 'S>) : Result<unit, HeatSinkFeedback> =
+        let rec loop signatures =
+            result {
+                match signatures with
+                | [] -> return ()
+                | signature :: tail ->
+                    do! sink.Emit signature
+                    return! loop tail
+            }
+
+        report |> heatSignatures source |> loop
+
     let private nonNegative (r: PS.Rational) : bool =
         PS.compare r PS.zero >= 0
 

--- a/tests/Tests.FSharp/RoomHorizon.Tests.fs
+++ b/tests/Tests.FSharp/RoomHorizon.Tests.fs
@@ -98,6 +98,65 @@ let ``paid branch can still be rejected by the finite horizon projection`` () =
     Assert.Equal(0, report.HorizonHeat.Units)
 
 [<Fact>]
+let ``rolling horizon exports forgetting as host heat`` () =
+    let current =
+        BoundedGSet.ofSeq<int> (config 2 BoundedGSetForgetPolicy.ForgetLowest) [ 1; 2 ]
+        |> mustOk
+        |> fun projection -> projection.State
+
+    let report =
+        [ candidate 3 "newer" "C" 1L 1L 1L ]
+        |> RH.update current (SoftThrottle.tank 1.0 0.0)
+        |> mustOk
+
+    let signatures = RH.heatSignatures "vision-test" report
+
+    Assert.Single(signatures) |> ignore
+    Assert.Equal("vision-test", signatures.[0].Source)
+    Assert.Equal("room-horizon.forgotten", signatures.[0].Kind)
+    Assert.Equal(1, signatures.[0].Units)
+    Assert.Equal(1_000_000L, signatures.[0].MassPpm)
+
+    let sink = RecordingHeatSink()
+    RH.emitHeat (sink :> IHeatSink) "vision-test" report |> mustOk
+
+    Assert.Single(sink.Signatures) |> ignore
+    Assert.Equal("room-horizon.forgotten", sink.Signatures.[0].Kind)
+
+[<Fact>]
+let ``no-forget horizon exports paid finite-view rejection as backpressure heat`` () =
+    let current =
+        BoundedGSet.ofSeq<int> (config 1 BoundedGSetForgetPolicy.RejectNew) [ 1 ]
+        |> mustOk
+        |> fun projection -> projection.State
+
+    let report =
+        [ candidate 2 "second" "B" 1L 1L 1L ]
+        |> RH.update current (SoftThrottle.tank 1.0 0.0)
+        |> mustOk
+
+    Assert.Equal<int list>([ 2 ], report.RejectedByHorizon |> GSet.toList)
+    Assert.Equal(0, report.HorizonHeat.Units)
+
+    let signatures = RH.heatSignatures "vision-test" report
+
+    Assert.Single(signatures) |> ignore
+    Assert.Equal("room-horizon.backpressure", signatures.[0].Kind)
+    Assert.Equal(1, signatures.[0].Units)
+
+[<Fact>]
+let ``byte-deferred futures stay cold until they enter the room`` () =
+    let report =
+        [ candidate 1 "too-expensive" "A" 1L 1L 2L ]
+        |> RH.admit (config 1 BoundedGSetForgetPolicy.RejectNew) (SoftThrottle.tank 1.0 0.0)
+        |> mustOk
+
+    Assert.Equal(Vision.RejectedWithBackpressure, report.Prediction.Outcome)
+    Assert.Empty(report.Boarded)
+    Assert.Empty(report.RejectedByHorizon |> GSet.toList)
+    Assert.Empty(RH.heatSignatures "vision-test" report)
+
+[<Fact>]
 let ``negative attention is feedback not an ordering trick`` () =
     let bad =
         { candidate 1 "bad" "A" 1L 1L 1L with


### PR DESCRIPTION
## What

- Added `RoomHorizon.heatSignatures` for finite-horizon forgetting and no-forget backpressure.
- Added `RoomHorizon.emitHeat` so room hosts can export those signatures through the existing injected `IHeatSink` boundary.
- Added tests that distinguish three cases: forgotten materialized keys emit heat, paid finite-view rejection emits backpressure heat, and byte-deferred futures stay cold.

## Why

The bounded horizon already separates byte admission from finite exterior capacity, but callers had to manually interpret `HorizonHeat` and `RejectedByHorizon`. This slice gives room/cabinet hosts a standard heat surface without contaminating the pure report: forgetting remains heat, no-forget rejection remains backpressure, and unaffordable futures do not spend heat before entering the room.

## Validation

- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter "FullyQualifiedName~RoomHorizon"`
- `dotnet build -c Release`
- `dotnet test Zeta.sln -c Release --no-build`
- `dotnet format --verify-no-changes`
- `bun run preflight:quick` (Go lint skipped locally because the toolchain is unavailable; CI still runs it)

Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: Codex
Agent-Model: gpt-5.5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: not-implied-by-credential
Human-Review-Evidence: none
Action-Mode: human-directed
Task: none
Co-Authored-By: Codex <noreply@openai.com>
