### PR TITLE
feat(setup): Ubuntu 22.04 jammy install-shield + apt aliases

### DIFF
--- a/.github/workflows/docker-ubuntu-jammy-install-sh-test.yml
+++ b/.github/workflows/docker-ubuntu-jammy-install-sh-test.yml
@@ -1,0 +1,69 @@
+# .github/workflows/docker-ubuntu-jammy-install-sh-test.yml
+#
+# Docker-based install.sh test on Ubuntu 22.04 (jammy) — B-0857 cross-OS install
+# parity lane for the LTS many cloud VMs and dev laptops still run. Sibling to:
+#   - docker-ubuntu-install-sh-test   (install.sh on bare Ubuntu 24.04, Docker)
+#   - docker-nixos-install-sh-test    (install.sh on NixOS userspace, Docker)
+#   - docker-windows-install-ps1-test (install.ps1 on Windows Server Core, Docker)
+#   - macos-install-sh-test           (install.sh on real macOS)
+#   - wsl-install-sh-test             (install.sh in WSL2 Ubuntu on a Windows host)
+#   - docker-ubuntu-jammy-install-sh-test (install.sh on bare Ubuntu 22.04 — THIS file)
+#
+# NON-BLOCKING (advisory): like macos-install-sh-test and
+# docker-windows-install-ps1-test, this workflow is NOT in branch-protection
+# required_status_checks — it reports signal without gating merge while jammy
+# parity stabilizes. Promote to required once green for several rounds.
+#
+# Security: no github.event.* values interpolated into run: lines.
+
+name: docker-ubuntu-jammy-install-sh-test
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths:
+      - "src/Core.TypeScript/ci/dockerfiles/ubuntu-jammy-install-sh-test/**"
+      - "tools/setup/**"
+      - "src/Core.TypeScript/accelerator/local-llm.ts"
+      - "src/Core.TypeScript/accelerator/validate-local-llm.ts"
+      - ".mise.toml"
+      - ".dockerignore"
+      - ".github/workflows/docker-ubuntu-jammy-install-sh-test.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "src/Core.TypeScript/ci/dockerfiles/ubuntu-jammy-install-sh-test/**"
+      - "tools/setup/**"
+      - "src/Core.TypeScript/accelerator/local-llm.ts"
+      - "src/Core.TypeScript/accelerator/validate-local-llm.ts"
+      - ".mise.toml"
+      - ".dockerignore"
+      - ".github/workflows/docker-ubuntu-jammy-install-sh-test.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: docker-ubuntu-jammy-install-sh-test-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  docker-ubuntu-jammy-test:
+    name: docker-ubuntu-jammy-install-sh-test
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: docker build (jammy — install.sh + local-LLM validation inside)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DOCKER_BUILDKIT=1 docker build \
+            --secret id=github_token,env=GITHUB_TOKEN \
+            -f src/Core.TypeScript/ci/dockerfiles/ubuntu-jammy-install-sh-test/Dockerfile \
+            -t zeta-ubuntu-jammy-install-sh-test \
+            .

--- a/.github/workflows/gitbash-install-routing-test.yml
+++ b/.github/workflows/gitbash-install-routing-test.yml
@@ -23,7 +23,8 @@
 # so this shield stays cheap.
 #
 # Complements the five existing install shields (brings coverage to 6/6 surfaces):
-#   - docker-ubuntu-install-sh-test   (install.sh on bare Ubuntu, Docker)
+#   - docker-ubuntu-install-sh-test   (install.sh on bare Ubuntu 24.04, Docker)
+#   - docker-ubuntu-jammy-install-sh-test (install.sh on bare Ubuntu 22.04, Docker)
 #   - docker-nixos-install-sh-test    (install.sh on NixOS userspace, Docker)
 #   - macos-install-sh-test           (install.sh on real macOS)
 #   - docker-windows-install-ps1-test (install.ps1 on Windows Server Core, Docker)

--- a/.github/workflows/macos-install-sh-test.yml
+++ b/.github/workflows/macos-install-sh-test.yml
@@ -5,7 +5,8 @@
 # macos.sh (Homebrew + brew ollama + mise toolchain + lean + jars + the
 # local-LLM model pull via common/local-llm.sh). Completes the install-shield
 # matrix — we already cover ubuntu/nixos/windows/wsl; this closes the mac gap:
-#   - docker-ubuntu-install-sh-test   (install.sh on bare Ubuntu, Docker)
+#   - docker-ubuntu-install-sh-test   (install.sh on bare Ubuntu 24.04, Docker)
+#   - docker-ubuntu-jammy-install-sh-test (install.sh on bare Ubuntu 22.04, Docker)
 #   - docker-nixos-install-sh-test    (install.sh on NixOS userspace, Docker)
 #   - docker-windows-install-ps1-test (install.ps1 on Windows Server Core, Docker)
 #   - wsl-install-sh-test             (install.sh in WSL2 Ubuntu on a Windows host)

--- a/.github/workflows/wsl-install-sh-test.yml
+++ b/.github/workflows/wsl-install-sh-test.yml
@@ -3,7 +3,8 @@
 # WSL install.sh test (B-0857 Windows parity — the WSL lane). Runs tools/setup/install.sh inside a
 # REAL WSL2 Ubuntu on a Windows host, which the Docker-Linux lane cannot exercise (no WSL kernel,
 # no /mnt interop, no systemd-absent quirks). Complements the other three install shields:
-#   - docker-ubuntu-install-sh-test   (install.sh on bare Ubuntu, Docker)
+#   - docker-ubuntu-install-sh-test   (install.sh on bare Ubuntu 24.04, Docker)
+#   - docker-ubuntu-jammy-install-sh-test (install.sh on bare Ubuntu 22.04, Docker)
 #   - docker-nixos-install-sh-test    (install.sh on NixOS userspace, Docker)
 #   - docker-windows-install-ps1-test (install.ps1 on Windows Server Core, Docker)
 #

--- a/src/Core.TypeScript/ci/dockerfiles/ubuntu-jammy-install-sh-test/Dockerfile
+++ b/src/Core.TypeScript/ci/dockerfiles/ubuntu-jammy-install-sh-test/Dockerfile
@@ -1,0 +1,81 @@
+# syntax=docker/dockerfile:1
+
+# src/Core.TypeScript/ci/dockerfiles/ubuntu-jammy-install-sh-test/Dockerfile
+#
+# Docker-based install.sh test on Ubuntu 22.04 (jammy) — sibling to
+# ubuntu-install-sh-test (24.04/noble). Exercises linux.sh's jammy apt
+# package aliases (libicu70/libssl3 vs noble libicu74/libssl3t64) on the
+# LTS many dev boxes and cloud VMs still run.
+#
+# The build IS the test: a failing install.sh / assert fails the build.
+# install.sh runs as root (linux.sh handles root-vs-sudo via `id -u`).
+
+# Pinned by digest (per .claude/rules/dep-pin-search-first-authority.md).
+# ubuntu:22.04 digest selected 2026-06-20 via `docker manifest inspect`;
+# bump: re-query registry-1.docker.io/v2/library/ubuntu/manifests/22.04.
+FROM ubuntu:22.04@sha256:ce941a2a18bbb922e434d6d6d2b31e571a5c3826eaf6ada0a41dcc905bd2d906
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl git xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PATH=/root/.bun/bin:/root/.local/share/mise/shims:/root/.local/bin:/usr/local/bin:/usr/bin:/bin
+
+WORKDIR /zeta
+COPY . /zeta
+
+RUN --mount=type=secret,id=github_token \
+    ZETA_INSTALL_FULL=1 \
+    GITHUB_TOKEN="$(cat /run/secrets/github_token 2>/dev/null || true)" \
+    ./tools/setup/install.sh
+
+RUN set -eu; \
+    export PATH="/root/.local/bin:$PATH"; \
+    command -v ollama; \
+    (ollama serve >/tmp/ollama.log 2>&1 &); \
+    for _ in $(seq 1 30); do \
+      curl -fsS http://127.0.0.1:11434/api/version >/dev/null 2>&1 && break; \
+      sleep 1; \
+    done; \
+    curl -fsS http://127.0.0.1:11434/api/version; \
+    MODEL="$(grep -E '^model' tools/setup/manifests/local-llm | awk '{print $2}')"; \
+    echo "asserting model: $MODEL"; \
+    ollama list; \
+    ollama list | awk 'NR>1 {print $1}' | grep -qx "$MODEL"; \
+    bun test src/Core.TypeScript/accelerator/local-llm.test.ts; \
+    bun src/Core.TypeScript/accelerator/validate-local-llm.ts --root "$PWD"
+
+RUN set -eu; \
+    export PATH="/root/.local/bin:$PATH"; \
+    MODEL="$(grep -E '^model' tools/setup/manifests/local-llm | awk '{print $2}')"; \
+    echo "=== 2nd install.sh run (idempotency) ==="; \
+    if ! ZETA_INSTALL_FULL=1 ./tools/setup/install.sh > /tmp/install-2nd.log 2>&1; then \
+      cat /tmp/install-2nd.log; \
+      echo "FAIL: 2nd install.sh run exited non-zero (a re-run must succeed cleanly)"; exit 1; \
+    fi; \
+    cat /tmp/install-2nd.log; \
+    echo "=== idempotency asserts ==="; \
+    grep -qF "local-llm model ${MODEL} already present" /tmp/install-2nd.log \
+      || { echo "FAIL: 2nd run did not report '${MODEL} already present' — idempotency hole"; exit 1; }; \
+    if grep -qF "pulling ${MODEL}" /tmp/install-2nd.log || grep -qF "pulling manifest" /tmp/install-2nd.log; then \
+      echo "FAIL: 2nd run RE-PULLED the model — caching/idempotency regression"; exit 1; \
+    fi; \
+    echo "OK: 2nd run idempotent — ${MODEL} already present, zero re-pull"
+
+RUN set -eu; \
+    SRC=/etc/apt/sources.list.d/zeta-unreachable-test.list; \
+    echo "deb [trusted=yes] https://zeta-unreachable.invalid/ubuntu jammy main" > "$SRC"; \
+    echo "=== 3rd install.sh run (unreachable apt-source resilience) ==="; \
+    if ! ZETA_INSTALL_FULL=1 ./tools/setup/install.sh > /tmp/install-resilience.log 2>&1; then \
+      cat /tmp/install-resilience.log; \
+      rm -f "$SRC"; \
+      echo "FAIL: install.sh aborted on an unreachable third-party apt source (it must warn + continue)"; exit 1; \
+    fi; \
+    rm -f "$SRC"; \
+    cat /tmp/install-resilience.log; \
+    echo "=== resilience asserts ==="; \
+    grep -qF "apt-get update reported errors" /tmp/install-resilience.log \
+      || { echo "FAIL: graceful path took but emitted NO warning — silent failure is a shield hole"; exit 1; }; \
+    echo "OK: unreachable apt source warned + continued (graceful, not silent)"

--- a/src/Core.TypeScript/ci/manifest-symmetry.test.ts
+++ b/src/Core.TypeScript/ci/manifest-symmetry.test.ts
@@ -167,6 +167,14 @@ test("local-llm install defaults to skip outside interactive/full install contex
   // The install shields are the explicit non-interactive opt-in path that asserts real Ollama.
   expect(ubuntuDockerfile).toContain("ZETA_INSTALL_FULL=1 \\\n    GITHUB_TOKEN=");
   expect(ubuntuDockerfile).toContain("if ! ZETA_INSTALL_FULL=1 ./tools/setup/install.sh");
+
+  const jammyDockerfile = readFileSync(
+    join(repoRoot, "src", "Core.TypeScript", "ci", "dockerfiles", "ubuntu-jammy-install-sh-test", "Dockerfile"),
+    "utf8",
+  );
+  expect(jammyDockerfile).toContain("ubuntu:22.04@");
+  expect(jammyDockerfile).toContain("ZETA_INSTALL_FULL=1 \\\n    GITHUB_TOKEN=");
+  expect(jammyDockerfile).toContain("if ! ZETA_INSTALL_FULL=1 ./tools/setup/install.sh");
 });
 
 test("NixOS and USB installer surfaces delegate agent/runtime drift to install graph", () => {

--- a/src/Core.TypeScript/hygiene/github-settings.expected.json
+++ b/src/Core.TypeScript/hygiene/github-settings.expected.json
@@ -254,6 +254,11 @@
       "state": "active"
     },
     {
+      "name": "docker-ubuntu-jammy-install-sh-test",
+      "path": ".github/workflows/docker-ubuntu-jammy-install-sh-test.yml",
+      "state": "active"
+    },
+    {
       "name": "docker-windows-install-ps1-test",
       "path": ".github/workflows/docker-windows-install-ps1-test.yml",
       "state": "active"

--- a/tools/setup/linux.sh
+++ b/tools/setup/linux.sh
@@ -86,6 +86,24 @@ elif [ -f "$APT_MANIFEST" ]; then
     { sub(/#.*$/, ""); gsub(/^[[:space:]]+|[[:space:]]+$/, "") }
     NF > 0 { print }
   ' "$APT_MANIFEST" | tr '\n' ' ')"
+  # manifests/apt canonical names target Ubuntu 24.04 (Noble). Map to jammy
+  # equivalents so install.sh works on 22.04 dev boxes / cloud VMs too.
+  if [ -f /etc/os-release ]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    if [ "${ID:-}" = "ubuntu" ] && [ "${VERSION_ID:-}" = "22.04" ]; then
+      for _pair in libicu74:libicu70 libssl3t64:libssl3; do
+        _noble="${_pair%%:*}"
+        _jammy="${_pair#*:}"
+        case " $PKGS " in
+          *" $_noble "*)
+            echo "↻ apt package alias: $_noble → $_jammy (Ubuntu 22.04 jammy)"
+            PKGS="${PKGS//$_noble/$_jammy}"
+            ;;
+        esac
+      done
+    fi
+  fi
   if [ -n "$PKGS" ]; then
     echo "↓ installing apt packages from $(basename "$APT_MANIFEST")..."
     # Use sudo only when not already root (CI containers often run as root).

--- a/tools/setup/manifests/apt
+++ b/tools/setup/manifests/apt
@@ -27,6 +27,7 @@ zstd        # required to extract ollama-linux-<arch>.tar.zst
 # work on TRULY bare ubuntu. Per Microsoft Learn linux-scripted-manual deps;
 # build-essential already pulls libstdc++6/libgcc-s1/zlib1g. Names are Ubuntu
 # 24.04 (Noble: libicu74, libssl3t64 post-time_t-transition).
+# linux.sh maps libicu74/libssl3t64 → libicu70/libssl3 on Ubuntu 22.04 (jammy).
 libicu74          # ICU — .NET globalization (the classic "dotnet exited" cause)
 libssl3t64        # OpenSSL 3 runtime (Noble t64 name)
 libgssapi-krb5-2  # Kerberos/GSSAPI — .NET networking


### PR DESCRIPTION
## Summary
- Map Noble `.NET` runtime apt names (`libicu74`, `libssl3t64`) to jammy equivalents in `linux.sh` — fixes `install.sh` on Ubuntu 22.04 cloud VMs.
- Add advisory `docker-ubuntu-jammy-install-sh-test` workflow + Dockerfile (non-blocking, same cadence as macOS/Windows install shields).

## Context
Observed on a jammy GCE box: `E: Unable to locate package libicu74` / `libssl3t64`. Manifest canonical names target 24.04; jammy gets runtime aliases at install time.

## Test plan
- [ ] `docker-ubuntu-jammy-install-sh-test` green on PR
- [ ] `docker-ubuntu-install-sh-test` + `docker-nixos-install-sh-test` still green (unchanged noble path)
- [ ] Re-run `./tools/setup/install.sh` on jammy cloud VM after merge


Made with [Cursor](https://cursor.com)