### PR TITLE
[codex] render darkhall heat as chip9 board

### DIFF
--- a/src/Core/DarkHallScheduler.fs
+++ b/src/Core/DarkHallScheduler.fs
@@ -42,6 +42,58 @@ module DarkHallScheduler =
     let backpressured (state: ScheduledRoomState) : bool =
         state.HeatRowsRev |> List.exists (fun row -> row.Backpressured > 0)
 
+    let private setColor (x: int) (y: int) (mask: byte) (frame: Chip8Cow.Frame) : Chip8Cow.Frame =
+        let idx = y * Chip8.DisplayW + x
+        let display =
+            if mask &&& 1uy <> 0uy then Map.add idx true frame.Display else Map.remove idx frame.Display
+
+        let hi = mask &&& 0b110uy
+        let extra = if hi = 0uy then Map.remove idx frame.Extra else Map.add idx hi frame.Extra
+
+        { frame with Display = display; Extra = extra }
+
+    let private drawLane (y: int) (start: int) (width: int) (mask: byte) (count: int) (frame: Chip8Cow.Frame) : Chip8Cow.Frame =
+        let lit = max 0 count |> min width
+
+        if lit = 0 then
+            frame
+        else
+            [ 0 .. lit - 1 ] |> List.fold (fun acc dx -> setColor (start + dx) y mask acc) frame
+
+    let private drawKindLane (y: int) (row: HeatBoundaryRow) (frame: Chip8Cow.Frame) : Chip8Cow.Frame =
+        row.HeatKinds
+        |> List.distinct
+        |> List.truncate 16
+        |> List.indexed
+        |> List.fold (fun acc (i, _) -> setColor (48 + i) y 4uy acc) frame
+
+    /// Host-visible CHIP-9 heat board. Each heat row becomes one display row:
+    /// red 0..15 = heat rejected, yellow 16..31 = backpressure, magenta
+    /// 32..47 = storage errors, blue 48..63 = distinct heat kinds.
+    let heatBoardFrame (seed: uint64) (rows: HeatBoundaryRow list) : Chip8Cow.Frame =
+        let visibleRows = rows |> List.rev |> List.truncate Chip8.DisplayH |> List.rev
+        let baseFrame = { Chip8Cow.create seed with Plane = 7uy }
+
+        visibleRows
+        |> List.indexed
+        |> List.fold
+            (fun frame (y, row) ->
+                frame
+                |> drawLane y 0 16 1uy row.HeatRejected
+                |> drawLane y 16 16 3uy row.Backpressured
+                |> drawLane y 32 16 5uy row.StorageErrors
+                |> drawKindLane y row)
+            baseFrame
+
+    let heatBoardFrameForState (seed: uint64) (state: ScheduledRoomState) : Chip8Cow.Frame =
+        state |> heatRows |> heatBoardFrame seed
+
+    let renderHeatBoard (seed: uint64) (rows: HeatBoundaryRow list) : string list =
+        rows |> heatBoardFrame seed |> Chip9Board.render
+
+    let renderHeatBoardForState (seed: uint64) (state: ScheduledRoomState) : string list =
+        state |> heatRows |> renderHeatBoard seed
+
     let private rowOfOutcome (tick: int) (outcome: RoomLoop.TickOutcome) : HeatBoundaryRow =
         { Tick = tick
           RoomName = outcome.Readout.RoomName

--- a/tests/Tests.FSharp/DarkHallScheduler.Tests.fs
+++ b/tests/Tests.FSharp/DarkHallScheduler.Tests.fs
@@ -34,6 +34,44 @@ let private timer =
     | _ -> false
 
 [<Fact>]
+let ``heat boundary rows render as a host visible CHIP-9 board`` () =
+    let row: Scheduler.HeatBoundaryRow =
+        { Tick = 7
+          RoomName = "darkhall"
+          HeatRejected = 2
+          Backpressured = 1
+          StorageErrors = 1
+          HeatKinds = [ "darkhall.machine.denied"; "meta-cart.policy-backpressure" ]
+          Reasons = [ "capacity=1"; "child launch denied" ] }
+
+    let frame = Scheduler.heatBoardFrame 99UL [ row ]
+
+    Assert.Equal(7uy, frame.Plane)
+    Assert.Equal(1uy, Chip8Cow.colorAt 0 0 frame)
+    Assert.Equal(1uy, Chip8Cow.colorAt 1 0 frame)
+    Assert.Equal(0uy, Chip8Cow.colorAt 2 0 frame)
+    Assert.Equal(3uy, Chip8Cow.colorAt 16 0 frame)
+    Assert.Equal(0uy, Chip8Cow.colorAt 17 0 frame)
+    Assert.Equal(5uy, Chip8Cow.colorAt 32 0 frame)
+    Assert.Equal(0uy, Chip8Cow.colorAt 33 0 frame)
+    Assert.Equal(4uy, Chip8Cow.colorAt 48 0 frame)
+    Assert.Equal(4uy, Chip8Cow.colorAt 49 0 frame)
+    Assert.Equal(0uy, Chip8Cow.colorAt 50 0 frame)
+
+    let rendered = Scheduler.renderHeatBoard 99UL [ row ]
+    let firstDisplayRow = rendered.[1]
+
+    Assert.Equal("plane\t7", rendered.[0])
+    Assert.Equal("11", firstDisplayRow.Substring(0, 2))
+    Assert.Equal("0", firstDisplayRow.Substring(2, 1))
+    Assert.Equal("3", firstDisplayRow.Substring(16, 1))
+    Assert.Equal("0", firstDisplayRow.Substring(17, 1))
+    Assert.Equal("5", firstDisplayRow.Substring(32, 1))
+    Assert.Equal("0", firstDisplayRow.Substring(33, 1))
+    Assert.Equal("44", firstDisplayRow.Substring(48, 2))
+    Assert.Equal("0", firstDisplayRow.Substring(50, 1))
+
+[<Fact>]
 let ``soft scheduler banks darkhall heat backpressure as a room boundary row`` () =
     task {
         let sink =


### PR DESCRIPTION
## What

- Adds a CHIP-9 host-visible heat board renderer for `DarkHallScheduler.HeatBoundaryRow` values.
- Maps scheduler heat into stable display lanes: rejected heat, backpressure, storage errors, and distinct heat kinds.
- Locks the frame colors and canonical `Chip9Board.render` transcript with an F# regression test.

## Why

Dark Hall room hosts need a small board-level readout for heat/backpressure, especially when CHIP-8/CHIP-9 rooms pass heat to the host boundary. This keeps the scheduler state observable without turning Q#/Bayesian/runtime cores into UI or storage surfaces.

## Validation

- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter FullyQualifiedName~DarkHallSchedulerTests`
- `dotnet build -c Release`
- `dotnet format --verify-no-changes`
- `dotnet test Zeta.sln -c Release --no-build`
- `bun src/Core.TypeScript/hygiene/audit-agencysignature-main-tip.ts --commit HEAD`

Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: Codex
Agent-Model: gpt-5.5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: not-implied-by-credential
Human-Review-Evidence: none
Action-Mode: human-directed
Task: none
