### PR TITLE
feat(core): export bounded gset heat

### DIFF
--- a/src/Core/Heat.fs
+++ b/src/Core/Heat.fs
@@ -50,6 +50,37 @@ type IHeatSink =
     abstract Emit: heat: HeatSignature -> Result<unit, HeatSinkFeedback>
 
 
+[<RequireQualifiedAccess>]
+module BoundedHeat =
+
+    /// Convert bounded finite-view loss into the common host-facing heat
+    /// signature. Empty heat stays cold: callers should not spend heat-channel
+    /// capacity to say that nothing was forgotten.
+    let signature
+        (source: string)
+        (kind: string)
+        (detail: string)
+        (heat: BoundedGSetHeat<'T>)
+        : HeatSignature option =
+        if heat.Units <= 0 then
+            None
+        else
+            Some(HeatSignature.ofMass source kind heat.Units (float heat.Units) detail)
+
+    /// Emit bounded finite-view loss through an injected host or in-room heat
+    /// sink. Sink backpressure is preserved on the typed feedback channel.
+    let emit
+        (sink: IHeatSink)
+        (source: string)
+        (kind: string)
+        (detail: string)
+        (heat: BoundedGSetHeat<'T>)
+        : Result<unit, HeatSinkFeedback> =
+        match signature source kind detail heat with
+        | None -> Ok()
+        | Some heatSignature -> sink.Emit heatSignature
+
+
 [<Sealed>]
 type NullHeatSink() =
     interface IHeatSink with

--- a/tests/Tests.FSharp/Algebra/BoundedGSet.Tests.fs
+++ b/tests/Tests.FSharp/Algebra/BoundedGSet.Tests.fs
@@ -132,3 +132,33 @@ let ``bounded union rejects mismatched projection policies`` () =
         left |> should equal forgetHighest3
         right |> should equal forgetLowest3
     | other -> failwithf "expected ConfigMismatch feedback, got %A" other
+
+[<Fact>]
+let ``bounded heat adapter exports forgotten finite-view loss to host sink`` () =
+    let projection = projectInts forgetLowest3 [ 1; 2; 3; 4 ]
+    let sink = RecordingHeatSink()
+
+    match
+        BoundedHeat.emit
+            (sink :> IHeatSink)
+            "bounded-gset-room"
+            "bounded-gset.forgotten"
+            "finite room projection forgot materialized keys"
+            projection.Heat
+    with
+    | Error feedback -> Assert.Fail(sprintf "unexpected heat sink feedback: %A" feedback)
+    | Ok () ->
+        let signatures = sink.Signatures |> Seq.toList
+        Assert.Single(signatures) |> ignore
+        Assert.Equal("bounded-gset-room", signatures.Head.Source)
+        Assert.Equal("bounded-gset.forgotten", signatures.Head.Kind)
+        Assert.Equal(1, signatures.Head.Units)
+        Assert.Equal(1_000_000L, signatures.Head.MassPpm)
+
+[<Fact>]
+let ``bounded heat adapter keeps empty heat cold`` () =
+    let sink = RecordingHeatSink()
+
+    match BoundedHeat.emit (sink :> IHeatSink) "bounded-gset-room" "bounded-gset.forgotten" "nothing forgotten" BoundedGSet.emptyHeat<int> with
+    | Error feedback -> Assert.Fail(sprintf "unexpected heat sink feedback: %A" feedback)
+    | Ok () -> Assert.Empty(sink.Signatures)


### PR DESCRIPTION

## What

- Adds a small BoundedHeat adapter that converts non-empty bounded G-set heat into the common HeatSignature shape.
- Adds an emit helper that routes finite-view loss through IHeatSink while preserving typed sink backpressure.
- Covers forgotten finite-view loss and the cold empty-heat path in the bounded G-set tests.

## Why

Bounded G-sets now make forgetting explicit, but callers should not have to hand-roll the host-facing heat vocabulary every time a finite projection drops materialized state. This keeps the algebra report pure while giving room, CHIP-8/9, and scheduler code one reusable boundary for "forgetting is heat" diagnostics.

## Validation

- dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter FullyQualifiedName~BoundedGSetTests
- dotnet build -c Release
- dotnet format --verify-no-changes
- dotnet test Zeta.sln -c Release --no-build

Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: Codex
Agent-Model: gpt-5.5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: not-implied-by-credential
Human-Review-Evidence: none
Action-Mode: human-directed
Task: none
Co-Authored-By: Codex <noreply@openai.com>