### PR TITLE
test(qsharp): guard zset isa oracle boundary

### DIFF
--- a/src/Core.QSharp.ReferenceOracle/zset-isa.test.ts
+++ b/src/Core.QSharp.ReferenceOracle/zset-isa.test.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+const source = readFileSync(join(import.meta.dir, "ZSetISA.qs"), "utf-8");
+
+const softOperators = ["Emit", "Retract", "Branch", "Join", "JoinWeighted", "Merge", "Fold"] as const;
+
+function operationBody(name: string): string {
+  const declarationStart = source.indexOf(`operation ${name}(`);
+  expect(declarationStart).toBeGreaterThanOrEqual(0);
+  if (declarationStart < 0) {
+    return "";
+  }
+
+  const bodyStart = source.indexOf("{", declarationStart);
+  expect(bodyStart).toBeGreaterThanOrEqual(0);
+  if (bodyStart < 0) {
+    return "";
+  }
+
+  let depth = 0;
+  for (let index = bodyStart; index < source.length; index += 1) {
+    const character = source[index];
+    if (character === "{") {
+      depth += 1;
+    } else if (character === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(bodyStart + 1, index);
+      }
+    }
+  }
+
+  expect(depth).toBe(0);
+  return "";
+}
+
+function expectNoTerminalReadout(name: string): void {
+  const body = operationBody(name);
+  expect(body).not.toMatch(/\bM\s*\(/);
+  expect(body).not.toMatch(/\bMeasure\b/);
+  expect(body).not.toMatch(/\bReset(?:All)?\s*\(/);
+}
+
+describe("ZSetISA Q# source treaty", () => {
+  test("declares the soft Z-set operator surface", () => {
+    for (const name of softOperators) {
+      expect(source).toContain(`operation ${name}(`);
+    }
+
+    expect(source).toContain("MERGE/FOLD = superposition/interference merge");
+    expect(source).toContain("Born collapse = sim-only");
+  });
+
+  test("keeps the primitive gate mappings byte-visible", () => {
+    expect(operationBody("Emit")).toContain("Ry(theta, k);");
+    expect(operationBody("Retract")).toContain("Adjoint Emit(k, theta);");
+    expect(operationBody("Branch")).toContain("H(k);");
+    expect(operationBody("Join")).toContain("CNOT(control, target);");
+    expect(operationBody("JoinWeighted")).toContain("Controlled Ry([control], (theta, target));");
+  });
+
+  test("keeps merge and fold as interference composition, not live measurement", () => {
+    const merge = operationBody("Merge");
+    expect(merge).toContain("sourceA(target);");
+    expect(merge).toContain("sourceB(target);");
+
+    const fold = operationBody("Fold");
+    expect(fold).toContain("for source in sources");
+    expect(fold).toContain("source(target);");
+
+    for (const name of softOperators) {
+      expectNoTerminalReadout(name);
+    }
+  });
+
+  test("confines measurement and reset to the sim-only verification entry point", () => {
+    const verifyIdentity = operationBody("VerifyIdentity");
+    expect(verifyIdentity).toContain("let r = M(q);");
+    expect(verifyIdentity).toContain("let r0 = M(qs[0]);");
+    expect(verifyIdentity).toContain("let r1 = M(qs[1]);");
+    expect(verifyIdentity).toContain("Reset(q);");
+    expect(verifyIdentity).toContain("ResetAll(qs);");
+  });
+});


### PR DESCRIPTION
## What

- Adds a source-level Bun treaty test for `src/Core.QSharp.ReferenceOracle/ZSetISA.qs`.
- Locks the soft Z-set operator surface: `Emit`, `Retract`, `Branch`, `Join`, `JoinWeighted`, `Merge`, and `Fold`.
- Asserts `Merge`/`Fold` stay interference composition while measurement and reset remain confined to the sim-only `VerifyIdentity` entry point.

## Why

Q# should remain a reference oracle and experiment surface, not the DBSP runtime. This guard keeps the experimental Z-set ISA honest: soft operators can compose amplitudes, but terminal readout cannot leak into the live operator surface.

## Validation

- `bun test src/Core.QSharp.ReferenceOracle/zset-isa.test.ts`
- `bun test src/Core.QSharp.ReferenceOracle`
- `bunx prettier --check src/Core.QSharp.ReferenceOracle/zset-isa.test.ts`
- `bun run preflight:quick` (Go lint skipped locally because the toolchain is unavailable; CI still runs it)
- `dotnet build -c Release`

Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: Codex
Agent-Model: gpt-5.5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: not-implied-by-credential
Human-Review-Evidence: none
Action-Mode: human-directed
Task: none
Co-Authored-By: Codex <noreply@openai.com>