### PR TITLE
fix(merkle): rustfmt the Rust Merkle proof golden-vector test (CI lint green)

### DIFF
--- a/src/Core.Rust.Merkle/tests/golden_vectors_proofs.rs
+++ b/src/Core.Rust.Merkle/tests/golden_vectors_proofs.rs
@@ -9,7 +9,7 @@
 //! the odd trailing node's sibling is itself with right=true.
 //! If this passes, Rust agrees with F#/C#/TS on every proof and every verification.
 
-use zeta_core_merkle::{verify_proof, MerkleTree};
+use zeta_core_merkle::{MerkleTree, verify_proof};
 
 fn hex_to_bytes(s: &str) -> Vec<u8> {
     (0..s.len())


### PR DESCRIPTION
Fixes the `lint (Rust)` gate failure: my Rust Merkle inclusion-proof leg (#8720) left `tests/golden_vectors_proofs.rs` not `rustfmt`-clean — the summoned agent ran `cargo clippy` + `cargo test` but not `cargo fmt --check`, which the gate's "Run Rust Lint Script" enforces.

rustfmt orders the import as `use zeta_core_merkle::{MerkleTree, verify_proof}` (types before functions); the file had them reversed. `cargo fmt --check` is now clean.

Note: the same gate run also has a **separate, pre-existing `cross-verify` failure** unrelated to this — `tests/cross-verification/zeta-ir-v1/` (added by #8725) has a golden but no oracle (assert-don't-skip). That's gen-gen domain work, surfaced separately; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)