### PR TITLE
feat(merkle): TypeScript oracle leg of the 4-language Merkle inclusion-proof byte-lock

### DIFF
--- a/src/Core.TypeScript/merkle/merkle-proofs.test.ts
+++ b/src/Core.TypeScript/merkle/merkle-proofs.test.ts
@@ -1,0 +1,66 @@
+import { test, expect } from "bun:test";
+import vectors from "./golden-vectors-merkle-proofs.json";
+import { MerkleTree, verifyProof, toHex, type ProofStep } from "./merkle";
+
+// Cross-language byte-lock: the TS Merkle inclusion-proof path must match the F#
+// canonical shape (src/Core/Merkle.fs `Proof`/`verifyProof`) byte-for-byte over
+// the same leaves. The fixture golden-vectors-merkle-proofs.json was frozen from
+// the F# treaty (22 vectors, hex-in-JSON). Each row carries the leaves, the proven
+// leaf index, the committed sibling path ({hash, right}), and the root. If this
+// passes, the TS leg agrees with F#/C#/Rust on every inclusion proof — closing the
+// TYPESCRIPT oracle leg of the 4-language Merkle proof byte-lock.
+
+const hexToBytes = (s: string): Uint8Array => {
+  const out = new Uint8Array(s.length / 2);
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(s.substr(i * 2, 2), 16);
+  return out;
+};
+
+interface Sibling {
+  hash: string;
+  right: boolean;
+}
+
+interface Case {
+  leaves: string[];
+  index: number;
+  siblings: Sibling[];
+  root: string;
+}
+
+const cases = vectors as Case[];
+
+test("proof golden vectors are present", () => {
+  expect(cases.length).toBe(22);
+});
+
+for (let i = 0; i < cases.length; i++) {
+  const c = cases[i]!;
+  test(`Merkle proof matches F# golden vector #${i} (${c.leaves.length} leaves, index ${c.index})`, () => {
+    const leaves = c.leaves.map(hexToBytes);
+    const tree = new MerkleTree(leaves);
+
+    // (a) The computed sibling path reproduces the committed vector byte-for-byte
+    //     (sibling hash hex + the right flag), in order.
+    const steps: ProofStep[] = tree.proof(c.index);
+    const got = steps.map((s) => ({ hash: toHex(s.sibling), right: s.right }));
+    const expected = c.siblings.map((s) => ({ hash: s.hash, right: s.right }));
+    expect(got).toEqual(expected);
+
+    // (b) Root matches.
+    expect(toHex(tree.root())).toBe(c.root);
+
+    // (c) verifyProof folds the proven leaf up to the committed root.
+    const rootHash = { hi: BigInt("0x" + c.root.slice(0, 16)), lo: BigInt("0x" + c.root.slice(16)) };
+    expect(verifyProof(leaves[c.index]!, steps, rootHash)).toBe(true);
+
+    // (d) Tampered leaf does not verify (flip byte 0, or use [0] if the leaf is empty).
+    const tampered = new Uint8Array(leaves[c.index]!);
+    if (tampered.length === 0) {
+      expect(verifyProof(new Uint8Array([0]), steps, rootHash)).toBe(false);
+    } else {
+      tampered[0] = tampered[0]! ^ 0xff;
+      expect(verifyProof(tampered, steps, rootHash)).toBe(false);
+    }
+  });
+}

--- a/src/Core.TypeScript/merkle/merkle.ts
+++ b/src/Core.TypeScript/merkle/merkle.ts
@@ -26,6 +26,18 @@ export interface MerkleHash {
 
 export const ZERO: MerkleHash = { hi: 0n, lo: 0n };
 
+/**
+ * One step of a Merkle inclusion proof: the sibling hash to combine with, and
+ * whether the sibling is the RIGHT child. `right === true` means the current
+ * accumulator is the LEFT child, so the parent is `combine(acc, sibling)`;
+ * `right === false` means the sibling is the LEFT child, so `combine(sibling, acc)`.
+ * Byte-identical to the F#/C#/Rust ProofStep ({ sibling, right }).
+ */
+export interface ProofStep {
+  readonly sibling: MerkleHash;
+  readonly right: boolean;
+}
+
 /** Hex representation (hi then lo, 16 hex digits each) — matches the other oracles' ToHex. */
 export const toHex = (h: MerkleHash): string => hex16(h.hi) + hex16(h.lo);
 
@@ -86,4 +98,47 @@ export class MerkleTree {
   leafHashes(): readonly MerkleHash[] {
     return this.levels[0]!;
   }
+
+  /**
+   * Merkle inclusion proof for the leaf at `index`: the O(log N) sibling path
+   * from that leaf up to (but excluding) the root. Byte-identical to F#'s
+   * `Proof(index)` (src/Core/Merkle.fs): walks levels[0 .. n-2], at each level
+   * `selfIsLeft = idx % 2 === 0`; the sibling is `idx + 1` when self is left
+   * (or self itself for the odd trailing node — duplicate-last), else `idx - 1`;
+   * pushes `{ sibling, right: selfIsLeft }`; then `idx = floor(idx / 2)`.
+   * A single-leaf tree has one level, so the path is empty.
+   */
+  proof(index: number): ProofStep[] {
+    const steps: ProofStep[] = [];
+    let idx = index;
+    // Walk every level except the topmost (the root level).
+    for (let level = 0; level < this.levels.length - 1; level++) {
+      const nodes = this.levels[level]!;
+      const selfIsLeft = idx % 2 === 0;
+      const siblingIdx = selfIsLeft
+        ? (idx + 1 < nodes.length ? idx + 1 : idx) // duplicate-last for odd trailing node
+        : idx - 1;
+      steps.push({ sibling: nodes[siblingIdx]!, right: selfIsLeft });
+      idx = Math.floor(idx / 2);
+    }
+    return steps;
+  }
+}
+
+/**
+ * Verify a Merkle inclusion proof: re-fold `leaf` up through the sibling `steps`
+ * and check the result equals `expectedRoot`. Byte-identical to F#'s
+ * `verifyProof`: `acc = ofBytes(leaf)`; per step `acc = right ? combine(acc, sibling)
+ * : combine(sibling, acc)`; returns `acc === expectedRoot`.
+ */
+export function verifyProof(
+  leaf: Uint8Array,
+  steps: ProofStep[],
+  expectedRoot: MerkleHash,
+): boolean {
+  let acc = ofBytes(leaf);
+  for (const step of steps) {
+    acc = step.right ? combine(acc, step.sibling) : combine(step.sibling, acc);
+  }
+  return acc.hi === expectedRoot.hi && acc.lo === expectedRoot.lo;
 }


### PR DESCRIPTION
Closes the **TypeScript leg** of the cross-language Merkle inclusion-proof treaty. The F# generating oracle froze `golden-vectors-merkle-proofs.json` (22 vectors, hex-in-JSON); this PR makes the TS oracle replay the exact F# fold and agree byte-for-byte.

## What was added

`src/Core.TypeScript/merkle/merkle.ts` (extends the existing TS parity oracle — reuses `combine`/`ofBytes`/`toHex`, no reimplementation):
- `export interface ProofStep { sibling; right }` — byte-identical to the F#/C#/Rust `ProofStep`.
- `MerkleTree.proof(index)` — walks `levels[0..n-2]`, `selfIsLeft = idx % 2 === 0`, sibling = `idx+1` (or self, duplicate-last) when left else `idx-1`, pushes `{ sibling, right: selfIsLeft }`, `idx = floor(idx/2)`. Single-leaf tree → empty path.
- `export function verifyProof(leaf, steps, root)` — `acc = ofBytes(leaf)`; per step `acc = right ? combine(acc, sibling) : combine(sibling, acc)`; `acc === root`. Touches only leaf + proof + root, never the tree.

`src/Core.TypeScript/merkle/merkle-proofs.test.ts` (new, loads the frozen fixture) — per vector asserts (a) `proof(index)` reproduces committed siblings byte-for-byte (`toHex` + `right`), (b) root matches, (c) `verifyProof` on the proven leaf is true, (d) a tampered leaf (flip byte 0, or `[0]` if empty) is false.

## Decisive gate

- Test command: `bun test` (in `src/Core.TypeScript/merkle/`) → **39 pass / 0 fail** across 2 files (106 expect calls).
- **All 22 proof vectors reproduced byte-for-byte** — no divergence; the fixture was not touched.
- `tsc --noEmit` clean under the repo strict settings (`verbatimModuleSyntax`, `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`).

Anchor: Merkle, CRYPTO 1987 (audit paths). No binary in the proof lineage (hex-in-JSON golden vectors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)