### PR TITLE
test(core): stop soft drive on heat backpressure

### DIFF
--- a/tests/Tests.FSharp/SoftDrive.Tests.fs
+++ b/tests/Tests.FSharp/SoftDrive.Tests.fs
@@ -74,3 +74,30 @@ let ``frame-aware driveFramesWithHeatSink exports prune heat to host`` () =
                 Assert.Equal("chip8-room", heat.Source)
                 Assert.Equal("soft-emu.prune", heat.Kind)
                 Assert.Equal(1, heat.Units))
+
+[<Fact>]
+let ``frame-aware driveFramesWithHeatSink stops when prune heat backpressures`` () =
+    let setup = Chip8Cow.create 1UL |> Chip8Cow.loadRom inputAfterOne
+
+    let sink =
+        BoundedHeatSink
+            { Capacity = 1
+              ForgetPolicy = BoundedGSetForgetPolicy.RejectNew }
+
+    let filler = HeatSignature.ofMass "test" "heat.fill" 1 1.0 "occupy bounded heat sink"
+
+    match (sink :> IHeatSink).Emit filler with
+    | Error e -> Assert.True(false, sprintf "unexpected heat sink prefill feedback: %A" e)
+    | Ok () -> ()
+
+    match SoftDrive.driveFramesWithHeatSink "chip8-room" (sink :> IHeatSink) SoftDashboard.sumMemory 1 1 1 1 setup with
+    | Ok _ -> Assert.True(false, "soft drive must stop when prune heat cannot cross the room boundary")
+    | Error(HeatSinkFeedback.Backpressure(heat, capacity, count)) ->
+        Assert.Equal("chip8-room", heat.Source)
+        Assert.Equal("soft-emu.prune", heat.Kind)
+        Assert.Equal(1, heat.Units)
+        Assert.Equal(500000L, heat.MassPpm)
+        Assert.Equal(1, capacity)
+        Assert.Equal(2, count)
+        Assert.Equal<HeatSignature list>([ filler ], sink.Stored)
+    | Error e -> Assert.True(false, sprintf "unexpected heat sink feedback: %A" e)


### PR DESCRIPTION
## What

- Adds a SoftDrive regression test proving frame-aware soft CHIP-8 control stops when pruning heat cannot cross a saturated bounded heat sink.

## Why

Soft pruning is allowed to erase low-weight futures only when the loss signal reaches the host or room boundary. A full heat channel must turn that attempted erasure into typed backpressure, keeping the tiny room honest about information loss.

## Validation

- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter FullyQualifiedName~SoftDriveTests`
- `dotnet build -c Release`
- `dotnet format --verify-no-changes`
- `dotnet test Zeta.sln -c Release --no-build`

Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: Codex
Agent-Model: gpt-5.5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: not-implied-by-credential
Human-Review-Evidence: none
Action-Mode: human-directed
Task: none
Co-Authored-By: Codex <noreply@openai.com>