### PR TITLE
feat(core): Merkle inclusion (audit) proofs over Z-sets — math-team row 4 (inclusion + no-forge)

### DIFF
--- a/src/Core/ZSetMerkle.fs
+++ b/src/Core/ZSetMerkle.fs
@@ -81,3 +81,89 @@ module ZSetMerkle =
     /// git-replacement / tamper-evident store, call `rootWith` with BLAKE3 instead (081KTGTJC1Q).
     let root (encodeKey: 'K -> byte[]) (z: ZSet<'K>) : MerkleHash =
         rootWith (fun (b: byte[]) -> MerkleHash.ofBytes (ReadOnlySpan<byte> b)) encodeKey z
+
+    // ── Inclusion (audit) proofs — math-team handoff row 4 (inclusion + no third-party forge) ──
+    //
+    // A root commits to the whole Z-set; an inclusion proof commits to ONE `(key, weight)` entry
+    // *under* that root. The soundness target (row 4): a third party holding only the proof + the
+    // root — never the tree — can verify membership, and cannot forge a proof for an entry that is
+    // not committed (any tampered leaf/weight/path recomputes a different root). This is the
+    // companion to `Merkle.Laws.Tests.fs`'s existing tamper-evidence ("equal roots ⟹ equal leaves"):
+    // that proves the root pins the leaves; this gives the succinct per-leaf witness of it.
+
+    /// One step on a Merkle audit path: the sibling digest and whether that sibling sits on the
+    /// RIGHT (so the current node is the LEFT child and `parent = combine self sibling`). When a
+    /// level has an odd trailing node the `fold` duplicates it, so that node's sibling IS itself
+    /// with `SiblingOnRight = true` — `proofForWith` records this faithfully so verification replays
+    /// the exact same construction `rootWith` used.
+    type MerkleStep = { Sibling: MerkleHash; SiblingOnRight: bool }
+
+    /// A self-contained inclusion (audit) proof that a single `(key, weight)` Z-set entry is
+    /// committed under a Merkle root. Verifiable by a third party holding ONLY the proof + the root.
+    /// `LeafKeyBytes` is the canonical `encodeKey` image (not the live `'K`), so the proof is
+    /// byte-portable across the four language oracles — the bytes are the treaty, same as the root.
+    type MerkleProof =
+        { LeafKeyBytes: byte[]
+          LeafWeight: Weight
+          Steps: MerkleStep[] }
+
+    /// Build an inclusion proof for `key` under the root of `z` (explicit hash). `None` when `key`
+    /// is not in the support (you cannot prove membership of a non-member — that absence is exactly
+    /// the no-forge property). The proof replays `rootWith`'s canonical order + odd-node duplication.
+    let proofForWith
+        (hash: byte[] -> MerkleHash)
+        (encodeKey: 'K -> byte[])
+        (z: ZSet<'K>)
+        (key: 'K)
+        : MerkleProof option =
+        let entries =
+            [| for e in z -> struct (encodeKey e.Key, e.Weight) |]
+            |> Array.sortWith (fun (struct (ka, _)) (struct (kb, _)) -> byteCompare ka kb)
+
+        let targetKey = encodeKey key
+
+        match entries |> Array.tryFindIndex (fun (struct (kb, _)) -> byteCompare kb targetKey = 0) with
+        | None -> None
+        | Some leafIdx ->
+            let struct (leafKeyBytes, leafWeight) = entries.[leafIdx]
+            let mutable level = entries |> Array.map (fun (struct (kb, w)) -> hash (leafBytes kb w))
+            let steps = ResizeArray<MerkleStep>()
+            let mutable idx = leafIdx
+            while level.Length > 1 do
+                let n = level.Length
+                let selfIsLeft = idx % 2 = 0
+                // selfIsLeft: sibling on the right (or self, when this is the odd trailing node).
+                // not selfIsLeft: self is the right child, sibling is the left neighbour.
+                let siblingIdx =
+                    if selfIsLeft then (if idx + 1 < n then idx + 1 else idx) else idx - 1
+                steps.Add({ Sibling = level.[siblingIdx]; SiblingOnRight = selfIsLeft })
+                let parents = Array.zeroCreate<MerkleHash> ((n + 1) / 2)
+                for i in 0 .. parents.Length - 1 do
+                    let a = level.[2 * i]
+                    let b = if 2 * i + 1 < n then level.[2 * i + 1] else a
+                    parents.[i] <- combine hash a b
+                level <- parents
+                idx <- idx / 2
+            Some
+                { LeafKeyBytes = leafKeyBytes
+                  LeafWeight = leafWeight
+                  Steps = steps.ToArray() }
+
+    /// Verify an inclusion proof against an expected root (explicit hash). Recomputes the leaf digest
+    /// from the proof's own `(LeafKeyBytes, LeafWeight)` and folds up the audit path — touching only
+    /// the proof + the root, never the tree. Returns `true` iff the recomputed root matches.
+    let verifyWith (hash: byte[] -> MerkleHash) (proof: MerkleProof) (expectedRoot: MerkleHash) : bool =
+        let mutable acc = hash (leafBytes proof.LeafKeyBytes proof.LeafWeight)
+        for step in proof.Steps do
+            acc <-
+                if step.SiblingOnRight then combine hash acc step.Sibling
+                else combine hash step.Sibling acc
+        acc.ToHex() = expectedRoot.ToHex()
+
+    /// Inclusion proof using the default digest (XxHash128). Pairs with `root`.
+    let proofFor (encodeKey: 'K -> byte[]) (z: ZSet<'K>) (key: 'K) : MerkleProof option =
+        proofForWith (fun (b: byte[]) -> MerkleHash.ofBytes (ReadOnlySpan<byte> b)) encodeKey z key
+
+    /// Verify an inclusion proof using the default digest (XxHash128). Pairs with `root`.
+    let verify (proof: MerkleProof) (expectedRoot: MerkleHash) : bool =
+        verifyWith (fun (b: byte[]) -> MerkleHash.ofBytes (ReadOnlySpan<byte> b)) proof expectedRoot

--- a/tests/Tests.FSharp/Formal/MerkleInclusion.Laws.Tests.fs
+++ b/tests/Tests.FSharp/Formal/MerkleInclusion.Laws.Tests.fs
@@ -1,0 +1,133 @@
+module Zeta.Tests.Formal.MerkleInclusionLawsTests
+
+open System
+open FsCheck.Xunit
+open global.Xunit
+open Zeta.Core
+
+// math-team handoff row 4 — inclusion (audit) proof soundness, FsCheck leg.
+//
+// Companion to `Merkle.Laws.Tests.fs`, which proves ROOT tamper-evidence
+// ("equal roots ⟹ equal leaves", structural + Z3). This file proves the
+// per-leaf witness of that: a succinct inclusion proof that
+//   (a) COMPLETENESS — every committed entry has a proof that verifies, and
+//   (b) SOUNDNESS / no third-party forge — you cannot verify a proof for a
+//       non-member, a tampered weight, a corrupted path, or against a
+//       different set's root.
+// Verification touches ONLY the proof + the root — never the tree (that
+// tree-freeness IS the third-party property). HONEST SCOPE matches the
+// sibling file: the structure is proven; the digest's collision-resistance
+// is the named crypto premise (XxHash128 is non-cryptographic — swap to
+// BLAKE3 for Byzantine integrity, per `Merkle.fs`). BP-16 cross-check: this
+// FsCheck leg pairs with the existing Z3 root-determines-leaves proof.
+
+module M = ZSetMerkle
+
+let private encodeKey (k: int) : byte[] = BitConverter.GetBytes k
+
+/// Distinct keys, each weight 1L — a clean support with no retraction/cancel.
+let private zsetOf (keys: int list) : ZSet<int> =
+    keys |> List.distinct |> List.map (fun k -> (k, 1L)) |> ZSet.ofSeq
+
+let private nonEmpty (keys: int list) : int list =
+    match List.distinct keys with
+    | [] -> [ 0 ]
+    | ks -> ks
+
+[<Property>]
+let ``completeness: every committed entry has a proof that verifies against the true root`` (keys: int list) =
+    let ks = nonEmpty keys
+    let z = zsetOf ks
+    let r = M.root encodeKey z
+    ks
+    |> List.forall (fun k ->
+        match M.proofFor encodeKey z k with
+        | Some p -> M.verify p r
+        | None -> false)
+
+[<Property>]
+let ``no-forge: a non-member key has no inclusion proof`` (keys: int list) (probe: int) =
+    let ks = nonEmpty keys
+    let z = zsetOf ks
+    if List.contains probe ks then true // vacuous when the probe is actually a member
+    else (M.proofFor encodeKey z probe).IsNone
+
+[<Property>]
+let ``no-forge: tampering the proven weight breaks verification`` (keys: int list) (delta: int) =
+    let ks = nonEmpty keys
+    let z = zsetOf ks
+    let r = M.root encodeKey z
+    match M.proofFor encodeKey z (List.head ks) with
+    | Some p when delta <> 0 ->
+        let tampered = { p with LeafWeight = p.LeafWeight + int64 delta }
+        not (M.verify tampered r)
+    | _ -> true
+
+[<Property>]
+let ``no-forge: a valid proof does not verify against a different set's root`` (a: int list) (b: int list) =
+    let ka = nonEmpty a
+    let kb = nonEmpty b
+    let ra = M.root encodeKey (zsetOf ka)
+    let rb = M.root encodeKey (zsetOf kb)
+    if ra.ToHex() = rb.ToHex() then true // only meaningful when the roots actually differ
+    else
+        match M.proofFor encodeKey (zsetOf ka) (List.head ka) with
+        | Some p -> not (M.verify p rb)
+        | None -> false
+
+[<Property>]
+let ``no-forge: corrupting any sibling on the audit path breaks verification`` (keys: int list) (i: int) =
+    let ks = nonEmpty keys
+    let z = zsetOf ks
+    let r = M.root encodeKey z
+    match M.proofFor encodeKey z (List.head ks) with
+    | Some p when p.Steps.Length > 0 ->
+        let j = (abs i) % p.Steps.Length
+        let s = p.Steps.[j]
+        // flip one bit of the sibling digest → a guaranteed-different sibling
+        let badSib = MerkleHash(s.Sibling.Hi ^^^ 1UL, s.Sibling.Lo)
+        let steps2 = Array.copy p.Steps
+        steps2.[j] <- { s with Sibling = badSib }
+        not (M.verify { p with Steps = steps2 } r)
+    | _ -> true
+
+[<Property>]
+let ``proofs are deterministic (same set + key → identical audit path)`` (keys: int list) =
+    let ks = nonEmpty keys
+    let z = zsetOf ks
+    let k = List.head ks
+    match M.proofFor encodeKey z k, M.proofFor encodeKey z k with
+    | Some a, Some b ->
+        a.LeafWeight = b.LeafWeight
+        && a.Steps.Length = b.Steps.Length
+        && Array.forall2
+            (fun (x: M.MerkleStep) (y: M.MerkleStep) ->
+                x.SiblingOnRight = y.SiblingOnRight
+                && x.Sibling.ToHex() = y.Sibling.ToHex())
+            a.Steps
+            b.Steps
+    | _ -> false
+
+[<Property>]
+let ``single-leaf tree: proof has no steps and verifies (root is the leaf)`` (k: int) =
+    let z = zsetOf [ k ]
+    let r = M.root encodeKey z
+    match M.proofFor encodeKey z k with
+    | Some p -> p.Steps.Length = 0 && M.verify p r
+    | None -> false
+
+[<Fact>]
+let ``third-party verification uses only the proof and the root`` () =
+    let z = zsetOf [ 3; 1; 4; 1; 5; 9; 2; 6 ]
+    let r = M.root encodeKey z
+    let p = (M.proofFor encodeKey z 4).Value
+    // a verifier with ONLY (p, r) accepts — verify's signature never sees z.
+    Assert.True(M.verify p r)
+
+[<Fact>]
+let ``retraction-native: a net-zero (retracted) entry has no inclusion proof`` () =
+    // +1 then −1 on key 7 cancels (Z-set retraction), so 7 leaves the support
+    // and cannot be proven included; 8 (net +1) still can.
+    let z = ZSet.ofSeq [ (7, 1L); (7, -1L); (8, 1L) ]
+    Assert.True((M.proofFor encodeKey z 7).IsNone)
+    Assert.True((M.proofFor encodeKey z 8).IsSome)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -470,6 +470,7 @@
     <Compile Include="DeltaLogEntryCodec.Tests.fs" />
     <Compile Include="Command.Tests.fs" />
     <Compile Include="Formal/Merkle.Laws.Tests.fs" />
+    <Compile Include="Formal/MerkleInclusion.Laws.Tests.fs" />
     <Compile Include="Formal/Sketch.Laws.Tests.fs" />
     <Compile Include="Formal/Metric.Bounds.Tests.fs" />
     <Compile Include="Formal/Tlc.Runner.Tests.fs" />


### PR DESCRIPTION
Discharges the **inclusion + no-third-party-forge** leg of math-team handoff **row 4**. Companion to `Merkle.Laws.Tests.fs` (which proves ROOT tamper-evidence, "equal roots ⟹ equal leaves") — this adds the succinct per-leaf **audit proof** of that membership.

## API (on `ZSetMerkle`, mirroring `rootWith`/`root`)
- **`MerkleStep` / `MerkleProof`** — a self-contained audit path bound to one `(LeafKeyBytes, LeafWeight)` entry. `LeafKeyBytes` is the canonical `encodeKey` image, so the proof is **byte-portable across the four language oracles** (the bytes are the treaty, same as the root).
- **`proofForWith` / `proofFor`** — build a proof for a key; `None` for a non-member (you cannot prove membership of a non-member — that absence *is* the no-forge property). Replays `rootWith`'s canonical byte-order + odd-node duplication exactly.
- **`verifyWith` / `verify`** — fold the audit path from the proof's own leaf; touches **only the proof + the root, never the tree** (the third-party property).

## Soundness suite (`MerkleInclusion.Laws.Tests.fs`, 9 tests, 9/9 green, verified directly)
- **Completeness** — every committed entry has a proof that verifies against the true root.
- **No-forge ×4** — non-member has no proof; tampered weight fails; corrupted path step fails; a valid proof fails against a *different* set's root.
- **Determinism**, **single-leaf** (empty path), **third-party** (verify sees only proof+root), and **retraction-native** — a `+1/−1` net-zero entry leaves the support and has no proof (DBSP/Z-set correction semantics, idempotency #6).

## Honest scope
Structure proven; the digest's collision-resistance is the **named crypto premise** (XxHash128 is non-cryptographic — swap to BLAKE3 for Byzantine integrity, per `Merkle.fs`). **BP-16**: this FsCheck leg pairs with the existing Z3 root-determines-leaves proof. **Follow-up (not in this PR):** the 4-language byte-locked golden vectors *for proofs* (the Rust/TS `golden-vectors-merkle.json` cover roots today).

Build: Core `0 warnings / 0 errors`; suite 9/9. Anchor: Merkle, CRYPTO 1987 (audit paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)