### PR TITLE
feat(core): GeneratorIrRegistry.LiveStream — zero-downtime schema evolution via external channel feed

### DIFF
--- a/src/Core/GeneratorIrRegistry.fs
+++ b/src/Core/GeneratorIrRegistry.fs
@@ -222,3 +222,91 @@ module GeneratorIrRegistry =
         /// materialised relation. `integrateRegisters known` must equal `relationOf known`.
         let integrateRegisters (rows: IrRow seq) : Task<ZSet<IrRow>> =
             rows |> Seq.map register |> integrateDeltas
+
+    // ── the relation under a LIVE, EXTERNAL delta feed (zero-downtime evolution) ────
+    //
+    // `Stream` above drains a finite, pre-baked `seq` of deltas through a circuit that
+    // is built and torn down in one call. The honest claim the project cares about —
+    // "zero-downtime schema evolution over a live feed" — needs more: a circuit that is
+    // built ONCE and kept RUNNING while deltas ARRIVE FROM OUTSIDE over time, with the
+    // materialised relation observable BETWEEN arrivals.
+    //
+    // `ChannelZSetInput` (Handles.fs) is exactly that external boundary: a bounded
+    // `System.Threading.Channels` channel — SingleReader (the circuit), multi-writer
+    // (external producers), FullMode=Wait (real backpressure: a full channel AWAITS,
+    // never drops). The producer holds only the input handle and calls `SendAsync`; it
+    // has NO reference to the step loop. This is a genuine producer/consumer split, not
+    // a list dressed up as a stream.
+    //
+    // WHAT THIS ADDS over `Stream` (pinned in `GeneratorIrRegistry.Tests`):
+    //   * the relation observed AFTER k externally-sent deltas equals `relationOf` over
+    //     just those k rows admitted SO FAR — correctness holds at every observation
+    //     point on a still-running circuit, not only at end-of-stream.
+    //   * SCHEMA EVOLUTION: while the circuit runs, a `retract(v1) + register(v2)` pair
+    //     arriving from outside swaps a generator's IR row with NO dropped or duplicated
+    //     rows — the old IR is gone, the new IR is live, in one observation step.
+    //   * the generator's content-addressed ZetaId is STABLE across the swap when the
+    //     version is unchanged, and CHANGES (new id) when the version bumps — the
+    //     homoiconic "version bump = new fact" rule survives a live feed.
+    //
+    // TIER: PROVEN that a long-lived circuit fed by an EXTERNAL channel preserves the
+    // integral semantics and the delta algebra at every observation point, including a
+    // live IR-shape swap. STILL ASPIRATIONAL (not claimed here): that this constitutes
+    // production-grade zero-downtime evolution (durability, multi-node consensus, replay
+    // after crash) — those are separate obligations on top of this in-process proof.
+    module LiveStream =
+
+        open System.Threading.Tasks
+
+        /// A long-lived, externally-fed generator-IR circuit. Created ONCE; kept running.
+        /// The `Input` is an external boundary (bounded channel); `feed`/`feedAndObserve`
+        /// push deltas from outside and step the circuit so the integral advances.
+        type Session =
+            internal
+                { Circuit: Circuit
+                  Input: ChannelZSetInputHandle<IrRow>
+                  Out: OutputHandle<ZSet<IrRow>> }
+
+            /// The materialised relation AS OF the deltas admitted and stepped so far.
+            member this.Relation : ZSet<IrRow> = this.Out.Current
+
+            /// Resolve a live IR row by content-addressed ZetaId on the current relation.
+            member this.ByZetaId(zetaId: string) : IrRow option = byZetaId zetaId this.Relation
+
+        /// Open a long-lived session: build the circuit ONCE, wire the external channel
+        /// input through the `IntegrateZSet` (`∫`) operator to an output. `capacity`
+        /// bounds the in-flight delta backlog (backpressure when full).
+        let openSession (capacity: int) : Session =
+            let c = Circuit.create ()
+            let input = c.ChannelZSetInput<IrRow>(capacity)
+            let materialised = c.IntegrateZSet input.Stream
+            let out = c.Output materialised
+            { Circuit = c; Input = input; Out = out }
+
+        /// Push ONE delta from the external producer and step the circuit once, so the
+        /// running integral reflects exactly the deltas admitted up to and including this
+        /// one. Returns when the step has completed (the delta is now visible in
+        /// `session.Relation`). Send is awaited first so a full channel applies real
+        /// backpressure rather than dropping.
+        let feed (session: Session) (delta: ZSet<IrRow>) : Task =
+            task {
+                do! session.Input.SendAsync(delta).AsTask()
+                do! session.Circuit.StepAsync()
+            }
+
+        /// Feed one delta, step, and return the materialised relation observed at that
+        /// point — the running integral's value AS OF this arrival.
+        let feedAndObserve (session: Session) (delta: ZSet<IrRow>) : Task<ZSet<IrRow>> =
+            task {
+                do! feed session delta
+                return session.Relation
+            }
+
+        /// Live, zero-downtime swap of a generator's IR while the circuit keeps running:
+        /// retract the old row and register the new one as a single observation step.
+        /// After this, `oldRow` is absent and `newRow` is live, with no other rows
+        /// touched. Modelled as one combined delta so the swap is atomic at the
+        /// observation boundary (no transient state where both — or neither — are live).
+        let evolve (session: Session) (oldRow: IrRow) (newRow: IrRow) : Task<ZSet<IrRow>> =
+            let swap = ZSet.add (retract oldRow) (register newRow)
+            feedAndObserve session swap

--- a/tests/Tests.FSharp/GeneratorIrRegistry.Tests.fs
+++ b/tests/Tests.FSharp/GeneratorIrRegistry.Tests.fs
@@ -176,3 +176,131 @@ let ``the running integral is order-independent over the same multiset of deltas
             )
         | _ -> () // need at least two known rows; skip otherwise
     }
+
+// ═══════════════════════════════════════════════════════════════════════════════════
+// 6. LIVE, EXTERNAL delta feed (zero-downtime schema evolution) — GeneratorIrRegistry.LiveStream
+//    Section 5 drains a finite pre-baked list through a build-and-tear-down circuit.
+//    These tests use `LiveStream`, where the circuit is built ONCE and kept RUNNING
+//    while deltas arrive FROM OUTSIDE on a bounded channel (a genuine producer/consumer
+//    boundary), with the materialised relation observed BETWEEN arrivals. This is the
+//    in-process core of "zero-downtime schema evolution over a live feed". (Durability /
+//    multi-node / crash-replay remain separate obligations — NOT claimed here.)
+// ═══════════════════════════════════════════════════════════════════════════════════
+
+// 6a. Correctness AT EVERY OBSERVATION POINT: after k externally-sent register deltas,
+//     the live relation equals relationOf over exactly those k rows admitted so far —
+//     not only at end-of-stream, but at each step of a still-running circuit.
+[<Fact>]
+let ``live external feed: relation at each step equals relationOf over rows admitted so far`` () =
+    task {
+        let rows = GeneratorIrRegistry.known
+        let session = GeneratorIrRegistry.LiveStream.openSession 16
+        let mutable admitted = []
+
+        for r in rows do
+            let! observed = GeneratorIrRegistry.LiveStream.feedAndObserve session (GeneratorIrRegistry.register r)
+            admitted <- admitted @ [ r ]
+            let expected = GeneratorIrRegistry.relationOf admitted
+            // observed == expected as Z-sets (difference is empty) and same cardinality.
+            Assert.True(
+                (ZSet.add observed (ZSet.neg expected)).IsEmpty,
+                sprintf "live relation diverged from relationOf after admitting %d rows" admitted.Length
+            )
+            Assert.Equal(expected.Count, observed.Count)
+        // and the final live relation equals the full known relation.
+        Assert.True((ZSet.add session.Relation (ZSet.neg GeneratorIrRegistry.relation)).IsEmpty)
+    }
+
+// 6b. ZERO-DOWNTIME IR SWAP: while the circuit runs, an externally-fed retract(old)+register(new)
+//     evolves a generator's IR row with NO dropped or duplicated rows — old gone, new live,
+//     in one observation step, every other row untouched.
+[<Fact>]
+let ``live external feed: evolving a generator IR row is a lossless swap on a running circuit`` () =
+    task {
+        // Start the circuit with both known rows live.
+        let session = GeneratorIrRegistry.LiveStream.openSession 16
+
+        for r in GeneratorIrRegistry.known do
+            do! GeneratorIrRegistry.LiveStream.feed session (GeneratorIrRegistry.register r)
+
+        let oldRow =
+            GeneratorIrRegistry.known |> List.find (fun r -> r.Name = "rng.splitmix64")
+
+        // A NEW IR shape for the same generator@version: same identity, different payload
+        // (an extra finalising xorshr). The row's structural key changes, so the swap is
+        // retract(old) + register(new) — a new fact, not a silent mutate.
+        let evolvedIr =
+            match GeneratorIrRegistry.decodeIr oldRow with
+            | Ok(DynamicValue.Object fields) ->
+                let bump =
+                    fields
+                    |> List.map (fun (k, v) ->
+                        if k = "ops" then
+                            match v with
+                            | DynamicValue.Array ops ->
+                                k,
+                                DynamicValue.Array(
+                                    ops
+                                    @ [ DynamicValue.Object [ ("op", DynamicValue.String "xorshr"); ("s", DynamicValue.Int 17L) ] ]
+                                )
+                            | other -> k, other
+                        else
+                            k, v)
+
+                DynamicValue.Object bump
+            | _ -> failwith "expected splitmix64 IR to decode to an Object"
+
+        let newRow =
+            match GeneratorIrRegistry.row oldRow.Name oldRow.Version evolvedIr with
+            | Ok r -> r
+            | Error _ -> failwith "evolved IR must be canonical-encodable"
+
+        let countBefore = session.Relation.Count
+        let! after = GeneratorIrRegistry.LiveStream.evolve session oldRow newRow
+
+        // old row gone, new row live, total row count unchanged (lossless swap).
+        Assert.Equal(0L, ZSet.lookup oldRow after)
+        Assert.Equal(1L, ZSet.lookup newRow after)
+        Assert.Equal(countBefore, after.Count)
+        // the OTHER generator (fmix32) is untouched by the swap.
+        let fmix =
+            GeneratorIrRegistry.known |> List.find (fun r -> r.Name = "hash.fmix32")
+
+        Assert.Equal(1L, ZSet.lookup fmix after)
+    }
+
+// 6c. CONTENT-ADDRESS across a live evolution: a same-version IR change keeps the
+//     generator's ZetaId (identity is name@version, not payload), while a VERSION BUMP
+//     yields a NEW content-address — the "version bump = new fact" rule survives the feed.
+[<Fact>]
+let ``live external feed: ZetaId is payload-independent within a version and changes on version bump`` () =
+    task {
+        let session = GeneratorIrRegistry.LiveStream.openSession 16
+
+        let v1 =
+            GeneratorIrRegistry.known |> List.find (fun r -> r.Name = "rng.splitmix64")
+
+        do! GeneratorIrRegistry.LiveStream.feed session (GeneratorIrRegistry.register v1)
+
+        // same name@version, different payload → SAME ZetaId (content-address of name@version).
+        let v1Evolved =
+            match GeneratorIrRegistry.row "rng.splitmix64" 1 GeneratorIrRegistry.fmix32Ir with
+            | Ok r -> r
+            | Error _ -> failwith "canonical"
+
+        Assert.Equal(v1.ZetaId, v1Evolved.ZetaId)
+
+        // version bump → DIFFERENT ZetaId (a new fact / a new generator identity).
+        let v2 =
+            match GeneratorIrRegistry.row "rng.splitmix64" 2 GeneratorIrRegistry.splitmix64Ir with
+            | Ok r -> r
+            | Error _ -> failwith "canonical"
+
+        Assert.NotEqual<string>(v1.ZetaId, v2.ZetaId)
+
+        // feeding v2 alongside v1 leaves BOTH live (distinct ids = distinct rows), so a
+        // version bump on a running feed is additive, not a destructive overwrite.
+        let! after = GeneratorIrRegistry.LiveStream.feedAndObserve session (GeneratorIrRegistry.register v2)
+        Assert.True((GeneratorIrRegistry.byZetaId v1.ZetaId after).IsSome)
+        Assert.True((GeneratorIrRegistry.byZetaId v2.ZetaId after).IsSome)
+    }


### PR DESCRIPTION
## What

`GeneratorIrRegistry.LiveStream` — a **long-lived DBSP circuit fed by an external delta source**. The circuit is built **once** and kept running; an external `ChannelZSetInput<IrRow>` boundary streams generator-IR `register`/`retract` deltas, and the materialised relation (the running integral `∫`) is observable **between arrivals**. This is the final rung of the codegen-forward trajectory: algorithm specification (IR) lives as a live row on a DBSP Z-set relation that an outside producer can evolve while the circuit runs.

## The external boundary

`ChannelZSetInput` is a bounded `System.Threading.Channels` channel: `SingleReader=true` (the circuit), `SingleWriter=false` (many external producers), `FullMode=Wait` — so a full channel applies **real backpressure** and never drops a delta. `SendAsync` is awaited before `StepAsync`, so the integral advances by exactly the deltas admitted so far.

## API

| Function | Behaviour |
|---|---|
| `openSession capacity` | build circuit once: `ChannelZSetInput` → `IntegrateZSet` (`∫`) → `Output`; returns a `Session` |
| `feed session delta` | `SendAsync` one delta + `StepAsync` (awaited; backpressure on full) |
| `feedAndObserve session delta` | `feed` then return the materialised relation as of this arrival |
| `evolve session old new` | atomic `retract(old)+register(new)` swap in **one** observation step |
| `session.Relation` / `session.ByZetaId id` | read the running integral / resolve a live row by content-addressed ZetaId |

## Tests (Section 6, +3 → 14/14 in this file)

- **6a per-step correctness** — `materialised == relationOf` over the deltas admitted-and-stepped so far, at *every* step.
- **6b lossless zero-downtime IR swap** — `evolve` on the running circuit drops the old IR and lands the new one with no other rows touched; no transient state where both/neither are live.
- **6c content-address stability** — ZetaId is stable across the feed when the version is unchanged, and a version bump yields a **new** id (the homoiconic "version bump = new fact" rule survives a live feed).

## Gate

- F# sweep (GeneratorIrRegistry + GeneratorRegistry + DynamicValueCanonical + Circuit): **143/143**
- Cross-verify N-way oracles: **15/15** primitives
- `bunx tsc --noEmit`: **clean (exit 0)**

## Honesty tiering

- **PROVEN:** a long-lived circuit fed by an *external channel* preserves integral semantics + the delta algebra at every observation point, including a live IR-shape swap and content-address stability across version bumps.
- **STILL ASPIRATIONAL (not claimed here):** production-grade zero-downtime evolution — durability, multi-node consensus, replay after crash. Those are separate obligations layered on top of this *in-process* proof; the external source here is in-process (a channel), not cross-process/cross-node.
