### PR TITLE
feat(installer): QEMU phase-3 first-session serial proof (S4)

### DIFF
--- a/.github/workflows/build-ai-cluster-iso.yml
+++ b/.github/workflows/build-ai-cluster-iso.yml
@@ -286,6 +286,7 @@ jobs:
         working-directory: full-ai-cluster
         env:
           SERIAL_LOG_OUT_PATH: ${{ github.workspace }}/qemu-full-install-serial.log
+          QEMU_FIRST_SESSION_PHASE3: ${{ github.event_name == 'workflow_dispatch' && '1' || '' }}
         run: |
           set -euo pipefail
           mapfile -t iso_candidates < <(find result/iso -maxdepth 1 -type f \( -name 'zeta-installer-*.iso' -o -name 'nixos-minimal-*.iso' \) | sort)

--- a/docs/trajectories/usb-zflash-installer/FIRST-SESSION.md
+++ b/docs/trajectories/usb-zflash-installer/FIRST-SESSION.md
@@ -31,7 +31,7 @@ which credentials to set up, which to skip, whether to stay local-only.
 
 | `docs/trajectories/usb-zflash-installer/HAT-ROUTING.md` | Slice 5 hat path → owner sketch |
 
-Not yet wired: QEMU phase-3 SSH executor (markers defined in `serial-markers.ts`).
+Not yet wired: QEMU phase-3 hard gate on push (opt-in via `QEMU_FIRST_SESSION_PHASE3=1` on workflow_dispatch).
 
 ## Reused from observe / workflow DUs
 
@@ -52,7 +52,7 @@ Per `docs/BUILD-GATES.md` — local prepush is the gate; peers replay; CI is sig
 | **S1** | Builder | `bun run preflight:quick` includes observe suite |
 | **S2** | Peer / builder | `validate-local-llm.ts` — Ollama chooser over menu labels |
 | **S3** | USB hat owner | Scripted `first-session` demo against mock LLM backend |
-| **S4** | Society cadence | QEMU SSH phase-3: login → `observe` / first-session transcript |
+| **S4** | Society cadence | QEMU phase-3: `QEMU_FIRST_SESSION_PHASE3=1` on scenario 2 workflow_dispatch |
 | **S6** | Human | Physical boot — feel of adventure UX |
 
 ## Vertical slices (roadmap)

--- a/docs/trajectories/usb-zflash-installer/RESUME.md
+++ b/docs/trajectories/usb-zflash-installer/RESUME.md
@@ -4,8 +4,8 @@ Status: active — shipped + iterating; first surfaced as a trajectory 2026-05-2
 Last refreshed: 2026-06-20
 Type: workstream (current-focus) — a trajectory the operator is *actively powering*. Many trajectories can be tracked; only a few are workstreams at once (finite-focus / WIP-bounded — a workstream is a trajectory under sustained thrust, and thrust budget is finite, so most trajectories coast). (Genus = "trajectory"; "workstream" is the species: a trajectory under sustained thrust toward a deliverable, vs. emergent-posture trajectories like `anti-infection`. See [`factory-trajectory-surface`](../factory-trajectory-surface/RESUME.md) for the genus/species taxonomy.) One of the operator's three current cluster workstreams (encryption / usb-zflash / ts-workflow-engine).
 Eventual encoding (design-stage — the human maintainer 2026-05-23 genetic-ID substrate + Clifford/HKT): this trajectory's state is trackable as a 128-bit genetic-ID seed (discrete, reversible via parser-combinator ↔ generator-function) → Clifford-space path (continuous, eventual). Mirrors the three-lane I8-lattice / I9-manifold split.
-Current blocker: post-login UX — slices 3–4 landed; QEMU phase-3 SSH proof next.
-Next concrete action: QEMU SSH phase-3 serial markers; slice 5 hat gates; physical WiFi out-of-band
+Current blocker: QEMU phase-3 wired (opt-in workflow_dispatch); society proof run next.
+Next concrete action: dispatch build-iso with QEMU_FIRST_SESSION_PHASE3=1; physical WiFi out-of-band
 
 ## Why This Exists
 

--- a/full-ai-cluster/nixos/modules/zeta-first-session.nix
+++ b/full-ai-cluster/nixos/modules/zeta-first-session.nix
@@ -98,7 +98,7 @@ in
         ConditionPathExists = [
           "/etc/zeta/qemu-first-session-ci"
           "!${cfg.markerPath}"
-          cfg.scriptPath
+          scriptPath
           bunShimPath
         ];
       };

--- a/full-ai-cluster/nixos/modules/zeta-first-session.nix
+++ b/full-ai-cluster/nixos/modules/zeta-first-session.nix
@@ -86,5 +86,40 @@ in
         fi
       '';
     };
+
+    # B-0891 phase-3: QEMU CI boot demo — runs once at multi-user when
+    # /etc/zeta/qemu-first-session-ci exists (written by zeta-install WIPE path).
+    # Tees stdout to ttyS0 so phase-2 serial capture sees first-session markers.
+    systemd.services.zeta-first-session-ci = {
+      description = "QEMU CI first-session demo (B-0891 phase-3)";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "local-fs.target" ];
+      unitConfig = {
+        ConditionPathExists = [
+          "/etc/zeta/qemu-first-session-ci"
+          "!${cfg.markerPath}"
+          cfg.scriptPath
+          bunShimPath
+        ];
+      };
+      serviceConfig = {
+        Type = "oneshot";
+        User = cfg.user;
+        Group = "users";
+        WorkingDirectory = cfg.repoRoot;
+        Environment = [
+          "HOME=${cfg.home}"
+          "ZETA_FIRST_SESSION_MARKER=${cfg.markerPath}"
+          "ZETA_FIRST_SESSION_TEE_CONSOLE=1"
+          "PATH=${cfg.home}/.local/share/mise/shims:${cfg.home}/.bun/bin:/run/current-system/sw/bin:/usr/bin:/bin"
+        ];
+        ExecStart = pkgs.writeShellScript "zeta-first-session-ci-start" ''
+          set -euo pipefail
+          cd "${cfg.repoRoot}"
+          "${bunShimPath}" "${scriptPath}" \
+            --demo --script skip-optional,complete --dry-run
+        '';
+      };
+    };
   };
 }

--- a/full-ai-cluster/usb-nixos-installer/zeta-install.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-install.sh
@@ -1346,6 +1346,15 @@ maybe_symlink() {
 maybe_symlink "$HOSTNAME_DST" /etc/zeta/cluster-node-id
 maybe_symlink /mnt/etc/zeta/operator-authorized-keys /etc/zeta/operator-authorized-keys
 
+# B-0891 QEMU phase-3: non-interactive CI installs enable boot-time first-session
+# demo (systemd oneshot tees markers to ttyS0; qemu-full-install-test asserts them).
+if [[ "${ZETA_AUTO_CONFIRM:-}" == "WIPE" ]]; then
+  sudo mkdir -p /mnt/etc/zeta
+  echo "qemu-ci-first-session" | sudo tee /mnt/etc/zeta/qemu-first-session-ci >/dev/null
+  sudo chmod 0644 /mnt/etc/zeta/qemu-first-session-ci
+  echo "[B-0891]   wrote /mnt/etc/zeta/qemu-first-session-ci (QEMU phase-3 boot demo)"
+fi
+
 echo "Running nixos-install --flake /mnt/etc/zeta/full-ai-cluster#$HOST ..."
 # --impure: required so builtins.pathExists + builtins.readFile in the
 # affected modules (injected-hostname.nix + operator-authorized-keys.nix)

--- a/src/Core.TypeScript/ci/qemu-first-session-phase3.test.ts
+++ b/src/Core.TypeScript/ci/qemu-first-session-phase3.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "bun:test";
+import { firstSessionMarkersSatisfied } from "./qemu-first-session-phase3";
+
+describe("qemu-first-session-phase3", () => {
+  it("firstSessionMarkersSatisfied passes when begin+complete present", () => {
+    const serial = ["zeta-first-session: begin", "zeta-first-session: complete"].join("\n");
+    expect(firstSessionMarkersSatisfied(serial)).toBe(true);
+  });
+
+  it("firstSessionMarkersSatisfied fails when only begin present", () => {
+    expect(firstSessionMarkersSatisfied("zeta-first-session: begin")).toBe(false);
+  });
+});

--- a/src/Core.TypeScript/ci/qemu-first-session-phase3.ts
+++ b/src/Core.TypeScript/ci/qemu-first-session-phase3.ts
@@ -1,0 +1,17 @@
+/**
+ * qemu-first-session-phase3.ts — B-0891 S4 society-cadence helpers.
+ *
+ * Opt-in via QEMU_FIRST_SESSION_PHASE3=1 on qemu-full-install-test phase 2.
+ * Installed nodes with /etc/zeta/qemu-first-session-ci run the boot demo
+ * service and tee markers to ttyS0.
+ */
+
+import { assertFirstSessionSerialMarkers } from "../zflash/test-harness/qemu-state";
+
+export function firstSessionPhase3Enabled(): boolean {
+  return process.env.QEMU_FIRST_SESSION_PHASE3 === "1";
+}
+
+export function firstSessionMarkersSatisfied(serialOutput: string): boolean {
+  return "ok" in assertFirstSessionSerialMarkers(serialOutput);
+}

--- a/src/Core.TypeScript/ci/qemu-full-install-test.test.ts
+++ b/src/Core.TypeScript/ci/qemu-full-install-test.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "bun:test";
 import { validateSelfRegCiCoherent } from "./self-reg-serial.ts";
 import {
   buildQemuDiskBootArgsPure,
+  detectInstalledLoginPrompt,
+  detectPhase2Success,
   detectUnexpectedControlPlaneLogin,
   extractGeneratedHostname,
   mergeFullInstallSerialLogs,
@@ -86,5 +88,32 @@ describe("qemu-full-install-test B-0835 hostname regression guard", () => {
   it("allows control-plane when no generated hostname was expected", () => {
     expect(detectUnexpectedControlPlaneLogin("control-plane login:", null)).toBeNull();
     expect(detectUnexpectedControlPlaneLogin("control-plane login:", "control-plane")).toBeNull();
+  });
+});
+
+describe("qemu-full-install-test phase 3 first-session markers", () => {
+  it("detectPhase2Success requires markers when phase3 flag set", () => {
+    const serial = "node-abc123 login:\n";
+    expect(detectPhase2Success(serial, "node-abc123", false).ok).toBe(true);
+    expect(detectPhase2Success(serial, "node-abc123", true).ok).toBe(false);
+  });
+
+  it("detectPhase2Success passes when login and first-session markers present", () => {
+    const serial = [
+      "zeta-first-session: begin",
+      "zeta-first-session: complete",
+      "node-abc123 login:",
+    ].join("\n");
+    const result = detectPhase2Success(serial, "node-abc123", true);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.reason).toContain("first-session markers");
+    }
+  });
+
+  it("detectInstalledLoginPrompt finds generated hostname login line", () => {
+    const result = detectInstalledLoginPrompt("boot\nzeta-a1b2c3 login:", "zeta-a1b2c3");
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.hostname).toBe("zeta-a1b2c3");
   });
 });

--- a/src/Core.TypeScript/ci/qemu-full-install-test.ts
+++ b/src/Core.TypeScript/ci/qemu-full-install-test.ts
@@ -5,7 +5,8 @@
  * QEMU full-install test (B-0831 Slice 1) for the canonical Zeta installer ISO.
  *
  * Phase 1 — boot installer ISO + virtual disk; wait for install completion.
- * Phase 2 — boot installed disk only; verify auto-generated hostname login banner.
+ * Phase 2 — boot installed disk only; verify login banner (+ optional phase-3
+ * first-session serial markers when QEMU_FIRST_SESSION_PHASE3=1).
  * Phase 1 also asserts iter-5.4.1-ci dry-run registration (B-0831 slice 2)
  * and tree-path coherence (B-0831 slice 3).
  *
@@ -26,6 +27,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { serialFirstBootInProgress } from "../zflash/test-harness/serial-markers";
 import { validateSelfRegCiCoherent } from "./self-reg-serial.ts";
+import {
+  firstSessionPhase3Enabled,
+  firstSessionMarkersSatisfied,
+} from "./qemu-first-session-phase3.ts";
 
 /** zeta-install.sh success banner (end of install script). */
 const INSTALL_COMPLETE_MARKER = "ZETA CLUSTER NODE INSTALL COMPLETE";
@@ -107,6 +112,71 @@ export function detectUnexpectedControlPlaneLogin(
     return `phase 2 FAILURE — B-0835 Bug 1 regression: saw "${CONTROL_PLANE_LOGIN_PROMPT}" but expected "${expectedHostname}"`;
   }
   return null;
+}
+
+/** Exported for unit tests. Detect installed-system login prompt in serial output. */
+export function detectInstalledLoginPrompt(
+  serialOutput: string,
+  expectedHostname: string | null,
+): { readonly ok: true; readonly reason: string; readonly hostname?: string } | { readonly ok: false } {
+  const loginNeedle = expectedHostname ? `${expectedHostname} login:` : null;
+  const welcomeNeedle = expectedHostname
+    ? `Welcome to ${expectedHostname} (Zeta cluster node)`
+    : null;
+
+  if (loginNeedle && serialOutput.includes(loginNeedle)) {
+    return {
+      ok: true,
+      reason: `login prompt "${loginNeedle}" observed`,
+      ...(expectedHostname !== null ? { hostname: expectedHostname } : {}),
+    };
+  }
+
+  if (welcomeNeedle && serialOutput.includes(welcomeNeedle) && serialOutput.includes("login:")) {
+    return {
+      ok: true,
+      reason: `login banner "${welcomeNeedle}" observed`,
+      ...(expectedHostname !== null ? { hostname: expectedHostname } : {}),
+    };
+  }
+
+  if (detectUnexpectedControlPlaneLogin(serialOutput, expectedHostname)) {
+    return { ok: false };
+  }
+
+  if (!loginNeedle) {
+    for (const match of serialOutput.matchAll(/(?:^|\n)([a-z0-9-]+) login:/gi)) {
+      const host = match[1];
+      if (host && host !== "zeta-installer") {
+        return {
+          ok: true,
+          reason: `login prompt "${host} login:" observed`,
+          hostname: host,
+        };
+      }
+    }
+  }
+
+  return { ok: false };
+}
+
+/** Exported for unit tests. Phase 2 (+ optional phase-3 first-session markers). */
+export function detectPhase2Success(
+  serialOutput: string,
+  expectedHostname: string | null,
+  requireFirstSession = false,
+): { readonly ok: true; readonly reason: string; readonly hostname?: string } | { readonly ok: false } {
+  const login = detectInstalledLoginPrompt(serialOutput, expectedHostname);
+  if (!login.ok) return { ok: false };
+  if (requireFirstSession && !firstSessionMarkersSatisfied(serialOutput)) {
+    return { ok: false };
+  }
+  const phase3Suffix = requireFirstSession ? " + first-session markers" : "";
+  return {
+    ok: true,
+    reason: `phase 2 SUCCESS — ${login.reason}${phase3Suffix}`,
+    ...(login.hostname !== undefined ? { hostname: login.hostname } : {}),
+  };
 }
 
 function usage(): never {
@@ -328,46 +398,26 @@ async function waitForInstallComplete(serialLogPath: string): Promise<InstallRes
 async function waitForInstalledLogin(
   serialLogPath: string,
   expectedHostname: string | null,
+  requireFirstSession: boolean,
 ): Promise<InstallResult> {
   const start = Date.now();
   const deadline = start + DISK_BOOT_TIMEOUT_SECONDS * 1000;
   const loginNeedle = expectedHostname ? `${expectedHostname} login:` : null;
-  const welcomeNeedle = expectedHostname
-    ? `Welcome to ${expectedHostname} (Zeta cluster node)`
-    : null;
   let lastReportedMinute = -1;
 
   while (Date.now() < deadline) {
     const elapsedSec = Math.floor((Date.now() - start) / 1000);
     const elapsedMin = Math.floor(elapsedSec / 60);
     if (elapsedMin > lastReportedMinute) {
-      const target = loginNeedle ?? "installed-system login prompt";
+      const target = requireFirstSession
+        ? `${loginNeedle ?? "login"} + first-session markers`
+        : (loginNeedle ?? "installed-system login prompt");
       console.log(
         `[qemu-full-install-test] phase 2: ${elapsedMin} min elapsed; waiting for "${target}"`,
       );
       lastReportedMinute = elapsedMin;
     }
     const content = readSerial(serialLogPath);
-
-    if (loginNeedle && content.includes(loginNeedle)) {
-      return {
-        exitCode: 0,
-        reason: `phase 2 SUCCESS — login prompt "${loginNeedle}" observed`,
-        serialLogTail: content.slice(-1500),
-        elapsedSeconds: elapsedSec,
-        ...(expectedHostname !== null ? { hostname: expectedHostname } : {}),
-      };
-    }
-
-    if (welcomeNeedle && content.includes(welcomeNeedle) && content.includes("login:")) {
-      return {
-        exitCode: 0,
-        reason: `phase 2 SUCCESS — login banner "${welcomeNeedle}" observed`,
-        serialLogTail: content.slice(-1500),
-        elapsedSeconds: elapsedSec,
-        ...(expectedHostname !== null ? { hostname: expectedHostname } : {}),
-      };
-    }
 
     const unexpectedControlPlaneReason = detectUnexpectedControlPlaneLogin(content, expectedHostname);
     if (unexpectedControlPlaneReason) {
@@ -379,19 +429,15 @@ async function waitForInstalledLogin(
       };
     }
 
-    if (!loginNeedle) {
-      for (const match of content.matchAll(/(?:^|\n)([a-z0-9-]+) login:/gi)) {
-        const host = match[1];
-        if (host && host !== "zeta-installer") {
-          return {
-            exitCode: 0,
-            reason: `phase 2 SUCCESS — login prompt "${host} login:" observed`,
-            serialLogTail: content.slice(-1500),
-            elapsedSeconds: elapsedSec,
-            hostname: host,
-          };
-        }
-      }
+    const success = detectPhase2Success(content, expectedHostname, requireFirstSession);
+    if (success.ok) {
+      return {
+        exitCode: 0,
+        reason: success.reason,
+        serialLogTail: content.slice(-1500),
+        elapsedSeconds: elapsedSec,
+        ...(success.hostname !== undefined ? { hostname: success.hostname } : {}),
+      };
     }
 
     const failMarker = checkFailureMarkers(content);
@@ -414,11 +460,14 @@ async function waitForInstalledLogin(
       : content.includes("EFI stub: Loaded initrd") && !content.includes("login:")
         ? " (serial stopped after EFI initrd — likely initrd cannot mount virtio root; verify hardware-configuration.nix copy at install + virtio_blk in initrd)"
         : "";
+  const phase3Hint = requireFirstSession && !firstSessionMarkersSatisfied(content)
+    ? " (login may be present but zeta-first-session: begin|complete markers missing — check zeta-first-session-ci.service)"
+    : "";
   return {
     exitCode: 1,
     reason: loginNeedle
-      ? `phase 2 timeout (${DISK_BOOT_TIMEOUT_SECONDS}s) waiting for "${loginNeedle}"${emptySerialHint}`
-      : `phase 2 timeout (${DISK_BOOT_TIMEOUT_SECONDS}s) waiting for installed-system login prompt${emptySerialHint}`,
+      ? `phase 2 timeout (${DISK_BOOT_TIMEOUT_SECONDS}s) waiting for "${loginNeedle}"${phase3Hint}${emptySerialHint}`
+      : `phase 2 timeout (${DISK_BOOT_TIMEOUT_SECONDS}s) waiting for installed-system login prompt${phase3Hint}${emptySerialHint}`,
     serialLogTail: content.slice(-3000),
     elapsedSeconds: Math.floor((Date.now() - start) / 1000),
   };
@@ -533,11 +582,16 @@ async function main(): Promise<never> {
   const hostname = phase1.hostname ?? extractGeneratedHostname(phase1Serial);
   console.log(`[qemu-full-install-test] phase 1 done; expected hostname: ${hostname ?? "(infer at login)"}`);
 
+  const requireFirstSession = firstSessionPhase3Enabled();
+  if (requireFirstSession) {
+    console.log("[qemu-full-install-test] phase 3 enabled (QEMU_FIRST_SESSION_PHASE3=1) — will assert first-session serial markers");
+  }
+
   const phase2 = await runQemuUntil(
     buildQemuDiskBootArgs(diskPath, phase2SerialLogPath, tmpDir),
     phase2SerialLogPath,
-    () => waitForInstalledLogin(phase2SerialLogPath, hostname),
-    "phase 2 (disk boot)",
+    () => waitForInstalledLogin(phase2SerialLogPath, hostname, requireFirstSession),
+    requireFirstSession ? "phase 2+3 (disk boot + first-session)" : "phase 2 (disk boot)",
   );
 
   writeArtifactSerialLog(phase1Serial, readSerial(phase2SerialLogPath));

--- a/src/Core.TypeScript/observe/first-session-run.ts
+++ b/src/Core.TypeScript/observe/first-session-run.ts
@@ -15,7 +15,7 @@
 
 import { createInterface } from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync, appendFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { ollamaBackend, type ModelBackend } from "../accelerator/local-llm";
 import {
@@ -37,6 +37,18 @@ import {
 } from "./first-session-executor";
 
 export const DEFAULT_MARKER_PATH = "/var/lib/zeta-first-session/complete.marker";
+
+/** Mirror serial markers to ttyS0 when ZETA_FIRST_SESSION_TEE_CONSOLE=1 (QEMU phase-3). */
+export function logSerial(line: string): void {
+  console.log(line);
+  if (process.env.ZETA_FIRST_SESSION_TEE_CONSOLE === "1") {
+    try {
+      appendFileSync("/dev/ttyS0", `${line}\n`);
+    } catch {
+      // headless / no serial — stdout-only is fine
+    }
+  }
+}
 
 export interface RunOptions {
   readonly markerPath: string;
@@ -170,7 +182,7 @@ async function pickAction(
     }
     const idx = Number(answer.trim());
     if (!Number.isInteger(idx) || idx < 0 || idx >= menu.length) {
-      console.log(`${SERIAL_PREFIX} invalid-choice`);
+      logSerial(`${SERIAL_PREFIX} invalid-choice`);
       return firstSessionOracle(session);
     }
     return menu[idx]!;
@@ -186,7 +198,7 @@ async function applyAction(
 ): Promise<NodeSessionState> {
   if (action.kind === "setup_credential") {
     if (opts.dryRun) {
-      console.log(`${SERIAL_PREFIX} dry-run setup ${action.vendor}`);
+      logSerial(`${SERIAL_PREFIX} dry-run setup ${action.vendor}`);
       return simulateFirstSession(session, action);
     }
     const result = executeSetupCredential(action.vendor, opts.runner, opts.home);
@@ -199,7 +211,7 @@ async function applyAction(
   }
 
   if (opts.dryRun) {
-    console.log(`${SERIAL_PREFIX} dry-run ${action.kind}`);
+    logSerial(`${SERIAL_PREFIX} dry-run ${action.kind}`);
   }
   return simulateFirstSession(session, action);
 }
@@ -207,11 +219,11 @@ async function applyAction(
 /** Main loop — exported for tests. */
 export async function runFirstSession(opts: RunOptions): Promise<NodeSessionState> {
   if (existsSync(opts.markerPath) && !opts.demo && !opts.dryRun) {
-    console.log(`${SERIAL_PREFIX} already-complete marker=${opts.markerPath}`);
+    logSerial(`${SERIAL_PREFIX} already-complete marker=${opts.markerPath}`);
     return { ...defaultNodeSession(), complete: true };
   }
 
-  console.log(`${SERIAL_PREFIX} begin`);
+  logSerial(`${SERIAL_PREFIX} begin`);
   let session = sessionFromProbe(opts.runner, opts.home);
   const demoQueue = opts.demo ? [...opts.demoScript] : [];
 
@@ -222,14 +234,14 @@ export async function runFirstSession(opts: RunOptions): Promise<NodeSessionStat
     const action = await pickAction(session, opts, demoQueue);
     if (!action) break;
 
-    console.log(`${SERIAL_PREFIX} choice kind=${action.kind}${"vendor" in action ? ` vendor=${action.vendor}` : ""}`);
+    logSerial(`${SERIAL_PREFIX} choice kind=${action.kind}${"vendor" in action ? ` vendor=${action.vendor}` : ""}`);
     session = await applyAction(session, action, opts);
 
     if (session.complete) {
       if (!opts.dryRun) {
         writeMarker(opts.markerPath);
       }
-      console.log(`${SERIAL_PREFIX} complete canSelfRegister=${session.credentials.gh === "ready"}`);
+      logSerial(`${SERIAL_PREFIX} complete canSelfRegister=${session.credentials.gh === "ready"}`);
       break;
     }
   }


### PR DESCRIPTION
## Summary
- Stamp `/etc/zeta/qemu-first-session-ci` on `ZETA_AUTO_CONFIRM=WIPE` installs and run `zeta-first-session-ci.service` at boot (demo dry-run, markers teed to ttyS0).
- Opt-in harness assertion: set `QEMU_FIRST_SESSION_PHASE3=1` on `qemu-full-install-test` phase 2 (enabled on scenario 2 `workflow_dispatch` only — push path unchanged).
- Adds `detectPhase2Success` / `qemu-first-session-phase3` helpers + unit tests (43 passing in touched suites).

## Test plan
- [x] `bun test src/Core.TypeScript/ci/qemu-first-session-phase3.test.ts src/Core.TypeScript/ci/qemu-full-install-test.test.ts`
- [ ] Society: `workflow_dispatch` build-ai-cluster-iso — scenario 2 should assert `zeta-first-session: begin|complete` on serial log
- [ ] Promote to hard gate on push after one green dispatch


Made with [Cursor](https://cursor.com)