### PR TITLE
[codex] host darkhall heat board in sim loop

### DIFF
--- a/src/Core/DarkHallScheduler.fs
+++ b/src/Core/DarkHallScheduler.fs
@@ -135,3 +135,31 @@ module DarkHallScheduler =
                 let! next = tick source sink requestFor choose state
                 return Ok next
             })
+
+    /// Run a bounded sim -> measure -> cut loop where the measurement is the
+    /// host-visible CHIP-9 heat board. This is the Dark Hall room loop shape for
+    /// production and tests alike: execution stays async in `SoftScheduler`,
+    /// while `SimLoop` banks the board readout before deciding whether to keep
+    /// going.
+    let heatBoardSimLoop
+        (name: string)
+        (room: DarkHall.Room)
+        (manifest: Chip9Capabilities.Manifest)
+        (matches: InterruptKind -> bool)
+        (sourceName: string)
+        (sink: IHeatSink)
+        (requestFor: RoomLoop.RequestResolver)
+        (choose: Runtime.ControllerReadout -> RoomLoop.ControllerChoice)
+        (interruptSource: SoftScheduler.Source)
+        (clock: int -> int64)
+        (budget: SimLoop.Budget)
+        (ctx: IntrCtx)
+        (seed: int64)
+        (ticksPerLap: int)
+        (cut: string list -> ScheduledRoomState -> bool)
+        =
+        let handler = roomTickHandler name matches sourceName sink requestFor choose
+        let measure = renderHeatBoardForState (uint64 seed)
+        let start = initial room manifest
+
+        SimLoop.run [ handler ] interruptSource measure cut clock budget ctx seed ticksPerLap start

--- a/tests/Tests.FSharp/DarkHallScheduler.Tests.fs
+++ b/tests/Tests.FSharp/DarkHallScheduler.Tests.fs
@@ -143,3 +143,74 @@ let ``soft scheduler banks darkhall heat backpressure as a room boundary row`` (
             | [ row ] -> Assert.Equal(1, row.Backpressured)
             | rows -> Assert.Fail(sprintf "expected one scheduler heat row, got %A" rows)
     }
+
+[<Fact>]
+let ``heat board sim loop measures backpressure before the cut closes`` () =
+    task {
+        let sink =
+            BoundedHeatSink
+                { Capacity = 1
+                  ForgetPolicy = BoundedGSetForgetPolicy.RejectNew }
+
+        let filler = HeatSignature.ofMass "test" "heat.fill" 1 1.0 "occupy bounded heat sink"
+
+        match (sink :> IHeatSink).Emit filler with
+        | Error feedback -> Assert.Fail(sprintf "expected heat sink prefill, got %A" feedback)
+        | Ok() -> ()
+
+        let child = CartFixtures.cart CartFixtures.chip9GreenDot
+        let caps = MetaCart.capabilityMap [ child, CartFixtures.chip9GreenDot.Capabilities ]
+
+        let launch: Runtime.MetaCartLaunch =
+            { Goal = 3
+              Seed = 1UL
+              ParentCapabilities = Chip9Capabilities.chip8Default
+              ChildCapabilitiesBySha = caps
+              Children = [ child ]
+              Parent = Chip8Cow.create 1UL }
+
+        let requestFor (action: Runtime.CabinetAction) =
+            if action.Id = "darkhall.play.meta-cart-host" then
+                Some(Runtime.RunMetaCart launch)
+            else
+                None
+
+        let budget: SimLoop.Budget =
+            { MaxLaps = 4
+              MaxTicks = 4
+              MaxMillis = 1_000L }
+
+        let! outcome =
+            Scheduler.heatBoardSimLoop
+                "darkhall-heat-board"
+                Arcade.room
+                Chip9Capabilities.chip8Default
+                timer
+                "darkhall-simloop"
+                (sink :> IHeatSink)
+                requestFor
+                (chooseById "darkhall.play.meta-cart-host")
+                (fun _ -> [ TimerElapsed 17 ])
+                int64
+                budget
+                (ctx ())
+                42L
+                1
+                (fun _ state -> not (Scheduler.backpressured state))
+
+        match outcome.Stopped with
+        | SimLoop.Stopped.CutChoseClose -> ()
+        | other -> Assert.Fail(sprintf "expected heat-board cut to close the loop, got %A" other)
+
+        match outcome.Laps with
+        | [ lap ] ->
+            Assert.Equal(1, lap.State.CompletedTicks)
+            Assert.True(Scheduler.backpressured lap.State)
+
+            let firstDisplayRow = lap.Measured.[1]
+
+            Assert.Equal("1", firstDisplayRow.Substring(0, 1))
+            Assert.Equal("3", firstDisplayRow.Substring(16, 1))
+            Assert.Equal("4", firstDisplayRow.Substring(48, 1))
+        | laps -> Assert.Fail(sprintf "expected one measured lap before cut, got %A" laps)
+    }


### PR DESCRIPTION
## What

- Adds `DarkHallScheduler.heatBoardSimLoop`, an async `SimLoop` adapter for Dark Hall scheduler ticks.
- Uses the CHIP-9 heat board transcript as the loop measurement, so sim -> measure -> cut can run over room heat/backpressure.
- Adds a regression proving a host-visible backpressure row is measured before the cut closes the loop.

## Why

The room framework should feel like test and production share one bounded execution shape: a room runs for a finite slice, banks an observable measurement, and decides whether to continue. This keeps scheduler execution async while making heat/backpressure visible to the host boundary.

## Validation

- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter FullyQualifiedName~DarkHallSchedulerTests`
- `dotnet build -c Release`
- `dotnet format --verify-no-changes`
- `dotnet test Zeta.sln -c Release --no-build`
- `bun src/Core.TypeScript/hygiene/audit-agencysignature-main-tip.ts --commit HEAD`

Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: Codex
Agent-Model: gpt-5.5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: not-implied-by-credential
Human-Review-Evidence: none
Action-Mode: human-directed
Task: none
