### PR TITLE
feat(core): admit darkhall heat continuations

### DIFF
--- a/src/Core/DarkHallScheduler.fs
+++ b/src/Core/DarkHallScheduler.fs
@@ -27,6 +27,18 @@ module DarkHallScheduler =
           LastTick: RoomLoop.TickOutcome option
           HeatRowsRev: HeatBoundaryRow list }
 
+    [<RequireQualifiedAccess>]
+    type HeatBoardContinuationFeedback =
+        | MalformedContinuation of token: string
+        | LoopIdMismatch of expected: string * actual: string
+        | StatePointerMismatch of expectedPrefix: string * actual: string
+        | ResumeTickOverflow of nextLap: int * ticksPerLap: int
+
+    type HeatBoardContinuationAdmission =
+        { Token: SimLoop.Continuation
+          StatePointer: string
+          ResumeBaseTick: int }
+
     let initial (room: DarkHall.Room) (manifest: Chip9Capabilities.Manifest) : ScheduledRoomState =
         { Loop = RoomLoop.initial room manifest
           CompletedTicks = 0
@@ -189,6 +201,9 @@ module DarkHallScheduler =
             (List.length outcome.Laps)
             outcome.Final.CompletedTicks
 
+    let private heatBoardStatePointerPrefix (loopId: string) : string =
+        sprintf "saves/darkhall/%s/" (continuationLoopId loopId)
+
     /// Mint the existing SimLoop continuation token for a heat-board run when
     /// the loop stopped on a budget rail. Cut-closed rooms and errored rooms do
     /// not respawn.
@@ -203,3 +218,49 @@ module DarkHallScheduler =
         (outcome: SimLoop.Outcome<ScheduledRoomState, string list>)
         : string option =
         outcome |> continueHeatBoardAfter loopId |> Option.map SimLoop.encodeContinuation
+
+    let private resumeBaseTick (nextLap: int) (ticksPerLap: int) : Result<int, HeatBoardContinuationFeedback> =
+        let perLap = max 1 ticksPerLap
+        let baseTick = int64 nextLap * int64 perLap
+
+        if baseTick > int64 System.Int32.MaxValue then
+            Error(HeatBoardContinuationFeedback.ResumeTickOverflow(nextLap, perLap))
+        else
+            Ok(int baseTick)
+
+    /// Admit a heat-board continuation token back through the Dark Hall boundary.
+    /// Arbitrary `spawn:*` text is not authority: the token must parse, match the
+    /// expected loop id, and point inside the heat-board save namespace before a
+    /// host runner can use it to offset the next bounded lap.
+    let admitHeatBoardContinuation
+        (loopId: string)
+        (ticksPerLap: int)
+        (tokenLine: string)
+        : Result<HeatBoardContinuationAdmission, HeatBoardContinuationFeedback> =
+        match SimLoop.parseContinuation tokenLine with
+        | None -> Error(HeatBoardContinuationFeedback.MalformedContinuation tokenLine)
+        | Some token ->
+            let expectedLoop = continuationLoopId loopId
+
+            if token.LoopId <> expectedLoop then
+                Error(HeatBoardContinuationFeedback.LoopIdMismatch(expectedLoop, token.LoopId))
+            else
+                let expectedPrefix = heatBoardStatePointerPrefix loopId
+
+                if not (token.StatePointer.StartsWith(expectedPrefix, System.StringComparison.Ordinal)) then
+                    Error(HeatBoardContinuationFeedback.StatePointerMismatch(expectedPrefix, token.StatePointer))
+                else
+                    resumeBaseTick token.NextLap ticksPerLap
+                    |> Result.map (fun baseTick ->
+                        { Token = token
+                          StatePointer = token.StatePointer
+                          ResumeBaseTick = baseTick })
+
+    /// Offset the injected interrupt source for a resumed heat-board run. The
+    /// source remains owned by the host; admission only tells it where the next
+    /// finite link starts.
+    let resumeHeatBoardSource
+        (admission: HeatBoardContinuationAdmission)
+        (source: SoftScheduler.Source)
+        : SoftScheduler.Source =
+        fun tick -> source (admission.ResumeBaseTick + tick)

--- a/tests/Tests.FSharp/DarkHallScheduler.Tests.fs
+++ b/tests/Tests.FSharp/DarkHallScheduler.Tests.fs
@@ -261,6 +261,16 @@ let ``budget stopped heat board sim loop mints a continuation token`` () =
             Assert.Equal(Some token, SimLoop.parseContinuation encoded)
             Assert.Equal(Some encoded, Scheduler.encodeHeatBoardContinuation "darkhall-heat-board" outcome)
 
+            match Scheduler.admitHeatBoardContinuation "darkhall-heat-board" 3 encoded with
+            | Error feedback -> Assert.Fail(sprintf "expected heat-board continuation admission, got %A" feedback)
+            | Ok admission ->
+                Assert.Equal(token, admission.Token)
+                Assert.Equal(expectedPointer, admission.StatePointer)
+                Assert.Equal(6, admission.ResumeBaseTick)
+
+                let resumed = Scheduler.resumeHeatBoardSource admission (fun tick -> [ TimerElapsed tick ])
+                Assert.Equal<InterruptKind list>([ TimerElapsed 11 ], resumed 5)
+
         match Scheduler.continueHeatBoardAfter "" outcome with
         | None -> Assert.Fail "empty loop ids should normalize into a parseable continuation"
         | Some token ->
@@ -275,3 +285,30 @@ let ``budget stopped heat board sim loop mints a continuation token`` () =
             Assert.Equal("saves/darkhall/darkhall-heat-board/lap-2-tick-2.heat-board", token.StatePointer)
             Assert.Equal(Some token, SimLoop.parseContinuation (SimLoop.encodeContinuation token))
     }
+
+[<Fact>]
+let ``heat board continuation admission refuses malformed and foreign spawn tokens`` () =
+    let admit = Scheduler.admitHeatBoardContinuation "darkhall-heat-board" 2
+
+    match admit "not-a-spawn-token" with
+    | Error(Scheduler.HeatBoardContinuationFeedback.MalformedContinuation token) ->
+        Assert.Equal("not-a-spawn-token", token)
+    | other -> Assert.Fail(sprintf "expected malformed token refusal, got %A" other)
+
+    match admit "spawn:other-loop:2:2:saves/darkhall/darkhall-heat-board/lap-2-tick-2.heat-board" with
+    | Error(Scheduler.HeatBoardContinuationFeedback.LoopIdMismatch(expected, actual)) ->
+        Assert.Equal("darkhall-heat-board", expected)
+        Assert.Equal("other-loop", actual)
+    | other -> Assert.Fail(sprintf "expected loop mismatch refusal, got %A" other)
+
+    match admit "spawn:darkhall-heat-board:2:2:saves/other/darkhall-heat-board/lap-2-tick-2.heat-board" with
+    | Error(Scheduler.HeatBoardContinuationFeedback.StatePointerMismatch(expectedPrefix, actual)) ->
+        Assert.Equal("saves/darkhall/darkhall-heat-board/", expectedPrefix)
+        Assert.Equal("saves/other/darkhall-heat-board/lap-2-tick-2.heat-board", actual)
+    | other -> Assert.Fail(sprintf "expected state-pointer mismatch refusal, got %A" other)
+
+    match admit "spawn:darkhall-heat-board:2147483647:0:saves/darkhall/darkhall-heat-board/lap-max.heat-board" with
+    | Error(Scheduler.HeatBoardContinuationFeedback.ResumeTickOverflow(nextLap, ticksPerLap)) ->
+        Assert.Equal(System.Int32.MaxValue, nextLap)
+        Assert.Equal(2, ticksPerLap)
+    | other -> Assert.Fail(sprintf "expected overflow refusal, got %A" other)


### PR DESCRIPTION
## Summary
- add a DarkHallScheduler admission gate for heat-board continuation tokens
- refuse malformed tokens, foreign loop ids, wrong save namespaces, and resume tick overflow as typed feedback
- expose the admitted resume base tick plus a source-offset helper for the host-owned interrupt source

## Validation
- dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter FullyQualifiedName~DarkHallSchedulerTests
- dotnet format --verify-no-changes
- dotnet build -c Release
- dotnet test Zeta.sln -c Release
- bun run preflight:quick

Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: Codex
Agent-Model: gpt-5.5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: not-implied-by-credential
Human-Review-Evidence: none
Action-Mode: human-directed
Task: none
Co-Authored-By: Codex <noreply@openai.com>