### PR TITLE
feat(core): add modulo gset heat policy

### DIFF
--- a/src/Core/BoundedGSet.fs
+++ b/src/Core/BoundedGSet.fs
@@ -210,3 +210,216 @@ module BoundedGSet =
                           Admission = admission
                           Heat = heatOf (difference before after) }
         }
+
+
+/// How a modulo GSet projection handles two distinct values that map to the
+/// same finite slot.
+[<RequireQualifiedAccess>]
+type ModuloGSetCollisionPolicy =
+    /// Preserve the existing occupant and backpressure the newcomer.
+    | RejectCollision
+    /// Replace the existing occupant and emit the evicted value as heat.
+    | ReplaceExisting
+
+/// Construction and admission feedback for modulo GSet views.
+[<RequireQualifiedAccess>]
+type ModuloGSetError =
+    | NonPositiveSlots of int
+
+/// A deterministic modulo-slot bound for a GSet projection.
+type ModuloGSetConfig =
+    { Slots: int
+      CollisionPolicy: ModuloGSetCollisionPolicy }
+
+/// Admission result for adding one value to a modulo GSet view.
+[<RequireQualifiedAccess>]
+type ModuloGSetAdmission =
+    | Admitted
+    | AlreadyPresent
+    | Replaced
+    | RejectedByCollision
+
+/// Result of projecting arbitrary input into a modulo GSet view.
+type ModuloGSetProjectionResult<'T when 'T : comparison> =
+    { State: ModuloGSet<'T>
+      Heat: BoundedGSetHeat<'T>
+      Rejected: int }
+
+/// Result of a single modulo add.
+and ModuloGSetAddResult<'T when 'T : comparison> =
+    { State: ModuloGSet<'T>
+      Admission: ModuloGSetAdmission
+      Slot: int
+      Heat: BoundedGSetHeat<'T> }
+
+/// A finite modulo-slot projection of a grow-only set.
+///
+/// This stores at most one materialized value per slot. The caller owns the
+/// slot function, which keeps domain-specific ordering/hash choices outside the
+/// core type and makes the budget policy explicit at the call site.
+and ModuloGSet<'T when 'T : comparison> =
+    private
+        { config: ModuloGSetConfig
+          slots: ImmutableSortedDictionary<int, 'T> }
+
+    member this.Config = this.config
+    member this.Slots = this.config.Slots
+    member this.CollisionPolicy = this.config.CollisionPolicy
+    member this.Count = this.slots.Count
+    member this.IsSaturated = this.Count >= this.config.Slots
+
+[<RequireQualifiedAccess>]
+module ModuloGSet =
+
+    let private validate (config: ModuloGSetConfig) : Result<ModuloGSetConfig, ModuloGSetError> =
+        if config.Slots <= 0 then
+            Error(ModuloGSetError.NonPositiveSlots config.Slots)
+        else
+            Ok config
+
+    let private normalizeSlot (slots: int) (rawSlot: int64) : int =
+        let modulus = int64 slots
+        let remainder = rawSlot % modulus
+        if remainder < 0L then
+            int (remainder + modulus)
+        else
+            int remainder
+
+    let emptyHeat<'T when 'T : comparison> : BoundedGSetHeat<'T> =
+        BoundedGSet.emptyHeat<'T>
+
+    let private heatOfOne (value: 'T) : BoundedGSetHeat<'T> =
+        { Forgotten = GSet.singleton value
+          Units = 1 }
+
+    let private combineHeat (left: BoundedGSetHeat<'T>) (right: BoundedGSetHeat<'T>) : BoundedGSetHeat<'T> =
+        { Forgotten = GSet.union left.Forgotten right.Forgotten
+          Units = left.Units + right.Units }
+
+    /// Build an empty modulo-slot view. Invalid slot counts stay on the
+    /// feedback channel.
+    let empty<'T when 'T : comparison> (config: ModuloGSetConfig) : Result<ModuloGSet<'T>, ModuloGSetError> =
+        result {
+            let! valid = validate config
+
+            return
+                { config = valid
+                  slots = ImmutableSortedDictionary<int, 'T>.Empty }
+        }
+
+    /// The current finite exterior view, forgetting slot placement.
+    let toGSet (modulo: ModuloGSet<'T>) : GSet<'T> =
+        modulo.slots.Values |> GSet.ofSeq
+
+    /// The current finite exterior view in canonical GSet order.
+    let toList (modulo: ModuloGSet<'T>) : 'T list =
+        modulo |> toGSet |> GSet.toList
+
+    /// Slot occupants in deterministic ascending-slot order.
+    let toSlotList (modulo: ModuloGSet<'T>) : (int * 'T) list =
+        modulo.slots
+        |> Seq.map (fun kvp -> kvp.Key, kvp.Value)
+        |> Seq.toList
+
+    let count (modulo: ModuloGSet<'T>) : int =
+        modulo.Count
+
+    let contains (value: 'T) (modulo: ModuloGSet<'T>) : bool =
+        modulo.slots.Values |> Seq.exists ((=) value)
+
+    /// Add one value using an explicit raw slot. The slot is normalized modulo
+    /// the configured slot count, so negative or oversized raw slots stay
+    /// deterministic instead of throwing.
+    let addWithSlot
+        (rawSlot: int64)
+        (value: 'T)
+        (modulo: ModuloGSet<'T>)
+        : Result<ModuloGSetAddResult<'T>, ModuloGSetError> =
+        result {
+            let! valid = validate modulo.Config
+            let slot = normalizeSlot valid.Slots rawSlot
+
+            match modulo.slots.TryGetValue slot with
+            | false, _ ->
+                return
+                    { State =
+                        { config = valid
+                          slots = modulo.slots.SetItem(slot, value) }
+                      Admission = ModuloGSetAdmission.Admitted
+                      Slot = slot
+                      Heat = emptyHeat }
+            | true, existing when existing = value ->
+                return
+                    { State = modulo
+                      Admission = ModuloGSetAdmission.AlreadyPresent
+                      Slot = slot
+                      Heat = emptyHeat }
+            | true, existing ->
+                match valid.CollisionPolicy with
+                | ModuloGSetCollisionPolicy.RejectCollision ->
+                    return
+                        { State = modulo
+                          Admission = ModuloGSetAdmission.RejectedByCollision
+                          Slot = slot
+                          Heat = emptyHeat }
+                | ModuloGSetCollisionPolicy.ReplaceExisting ->
+                    return
+                        { State =
+                            { config = valid
+                              slots = modulo.slots.SetItem(slot, value) }
+                          Admission = ModuloGSetAdmission.Replaced
+                          Slot = slot
+                          Heat = heatOfOne existing }
+        }
+
+    /// Add one value using a caller-owned slot function.
+    let add
+        (slotOf: 'T -> int64)
+        (value: 'T)
+        (modulo: ModuloGSet<'T>)
+        : Result<ModuloGSetAddResult<'T>, ModuloGSetError> =
+        addWithSlot (slotOf value) value modulo
+
+    /// Build a modulo view from stable input order.
+    let ofSeq
+        (slotOf: 'T -> int64)
+        (config: ModuloGSetConfig)
+        (values: seq<'T>)
+        : Result<ModuloGSetProjectionResult<'T>, ModuloGSetError> =
+        match empty config with
+        | Error e -> Error e
+        | Ok state ->
+            use enumerator = values.GetEnumerator()
+            let mutable current = state
+            let mutable heat = emptyHeat
+            let mutable rejected = 0
+            let mutable error: ModuloGSetError option = None
+
+            while error.IsNone && enumerator.MoveNext() do
+                match add slotOf enumerator.Current current with
+                | Error e -> error <- Some e
+                | Ok added ->
+                    current <- added.State
+                    heat <- combineHeat heat added.Heat
+
+                    match added.Admission with
+                    | ModuloGSetAdmission.RejectedByCollision -> rejected <- rejected + 1
+                    | ModuloGSetAdmission.Admitted
+                    | ModuloGSetAdmission.AlreadyPresent
+                    | ModuloGSetAdmission.Replaced -> ()
+
+            match error with
+            | Some e -> Error e
+            | None ->
+                Ok
+                    { State = current
+                      Heat = heat
+                      Rejected = rejected }
+
+    /// Build a modulo view from a canonical GSet order.
+    let ofGSet
+        (slotOf: 'T -> int64)
+        (config: ModuloGSetConfig)
+        (values: GSet<'T>)
+        : Result<ModuloGSetProjectionResult<'T>, ModuloGSetError> =
+        values |> GSet.toSeq |> ofSeq slotOf config

--- a/tests/Tests.FSharp/Algebra/BoundedGSet.Tests.fs
+++ b/tests/Tests.FSharp/Algebra/BoundedGSet.Tests.fs
@@ -16,10 +16,23 @@ let private forgetLowest3 =
     { Capacity = 3
       ForgetPolicy = BoundedGSetForgetPolicy.ForgetLowest }
 
+let private moduloReject4 =
+    { Slots = 4
+      CollisionPolicy = ModuloGSetCollisionPolicy.RejectCollision }
+
+let private moduloReplace4 =
+    { Slots = 4
+      CollisionPolicy = ModuloGSetCollisionPolicy.ReplaceExisting }
+
 let private unwrap =
     function
     | Ok value -> value
     | Error error -> failwithf "unexpected bounded GSet error: %A" error
+
+let private unwrapModulo =
+    function
+    | Ok value -> value
+    | Error error -> failwithf "unexpected modulo GSet error: %A" error
 
 let private projectInts config values =
     BoundedGSet.ofSeq<int> config values |> unwrap
@@ -36,6 +49,16 @@ let ``invalid capacity returns feedback instead of throwing`` () =
     match BoundedGSet.empty<int> config with
     | Error(BoundedGSetError.NonPositiveCapacity 0) -> ()
     | other -> failwithf "expected NonPositiveCapacity feedback, got %A" other
+
+[<Fact>]
+let ``invalid modulo slots return feedback instead of throwing`` () =
+    let config =
+        { Slots = 0
+          CollisionPolicy = ModuloGSetCollisionPolicy.RejectCollision }
+
+    match ModuloGSet.empty<int> config with
+    | Error(ModuloGSetError.NonPositiveSlots 0) -> ()
+    | other -> failwithf "expected NonPositiveSlots feedback, got %A" other
 
 [<Fact>]
 let ``reject-new policy backpressures instead of forgetting`` () =
@@ -162,3 +185,60 @@ let ``bounded heat adapter keeps empty heat cold`` () =
     match BoundedHeat.emit (sink :> IHeatSink) "bounded-gset-room" "bounded-gset.forgotten" "nothing forgotten" BoundedGSet.emptyHeat<int> with
     | Error feedback -> Assert.Fail(sprintf "unexpected heat sink feedback: %A" feedback)
     | Ok () -> Assert.Empty(sink.Signatures)
+
+[<Fact>]
+let ``modulo GSet rejects collisions without forgetting`` () =
+    let start = ModuloGSet.empty<int> moduloReject4 |> unwrapModulo
+
+    let first = ModuloGSet.add (fun value -> int64 value) 1 start |> unwrapModulo
+    first.Admission |> should equal ModuloGSetAdmission.Admitted
+    first.Slot |> should equal 1
+    first.State |> ModuloGSet.toList |> should equal [ 1 ]
+
+    let collision = ModuloGSet.add (fun value -> int64 value) 5 first.State |> unwrapModulo
+    collision.Admission |> should equal ModuloGSetAdmission.RejectedByCollision
+    collision.Slot |> should equal 1
+    collision.State |> ModuloGSet.toList |> should equal [ 1 ]
+    Assert.Empty(collision.Heat.Forgotten |> GSet.toList)
+    collision.Heat.Units |> should equal 0
+
+[<Fact>]
+let ``modulo GSet replacement emits forgotten occupant as heat`` () =
+    let start = ModuloGSet.empty<string> moduloReplace4 |> unwrapModulo
+
+    let old = ModuloGSet.addWithSlot -1L "old" start |> unwrapModulo
+    old.Admission |> should equal ModuloGSetAdmission.Admitted
+    old.Slot |> should equal 3
+
+    let replaced = ModuloGSet.addWithSlot 7L "new" old.State |> unwrapModulo
+    replaced.Admission |> should equal ModuloGSetAdmission.Replaced
+    replaced.Slot |> should equal 3
+    replaced.State |> ModuloGSet.toSlotList |> should equal [ 3, "new" ]
+    replaced.Heat.Forgotten |> GSet.toList |> should equal [ "old" ]
+    replaced.Heat.Units |> should equal 1
+
+[<Fact>]
+let ``modulo GSet projection from GSet is deterministic and bounded`` () =
+    let source = GSet.ofSeq [ 3; 0; 1; 0 ]
+
+    let projected =
+        ModuloGSet.ofGSet (fun value -> int64 (value % 3)) { moduloReplace4 with Slots = 3 } source
+        |> unwrapModulo
+
+    projected.State |> ModuloGSet.toSlotList |> should equal [ 0, 3; 1, 1 ]
+    projected.State |> ModuloGSet.toList |> should equal [ 1; 3 ]
+    projected.Heat.Forgotten |> GSet.toList |> should equal [ 0 ]
+    projected.Heat.Units |> should equal 1
+    projected.Rejected |> should equal 0
+
+[<Fact>]
+let ``modulo GSet projection counts cold collision backpressure`` () =
+    let projected =
+        ModuloGSet.ofSeq (fun value -> int64 (value % 2)) { moduloReject4 with Slots = 2 } [ 0; 2; 4; 1 ]
+        |> unwrapModulo
+
+    projected.State |> ModuloGSet.toSlotList |> should equal [ 0, 0; 1, 1 ]
+    projected.State |> ModuloGSet.toList |> should equal [ 0; 1 ]
+    Assert.Empty(projected.Heat.Forgotten |> GSet.toList)
+    projected.Heat.Units |> should equal 0
+    projected.Rejected |> should equal 2


### PR DESCRIPTION
## Summary
- adds `ModuloGSet` as a finite slot projection over grow-only sets
- supports no-forget collision backpressure and replacement-with-heat policies
- streams projection input and keeps caller-owned slot functions outside core hashing assumptions

## Validation
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter FullyQualifiedName~BoundedGSetTests`
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test Zeta.sln -c Release`

Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: Codex
Agent-Model: gpt-5.5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: not-implied-by-credential
Human-Review-Evidence: none
Action-Mode: human-directed
Task: modulo-gset-heat-policy
Co-Authored-By: Codex <noreply@openai.com>