### PR TITLE
feat(core): EntityFederations — Wikidata leg to federation parity with the IMDb co-star leg

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -316,6 +316,7 @@
     <Compile Include="MintPanel.fs" />
     <Compile Include="DemoDashboard.fs" />
     <Compile Include="DemoPipeline.fs" />
+    <Compile Include="EntityFederations.fs" />
     <Compile Include="IdentityCapacity.fs" />
     <Compile Include="TrustCalculus.fs" />
     <Compile Include="PrivacyEconomy.fs" />

--- a/src/Core/EntityFederations.fs
+++ b/src/Core/EntityFederations.fs
@@ -1,0 +1,59 @@
+namespace Zeta.Core
+
+open System
+
+/// **`EntityFederations` — the Wikidata analog of `CostarFederations` (Aaron 2026-06-19, shadow\*).**
+///
+/// Brings the Wikipedia/Wikidata entity graph to parity with the IMDb co-star leg: **reverse-mint** the
+/// entity-relation links (each unordered pair rated by how many relations connect them — the objective rating,
+/// the QPG analogue on the knowledge graph), characterize the **emergent federations** (`CoEmpowerGraph.health`
+/// — neutral, measured by co-empowerment/diversity, not hunted), and compute **degrees of separation** (the
+/// entity-graph analogue of the Bacon number, reusing the generic `ImdbDataset.baconNumber` BFS). Pure,
+/// offline, DST-deterministic.
+[<RequireQualifiedAccess>]
+module EntityFederations =
+
+    /// A reverse-minted entity link — a remembered relation between two entities — rated by `Relations` (the
+    /// number of relations connecting the unordered pair). `Subject < Object` (ordinal).
+    type EntityLink =
+        { Subject: string
+          Object: string
+          Relations: int }
+
+    /// **Reverse-mint** every entity link from the relation triples: each unordered pair sharing ≥ 1 relation
+    /// becomes an `EntityLink` rated by its relation count. Deterministic (ordinal-sorted).
+    let reverseMint (triples: WikidataGraph.Triple list) : EntityLink list =
+        let pairs = System.Collections.Generic.Dictionary<struct (string * string), int>()
+
+        for t in triples do
+            let a, b =
+                if String.CompareOrdinal(t.Subject, t.Object) <= 0 then t.Subject, t.Object else t.Object, t.Subject
+
+            if not (String.Equals(a, b, StringComparison.Ordinal)) then
+                let key = struct (a, b)
+                let prev =
+                    match pairs.TryGetValue key with
+                    | true, v -> v
+                    | _ -> 0
+                pairs.[key] <- prev + 1
+
+        [ for kv in pairs ->
+              let struct (a, b) = kv.Key
+              { Subject = a; Object = b; Relations = kv.Value } ]
+        |> List.sortWith (fun x y ->
+            let c = String.CompareOrdinal(x.Subject, y.Subject)
+            if c <> 0 then c else String.CompareOrdinal(x.Object, y.Object))
+
+    /// The full characterization: the minted entity links, the emergent-federation health, and degrees of
+    /// separation from a chosen source entity (Q-id).
+    type Report =
+        { Links: EntityLink list
+          Health: CoEmpowerGraph.Health
+          Hops: Map<string, int> }
+
+    let report (kinds: int) (seed: int) (source: string) (triples: WikidataGraph.Triple list) : Report =
+        let entities, adjacency = WikidataGraph.adjacency triples
+        let _, graph = WikidataGraph.toCoEmpowerGraph kinds seed triples
+        { Links = reverseMint triples
+          Health = CoEmpowerGraph.health graph
+          Hops = ImdbDataset.baconNumber entities adjacency source }

--- a/tests/Tests.FSharp/Formal/EntityFederations.Tests.fs
+++ b/tests/Tests.FSharp/Formal/EntityFederations.Tests.fs
@@ -1,0 +1,38 @@
+module Zeta.Tests.Formal.EntityFederationsTests
+
+open FsUnit.Xunit
+open global.Xunit
+open Zeta.Core
+
+module E = Zeta.Core.EntityFederations
+module W = Zeta.Core.WikidataGraph
+
+// fixture: Q42–Q5 (twice → 2 relations), Q5–Q1 (once). Knowledge-graph chain Q42–Q5–Q1.
+let private triples =
+    [ ({ Subject = "Q42"; Object = "Q5" }: W.Triple)
+      { Subject = "Q5"; Object = "Q1" }
+      { Subject = "Q42"; Object = "Q5" } ]
+
+[<Fact>]
+let ``reverse-mint rates each entity link by its relation count`` () =
+    E.reverseMint triples
+    |> should
+        equal
+        [ ({ Subject = "Q1"; Object = "Q5"; Relations = 1 }: E.EntityLink)
+          { Subject = "Q42"; Object = "Q5"; Relations = 2 } ] // Q42–Q5 connected twice
+
+[<Fact>]
+let ``report carries federation health + degrees of separation from a source entity`` () =
+    let r = E.report 4 7 "Q42" triples
+    r.Links.Length |> should equal 2
+    r.Hops.["Q42"] |> should equal 0
+    r.Hops.["Q5"] |> should equal 1
+    r.Hops.["Q1"] |> should equal 2 // Q42 → Q5 → Q1
+    r.Health.Diversity |> should be (greaterThanOrEqualTo 1)
+
+[<Fact>]
+let ``the entity federation report is deterministic (DST)`` () =
+    let a = E.report 4 7 "Q42" triples
+    let b = E.report 4 7 "Q42" triples
+    a.Links |> should equal b.Links
+    a.Health |> should equal b.Health

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -357,6 +357,7 @@
     <Compile Include="Formal/MintPanel.Tests.fs" />
     <Compile Include="Formal/DemoDashboard.Tests.fs" />
     <Compile Include="Formal/DemoPipeline.Tests.fs" />
+    <Compile Include="Formal/EntityFederations.Tests.fs" />
     <Compile Include="Simulation/CartelToy.Tests.fs" />
 
     <!-- Circuit/ -->


### PR DESCRIPTION
Aaron 2026-06-19 *"keep going"* + *"i like the federation stuff."* The Wikidata analog of CostarFederations: **reverse-mint entity-relation links** (rated by relation count — the QPG analogue on the knowledge graph) + **report** (CoEmpowerGraph federation health + degrees-of-separation BFS, reusing the generic `ImdbDataset.baconNumber`). Both grounding sources now run the **same** reverse-mint → federation machinery.

**`src/Core/EntityFederations.fs`:** `EntityLink`; `reverseMint`; `Report{Links;Health;Hops}`; `report`. **3 tests green**, Core 0-warning: relation-count rating (Q42–Q5 = 2); report (health + hops 0/1/2); DST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)