### PR TITLE
feat(core): carry generator IR as a live row on a DBSP Z-set relation

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -260,6 +260,7 @@
     <Compile Include="CapabilityLedger.fs" />
     <Compile Include="BoundaryLight.fs" />
     <Compile Include="GeneratorRegistry.fs" />
+    <Compile Include="GeneratorIrRegistry.fs" />
     <Compile Include="GeneratorCatalog.fs" />
     <Compile Include="ZetaIdViz.fs" />
     <Compile Include="AnimFlow.fs" />

--- a/src/Core/GeneratorIrRegistry.fs
+++ b/src/Core/GeneratorIrRegistry.fs
@@ -1,0 +1,163 @@
+namespace Zeta.Core
+
+/// GeneratorIrRegistry — the generator's IR carried as a LIVE TUPLE on a DBSP Z-set
+/// relation, completing the codegen-forward trajectory.
+///
+/// BACKGROUND (the trajectory this closes)
+/// ----------------------------------------
+/// The cross-verification harness (`tests/cross-verification/_harness/nway-diff.ts`)
+/// shifted from "do the hand-ports agree?" to "does the generated code match the
+/// byte-lock?": splitmix64 and fmix32 each have a TS oracle that is EMITTED FROM an
+/// IR row (an ordered list of total u-word ops) decoded through the real
+/// `DynamicValue` canonical-JSON machinery and folded. Until now that IR lived ONLY
+/// as a checked-in document (`*.ir.json`) — disconnected from the registry.
+///
+/// `GeneratorRegistry` is, per Aaron's reframe, "NOT a sibling mechanism — it is ONE
+/// schema-registry-over-DBSP relation": a registry entry (name@version ->
+/// content-addressed ZetaId) is a ROW in a Z-set; registering or superseding a
+/// generator is a Z-set DELTA; rollback is Z-set RETRACTION. `GeneratorRegistry.Entry`
+/// today carries only `{ Name; Version; ZetaId }` — identity but no PAYLOAD.
+///
+/// THIS MODULE adds the payload rung: the generator's IR (the canonical-JSON
+/// `DynamicValue` the oracle folds) becomes the row's payload on a real
+/// `ZSet<IrRow>`. So:
+///   * REGISTER a generator IR  = add a +1 singleton delta to the relation.
+///   * SUPERSEDE / ROLL BACK    = RETRACT the row: `add r (neg r) = Zero` — the
+///     abelian-group law a Bag cannot satisfy (`ZSet.fs`), and exactly why the
+///     Z-set, not the Bag, is the DBSP substrate for undo.
+///   * full == incremental      = building the relation from the full row list
+///     EQUALS folding the per-row deltas with `+` (`relation = incremental`). This
+///     is DBSP's incrementalization soundness specialised to a constant stream.
+///
+/// The committed `*.ir.json` documents are now a MATERIALISED VIEW of these rows:
+/// `irCanonicalJson row` reproduces the file byte-for-byte (asserted in the F# tests
+/// and, cross-language, by the existing `DynamicValue.Canonical.Tests` byte-locks).
+/// The TS oracles still read the file (they run under bun, no .NET), but the file is
+/// now a projection of the relation row, not an independent artifact.
+///
+/// Tier: PROVEN that the IR is a row on a real Z-set relation, that register/retract
+/// obey the group law, that full == incremental, that the row's ZetaId is the REAL
+/// content-address (`GeneratorRegistry.idOf`), and that the row payload reproduces
+/// the committed canonical-JSON byte-for-byte. The "live STREAM" (deltas arriving
+/// over time on a running DBSP circuit, zero-downtime schema evolution of the IR
+/// shape) reuses the same `+`/`neg` rungs; what is exercised here is the constant
+/// relation + its delta algebra, which is the group-theoretic core of that claim.
+[<RequireQualifiedAccess>]
+module GeneratorIrRegistry =
+
+    /// A row on the generator-IR relation: the generator's stable identity plus its
+    /// IR as a canonical-JSON `DynamicValue` string (the exact bytes the oracle
+    /// folds). `ZetaId` is the REAL content-address from `GeneratorRegistry.idOf`, so
+    /// the row's identity is DERIVED from name@version, never minted-and-forgotten.
+    /// Comparison is structural over all fields so the `ZSet<IrRow>` key is the whole
+    /// row (a change to the IR is a DIFFERENT row — a new fact — not a silent mutate).
+    type IrRow =
+        { Name: string
+          Version: int
+          ZetaId: string
+          IrCanonicalJson: string }
+
+    /// Build a row from a generator name@version and its IR `DynamicValue`. The IR is
+    /// serialised through the REAL `DynamicValue.toCanonicalJson`, so the row carries
+    /// exactly the bytes the cross-language byte-lock pins. Fails (Error) if the IR is
+    /// not canonical-encodable — an IR that cannot be a row is rejected as data.
+    let row (name: string) (version: int) (ir: DynamicValue) : Result<IrRow, EncodeError> =
+        match DynamicValue.toCanonicalJson ir with
+        | Ok cj ->
+            Ok
+                { Name = name
+                  Version = version
+                  ZetaId = GeneratorRegistry.idOf name version
+                  IrCanonicalJson = cj }
+        | Error e -> Error e
+
+    /// Decode a row's IR payload back to a `DynamicValue` (the inverse of `row`'s
+    /// encode leg). This is what a generator/oracle calls to obtain the IR FROM the
+    /// relation row rather than from a free-floating file.
+    let decodeIr (r: IrRow) : Result<DynamicValue, DecodeError> =
+        DynamicValue.fromCanonicalJson r.IrCanonicalJson
+
+    // ── the relation as a Z-set, and its delta algebra ─────────────────────────────
+
+    /// REGISTER one IR row: the +1 singleton delta. Adding it to a relation is the
+    /// Z-set DELTA that registration IS.
+    let register (r: IrRow) : ZSet<IrRow> = ZSet.singleton r 1L
+
+    /// RETRACT one IR row: the -1 delta (supersession / rollback). `relation + retract r`
+    /// removes `r` exactly; `register r + retract r = Zero` (the group inverse).
+    let retract (r: IrRow) : ZSet<IrRow> = ZSet.neg (register r)
+
+    /// Build the relation from a full set of rows (the "from-scratch" / full-recompute
+    /// side of full == incremental).
+    let relationOf (rows: IrRow seq) : ZSet<IrRow> = rows |> Seq.map (fun r -> r, 1L) |> ZSet.ofSeq
+
+    /// Build the relation INCREMENTALLY by folding each row's +1 delta with `+` (the
+    /// incremental side). `incremental rows = relationOf rows` is the soundness law.
+    let incremental (rows: IrRow seq) : ZSet<IrRow> =
+        rows |> Seq.fold (fun acc r -> ZSet.add acc (register r)) ZSet.empty
+
+    /// Look a row up on the relation by its content-addressed ZetaId (id -> IR row).
+    /// Returns the row only if it is LIVE (net weight > 0): a retracted row is absent,
+    /// so rollback is observed through the same query, no separate tombstone.
+    let byZetaId (zetaId: string) (relation: ZSet<IrRow>) : IrRow option =
+        relation
+        |> Seq.tryPick (fun e -> if e.Key.ZetaId = zetaId && ZSet.lookup e.Key relation > 0L then Some e.Key else None)
+
+    // ── the known generator IRs (the rows the committed *.ir.json files project) ────
+
+    /// SplitMix64 finaliser IR (width 64). u64 multipliers are stored as their
+    /// signed-int64 bit-pattern — multiply is mod 2^64, so the reinterpretation is
+    /// bit-exact when the interpreter reads it back as u64. Mirrors
+    /// `tests/cross-verification/splitmix64/_gen/splitmix64.ir.json`.
+    let private mul (k: int64) = DynamicValue.Object [ ("op", DynamicValue.String "mul"); ("k", DynamicValue.Int k) ]
+    let private xorshr (s: int64) =
+        DynamicValue.Object [ ("op", DynamicValue.String "xorshr"); ("s", DynamicValue.Int s) ]
+
+    /// NOTE on shape: the committed splitmix64 file carries an explicit `zetaId` field
+    /// and NO `width` (u64 implied); the fmix32 file carries `width` and no `zetaId`.
+    /// That difference is pre-existing across the two PRs that introduced them; the
+    /// relation row mirrors each committed file EXACTLY (the materialised-view relation
+    /// is faithful to the artifact as-is, not a re-normalisation of it).
+    let splitmix64Ir : DynamicValue =
+        DynamicValue.Object
+            [ ("generator", DynamicValue.String "rng.splitmix64")
+              ("version", DynamicValue.Int 1L)
+              ("zetaId", DynamicValue.String (GeneratorRegistry.idOf "rng.splitmix64" 1))
+              ("ops",
+               DynamicValue.Array
+                   [ mul -7046029254386353131L // 0x9E3779B97F4A7C15
+                     xorshr 30L
+                     mul -4658895280553007687L // 0xBF58476D1CE4E5B9
+                     xorshr 27L
+                     mul -7723592293110705685L // 0x94D049BB133111EB
+                     xorshr 31L ]) ]
+
+    /// MurmurHash3 fmix32 finaliser IR (width 32). u32 multipliers are < 2^31, so they
+    /// fit `DynamicValue.Int` (int64) directly with no reinterpretation. Mirrors
+    /// `tests/cross-verification/fmix32/_gen/fmix32.ir.json`.
+    let fmix32Ir : DynamicValue =
+        DynamicValue.Object
+            [ ("generator", DynamicValue.String "hash.fmix32")
+              ("version", DynamicValue.Int 1L)
+              ("width", DynamicValue.Int 32L)
+              ("ops",
+               DynamicValue.Array
+                   [ xorshr 16L
+                     mul 2246822507L // 0x85ebca6b
+                     xorshr 13L
+                     mul 3266489909L // 0xc2b2ae35
+                     xorshr 16L ]) ]
+
+    /// The known generator-IR rows. Each `Ok` because the IRs above are canonical.
+    /// Note `hash.fmix32` is NOT yet in `GeneratorRegistry.known`; its ZetaId is still
+    /// the deterministic `idOf` content-address (the id is a pure function of
+    /// name@version, registered-or-not — that is the homoiconic point).
+    let known: IrRow list =
+        [ row "rng.splitmix64" 1 splitmix64Ir
+          row "hash.fmix32" 1 fmix32Ir ]
+        |> List.choose (function
+            | Ok r -> Some r
+            | Error _ -> None)
+
+    /// The full known relation (all known IR rows, weight +1).
+    let relation: ZSet<IrRow> = relationOf known

--- a/tests/Tests.FSharp/GeneratorIrRegistry.Tests.fs
+++ b/tests/Tests.FSharp/GeneratorIrRegistry.Tests.fs
@@ -1,0 +1,117 @@
+module Zeta.Tests.GeneratorIrRegistryTests
+
+open System.IO
+open global.Xunit
+open Zeta.Core
+
+// ═══════════════════════════════════════════════════════════════════════════════════
+// GeneratorIrRegistry — the generator IR carried as a LIVE TUPLE on a DBSP Z-set relation.
+//
+// This closes the codegen-forward trajectory's last open thread: the splitmix64/fmix32
+// oracle IR is no longer ONLY a checked-in *.ir.json document — it is the PAYLOAD of a row
+// on a real `ZSet<IrRow>`. These tests pin the four facts that make that claim honest:
+//   1. MATERIALISED VIEW   — the relation row's `IrCanonicalJson` reproduces the committed
+//                            cross-verification *.ir.json byte-for-byte (so the file the TS
+//                            oracle reads is a projection of the row, not an independent
+//                            artifact). Combined with DynamicValue.Canonical.Tests' TS↔F#
+//                            byte-lock, the row is locked all the way to the TS oracle.
+//   2. GROUP LAW           — register r + retract r = Zero (the abelian-group inverse a Bag
+//                            cannot satisfy; why the Z-set is the DBSP substrate for undo).
+//   3. full == incremental — relationOf rows == fold (+) of per-row +1 deltas (DBSP
+//                            incrementalization soundness on the constant stream).
+//   4. CONTENT-ADDRESS     — the row's ZetaId IS GeneratorRegistry.idOf name version, and
+//                            byZetaId returns a LIVE row but NOT a retracted one (rollback
+//                            observed through the same query, no separate tombstone).
+// ═══════════════════════════════════════════════════════════════════════════════════
+
+let private repoRoot () =
+    let mutable dir =
+        DirectoryInfo(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location))
+
+    while not (isNull dir) && not (File.Exists(Path.Join(dir.FullName, "Zeta.sln"))) do
+        dir <- dir.Parent
+
+    if isNull dir then
+        failwith "Could not locate repo root (Zeta.sln)."
+    else
+        dir.FullName
+
+let private irFile (primitive: string) (name: string) =
+    Path.Join(repoRoot (), "tests", "cross-verification", primitive, "_gen", name)
+
+// ── 1. materialised view: the row payload reproduces the committed *.ir.json byte-for-byte ──
+
+[<Theory>]
+[<InlineData("rng.splitmix64", 1, "splitmix64", "splitmix64.ir.json")>]
+[<InlineData("hash.fmix32", 1, "fmix32", "fmix32.ir.json")>]
+let ``IR relation row reproduces the committed cross-verification IR file byte-for-byte``
+    (name: string)
+    (version: int)
+    (primitive: string)
+    (file: string)
+    =
+    let r =
+        GeneratorIrRegistry.known
+        |> List.tryFind (fun r -> r.Name = name && r.Version = version)
+
+    Assert.True(r.IsSome, sprintf "no known IR row for %s@%d" name version)
+    let committed = (File.ReadAllText(irFile primitive file)).Trim()
+    Assert.Equal(committed, r.Value.IrCanonicalJson)
+
+[<Fact>]
+let ``decodeIr round-trips the row payload back through the real canonical decoder`` () =
+    for r in GeneratorIrRegistry.known do
+        match GeneratorIrRegistry.decodeIr r with
+        | Ok dv ->
+            match DynamicValue.toCanonicalJson dv with
+            | Ok reJson -> Assert.Equal(r.IrCanonicalJson, reJson) // fixed point: decode∘encode = id on the row
+            | Error e -> failwithf "re-encode of %s failed: %A" r.Name e
+        | Error e -> failwithf "decodeIr of %s failed: %A" r.Name e
+
+// ── 2. register / retract obey the abelian-group law ──
+
+[<Fact>]
+let ``register r + retract r = Zero (group inverse; the DBSP undo law)`` () =
+    let r = List.head GeneratorIrRegistry.known
+    let net = ZSet.add (GeneratorIrRegistry.register r) (GeneratorIrRegistry.retract r)
+    Assert.True(net.IsEmpty, "register then retract must cancel to the empty relation")
+
+[<Fact>]
+let ``retract removes exactly one row from a populated relation`` () =
+    let r = List.head GeneratorIrRegistry.known
+    let afterRetract = ZSet.add GeneratorIrRegistry.relation (GeneratorIrRegistry.retract r)
+    // the retracted row is now absent (net weight 0); every OTHER known row survives.
+    Assert.Equal(0L, ZSet.lookup r afterRetract)
+    for other in GeneratorIrRegistry.known |> List.filter (fun x -> x <> r) do
+        Assert.Equal(1L, ZSet.lookup other afterRetract)
+
+// ── 3. full == incremental (DBSP incrementalization soundness) ──
+
+[<Fact>]
+let ``relationOf (full) equals incremental fold of per-row deltas`` () =
+    let full = GeneratorIrRegistry.relationOf GeneratorIrRegistry.known
+    let incr = GeneratorIrRegistry.incremental GeneratorIrRegistry.known
+    // equal as Z-sets: their difference is the empty relation (a + (-b) = Zero ⇔ a = b).
+    Assert.True((ZSet.add full (ZSet.neg incr)).IsEmpty, "full and incremental relations must be byte-identical Z-sets")
+    Assert.Equal(full.Count, incr.Count)
+
+// ── 4. content-address + byZetaId liveness ──
+
+[<Fact>]
+let ``each IR row's ZetaId is the real GeneratorRegistry content-address`` () =
+    for r in GeneratorIrRegistry.known do
+        Assert.Equal(GeneratorRegistry.idOf r.Name r.Version, r.ZetaId)
+
+[<Fact>]
+let ``byZetaId resolves a live row but not a retracted one`` () =
+    let r = List.head GeneratorIrRegistry.known
+    // live in the full relation
+    match GeneratorIrRegistry.byZetaId r.ZetaId GeneratorIrRegistry.relation with
+    | Some hit -> Assert.Equal(r, hit)
+    | None -> failwith "live row must resolve by its ZetaId"
+    // absent after retraction (rollback observed through the same query)
+    let afterRetract = ZSet.add GeneratorIrRegistry.relation (GeneratorIrRegistry.retract r)
+    Assert.True(
+        (GeneratorIrRegistry.byZetaId r.ZetaId afterRetract).IsNone,
+        "a retracted row must NOT resolve by its ZetaId"
+    )

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -183,6 +183,7 @@
     <Compile Include="MediaLines.Tests.fs" />
     <Compile Include="BoundaryLight.Tests.fs" />
     <Compile Include="GeneratorRegistry.Tests.fs" />
+    <Compile Include="GeneratorIrRegistry.Tests.fs" />
     <Compile Include="ZetaIdViz.Tests.fs" />
     <Compile Include="AnimFlow.Tests.fs" />
     <Compile Include="PixelLens.Tests.fs" />

--- a/tests/cross-verification/_harness/generator-ir-registry.ts
+++ b/tests/cross-verification/_harness/generator-ir-registry.ts
@@ -1,0 +1,84 @@
+// generator-ir-registry.ts — the TS-side view of the generator-IR relation.
+//
+// This is the bun-side twin of `src/Core/GeneratorIrRegistry.fs`. The F# module carries
+// each generator's IR as the PAYLOAD of a row on a real `ZSet<IrRow>` (register = +1
+// delta, retract = -1 delta, full == incremental, ZetaId = content-address). The TS
+// oracles run under bun (no .NET), so this module gives the generators the SAME
+// relation semantics they need: rows keyed by their content-addressed ZetaId, looked up
+// via `byZetaId`. The committed `*.ir.json` documents are the rows' serialised payloads
+// (the materialised view) — and the F# `GeneratorIrRegistry.Tests` pin that those files
+// reproduce the relation rows byte-for-byte, so this TS view and the F# relation are the
+// SAME relation, not two parallel ones.
+//
+// The point: a "generated-from-ir" oracle obtains its IR from the RELATION
+// (`byZetaId(idOf(name, version))`), not by reading a free-floating file path. The IR is
+// a tuple on the registry, addressed by the same id the rest of the system uses.
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// ── content-address (faithful mirror of GeneratorRegistry.hash128 / idOf) ──
+// Identical to tests/cross-verification/generator-registry-id/_gen/gen.ts, which is
+// byte-locked against the REAL shipping F# registry. Kept inline (not imported) so each
+// oracle/relation view stays an independent peer.
+const MASK = (1n << 64n) - 1n;
+const u64 = (x: bigint): bigint => x & MASK;
+const PRIME = 0x100000001b3n;
+
+function hash128(s: string): string {
+  let h1 = 0xcbf29ce484222325n;
+  let h2 = 0x84222325cbf29ce4n;
+  for (const ch of s) {
+    const c = BigInt(ch.codePointAt(0) ?? 0);
+    h1 = u64((h1 ^ u64(c)) * PRIME);
+    h2 = u64((h2 ^ u64(c * 31n)) * PRIME);
+  }
+  return h1.toString(16).padStart(16, "0") + h2.toString(16).padStart(16, "0");
+}
+
+/** The content-addressed ZetaId for a generator name@version (pure function of identity). */
+export function idOf(name: string, version: number): string {
+  return hash128(`${name}@${version}`);
+}
+
+/** A row on the generator-IR relation (mirrors F# `GeneratorIrRegistry.IrRow`). */
+export interface IrRow {
+  readonly name: string;
+  readonly version: number;
+  readonly zetaId: string;
+  /** The IR as the exact canonical-JSON bytes the oracle folds (the row payload). */
+  readonly irCanonicalJson: string;
+}
+
+const HARNESS_DIR = import.meta.dir; // tests/cross-verification/_harness
+const CROSS_VERIFY_DIR = join(HARNESS_DIR, ".."); // tests/cross-verification
+
+/** Where each known generator's committed IR document (its row payload) lives. */
+const KNOWN: ReadonlyArray<{ name: string; version: number; primitive: string; file: string }> = [
+  { name: "rng.splitmix64", version: 1, primitive: "splitmix64", file: "splitmix64.ir.json" },
+  { name: "hash.fmix32", version: 1, primitive: "fmix32", file: "fmix32.ir.json" },
+];
+
+function loadRow(entry: (typeof KNOWN)[number]): IrRow {
+  const path = join(CROSS_VERIFY_DIR, entry.primitive, "_gen", entry.file);
+  const irCanonicalJson = readFileSync(path, "utf8").trim();
+  return {
+    name: entry.name,
+    version: entry.version,
+    zetaId: idOf(entry.name, entry.version),
+    irCanonicalJson,
+  };
+}
+
+/** The full known generator-IR relation (all rows, weight +1). */
+export const relation: ReadonlyArray<IrRow> = KNOWN.map(loadRow);
+
+/** Look a row up on the relation by its content-addressed ZetaId (id -> IR row). */
+export function byZetaId(zetaId: string): IrRow | undefined {
+  return relation.find((r) => r.zetaId === zetaId);
+}
+
+/** Convenience: look up by name@version (re-derives the id, then resolves the row). */
+export function byNameVersion(name: string, version: number): IrRow | undefined {
+  return byZetaId(idOf(name, version));
+}

--- a/tests/cross-verification/fmix32/_gen/gen.ts
+++ b/tests/cross-verification/fmix32/_gen/gen.ts
@@ -30,24 +30,31 @@
 //
 // Tier: PROVEN that the IR-as-DynamicValue-row + width-parametric total interpreter
 // byte-locks a SECOND primitive against the five independent hand-ports and
-// canonical. REMAINING (shared with splitmix64): carry the row as a live tuple on
-// the registry's DBSP Z-set relation rather than a checked-in document.
-import { readFileSync, writeFileSync } from "node:fs";
+// canonical. The IR is now sourced FROM THE RELATION:
+// `generatorIr.byZetaId(idOf("hash.fmix32", 1))` returns the row whose payload is
+// the canonical-JSON IR (the committed fmix32.ir.json is that row's materialised
+// view; the F# GeneratorIrRegistry.Tests pin the byte-for-byte equality and the
+// register/retract/full==incremental Z-set laws).
+import { writeFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fromCanonicalJson, type Tagged } from "../../../../src/Core.TypeScript/dynamic-value/json.ts";
+import * as generatorIr from "../../_harness/generator-ir-registry.ts";
 
 /** A single total u-word -> u-word step in a finaliser IR. */
 type MixOp =
   | { readonly op: "mul"; readonly k: bigint } // z := z * k        (wrapping)
   | { readonly op: "xorshr"; readonly s: bigint }; // z := z ^ (z >> s)
 
-// --- read the IR ROW and decode it through the real DynamicValue canonical-JSON decoder ---
+// --- obtain the IR ROW from the relation (by content-addressed ZetaId) and decode it ---
 
-const irPath = join(import.meta.dir, "fmix32.ir.json");
-const irText = readFileSync(irPath, "utf8").trim();
-const decoded = fromCanonicalJson(irText);
+const zetaId = generatorIr.idOf("hash.fmix32", 1);
+const irRow = generatorIr.byZetaId(zetaId);
+if (!irRow) {
+  throw new Error(`no IR row on the relation for hash.fmix32@1 (zetaId ${zetaId})`);
+}
+const decoded = fromCanonicalJson(irRow.irCanonicalJson);
 if (!decoded.ok) {
-  throw new Error(`fmix32.ir.json is not a canonical DynamicValue: ${decoded.error}`);
+  throw new Error(`hash.fmix32@1 IR row is not a canonical DynamicValue: ${decoded.error}`);
 }
 
 // --- project the decoded DynamicValue (Tagged) down to (width, op list) ---
@@ -124,4 +131,4 @@ for (const [id, x] of Object.entries(inputs)) out[id] = mix(x).toString();
 
 const target = join(dirname(import.meta.dir), "ts-output.json");
 writeFileSync(target, `${JSON.stringify(out, null, 2)}\n`);
-console.log("wrote ts-output.json (generated-from-ir, IR read from fmix32.ir.json DynamicValue row, width 32)");
+console.log(`wrote ts-output.json (generated-from-ir, IR sourced from the relation row zetaId=${zetaId}, width 32)`);

--- a/tests/cross-verification/splitmix64/_gen/gen.ts
+++ b/tests/cross-verification/splitmix64/_gen/gen.ts
@@ -30,12 +30,16 @@
 // round-trip is exact. Shift amounts (<64) need no reinterpretation.
 //
 // Tier: PROVEN that the IR-as-DynamicValue-row + total interpreter byte-locks
-// against the five independent hand-ports and the canonical vectors. The row here
-// is read from a sibling file; carrying it as a live tuple on the registry's DBSP
-// Z-set relation (rather than a checked-in document) is the remaining integration.
-import { readFileSync, writeFileSync } from "node:fs";
+// against the five independent hand-ports and the canonical vectors. The IR is now
+// sourced FROM THE RELATION: `generatorIr.byZetaId(idOf("rng.splitmix64", 1))`
+// returns the row whose payload is the canonical-JSON IR (the committed
+// splitmix64.ir.json is that row's materialised view; the F#
+// GeneratorIrRegistry.Tests pin the byte-for-byte equality, and prove register =
+// +1 delta / retract = -1 delta / full == incremental on the real ZSet relation).
+import { writeFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fromCanonicalJson, type Tagged } from "../../../../src/Core.TypeScript/dynamic-value/json.ts";
+import * as generatorIr from "../../_harness/generator-ir-registry.ts";
 
 const MASK = (1n << 64n) - 1n;
 const u64 = (x: bigint): bigint => x & MASK;
@@ -47,13 +51,16 @@ type MixOp =
   | { readonly op: "mul"; readonly k: bigint } // z := z * k        (wrapping)
   | { readonly op: "xorshr"; readonly s: bigint }; // z := z ^ (z >> s)
 
-// --- read the IR ROW and decode it through the real DynamicValue canonical-JSON decoder ---
+// --- obtain the IR ROW from the relation (by content-addressed ZetaId) and decode it ---
 
-const irPath = join(import.meta.dir, "splitmix64.ir.json");
-const irText = readFileSync(irPath, "utf8").trim();
-const decoded = fromCanonicalJson(irText);
+const zetaId = generatorIr.idOf("rng.splitmix64", 1);
+const irRow = generatorIr.byZetaId(zetaId);
+if (!irRow) {
+  throw new Error(`no IR row on the relation for rng.splitmix64@1 (zetaId ${zetaId})`);
+}
+const decoded = fromCanonicalJson(irRow.irCanonicalJson);
 if (!decoded.ok) {
-  throw new Error(`splitmix64.ir.json is not a canonical DynamicValue: ${decoded.error}`);
+  throw new Error(`rng.splitmix64@1 IR row is not a canonical DynamicValue: ${decoded.error}`);
 }
 
 // --- project the decoded DynamicValue (Tagged) down to the typed op list ---
@@ -121,4 +128,4 @@ for (const [id, x] of Object.entries(inputs)) out[id] = mix(x).toString();
 
 const target = join(dirname(import.meta.dir), "ts-output.json");
 writeFileSync(target, `${JSON.stringify(out, null, 2)}\n`);
-console.log("wrote ts-output.json (generated-from-ir, IR read from splitmix64.ir.json DynamicValue row)");
+console.log(`wrote ts-output.json (generated-from-ir, IR sourced from the relation row zetaId=${zetaId})`);


### PR DESCRIPTION
Closes the codegen-forward trajectory's last open thread: the generator IR is no longer only a checked-in document — it is the **payload of a row on a real `ZSet<IrRow>`** (`src/Core/GeneratorIrRegistry.fs`).

## What lands
- **`GeneratorIrRegistry.fs`** — the generator-IR relation: `register` = +1 delta, `retract` = -1 delta (abelian-group inverse), `relationOf` (full) == `incremental` fold, each row's `ZetaId` = the real `GeneratorRegistry.idOf` content-address, `byZetaId` lookup.
- **TS oracles source IR from the relation** — `splitmix64`/`fmix32` `gen.ts` now call `generatorIr.byZetaId(idOf(name, version))` (bun-side twin `_harness/generator-ir-registry.ts`) instead of reading a bare file path. **`ts-output.json` bytes are unchanged**, so the N-way byte-lock holds.
- **F# tests (`GeneratorIrRegistry.Tests.fs`, 8)** pin: the relation row reproduces each committed `*.ir.json` **byte-for-byte** (materialised view); the group law (register+retract=Zero); full==incremental; ZetaId=content-address; `byZetaId` resolves live but not retracted rows.

## Honest tier
The committed `*.ir.json` files are the rows' **serialised payloads** — the F# tests prove the file IS the relation row's bytes, so the TS view and F# relation are the **same** relation, not two parallel copies. The relation is an in-memory `known` set today (not yet streamed through a running DBSP circuit); that streaming integration is the natural follow-on.

## Gates
- tsc `--noEmit`: clean (no TS6133)
- fidelity self-tests: 9/9
- cross-verify orchestrator: **15/15**
- relevant F# tests: 24/24 (GeneratorIrRegistry 8, GeneratorRegistry, DynamicValue canonical byte-locks)