### PR TITLE
feat(core): resume darkhall heat board snapshots

### DIFF
--- a/docs/handoffs/2026-06-20-alexa-to-math-team-phase-d-gen-gen-research-discharge.md
+++ b/docs/handoffs/2026-06-20-alexa-to-math-team-phase-d-gen-gen-research-discharge.md
@@ -100,6 +100,7 @@ Refined targets T1/T2/bridge + revised priority list in the routing doc's UPDATE
 | Bridge | Reflection-grade ↔ CD-grade functor (open §B, off critical path) | Lean | L (research) |
 
 **Key decisions:**
+
 - Homoiconic IR (same schema, different dimension) — NOT a separate meta-IR tier
 - Concrete N=4 base case already proven (AdinkraCode.Tests + CayleyDicksonAdinkra.Tests) — no rework
 - The ECC self-correction forces fixpoint convergence (generation + drift-correction are dual) — must be discharged, not assumed

--- a/src/Core/DarkHallScheduler.fs
+++ b/src/Core/DarkHallScheduler.fs
@@ -35,6 +35,7 @@ module DarkHallScheduler =
         | StatePointerMismatch of expectedPrefix: string * actual: string
         | ResumeTickOverflow of nextLap: int * ticksPerLap: int
         | SnapshotLapMismatch of expected: int * actual: int
+        | SnapshotTickMismatch of expected: int * actual: int
         | SnapshotMissing of pointer: string
         | SnapshotStoreRejected of pointer: string * reason: string
 
@@ -444,6 +445,8 @@ module DarkHallScheduler =
                     | Ok start ->
                         if start.CompletedLaps <> admission.Token.NextLap then
                             return Error(HeatBoardContinuationFeedback.SnapshotLapMismatch(admission.Token.NextLap, start.CompletedLaps))
+                        elif start.CompletedTicks <> admission.ResumeBaseTick then
+                            return Error(HeatBoardContinuationFeedback.SnapshotTickMismatch(admission.ResumeBaseTick, start.CompletedTicks))
                         else
                             let resumedSource = resumeHeatBoardSource admission interruptSource
 

--- a/src/Core/DarkHallScheduler.fs
+++ b/src/Core/DarkHallScheduler.fs
@@ -213,9 +213,16 @@ module DarkHallScheduler =
         =
         task {
             let handler = roomTickHandler name matches sourceName sink requestFor choose
-            let measure = renderHeatBoardForState (uint64 seed)
+            let mutable lapBoundary = start.CompletedLaps
+            let mutable cutState = start
+            let measure state =
+                lapBoundary <- lapBoundary + 1
+                cutState <- { state with CompletedLaps = lapBoundary }
+                renderHeatBoardForState (uint64 seed) cutState
 
-            let! outcome = SimLoop.run [ handler ] interruptSource measure cut clock budget ctx seed ticksPerLap start
+            let cutAtLap measured _state = cut measured cutState
+
+            let! outcome = SimLoop.run [ handler ] interruptSource measure cutAtLap clock budget ctx seed ticksPerLap start
             return stampCumulativeLaps start.CompletedLaps outcome
         }
 

--- a/src/Core/DarkHallScheduler.fs
+++ b/src/Core/DarkHallScheduler.fs
@@ -33,11 +33,41 @@ module DarkHallScheduler =
         | LoopIdMismatch of expected: string * actual: string
         | StatePointerMismatch of expectedPrefix: string * actual: string
         | ResumeTickOverflow of nextLap: int * ticksPerLap: int
+        | SnapshotMissing of pointer: string
+        | SnapshotStoreRejected of pointer: string * reason: string
 
     type HeatBoardContinuationAdmission =
         { Token: SimLoop.Continuation
           StatePointer: string
           ResumeBaseTick: int }
+
+    type IHeatBoardStateStore =
+        abstract WriteAsync:
+            pointer: string *
+            state: ScheduledRoomState *
+            ct: System.Threading.CancellationToken ->
+                System.Threading.Tasks.Task<Result<unit, HeatBoardContinuationFeedback>>
+
+        abstract ReadAsync:
+            pointer: string *
+            ct: System.Threading.CancellationToken ->
+                System.Threading.Tasks.Task<Result<ScheduledRoomState, HeatBoardContinuationFeedback>>
+
+    [<Sealed>]
+    type InMemoryHeatBoardStateStore() =
+        let snapshots = System.Collections.Generic.Dictionary<string, ScheduledRoomState>(System.StringComparer.Ordinal)
+        let gate = obj ()
+
+        interface IHeatBoardStateStore with
+            member _.WriteAsync(pointer, state, _ct) =
+                lock gate (fun () -> snapshots.[pointer] <- state)
+                System.Threading.Tasks.Task.FromResult(Ok())
+
+            member _.ReadAsync(pointer, _ct) =
+                match lock gate (fun () -> snapshots.TryGetValue pointer) with
+                | true, state -> System.Threading.Tasks.Task.FromResult(Ok state)
+                | false, _ ->
+                    System.Threading.Tasks.Task.FromResult(Error(HeatBoardContinuationFeedback.SnapshotMissing pointer))
 
     let initial (room: DarkHall.Room) (manifest: Chip9Capabilities.Manifest) : ScheduledRoomState =
         { Loop = RoomLoop.initial room manifest
@@ -148,6 +178,27 @@ module DarkHallScheduler =
                 return Ok next
             })
 
+    let heatBoardSimLoopFromState
+        (name: string)
+        (matches: InterruptKind -> bool)
+        (sourceName: string)
+        (sink: IHeatSink)
+        (requestFor: RoomLoop.RequestResolver)
+        (choose: Runtime.ControllerReadout -> RoomLoop.ControllerChoice)
+        (interruptSource: SoftScheduler.Source)
+        (clock: int -> int64)
+        (budget: SimLoop.Budget)
+        (ctx: IntrCtx)
+        (seed: int64)
+        (ticksPerLap: int)
+        (cut: string list -> ScheduledRoomState -> bool)
+        (start: ScheduledRoomState)
+        =
+        let handler = roomTickHandler name matches sourceName sink requestFor choose
+        let measure = renderHeatBoardForState (uint64 seed)
+
+        SimLoop.run [ handler ] interruptSource measure cut clock budget ctx seed ticksPerLap start
+
     /// Run a bounded sim -> measure -> cut loop where the measurement is the
     /// host-visible CHIP-9 heat board. This is the Dark Hall room loop shape for
     /// production and tests alike: execution stays async in `SoftScheduler`,
@@ -170,11 +221,23 @@ module DarkHallScheduler =
         (ticksPerLap: int)
         (cut: string list -> ScheduledRoomState -> bool)
         =
-        let handler = roomTickHandler name matches sourceName sink requestFor choose
-        let measure = renderHeatBoardForState (uint64 seed)
         let start = initial room manifest
 
-        SimLoop.run [ handler ] interruptSource measure cut clock budget ctx seed ticksPerLap start
+        heatBoardSimLoopFromState
+            name
+            matches
+            sourceName
+            sink
+            requestFor
+            choose
+            interruptSource
+            clock
+            budget
+            ctx
+            seed
+            ticksPerLap
+            cut
+            start
 
     let private pointerSafe (value: string) : string =
         value
@@ -222,8 +285,9 @@ module DarkHallScheduler =
     let private resumeBaseTick (nextLap: int) (ticksPerLap: int) : Result<int, HeatBoardContinuationFeedback> =
         let perLap = max 1 ticksPerLap
         let baseTick = int64 nextLap * int64 perLap
+        let lastTickInLap = baseTick + int64 perLap - 1L
 
-        if baseTick > int64 System.Int32.MaxValue then
+        if lastTickInLap > int64 System.Int32.MaxValue then
             Error(HeatBoardContinuationFeedback.ResumeTickOverflow(nextLap, perLap))
         else
             Ok(int baseTick)
@@ -264,3 +328,69 @@ module DarkHallScheduler =
         (source: SoftScheduler.Source)
         : SoftScheduler.Source =
         fun tick -> source (admission.ResumeBaseTick + tick)
+
+    let saveHeatBoardStateAsync
+        (store: IHeatBoardStateStore)
+        (loopId: string)
+        (outcome: SimLoop.Outcome<ScheduledRoomState, string list>)
+        (ct: System.Threading.CancellationToken)
+        : System.Threading.Tasks.Task<Result<string, HeatBoardContinuationFeedback>> =
+        task {
+            let pointer = heatBoardStatePointer loopId outcome
+            let! saved = store.WriteAsync(pointer, outcome.Final, ct)
+
+            return saved |> Result.map (fun () -> pointer)
+        }
+
+    /// Resume a heat-board loop from a previously saved state pointer. The token
+    /// admission and the snapshot load both stay on the typed feedback channel;
+    /// the returned `Outcome` is still one finite `SimLoop` link.
+    let resumeHeatBoardSimLoop
+        (loopId: string)
+        (store: IHeatBoardStateStore)
+        (name: string)
+        (matches: InterruptKind -> bool)
+        (sourceName: string)
+        (sink: IHeatSink)
+        (requestFor: RoomLoop.RequestResolver)
+        (choose: Runtime.ControllerReadout -> RoomLoop.ControllerChoice)
+        (interruptSource: SoftScheduler.Source)
+        (clock: int -> int64)
+        (budget: SimLoop.Budget)
+        (ctx: IntrCtx)
+        (seed: int64)
+        (ticksPerLap: int)
+        (cut: string list -> ScheduledRoomState -> bool)
+        (tokenLine: string)
+        (ct: System.Threading.CancellationToken)
+        : System.Threading.Tasks.Task<Result<SimLoop.Outcome<ScheduledRoomState, string list>, HeatBoardContinuationFeedback>> =
+        task {
+            match admitHeatBoardContinuation loopId ticksPerLap tokenLine with
+            | Error feedback -> return Error feedback
+            | Ok admission ->
+                let! loaded = store.ReadAsync(admission.StatePointer, ct)
+
+                match loaded with
+                | Error feedback -> return Error feedback
+                | Ok start ->
+                    let resumedSource = resumeHeatBoardSource admission interruptSource
+
+                    let! outcome =
+                        heatBoardSimLoopFromState
+                            name
+                            matches
+                            sourceName
+                            sink
+                            requestFor
+                            choose
+                            resumedSource
+                            clock
+                            budget
+                            ctx
+                            seed
+                            ticksPerLap
+                            cut
+                            start
+
+                    return Ok outcome
+        }

--- a/src/Core/DarkHallScheduler.fs
+++ b/src/Core/DarkHallScheduler.fs
@@ -34,6 +34,7 @@ module DarkHallScheduler =
         | LoopIdMismatch of expected: string * actual: string
         | StatePointerMismatch of expectedPrefix: string * actual: string
         | ResumeTickOverflow of nextLap: int * ticksPerLap: int
+        | SnapshotLapMismatch of expected: int * actual: int
         | SnapshotMissing of pointer: string
         | SnapshotStoreRejected of pointer: string * reason: string
 
@@ -321,6 +322,24 @@ module DarkHallScheduler =
         else
             Ok(int baseTick)
 
+    let private resumeLinkBaseTick
+        (nextLap: int)
+        (ticksPerLap: int)
+        (budget: SimLoop.Budget)
+        : Result<int, HeatBoardContinuationFeedback> =
+        let perLap = int64 (max 1 ticksPerLap)
+        let maxLaps = int64 (max 1 budget.MaxLaps)
+        let maxTicks = int64 (max 1 budget.MaxTicks)
+        let tickBoundedLaps = (maxTicks + perLap - 1L) / perLap
+        let linkLaps = min maxLaps tickBoundedLaps
+        let baseTick = int64 nextLap * perLap
+        let lastTickInLink = baseTick + linkLaps * perLap - 1L
+
+        if lastTickInLink > int64 System.Int32.MaxValue then
+            Error(HeatBoardContinuationFeedback.ResumeTickOverflow(nextLap, int perLap))
+        else
+            Ok(int baseTick)
+
     /// Admit a heat-board continuation token back through the Dark Hall boundary.
     /// Arbitrary `spawn:*` text is not authority: the token must parse, match the
     /// expected loop id, and point inside the heat-board save namespace before a
@@ -356,7 +375,13 @@ module DarkHallScheduler =
         (admission: HeatBoardContinuationAdmission)
         (source: SoftScheduler.Source)
         : SoftScheduler.Source =
-        fun tick -> source (admission.ResumeBaseTick + tick)
+        fun tick ->
+            let absoluteTick = int64 admission.ResumeBaseTick + int64 tick
+
+            if absoluteTick > int64 System.Int32.MaxValue then
+                []
+            else
+                source (int absoluteTick)
 
     let saveHeatBoardStateAsync
         (store: IHeatBoardStateStore)
@@ -397,29 +422,36 @@ module DarkHallScheduler =
             match admitHeatBoardContinuation loopId ticksPerLap tokenLine with
             | Error feedback -> return Error feedback
             | Ok admission ->
-                let! loaded = store.ReadAsync(admission.StatePointer, ct)
-
-                match loaded with
+                match resumeLinkBaseTick admission.Token.NextLap ticksPerLap budget with
                 | Error feedback -> return Error feedback
-                | Ok start ->
-                    let resumedSource = resumeHeatBoardSource admission interruptSource
+                | Ok baseTick ->
+                    let admission = { admission with ResumeBaseTick = baseTick }
+                    let! loaded = store.ReadAsync(admission.StatePointer, ct)
 
-                    let! outcome =
-                        heatBoardSimLoopFromState
-                            name
-                            matches
-                            sourceName
-                            sink
-                            requestFor
-                            choose
-                            resumedSource
-                            clock
-                            budget
-                            ctx
-                            seed
-                            ticksPerLap
-                            cut
-                            start
+                    match loaded with
+                    | Error feedback -> return Error feedback
+                    | Ok start ->
+                        if start.CompletedLaps <> admission.Token.NextLap then
+                            return Error(HeatBoardContinuationFeedback.SnapshotLapMismatch(admission.Token.NextLap, start.CompletedLaps))
+                        else
+                            let resumedSource = resumeHeatBoardSource admission interruptSource
 
-                    return Ok outcome
+                            let! outcome =
+                                heatBoardSimLoopFromState
+                                    name
+                                    matches
+                                    sourceName
+                                    sink
+                                    requestFor
+                                    choose
+                                    resumedSource
+                                    clock
+                                    budget
+                                    ctx
+                                    seed
+                                    ticksPerLap
+                                    cut
+                                    start
+
+                            return Ok outcome
         }

--- a/src/Core/DarkHallScheduler.fs
+++ b/src/Core/DarkHallScheduler.fs
@@ -24,6 +24,7 @@ module DarkHallScheduler =
     type ScheduledRoomState =
         { Loop: RoomLoop.LoopState
           CompletedTicks: int
+          CompletedLaps: int
           LastTick: RoomLoop.TickOutcome option
           HeatRowsRev: HeatBoundaryRow list }
 
@@ -72,6 +73,7 @@ module DarkHallScheduler =
     let initial (room: DarkHall.Room) (manifest: Chip9Capabilities.Manifest) : ScheduledRoomState =
         { Loop = RoomLoop.initial room manifest
           CompletedTicks = 0
+          CompletedLaps = 0
           LastTick = None
           HeatRowsRev = [] }
 
@@ -149,8 +151,22 @@ module DarkHallScheduler =
         let tick = state.CompletedTicks + 1
         { Loop = outcome.State
           CompletedTicks = tick
+          CompletedLaps = state.CompletedLaps
           LastTick = Some outcome
           HeatRowsRev = rowOfOutcome tick outcome :: state.HeatRowsRev }
+
+    let private stampCumulativeLaps
+        (startLaps: int)
+        (outcome: SimLoop.Outcome<ScheduledRoomState, string list>)
+        : SimLoop.Outcome<ScheduledRoomState, string list> =
+        let laps =
+            outcome.Laps
+            |> List.mapi (fun i lap ->
+                { lap with State = { lap.State with CompletedLaps = startLaps + i + 1 } })
+
+        let final = { outcome.Final with CompletedLaps = startLaps + List.length outcome.Laps }
+
+        { outcome with Laps = laps; Final = final }
 
     let tick
         (source: string)
@@ -194,10 +210,13 @@ module DarkHallScheduler =
         (cut: string list -> ScheduledRoomState -> bool)
         (start: ScheduledRoomState)
         =
-        let handler = roomTickHandler name matches sourceName sink requestFor choose
-        let measure = renderHeatBoardForState (uint64 seed)
+        task {
+            let handler = roomTickHandler name matches sourceName sink requestFor choose
+            let measure = renderHeatBoardForState (uint64 seed)
 
-        SimLoop.run [ handler ] interruptSource measure cut clock budget ctx seed ticksPerLap start
+            let! outcome = SimLoop.run [ handler ] interruptSource measure cut clock budget ctx seed ticksPerLap start
+            return stampCumulativeLaps start.CompletedLaps outcome
+        }
 
     /// Run a bounded sim -> measure -> cut loop where the measurement is the
     /// host-visible CHIP-9 heat board. This is the Dark Hall room loop shape for
@@ -261,7 +280,7 @@ module DarkHallScheduler =
         sprintf
             "saves/darkhall/%s/lap-%d-tick-%d.heat-board"
             (continuationLoopId loopId)
-            (List.length outcome.Laps)
+            outcome.Final.CompletedLaps
             outcome.Final.CompletedTicks
 
     let private heatBoardStatePointerPrefix (loopId: string) : string =
@@ -274,7 +293,17 @@ module DarkHallScheduler =
         (loopId: string)
         (outcome: SimLoop.Outcome<ScheduledRoomState, string list>)
         : SimLoop.Continuation option =
-        SimLoop.continueAfter (continuationLoopId loopId) (heatBoardStatePointer loopId outcome) outcome
+        match outcome.Stopped with
+        | SimLoop.Stopped.LapBudget
+        | SimLoop.Stopped.TickBudget
+        | SimLoop.Stopped.ClockBudget ->
+            Some
+                { LoopId = continuationLoopId loopId
+                  NextLap = outcome.Final.CompletedLaps
+                  TicksSpent = List.length outcome.Laps
+                  StatePointer = heatBoardStatePointer loopId outcome }
+        | SimLoop.Stopped.CutChoseClose
+        | SimLoop.Stopped.RoomError _ -> None
 
     let encodeHeatBoardContinuation
         (loopId: string)

--- a/src/Core/DarkHallScheduler.fs
+++ b/src/Core/DarkHallScheduler.fs
@@ -341,8 +341,12 @@ module DarkHallScheduler =
         let linkLaps = min maxLaps tickBoundedLaps
         let baseTick = int64 nextLap * perLap
         let lastTickInLink = baseTick + linkLaps * perLap - 1L
+        let completedLapBoundary = int64 nextLap + linkLaps
 
-        if lastTickInLink > int64 System.Int32.MaxValue then
+        if
+            lastTickInLink > int64 System.Int32.MaxValue
+            || completedLapBoundary > int64 System.Int32.MaxValue
+        then
             Error(HeatBoardContinuationFeedback.ResumeTickOverflow(nextLap, int perLap))
         else
             Ok(int baseTick)

--- a/tests/Tests.FSharp/DarkHallScheduler.Tests.fs
+++ b/tests/Tests.FSharp/DarkHallScheduler.Tests.fs
@@ -469,6 +469,81 @@ let ``saved heat board state resumes as the next finite sim loop link`` () =
     }
 
 [<Fact>]
+let ``resumed heat board cut observes cumulative lap boundaries`` () =
+    task {
+        let store = Scheduler.InMemoryHeatBoardStateStore() :> Scheduler.IHeatBoardStateStore
+        let source absoluteTick =
+            if absoluteTick >= 2 && absoluteTick <= 5 then
+                [ TimerElapsed absoluteTick ]
+            else
+                []
+
+        let! first =
+            Scheduler.heatBoardSimLoop
+                "darkhall-heat-board"
+                Arcade.room
+                Chip9Capabilities.chip8Default
+                timer
+                "darkhall-simloop"
+                (NullHeatSink() :> IHeatSink)
+                (fun _ -> None)
+                (chooseById "darkhall.edit-grammar")
+                (fun _ -> [ TimerElapsed 17 ])
+                int64
+                (budget 2)
+                (ctx ())
+                42L
+                1
+                (fun _ _ -> true)
+
+        let! pointerResult =
+            Scheduler.saveHeatBoardStateAsync
+                store
+                "darkhall-heat-board"
+                first
+                System.Threading.CancellationToken.None
+
+        match pointerResult with
+        | Error feedback -> Assert.Fail(sprintf "expected saved state pointer, got %A" feedback)
+        | Ok _ -> ()
+
+        let tokenLine =
+            match Scheduler.encodeHeatBoardContinuation "darkhall-heat-board" first with
+            | Some token -> token
+            | None ->
+                Assert.Fail "budget-stopped heat-board run should encode a continuation"
+                ""
+
+        let! resumed =
+            Scheduler.resumeHeatBoardSimLoop
+                "darkhall-heat-board"
+                store
+                "darkhall-heat-board"
+                timer
+                "darkhall-simloop"
+                (NullHeatSink() :> IHeatSink)
+                (fun _ -> None)
+                (chooseById "darkhall.edit-grammar")
+                source
+                int64
+                (budget 4)
+                (ctx ())
+                42L
+                1
+                (fun _ state -> state.CompletedLaps < 4)
+                tokenLine
+                System.Threading.CancellationToken.None
+
+        match resumed with
+        | Error feedback -> Assert.Fail(sprintf "expected resumed heat-board link, got %A" feedback)
+        | Ok outcome ->
+            Assert.Equal(SimLoop.Stopped.CutChoseClose, outcome.Stopped)
+            Assert.Equal(4, outcome.Final.CompletedLaps)
+            Assert.Equal(4, outcome.Final.CompletedTicks)
+            Assert.Equal<int list>([ 3; 4 ], outcome.Laps |> List.map (fun lap -> lap.State.CompletedLaps))
+    }
+
+[<Fact>]
 let ``resume refuses a valid continuation when the state snapshot is missing`` () =
     task {
         let missingPointer = "saves/darkhall/darkhall-heat-board/lap-2-tick-2.heat-board"

--- a/tests/Tests.FSharp/DarkHallScheduler.Tests.fs
+++ b/tests/Tests.FSharp/DarkHallScheduler.Tests.fs
@@ -33,6 +33,11 @@ let private timer =
     | TimerElapsed _ -> true
     | _ -> false
 
+let private budget maxLaps : SimLoop.Budget =
+    { MaxLaps = maxLaps
+      MaxTicks = 64
+      MaxMillis = 1_000L }
+
 [<Fact>]
 let ``heat boundary rows render as a host visible CHIP-9 board`` () =
     let row: Scheduler.HeatBoundaryRow =
@@ -312,3 +317,118 @@ let ``heat board continuation admission refuses malformed and foreign spawn toke
         Assert.Equal(System.Int32.MaxValue, nextLap)
         Assert.Equal(2, ticksPerLap)
     | other -> Assert.Fail(sprintf "expected overflow refusal, got %A" other)
+
+[<Fact>]
+let ``saved heat board state resumes as the next finite sim loop link`` () =
+    task {
+        let store = Scheduler.InMemoryHeatBoardStateStore() :> Scheduler.IHeatBoardStateStore
+        let source absoluteTick =
+            if absoluteTick = 2 || absoluteTick = 3 then
+                [ TimerElapsed absoluteTick ]
+            else
+                []
+
+        let! first =
+            Scheduler.heatBoardSimLoop
+                "darkhall-heat-board"
+                Arcade.room
+                Chip9Capabilities.chip8Default
+                timer
+                "darkhall-simloop"
+                (NullHeatSink() :> IHeatSink)
+                (fun _ -> None)
+                (chooseById "darkhall.edit-grammar")
+                (fun _ -> [ TimerElapsed 17 ])
+                int64
+                (budget 2)
+                (ctx ())
+                42L
+                1
+                (fun _ _ -> true)
+
+        Assert.Equal(SimLoop.Stopped.LapBudget, first.Stopped)
+        Assert.Equal(2, first.Final.CompletedTicks)
+
+        let! pointerResult =
+            Scheduler.saveHeatBoardStateAsync
+                store
+                "darkhall-heat-board"
+                first
+                System.Threading.CancellationToken.None
+
+        let pointer =
+            match pointerResult with
+            | Ok pointer -> pointer
+            | Error feedback ->
+                Assert.Fail(sprintf "expected saved state pointer, got %A" feedback)
+                ""
+
+        let tokenLine =
+            match Scheduler.encodeHeatBoardContinuation "darkhall-heat-board" first with
+            | Some token -> token
+            | None ->
+                Assert.Fail "budget-stopped heat-board run should encode a continuation"
+                ""
+
+        let! resumed =
+            Scheduler.resumeHeatBoardSimLoop
+                "darkhall-heat-board"
+                store
+                "darkhall-heat-board"
+                timer
+                "darkhall-simloop"
+                (NullHeatSink() :> IHeatSink)
+                (fun _ -> None)
+                (chooseById "darkhall.edit-grammar")
+                source
+                int64
+                (budget 2)
+                (ctx ())
+                42L
+                1
+                (fun _ _ -> true)
+                tokenLine
+                System.Threading.CancellationToken.None
+
+        match resumed with
+        | Error feedback -> Assert.Fail(sprintf "expected resumed heat-board link, got %A" feedback)
+        | Ok outcome ->
+            Assert.Equal(SimLoop.Stopped.LapBudget, outcome.Stopped)
+            Assert.Equal(4, outcome.Final.CompletedTicks)
+            Assert.Equal(pointer, Scheduler.heatBoardStatePointer "darkhall-heat-board" first)
+            Assert.Equal(2, outcome.Laps.Length)
+            Assert.Equal<int list>([ 3; 4 ], outcome.Laps |> List.map (fun lap -> lap.State.CompletedTicks))
+    }
+
+[<Fact>]
+let ``resume refuses a valid continuation when the state snapshot is missing`` () =
+    task {
+        let missingPointer = "saves/darkhall/darkhall-heat-board/lap-2-tick-2.heat-board"
+        let tokenLine = sprintf "spawn:darkhall-heat-board:2:2:%s" missingPointer
+        let store = Scheduler.InMemoryHeatBoardStateStore() :> Scheduler.IHeatBoardStateStore
+
+        let! resumed =
+            Scheduler.resumeHeatBoardSimLoop
+                "darkhall-heat-board"
+                store
+                "darkhall-heat-board"
+                timer
+                "darkhall-simloop"
+                (NullHeatSink() :> IHeatSink)
+                (fun _ -> None)
+                (chooseById "darkhall.edit-grammar")
+                (fun _ -> [ TimerElapsed 17 ])
+                int64
+                (budget 1)
+                (ctx ())
+                42L
+                1
+                (fun _ _ -> true)
+                tokenLine
+                System.Threading.CancellationToken.None
+
+        match resumed with
+        | Error(Scheduler.HeatBoardContinuationFeedback.SnapshotMissing pointer) ->
+            Assert.Equal(missingPointer, pointer)
+        | other -> Assert.Fail(sprintf "expected missing snapshot feedback, got %A" other)
+    }

--- a/tests/Tests.FSharp/DarkHallScheduler.Tests.fs
+++ b/tests/Tests.FSharp/DarkHallScheduler.Tests.fs
@@ -675,3 +675,37 @@ let ``resume refuses a finite link whose offset would overflow after the first l
             Assert.Equal(1, ticksPerLap)
         | other -> Assert.Fail(sprintf "expected resumed-link overflow feedback, got %A" other)
     }
+
+[<Fact>]
+let ``resume refuses a one-lap link whose completed lap would overflow`` () =
+    task {
+        let pointer = "saves/darkhall/darkhall-heat-board/lap-max.heat-board"
+        let tokenLine = sprintf "spawn:darkhall-heat-board:%d:0:%s" System.Int32.MaxValue pointer
+        let store = Scheduler.InMemoryHeatBoardStateStore() :> Scheduler.IHeatBoardStateStore
+
+        let! resumed =
+            Scheduler.resumeHeatBoardSimLoop
+                "darkhall-heat-board"
+                store
+                "darkhall-heat-board"
+                timer
+                "darkhall-simloop"
+                (NullHeatSink() :> IHeatSink)
+                (fun _ -> None)
+                (chooseById "darkhall.edit-grammar")
+                (fun _ -> [ TimerElapsed 17 ])
+                int64
+                (budget 1)
+                (ctx ())
+                42L
+                1
+                (fun _ _ -> true)
+                tokenLine
+                System.Threading.CancellationToken.None
+
+        match resumed with
+        | Error(Scheduler.HeatBoardContinuationFeedback.ResumeTickOverflow(nextLap, ticksPerLap)) ->
+            Assert.Equal(System.Int32.MaxValue, nextLap)
+            Assert.Equal(1, ticksPerLap)
+        | other -> Assert.Fail(sprintf "expected one-lap completed-lap overflow feedback, got %A" other)
+    }

--- a/tests/Tests.FSharp/DarkHallScheduler.Tests.fs
+++ b/tests/Tests.FSharp/DarkHallScheduler.Tests.fs
@@ -500,3 +500,103 @@ let ``resume refuses a valid continuation when the state snapshot is missing`` (
             Assert.Equal(missingPointer, pointer)
         | other -> Assert.Fail(sprintf "expected missing snapshot feedback, got %A" other)
     }
+
+[<Fact>]
+let ``resume refuses a token whose lap does not match the loaded snapshot`` () =
+    task {
+        let store = Scheduler.InMemoryHeatBoardStateStore() :> Scheduler.IHeatBoardStateStore
+
+        let! first =
+            Scheduler.heatBoardSimLoop
+                "darkhall-heat-board"
+                Arcade.room
+                Chip9Capabilities.chip8Default
+                timer
+                "darkhall-simloop"
+                (NullHeatSink() :> IHeatSink)
+                (fun _ -> None)
+                (chooseById "darkhall.edit-grammar")
+                (fun _ -> [ TimerElapsed 17 ])
+                int64
+                (budget 2)
+                (ctx ())
+                42L
+                1
+                (fun _ _ -> true)
+
+        let! pointerResult =
+            Scheduler.saveHeatBoardStateAsync
+                store
+                "darkhall-heat-board"
+                first
+                System.Threading.CancellationToken.None
+
+        let pointer =
+            match pointerResult with
+            | Ok pointer -> pointer
+            | Error feedback ->
+                Assert.Fail(sprintf "expected saved state pointer, got %A" feedback)
+                ""
+
+        let tokenLine = sprintf "spawn:darkhall-heat-board:4:2:%s" pointer
+
+        let! resumed =
+            Scheduler.resumeHeatBoardSimLoop
+                "darkhall-heat-board"
+                store
+                "darkhall-heat-board"
+                timer
+                "darkhall-simloop"
+                (NullHeatSink() :> IHeatSink)
+                (fun _ -> None)
+                (chooseById "darkhall.edit-grammar")
+                (fun _ -> [ TimerElapsed 17 ])
+                int64
+                (budget 2)
+                (ctx ())
+                42L
+                1
+                (fun _ _ -> true)
+                tokenLine
+                System.Threading.CancellationToken.None
+
+        match resumed with
+        | Error(Scheduler.HeatBoardContinuationFeedback.SnapshotLapMismatch(expected, actual)) ->
+            Assert.Equal(4, expected)
+            Assert.Equal(2, actual)
+        | other -> Assert.Fail(sprintf "expected snapshot lap mismatch feedback, got %A" other)
+    }
+
+[<Fact>]
+let ``resume refuses a finite link whose offset would overflow after the first lap`` () =
+    task {
+        let pointer = "saves/darkhall/darkhall-heat-board/lap-max.heat-board"
+        let tokenLine = sprintf "spawn:darkhall-heat-board:%d:0:%s" System.Int32.MaxValue pointer
+        let store = Scheduler.InMemoryHeatBoardStateStore() :> Scheduler.IHeatBoardStateStore
+
+        let! resumed =
+            Scheduler.resumeHeatBoardSimLoop
+                "darkhall-heat-board"
+                store
+                "darkhall-heat-board"
+                timer
+                "darkhall-simloop"
+                (NullHeatSink() :> IHeatSink)
+                (fun _ -> None)
+                (chooseById "darkhall.edit-grammar")
+                (fun _ -> [ TimerElapsed 17 ])
+                int64
+                (budget 2)
+                (ctx ())
+                42L
+                1
+                (fun _ _ -> true)
+                tokenLine
+                System.Threading.CancellationToken.None
+
+        match resumed with
+        | Error(Scheduler.HeatBoardContinuationFeedback.ResumeTickOverflow(nextLap, ticksPerLap)) ->
+            Assert.Equal(System.Int32.MaxValue, nextLap)
+            Assert.Equal(1, ticksPerLap)
+        | other -> Assert.Fail(sprintf "expected resumed-link overflow feedback, got %A" other)
+    }

--- a/tests/Tests.FSharp/DarkHallScheduler.Tests.fs
+++ b/tests/Tests.FSharp/DarkHallScheduler.Tests.fs
@@ -250,6 +250,7 @@ let ``budget stopped heat board sim loop mints a continuation token`` () =
 
         Assert.Equal(SimLoop.Stopped.LapBudget, outcome.Stopped)
         Assert.Equal(2, outcome.Final.CompletedTicks)
+        Assert.Equal(2, outcome.Final.CompletedLaps)
 
         let expectedPointer = "saves/darkhall/darkhall-heat-board/lap-2-tick-2.heat-board"
         Assert.Equal(expectedPointer, Scheduler.heatBoardStatePointer "darkhall-heat-board" outcome)
@@ -323,7 +324,7 @@ let ``saved heat board state resumes as the next finite sim loop link`` () =
     task {
         let store = Scheduler.InMemoryHeatBoardStateStore() :> Scheduler.IHeatBoardStateStore
         let source absoluteTick =
-            if absoluteTick = 2 || absoluteTick = 3 then
+            if absoluteTick >= 2 && absoluteTick <= 5 then
                 [ TimerElapsed absoluteTick ]
             else
                 []
@@ -348,6 +349,7 @@ let ``saved heat board state resumes as the next finite sim loop link`` () =
 
         Assert.Equal(SimLoop.Stopped.LapBudget, first.Stopped)
         Assert.Equal(2, first.Final.CompletedTicks)
+        Assert.Equal(2, first.Final.CompletedLaps)
 
         let! pointerResult =
             Scheduler.saveHeatBoardStateAsync
@@ -390,14 +392,80 @@ let ``saved heat board state resumes as the next finite sim loop link`` () =
                 tokenLine
                 System.Threading.CancellationToken.None
 
-        match resumed with
-        | Error feedback -> Assert.Fail(sprintf "expected resumed heat-board link, got %A" feedback)
+        let second =
+            match resumed with
+            | Error feedback ->
+                Assert.Fail(sprintf "expected resumed heat-board link, got %A" feedback)
+                Unchecked.defaultof<_>
+            | Ok outcome ->
+                Assert.Equal(SimLoop.Stopped.LapBudget, outcome.Stopped)
+                Assert.Equal(4, outcome.Final.CompletedTicks)
+                Assert.Equal(4, outcome.Final.CompletedLaps)
+                Assert.Equal(pointer, Scheduler.heatBoardStatePointer "darkhall-heat-board" first)
+                Assert.Equal(2, outcome.Laps.Length)
+                Assert.Equal<int list>([ 3; 4 ], outcome.Laps |> List.map (fun lap -> lap.State.CompletedTicks))
+                Assert.Equal<int list>([ 3; 4 ], outcome.Laps |> List.map (fun lap -> lap.State.CompletedLaps))
+                outcome
+
+        let! secondPointerResult =
+            Scheduler.saveHeatBoardStateAsync
+                store
+                "darkhall-heat-board"
+                second
+                System.Threading.CancellationToken.None
+
+        let secondPointer =
+            match secondPointerResult with
+            | Ok pointer -> pointer
+            | Error feedback ->
+                Assert.Fail(sprintf "expected saved second state pointer, got %A" feedback)
+                ""
+
+        Assert.Equal("saves/darkhall/darkhall-heat-board/lap-4-tick-4.heat-board", secondPointer)
+
+        let secondTokenLine =
+            match Scheduler.encodeHeatBoardContinuation "darkhall-heat-board" second with
+            | Some token -> token
+            | None ->
+                Assert.Fail "second budget-stopped heat-board run should encode a continuation"
+                ""
+
+        match SimLoop.parseContinuation secondTokenLine with
+        | Some token ->
+            Assert.Equal(4, token.NextLap)
+            Assert.Equal(2, token.TicksSpent)
+            Assert.Equal(secondPointer, token.StatePointer)
+        | None -> Assert.Fail(sprintf "expected parseable second continuation, got %s" secondTokenLine)
+
+        let! third =
+            Scheduler.resumeHeatBoardSimLoop
+                "darkhall-heat-board"
+                store
+                "darkhall-heat-board"
+                timer
+                "darkhall-simloop"
+                (NullHeatSink() :> IHeatSink)
+                (fun _ -> None)
+                (chooseById "darkhall.edit-grammar")
+                source
+                int64
+                (budget 2)
+                (ctx ())
+                42L
+                1
+                (fun _ _ -> true)
+                secondTokenLine
+                System.Threading.CancellationToken.None
+
+        match third with
+        | Error feedback -> Assert.Fail(sprintf "expected second resumed heat-board link, got %A" feedback)
         | Ok outcome ->
             Assert.Equal(SimLoop.Stopped.LapBudget, outcome.Stopped)
-            Assert.Equal(4, outcome.Final.CompletedTicks)
-            Assert.Equal(pointer, Scheduler.heatBoardStatePointer "darkhall-heat-board" first)
+            Assert.Equal(6, outcome.Final.CompletedTicks)
+            Assert.Equal(6, outcome.Final.CompletedLaps)
             Assert.Equal(2, outcome.Laps.Length)
-            Assert.Equal<int list>([ 3; 4 ], outcome.Laps |> List.map (fun lap -> lap.State.CompletedTicks))
+            Assert.Equal<int list>([ 5; 6 ], outcome.Laps |> List.map (fun lap -> lap.State.CompletedTicks))
+            Assert.Equal<int list>([ 5; 6 ], outcome.Laps |> List.map (fun lap -> lap.State.CompletedLaps))
     }
 
 [<Fact>]

--- a/tests/Tests.FSharp/DarkHallScheduler.Tests.fs
+++ b/tests/Tests.FSharp/DarkHallScheduler.Tests.fs
@@ -643,6 +643,72 @@ let ``resume refuses a token whose lap does not match the loaded snapshot`` () =
     }
 
 [<Fact>]
+let ``resume refuses a token whose tick boundary does not match the loaded snapshot`` () =
+    task {
+        let store = Scheduler.InMemoryHeatBoardStateStore() :> Scheduler.IHeatBoardStateStore
+
+        let! first =
+            Scheduler.heatBoardSimLoop
+                "darkhall-heat-board"
+                Arcade.room
+                Chip9Capabilities.chip8Default
+                timer
+                "darkhall-simloop"
+                (NullHeatSink() :> IHeatSink)
+                (fun _ -> None)
+                (chooseById "darkhall.edit-grammar")
+                (fun _ -> [ TimerElapsed 17 ])
+                int64
+                (budget 2)
+                (ctx ())
+                42L
+                2
+                (fun _ _ -> true)
+
+        let! pointerResult =
+            Scheduler.saveHeatBoardStateAsync
+                store
+                "darkhall-heat-board"
+                first
+                System.Threading.CancellationToken.None
+
+        let pointer =
+            match pointerResult with
+            | Ok pointer -> pointer
+            | Error feedback ->
+                Assert.Fail(sprintf "expected saved state pointer, got %A" feedback)
+                ""
+
+        let tokenLine = sprintf "spawn:darkhall-heat-board:2:2:%s" pointer
+
+        let! resumed =
+            Scheduler.resumeHeatBoardSimLoop
+                "darkhall-heat-board"
+                store
+                "darkhall-heat-board"
+                timer
+                "darkhall-simloop"
+                (NullHeatSink() :> IHeatSink)
+                (fun _ -> None)
+                (chooseById "darkhall.edit-grammar")
+                (fun _ -> [ TimerElapsed 17 ])
+                int64
+                (budget 1)
+                (ctx ())
+                42L
+                1
+                (fun _ _ -> true)
+                tokenLine
+                System.Threading.CancellationToken.None
+
+        match resumed with
+        | Error(Scheduler.HeatBoardContinuationFeedback.SnapshotTickMismatch(expected, actual)) ->
+            Assert.Equal(2, expected)
+            Assert.Equal(4, actual)
+        | other -> Assert.Fail(sprintf "expected snapshot tick mismatch feedback, got %A" other)
+    }
+
+[<Fact>]
 let ``resume refuses a finite link whose offset would overflow after the first lap`` () =
     task {
         let pointer = "saves/darkhall/darkhall-heat-board/lap-max.heat-board"

--- a/tests/cross-verification/zeta-ir-v1/cross-verify.ts
+++ b/tests/cross-verification/zeta-ir-v1/cross-verify.ts
@@ -44,6 +44,18 @@ const known: readonly Ir[] = [
       { op: "xorshr", s: "16" },
     ],
   },
+  {
+    generator: "hash.fmix64",
+    version: 1,
+    width: 64,
+    ops: [
+      { op: "xorshr", s: "33" },
+      { op: "mul", k: "-49064778989728563" },
+      { op: "xorshr", s: "33" },
+      { op: "mul", k: "-4265267296055464877" },
+      { op: "xorshr", s: "33" },
+    ],
+  },
 ];
 
 function opJson(op: Op): string {


### PR DESCRIPTION
## Summary
- add a source-owned `IHeatBoardStateStore` boundary and in-memory reference implementation
- add save/load helpers so a heat-board continuation can load its saved `ScheduledRoomState` and run the next bounded SimLoop link
- keep missing snapshots, bad tokens, foreign loop ids, bad namespaces, and resume tick overflow on `HeatBoardContinuationFeedback`
- tighten resume admission so the full next lap fits in `int` tick space before offsetting the host interrupt source

## Validation
- dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter FullyQualifiedName~DarkHallSchedulerTests
- dotnet format --verify-no-changes
- dotnet build -c Release
- dotnet test Zeta.sln -c Release
- bun run preflight:quick

Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: Codex
Agent-Model: gpt-5.5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: not-implied-by-credential
Human-Review-Evidence: none
Action-Mode: human-directed
Task: none
Co-Authored-By: Codex <noreply@openai.com>