### PR TITLE
test(core): route horizon heat through bounded adapter

### DIFF
--- a/src/Core/RoomHorizon.fs
+++ b/src/Core/RoomHorizon.fs
@@ -55,11 +55,11 @@ module RoomHorizon =
     /// Forgotten materialized keys are heat. Paid futures that still cannot fit
     /// the finite exterior view are backpressure heat.
     let heatSignatures (source: string) (report: Report<'K, 'S>) : HeatSignature list =
-        [ positiveSignature
+        [ BoundedHeat.signature
               source
               "room-horizon.forgotten"
-              report.HorizonHeat.Units
               "bounded horizon forgot materialized keys"
+              report.HorizonHeat
           positiveSignature
               source
               "room-horizon.backpressure"

--- a/tests/Tests.FSharp/RoomHorizon.Tests.fs
+++ b/tests/Tests.FSharp/RoomHorizon.Tests.fs
@@ -124,6 +124,34 @@ let ``rolling horizon exports forgetting as host heat`` () =
     Assert.Equal("room-horizon.forgotten", sink.Signatures.[0].Kind)
 
 [<Fact>]
+let ``rolling horizon preserves heat sink backpressure as typed feedback`` () =
+    let current =
+        BoundedGSet.ofSeq<int> (config 2 BoundedGSetForgetPolicy.ForgetLowest) [ 1; 2 ]
+        |> mustOk
+        |> fun projection -> projection.State
+
+    let report =
+        [ candidate 3 "newer" "C" 1L 1L 1L ]
+        |> RH.update current (SoftThrottle.tank 1.0 0.0)
+        |> mustOk
+
+    let sink =
+        BoundedHeatSink
+            { Capacity = 1
+              ForgetPolicy = BoundedGSetForgetPolicy.RejectNew }
+
+    let filler = HeatSignature.ofMass "occupied" "heat.fill" 1 1.0 "pre-fill bounded heat sink"
+    (sink :> IHeatSink).Emit filler |> mustOk
+
+    match RH.emitHeat (sink :> IHeatSink) "vision-test" report with
+    | Ok () -> Assert.Fail("expected bounded heat sink backpressure")
+    | Error(HeatSinkFeedback.Backpressure(heat, capacity, count)) ->
+        Assert.Equal("room-horizon.forgotten", heat.Kind)
+        Assert.Equal(1, capacity)
+        Assert.Equal(2, count)
+    | Error feedback -> Assert.Fail(sprintf "unexpected heat sink feedback: %A" feedback)
+
+[<Fact>]
 let ``no-forget horizon exports paid finite-view rejection as backpressure heat`` () =
     let current =
         BoundedGSet.ofSeq<int> (config 1 BoundedGSetForgetPolicy.RejectNew) [ 1 ]


### PR DESCRIPTION

## What

- Routes RoomHorizon forgotten-key heat through the shared BoundedHeat signature adapter.
- Adds a RoomHorizon regression test proving bounded heat sink backpressure stays typed when the heat channel is full.

## Why

The finite horizon should not hand-roll the heat vocabulary for bounded G-set loss now that bounded finite-view heat has a source-owned adapter. This keeps room horizon, CHIP-8/9, and scheduler code converging on one heat/backpressure boundary while preserving the cold no-forget path.

## Validation

- dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter FullyQualifiedName~RoomHorizonTests
- dotnet build -c Release
- dotnet format --verify-no-changes
- dotnet test Zeta.sln -c Release --no-build

Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: Codex
Agent-Model: gpt-5.5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: not-implied-by-credential
Human-Review-Evidence: none
Action-Mode: human-directed
Task: none
Co-Authored-By: Codex <noreply@openai.com>