### PR TITLE
test(qsharp): guard flow-bit source oracle

### DIFF
--- a/registry/complexity-registry.yaml
+++ b/registry/complexity-registry.yaml
@@ -355,6 +355,12 @@
     "space": "O(1)"
     "by": "Derived"
   -
+    "artifact": "rng.splitmix64"
+    "op": "mix"
+    "time": "O(1)"
+    "space": "O(1)"
+    "by": "Derived"
+  -
     "artifact": "engine.zeta-bayesian"
     "op": "run"
     "time": "O(rounds·factors)"

--- a/src/Core.QSharp.ReferenceOracle/flow-bit-source.test.ts
+++ b/src/Core.QSharp.ReferenceOracle/flow-bit-source.test.ts
@@ -1,0 +1,77 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+const source = readFileSync(join(import.meta.dir, "ZetaReferenceOracle.qs"), "utf-8");
+
+const flowBitApplyOperations = [
+  "ApplyExternalBitDifferentiator",
+  "ApplyExternalBitDistinguishZero",
+  "ApplyExternalBitDistinguishOne",
+] as const;
+
+function operationBody(name: string): string {
+  const declarationStart = source.indexOf(`operation ${name}(`);
+  expect(declarationStart).toBeGreaterThanOrEqual(0);
+  if (declarationStart < 0) {
+    return "";
+  }
+
+  const bodyStart = source.indexOf("{", declarationStart);
+  expect(bodyStart).toBeGreaterThanOrEqual(0);
+  if (bodyStart < 0) {
+    return "";
+  }
+
+  let depth = 0;
+  for (let index = bodyStart; index < source.length; index += 1) {
+    const character = source[index];
+    if (character === "{") {
+      depth += 1;
+    } else if (character === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(bodyStart + 1, index);
+      }
+    }
+  }
+
+  expect(depth).toBe(0);
+  return "";
+}
+
+function expectNoTerminalReadout(name: string): void {
+  const body = operationBody(name);
+  expect(body).not.toMatch(/\bM\s*\(/);
+  expect(body).not.toMatch(/\bMeasure\b/);
+  expect(body).not.toMatch(/\bReset(?:All)?\s*\(/);
+}
+
+describe("Q# flow-bit source treaty", () => {
+  test("keeps external entropy differentiation as H, optional Z, H", () => {
+    const differentiator = operationBody("ApplyExternalBitDifferentiator");
+
+    expect(differentiator).toContain("H(qs[0]);");
+    expect(differentiator).toContain("if externalBit");
+    expect(differentiator).toContain("Z(qs[0]);");
+    expect(differentiator.match(/H\(qs\[0\]\);/g)).toHaveLength(2);
+  });
+
+  test("names the two measured identity branches without changing the live circuit", () => {
+    expect(operationBody("ApplyExternalBitDistinguishZero")).toContain("ApplyExternalBitDifferentiator(false, qs);");
+    expect(operationBody("ApplyExternalBitDistinguishOne")).toContain("ApplyExternalBitDifferentiator(true, qs);");
+
+    for (const name of flowBitApplyOperations) {
+      expectNoTerminalReadout(name);
+    }
+  });
+
+  test("confines collapse to the terminal self-contained Q# readout operation", () => {
+    const measurement = operationBody("MeasureExternalBitDifferentiator");
+
+    expect(measurement).toContain("ApplyExternalBitDifferentiator(externalBit, [q]);");
+    expect(measurement).toContain("let measured = M(q);");
+    expect(measurement).toContain("Reset(q);");
+    expect(measurement).toContain("return measured;");
+  });
+});

--- a/src/Core.TypeScript/complexity/complexity-registry.gen.ts
+++ b/src/Core.TypeScript/complexity/complexity-registry.gen.ts
@@ -72,6 +72,7 @@ export const DECLARED: Record<string, Cost> = {
   "shape.exchange-worldlines:draw": { time: "O(crossings·strands)", space: "O(strands)", by: "Derived" },
   "shape.kitaev-chain:draw": { time: "O(sites)", space: "O(sites)", by: "Derived" },
   "shape.crossing:draw": { time: "O(1)", space: "O(1)", by: "Derived" },
+  "rng.splitmix64:mix": { time: "O(1)", space: "O(1)", by: "Derived" },
   "engine.zeta-bayesian:run": { time: "O(rounds·factors)", space: "O(vars+factors)", by: "Derived" },
   "engine.infer-net:run": { time: "O(rounds·factors)", space: "O(model)", by: "Derived" },
   "engine.mock-flat:run": { time: "O(vars)", space: "O(vars)", by: "Derived" },

--- a/src/Core/ComplexityRegistry.fs
+++ b/src/Core/ComplexityRegistry.fs
@@ -93,6 +93,7 @@ module ComplexityRegistry =
               ("shape.exchange-worldlines", "draw"), c "O(crossings·strands)" "O(strands)" Derived
               ("shape.kitaev-chain", "draw"), c "O(sites)" "O(sites)" Derived
               ("shape.crossing", "draw"), c "O(1)" "O(1)" Derived
+              ("rng.splitmix64", "mix"), c "O(1)" "O(1)" Derived
               ("engine.zeta-bayesian", "run"), c "O(rounds·factors)" "O(vars+factors)" Derived
               ("engine.infer-net", "run"), c "O(rounds·factors)" "O(model)" Derived
               ("engine.mock-flat", "run"), c "O(vars)" "O(vars)" Derived

--- a/src/Core/DemoDashboard.fs
+++ b/src/Core/DemoDashboard.fs
@@ -8,7 +8,7 @@ open System.Globalization
 /// One static **HTML/CSS page (no JS)** composing the shipped demo renders into a single view: the **Zeta-NTP
 /// clock** + **grounding** indicator, the **federation graph** (`CoEmpowerGraphSvg`), the **minted-NFT cards**
 /// (`MintPanel`), and the optional **societal-DORA dials** (`SocietalDoraSvg`). Deterministic + byte-lockable
-/// (the clock is injected, not `DateTime.Now`); the whole arc — fetch → graph → federations → minted links →
+/// (the clock is injected, not read from ambient wall time); the whole arc — fetch → graph → federations → minted links →
 /// dials — on one page.
 [<RequireQualifiedAccess>]
 module DemoDashboard =

--- a/src/Core/MintPanel.fs
+++ b/src/Core/MintPanel.fs
@@ -9,8 +9,8 @@ open System.Globalization
 /// is a **minted relational NFT** — *an objectively-rateable remembered link between two travelers*, rated by
 /// shared titles — stamped with the **Zeta-NTP mint time** (the soft-phase tick + the correlated UTC observation
 /// ± uncertainty) and a **grounding indicator** (backed by a real source = grounded; unbacked = the
-/// children's-game / not-real warning). Deterministic + byte-lockable: the clock is **injected** (not
-/// `DateTime.Now` — noninterference), so the same inputs render the same page.
+/// children's-game / not-real warning). Deterministic + byte-lockable: the clock is **injected**,
+/// not read from ambient wall time, so the same inputs render the same page.
 [<RequireQualifiedAccess>]
 module MintPanel =
 


### PR DESCRIPTION
## What

- Adds a source-level Bun treaty test for `ZetaReferenceOracle.qs` flow-bit operations.
- Pins the external-bit differentiator as `H`, optional `Z`, `H`.
- Asserts the live apply operations do not measure or reset, while the self-contained measurement operation owns terminal collapse.
- Declares `rng.splitmix64:mix` as `O(1)` time and `O(1)` space in the canonical complexity registry and regenerates the F#/TS outputs.
- Removes banned ambient-clock tokens from `MintPanel.fs` and `DemoDashboard.fs` docs so the deterministic lint stays mechanical without an allowlist escape.

## Why

The bit-from-flow experiment needs a stable Q# oracle boundary before deeper room, Bayesian, or below-FPGA work. This keeps the reference circuit readable and protects the distinction between unitary live flow and terminal observable readout.

The current main refresh also exposed honest budget/entropy failures: an unpriced SplitMix64 generator and wall-clock spellings in Core doc comments. These now report cleanly through the existing gates.

## Validation

- `bun src/Core.TypeScript/complexity/complexity-generator.ts`
- `bun test src/Core.QSharp.ReferenceOracle`
- `dotnet build -c Release`
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --no-build`
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --no-build --filter FullyQualifiedName~DeterminismLintTests`
- `bun run preflight:quick` (Go lint skipped locally because the toolchain is unavailable; CI still runs it)
- `bunx prettier --check src/Core.QSharp.ReferenceOracle/flow-bit-source.test.ts src/Core.TypeScript/complexity/complexity-registry.gen.ts`

Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: Codex
Agent-Model: gpt-5.5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: not-implied-by-credential
Human-Review-Evidence: none
Action-Mode: human-directed
Task: none
Co-Authored-By: Codex <noreply@openai.com>