### PR TITLE
feat(core): expose darkhall heat readout

### DIFF
--- a/src/Core/DarkHallRoomLoop.fs
+++ b/src/Core/DarkHallRoomLoop.fs
@@ -29,6 +29,13 @@ module DarkHallRoomLoop =
 
     type RequestResolver = Runtime.CabinetAction -> Runtime.RunRequest option
 
+    type HeatReadout =
+        { HeatRejected: int
+          Backpressured: int
+          StorageErrors: int
+          HeatKinds: string list
+          Reasons: string list }
+
     [<RequireQualifiedAccess>]
     type TickFeedback =
         | CellUnbound of cell: int
@@ -55,6 +62,7 @@ module DarkHallRoomLoop =
           Choice: ControllerChoice
           Action: Runtime.CabinetAction option
           Result: Result<Runtime.RunResult, TickFeedback>
+          Heat: HeatReadout
           State: LoopState }
 
     type RunOutcome =
@@ -74,6 +82,49 @@ module DarkHallRoomLoop =
     let private append (event: LoopEvent) (state: LoopState) : LoopState =
         { state with EventsRev = event :: state.EventsRev }
 
+    let emptyHeatReadout : HeatReadout =
+        { HeatRejected = 0
+          Backpressured = 0
+          StorageErrors = 0
+          HeatKinds = []
+          Reasons = [] }
+
+    let private boundedGSetErrorReason =
+        function
+        | BoundedGSetError.NonPositiveCapacity capacity -> sprintf "heat storage non-positive capacity %d" capacity
+        | BoundedGSetError.CapacityExceeded(capacity, count) ->
+            sprintf "heat storage capacity exceeded capacity=%d count=%d" capacity count
+        | BoundedGSetError.ConfigMismatch(left, right) ->
+            sprintf
+                "heat storage config mismatch left-capacity=%d right-capacity=%d"
+                left.Capacity
+                right.Capacity
+
+    let private heatSinkFeedbackReadout =
+        function
+        | HeatSinkFeedback.Backpressure(heat, capacity, count) ->
+            { emptyHeatReadout with
+                HeatRejected = 1
+                Backpressured = 1
+                HeatKinds = [ heat.Kind ]
+                Reasons = [ sprintf "heat sink backpressure kind=%s capacity=%d count=%d" heat.Kind capacity count ] }
+        | HeatSinkFeedback.StorageError error ->
+            { emptyHeatReadout with
+                HeatRejected = 1
+                StorageErrors = 1
+                Reasons = [ boundedGSetErrorReason error ] }
+
+    let private heatReadoutOfRuntimeFeedback =
+        function
+        | Runtime.Feedback.HeatRejected(_, feedback) -> heatSinkFeedbackReadout feedback
+        | Runtime.Feedback.MetaCartFeedback(MetaCart.Feedback.HeatRejected(_, feedback)) -> heatSinkFeedbackReadout feedback
+        | _ -> emptyHeatReadout
+
+    let private heatReadoutOfResult =
+        function
+        | Error(TickFeedback.RuntimeFeedback feedback) -> heatReadoutOfRuntimeFeedback feedback
+        | _ -> emptyHeatReadout
+
     let private complete
         (readout: Runtime.ControllerReadout)
         (choice: ControllerChoice)
@@ -85,6 +136,7 @@ module DarkHallRoomLoop =
           Choice = choice
           Action = action
           Result = result
+          Heat = heatReadoutOfResult result
           State = state }
 
     let private cellForAction (action: Runtime.CabinetAction) (readout: Runtime.ControllerReadout) : int option =

--- a/tests/Tests.FSharp/DarkHallRoomLoop.Tests.fs
+++ b/tests/Tests.FSharp/DarkHallRoomLoop.Tests.fs
@@ -139,6 +139,59 @@ let ``tick appends runtime refusal and emits heat for denied cabinet capability`
     | other -> Assert.Fail(sprintf "expected denied capability, got %A" other)
 
 [<Fact>]
+let ``tick readout exposes heat backpressure when denied cabinet heat cannot cross boundary`` () =
+    let sink =
+        BoundedHeatSink
+            { Capacity = 1
+              ForgetPolicy = BoundedGSetForgetPolicy.RejectNew }
+
+    let filler = HeatSignature.ofMass "test" "heat.fill" 1 1.0 "occupy bounded heat sink"
+
+    match (sink :> IHeatSink).Emit filler with
+    | Error feedback -> Assert.Fail(sprintf "expected heat sink prefill, got %A" feedback)
+    | Ok() -> ()
+
+    let child = CartFixtures.cart CartFixtures.chip9GreenDot
+    let caps = MetaCart.capabilityMap [ child, CartFixtures.chip9GreenDot.Capabilities ]
+
+    let launch: Runtime.MetaCartLaunch =
+        { Goal = 3
+          Seed = 1UL
+          ParentCapabilities = Chip9Capabilities.chip8Default
+          ChildCapabilitiesBySha = caps
+          Children = [ child ]
+          Parent = Chip8Cow.create 1UL }
+
+    let requestFor (action: Runtime.CabinetAction) =
+        if action.Id = "darkhall.play.meta-cart-host" then
+            Some(Runtime.RunMetaCart launch)
+        else
+            None
+
+    let outcome =
+        RoomLoop.tick
+            "darkhall-room-loop"
+            (sink :> IHeatSink)
+            requestFor
+            (chooseById "darkhall.play.meta-cart-host")
+            (RoomLoop.initial Arcade.room Chip9Capabilities.chip8Default)
+        |> wait
+
+    match outcome.Result with
+    | Error(RoomLoop.TickFeedback.RuntimeFeedback(Runtime.Feedback.HeatRejected(address, HeatSinkFeedback.Backpressure(heat, capacity, count)))) ->
+        Assert.Equal(mkAddress "play" "meta-cart-host", address)
+        Assert.Equal("darkhall.machine.denied", heat.Kind)
+        Assert.Equal(1, capacity)
+        Assert.Equal(2, count)
+    | other -> Assert.Fail(sprintf "expected heat backpressure, got %A" other)
+
+    Assert.Equal(1, outcome.Heat.HeatRejected)
+    Assert.Equal(1, outcome.Heat.Backpressured)
+    Assert.Equal(0, outcome.Heat.StorageErrors)
+    Assert.Equal<string list>([ "darkhall.machine.denied" ], outcome.Heat.HeatKinds)
+    Assert.Contains("capacity=1", System.String.Join(";", outcome.Heat.Reasons))
+
+[<Fact>]
 let ``run is bounded and carries state through consecutive room ticks`` () =
     let sink = RecordingHeatSink()
     let state = RoomLoop.initial Arcade.room Chip9Capabilities.chip8Default


### PR DESCRIPTION
## What

- Adds a `HeatReadout` summary to DarkHallRoomLoop tick outcomes.
- Summarizes heat rejection, sink backpressure, storage errors, heat kinds, and readable reasons for runtime heat feedback.
- Adds a room-loop regression test proving denied cabinet heat becomes observable tick backpressure when the heat boundary is saturated.

## Why

Room schedulers and CHIP-9 hosts need to see heat at the room boundary without spelunking nested runtime feedback. The 4x4 GridBinding remains placement-only; ControllerReadout and TickOutcome carry the controller-facing observation.

## Validation

- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter FullyQualifiedName~DarkHallRoomLoopTests`
- `dotnet build -c Release`
- `dotnet format --verify-no-changes`
- `dotnet test Zeta.sln -c Release --no-build`

Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: Codex
Agent-Model: gpt-5.5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: not-implied-by-credential
Human-Review-Evidence: none
Action-Mode: human-directed
Task: none
Co-Authored-By: Codex <noreply@openai.com>