### PR TITLE
feat(core): schedule darkhall heat readouts

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -358,6 +358,7 @@
     <Compile Include="Arcade.fs" />
     <Compile Include="DarkHallCabinetRuntime.fs" />
     <Compile Include="DarkHallRoomLoop.fs" />
+    <Compile Include="DarkHallScheduler.fs" />
     <Compile Include="ReticulumQuantum.fs" />
     <Compile Include="Skadium.fs" />
     <Compile Include="BowlingAlley.fs" />

--- a/src/Core/DarkHallScheduler.fs
+++ b/src/Core/DarkHallScheduler.fs
@@ -1,0 +1,85 @@
+namespace Zeta.Core
+
+/// Scheduler-facing boundary for Dark Hall rooms.
+///
+/// `DarkHallRoomLoop` owns observe -> choose -> execute -> append. This module
+/// only adapts that loop to the soft scheduler and banks the heat readout as a
+/// first-class row, so CHIP-9/room hosts can see backpressure without unpacking
+/// nested runtime feedback.
+[<RequireQualifiedAccess>]
+module DarkHallScheduler =
+
+    module RoomLoop = DarkHallRoomLoop
+    module Runtime = DarkHallCabinetRuntime
+
+    type HeatBoundaryRow =
+        { Tick: int
+          RoomName: string
+          HeatRejected: int
+          Backpressured: int
+          StorageErrors: int
+          HeatKinds: string list
+          Reasons: string list }
+
+    type ScheduledRoomState =
+        { Loop: RoomLoop.LoopState
+          CompletedTicks: int
+          LastTick: RoomLoop.TickOutcome option
+          HeatRowsRev: HeatBoundaryRow list }
+
+    let initial (room: DarkHall.Room) (manifest: Chip9Capabilities.Manifest) : ScheduledRoomState =
+        { Loop = RoomLoop.initial room manifest
+          CompletedTicks = 0
+          LastTick = None
+          HeatRowsRev = [] }
+
+    let heatRows (state: ScheduledRoomState) : HeatBoundaryRow list =
+        List.rev state.HeatRowsRev
+
+    let lastHeatRow (state: ScheduledRoomState) : HeatBoundaryRow option =
+        state.HeatRowsRev |> List.tryHead
+
+    let backpressured (state: ScheduledRoomState) : bool =
+        state.HeatRowsRev |> List.exists (fun row -> row.Backpressured > 0)
+
+    let private rowOfOutcome (tick: int) (outcome: RoomLoop.TickOutcome) : HeatBoundaryRow =
+        { Tick = tick
+          RoomName = outcome.Readout.RoomName
+          HeatRejected = outcome.Heat.HeatRejected
+          Backpressured = outcome.Heat.Backpressured
+          StorageErrors = outcome.Heat.StorageErrors
+          HeatKinds = outcome.Heat.HeatKinds
+          Reasons = outcome.Heat.Reasons }
+
+    let record (outcome: RoomLoop.TickOutcome) (state: ScheduledRoomState) : ScheduledRoomState =
+        let tick = state.CompletedTicks + 1
+        { Loop = outcome.State
+          CompletedTicks = tick
+          LastTick = Some outcome
+          HeatRowsRev = rowOfOutcome tick outcome :: state.HeatRowsRev }
+
+    let tick
+        (source: string)
+        (sink: IHeatSink)
+        (requestFor: RoomLoop.RequestResolver)
+        (choose: Runtime.ControllerReadout -> RoomLoop.ControllerChoice)
+        (state: ScheduledRoomState)
+        =
+        task {
+            let! outcome = RoomLoop.tick source sink requestFor choose state.Loop
+            return record outcome state
+        }
+
+    let roomTickHandler
+        (name: string)
+        (matches: InterruptKind -> bool)
+        (source: string)
+        (sink: IHeatSink)
+        (requestFor: RoomLoop.RequestResolver)
+        (choose: Runtime.ControllerReadout -> RoomLoop.ControllerChoice)
+        : SoftScheduler.HandlerK<ScheduledRoomState> =
+        SoftScheduler.handlerK name matches (fun _intr _ctx state ->
+            task {
+                let! next = tick source sink requestFor choose state
+                return Ok next
+            })

--- a/tests/Tests.FSharp/DarkHallScheduler.Tests.fs
+++ b/tests/Tests.FSharp/DarkHallScheduler.Tests.fs
@@ -1,0 +1,107 @@
+module Zeta.Tests.DarkHallSchedulerTests
+
+open System.Diagnostics
+open System.Threading.Tasks
+open global.Xunit
+open Zeta.Core
+
+module Runtime = DarkHallCabinetRuntime
+module RoomLoop = DarkHallRoomLoop
+module Scheduler = DarkHallScheduler
+
+let private ctx () : IntrCtx =
+    { Memetic = "darkhall-scheduler"
+      Prompt = ""
+      Trust = ""
+      Log = ""
+      Otel = ActivityContext() }
+
+let private chooseById id (readout: Runtime.ControllerReadout) : RoomLoop.ControllerChoice =
+    let cell =
+        GridBinding.bound readout.Grid
+        |> List.tryFind (fun (_, action) -> action.Id = id)
+        |> Option.map fst
+        |> Option.defaultValue -1
+
+    { Cell = cell
+      Tier = RoomLoop.ChoiceTier.Operator
+      Confidence = 1.0
+      Reason = "test-selected action id" }
+
+let private timer =
+    function
+    | TimerElapsed _ -> true
+    | _ -> false
+
+[<Fact>]
+let ``soft scheduler banks darkhall heat backpressure as a room boundary row`` () =
+    task {
+        let sink =
+            BoundedHeatSink
+                { Capacity = 1
+                  ForgetPolicy = BoundedGSetForgetPolicy.RejectNew }
+
+        let filler = HeatSignature.ofMass "test" "heat.fill" 1 1.0 "occupy bounded heat sink"
+
+        match (sink :> IHeatSink).Emit filler with
+        | Error feedback -> Assert.Fail(sprintf "expected heat sink prefill, got %A" feedback)
+        | Ok() -> ()
+
+        let child = CartFixtures.cart CartFixtures.chip9GreenDot
+        let caps = MetaCart.capabilityMap [ child, CartFixtures.chip9GreenDot.Capabilities ]
+
+        let launch: Runtime.MetaCartLaunch =
+            { Goal = 3
+              Seed = 1UL
+              ParentCapabilities = Chip9Capabilities.chip8Default
+              ChildCapabilitiesBySha = caps
+              Children = [ child ]
+              Parent = Chip8Cow.create 1UL }
+
+        let requestFor (action: Runtime.CabinetAction) =
+            if action.Id = "darkhall.play.meta-cart-host" then
+                Some(Runtime.RunMetaCart launch)
+            else
+                None
+
+        let handler =
+            Scheduler.roomTickHandler
+                "darkhall-room"
+                timer
+                "darkhall-scheduler"
+                (sink :> IHeatSink)
+                requestFor
+                (chooseById "darkhall.play.meta-cart-host")
+
+        let source _ = [ TimerElapsed 17 ]
+        let initial = Scheduler.initial Arcade.room Chip9Capabilities.chip8Default
+        let! result = (SoftScheduler.driveK [ handler ] source).Run(ctx ()) 42L initial 1
+
+        match result with
+        | Error feedback -> Assert.Fail(sprintf "heat backpressure should stay in the room readout, got %A" feedback)
+        | Ok final ->
+            Assert.Equal(1, final.CompletedTicks)
+            Assert.True(Scheduler.backpressured final)
+
+            match final.LastTick with
+            | None -> Assert.Fail "scheduler should bank the last room tick"
+            | Some tick ->
+                match tick.Result with
+                | Error(RoomLoop.TickFeedback.RuntimeFeedback(Runtime.Feedback.HeatRejected _)) -> ()
+                | other -> Assert.Fail(sprintf "expected room tick heat rejection, got %A" other)
+
+            match Scheduler.lastHeatRow final with
+            | None -> Assert.Fail "scheduler should expose the latest heat row"
+            | Some row ->
+                Assert.Equal(1, row.Tick)
+                Assert.Equal("darkhall", row.RoomName)
+                Assert.Equal(1, row.HeatRejected)
+                Assert.Equal(1, row.Backpressured)
+                Assert.Equal(0, row.StorageErrors)
+                Assert.Equal<string list>([ "darkhall.machine.denied" ], row.HeatKinds)
+                Assert.Contains("capacity=1", System.String.Join(";", row.Reasons))
+
+            match Scheduler.heatRows final with
+            | [ row ] -> Assert.Equal(1, row.Backpressured)
+            | rows -> Assert.Fail(sprintf "expected one scheduler heat row, got %A" rows)
+    }

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -138,6 +138,7 @@
     <Compile Include="Arcade.Tests.fs" />
     <Compile Include="DarkHallCabinetRuntime.Tests.fs" />
     <Compile Include="DarkHallRoomLoop.Tests.fs" />
+    <Compile Include="DarkHallScheduler.Tests.fs" />
     <Compile Include="BowlingAlley.Tests.fs" />
     <Compile Include="Skadium.Tests.fs" />
     <Compile Include="DevRoom.Tests.fs" />


### PR DESCRIPTION
## What

- Adds `DarkHallScheduler`, a `SoftScheduler.HandlerK` adapter for Dark Hall room ticks.
- Banks each tick's `HeatReadout` as a first-class `HeatBoundaryRow` on scheduler state.
- Adds a scheduler-level regression proving saturated no-forget heat backpressure remains observable without becoming `InterruptFeedback`.

## Why

Room and CHIP-9 hosts need heat/backpressure as scheduler-visible state, not hidden nested runtime feedback. This keeps emulator/runtime cores clean: the injected scheduler/host boundary carries the observation.

## Validation

- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter FullyQualifiedName~DarkHallSchedulerTests`
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --no-build --filter FullyQualifiedName~DarkHallSchedulerTests\|FullyQualifiedName~DarkHallRoomLoopTests\|FullyQualifiedName~DarkHallCabinetRuntimeTests`
- `dotnet build -c Release`
- `dotnet format --verify-no-changes`
- `dotnet test Zeta.sln -c Release --no-build`

Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: Codex
Agent-Model: gpt-5.5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: not-implied-by-credential
Human-Review-Evidence: none
Action-Mode: human-directed
Task: none
Co-Authored-By: Codex <noreply@openai.com>
