### PR TITLE
feat(core): mint darkhall heat continuations

### DIFF
--- a/src/Core.Rust.Merkle/tests/golden_vectors_proofs.rs
+++ b/src/Core.Rust.Merkle/tests/golden_vectors_proofs.rs
@@ -9,7 +9,7 @@
 //! the odd trailing node's sibling is itself with right=true.
 //! If this passes, Rust agrees with F#/C#/TS on every proof and every verification.
 
-use zeta_core_merkle::{verify_proof, MerkleTree};
+use zeta_core_merkle::{MerkleTree, verify_proof};
 
 fn hex_to_bytes(s: &str) -> Vec<u8> {
     (0..s.len())

--- a/src/Core/DarkHallScheduler.fs
+++ b/src/Core/DarkHallScheduler.fs
@@ -174,18 +174,18 @@ module DarkHallScheduler =
         |> Seq.toArray
         |> fun chars -> System.String(chars)
 
+    let private continuationLoopId (loopId: string) : string =
+        match pointerSafe loopId with
+        | "" -> "darkhall"
+        | id -> id
+
     /// Deterministic save pointer for the latest heat-board state. The pointer
     /// names the room/lap/tick boundary; the host decides where the actual save
     /// payload is written.
     let heatBoardStatePointer (loopId: string) (outcome: SimLoop.Outcome<ScheduledRoomState, string list>) : string =
-        let safeLoopId =
-            match pointerSafe loopId with
-            | "" -> "darkhall"
-            | id -> id
-
         sprintf
             "saves/darkhall/%s/lap-%d-tick-%d.heat-board"
-            safeLoopId
+            (continuationLoopId loopId)
             (List.length outcome.Laps)
             outcome.Final.CompletedTicks
 
@@ -196,7 +196,7 @@ module DarkHallScheduler =
         (loopId: string)
         (outcome: SimLoop.Outcome<ScheduledRoomState, string list>)
         : SimLoop.Continuation option =
-        SimLoop.continueAfter loopId (heatBoardStatePointer loopId outcome) outcome
+        SimLoop.continueAfter (continuationLoopId loopId) (heatBoardStatePointer loopId outcome) outcome
 
     let encodeHeatBoardContinuation
         (loopId: string)

--- a/src/Core/DarkHallScheduler.fs
+++ b/src/Core/DarkHallScheduler.fs
@@ -163,3 +163,43 @@ module DarkHallScheduler =
         let start = initial room manifest
 
         SimLoop.run [ handler ] interruptSource measure cut clock budget ctx seed ticksPerLap start
+
+    let private pointerSafe (value: string) : string =
+        value
+        |> Seq.map (fun c ->
+            if System.Char.IsLetterOrDigit c || c = '-' || c = '_' then
+                c
+            else
+                '-')
+        |> Seq.toArray
+        |> fun chars -> System.String(chars)
+
+    /// Deterministic save pointer for the latest heat-board state. The pointer
+    /// names the room/lap/tick boundary; the host decides where the actual save
+    /// payload is written.
+    let heatBoardStatePointer (loopId: string) (outcome: SimLoop.Outcome<ScheduledRoomState, string list>) : string =
+        let safeLoopId =
+            match pointerSafe loopId with
+            | "" -> "darkhall"
+            | id -> id
+
+        sprintf
+            "saves/darkhall/%s/lap-%d-tick-%d.heat-board"
+            safeLoopId
+            (List.length outcome.Laps)
+            outcome.Final.CompletedTicks
+
+    /// Mint the existing SimLoop continuation token for a heat-board run when
+    /// the loop stopped on a budget rail. Cut-closed rooms and errored rooms do
+    /// not respawn.
+    let continueHeatBoardAfter
+        (loopId: string)
+        (outcome: SimLoop.Outcome<ScheduledRoomState, string list>)
+        : SimLoop.Continuation option =
+        SimLoop.continueAfter loopId (heatBoardStatePointer loopId outcome) outcome
+
+    let encodeHeatBoardContinuation
+        (loopId: string)
+        (outcome: SimLoop.Outcome<ScheduledRoomState, string list>)
+        : string option =
+        outcome |> continueHeatBoardAfter loopId |> Option.map SimLoop.encodeContinuation

--- a/tests/Tests.FSharp/DarkHallScheduler.Tests.fs
+++ b/tests/Tests.FSharp/DarkHallScheduler.Tests.fs
@@ -260,4 +260,18 @@ let ``budget stopped heat board sim loop mints a continuation token`` () =
             let encoded = SimLoop.encodeContinuation token
             Assert.Equal(Some token, SimLoop.parseContinuation encoded)
             Assert.Equal(Some encoded, Scheduler.encodeHeatBoardContinuation "darkhall-heat-board" outcome)
+
+        match Scheduler.continueHeatBoardAfter "" outcome with
+        | None -> Assert.Fail "empty loop ids should normalize into a parseable continuation"
+        | Some token ->
+            Assert.Equal("darkhall", token.LoopId)
+            Assert.Equal("saves/darkhall/darkhall/lap-2-tick-2.heat-board", token.StatePointer)
+            Assert.Equal(Some token, SimLoop.parseContinuation (SimLoop.encodeContinuation token))
+
+        match Scheduler.continueHeatBoardAfter "darkhall:heat/board" outcome with
+        | None -> Assert.Fail "unsafe loop ids should normalize into a parseable continuation"
+        | Some token ->
+            Assert.Equal("darkhall-heat-board", token.LoopId)
+            Assert.Equal("saves/darkhall/darkhall-heat-board/lap-2-tick-2.heat-board", token.StatePointer)
+            Assert.Equal(Some token, SimLoop.parseContinuation (SimLoop.encodeContinuation token))
     }

--- a/tests/Tests.FSharp/DarkHallScheduler.Tests.fs
+++ b/tests/Tests.FSharp/DarkHallScheduler.Tests.fs
@@ -202,6 +202,8 @@ let ``heat board sim loop measures backpressure before the cut closes`` () =
         | SimLoop.Stopped.CutChoseClose -> ()
         | other -> Assert.Fail(sprintf "expected heat-board cut to close the loop, got %A" other)
 
+        Assert.True(Scheduler.continueHeatBoardAfter "darkhall-heat-board" outcome |> Option.isNone)
+
         match outcome.Laps with
         | [ lap ] ->
             Assert.Equal(1, lap.State.CompletedTicks)
@@ -213,4 +215,49 @@ let ``heat board sim loop measures backpressure before the cut closes`` () =
             Assert.Equal("3", firstDisplayRow.Substring(16, 1))
             Assert.Equal("4", firstDisplayRow.Substring(48, 1))
         | laps -> Assert.Fail(sprintf "expected one measured lap before cut, got %A" laps)
+    }
+
+[<Fact>]
+let ``budget stopped heat board sim loop mints a continuation token`` () =
+    task {
+        let budget: SimLoop.Budget =
+            { MaxLaps = 2
+              MaxTicks = 16
+              MaxMillis = 1_000L }
+
+        let! outcome =
+            Scheduler.heatBoardSimLoop
+                "darkhall-heat-board"
+                Arcade.room
+                Chip9Capabilities.chip8Default
+                timer
+                "darkhall-simloop"
+                (NullHeatSink() :> IHeatSink)
+                (fun _ -> None)
+                (chooseById "darkhall.edit-grammar")
+                (fun _ -> [ TimerElapsed 17 ])
+                int64
+                budget
+                (ctx ())
+                42L
+                1
+                (fun _ _ -> true)
+
+        Assert.Equal(SimLoop.Stopped.LapBudget, outcome.Stopped)
+        Assert.Equal(2, outcome.Final.CompletedTicks)
+
+        let expectedPointer = "saves/darkhall/darkhall-heat-board/lap-2-tick-2.heat-board"
+        Assert.Equal(expectedPointer, Scheduler.heatBoardStatePointer "darkhall-heat-board" outcome)
+
+        match Scheduler.continueHeatBoardAfter "darkhall-heat-board" outcome with
+        | None -> Assert.Fail "budget-stopped heat-board loops should schedule a continuation"
+        | Some token ->
+            Assert.Equal("darkhall-heat-board", token.LoopId)
+            Assert.Equal(2, token.NextLap)
+            Assert.Equal(2, token.TicksSpent)
+            Assert.Equal(expectedPointer, token.StatePointer)
+
+            let encoded = SimLoop.encodeContinuation token
+            Assert.Equal(Some token, SimLoop.parseContinuation encoded)
+            Assert.Equal(Some encoded, Scheduler.encodeHeatBoardContinuation "darkhall-heat-board" outcome)
     }

--- a/tests/cross-verification/zeta-ir-v1/cross-verify.ts
+++ b/tests/cross-verification/zeta-ir-v1/cross-verify.ts
@@ -1,0 +1,100 @@
+// zeta-ir-v1 frozen-layout cross-verification oracle.
+//
+// This is the toolchain-free guard for the frozen generator-IR envelope. The F#
+// tests prove the shipping `ZetaIrV1` module reproduces this file byte-for-byte;
+// this CI oracle makes the cross-verification runner refuse an unchecked
+// primitive directory.
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+type Op =
+  | { readonly op: "mul"; readonly k: string }
+  | { readonly op: "xorshr"; readonly s: string };
+
+interface Ir {
+  readonly generator: string;
+  readonly version: number;
+  readonly width: number;
+  readonly ops: readonly Op[];
+}
+
+const known: readonly Ir[] = [
+  {
+    generator: "rng.splitmix64",
+    version: 1,
+    width: 64,
+    ops: [
+      { op: "mul", k: "-7046029254386353131" },
+      { op: "xorshr", s: "30" },
+      { op: "mul", k: "-4658895280553007687" },
+      { op: "xorshr", s: "27" },
+      { op: "mul", k: "-7723592293110705685" },
+      { op: "xorshr", s: "31" },
+    ],
+  },
+  {
+    generator: "hash.fmix32",
+    version: 1,
+    width: 32,
+    ops: [
+      { op: "xorshr", s: "16" },
+      { op: "mul", k: "2246822507" },
+      { op: "xorshr", s: "13" },
+      { op: "mul", k: "3266489909" },
+      { op: "xorshr", s: "16" },
+    ],
+  },
+];
+
+function opJson(op: Op): string {
+  return op.op === "mul" ? `{"op":"mul","k":${op.k}}` : `{"op":"xorshr","s":${op.s}}`;
+}
+
+function canonicalIrJson(ir: Ir): string {
+  return `{"schema":"zeta-ir-v1","generator":${JSON.stringify(ir.generator)},"version":${ir.version},"width":${ir.width},"ops":[${ir.ops.map(opJson).join(",")}]}`;
+}
+
+const goldenPath = join(import.meta.dir, "zeta-ir-v1.golden.json");
+const golden = JSON.parse(readFileSync(goldenPath, "utf8")) as Record<string, string>;
+const expected = new Map(known.map((ir) => [ir.generator, canonicalIrJson(ir)]));
+
+let mismatches = 0;
+
+console.log("zeta-ir-v1 cross-verification:");
+console.log(`  expected frozen IRs: ${expected.size}`);
+
+for (const key of Object.keys(golden).sort()) {
+  if (!expected.has(key)) {
+    console.error(`  unexpected generator in golden: ${key}`);
+    mismatches++;
+  }
+}
+
+for (const [generator, expectedJson] of expected) {
+  const actual = golden[generator];
+  if (actual === undefined) {
+    console.error(`  missing generator in golden: ${generator}`);
+    mismatches++;
+    continue;
+  }
+
+  if (actual !== expectedJson) {
+    console.error(`  ${generator} MISMATCH`);
+    console.error(`    expected: ${expectedJson}`);
+    console.error(`    actual:   ${actual}`);
+    mismatches++;
+  }
+
+  if (actual.includes("zetaId")) {
+    console.error(`  ${generator} carries forbidden stored zetaId`);
+    mismatches++;
+  }
+}
+
+if (mismatches === 0) {
+  console.log(`  TS oracle agrees with all ${expected.size} frozen zeta-ir-v1 rows.`);
+  process.exit(0);
+}
+
+console.error(`  ${mismatches} mismatch(es).`);
+process.exit(1);


### PR DESCRIPTION
# Summary

Adds DarkHall heat-board continuation helpers so a budget-stopped room loop can schedule itself forward with the existing `SimLoop` spawn-token contract. The helper derives a deterministic heat-board state pointer from the measured lap/tick boundary, while cut-closed and errored rooms still refuse continuation. Also fixes two gate drifts from latest main: one rustfmt import-order issue in the Merkle proof test and the missing zeta-ir-v1 cross-verification oracle that made `cross-verify-all` reject an unchecked primitive directory.

# Spec alignment

Touches the bounded room loop / DarkHall scheduler surface in `src/Core`. Observable behavior changes only by exposing a typed continuation helper over the already-existing `SimLoop` continuation contract; runtime arithmetic and cut behavior are unchanged. The zeta-ir-v1 addition is a CI oracle over an existing frozen golden file; it does not change the IR layout.

# Tests

- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter FullyQualifiedName~DarkHallSchedulerTests` — 4 passed
- `dotnet format --verify-no-changes` — 0 formatting failures
- `dotnet build -c Release` — 0 warnings, 0 errors
- `dotnet test Zeta.sln -c Release` — 3542 passed, 4 skipped, 0 failed after review fix
- `bun tests/cross-verification/zeta-ir-v1/cross-verify.ts` — passed
- `bun src/Core.TypeScript/ci/cross-verify-all.ts` — 17/17 primitives passed
- `bun run preflight:quick` — all 8 executed checks passed; Go lint skipped locally because the Go toolchain is unavailable
- `bun src/Core.TypeScript/hygiene/audit-agencysignature-main-tip.ts --commit HEAD` — PASS

# Validation

- [x] Tests pass locally (0 warn, 0 err)
- [x] Any new docstring claim has a falsifying test
- [x] `openspec/specs/**` updated if observable behaviour changed
- [ ] `docs/ROUND-HISTORY.md` entry if notable
- [ ] Skill changes went through the `skill-creator` workflow

# Notes

This is the small self-scheduling bridge: heat-board loops can now stop honestly on budget rails, hand the host a parseable spawn line, and continue later without pretending the room had infinite time in one run. Review follow-up normalizes the continuation loop id itself, so empty or separator-heavy IDs still encode as parseable spawn tokens.

Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: Codex
Agent-Model: gpt-5.5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: not-implied-by-credential
Human-Review-Evidence: none
Action-Mode: human-directed
Task: none
Co-Authored-By: Codex <noreply@openai.com>
