### PR TITLE
feat(core): Merkle inclusion-proof — C# oracle leg of the 4-lang byte-lock

### DIFF
--- a/src/Core.CSharp.Merkle/MerkleProofStep.cs
+++ b/src/Core.CSharp.Merkle/MerkleProofStep.cs
@@ -1,0 +1,11 @@
+namespace Zeta.Core.CSharp;
+
+/// <summary>
+/// One step of a Merkle inclusion (audit) proof: the sibling digest at a level
+/// plus which side it occupies. <see cref="SiblingOnRight"/> = true ⇒ the sibling
+/// is the RIGHT child (the current node is the LEFT child, so
+/// <c>parent = Combine(self, sibling)</c>); false ⇒ <c>parent = Combine(sibling, self)</c>.
+/// Mirrors the F# <c>MerkleProofStep</c> record (<c>src/Core/Merkle.fs</c>) byte-for-byte,
+/// so the same <c>(leaf, steps, root)</c> verifies identically across the F#/Rust/TS/C# oracles.
+/// </summary>
+public readonly record struct MerkleProofStep(MerkleHash Sibling, bool SiblingOnRight);

--- a/src/Core.CSharp.Merkle/MerkleTree.cs
+++ b/src/Core.CSharp.Merkle/MerkleTree.cs
@@ -48,4 +48,63 @@ public sealed class MerkleTree
 
     /// <summary>The leaf hashes (level 0), useful for diffing.</summary>
     public MerkleHash[] LeafHashes => _levels[0];
+
+    /// <summary>
+    /// Inclusion (audit) proof for the leaf at <paramref name="index"/>: the sibling
+    /// digest at each level from leaf to root, with its side. A verifier holding only
+    /// the leaf, this proof, and the root can confirm membership without the tree
+    /// (see <see cref="VerifyProof"/>). Replays the exact fold (duplicate-last on an
+    /// odd trailing node → sibling is self, on the right), matching the F#
+    /// <c>MerkleTree.Proof</c> step-for-step.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">Leaf index out of range.</exception>
+    public MerkleProofStep[] Proof(int index)
+    {
+        var leafCount = _levels[0].Length;
+        if (index < 0 || index >= leafCount)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(index),
+                index,
+                $"leaf index {index.ToString(System.Globalization.CultureInfo.InvariantCulture)} out of range [0, {leafCount.ToString(System.Globalization.CultureInfo.InvariantCulture)})");
+        }
+
+        var steps = new List<MerkleProofStep>();
+        var idx = index;
+        // Walk levels[0 .. n-2]; the last level is the root (no sibling).
+        for (var lvl = 0; lvl < _levels.Length - 1; lvl++)
+        {
+            var cur = _levels[lvl];
+            var selfIsLeft = idx % 2 == 0;
+            var siblingIdx = selfIsLeft
+                ? (idx + 1 < cur.Length ? idx + 1 : idx) // odd trailing node → sibling is self
+                : idx - 1;
+            steps.Add(new MerkleProofStep(cur[siblingIdx], selfIsLeft));
+            idx /= 2;
+        }
+
+        return steps.ToArray();
+    }
+
+    /// <summary>
+    /// Verify an inclusion proof: re-hash <paramref name="leaf"/>, fold the audit
+    /// <paramref name="steps"/> up, and check the result equals
+    /// <paramref name="expectedRoot"/>. Touches ONLY the leaf, the proof, and the root —
+    /// never the tree (the third-party property). The fold matches <see cref="Proof"/> +
+    /// <see cref="MerkleHash.Combine"/> byte-for-byte, so the same <c>(leaf, steps, root)</c>
+    /// verifies identically in the F#/Rust/TS oracles.
+    /// </summary>
+    public static bool VerifyProof(byte[] leaf, MerkleProofStep[] steps, MerkleHash expectedRoot)
+    {
+        ArgumentNullException.ThrowIfNull(steps);
+        var acc = MerkleHash.OfBytes(leaf);
+        foreach (var step in steps)
+        {
+            acc = step.SiblingOnRight
+                ? MerkleHash.Combine(acc, step.Sibling)
+                : MerkleHash.Combine(step.Sibling, acc);
+        }
+
+        return acc.Equals(expectedRoot);
+    }
 }

--- a/tests/Tests.CSharp/Algebra/MerkleProofGoldenVectorsTests.cs
+++ b/tests/Tests.CSharp/Algebra/MerkleProofGoldenVectorsTests.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text.Json;
+using Xunit;
+
+namespace Zeta.Tests.CSharp.Algebra;
+
+/// <summary>
+/// Merkle inclusion-proof cross-language byte-lock — the C# oracle leg of the
+/// 4-language (F#/TS/Rust/C#) treaty. Replays the FROZEN golden vectors authored
+/// by the F# reference (<c>src/Core/Merkle.fs</c>) and asserts that the C# port
+/// (<c>src/Core.CSharp.Merkle/MerkleTree.cs</c>) reproduces every committed
+/// proof step, root, and verification result byte-for-byte. The F# treaty is
+/// authoritative; this test never edits the fixture.
+///
+/// Vector schema (hex-in-JSON, per <c>no-binary-in-proof-lineage</c>):
+/// <c>{"leaves":["&lt;hex&gt;"...],"index":N,"siblings":[{"hash":"&lt;hex&gt;","right":bool}],"root":"&lt;hex&gt;"}</c>.
+/// <c>right=true</c> ⇒ the sibling is the RIGHT child (current node LEFT,
+/// <c>parent=Combine(self,sibling)</c>); the odd trailing node's sibling is itself, right=true.
+/// </summary>
+public class MerkleProofGoldenVectorsTests
+{
+    private sealed record ProofStepVector(string Hash, bool Right);
+
+    private sealed record ProofVector(
+        IReadOnlyList<string> Leaves,
+        int Index,
+        IReadOnlyList<ProofStepVector> Siblings,
+        string Root);
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(
+            Path.GetDirectoryName(typeof(MerkleProofGoldenVectorsTests).Assembly.Location)!);
+        while (dir is not null && !File.Exists(Path.Join(dir.FullName, "Zeta.sln")))
+        {
+            dir = dir.Parent;
+        }
+
+        return dir?.FullName
+            ?? throw new InvalidOperationException(
+                "Could not locate repo root (Zeta.sln) from test assembly location.");
+    }
+
+    private static byte[] FromHex(string hex)
+    {
+        if (hex.Length == 0)
+        {
+            return Array.Empty<byte>();
+        }
+
+        var bytes = new byte[hex.Length / 2];
+        for (var i = 0; i < bytes.Length; i++)
+        {
+            bytes[i] = byte.Parse(
+                hex.AsSpan(i * 2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        }
+
+        return bytes;
+    }
+
+    private static List<ProofVector> LoadVectors()
+    {
+        var path = Path.Join(
+            RepoRoot(), "src", "Core.TypeScript", "merkle", "golden-vectors-merkle-proofs.json");
+        var json = File.ReadAllText(path);
+        using var doc = JsonDocument.Parse(json);
+        var vectors = new List<ProofVector>();
+        foreach (var rowElement in doc.RootElement.EnumerateArray())
+        {
+            var leaves = new List<string>();
+            foreach (var leaf in rowElement.GetProperty("leaves").EnumerateArray())
+            {
+                leaves.Add(leaf.GetString() ?? "");
+            }
+
+            var siblings = new List<ProofStepVector>();
+            foreach (var sib in rowElement.GetProperty("siblings").EnumerateArray())
+            {
+                siblings.Add(new ProofStepVector(
+                    sib.GetProperty("hash").GetString() ?? "",
+                    sib.GetProperty("right").GetBoolean()));
+            }
+
+            vectors.Add(new ProofVector(
+                leaves,
+                rowElement.GetProperty("index").GetInt32(),
+                siblings,
+                rowElement.GetProperty("root").GetString() ?? ""));
+        }
+
+        return vectors;
+    }
+
+    public static IEnumerable<object[]> RowIndices()
+    {
+        var count = LoadVectors().Count;
+        for (var i = 0; i < count; i++)
+        {
+            yield return new object[] { i };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(RowIndices))]
+    public void ProofReproducesCommittedVector(int row)
+    {
+        var vector = LoadVectors()[row];
+
+        var leaves = new byte[vector.Leaves.Count][];
+        for (var i = 0; i < leaves.Length; i++)
+        {
+            leaves[i] = FromHex(vector.Leaves[i]);
+        }
+
+        var tree = new Zeta.Core.CSharp.MerkleTree(leaves);
+
+        // (b) Root matches the committed root byte-for-byte.
+        Assert.Equal(vector.Root, tree.Root.ToHex());
+
+        // (a) Proof reproduces the committed siblings byte-for-byte (ToHex + SiblingOnRight).
+        var steps = tree.Proof(vector.Index);
+        Assert.Equal(vector.Siblings.Count, steps.Length);
+        for (var s = 0; s < steps.Length; s++)
+        {
+            Assert.Equal(vector.Siblings[s].Hash, steps[s].Sibling.ToHex());
+            Assert.Equal(vector.Siblings[s].Right, steps[s].SiblingOnRight);
+        }
+
+        // (c) VerifyProof over the genuine leaf returns true.
+        var expectedRoot = tree.Root;
+        var leaf = leaves[vector.Index];
+        Assert.True(
+            Zeta.Core.CSharp.MerkleTree.VerifyProof(leaf, steps, expectedRoot),
+            $"row {row.ToString(CultureInfo.InvariantCulture)}: VerifyProof should accept the genuine leaf");
+
+        // (d) A tampered leaf (flip byte 0, or a single non-zero byte if empty) fails.
+        byte[] tampered;
+        if (leaf.Length == 0)
+        {
+            tampered = new byte[] { 0x01 };
+        }
+        else
+        {
+            tampered = (byte[])leaf.Clone();
+            tampered[0] ^= 0x01;
+        }
+
+        Assert.False(
+            Zeta.Core.CSharp.MerkleTree.VerifyProof(tampered, steps, expectedRoot),
+            $"row {row.ToString(CultureInfo.InvariantCulture)}: VerifyProof must reject a tampered leaf");
+    }
+
+    [Fact]
+    public void FixtureHasExpectedVectorCount()
+    {
+        Assert.Equal(22, LoadVectors().Count);
+    }
+}

--- a/tests/Tests.CSharp/Tests.CSharp.csproj
+++ b/tests/Tests.CSharp/Tests.CSharp.csproj
@@ -28,6 +28,7 @@
     <ProjectReference Include="..\..\src\Core.CSharp.Sha256\Zeta.Core.CSharp.Sha256.csproj" />
     <ProjectReference Include="..\..\src\Core.CSharp.Blake3\Zeta.Core.CSharp.Blake3.csproj" />
     <ProjectReference Include="..\..\src\Core.CSharp.AceCanonical\Zeta.Core.CSharp.AceCanonical.csproj" />
+    <ProjectReference Include="..\..\src\Core.CSharp.Merkle\Zeta.Core.CSharp.Merkle.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## What

Closes the **C# oracle leg** of the 4-language Merkle inclusion-proof byte-lock.
The F# treaty + the frozen 22-vector golden fixture landed in #8719; this makes
the C# generic-Merkle port reproduce every committed proof step, root, and
verification result **byte-for-byte**.

## Added

- **`src/Core.CSharp.Merkle/MerkleProofStep.cs`** — `public readonly record struct MerkleProofStep(MerkleHash Sibling, bool SiblingOnRight)`. Own file (analyzer MA0048: file name must match type name).
- **`src/Core.CSharp.Merkle/MerkleTree.cs`** — `MerkleProofStep[] Proof(int index)` (walks `levels[0..n-2]`, `selfIsLeft = idx%2==0`, duplicate-last on odd trailing node) + `static bool VerifyProof(byte[] leaf, MerkleProofStep[] steps, MerkleHash expectedRoot)` (folds `acc = right ? Combine(acc,sib) : Combine(sib,acc)`). Matches the F# `Merkle.fs` fold byte-for-byte; reuses existing `MerkleHash.Combine`/`OfBytes` — no hashing reimplemented.
- **`tests/Tests.CSharp/Algebra/MerkleProofGoldenVectorsTests.cs`** — replays the frozen `src/Core.TypeScript/merkle/golden-vectors-merkle-proofs.json` (repo-root resolution from the test assembly). Per row asserts: (a) `Proof(index)` reproduces committed siblings byte-for-byte (`ToHex` + `SiblingOnRight`), (b) `Root` matches, (c) `VerifyProof(genuine leaf)` true, (d) tampered leaf (flip byte 0; `0x01` if empty) false. Plus a 22-vector count guard.
- **`tests/Tests.CSharp/Tests.CSharp.csproj`** — added `ProjectReference` to `Zeta.Core.CSharp.Merkle`.

## Gate

- All **22** committed vectors reproduced byte-for-byte (fixture untouched — F# treaty authoritative).
- New tests: **23/23 green** (22 rows + count guard).
- Full `Tests.CSharp` suite: **330/330 green**.
- `dotnet build -c Release`: **0 warnings / 0 errors** (TreatWarningsAsErrors on).

Remaining legs (separate PRs): Rust + TS verify-only replays of the same frozen fixture.

Anchor: Merkle, CRYPTO 1987 (audit paths). No binary in the proof lineage (hex-in-JSON golden vectors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
