### PR TITLE
feat(core): DemoDashboard — the unified living dashboard (graph + DORA dials + minted links + Zeta-NTP clock, one page)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -313,6 +313,7 @@
     <Compile Include="GraphSnapshot.fs" />
     <Compile Include="CoEmpowerGraphSvg.fs" />
     <Compile Include="MintPanel.fs" />
+    <Compile Include="DemoDashboard.fs" />
     <Compile Include="IdentityCapacity.fs" />
     <Compile Include="TrustCalculus.fs" />
     <Compile Include="PrivacyEconomy.fs" />

--- a/src/Core/DemoDashboard.fs
+++ b/src/Core/DemoDashboard.fs
@@ -1,0 +1,73 @@
+namespace Zeta.Core
+
+open System
+open System.Globalization
+
+/// **`DemoDashboard` — the unified living dashboard (Aaron 2026-06-19, shadow\*).**
+///
+/// One static **HTML/CSS page (no JS)** composing the shipped demo renders into a single view: the **Zeta-NTP
+/// clock** + **grounding** indicator, the **federation graph** (`CoEmpowerGraphSvg`), the **minted-NFT cards**
+/// (`MintPanel`), and the optional **societal-DORA dials** (`SocietalDoraSvg`). Deterministic + byte-lockable
+/// (the clock is injected, not `DateTime.Now`); the whole arc — fetch → graph → federations → minted links →
+/// dials — on one page.
+[<RequireQualifiedAccess>]
+module DemoDashboard =
+
+    let private si (i: int64) : string = i.ToString(CultureInfo.InvariantCulture)
+
+    let private esc (s: string) : string =
+        s
+            .Replace("&", "&amp;", StringComparison.Ordinal)
+            .Replace("<", "&lt;", StringComparison.Ordinal)
+            .Replace(">", "&gt;", StringComparison.Ordinal)
+
+    let private css =
+        "body{font-family:system-ui,sans-serif;background:#1b1f24;color:#e6e6e6;margin:0;padding:24px}" +
+        "h1{font-size:22px;font-weight:600}h2{font-size:15px;color:#9fb6c9;margin:18px 0 8px}" +
+        ".clock{font-family:monospace;color:#9fb6c9}.ok{color:#54b894}.warn{color:#e0563f}" +
+        ".row{display:flex;flex-wrap:wrap;gap:28px;align-items:flex-start}" +
+        ".grid{display:flex;flex-wrap:wrap;gap:12px}" +
+        ".nft{background:#222831;border:1px solid #3a424c;border-radius:8px;padding:12px 14px;min-width:170px}" +
+        ".pair{font-weight:600}.link{color:#3399cc}.rating{color:#9fb6c9;font-size:13px;margin-top:6px}" +
+        "footer{margin-top:20px;color:#6b7682;font-size:12px}"
+
+    /// The complete dashboard page. `dora = None` omits the dials section.
+    let renderPage
+        (clock: MintPanel.MintClock)
+        (grounded: bool)
+        (source: string)
+        (graph: CoEmpowerGraph.Graph)
+        (links: CostarFederations.MintedLink list)
+        (dora: SocietalDora.Metrics option)
+        : string =
+        let cards = links |> List.map MintPanel.renderCard |> String.concat ""
+
+        let groundBadge =
+            if grounded then
+                String.Concat("<span class=\"ok\">&#10003; grounded — backed by ", esc source, "</span>")
+            else
+                "<span class=\"warn\">&#9888; ungrounded — unbacked (not real)</span>"
+
+        let clockLine =
+            String.Concat("phase ", si clock.Phase, " &middot; UTC ", esc clock.Utc, " &plusmn; ", si clock.UncertaintyMs, "ms")
+
+        let dialsBlk =
+            match dora with
+            | Some m -> String.Concat("<h2>Societal-DORA health</h2>", SocietalDoraSvg.render m)
+            | None -> ""
+
+        String.Concat(
+            "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>Zeta — living dashboard</title><style>",
+            css,
+            "</style></head><body><h1>Zeta — living dashboard</h1><div class=\"clock\">",
+            clockLine,
+            "</div><div>",
+            groundBadge,
+            "</div><div class=\"row\"><div><h2>Federation graph</h2>",
+            CoEmpowerGraphSvg.render 280 graph,
+            "</div><div>",
+            dialsBlk,
+            "</div></div><h2>Minted relational links</h2><div class=\"grid\">",
+            cards,
+            "</div><footer>Federation graph + societal-DORA dials + minted NFT links, one page. Mint-time = soft-phase + UTC. No JS; deterministic.</footer></body></html>"
+        )

--- a/tests/Tests.FSharp/Formal/DemoDashboard.Tests.fs
+++ b/tests/Tests.FSharp/Formal/DemoDashboard.Tests.fs
@@ -1,0 +1,59 @@
+module Zeta.Tests.Formal.DemoDashboardTests
+
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Core
+
+module D = Zeta.Core.DemoDashboard
+module M = Zeta.Core.MintPanel
+module G = Zeta.Core.CoEmpowerGraph
+module F = Zeta.Core.CostarFederations
+module I = Zeta.Core.ImdbDataset
+
+let private graph () : G.Graph =
+    { G.N = 3
+      G.Identity = [| 1; 2; 3 |]
+      G.Adjacency = [| [| 1 |]; [| 0; 2 |]; [| 1 |] |]
+      G.Role = [| G.Creator; G.Audience; G.Audience |] }
+
+let private links =
+    F.reverseMint (
+        I.parsePrincipals
+            [ "tconst\tordering\tnconst\tcategory\tjob\tcharacters"
+              "tt001\t1\tnm0001\tactor\t\\N\t\\N"
+              "tt001\t2\tnm0002\tactress\t\\N\t\\N" ]
+    )
+
+let private clock = { M.Phase = 7L; M.Utc = "2026-06-19T12:00:00Z"; M.UncertaintyMs = 5L }
+
+let private dora: SocietalDora.Metrics =
+    { EmpowermentFrequency = 0.7
+      CaptureRate = 0.3
+      MeanRecoveryLength = 1.5
+      MirrorRate = 0.1
+      MeanCoupledGain = 0.4
+      MeanQpg = 0.3
+      QpgWeightedEmpowerment = 0.25 }
+
+[<Fact>]
+let ``the dashboard is one complete scriptless HTML page composing graph + clock + grounding + minted links`` () =
+    let html = D.renderPage clock true "IMDb" (graph ()) links (Some dora)
+    html.StartsWith("<!DOCTYPE html>", System.StringComparison.Ordinal) |> should equal true
+    html.Contains "</html>" |> should equal true
+    html.Contains "<script" |> should equal false
+    html.Contains "<svg" |> should equal true // the federation graph
+    html.Contains "phase 7" |> should equal true // Zeta-NTP clock
+    html.Contains "grounded — backed by IMDb" |> should equal true
+    html.Contains "nm0001" |> should equal true // a minted link
+    html.Contains "Societal-DORA health" |> should equal true // the dials section
+
+[<Fact>]
+let ``dora = None omits the dials section`` () =
+    let html = D.renderPage clock true "IMDb" (graph ()) links None
+    html.Contains "Societal-DORA health" |> should equal false
+    html.Contains "<svg" |> should equal true // graph still present
+
+[<Fact>]
+let ``the dashboard render is deterministic`` () =
+    D.renderPage clock true "IMDb" (graph ()) links (Some dora)
+    |> should equal (D.renderPage clock true "IMDb" (graph ()) links (Some dora))

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -354,6 +354,7 @@
     <Compile Include="Formal/GraphSnapshot.Tests.fs" />
     <Compile Include="Formal/CoEmpowerGraphSvg.Tests.fs" />
     <Compile Include="Formal/MintPanel.Tests.fs" />
+    <Compile Include="Formal/DemoDashboard.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />
 
     <!-- Circuit/ -->


### PR DESCRIPTION
Aaron 2026-06-19 *"what's next, let's do it."* Composes the shipped demo renders into **one static HTML/CSS page (no JS)**: Zeta-NTP clock + grounding, the **federation graph** (CoEmpowerGraphSvg), the **minted-NFT cards** (MintPanel), and optional **societal-DORA dials** (SocietalDoraSvg) — the whole arc on one page. Deterministic (injected clock).

**`src/Core/DemoDashboard.fs`:** `renderPage` reusing the three render families. **3 tests green**, Core 0-warning: complete scriptless composite page; `dora=None` omits the dials; deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)