### PR TITLE
feat(core): DemoPipeline — the whole IMDb arc as one DST-replayable path (recorded fetch → dashboard + snapshot)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -315,6 +315,7 @@
     <Compile Include="CoEmpowerGraphSvg.fs" />
     <Compile Include="MintPanel.fs" />
     <Compile Include="DemoDashboard.fs" />
+    <Compile Include="DemoPipeline.fs" />
     <Compile Include="IdentityCapacity.fs" />
     <Compile Include="TrustCalculus.fs" />
     <Compile Include="PrivacyEconomy.fs" />

--- a/src/Core/DemoPipeline.fs
+++ b/src/Core/DemoPipeline.fs
@@ -1,0 +1,51 @@
+namespace Zeta.Core
+
+/// **`DemoPipeline` — the whole IMDb/Wikipedia arc as one DST-replayable path (Aaron 2026-06-19, shadow\*).**
+///
+/// The capstone that wires every slice into a single call: a (recorded, for DST) **live fetch** →
+/// `ImdbDataset.Principal`s → **reverse-mint** links (`CostarFederations`) + the **federation graph**
+/// (`CoEmpowerGraph`) → the **rendered dashboard** (`DemoDashboard`) and a **content-addressed snapshot**
+/// (`GraphSnapshot`). Network enters only through the injected `LiveLegs.Fetch` port; everything else is pure,
+/// so the entire pipeline is offline-testable and replayable.
+[<RequireQualifiedAccess>]
+module DemoPipeline =
+
+    /// Fetch + concatenate the cast credits of several movies via the injected port (recorded ⇒ DST replay).
+    let fetchPrincipals
+        (fetch: LiveLegs.Fetch)
+        (apiKey: string)
+        (movieIds: string list)
+        : Async<ImdbDataset.Principal list> =
+        async {
+            let acc = System.Collections.Generic.List<ImdbDataset.Principal>()
+
+            for id in movieIds do
+                let! ps = LiveLegs.Tmdb.fetchCredits fetch apiKey id
+                acc.AddRange ps
+
+            return List.ofSeq acc
+        }
+
+    /// The full demo render: principals → dashboard HTML (federation graph + minted links + Zeta-NTP clock +
+    /// grounding). The clock is injected (DST); `dora` dials omitted (the co-star graph isn't a DORA edge set).
+    let renderDashboard
+        (clock: MintPanel.MintClock)
+        (grounded: bool)
+        (source: string)
+        (kinds: int)
+        (seed: int)
+        (principals: ImdbDataset.Principal list)
+        : string =
+        let links = CostarFederations.reverseMint principals
+        let _, graph = ImdbDataset.toCoEmpowerGraph kinds seed principals
+        DemoDashboard.renderPage clock grounded source graph links None
+
+    /// Persist the reified co-star graph as a content-addressed snapshot (returns the `MerkleHash` + store).
+    let snapshot
+        (kinds: int)
+        (seed: int)
+        (principals: ImdbDataset.Principal list)
+        (store: ContentStore.Store<string>)
+        : Result<MerkleHash * ContentStore.Store<string>, string> =
+        let _, graph = ImdbDataset.toCoEmpowerGraph kinds seed principals
+        GraphSnapshot.store graph store

--- a/tests/Tests.FSharp/Formal/DemoPipeline.Tests.fs
+++ b/tests/Tests.FSharp/Formal/DemoPipeline.Tests.fs
@@ -1,0 +1,58 @@
+module Zeta.Tests.Formal.DemoPipelineTests
+
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Core
+
+module P = Zeta.Core.DemoPipeline
+module L = Zeta.Core.LiveLegs
+module M = Zeta.Core.MintPanel
+
+// two recorded TMDB credits responses (Keanu/6384 is in both → the connector)
+let private creds603 =
+    """{"id":603,"cast":[{"id":6384,"name":"Keanu Reeves"},{"id":2975,"name":"Laurence Fishburne"}]}"""
+
+let private creds604 =
+    """{"id":604,"cast":[{"id":6384,"name":"Keanu Reeves"},{"id":1331,"name":"Carrie-Anne Moss"}]}"""
+
+let private fetch =
+    L.recordedFetch (
+        Map.ofList
+            [ L.Tmdb.creditsUrl "KEY" "603", creds603
+              L.Tmdb.creditsUrl "KEY" "604", creds604 ]
+    )
+
+let private clock = { M.Phase = 1L; M.Utc = "2026-06-19T12:00:00Z"; M.UncertaintyMs = 2L }
+
+[<Fact>]
+let ``fetchPrincipals pulls + concatenates cast across movies (via the recorded port)`` () =
+    let ps = P.fetchPrincipals fetch "KEY" [ "603"; "604" ] |> Async.RunSynchronously
+    ps.Length |> should equal 4 // 2 cast × 2 movies
+    ps |> List.map (fun p -> p.Nconst) |> List.contains "tmdb:6384" |> should equal true
+
+[<Fact>]
+let ``end-to-end: recorded fetch → principals → rendered dashboard (one DST path)`` () =
+    let ps = P.fetchPrincipals fetch "KEY" [ "603"; "604" ] |> Async.RunSynchronously
+    let html = P.renderDashboard clock true "TMDB" 4 7 ps
+    html.StartsWith("<!DOCTYPE html>", System.StringComparison.Ordinal) |> should equal true
+    html.Contains "<script" |> should equal false
+    html.Contains "<svg" |> should equal true // the federation graph
+    html.Contains "tmdb:6384" |> should equal true // a minted co-star link (the connector)
+    html.Contains "phase 1" |> should equal true // Zeta-NTP clock
+
+[<Fact>]
+let ``snapshot persists the reified graph and round-trips by content hash`` () =
+    let ps = P.fetchPrincipals fetch "KEY" [ "603"; "604" ] |> Async.RunSynchronously
+    match P.snapshot 4 7 ps (GraphSnapshot.emptyStore ()) with
+    | Ok(h, store) ->
+        match GraphSnapshot.load h store with
+        | Some(Ok g) -> g.N |> should equal 3 // 6384, 2975, 1331
+        | other -> failwithf "expected Some(Ok graph), got %A" other
+    | Error e -> failwith e
+
+[<Fact>]
+let ``the pipeline is deterministic (DST): same recordings → same dashboard`` () =
+    let run () =
+        let ps = P.fetchPrincipals fetch "KEY" [ "603"; "604" ] |> Async.RunSynchronously
+        P.renderDashboard clock true "TMDB" 4 7 ps
+    run () |> should equal (run ())

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -356,6 +356,7 @@
     <Compile Include="Formal/CoEmpowerGraphSvg.Tests.fs" />
     <Compile Include="Formal/MintPanel.Tests.fs" />
     <Compile Include="Formal/DemoDashboard.Tests.fs" />
+    <Compile Include="Formal/DemoPipeline.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />
 
     <!-- Circuit/ -->


### PR DESCRIPTION
Aaron 2026-06-19 *"lets keep going."* The capstone wiring every slice into one call: a (recorded, for DST) **live fetch** via the `LiveLegs.Fetch` port → `ImdbDataset.Principal`s → **reverse-mint** links + the **federation graph** → the **rendered dashboard** + a **content-addressed snapshot**. Network enters only through the injected port; the rest is pure → offline-testable + replayable.

**`src/Core/DemoPipeline.fs`:** `fetchPrincipals`, `renderDashboard`, `snapshot`. **4 tests green**, Core 0-warning: concatenates cast across 2 recorded movies (Keanu = connector); end-to-end recorded-fetch → rendered dashboard; snapshot round-trips by hash; DST determinism. Closes the demo arc: fetch → parse → graph → reverse-mint → federations → render + persist, all behind the metered port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)