### PR TITLE
feat(core): GraphSnapshot — content-addressed MerkleFS persistence for the reified graphs

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -310,6 +310,7 @@
     <Compile Include="CostarZSet.fs" />
     <Compile Include="LiveLegs.fs" />
     <Compile Include="WikidataGraph.fs" />
+    <Compile Include="GraphSnapshot.fs" />
     <Compile Include="IdentityCapacity.fs" />
     <Compile Include="TrustCalculus.fs" />
     <Compile Include="PrivacyEconomy.fs" />

--- a/src/Core/GraphSnapshot.fs
+++ b/src/Core/GraphSnapshot.fs
@@ -1,0 +1,104 @@
+namespace Zeta.Core
+
+/// **`GraphSnapshot` — content-addressed MerkleFS persistence for the reified graphs (Aaron 2026-06-19, shadow\*).**
+///
+/// Closes the cache → durable-snapshot loop: a reified `CoEmpowerGraph.Graph` (the unified target both the IMDb
+/// co-star leg and the Wikidata entity leg project to) is serialized to a **deterministic canonical JSON** blob
+/// and stored in a **content-addressed store** (`ContentStore`, the primitive under `CasStore`/MerkleFS) — so a
+/// snapshot is **hash-addressed, dedup'd, and content-equal ⇒ hash-equal** (same graph ⇒ same `MerkleHash`).
+///
+/// **Format choice:** canonical JSON (via `DynamicValue.toCanonicalJson`, whose proven inverse is
+/// `fromCanonicalJson`) — deterministic, round-trippable, and **git-diffable** (the most git-native option; it
+/// also sidesteps `no-binary-in-proof-lineage` entirely since the blob is text). Arrow/Parquet/CBOR remain
+/// available alternatives for large fixtures (data snapshots may be binary; only verification golden vectors
+/// must stay text). DST-clean: serialization is pure; the hash is `XxHash128` of the UTF-8 bytes.
+[<RequireQualifiedAccess>]
+module GraphSnapshot =
+
+    let private asInt =
+        function
+        | DynamicValue.Int i -> Some(int i)
+        | _ -> None
+
+    let private asArray =
+        function
+        | DynamicValue.Array a -> Some a
+        | _ -> None
+
+    let private field (k: string) (dv: DynamicValue) : DynamicValue option =
+        match dv with
+        | DynamicValue.Object kvs -> kvs |> List.tryPick (fun (kk, v) -> if kk = k then Some v else None)
+        | _ -> None
+
+    /// Encode a graph as a `DynamicValue` record: `n`, `identity[]`, `adjacency[][]`, `role[]` (0=Creator, 1=Audience).
+    let toDynamicValue (g: CoEmpowerGraph.Graph) : DynamicValue =
+        DynamicValue.Object
+            [ "n", DynamicValue.Int(int64 g.N)
+              "identity", DynamicValue.Array [ for x in g.Identity -> DynamicValue.Int(int64 x) ]
+              "adjacency",
+              DynamicValue.Array
+                  [ for row in g.Adjacency -> DynamicValue.Array [ for v in row -> DynamicValue.Int(int64 v) ] ]
+              "role",
+              DynamicValue.Array
+                  [ for r in g.Role ->
+                        DynamicValue.Int(
+                            match r with
+                            | CoEmpowerGraph.Creator -> 0L
+                            | CoEmpowerGraph.Audience -> 1L
+                        ) ] ]
+
+    /// Decode a graph from its `DynamicValue` form (order-independent; validates lengths against `n`).
+    let ofDynamicValue (dv: DynamicValue) : Result<CoEmpowerGraph.Graph, string> =
+        match
+            field "n" dv |> Option.bind asInt,
+            field "identity" dv |> Option.bind asArray,
+            field "adjacency" dv |> Option.bind asArray,
+            field "role" dv |> Option.bind asArray
+        with
+        | Some n, Some idDv, Some adjDv, Some roleDv ->
+            let identity = idDv |> List.choose asInt |> List.toArray
+
+            let adjacency =
+                adjDv
+                |> List.choose asArray
+                |> List.map (fun row -> row |> List.choose asInt |> List.toArray)
+                |> List.toArray
+
+            let role =
+                roleDv
+                |> List.choose asInt
+                |> List.map (fun i -> if i = 0 then CoEmpowerGraph.Creator else CoEmpowerGraph.Audience)
+                |> List.toArray
+
+            if identity.Length = n && adjacency.Length = n && role.Length = n then
+                Ok
+                    { CoEmpowerGraph.N = n
+                      CoEmpowerGraph.Identity = identity
+                      CoEmpowerGraph.Adjacency = adjacency
+                      CoEmpowerGraph.Role = role }
+            else
+                Error "GraphSnapshot.ofDynamicValue: array length ≠ n"
+        | _ -> Error "GraphSnapshot.ofDynamicValue: missing or mistyped fields"
+
+    /// Serialize a graph to its canonical-JSON snapshot blob.
+    let serialize (g: CoEmpowerGraph.Graph) : Result<string, string> =
+        DynamicValue.toCanonicalJson (toDynamicValue g) |> Result.mapError (sprintf "%A")
+
+    /// Deserialize a snapshot blob back to a graph.
+    let deserialize (json: string) : Result<CoEmpowerGraph.Graph, string> =
+        DynamicValue.fromCanonicalJson json |> Result.mapError (sprintf "%A") |> Result.bind ofDynamicValue
+
+    let private hashBytes: byte[] -> MerkleHash = ContentHasher.hashOf ContentHasher.defaultHasher
+    let private hashOf (s: string) : MerkleHash = hashBytes (System.Text.Encoding.UTF8.GetBytes s)
+
+    /// An empty content-addressed snapshot store (blobs keyed by the `XxHash128` of their canonical JSON).
+    let emptyStore () : ContentStore.Store<string> = ContentStore.create hashOf
+
+    /// Persist a graph: serialize → content-address. Returns the `MerkleHash` + the updated store (same graph ⇒
+    /// same hash ⇒ dedup'd).
+    let store (g: CoEmpowerGraph.Graph) (s: ContentStore.Store<string>) : Result<MerkleHash * ContentStore.Store<string>, string> =
+        serialize g |> Result.map (fun json -> ContentStore.put json s)
+
+    /// Load a graph by its content hash (`None` if absent; `Some (Error …)` if the blob is corrupt).
+    let load (h: MerkleHash) (s: ContentStore.Store<string>) : Result<CoEmpowerGraph.Graph, string> option =
+        ContentStore.get h s |> Option.map deserialize

--- a/tests/Tests.FSharp/Formal/GraphSnapshot.Tests.fs
+++ b/tests/Tests.FSharp/Formal/GraphSnapshot.Tests.fs
@@ -1,0 +1,63 @@
+module Zeta.Tests.Formal.GraphSnapshotTests
+
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Core
+
+module S = Zeta.Core.GraphSnapshot
+module G = Zeta.Core.CoEmpowerGraph
+
+// ═══════════════════════════════════════════════════════════════════
+// GraphSnapshot — content-addressed MerkleFS persistence of the reified
+// CoEmpowerGraph: canonical-JSON blob → ContentStore (XxHash128). Same
+// graph ⇒ same hash (content-addressing); round-trips losslessly.
+// ═══════════════════════════════════════════════════════════════════
+
+// a small mixed-role graph (a 3-node path; node 1 a Creator)
+let private g () : G.Graph =
+    { G.N = 3
+      G.Identity = [| 2; 1; 3 |]
+      G.Adjacency = [| [| 1 |]; [| 0; 2 |]; [| 1 |] |]
+      G.Role = [| G.Audience; G.Creator; G.Audience |] }
+
+[<Fact>]
+let ``serialize → deserialize round-trips losslessly`` () =
+    match S.deserialize (S.serialize (g ()) |> function Ok j -> j | Error e -> failwith e) with
+    | Ok back -> back |> should equal (g ())
+    | Error e -> failwith e
+
+[<Fact>]
+let ``content-addressing: the same graph stores to the same hash (dedup)`` () =
+    let s0 = S.emptyStore ()
+    match S.store (g ()) s0 with
+    | Ok(h1, s1) ->
+        match S.store (g ()) s1 with
+        | Ok(h2, _) -> h1 |> should equal h2 // identical graph → identical content hash
+        | Error e -> failwith e
+    | Error e -> failwith e
+
+[<Fact>]
+let ``store then load returns the graph by its content hash`` () =
+    let s0 = S.emptyStore ()
+    match S.store (g ()) s0 with
+    | Ok(h, s1) ->
+        match S.load h s1 with
+        | Some(Ok back) -> back |> should equal (g ())
+        | other -> failwithf "expected Some(Ok graph), got %A" other
+    | Error e -> failwith e
+
+[<Fact>]
+let ``different graphs get different content hashes`` () =
+    let s0 = S.emptyStore ()
+    let g2 = { (g ()) with G.Identity = [| 9; 1; 3 |] } // perturb one identity
+    match S.store (g ()) s0, S.store g2 s0 with
+    | Ok(h1, _), Ok(h2, _) -> h1 |> should not' (equal h2)
+    | _ -> failwith "store failed"
+
+[<Fact>]
+let ``load of an absent hash is None`` () =
+    let s0 = S.emptyStore ()
+    // hash some other graph, then look it up in the EMPTY store
+    match S.store (g ()) (S.emptyStore ()) with
+    | Ok(h, _) -> S.load h s0 |> should equal (None: Result<G.Graph, string> option)
+    | Error e -> failwith e

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -351,6 +351,7 @@
     <Compile Include="Formal/CostarZSet.Tests.fs" />
     <Compile Include="Formal/LiveLegs.Tests.fs" />
     <Compile Include="Formal/WikidataGraph.Tests.fs" />
+    <Compile Include="Formal/GraphSnapshot.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />
 
     <!-- Circuit/ -->


### PR DESCRIPTION
Aaron 2026-06-19 (picked MerkleFS snapshot persistence). Closes the **cache → durable-snapshot** loop: a reified `CoEmpowerGraph.Graph` (the unified target of both the IMDb co-star and Wikidata entity legs) serializes to **deterministic canonical JSON** and stores in a **content-addressed `ContentStore`** (the primitive under CasStore/MerkleFS) — hash-addressed, **dedup'd, content-equal ⇒ hash-equal**.

**`src/Core/GraphSnapshot.fs`:** `toDynamicValue`/`ofDynamicValue` (graph ⇄ DV, order-independent, length-validated); `serialize`/`deserialize` (canonical JSON — text, **git-diffable**, sidesteps no-binary-in-proof-lineage); `emptyStore`/`store`/`load` (XxHash128 via the `ContentHasher` port). Arrow/Parquet/CBOR remain alternatives for large fixtures.

**5 tests green**, Core 0-warning: round-trip; content-addressing (dedup); store→load; distinct hashes; absent→None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)