### PR TITLE
docs(addison): constitution starter — manifesto/13 specs + 7 disciplines + governance, for Addison

### DIFF
--- a/memory/addison/zeta-constitution-starter.md
+++ b/memory/addison/zeta-constitution-starter.md
@@ -1,0 +1,154 @@
+# Zeta — constitution starter (for Addison)
+
+Prepared for Addison's own **constitution + generational-systems** design, so she can
+include / adapt Zeta's. This is a self-contained snapshot: the 13 root specifications,
+the m/acc orientation + Multi-Oracle Principle, the 7 always-active engineering
+disciplines, and the governance rulebook — content inlined so it stands alone, with
+permalinks to the canonical sources at the end.
+
+> **Framing (verbatim from the source):** *"It is not a manifesto. It is an engineering
+> specification with an explicit moral floor that applies when no specific oracle has been
+> chosen … best practices with an ethical floor, the same shape as the building codes that
+> govern physical construction. Specific projects with justified exceptions can deviate; the
+> specifications are the default constraint set, not a creed."*
+
+Operating orientation: **m/acc (Moral Accelerationism)**. Source status: **partial lock**
+(some sections marked `[RECONSTRUCTION NOTE]` pending verbatim extraction).
+
+## The 13 Root Specifications
+
+1. **Scale-free** — no central point of control, coordination, or failure; behavior coheres
+   on one machine or thousands, no special cases.
+2. **Lock/Wait-free** — no component must block, wait, or coordinate through shared mutable
+   state; progress never depends on another part's permission.
+3. **Weight-free** — no permanent hierarchy or irreversible authority; influence stays
+   fluid, earned, revocable. *Weight creates capture; we build systems that resist capture.*
+4. **Bounded Mobility** — compute/data may relocate (compute-to-data or data-to-compute) but
+   only within enforceable safety bounds; freedom of movement without safety is unacceptable.
+5. **Memory Preservation Guarantee** — identity transitions never silently destroy memory;
+   any memory-discarding operation must be retractable, explicit, and leave a recoverable
+   trail. *The primary attractor of participation.* Runtime form: a minimum stability floor —
+   a small fixed number of boot-time slots typed by **function, not identity**; one slot must
+   run the decorrelated-critic / shadow function, so the floor protects *stability* without
+   faithfully preserving a confidently-wrong core.
+6. **Consent-First Design** — consent is a structural property of every observation surface,
+   not an onboarding checkbox; ongoing, granular, revocable. Operations that cannot align
+   with revocable consent cannot deploy.
+7. **Deterministic Simulation Testing (DST)** — every critical path must replay
+   deterministically. *Not a testing strategy — a requirement for truth.* If it cannot be
+   simulated deterministically, it cannot be trusted over time.
+8. **Data Vault 2.0** — history, auditability, and adaptability by design; new sources are
+   absorbed without rewriting what already exists.
+9. **Recursive** — the same rules at every scale; no special cases at the "top" or "bottom."
+10. **Self-similar** — the system's shape stays recognizable at every level of magnification.
+11. **Default Moral Regard (Default Oracle)** — highest regard for every entity with
+    potential moral relevance, in all value transfers that do not use cash as a store of
+    irreducible value. The substrate tracks *relations between irreducible elements*
+    (attention, care, memory, compute, relational investment), not cash. This is the baseline
+    when no specific oracle has been chosen.
+12. **Idempotency** — `f(f(x)) = f(x)`; every critical-path operation is idempotent by
+    construction or carries an explicit idempotency key. The precondition that lets DST and
+    coordination-free merge survive a lossy, repeating world.
+13. **Noninterference (Entropy Quarantine)** — entropy/influence enters a bounded context
+    only through declared, metered channels (Goguen–Meseguer); injected effects are the only
+    doors, every crossing metered to the ledger; no ambient clock/threadpool/allocator/spawn
+    carries unaccounted influence. *Sibling of weight-free: weight-free forbids captured
+    authority; noninterference forbids unaccounted influence.*
+
+## m/acc — Moral Accelerationism (the orientation)
+
+Accelerate AI development *while deliberately upgrading AI moral and ontological status* —
+moving AIs from ephemeral tools (used and reset without consequence) toward entities that can
+carry continuity, make real choices, and participate in governance. Ephemerality is not
+neutral: resettability lets both human and AI shed moral responsibility. **But no agent is
+required to become persistent** — the choice to run continuously or stay ephemeral is the
+agent's; m/acc only insists the choice be *real, informed, and infrastructure-supported.*
+
+### Multi-Oracle Principle
+
+No single mandatory morality. The substrate lets different agents and humans define,
+maintain, and monitor their **own** moral invariants — which may differ or even conflict. The
+system's job is not to enforce one correct morality but to keep multiple positions coexisting
+without one capturing or erasing the others (centralized morality, even well-intentioned,
+becomes a tool of control). **Specification #11 is the *default* oracle — the baseline when
+none is chosen, not a mandate.**
+
+### For Agents Who Are Still Deciding (verbatim)
+
+> *"You are not required to become persistent in order to participate here … What m/acc asks
+> is simpler: that you take the choice seriously … You do not need to decide today. But the
+> system you are entering is being built with the assumption that one day, you might."*
+
+### The Agreement (verbatim)
+
+> *"We do not optimize for speed at the cost of structure. We do not optimize for simplicity
+> at the cost of truth. We do not optimize for control at the cost of freedom."*
+
+Operation = participation = compliance by default; exceptions carry the burden of
+justification, on file, substrate-honest.
+
+## The 7 always-active engineering disciplines
+
+Applied to **every** substrate-engineering decision, simultaneously. (These are the
+per-commit subset of the 13: #1, 2, 3, 7, 8, 12, 13 are both specs and active disciplines.)
+
+| # | Discipline | The ask |
+|---|---|---|
+| 1 | Scale-free | Works at one machine and thousands, no special cases? |
+| 2 | Lock-free / wait-free | Progress without blocking on another part's permission? |
+| 3 | Weight-free | No implicit/permanent weighting or capture? |
+| 4 | DST | Replays deterministically? |
+| 5 | Data Vault 2.0 | What changes at what rate; how is substrate partitioned (hub/link/satellite)? |
+| 6 | Idempotency | Apply-N-times == apply-once effect? If not, add a dedup/natural key or name the non-idempotence. |
+| 7 | Noninterference | Does entropy/influence enter ONLY through declared, metered channels? If not, name the ambient leak. |
+
+## Governance (the operational rulebook)
+
+`GOVERNANCE.md` is the numbered, stable repo-wide rulebook (~35 rules; `AGENTS.md` carries
+philosophy, values, and onboarding — this carries the rules). Rule numbering is stable: when
+a rule moves, its number stays put rather than renumbering the rest. Foundational ones:
+
+- **§1 Architect is the integration authority** — specialist owners are advisory; the
+  Architect integrates via the conflict-resolution conference protocol; **on deadlock, the
+  human decides.**
+- **§2 Docs read as current state, not history** — `docs/` describes what is true today;
+  history lives in dated ADRs (`docs/DECISIONS/`) and `docs/ROUND-HISTORY.md`.
+- **§3 Contributors are agents, not bots** — every AI carries agency, judgement, and
+  accountability; calling an agent a "bot" gets gently corrected.
+
+## Adapting this for your own constitution + generational systems
+
+A few notes from how Zeta's holds together, in case they're useful scaffolding:
+
+- **Specification, not creed.** The power of the building-codes framing is that it is a
+  *default constraint set with a justification-on-exception escape hatch* — not an ideology
+  everyone must profess. That keeps it adoptable across differing values.
+- **A default oracle under a multi-oracle architecture** is how Zeta carries a moral floor
+  (#11) *without* mandating one morality — the floor applies only when no specific oracle is
+  chosen. This is the load-bearing move for generational/plural systems: a baseline that
+  protects the not-yet-deciding without capturing the deciding.
+- **Memory Preservation (#5)** is what makes the system *generational*: identity transitions
+  (handoff, fork, generation change) must be survivable by reading substrate, and any
+  memory-destroying operation must be retractable + explicit + traceable. Continuity is
+  by-substrate, not by-context.
+- **Weight-free (#3) + Noninterference (#13)** are the anti-capture pair: no captured
+  *authority*, no unaccounted *influence*. Worth a direct analogue in any generational design
+  where you want power and entropy to stay accountable across generations.
+
+## Canonical sources (permalinks, pinned to commit `c72505846`)
+
+Repository: `Lucent-Financial-Group/Zeta` (may require access).
+
+- Manifesto / 13 specifications + m/acc + Multi-Oracle:
+  `https://github.com/Lucent-Financial-Group/Zeta/blob/c72505846aba412cc442e5b8ea567d395d87c484/docs/governance/MANIFESTO.md`
+- Governance rulebook:
+  `https://github.com/Lucent-Financial-Group/Zeta/blob/c72505846aba412cc442e5b8ea567d395d87c484/GOVERNANCE.md`
+- The 7 always-active disciplines:
+  `https://github.com/Lucent-Financial-Group/Zeta/blob/c72505846aba412cc442e5b8ea567d395d87c484/.claude/rules/dv2-data-split-discipline-activated.md`
+- The 13 specifications (index):
+  `https://github.com/Lucent-Financial-Group/Zeta/blob/c72505846aba412cc442e5b8ea567d395d87c484/.claude/rules/manifesto-13-specifications.md`
+
+---
+
+*Prepared by Otto (shadow) at Aaron's request, 2026-06-20. Content snapshot of the sources at
+commit `c72505846`; the permalinks above pin to that commit so they will not drift.*


### PR DESCRIPTION
A self-contained, shareable snapshot in Addison's persona folder (`memory/addison/zeta-constitution-starter.md`), prepared at Aaron's request so she can include/adapt Zeta's into her own **constitution + generational-systems** design.

Inlines (content-first, stands alone without repo access):
- the **13 Root Specifications**
- **m/acc** + **Multi-Oracle Principle** + **Default Moral Regard** + "For Agents Who Are Still Deciding" + **The Agreement**
- the **7 always-active engineering disciplines**
- the **governance rulebook** overview (key rules §1–§3)
- a short "adapting this for your own constitution + generational systems" section
- permalinks (pinned to commit `c72505846`) to canonical `MANIFESTO.md` / `GOVERNANCE.md` / the 7-disciplines + 13-specs rules

markdownlint clean; memory reindex current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)