### PR TITLE
feat(core): stream the generator-IR relation through a running DBSP circuit

### DIFF
--- a/src/Core/GeneratorIrRegistry.fs
+++ b/src/Core/GeneratorIrRegistry.fs
@@ -161,3 +161,64 @@ module GeneratorIrRegistry =
 
     /// The full known relation (all known IR rows, weight +1).
     let relation: ZSet<IrRow> = relationOf known
+
+    // ── the relation as the RUNNING INTEGRAL of a delta stream ─────────────────────
+    //
+    // Everything above treats the relation as a constant value (full fold) or a static
+    // sum of deltas. The final rung is to let the deltas ARRIVE OVER TIME on a running
+    // DBSP circuit: feed each +1 (register) / -1 (retract) Z-set delta into a
+    // `ZSetInput`, `IntegrateZSet` it, and step the circuit. The integrator's output is
+    // the materialised relation AS OF the deltas seen so far. This is DBSP's `∫`
+    // (integration) operator — the same one the rest of the engine runs — specialised
+    // to the generator-IR relation.
+    //
+    // SOUNDNESS this exercises (pinned in `GeneratorIrRegistry.Tests`):
+    //   * circuit-output AFTER all register deltas == `relationOf known` (the running
+    //     integral converges to the full relation — DBSP incrementalisation soundness).
+    //   * a retract (-1) delta arriving later REMOVES the row from the live output
+    //     (`register r` then `retract r` => the row is gone), which is rollback observed
+    //     on a running stream, not just in the static `add r (neg r) = Zero` algebra.
+    //   * order independence: the integral is a sum in the abelian group, so any
+    //     interleaving of the same multiset of deltas yields the same materialised
+    //     relation.
+    module Stream =
+
+        open System.Threading.Tasks
+
+        /// Run a sequence of Z-set deltas (each a `register`/`retract` result, or any
+        /// `ZSet<IrRow>` delta) through a real DBSP circuit and return the materialised
+        /// relation after all deltas have been stepped. One `Step` per delta, so the
+        /// caller can also observe intermediate states via `stepwise` below.
+        let integrateDeltas (deltas: ZSet<IrRow> seq) : Task<ZSet<IrRow>> =
+            task {
+                let c = Circuit.create ()
+                let input = c.ZSetInput<IrRow>()
+                let materialised = c.IntegrateZSet input.Stream
+                let out = c.Output materialised
+                for d in deltas do
+                    input.Send d
+                    do! c.StepAsync()
+                return out.Current
+            }
+
+        /// Run the deltas through a circuit and return the materialised relation after
+        /// EACH delta (the running integral's trajectory). Useful for asserting that a
+        /// retract removes a row mid-stream, not only at the end.
+        let stepwise (deltas: ZSet<IrRow> seq) : Task<ZSet<IrRow> list> =
+            task {
+                let c = Circuit.create ()
+                let input = c.ZSetInput<IrRow>()
+                let materialised = c.IntegrateZSet input.Stream
+                let out = c.Output materialised
+                let acc = ResizeArray<ZSet<IrRow>>()
+                for d in deltas do
+                    input.Send d
+                    do! c.StepAsync()
+                    acc.Add out.Current
+                return List.ofSeq acc
+            }
+
+        /// Convenience: stream the +1 register delta for each row, returning the
+        /// materialised relation. `integrateRegisters known` must equal `relationOf known`.
+        let integrateRegisters (rows: IrRow seq) : Task<ZSet<IrRow>> =
+            rows |> Seq.map register |> integrateDeltas

--- a/tests/Tests.FSharp/GeneratorIrRegistry.Tests.fs
+++ b/tests/Tests.FSharp/GeneratorIrRegistry.Tests.fs
@@ -115,3 +115,64 @@ let ``byZetaId resolves a live row but not a retracted one`` () =
         (GeneratorIrRegistry.byZetaId r.ZetaId afterRetract).IsNone,
         "a retracted row must NOT resolve by its ZetaId"
     )
+
+
+// ── 5. RUNNING DBSP CIRCUIT: the relation as the integral of a delta stream ─────────
+//
+// The four facts above treat the relation as a constant value or a static sum of
+// deltas. These pin the final rung: the deltas ARRIVE OVER TIME on a real DBSP circuit
+// (ZSetInput -> IntegrateZSet -> Output, stepped once per delta), and the integrator's
+// output is the materialised relation. This is the same `∫` operator the rest of the
+// engine runs, specialised to the generator-IR relation.
+
+// 5a. The running integral of the +1 register deltas CONVERGES to the full relation:
+//     integrateRegisters known == relationOf known (DBSP incrementalisation soundness).
+[<Fact>]
+let ``streaming the register deltas through a DBSP circuit materialises relationOf`` () =
+    task {
+        let! materialised = GeneratorIrRegistry.Stream.integrateRegisters GeneratorIrRegistry.known
+        let full = GeneratorIrRegistry.relation
+        Assert.True(
+            (ZSet.add materialised (ZSet.neg full)).IsEmpty,
+            "circuit-materialised relation must equal relationOf known"
+        )
+        Assert.Equal(full.Count, materialised.Count)
+    }
+
+// 5b. A retract (-1) delta arriving LATER removes the row from the live output — rollback
+//     observed mid-stream on a running circuit, not just in the static algebra.
+[<Fact>]
+let ``a retract delta arriving on the stream removes the row from the live integral`` () =
+    task {
+        let r = List.head GeneratorIrRegistry.known
+        // register r, then later retract r: the running integral must end empty of r.
+        let deltas =
+            [ GeneratorIrRegistry.register r; GeneratorIrRegistry.retract r ]
+        let! trajectory = GeneratorIrRegistry.Stream.stepwise deltas
+        match trajectory with
+        | [ afterRegister; afterRetract ] ->
+            Assert.Equal(1L, ZSet.lookup r afterRegister) // present after the +1 step
+            Assert.Equal(0L, ZSet.lookup r afterRetract) // gone after the -1 step
+            Assert.True((GeneratorIrRegistry.byZetaId r.ZetaId afterRetract).IsNone)
+        | _ -> failwith "expected a two-step trajectory"
+    }
+
+// 5c. ORDER INDEPENDENCE: the integral is a sum in the abelian group, so any interleaving
+//     of the SAME multiset of deltas yields the SAME materialised relation.
+[<Fact>]
+let ``the running integral is order-independent over the same multiset of deltas`` () =
+    task {
+        match GeneratorIrRegistry.known with
+        | a :: b :: _ ->
+            let! forward =
+                GeneratorIrRegistry.Stream.integrateDeltas
+                    [ GeneratorIrRegistry.register a; GeneratorIrRegistry.register b ]
+            let! reversed =
+                GeneratorIrRegistry.Stream.integrateDeltas
+                    [ GeneratorIrRegistry.register b; GeneratorIrRegistry.register a ]
+            Assert.True(
+                (ZSet.add forward (ZSet.neg reversed)).IsEmpty,
+                "delta order must not change the materialised relation"
+            )
+        | _ -> () // need at least two known rows; skip otherwise
+    }


### PR DESCRIPTION
## What

`GeneratorIrRegistry` carried the generator IR as a row on a `ZSet<IrRow>`, but the relation was the integral of a **static** sum of deltas. This adds `GeneratorIrRegistry.Stream` — the relation as the **running integral of a delta stream** on a real DBSP circuit (`ZSetInput → IntegrateZSet → Output`, stepped once per delta). Same `∫` operator the rest of the engine runs.

This discharges the last narrowed open thread of the codegen-forward trajectory (splitmix64 → fmix32 → IR-as-row → **IR as a live row on a running circuit**).

## Honest tier

PROVEN (pinned in tests, 11/11):
- `integrateRegisters known == relationOf known` — the running integral converges to the full relation (DBSP incrementalisation soundness).
- A `retract` (−1) delta arriving **mid-stream** removes the row from the live output — rollback observed on a running circuit, not just the static `add r (neg r) = Zero` algebra.
- **Order independence** over the same multiset of deltas (abelian-group sum).

Scope note: this exercises a circuit fed a finite delta sequence in one process. A long-lived circuit fed by an external delta source (zero-downtime schema evolution over a live feed) reuses these exact rungs; what is proven here is the integration semantics and the delta algebra, end to end on a real circuit.

## Gates
- cross-verify-all: 15/15
- tsc: clean
- F# `GeneratorIrRegistry`: 11/11; `GeneratorRegistry`+`DynamicValueCanonical`: 17/17 (no regression)