### PR TITLE
feat(installer): promote phase-3 push gate + NixOS mise bootstrap

### DIFF
--- a/.github/workflows/build-ai-cluster-iso.yml
+++ b/.github/workflows/build-ai-cluster-iso.yml
@@ -280,13 +280,15 @@ jobs:
       #
       # Security: no github.event.* interpolation; ISO path comes from
       # prior workflow step's filesystem find.
+      # B-0891 phase-3: first-session serial markers on scenario 2 (push +
+      # workflow_dispatch). Society proof: run 27862943618 (2026-06-20).
       - name: B-0891 scenario 2 — boot + install substrate (B-0831 Slice 1)
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         timeout-minutes: 90
         working-directory: full-ai-cluster
         env:
           SERIAL_LOG_OUT_PATH: ${{ github.workspace }}/qemu-full-install-serial.log
-          QEMU_FIRST_SESSION_PHASE3: ${{ github.event_name == 'workflow_dispatch' && '1' || '' }}
+          QEMU_FIRST_SESSION_PHASE3: "1"
         run: |
           set -euo pipefail
           mapfile -t iso_candidates < <(find result/iso -maxdepth 1 -type f \( -name 'zeta-installer-*.iso' -o -name 'nixos-minimal-*.iso' \) | sort)

--- a/.mise.toml
+++ b/.mise.toml
@@ -118,8 +118,9 @@ node = "24"
 # unauthenticated GitHub API rate-limits the shared runner IP;
 # scratch + SQLSharp both disable this check. Round-32 v1.0
 # security scope treats python-attestation on CI as a post-v1
-# hardening item (`SECURITY-BACKLOG.md`).
-python.github_attestations = false
+# hardening item (`SECURITY-BACKLOG.md`). Disabled via
+# MISE_PYTHON_GITHUB_ATTESTATIONS in tools/setup/common/mise.sh (not here —
+# nixpkgs mise 2025.11.x on cluster nodes predates the v2026.3.18 key).
 # Auto-activate uv-created venvs when mise enters a directory.
 # QoL: `uv run` / venv switching seamless. From ../scratch.
 python.uv_venv_auto = "source"

--- a/docs/trajectories/usb-zflash-installer/FIRST-SESSION.md
+++ b/docs/trajectories/usb-zflash-installer/FIRST-SESSION.md
@@ -1,6 +1,6 @@
 # First-session vertical — post-login choose-your-own-adventure
 
-Status: slice 4 landed (nodeSession World channel + grammar-16 overlay)
+Status: slice 4 landed; S4 society proof green (QEMU phase-3, run [27862943618](https://github.com/Lucent-Financial-Group/Zeta/actions/runs/27862943618))
 Owner hat (tentative): **usb-zflash-installer** + **observe** composes
 Last refreshed: 2026-06-20
 
@@ -31,7 +31,9 @@ which credentials to set up, which to skip, whether to stay local-only.
 
 | `docs/trajectories/usb-zflash-installer/HAT-ROUTING.md` | Slice 5 hat path → owner sketch |
 
-Not yet wired: QEMU phase-3 hard gate on push (opt-in via `QEMU_FIRST_SESSION_PHASE3=1` on workflow_dispatch).
+QEMU phase-3 hard gate on push: scenario 2 sets `QEMU_FIRST_SESSION_PHASE3=1` on every `build-ai-cluster-iso` push + workflow_dispatch (promoted after society proof run 27862943618).
+
+**Next vertical:** S6 physical first-login UX (menu copy, flow, feel) — design pass in progress with operator family.
 
 ## Reused from observe / workflow DUs
 
@@ -52,8 +54,8 @@ Per `docs/BUILD-GATES.md` — local prepush is the gate; peers replay; CI is sig
 | **S1** | Builder | `bun run preflight:quick` includes observe suite |
 | **S2** | Peer / builder | `validate-local-llm.ts` — Ollama chooser over menu labels |
 | **S3** | USB hat owner | Scripted `first-session` demo against mock LLM backend |
-| **S4** | Society cadence | QEMU phase-3: `QEMU_FIRST_SESSION_PHASE3=1` on scenario 2 workflow_dispatch |
-| **S6** | Human | Physical boot — feel of adventure UX |
+| **S4** | Society cadence | QEMU phase-3: `QEMU_FIRST_SESSION_PHASE3=1` on scenario 2 (push + workflow_dispatch) |
+| **S6** | Human (+ co-design) | Physical boot — first-login adventure UX (menu, pacing, copy) |
 
 ## Vertical slices (roadmap)
 

--- a/docs/trajectories/usb-zflash-installer/RESUME.md
+++ b/docs/trajectories/usb-zflash-installer/RESUME.md
@@ -4,8 +4,8 @@ Status: active — shipped + iterating; first surfaced as a trajectory 2026-05-2
 Last refreshed: 2026-06-20
 Type: workstream (current-focus) — a trajectory the operator is *actively powering*. Many trajectories can be tracked; only a few are workstreams at once (finite-focus / WIP-bounded — a workstream is a trajectory under sustained thrust, and thrust budget is finite, so most trajectories coast). (Genus = "trajectory"; "workstream" is the species: a trajectory under sustained thrust toward a deliverable, vs. emergent-posture trajectories like `anti-infection`. See [`factory-trajectory-surface`](../factory-trajectory-surface/RESUME.md) for the genus/species taxonomy.) One of the operator's three current cluster workstreams (encryption / usb-zflash / ts-workflow-engine).
 Eventual encoding (design-stage — the human maintainer 2026-05-23 genetic-ID substrate + Clifford/HKT): this trajectory's state is trackable as a 128-bit genetic-ID seed (discrete, reversible via parser-combinator ↔ generator-function) → Clifford-space path (continuous, eventual). Mirrors the three-lane I8-lattice / I9-manifold split.
-Current blocker: QEMU phase-3 wired (opt-in workflow_dispatch); society proof run next.
-Next concrete action: dispatch build-iso with QEMU_FIRST_SESSION_PHASE3=1; physical WiFi out-of-band
+Current blocker: none for QEMU phase-3 (S4 green); physical S6 UX + WiFi (B-0792) out-of-band.
+Next concrete action: co-design first-login UX (S6); slice 5 CODEOWNERS when teams confirmed; mise bootstrap on NixOS install (system mise, not tarball) — fixes profile.d first-session on metal.
 
 ## Why This Exists
 
@@ -59,7 +59,7 @@ bringup.
 
 ## Current Next Action
 
-QEMU scenarios 1–4 green ([run 27854227014](https://github.com/Lucent-Financial-Group/Zeta/actions/runs/27854227014)); 3+4 hard gate on `workflow_dispatch`. **Post-login:** [FIRST-SESSION.md](./FIRST-SESSION.md) slice 3 — profile.d adventure + gh executor on installed nodes.
+QEMU scenarios 1–4 green; scenario 2 asserts first-session serial markers on **push** (phase-3 promoted after [run 27862943618](https://github.com/Lucent-Financial-Group/Zeta/actions/runs/27862943618)). **Post-login:** [FIRST-SESSION.md](./FIRST-SESSION.md) slices 1–4 landed; **next** S6 physical UX co-design + slice 5 CODEOWNERS.
 
 ## Society validation (not PR-centric)
 

--- a/full-ai-cluster/nixos/modules/common.nix
+++ b/full-ai-cluster/nixos/modules/common.nix
@@ -315,6 +315,7 @@
     # mise activate sets up shims for all .mise.toml runtimes (bun,
     # node, dotnet, python, java, uv, actionlint, shellcheck, etc.)
     if command -v mise >/dev/null 2>&1; then
+      export MISE_PYTHON_GITHUB_ATTESTATIONS="''${MISE_PYTHON_GITHUB_ATTESTATIONS:-0}"
       _zeta_repo=""
       if [ -f /etc/zeta/.mise.toml ]; then
         _zeta_repo="/etc/zeta"

--- a/full-ai-cluster/nixos/modules/common.nix
+++ b/full-ai-cluster/nixos/modules/common.nix
@@ -315,6 +315,17 @@
     # mise activate sets up shims for all .mise.toml runtimes (bun,
     # node, dotnet, python, java, uv, actionlint, shellcheck, etc.)
     if command -v mise >/dev/null 2>&1; then
+      _zeta_repo=""
+      if [ -f /etc/zeta/.mise.toml ]; then
+        _zeta_repo="/etc/zeta"
+      elif [ -f "$HOME/Zeta/.mise.toml" ]; then
+        _zeta_repo="$HOME/Zeta"
+      fi
+      # Recovery: non-interactive install may have skipped mise install (tarball
+      # mise is not FHS-compatible on NixOS). Lazy-install runtimes on first login.
+      if [ -n "$_zeta_repo" ] && [ ! -x "$HOME/.local/share/mise/shims/bun" ]; then
+        (cd "$_zeta_repo" && mise trust .mise.toml >/dev/null 2>&1; MISE_ENV=full mise install) >/dev/null 2>&1 || true
+      fi
       eval "$(mise activate bash)"
     fi
     # bun's `bun install --global` writes manifest-driven agent CLI

--- a/full-ai-cluster/nixos/modules/zeta-first-session.nix
+++ b/full-ai-cluster/nixos/modules/zeta-first-session.nix
@@ -13,6 +13,7 @@
 let
   cfg = config.zeta.firstSession;
   bunShimPath = "${cfg.home}/.local/share/mise/shims/bun";
+  bunNixPath = lib.getExe pkgs.bun;
   scriptPath = "${cfg.repoRoot}/src/Core.TypeScript/observe/first-session-run.ts";
 in
 {
@@ -67,7 +68,14 @@ in
           case "$-" in
             *i*)
               if [ -z "''${ZETA_FIRST_SESSION_RUNNING:-}" ] && [ ! -f "${cfg.markerPath}" ]; then
-                if [ -f "${scriptPath}" ] && [ -x "${bunShimPath}" ]; then
+                _bun=""
+                for _c in "${bunShimPath}" "${cfg.home}/.bun/bin/bun" "${bunNixPath}"; do
+                  if [ -x "$_c" ]; then
+                    _bun="$_c"
+                    break
+                  fi
+                done
+                if [ -f "${scriptPath}" ] && [ -n "$_bun" ]; then
                   export ZETA_FIRST_SESSION_RUNNING=1
                   export ZETA_FIRST_SESSION_MARKER="${cfg.markerPath}"
                   export HOME="${cfg.home}"
@@ -75,10 +83,10 @@ in
                   LLM_FLAG=""
                   ${lib.optionalString cfg.useLlm "LLM_FLAG=\"--llm\""}
                   echo "zeta-first-session: launching post-login credential adventure..."
-                  cd "${cfg.repoRoot}" && "${bunShimPath}" "${scriptPath}" $LLM_FLAG || true
+                  cd "${cfg.repoRoot}" && "$_bun" "${scriptPath}" $LLM_FLAG || true
                   unset ZETA_FIRST_SESSION_RUNNING
                 else
-                  echo "zeta-first-session: script or bun shim missing — skipping (install substrate incomplete?)"
+                  echo "zeta-first-session: script or bun missing — skipping (install substrate incomplete?)"
                 fi
               fi
               ;;

--- a/full-ai-cluster/nixos/modules/zeta-first-session.nix
+++ b/full-ai-cluster/nixos/modules/zeta-first-session.nix
@@ -68,6 +68,27 @@ in
           case "$-" in
             *i*)
               if [ -z "''${ZETA_FIRST_SESSION_RUNNING:-}" ] && [ ! -f "${cfg.markerPath}" ]; then
+                # Codex P2 (#8738): this hook is sourced BEFORE zeta-user-paths.sh
+                # (lexical profile.d order), where the lazy `mise install` recovery
+                # lives. Since the bun fallback below now lets the conductor launch
+                # with no agent CLIs yet, completing/skipping the adventure would
+                # write the marker and never rerun after the CLIs finally install.
+                # Run the same recovery HERE first so the agent CLIs exist (or were
+                # attempted) before the marker can be written. Idempotent: only runs
+                # when the mise bun shim is still absent.
+                export MISE_PYTHON_GITHUB_ATTESTATIONS="''${MISE_PYTHON_GITHUB_ATTESTATIONS:-0}"
+                if command -v mise >/dev/null 2>&1 && [ ! -x "${bunShimPath}" ]; then
+                  _zeta_repo=""
+                  if [ -f "${cfg.repoRoot}/.mise.toml" ]; then
+                    _zeta_repo="${cfg.repoRoot}"
+                  elif [ -f "${cfg.home}/Zeta/.mise.toml" ]; then
+                    _zeta_repo="${cfg.home}/Zeta"
+                  fi
+                  if [ -n "$_zeta_repo" ]; then
+                    echo "zeta-first-session: installing runtimes before adventure (mise recovery)..."
+                    (cd "$_zeta_repo" && mise trust .mise.toml >/dev/null 2>&1; MISE_ENV=full mise install) >/dev/null 2>&1 || true
+                  fi
+                fi
                 _bun=""
                 for _c in "${bunShimPath}" "${cfg.home}/.bun/bin/bun" "${bunNixPath}"; do
                   if [ -x "$_c" ]; then

--- a/full-ai-cluster/usb-nixos-installer/nixos/installer/configuration.nix
+++ b/full-ai-cluster/usb-nixos-installer/nixos/installer/configuration.nix
@@ -191,6 +191,10 @@
     # writing to /mnt/etc/zeta/initial-hashedpassword.
     mkpasswd
     nh
+    # iter-5.5.0 (B-0848): target bootstrap (zeta-install.sh Step 6.95a)
+    # runs tools/setup/install.sh on the live ISO as the zeta user. Nix-provided
+    # mise is required — upstream release tarballs are not FHS-compatible on NixOS.
+    mise
     # Declarative disk partitioning — used by the cookie-cutter
     # disko-shapes/ modules. Pre-staged on the ISO so installs
     # don't need network access just to fetch disko itself.

--- a/full-ai-cluster/usb-nixos-installer/zeta-install.sh
+++ b/full-ai-cluster/usb-nixos-installer/zeta-install.sh
@@ -1501,9 +1501,11 @@ if [ -d "$ZETA_HOME" ]; then
   # an interactive dev shell.
   if [ -d "$ZETA_HOME/Zeta" ]; then
     echo "[iter-5.5.0] running tools/setup/install.sh (target runtime + declarative agent CLI bootstrap)..."
+    ZETA_TARGET_PATH="/run/current-system/sw/bin:/run/current-system/sw/sbin:${ZETA_HOME}/.local/bin:/usr/bin:/bin"
     sudo -u "#$ZETA_UID" \
       HOME="$ZETA_HOME" \
       BUN_INSTALL="$ZETA_HOME/.bun" \
+      PATH="$ZETA_TARGET_PATH" \
       ZETA_INSTALL_NIXOS_MODE=installed \
       ZETA_INSTALL_FULL=1 \
       bash -c "cd $ZETA_HOME/Zeta && ZETA_HOST_TIER=full tools/setup/install.sh" 2>&1 | tail -10 || \
@@ -1593,7 +1595,7 @@ if [ -d "$ZETA_HOME" ]; then
     # See SECURITY block above for full lifecycle.
     ZETA_CREDS_PASSPHRASE="$ZETA_CREDS_PASSPHRASE_VAL" sudo --preserve-env=ZETA_CREDS_PASSPHRASE -u "#$ZETA_UID" \
       HOME="$ZETA_HOME" BUN_INSTALL="$ZETA_HOME/.bun" \
-      bash -c "set -o pipefail; eval \"\$(mise activate bash 2>/dev/null || true)\"; cd '$ZETA_HOME/Zeta' && bun tools/installer/zeta-creds-picker.ts --usb-uuid '$USB_UUID' --output /mnt/boot/zeta-creds.enc --passphrase-env ZETA_CREDS_PASSPHRASE" || \
+      bash -c "set -o pipefail; export PATH='/run/current-system/sw/bin:/run/current-system/sw/sbin:${ZETA_HOME}/.local/share/mise/shims:${ZETA_HOME}/.bun/bin:/usr/bin:/bin'; eval \"\$(mise activate bash 2>/dev/null || true)\"; cd '$ZETA_HOME/Zeta' && bun tools/installer/zeta-creds-picker.ts --usb-uuid '$USB_UUID' --output /mnt/boot/zeta-creds.enc --passphrase-env ZETA_CREDS_PASSPHRASE" || \
         echo "[iter-5.5.0]   WARN: picker exited non-zero; cred-blob may be partial"
   else
     echo "[iter-5.5.0]   SKIP 6.95-picker: $PICKER_SKIP_REASON"

--- a/src/Core.TypeScript/ci/dockerfiles/nixos-install-sh-test/Dockerfile
+++ b/src/Core.TypeScript/ci/dockerfiles/nixos-install-sh-test/Dockerfile
@@ -46,9 +46,9 @@ RUN touch /etc/NIXOS
 # its own process; Docker doesn't persist exports across RUN layers;
 # without this ENV, the validation RUNs below would fail because
 # mise/bun aren't on PATH in the fresh layer's shell). install.sh
-# on NixOS uses nix-provided mise (linux.sh); shims land at
-# ~/.local/share/mise/shims/; bun --global lands at ~/.bun/bin/.
-ENV PATH=/root/.bun/bin:/root/.local/share/mise/shims:/nix/var/nix/profiles/default/bin:/root/.local/bin:/usr/local/bin:/usr/bin:/bin
+# installs mise to ~/.local/bin/mise and shims to ~/.local/share/mise/
+# shims/; bun --global lands at ~/.bun/bin/.
+ENV PATH=/root/.bun/bin:/root/.local/share/mise/shims:/root/.local/bin:/nix/var/nix/profiles/default/bin:/usr/local/bin:/usr/bin:/bin
 
 # Install the NixOS userspace commands install.sh invokes plus the runtime
 # libraries expected by the dynamically linked .mise.toml toolchain downloads
@@ -57,7 +57,6 @@ ENV PATH=/root/.bun/bin:/root/.local/share/mise/shims:/nix/var/nix/profiles/defa
 RUN set -eu; \
     nix-env -iA \
     nixpkgs.nix \
-    nixpkgs.mise \
     nixpkgs.bash \
     nixpkgs.coreutils \
     nixpkgs.findutils \

--- a/src/Core.TypeScript/ci/dockerfiles/nixos-install-sh-test/Dockerfile
+++ b/src/Core.TypeScript/ci/dockerfiles/nixos-install-sh-test/Dockerfile
@@ -46,9 +46,9 @@ RUN touch /etc/NIXOS
 # its own process; Docker doesn't persist exports across RUN layers;
 # without this ENV, the validation RUNs below would fail because
 # mise/bun aren't on PATH in the fresh layer's shell). install.sh
-# installs mise to ~/.local/bin/mise and shims to ~/.local/share/mise/
-# shims/; bun --global lands at ~/.bun/bin/.
-ENV PATH=/root/.bun/bin:/root/.local/share/mise/shims:/root/.local/bin:/nix/var/nix/profiles/default/bin:/usr/local/bin:/usr/bin:/bin
+# on NixOS uses nix-provided mise (linux.sh); shims land at
+# ~/.local/share/mise/shims/; bun --global lands at ~/.bun/bin/.
+ENV PATH=/root/.bun/bin:/root/.local/share/mise/shims:/nix/var/nix/profiles/default/bin:/root/.local/bin:/usr/local/bin:/usr/bin:/bin
 
 # Install the NixOS userspace commands install.sh invokes plus the runtime
 # libraries expected by the dynamically linked .mise.toml toolchain downloads
@@ -57,6 +57,7 @@ ENV PATH=/root/.bun/bin:/root/.local/share/mise/shims:/root/.local/bin:/nix/var/
 RUN set -eu; \
     nix-env -iA \
     nixpkgs.nix \
+    nixpkgs.mise \
     nixpkgs.bash \
     nixpkgs.coreutils \
     nixpkgs.findutils \

--- a/tools/setup/common/mise.sh
+++ b/tools/setup/common/mise.sh
@@ -11,6 +11,11 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 
+# Disable python GitHub artifact attestation checks (CI rate-limit + nixpkgs
+# mise 2025.11.x on cluster nodes cannot parse python.github_attestations in
+# .mise.toml — v2026.3.18+ only). Env works on all supported mise versions.
+export MISE_PYTHON_GITHUB_ATTESTATIONS="${MISE_PYTHON_GITHUB_ATTESTATIONS:-0}"
+
 if [ ! -f "$REPO_ROOT/.mise.toml" ]; then
   echo "error: no .mise.toml at repo root"
   exit 1

--- a/tools/setup/common/shellenv.sh
+++ b/tools/setup/common/shellenv.sh
@@ -94,6 +94,7 @@ mkdir -p "$ZETA_ENV_DIR"
   # Ubuntu + macOS matrix. If CI surfaces a step that needs
   # shims, flip back to `mise activate bash --shims` and file
   # a DEBT entry explaining which step failed and why.
+  echo "export MISE_PYTHON_GITHUB_ATTESTATIONS=\"\${MISE_PYTHON_GITHUB_ATTESTATIONS:-0}\""
   if command -v mise >/dev/null 2>&1; then
     echo "if [ -n \"\${ZSH_VERSION:-}\" ]; then"
     echo "  eval \"\$(mise activate zsh)\""

--- a/tools/setup/install.ps1
+++ b/tools/setup/install.ps1
@@ -239,6 +239,9 @@ try {
     $env:MISE_ENV = 'full'
     Invoke-Tool { mise trust "$RepoRoot\.mise.full.toml" } 'mise trust (.mise.full.toml)'
   }
+  # Parity with tools/setup/common/mise.sh: old NixOS mise cannot parse
+  # python.github_attestations in .mise.toml (v2026.3.18+ only); env works everywhere.
+  if (-not $env:MISE_PYTHON_GITHUB_ATTESTATIONS) { $env:MISE_PYTHON_GITHUB_ATTESTATIONS = '0' }
   Invoke-Tool { mise install } 'mise install'
 } finally { Pop-Location }
 

--- a/tools/setup/linux.sh
+++ b/tools/setup/linux.sh
@@ -168,16 +168,22 @@ fi
 # MISE_VERSION + both MISE_SHA256_* values together — they form a
 # content-pin set.
 # Skipped on real NixOS — tarball mise is not FHS-compatible; use system mise.
-# B-0849 docker harness (/.dockerenv + glibc loader) still uses the tarball.
+# B-0849 docker harness wires /lib64/ld-linux-*.so.* so tarball mise works there.
+linux_sh_nixos_tarball_mise_allowed() {
+  [ -f /.dockerenv ] \
+    || [ -e /lib64/ld-linux-x86-64.so.2 ] \
+    || [ -e /lib/ld-linux-aarch64.so.1 ]
+}
+
 if ! command -v mise >/dev/null 2>&1; then
-  if [ "$IS_NIXOS" = 1 ] && [ ! -f /.dockerenv ]; then
+  if [ "$IS_NIXOS" = 1 ] && ! linux_sh_nixos_tarball_mise_allowed; then
     echo "error: mise not found on PATH on NixOS" >&2
     echo "  declare mise in environment.systemPackages (installer ISO + common.nix)" >&2
     echo "  and ensure /run/current-system/sw/bin is on PATH during target bootstrap" >&2
     exit 1
   fi
-  if [ "$IS_NIXOS" = 1 ] && [ -f /.dockerenv ]; then
-    echo "↓ NixOS docker harness: installing mise from pinned tarball (FHS glibc loader)..."
+  if [ "$IS_NIXOS" = 1 ]; then
+    echo "↓ NixOS (docker/FHS): installing mise from pinned tarball..."
   else
     echo "↓ installing mise from pinned release tarball..."
   fi

--- a/tools/setup/linux.sh
+++ b/tools/setup/linux.sh
@@ -135,6 +135,31 @@ fi
 echo "✓ apt packages up to date"
 
 # ── 2. mise ─────────────────────────────────────────────────────────
+# NixOS: use declarative system mise (common.nix / installer ISO). Upstream
+# release tarballs are glibc-linked and fail with "cannot execute: required
+# file not found" when copied to ~/.local/bin (observed iter-5.5.0 QEMU CI +
+# zeta-install.sh Step 6.95a on the live ISO).
+linux_sh_prepend_nixos_mise() {
+  for _bin_dir in \
+      /run/current-system/sw/bin \
+      "${HOME}/.nix-profile/bin" \
+      /nix/var/nix/profiles/default/bin; do
+    if [ -x "${_bin_dir}/mise" ]; then
+      export PATH="${_bin_dir}:${PATH}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+if [ "$IS_NIXOS" = 1 ]; then
+  linux_sh_prepend_nixos_mise || true
+  if [ -f "${HOME}/.local/bin/mise" ] && ! "${HOME}/.local/bin/mise" --version >/dev/null 2>&1; then
+    echo "↻ removing broken tarball mise from ${HOME}/.local/bin/mise (not executable on NixOS)"
+    rm -f "${HOME}/.local/bin/mise"
+  fi
+fi
+
 # Pinned to a specific mise release tarball + verified SHA256 (per
 # arch). Resolves Scorecard PinnedDependenciesID #16 (downloadThenRun
 # not pinned by hash). The official `curl mise.run | sh` installer
@@ -142,7 +167,14 @@ echo "✓ apt packages up to date"
 # flags. Bumping: pull /repos/jdx/mise/releases/latest, update
 # MISE_VERSION + both MISE_SHA256_* values together — they form a
 # content-pin set.
+# Skipped on NixOS — tarball mise is not FHS-compatible; use system mise.
 if ! command -v mise >/dev/null 2>&1; then
+  if [ "$IS_NIXOS" = 1 ]; then
+    echo "error: mise not found on PATH on NixOS" >&2
+    echo "  declare mise in environment.systemPackages (installer ISO + common.nix)" >&2
+    echo "  and ensure /run/current-system/sw/bin is on PATH during target bootstrap" >&2
+    exit 1
+  fi
   echo "↓ installing mise from pinned release tarball..."
   MISE_VERSION="v2026.4.24"
   MISE_SHA256_X64="de2f924940c29b8983035833e2fb3a50092c5794562ca0dcd0cf87b40cae2c58"

--- a/tools/setup/linux.sh
+++ b/tools/setup/linux.sh
@@ -167,15 +167,20 @@ fi
 # flags. Bumping: pull /repos/jdx/mise/releases/latest, update
 # MISE_VERSION + both MISE_SHA256_* values together — they form a
 # content-pin set.
-# Skipped on NixOS — tarball mise is not FHS-compatible; use system mise.
+# Skipped on real NixOS — tarball mise is not FHS-compatible; use system mise.
+# B-0849 docker harness (/.dockerenv + glibc loader) still uses the tarball.
 if ! command -v mise >/dev/null 2>&1; then
-  if [ "$IS_NIXOS" = 1 ]; then
+  if [ "$IS_NIXOS" = 1 ] && [ ! -f /.dockerenv ]; then
     echo "error: mise not found on PATH on NixOS" >&2
     echo "  declare mise in environment.systemPackages (installer ISO + common.nix)" >&2
     echo "  and ensure /run/current-system/sw/bin is on PATH during target bootstrap" >&2
     exit 1
   fi
-  echo "↓ installing mise from pinned release tarball..."
+  if [ "$IS_NIXOS" = 1 ] && [ -f /.dockerenv ]; then
+    echo "↓ NixOS docker harness: installing mise from pinned tarball (FHS glibc loader)..."
+  else
+    echo "↓ installing mise from pinned release tarball..."
+  fi
   MISE_VERSION="v2026.4.24"
   MISE_SHA256_X64="de2f924940c29b8983035833e2fb3a50092c5794562ca0dcd0cf87b40cae2c58"
   MISE_SHA256_ARM64="cf5f4899c3f1b56239d2eedf173c68c47b7db95400c4fa1b61e943dee4965727"


### PR DESCRIPTION
## Summary
- Promote QEMU phase-3 (`QEMU_FIRST_SESSION_PHASE3=1`) to scenario 2 on every `build-ai-cluster-iso` **push** — society proof [run 27862943618](https://github.com/Lucent-Financial-Group/Zeta/actions/runs/27862943618) green
- Fix NixOS mise bootstrap during `zeta-install.sh` Step 6.95a: upstream tarball mise fails on NixOS (`cannot execute: required file not found`); use nixpkgs `mise` instead
- Installer ISO now ships `mise`; target bootstrap passes `/run/current-system/sw/bin` on PATH
- First-login recovery: lazy `mise install` in `zeta-user-paths.sh` if bun shim missing; first-session profile.d falls back to `~/.bun/bin` or nixpkgs `bun`
- Trajectory docs updated (S4 complete, S6 UX co-design next)

## Test plan
- [ ] `nix flake check --no-build` (local)
- [ ] `docker-nixos-install-sh-test` workflow
- [ ] `build-ai-cluster-iso` scenario 2 with phase-3 markers on push


Made with [Cursor](https://cursor.com)