### PR TITLE
feat(core): Merkle inclusion-proof Rust oracle leg — replays the frozen 4-lang treaty byte-for-byte

### DIFF
--- a/src/Core.Rust.Merkle/src/lib.rs
+++ b/src/Core.Rust.Merkle/src/lib.rs
@@ -121,4 +121,85 @@ impl MerkleTree {
     pub fn leaf_hashes(&self) -> &[MerkleHash] {
         &self.levels[0]
     }
+
+    /// Inclusion (audit) proof for the leaf at `index`: the sibling digest at each
+    /// level from leaf to root, with its side. A verifier holding only the leaf, this
+    /// proof, and the root can confirm membership without the tree (see [`verify_proof`]).
+    /// Replays the exact F# fold (duplicate-last on an odd trailing node → sibling is
+    /// self, on the right). Mirrors `MerkleTree.Proof` in `src/Core/Merkle.fs`.
+    ///
+    /// # Panics
+    /// Panics if `index >= leaf count` (leaf-index out of range), matching the F#
+    /// `invalidArg`.
+    pub fn proof(&self, index: usize) -> Vec<ProofStep> {
+        let level0 = &self.levels[0];
+        assert!(
+            index < level0.len(),
+            "leaf index {index} out of range [0, {})",
+            level0.len()
+        );
+        let mut steps = Vec::with_capacity(self.levels.len().saturating_sub(1));
+        let mut idx = index;
+        // Walk levels[0 .. n-2]; the last level is the root (no sibling).
+        for lvl in 0..self.levels.len().saturating_sub(1) {
+            let cur = &self.levels[lvl];
+            let self_is_left = idx.is_multiple_of(2);
+            let sibling_idx = if self_is_left {
+                if idx + 1 < cur.len() {
+                    idx + 1
+                } else {
+                    idx // duplicate-last: odd trailing node's sibling is itself
+                }
+            } else {
+                idx - 1
+            };
+            steps.push(ProofStep {
+                sibling: cur[sibling_idx],
+                right: self_is_left,
+            });
+            idx /= 2;
+        }
+        steps
+    }
+}
+
+/// One step of a Merkle inclusion proof: a sibling digest and which side it sits on.
+/// `right == true` means the sibling is the RIGHT child (the current accumulator is the
+/// LEFT child, so `parent = combine(self, sibling)`). Mirrors the F# `MerkleProofStep`
+/// and the `{"hash","right"}` golden-vector schema.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct ProofStep {
+    /// The sibling node's digest at this level.
+    pub sibling: MerkleHash,
+    /// `true` ⇒ sibling is the RIGHT child (combine self then sibling);
+    /// `false` ⇒ sibling is the LEFT child (combine sibling then self).
+    pub right: bool,
+}
+
+/// Verify an inclusion proof against `expected_root` using an explicit hashing port:
+/// re-hash `leaf`, fold the audit `steps` up, and check the result equals the root.
+/// Touches ONLY the leaf, the proof, and the root — never the tree (the third-party
+/// property). Matches `MerkleTree.verifyProof` (`src/Core/Merkle.fs`) byte-for-byte.
+pub fn verify_proof_with_hasher<H: Hasher128>(
+    leaf: &[u8],
+    steps: &[ProofStep],
+    expected_root: MerkleHash,
+    hasher: &H,
+) -> bool {
+    let mut acc = hasher.hash128(leaf);
+    for step in steps {
+        acc = if step.right {
+            hasher.combine(acc, step.sibling)
+        } else {
+            hasher.combine(step.sibling, acc)
+        };
+    }
+    acc == expected_root
+}
+
+/// Verify an inclusion proof using the default XXH3-128 adapter (requires the `xxh3`
+/// feature). See [`verify_proof_with_hasher`].
+#[cfg(feature = "xxh3")]
+pub fn verify_proof(leaf: &[u8], steps: &[ProofStep], expected_root: MerkleHash) -> bool {
+    verify_proof_with_hasher(leaf, steps, expected_root, &Xxh3Hasher128)
 }

--- a/src/Core.Rust.Merkle/tests/golden_vectors_proofs.rs
+++ b/src/Core.Rust.Merkle/tests/golden_vectors_proofs.rs
@@ -1,0 +1,100 @@
+//! Cross-language byte-lock (proof leg): the Rust Merkle inclusion proof + verification
+//! must match the F# implementation byte-for-byte. The fixture
+//! `golden-vectors-merkle-proofs.json` was generated from `src/Core/Merkle.fs`
+//! (`MerkleTree.Proof` + `MerkleTree.verifyProof`) and covers single/odd/even fan-in
+//! shapes across all indices. Schema per row:
+//!   {"leaves":["<hex>"...],"index":N,
+//!    "siblings":[{"hash":"<hex>","right":true|false}],"root":"<hex>"}
+//! `right=true` ⇒ sibling is the RIGHT child (current node LEFT, parent=combine(self,sib));
+//! the odd trailing node's sibling is itself with right=true.
+//! If this passes, Rust agrees with F#/C#/TS on every proof and every verification.
+
+use zeta_core_merkle::{verify_proof, MerkleTree};
+
+fn hex_to_bytes(s: &str) -> Vec<u8> {
+    (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).expect("valid hex"))
+        .collect()
+}
+
+#[test]
+fn merkle_proofs_match_fsharp_golden_vectors() {
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/golden-vectors-merkle-proofs.json"
+    );
+    let text = std::fs::read_to_string(path).expect("read proof golden vectors");
+    let cases: serde_json::Value = serde_json::from_str(&text).expect("parse proof golden vectors");
+
+    let arr = cases.as_array().expect("top-level array");
+    assert_eq!(arr.len(), 22, "expected the frozen 22-vector treaty");
+
+    for (row, case) in arr.iter().enumerate() {
+        let leaves: Vec<Vec<u8>> = case["leaves"]
+            .as_array()
+            .expect("leaves array")
+            .iter()
+            .map(|l| hex_to_bytes(l.as_str().expect("leaf hex string")))
+            .collect();
+        let index = case["index"].as_u64().expect("index") as usize;
+        let expected_root_hex = case["root"].as_str().expect("root hex string");
+        let expected_siblings = case["siblings"].as_array().expect("siblings array");
+
+        let tree = MerkleTree::new(&leaves);
+
+        // (b) root matches the F# treaty.
+        let root = tree.root();
+        assert_eq!(
+            root.to_hex(),
+            expected_root_hex,
+            "row {row}: root mismatch for index={index}, leaves={:?}",
+            case["leaves"]
+        );
+
+        // (a) proof reproduces committed siblings byte-for-byte (hash hex + right flag).
+        let proof = tree.proof(index);
+        assert_eq!(
+            proof.len(),
+            expected_siblings.len(),
+            "row {row}: proof length mismatch (got {}, expected {})",
+            proof.len(),
+            expected_siblings.len()
+        );
+        for (step_i, (got, want)) in proof.iter().zip(expected_siblings.iter()).enumerate() {
+            let want_hash = want["hash"].as_str().expect("sibling hash hex");
+            let want_right = want["right"].as_bool().expect("sibling right flag");
+            assert_eq!(
+                got.sibling.to_hex(),
+                want_hash,
+                "row {row} step {step_i}: sibling hash mismatch (got {}, expected {})",
+                got.sibling.to_hex(),
+                want_hash
+            );
+            assert_eq!(
+                got.right, want_right,
+                "row {row} step {step_i}: right flag mismatch (got {}, expected {})",
+                got.right, want_right
+            );
+        }
+
+        // (c) verify_proof(leaf, steps, root) is true.
+        let leaf = &leaves[index];
+        assert!(
+            verify_proof(leaf, &proof, root),
+            "row {row}: verify_proof should accept the genuine (leaf, proof, root)"
+        );
+
+        // (d) a tampered leaf fails (flip byte 0, or use [0] if the leaf is empty).
+        let mut tampered = leaf.clone();
+        if tampered.is_empty() {
+            tampered.push(0);
+        } else {
+            tampered[0] ^= 0x01;
+        }
+        assert!(
+            !verify_proof(&tampered, &proof, root),
+            "row {row}: verify_proof must reject a tampered leaf"
+        );
+    }
+}


### PR DESCRIPTION
Closes the **RUST leg** of the 4-language Merkle inclusion-proof byte-lock. The F# treaty (`MerkleTree.Proof` + `verifyProof`, `src/Core/Merkle.fs`) and the frozen **22-vector** hex-in-JSON fixture (`src/Core.Rust.Merkle/tests/golden-vectors-merkle-proofs.json`) are already on `main`; this ports the proof + verify side and asserts byte-for-byte agreement against that authoritative fixture.

## What was added

`src/Core.Rust.Merkle/src/lib.rs`:
- `pub struct ProofStep { sibling: MerkleHash, right: bool }` — mirrors the F# `MerkleProofStep` and the `{"hash","right"}` schema. `right=true` ⇒ sibling is the RIGHT child (`parent = combine(self, sibling)`).
- `MerkleTree::proof(&self, index) -> Vec<ProofStep>` — exact F# fold: `selfIsLeft` via `idx.is_multiple_of(2)`, duplicate-last on an odd trailing node (sibling is self, on the right), walks `levels[0..n-2]`, panics on out-of-range like the F# `invalidArg`.
- `verify_proof(leaf, steps, expected_root)` + `verify_proof_with_hasher` (zero-dep core variant; the `xxh3` one is the default-feature adapter). **Reuses the existing `Hasher128::combine` / `hash128`** — no reimplemented hashing (prior-art gate).

`src/Core.Rust.Merkle/tests/golden_vectors_proofs.rs` (copies the `env!(CARGO_MANIFEST_DIR)` + `serde_json` loading pattern from `golden_vectors.rs`): for all 22 rows asserts (a) proof reproduces committed siblings byte-for-byte (hash hex + `right` flag), (b) root matches, (c) `verify_proof` accepts the genuine `(leaf, proof, root)`, (d) a tampered leaf (flip byte 0, or `[0]` if empty) is rejected.

## Gate

- All **22 vectors reproduced byte-for-byte** — no divergence.
- `cargo test` green: 2 integration tests pass (root leg + proof leg), 0 failures.
- `cargo build` clean; `cargo clippy --all-targets -- -D warnings` clean.
- JSON fixture **untouched** — the F# treaty is authoritative.

Anchor: Merkle, CRYPTO 1987 (audit paths). No binary in the proof lineage (hex-in-JSON golden vectors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)