### PR TITLE
feat(cross-verify): registry-sourced provenance for generated-from-ir oracle

### DIFF
--- a/src/Core/GeneratorRegistry.fs
+++ b/src/Core/GeneratorRegistry.fs
@@ -87,6 +87,7 @@ module GeneratorRegistry =
           register "shape.exchange-worldlines" 1
           register "shape.kitaev-chain" 1
           register "shape.crossing" 1
+          register "rng.splitmix64" 1
           register "engine.zeta-bayesian" 1
           register "engine.infer-net" 1
           register "engine.mock-flat" 1

--- a/tests/Tests.FSharp/GeneratorRegistry.Tests.fs
+++ b/tests/Tests.FSharp/GeneratorRegistry.Tests.fs
@@ -27,6 +27,18 @@ let ``every known generator has a distinct id (no collisions in the stable set)`
     Assert.Equal(List.length ids, ids |> List.distinct |> List.length)
 
 [<Fact>]
+let ``rng.splitmix64 is registered and its ZetaId is pinned (cross-verification byte-lock anchor)`` () =
+    // The splitmix64 cross-verification oracle is `generated-from-ir`: it references
+    // its generator by this content-addressed id. The id is byte-locked across TS
+    // and F# in tests/cross-verification/generator-registry-id, so pin it here too —
+    // any drift (a renamed generator, a changed hash) breaks this AND the oracle
+    // reference at once, never silently.
+    let e = GeneratorRegistry.byName "rng.splitmix64" |> Option.get
+    Assert.Equal(1, e.Version)
+    Assert.Equal("129c1fac3a48075b481c0f10f30deb06", e.ZetaId)
+    Assert.Equal("129c1fac3a48075b481c0f10f30deb06", GeneratorRegistry.idOf "rng.splitmix64" 1)
+
+[<Fact>]
 let ``ROTOR: a quarter-turn unit rotor sweeps a seed vector around the center (the rotational generator)`` () =
     let re, im = B.rotorOf 1 4 1000 // 1/4 turn, unit growth (a circle)
     let curve = B.rotorCurve (B.p 10 10) 6.0 0.0 re im 4

--- a/tests/cross-verification/generator-registry-id/_gen/gen.fsx
+++ b/tests/cross-verification/generator-registry-id/_gen/gen.fsx
@@ -1,0 +1,48 @@
+// F# oracle for GeneratorRegistry content-addresses — emits fsharp-output.json.
+//
+// Unlike the other cross-verification F# oracles (which recompute from scratch to
+// stay independent), this one references the REAL shipping `GeneratorRegistry`
+// from the compiled Core assembly. That is deliberate and stronger here: the
+// whole point of this primitive is to prove the in-tree registry's content-address
+// agrees, cross-language, with an independent re-derivation (the TS oracle, which
+// DOES recompute hash128/idOf from scratch). So:
+//   * For a REGISTERED generator (`rng.splitmix64`) we resolve via `byName` and
+//     read `.ZetaId` — proving it is an actual registry ROW, not just a hash of
+//     an arbitrary string.
+//   * For the remaining vectors we call `idOf name version` directly (the pure
+//     content-address), covering version-bump distinctness etc.
+// The TS oracle's independent recompute byte-locking against THIS real-registry
+// output is the evidence that the id is reproducible everywhere ("treaty over
+// generators").
+#r "../../../../src/Core/bin/Release/net10.0/Zeta.Core.dll"
+open System.IO
+open System.Text
+open Zeta.Core
+
+// Resolve a registered generator by name (registry ROW), else fall back to the
+// pure content-address. Both must equal the canonical vector.
+let resolve (name: string) (version: int) : string =
+    match GeneratorRegistry.byName name with
+    | Some e when e.Version = version -> e.ZetaId
+    | _ -> GeneratorRegistry.idOf name version
+
+let inputs =
+    [ "rng.splitmix64@1", "rng.splitmix64", 1
+      "boundary.glow@1", "boundary.glow", 1
+      "boundary.glow@2", "boundary.glow", 2
+      "kernel.rbf@1", "kernel.rbf", 1
+      "zetaid.glyph@1", "zetaid.glyph", 1 ]
+
+let sb = StringBuilder()
+sb.AppendLine("{") |> ignore
+sb.AppendLine("  \"_source\": \"generated-from-ir\",") |> ignore
+inputs
+|> List.iteri (fun i (id, name, version) ->
+    let comma = if i < inputs.Length - 1 then "," else ""
+    sb.AppendLine(sprintf "  \"%s\": \"%s\"%s" id (resolve name version) comma) |> ignore)
+sb.AppendLine("}") |> ignore
+
+let here = __SOURCE_DIRECTORY__
+let target = Path.Combine(Path.GetDirectoryName(here), "fsharp-output.json")
+File.WriteAllText(target, sb.ToString())
+printfn "wrote fsharp-output.json"

--- a/tests/cross-verification/generator-registry-id/_gen/gen.ts
+++ b/tests/cross-verification/generator-registry-id/_gen/gen.ts
@@ -1,0 +1,53 @@
+// TS oracle for GeneratorRegistry.idOf — recomputes the content-addressed ZetaId
+// for each canonical `name@version` and emits ts-output.json.
+//
+// This is a faithful independent re-derivation of the F# `hash128`/`idOf`
+// (src/Core/GeneratorRegistry.fs): a two-lane FNV-1a-ish 128-bit fold over the
+// string `"{name}@{version}"`, all arithmetic wrapping uint64, printed as 32-hex
+// (h1 then h2). It does NOT import any zeta port — it is a genuine independent
+// oracle, so cross-language agreement is real evidence, not re-serialisation.
+//
+// The emitted oracle tags itself `_source: generated-from-ir`: the registry id IS
+// the IR coordinate. `rng.splitmix64@1` is the generator behind the splitmix64
+// oracle, so this byte-lock is what ties that oracle's provenance to a real,
+// reproducible, content-addressed registry row rather than a free-floating literal.
+
+import { writeFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+
+const MASK = (1n << 64n) - 1n;
+const u64 = (x: bigint): bigint => x & MASK;
+const PRIME = 0x100000001b3n;
+
+/** Mirror of GeneratorRegistry.hash128: two FNV-1a-ish u64 lanes over the string. */
+function hash128(s: string): string {
+  let h1 = 0xcbf29ce484222325n;
+  let h2 = 0x84222325cbf29ce4n;
+  for (const ch of s) {
+    const c = BigInt(ch.codePointAt(0) ?? 0);
+    h1 = u64((h1 ^ u64(c)) * PRIME);
+    h2 = u64((h2 ^ u64(c * 31n)) * PRIME);
+  }
+  return h1.toString(16).padStart(16, "0") + h2.toString(16).padStart(16, "0");
+}
+
+/** Mirror of GeneratorRegistry.idOf. */
+function idOf(name: string, version: number): string {
+  return hash128(`${name}@${version}`);
+}
+
+// (name, version) inputs — keyed by the canonical id `name@version`.
+const inputs: { id: string; name: string; version: number }[] = [
+  { id: "rng.splitmix64@1", name: "rng.splitmix64", version: 1 },
+  { id: "boundary.glow@1", name: "boundary.glow", version: 1 },
+  { id: "boundary.glow@2", name: "boundary.glow", version: 2 },
+  { id: "kernel.rbf@1", name: "kernel.rbf", version: 1 },
+  { id: "zetaid.glyph@1", name: "zetaid.glyph", version: 1 },
+];
+
+const out: Record<string, string> = { _source: "generated-from-ir" };
+for (const { id, name, version } of inputs) out[id] = idOf(name, version);
+
+const target = join(dirname(import.meta.dir), "ts-output.json");
+writeFileSync(target, `${JSON.stringify(out, null, 2)}\n`);
+console.log("wrote ts-output.json (generated-from-ir)");

--- a/tests/cross-verification/generator-registry-id/compare.ts
+++ b/tests/cross-verification/generator-registry-id/compare.ts
@@ -1,0 +1,13 @@
+// GeneratorRegistry content-address (idOf) cross-verification oracle.
+//
+// Delegates to the shared N-way byte-diff harness: every present language oracle
+// must agree with each other AND with the canonical `result` values in
+// vectors.yaml. The value is `idOf name version` — the deterministic, content-
+// addressed ZetaId a generator earns from its stable name@version
+// (src/Core/GeneratorRegistry.fs). Byte-lock here proves the "treaty over
+// generators": the same generator name yields the SAME id on every oracle, which
+// is what lets a `generated-from-ir` oracle reference its generator by id and have
+// every node resolve it identically (it cannot float apart).
+import { runNWayDiff } from "../_harness/nway-diff.ts";
+
+process.exit(await runNWayDiff({ dir: import.meta.dir }));

--- a/tests/cross-verification/generator-registry-id/fsharp-output.json
+++ b/tests/cross-verification/generator-registry-id/fsharp-output.json
@@ -1,0 +1,8 @@
+{
+  "_source": "generated-from-ir",
+  "rng.splitmix64@1": "129c1fac3a48075b481c0f10f30deb06",
+  "boundary.glow@1": "bb074fb3fefaa419c660f62218eeb912",
+  "boundary.glow@2": "bb074cb3fefa9f00c661972218efcaa5",
+  "kernel.rbf@1": "28e0a82bea989793c194656392bd1096",
+  "zetaid.glyph@1": "f42317cf4d9df65dbb63d5e27430f384"
+}

--- a/tests/cross-verification/generator-registry-id/ts-output.json
+++ b/tests/cross-verification/generator-registry-id/ts-output.json
@@ -1,0 +1,8 @@
+{
+  "_source": "generated-from-ir",
+  "rng.splitmix64@1": "129c1fac3a48075b481c0f10f30deb06",
+  "boundary.glow@1": "bb074fb3fefaa419c660f62218eeb912",
+  "boundary.glow@2": "bb074cb3fefa9f00c661972218efcaa5",
+  "kernel.rbf@1": "28e0a82bea989793c194656392bd1096",
+  "zetaid.glyph@1": "f42317cf4d9df65dbb63d5e27430f384"
+}

--- a/tests/cross-verification/generator-registry-id/vectors.yaml
+++ b/tests/cross-verification/generator-registry-id/vectors.yaml
@@ -1,0 +1,37 @@
+version: 1
+description: >-
+  GeneratorRegistry content-address golden vectors — the cross-language byte-lock
+  for `idOf name version` (src/Core/GeneratorRegistry.fs). A generator's ZetaId is
+  a PURE FUNCTION of its stable `name@version`: a two-lane FNV-1a-ish 128-bit fold
+  (h1 seeded 0xcbf29ce484222325, h2 seeded 0x84222325cbf29ce4, each char mixes
+  c into h1 and c*31 into h2, prime 0x100000001b3, all wrapping uint64), printed
+  as 32 lowercase hex (h1 then h2). This is the "treaty over generators": the same
+  generator name means the SAME id on every node/oracle, so a filetype can refer
+  to its artifacts by id and every language resolves it identically. Agreement here
+  is load-bearing for the codegen-forward pipeline — a `generated-from-ir` oracle
+  references its generator by this id, so the id must be reproducible cross-language
+  or the reference floats apart.
+  `rng.splitmix64@1` is the generator behind the splitmix64 cross-verification
+  oracle (tests/cross-verification/splitmix64), tying that oracle's provenance to a
+  real registered, content-addressed registry row rather than an inline literal.
+vectors:
+  - id: rng.splitmix64@1
+    name: rng.splitmix64
+    gen_version: 1
+    result: "129c1fac3a48075b481c0f10f30deb06"
+  - id: boundary.glow@1
+    name: boundary.glow
+    gen_version: 1
+    result: "bb074fb3fefaa419c660f62218eeb912"
+  - id: boundary.glow@2
+    name: boundary.glow
+    gen_version: 2
+    result: "bb074cb3fefa9f00c661972218efcaa5"
+  - id: kernel.rbf@1
+    name: kernel.rbf
+    gen_version: 1
+    result: "28e0a82bea989793c194656392bd1096"
+  - id: zetaid.glyph@1
+    name: zetaid.glyph
+    gen_version: 1
+    result: "f42317cf4d9df65dbb63d5e27430f384"

--- a/tests/cross-verification/splitmix64/_gen/gen.ts
+++ b/tests/cross-verification/splitmix64/_gen/gen.ts
@@ -26,11 +26,23 @@
 // generator contract.
 //
 // Tier: PROVEN that a data-defined IR + total interpreter byte-locks against the
-// independent hand-ports. The IR here is an inline literal, NOT yet a row read
-// from a DynamicValue Z-set schema (`src/Core/GeneratorRegistry.fs`) — that
-// registry-sourced IR remains the next step.
+// independent hand-ports. The generator now has a REGISTERED, content-addressed
+// identity (`rng.splitmix64@1` in `src/Core/GeneratorRegistry.fs`, id byte-locked
+// cross-language in `../generator-registry-id`). The IR payload itself is still an
+// inline literal here, not yet serialised AS a DynamicValue row carried on the
+// registry's Z-set — wiring the IR-as-data through the registry relation is the
+// remaining step.
 import { writeFileSync } from "node:fs";
 import { join, dirname } from "node:path";
+
+// REGISTRY PROVENANCE — this generator's content-addressed ZetaId.
+// `rng.splitmix64@1` is a registered row in `src/Core/GeneratorRegistry.fs`; its
+// content-address is byte-locked cross-language in
+// `tests/cross-verification/generator-registry-id` and pinned in
+// `tests/Tests.FSharp/GeneratorRegistry.Tests.fs`. Referencing the generator by
+// this derived id (not a minted-and-forgotten one) is what makes "generated-from-
+// ir" point at a real registry row rather than a free-floating literal:
+//   idOf("rng.splitmix64", 1) == 129c1fac3a48075b481c0f10f30deb06
 
 const MASK = (1n << 64n) - 1n;
 const u64 = (x: bigint): bigint => x & MASK;


### PR DESCRIPTION
## What
Upgrades the `generated-from-ir` splitmix64 oracle so its provenance points at a **real, content-addressed `GeneratorRegistry` row** rather than a free-floating literal — the next step on the codegen-forward trajectory.

## Changes
- **Registers `rng.splitmix64@1`** in `src/Core/GeneratorRegistry.fs` (the generator behind the splitmix64 cross-verification oracle).
- **New cross-verification primitive `generator-registry-id`** that byte-locks `idOf(name@version)` across languages:
  - TS oracle independently re-derives `hash128`/`idOf` from scratch.
  - F# oracle resolves via the **real shipping** `GeneratorRegistry` (`byName → .ZetaId` for the registered row).
  - Both agree with the canonical vectors on 5 ids → proves the *treaty over generators*: the same name yields the same id on every oracle, so a generated-from-ir oracle's id reference **cannot float apart across nodes**.
- **Pins** `rng.splitmix64@1`'s ZetaId (`129c1fac…deb06`) in the F# registry tests so a rename / hash change breaks loudly, never silently.
- `splitmix64/_gen/gen.ts` documents its registry provenance + honest tier.

## Why it matters
The harness docs describe oracles "emitted from the IR via registered generators … a registry entry (name@version → content-addressed ZetaId)". This PR makes that reference concrete and cross-language byte-locked.

## Validation
- `bun src/Core.TypeScript/ci/cross-verify-all.ts` → **14/14 primitives passed**
- F# `GeneratorRegistry` tests → **6/6** (incl. the new pinned-id test)
- tsc gate green

## Tier (honest)
**PROVEN:** the generator now has a registered, content-addressed identity, byte-locked TS↔F#. **Remaining:** serialising the IR *payload* itself AS a `DynamicValue` row carried on the registry's Z-set relation (today the mix-op IR is still an inline literal in `gen.ts`).