### PR TITLE
feat(cross-verify): SplitMix64 generated-from-ir oracle reads its IR from a DynamicValue row

### DIFF
--- a/tests/Tests.FSharp/DynamicValue.Canonical.Tests.fs
+++ b/tests/Tests.FSharp/DynamicValue.Canonical.Tests.fs
@@ -201,3 +201,50 @@ let ``CANONICAL DynamicValue: every JSON seed vector is a fixed point of encode�
                 | Error e -> Some(sprintf "%s: re-encode failed: %A" name e)
             | Error e -> Some(sprintf "%s: seed json failed to decode: %A" name e))
     Assert.True(Array.isEmpty failures, "JSON seed fixed-point failures:\n" + System.String.Join("\n", failures))
+// ═══════════════════════════════════════════════════════════════════
+// CODEGEN-FORWARD: the SplitMix64 generator's IR is a DynamicValue ROW.
+// The cross-verification oracle tests/cross-verification/splitmix64 is
+// "generated-from-ir": its TS generator READS the finalizer IR from
+// `_gen/splitmix64.ir.json` (a canonical-JSON DynamicValue) and folds it.
+// This test pins the CROSS-LANGUAGE byte-lock of that row: the REAL shipping
+// F# `DynamicValue.toCanonicalJson`, given the same IR, must reproduce the
+// committed row byte-for-byte (so the row is a genuine schema value both
+// languages agree on, not a TS-only artifact), and the row must round-trip.
+// u64 multiplier constants are stored as their signed-int64 bit-pattern
+// (the mix multiply is mod 2^64, so the reinterpretation is exact).
+[<Fact>]
+let ``CODEGEN-FORWARD: SplitMix64 IR row byte-locks F# toCanonicalJson and round-trips`` () =
+    let i (n: int64) = DynamicValue.Int n
+    let s (x: string) = DynamicValue.String x
+    let op name key (v: int64) = DynamicValue.Object [ ("op", s name); (key, i v) ]
+
+    let ir =
+        DynamicValue.Object
+            [ ("generator", s "rng.splitmix64")
+              ("version", i 1L)
+              ("zetaId", s "129c1fac3a48075b481c0f10f30deb06")
+              ("ops",
+               DynamicValue.Array
+                   [ op "mul" "k" 0x9e3779b97f4a7c15L
+                     op "xorshr" "s" 30L
+                     op "mul" "k" 0xbf58476d1ce4e5b9L
+                     op "xorshr" "s" 27L
+                     op "mul" "k" 0x94d049bb133111ebL
+                     op "xorshr" "s" 31L ]) ]
+
+    let rowPath =
+        Path.Join(repoRoot (), "tests", "cross-verification", "splitmix64", "_gen", "splitmix64.ir.json")
+
+    let rowText = (File.ReadAllText rowPath).Trim()
+
+    match DynamicValue.toCanonicalJson ir with
+    | Ok cj ->
+        Assert.Equal(rowText, cj) // byte-identical to the committed row the TS oracle reads
+        // and the committed row decodes + re-encodes to itself (canonical fixed point)
+        match DynamicValue.fromCanonicalJson rowText with
+        | Ok decoded ->
+            match DynamicValue.toCanonicalJson decoded with
+            | Ok reJson -> Assert.Equal(rowText, reJson)
+            | Error e -> failwithf "IR row re-encode failed: %A" e
+        | Error e -> failwithf "IR row failed to decode: %A" e
+    | Error e -> failwithf "IR encode failed: %A" e

--- a/tests/cross-verification/splitmix64/_gen/gen-ir.test.ts
+++ b/tests/cross-verification/splitmix64/_gen/gen-ir.test.ts
@@ -2,36 +2,59 @@
 //
 // WHY THIS EXISTS
 // ---------------
-// The TS oracle for splitmix64 is now "generated-from-ir": the mixer is data
-// (an ordered list of total u64->u64 ops) folded by a tiny interpreter, rather
-// than hand-written imperative code (see `gen.ts`). The N-way harness already
-// proves the EMITTED bytes byte-lock against the five independent hand-ports.
+// The TS oracle for splitmix64 is "generated-from-ir": the mixer is DATA — an
+// ordered list of total u64->u64 ops carried in a real DynamicValue row
+// (`splitmix64.ir.json`), decoded through the project's canonical-JSON decoder and
+// folded by a tiny interpreter (see `gen.ts`). The N-way harness already proves the
+// EMITTED bytes byte-lock against the five independent hand-ports.
 //
-// This test guards the layer beneath that: it proves the IR + interpreter is
-// the actual source of those bytes, and — crucially — that CORRUPTING the IR by
-// a single constant produces a DIFFERENT result. That is the generator-fidelity
-// invariant the codegen-forward trajectory in `_harness/nway-diff.ts` names: a
-// green that cannot turn red when the generator is wrong is a Sybil green. If a
-// wrong IR silently produced the right bytes, the byte-lock would be meaningless.
+// This test guards the layer beneath that. It proves three things:
+//   1. the IR ROW is a CANONICAL DynamicValue (the real `fromCanonicalJson`
+//      accepts it AND the fixed-point `canonicalJson(decode(x)) === x` holds) —
+//      so the row is genuinely a schema value, not loose JSON;
+//   2. the IR decoded FROM THE ROW reproduces the canonical golden vectors;
+//   3. CORRUPTING the IR (one constant, or a dropped round) DIVERGES — the
+//      generator-fidelity invariant the codegen-forward trajectory names: a green
+//      that cannot turn red when the generator is wrong is a Sybil green.
 //
 // Run: `bun test tests/cross-verification/splitmix64/_gen/gen-ir.test.ts`
 
 import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { canonicalJson, fromCanonicalJson, type Tagged } from "../../../../src/Core.TypeScript/dynamic-value/json.ts";
 
 const MASK = (1n << 64n) - 1n;
 const u64 = (x: bigint): bigint => x & MASK;
 
 type MixOp = { readonly op: "mul"; readonly k: bigint } | { readonly op: "xorshr"; readonly s: bigint };
 
-/** The canonical SplitMix64 finalizer IR (kept in sync with gen.ts). */
-const SPLITMIX64_IR: readonly MixOp[] = [
-  { op: "mul", k: 0x9e3779b97f4a7c15n },
-  { op: "xorshr", s: 30n },
-  { op: "mul", k: 0xbf58476d1ce4e5b9n },
-  { op: "xorshr", s: 27n },
-  { op: "mul", k: 0x94d049bb133111ebn },
-  { op: "xorshr", s: 31n },
-];
+// --- load the IR from the real DynamicValue row, exactly as gen.ts does ---
+
+const IR_TEXT = readFileSync(join(import.meta.dir, "splitmix64.ir.json"), "utf8").trim();
+
+function field(obj: Tagged, key: string): Tagged {
+  if (obj.t !== "obj") throw new Error("expected object");
+  const hit = obj.v.find(([k]) => k === key);
+  if (!hit) throw new Error(`missing field ${key}`);
+  return hit[1];
+}
+function parseOps(ir: Tagged): MixOp[] {
+  const ops = field(ir, "ops");
+  if (ops.t !== "arr") throw new Error("ops must be array");
+  return ops.v.map((node): MixOp => {
+    const opNode = field(node, "op");
+    if (opNode.t !== "str") throw new Error("op must be str");
+    if (opNode.v === "mul") {
+      const k = field(node, "k");
+      if (k.t !== "int") throw new Error("k must be int");
+      return { op: "mul", k: u64(BigInt(k.v)) }; // reinterpret stored i64 -> u64
+    }
+    const s = field(node, "s");
+    if (s.t !== "int") throw new Error("s must be int");
+    return { op: "xorshr", s: BigInt(s.v) };
+  });
+}
 
 /** The same total interpreter gen.ts uses. */
 function runIr(ir: readonly MixOp[], x: bigint): bigint {
@@ -54,19 +77,33 @@ const GOLDEN: Record<string, string> = {
   "11400714819323198485": "5878998237028904013",
 };
 
-test("IR interpreter reproduces the canonical SplitMix64 golden vectors", () => {
+test("the IR row is a CANONICAL DynamicValue (decoder accepts it; fixed-point holds)", () => {
+  const decoded = fromCanonicalJson(IR_TEXT);
+  expect(decoded.ok).toBe(true);
+  if (!decoded.ok) return;
+  // fixed-point: re-encoding the decoded value reproduces the row byte-for-byte.
+  expect(canonicalJson(decoded.value)).toBe(IR_TEXT);
+});
+
+test("IR decoded FROM THE ROW reproduces the canonical SplitMix64 golden vectors", () => {
+  const decoded = fromCanonicalJson(IR_TEXT);
+  expect(decoded.ok).toBe(true);
+  if (!decoded.ok) return;
+  const ir = parseOps(decoded.value);
   for (const [input, expected] of Object.entries(GOLDEN)) {
-    expect(runIr(SPLITMIX64_IR, BigInt(input)).toString()).toBe(expected);
+    expect(runIr(ir, BigInt(input)).toString()).toBe(expected);
   }
 });
 
 test("a one-constant corruption of the IR diverges from the golden (fidelity bites)", () => {
+  const decoded = fromCanonicalJson(IR_TEXT);
+  if (!decoded.ok) throw new Error("row did not decode");
+  const ir = parseOps(decoded.value);
   // Flip the last finalizer multiplier's low bit. A wrong generator must NOT
   // silently produce the right bytes.
-  const corrupt: MixOp[] = SPLITMIX64_IR.map((op) =>
+  const corrupt: MixOp[] = ir.map((op) =>
     op.op === "mul" && op.k === 0x94d049bb133111ebn ? { op: "mul", k: 0x94d049bb133111ean } : op,
   );
-  // For the nonzero inputs the corrupted IR must differ from the golden.
   let differedSomewhere = false;
   for (const [input, expected] of Object.entries(GOLDEN)) {
     if (input === "0") continue; // 0 maps to 0 under any multiply
@@ -76,6 +113,9 @@ test("a one-constant corruption of the IR diverges from the golden (fidelity bit
 });
 
 test("dropping a round from the IR diverges from the golden", () => {
-  const truncated = SPLITMIX64_IR.slice(0, SPLITMIX64_IR.length - 1); // drop final xor-shift
+  const decoded = fromCanonicalJson(IR_TEXT);
+  if (!decoded.ok) throw new Error("row did not decode");
+  const ir = parseOps(decoded.value);
+  const truncated = ir.slice(0, ir.length - 1); // drop final xor-shift
   expect(runIr(truncated, 1n).toString()).not.toBe(GOLDEN["1"]);
 });

--- a/tests/cross-verification/splitmix64/_gen/gen.ts
+++ b/tests/cross-verification/splitmix64/_gen/gen.ts
@@ -1,70 +1,97 @@
-// IR-DRIVEN TS oracle for SplitMix64 — the first "generated-from-ir" oracle.
+// IR-DRIVEN TS oracle for SplitMix64 — a "generated-from-ir" oracle whose IR is a
+// real DynamicValue ROW, not an inline literal.
 //
-// WHAT CHANGED (codegen-forward, 2026-06-20)
-// ------------------------------------------
-// Previously this file recomputed the mixer with hand-written imperative steps
-// (a literal port). It now does NOT contain the algorithm as code — it contains
-// the algorithm as DATA (`SPLITMIX64_IR`), and a tiny total interpreter folds
-// that IR over each input. This is the smallest honest instance of the
-// codegen-forward trajectory documented in `_harness/nway-diff.ts`:
+// THE TRAJECTORY (codegen-forward)
+// --------------------------------
+// `_harness/nway-diff.ts` documents the shift from "do the hand-ports agree?" to
+// "does the generated code match the byte-lock?". This oracle does NOT contain the
+// SplitMix64 algorithm as code. It READS the algorithm as DATA from a serialised
+// DynamicValue document (`splitmix64.ir.json`), DECODES it with the project's real
+// canonical-JSON decoder (`src/Core.TypeScript/dynamic-value/json.ts` —
+// `fromCanonicalJson`), and a tiny total interpreter folds the decoded ops over
+// each input. The emitted oracle tags itself `"_source": "generated-from-ir"`; the
+// N-way harness byte-locks it against the five independent hand-ports + canonical.
 //
-//   "this harness then shifts from 'do the hand-ports agree?' to 'does the
-//    generated code match the byte-lock?'"
+// WHY A DynamicValue ROW (the schema, not a literal)
+// --------------------------------------------------
+// The IR is the payload of the registered generator `rng.splitmix64@1`
+// (`src/Core/GeneratorRegistry.fs`; id `129c1fac…deb06`, byte-locked cross-language
+// in `../generator-registry-id`). Storing the IR as a canonical DynamicValue makes
+// it a genuine row in the universal value schema: language-neutral, byte-lockable,
+// and decoded here through the SAME decoder the rest of Zeta uses — so a malformed
+// or non-canonical IR is rejected as data, never silently mis-folded.
 //
-// The emitted oracle tags itself `"_source": "generated-from-ir"`. The N-way
-// harness then byte-locks THIS generated output against the five independent
-// hand-ports (fsharp/cs/rust/python/go) AND the canonical vectors. If the IR or
-// the interpreter is wrong, the byte-lock turns red and names TS as the
-// dissenter — exactly the generator-fidelity check the trajectory calls for.
+// INT64 DOMAIN NOTE (honest constraint)
+// -------------------------------------
+// DynamicValue.Int is int64, but SplitMix64's multiplier constants are u64. They
+// are therefore stored as their two's-complement SIGNED-int64 bit-pattern (e.g.
+// 0x9e3779b97f4a7c15 -> -7046029254386353131). Because the mix multiply is mod
+// 2^64, reinterpreting the stored i64 back to u64 (`& MASK`) is bit-identical — the
+// round-trip is exact. Shift amounts (<64) need no reinterpretation.
 //
-// IR SHAPE — the finalizer as an ordered list of total u64->u64 ops
-// -----------------------------------------------------------------
-// SplitMix64's finalizer (Vigna, arXiv:1410.0530 §3) is a seed multiply then a
-// sequence of (xor-shift, multiply) rounds then a final xor-shift. Expressed as
-// data, every op is a total wrapping-u64 function, so the whole IR is a total
-// fold — DST-deterministic and byte-lockable, matching the `gen/README.md`
-// generator contract.
-//
-// Tier: PROVEN that a data-defined IR + total interpreter byte-locks against the
-// independent hand-ports. The generator now has a REGISTERED, content-addressed
-// identity (`rng.splitmix64@1` in `src/Core/GeneratorRegistry.fs`, id byte-locked
-// cross-language in `../generator-registry-id`). The IR payload itself is still an
-// inline literal here, not yet serialised AS a DynamicValue row carried on the
-// registry's Z-set — wiring the IR-as-data through the registry relation is the
-// remaining step.
-import { writeFileSync } from "node:fs";
+// Tier: PROVEN that the IR-as-DynamicValue-row + total interpreter byte-locks
+// against the five independent hand-ports and the canonical vectors. The row here
+// is read from a sibling file; carrying it as a live tuple on the registry's DBSP
+// Z-set relation (rather than a checked-in document) is the remaining integration.
+import { readFileSync, writeFileSync } from "node:fs";
 import { join, dirname } from "node:path";
-
-// REGISTRY PROVENANCE — this generator's content-addressed ZetaId.
-// `rng.splitmix64@1` is a registered row in `src/Core/GeneratorRegistry.fs`; its
-// content-address is byte-locked cross-language in
-// `tests/cross-verification/generator-registry-id` and pinned in
-// `tests/Tests.FSharp/GeneratorRegistry.Tests.fs`. Referencing the generator by
-// this derived id (not a minted-and-forgotten one) is what makes "generated-from-
-// ir" point at a real registry row rather than a free-floating literal:
-//   idOf("rng.splitmix64", 1) == 129c1fac3a48075b481c0f10f30deb06
+import { fromCanonicalJson, type Tagged } from "../../../../src/Core.TypeScript/dynamic-value/json.ts";
 
 const MASK = (1n << 64n) - 1n;
 const u64 = (x: bigint): bigint => x & MASK;
+/** Reinterpret a stored signed-int64 back to the u64 it bit-encodes. */
+const fromI64 = (i: bigint): bigint => u64(i);
 
 /** A single total u64->u64 step in the finalizer IR. */
 type MixOp =
   | { readonly op: "mul"; readonly k: bigint } // z := z * k        (wrapping)
   | { readonly op: "xorshr"; readonly s: bigint }; // z := z ^ (z >> s)
 
-/** The SplitMix64 finalizer, as data. Change a constant here and the byte-lock
- *  will catch the divergence. */
-const SPLITMIX64_IR: readonly MixOp[] = [
-  { op: "mul", k: 0x9e3779b97f4a7c15n },
-  { op: "xorshr", s: 30n },
-  { op: "mul", k: 0xbf58476d1ce4e5b9n },
-  { op: "xorshr", s: 27n },
-  { op: "mul", k: 0x94d049bb133111ebn },
-  { op: "xorshr", s: 31n },
-];
+// --- read the IR ROW and decode it through the real DynamicValue canonical-JSON decoder ---
 
-/** The total interpreter: fold the IR over an input. It has no algorithm-
- *  specific branching — it only knows how to apply the two op kinds. */
+const irPath = join(import.meta.dir, "splitmix64.ir.json");
+const irText = readFileSync(irPath, "utf8").trim();
+const decoded = fromCanonicalJson(irText);
+if (!decoded.ok) {
+  throw new Error(`splitmix64.ir.json is not a canonical DynamicValue: ${decoded.error}`);
+}
+
+// --- project the decoded DynamicValue (Tagged) down to the typed op list ---
+
+function field(obj: Tagged, key: string): Tagged {
+  if (obj.t !== "obj") throw new Error("IR: expected object");
+  const hit = obj.v.find(([k]) => k === key);
+  if (!hit) throw new Error(`IR: missing field "${key}"`);
+  return hit[1];
+}
+function asInt(v: Tagged): bigint {
+  if (v.t !== "int") throw new Error("IR: expected int");
+  return BigInt(v.v);
+}
+function asStr(v: Tagged): string {
+  if (v.t !== "str") throw new Error("IR: expected string");
+  return v.v;
+}
+
+function parseOps(ir: Tagged): readonly MixOp[] {
+  const opsNode = field(ir, "ops");
+  if (opsNode.t !== "arr") throw new Error("IR: ops must be an array");
+  return opsNode.v.map((node): MixOp => {
+    const op = asStr(field(node, "op"));
+    switch (op) {
+      case "mul":
+        return { op: "mul", k: fromI64(asInt(field(node, "k"))) };
+      case "xorshr":
+        return { op: "xorshr", s: asInt(field(node, "s")) };
+      default:
+        throw new Error(`IR: unknown op "${op}"`);
+    }
+  });
+}
+
+const SPLITMIX64_IR: readonly MixOp[] = parseOps(decoded.value);
+
+/** The total interpreter: fold the IR (decoded from the row) over an input. */
 function mix(x: bigint): bigint {
   return SPLITMIX64_IR.reduce((z, step) => {
     switch (step.op) {
@@ -94,4 +121,4 @@ for (const [id, x] of Object.entries(inputs)) out[id] = mix(x).toString();
 
 const target = join(dirname(import.meta.dir), "ts-output.json");
 writeFileSync(target, `${JSON.stringify(out, null, 2)}\n`);
-console.log("wrote ts-output.json (generated-from-ir)");
+console.log("wrote ts-output.json (generated-from-ir, IR read from splitmix64.ir.json DynamicValue row)");

--- a/tests/cross-verification/splitmix64/_gen/splitmix64.ir.json
+++ b/tests/cross-verification/splitmix64/_gen/splitmix64.ir.json
@@ -1,0 +1,1 @@
+{"generator":"rng.splitmix64","version":1,"zetaId":"129c1fac3a48075b481c0f10f30deb06","ops":[{"op":"mul","k":-7046029254386353131},{"op":"xorshr","s":30},{"op":"mul","k":-4658895280553007687},{"op":"xorshr","s":27},{"op":"mul","k":-7723592293110705685},{"op":"xorshr","s":31}]}


### PR DESCRIPTION
## What
Completes the codegen-forward step started in #8679: the splitmix64 `generated-from-ir` oracle's IR is no longer an inline TS literal — it is a **real DynamicValue row**, byte-locked cross-language.

## Changes
- **`splitmix64/_gen/splitmix64.ir.json`** — the finalizer IR as a canonical-JSON DynamicValue (`ops` as objects; u64 multipliers stored as their **signed-int64 bit-pattern**, since `DynamicValue.Int` is int64 and the mix multiply is mod 2^64, so the reinterpretation is bit-exact).
- **`gen.ts`** now READS that row, DECODES it via the project's real canonical-JSON decoder (`fromCanonicalJson`), projects the decoded `Tagged` ops, and folds. The mixer algorithm no longer appears as code in the generator — it lives in the row. Emitted `ts-output.json` is **byte-identical** (all 6 oracles still agree on 10 vectors).
- **`gen-ir.test.ts`** upgraded to load the IR FROM the row, assert it is a canonical DynamicValue (decoder accepts + fixed-point `canonicalJson(decode x) == x`), and that corruption still bites.
- **F# test** (`DynamicValue.Canonical.Tests.fs`) pins the cross-language byte-lock: the **real shipping** `DynamicValue.toCanonicalJson` reproduces `splitmix64.ir.json` byte-for-byte and round-trips it — proving the row is a schema value **both languages agree on**, not a TS-only artifact.

## Why it matters
This makes "the IR is a row in the schema" literally true: the generator reads its algorithm from a serialised DynamicValue, decoded through the same canonical-JSON machinery the rest of Zeta uses, and that row's bytes are locked across TS and F#.

## Validation
- `cross-verify-all` → **14/14**
- splitmix64 `gen-ir.test` → **4/4**
- F# `DynamicValueCanonicalTests` → **9/9** (incl. the new IR-row byte-lock)
- tsc gate green

## Tier (honest)
**PROVEN:** IR-as-DynamicValue-row + total interpreter byte-locks against the five independent hand-ports and canonical, with the row's encoding locked TS↔F#. **Remaining:** carrying the row as a live tuple on the registry's DBSP Z-set relation (today it is a checked-in canonical document).