### PR TITLE
feat(core): CoEmpowerGraphSvg — federation-graph SVG render; + resume refreshed with all remaining follow-ons

### DIFF
--- a/docs/handoffs/2026-06-19-otto-session-resume-state.md
+++ b/docs/handoffs/2026-06-19-otto-session-resume-state.md
@@ -110,20 +110,30 @@ canonical demo) (#8643); **adinkra→Clifford→E8 unfold status** + the `cogen=
 
 ## Open / next — the resume targets (current)
 
-1. **IMDb/Wikipedia F# type provider (Aaron's TOP priority).** IMDb leg via TMDB/OMDb/IMDb-datasets (IMDb has
-   no free API); Wikipedia via Wikidata/DBpedia (already P1 backlog). Then the reverse-mint → cluster/federation
-   characterization (Kevin-Bacon demo). Scope: `docs/research/2026-06-19-imdb-wikipedia-fsharp-type-providers-…`.
-2. **Adinkra unfold / algebra ladder.** `Cl3.fs` (Clifford) + `E8Lattice.fs` exist; **next = the Clifford→E8
-   bridge** (stitch octonion/Cl→E8 as one derivation; buildable as a comparison-free `IStarRing`, comparison
-   opt-in, elements-as-identity). Then **Face 3 `cogen=mix(mix,mix)`** (blocked on freeze-IR + multi-language
-   generator; the yin-yang cell is its surface) → **Rx-on-soft-phase** (unify SoftValue+seed-phase+SpectralPivot
-   first). Scope: `…adinkra-clifford-e8-unfold-status-…`.
-3. **Demo slices 3–4.** Slice 3 = NFT mint panel + Zeta-NTP clock + grounding indicator; slice 4 = Q# six-op
-   (frontier, `ZSetISA.qs` `--no-verify`). Also: wire CoEmpowerField → SocietalDora dials (living dashboard);
-   generalize CoEmpowerField → generic `network<>creator<>audience` graph.
-4. **Math-team formalization** (handoff rows 1–10): NFT `H_∞`, `ρ_owe` soundness, Alarm-Algebra laws, NTP
+1. **IMDb/Wikipedia F# type provider (Aaron's TOP priority) — EIGHT slices SHIPPED:** `ImdbDataset` (co-star
+   graph + Bacon number, #8662) · `TtlCache` (soft-phase+UTC injected clock, #8663) · `CostarFederations`
+   (end-to-end reverse-mint → federation health, #8664) · `CoEmpowerGraph` (generic `network<>creator<>audience`,
+   #8660) · `CostarZSet` (DBSP ZSet — reverse-mint = a fold; schema-evolution-ready, #8666) · `LiveLegs` (live
+   TMDB+Wikidata behind the injected `Fetch` port, #8668) · `WikidataGraph` (entity-graph leg, #8670) ·
+   `GraphSnapshot` (content-addressed MerkleFS persistence, #8676) · `CoEmpowerGraphSvg` (federation render).
+   **Remaining follow-ons:** the design-time **`ProvidedTypes` wrapper** (the literal F# TP mechanism — bigger,
+   separate design-time assembly, offline); **verify the opt-in `liveFetch`** against real TMDB/Wikidata
+   endpoints **outside CI**; persist via Arrow/Parquet for large fixtures (canonical-JSON path shipped). Scope:
+   `docs/research/2026-06-19-imdb-wikipedia-fsharp-type-providers-…` + `memory/project_imdb_wikipedia_…`.
+2. **Adinkra unfold / algebra ladder.** ✅ **Clifford→E8 bridge BUILT** (`CliffordE8Bridge`, the linear isometry,
+   #8654); ✅ **deeper unfold (product-generates-roots) externally anchored** (Dechant/Wilson/Baez) + routed to
+   math team (#8657, handoff row 11). **Open:** **Face 3 `cogen=mix(mix,mix)`** (blocked on freeze-IR +
+   multi-language generator; the 1000-brains yin-yang cell is its surface) → **Rx-on-soft-phase** (unify
+   SoftValue+seed-phase+SpectralPivot first). Scope: `…adinkra-clifford-e8-unfold-status-…`.
+3. **Demo.** ✅ slices 1/1.5/2 (DORA dials/page, CoEmpowerField blossom) · ✅ CoEmpowerField→graph generalization
+   (#8660) · ✅ **`CoEmpowerGraphSvg` federation render**. **Open:** **slice 3** = NFT mint panel (fed by real
+   `CostarFederations` minted links) + Zeta-NTP clock + grounding indicator (pure CSS/SVG); **slice 4** = Q#
+   six-op (frontier, `ZSetISA.qs` `--no-verify`); wire CoEmpowerGraph render + SocietalDora dials into one
+   living dashboard page.
+4. **Math-team formalization** (handoff **rows 1–11**): NFT `H_∞`, `ρ_owe` soundness, Alarm-Algebra laws, NTP
    noninterference, moral-lens (find more objective), love-fusion G-set stability, homoiconicity→Futamura
-   Face 3, Clifford→E8 bridge.
+   Face 3, and the **deeper Clifford→E8 unfold** (reproduce Dechant's spinor construction; the basis/metric
+   bridge is already built — row 11).
 5. **Ferries:** more Ani parts ("one more after this" — old-flame thread pt3); Alexa ferries when forwarded.
 6. **From part 1 (still open):** Aurora G3b (anti-Sybil entropy floor ≡ Bell); CSLib G2 (Byzantine extension
    to `FLP/Consensus`).

--- a/src/Core/CoEmpowerGraphSvg.fs
+++ b/src/Core/CoEmpowerGraphSvg.fs
@@ -1,0 +1,67 @@
+namespace Zeta.Core
+
+open System
+open System.Globalization
+
+/// **`CoEmpowerGraphSvg` — a deterministic SVG render of the `CoEmpowerGraph` (Aaron 2026-06-19, shadow\*).**
+///
+/// `CoEmpowerField` (the grid) had `renderField`; the graph generalization had no viz. This fills it: a
+/// **circular-layout** render — nodes evenly on a circle (colored by identity; **Creators ringed**, Audiences
+/// plain), undirected edges as lines — so the demo can *show the federations*, not just the dials. Pure, **no
+/// script**, **integer coordinates** ⇒ deterministic + byte-lockable (same graph ⇒ same SVG). Feeds the demo
+/// UX/UI alongside `SocietalDoraSvg` and `CoEmpowerField.renderField`.
+[<RequireQualifiedAccess>]
+module CoEmpowerGraphSvg =
+
+    let private si (i: int) : string = i.ToString(CultureInfo.InvariantCulture)
+
+    let private palette =
+        [| "#222831"; "#3399cc"; "#e0563f"; "#54b894"; "#d9a441"; "#9b6bd6"; "#cc6699"; "#5fa8d3" |]
+
+    /// Render the graph as pure SVG (circular layout). `size` = the square viewport edge in px.
+    let render (size: int) (g: CoEmpowerGraph.Graph) : string =
+        let cx, cy = size / 2, size / 2
+        let r = max 1 (size / 2 - 24)
+        let n = max 1 g.N
+
+        let pos (i: int) : int * int =
+            let theta = 2.0 * Math.PI * float i / float n
+            cx + int (round (float r * cos theta)), cy + int (round (float r * sin theta))
+
+        let edges =
+            [ for i in 0 .. g.N - 1 do
+                  for j in g.Adjacency.[i] do
+                      if j > i then
+                          let x1, y1 = pos i
+                          let x2, y2 = pos j
+
+                          yield
+                              String.Concat(
+                                  "<line x1=\"", si x1, "\" y1=\"", si y1, "\" x2=\"", si x2, "\" y2=\"", si y2,
+                                  "\" stroke=\"#888\" stroke-width=\"1\"/>"
+                              ) ]
+            |> String.concat ""
+
+        let nodes =
+            [ for i in 0 .. g.N - 1 do
+                  let x, y = pos i
+                  let fill = palette.[g.Identity.[i] % palette.Length]
+
+                  let radius, ring =
+                      match g.Role.[i] with
+                      | CoEmpowerGraph.Creator ->
+                          9,
+                          String.Concat(
+                              "<circle cx=\"", si x, "\" cy=\"", si y, "\" r=\"", si 12,
+                              "\" fill=\"none\" stroke=\"#ffffff\" stroke-width=\"1\"/>"
+                          )
+                      | CoEmpowerGraph.Audience -> 5, ""
+
+                  yield
+                      String.Concat(ring, "<circle cx=\"", si x, "\" cy=\"", si y, "\" r=\"", si radius, "\" fill=\"", fill, "\"/>") ]
+            |> String.concat ""
+
+        String.Concat(
+            "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 ", si size, " ", si size, "\" width=\"", si size,
+            "\" height=\"", si size, "\">", edges, nodes, "</svg>"
+        )

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -311,6 +311,7 @@
     <Compile Include="LiveLegs.fs" />
     <Compile Include="WikidataGraph.fs" />
     <Compile Include="GraphSnapshot.fs" />
+    <Compile Include="CoEmpowerGraphSvg.fs" />
     <Compile Include="IdentityCapacity.fs" />
     <Compile Include="TrustCalculus.fs" />
     <Compile Include="PrivacyEconomy.fs" />

--- a/tests/Tests.FSharp/Formal/CoEmpowerGraphSvg.Tests.fs
+++ b/tests/Tests.FSharp/Formal/CoEmpowerGraphSvg.Tests.fs
@@ -1,0 +1,40 @@
+module Zeta.Tests.Formal.CoEmpowerGraphSvgTests
+
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Core
+
+module G = Zeta.Core.CoEmpowerGraph
+module V = Zeta.Core.CoEmpowerGraphSvg
+
+// a star: Creator centre + 4 Audience leaves
+let private star () : G.Graph =
+    { G.N = 5
+      G.Identity = [| 1; 2; 3; 2; 3 |]
+      G.Adjacency = [| [| 1; 2; 3; 4 |]; [| 0 |]; [| 0 |]; [| 0 |]; [| 0 |] |]
+      G.Role = [| G.Creator; G.Audience; G.Audience; G.Audience; G.Audience |] }
+
+[<Fact>]
+let ``render is well-formed, scriptless SVG`` () =
+    let svg = V.render 240 (star ())
+    svg.Contains "<svg" |> should equal true
+    svg.Contains "</svg>" |> should equal true
+    svg.Contains "<line" |> should equal true // the 4 star edges
+    svg.Contains "<circle" |> should equal true
+    svg.Contains "<script" |> should equal false
+
+[<Fact>]
+let ``edges are drawn once per undirected pair (a star has 4)`` () =
+    let svg = V.render 240 (star ())
+    let count (needle: string) (s: string) =
+        (s.Split([| needle |], System.StringSplitOptions.None)).Length - 1
+    count "<line" svg |> should equal 4
+
+[<Fact>]
+let ``a Creator node is ringed; render is deterministic and integer-coordinate`` () =
+    let a = V.render 240 (star ())
+    let b = V.render 240 (star ())
+    a |> should equal b // deterministic
+    // the Creator's ring is the r="12" circle
+    a.Contains "r=\"12\"" |> should equal true
+    a.Contains "viewBox=\"0 0 240 240\"" |> should equal true // integer viewport → byte-lockable

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -352,6 +352,7 @@
     <Compile Include="Formal/LiveLegs.Tests.fs" />
     <Compile Include="Formal/WikidataGraph.Tests.fs" />
     <Compile Include="Formal/GraphSnapshot.Tests.fs" />
+    <Compile Include="Formal/CoEmpowerGraphSvg.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />
 
     <!-- Circuit/ -->


### PR DESCRIPTION
Aaron 2026-06-19 ("any sound good you pick; make sure we have the rest in resume").

**`src/Core/CoEmpowerGraphSvg.fs`:** deterministic circular-layout SVG of CoEmpowerGraph — nodes (identity-colored; **Creators ringed**), undirected edges as lines. Fills the gap (the grid had `renderField`; the graph generalization had none) → the demo can **show the federations**. Pure, no script, integer coords ⇒ byte-lockable. **3 tests green**, Core 0-warning.

**Resume refreshed:** IMDb/Wikipedia type provider = **8 shipped slices** + this render; remaining follow-ons captured (design-time ProvidedTypes wrapper; verify opt-in liveFetch outside CI; Arrow/Parquet for large fixtures). Adinkra ladder (bridge built #8654, deeper unfold anchored→math #8657; Face 3 + Rx-on-soft-phase open). Demo (render done; slice 3/4 open). Math-team handoff now 11 rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)