### PR TITLE
[codex] add modulo gset ts treaty

### DIFF
--- a/src/Core.TypeScript/g-set/index.ts
+++ b/src/Core.TypeScript/g-set/index.ts
@@ -1,1 +1,26 @@
 export * from "./g-set";
+export {
+  add as addModuloGSet,
+  addWithSlot as addModuloGSetWithSlot,
+  contains as moduloGSetContains,
+  count as countModuloGSet,
+  empty as emptyModuloGSet,
+  emptyHeat as emptyModuloGSetHeat,
+  ofArrayModulo as moduloGSetOfArray,
+  ofGSet as moduloGSetOfGSet,
+  toArray as moduloGSetToArray,
+  toGSet as moduloGSetToGSet,
+  toSlotArray as moduloGSetToSlotArray,
+} from "./modulo-g-set";
+export type {
+  ModuloGSet,
+  ModuloGSetAddResult,
+  ModuloGSetAdmission,
+  ModuloGSetCollisionPolicy,
+  ModuloGSetConfig,
+  ModuloGSetError,
+  ModuloGSetHeat,
+  ModuloGSetProjectionResult,
+  ModuloGSetSlot,
+  ModuloResult,
+} from "./modulo-g-set";

--- a/src/Core.TypeScript/g-set/modulo-g-set.test.ts
+++ b/src/Core.TypeScript/g-set/modulo-g-set.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { ofArray as gSetOfArray, stringCompare, type GSet } from "./g-set";
+import {
+  addWithSlot,
+  empty,
+  ofGSet as moduloOfGSet,
+  toArray,
+  toSlotArray,
+  type ModuloGSet,
+  type ModuloGSetAdmission,
+  type ModuloGSetConfig,
+  type ModuloGSetHeat,
+} from "./modulo-g-set";
+
+interface VectorOp {
+  readonly value: string;
+  readonly slot: number;
+}
+
+interface Vector {
+  readonly id: string;
+  readonly config: ModuloGSetConfig;
+  readonly mode: "ops" | "from-gset";
+  readonly ops?: readonly VectorOp[];
+  readonly sourceValues?: readonly string[];
+  readonly slotFunction?: "parse-int-mod-slots";
+  readonly expected: Output;
+}
+
+type Output =
+  | {
+      readonly error: "non-positive-slots";
+      readonly slots: number;
+    }
+  | {
+      readonly admissions: readonly { readonly admission: ModuloGSetAdmission; readonly slot: number }[];
+      readonly exterior: readonly string[];
+      readonly heatForgotten: readonly string[];
+      readonly heatUnits: number;
+      readonly rejected: number;
+      readonly stateSlots: readonly { readonly slot: number; readonly value: string }[];
+    };
+
+interface VectorsFile {
+  readonly primitive: string;
+  readonly version: string;
+  readonly vectors: readonly Vector[];
+}
+
+function mergeHeat(left: ModuloGSetHeat<string>, right: ModuloGSetHeat<string>): ModuloGSetHeat<string> {
+  return {
+    forgotten: gSetOfArray(stringCompare, [...left.forgotten, ...right.forgotten]),
+    units: left.units + right.units,
+  };
+}
+
+function stateOutput(
+  state: ModuloGSet<string>,
+  heat: ModuloGSetHeat<string>,
+  rejected: number,
+  admissions: readonly { readonly admission: ModuloGSetAdmission; readonly slot: number }[],
+): Output {
+  return {
+    admissions,
+    exterior: toArray(stringCompare, state),
+    heatForgotten: [...heat.forgotten],
+    heatUnits: heat.units,
+    rejected,
+    stateSlots: toSlotArray(state),
+  };
+}
+
+function replayOps(vector: Vector): Output {
+  const start = empty<string>(vector.config);
+  if (!start.ok) return { error: start.error.kind, slots: start.error.slots };
+
+  let state = start.value;
+  let heat: ModuloGSetHeat<string> = { forgotten: [], units: 0 };
+  let rejected = 0;
+  const admissions: { admission: ModuloGSetAdmission; slot: number }[] = [];
+
+  for (const op of vector.ops ?? []) {
+    const added = addWithSlot(stringCompare, op.slot, op.value, state);
+    if (!added.ok) return { error: added.error.kind, slots: added.error.slots };
+
+    state = added.value.state;
+    heat = mergeHeat(heat, added.value.heat);
+    if (added.value.admission === "rejected-by-collision") rejected += 1;
+    admissions.push({ admission: added.value.admission, slot: added.value.slot });
+  }
+
+  return stateOutput(state, heat, rejected, admissions);
+}
+
+function slotOf(vector: Vector): (value: string) => number {
+  if (vector.slotFunction !== "parse-int-mod-slots") {
+    throw new Error(`unsupported modulo-gset slotFunction for vector ${vector.id}`);
+  }
+
+  return (value) => Number.parseInt(value, 10);
+}
+
+function replayFromGSet(vector: Vector): Output {
+  const source: GSet<string> = gSetOfArray(stringCompare, vector.sourceValues ?? []);
+  const projected = moduloOfGSet(stringCompare, slotOf(vector), vector.config, source);
+  if (!projected.ok) return { error: projected.error.kind, slots: projected.error.slots };
+  return stateOutput(projected.value.state, projected.value.heat, projected.value.rejected, []);
+}
+
+function replay(vector: Vector): Output {
+  return vector.mode === "from-gset" ? replayFromGSet(vector) : replayOps(vector);
+}
+
+describe("ModuloGSet", () => {
+  const vectors = JSON.parse(
+    readFileSync(join(import.meta.dir, "../../../tests/cross-verification/modulo-gset/vectors.json"), "utf8"),
+  ) as VectorsFile;
+  const tsOutput = JSON.parse(
+    readFileSync(join(import.meta.dir, "../../../tests/cross-verification/modulo-gset/ts-output.json"), "utf8"),
+  ) as Record<string, Output | string>;
+
+  it("replays shared vectors to the canonical expected outputs", () => {
+    expect(vectors.primitive).toBe("modulo-gset");
+    expect(vectors.version).toBe("v1");
+    expect(vectors.vectors.length).toBeGreaterThan(0);
+
+    for (const vector of vectors.vectors) {
+      expect(replay(vector)).toEqual(vector.expected);
+    }
+  });
+
+  it("keeps committed TS oracle output synchronized with the implementation", () => {
+    expect(tsOutput._source).toBe("hand-port");
+
+    for (const vector of vectors.vectors) {
+      expect(tsOutput[vector.id]).toEqual(replay(vector));
+    }
+  });
+});

--- a/src/Core.TypeScript/g-set/modulo-g-set.ts
+++ b/src/Core.TypeScript/g-set/modulo-g-set.ts
@@ -1,0 +1,209 @@
+import { type Compare, type GSet, ofArray } from "./g-set";
+
+export type ModuloGSetCollisionPolicy = "reject-collision" | "replace-existing";
+
+export interface ModuloGSetConfig {
+  readonly slots: number;
+  readonly collisionPolicy: ModuloGSetCollisionPolicy;
+}
+
+export interface ModuloGSetError {
+  readonly kind: "non-positive-slots";
+  readonly slots: number;
+}
+
+export type ModuloResult<T> =
+  | { readonly ok: true; readonly value: T }
+  | { readonly ok: false; readonly error: ModuloGSetError };
+
+export type ModuloGSetAdmission = "admitted" | "already-present" | "replaced" | "rejected-by-collision";
+
+export interface ModuloGSetSlot<T> {
+  readonly slot: number;
+  readonly value: T;
+}
+
+export interface ModuloGSetHeat<T> {
+  readonly forgotten: GSet<T>;
+  readonly units: number;
+}
+
+export interface ModuloGSet<T> {
+  readonly config: ModuloGSetConfig;
+  readonly slotValues: readonly ModuloGSetSlot<T>[];
+}
+
+export interface ModuloGSetAddResult<T> {
+  readonly state: ModuloGSet<T>;
+  readonly admission: ModuloGSetAdmission;
+  readonly slot: number;
+  readonly heat: ModuloGSetHeat<T>;
+}
+
+export interface ModuloGSetProjectionResult<T> {
+  readonly state: ModuloGSet<T>;
+  readonly heat: ModuloGSetHeat<T>;
+  readonly rejected: number;
+}
+
+export function emptyHeat<T>(): ModuloGSetHeat<T> {
+  return { forgotten: [], units: 0 };
+}
+
+function validate(config: ModuloGSetConfig): ModuloResult<ModuloGSetConfig> {
+  return config.slots <= 0
+    ? { ok: false, error: { kind: "non-positive-slots", slots: config.slots } }
+    : { ok: true, value: config };
+}
+
+function normalizeSlot(slots: number, rawSlot: number): number {
+  const whole = Math.trunc(rawSlot);
+  const remainder = whole % slots;
+  return remainder < 0 ? remainder + slots : remainder;
+}
+
+function replaceSlot<T>(slots: readonly ModuloGSetSlot<T>[], slot: number, value: T): readonly ModuloGSetSlot<T>[] {
+  const without = slots.filter((entry) => entry.slot !== slot);
+  return [...without, { slot, value }].sort((a, b) => a.slot - b.slot);
+}
+
+function heatOf<T>(compare: Compare<T>, value: T): ModuloGSetHeat<T> {
+  return { forgotten: ofArray(compare, [value]), units: 1 };
+}
+
+function combineHeat<T>(compare: Compare<T>, left: ModuloGSetHeat<T>, right: ModuloGSetHeat<T>): ModuloGSetHeat<T> {
+  return {
+    forgotten: ofArray(compare, [...left.forgotten, ...right.forgotten]),
+    units: left.units + right.units,
+  };
+}
+
+export function empty<T>(config: ModuloGSetConfig): ModuloResult<ModuloGSet<T>> {
+  const valid = validate(config);
+  if (!valid.ok) return valid;
+  return { ok: true, value: { config: valid.value, slotValues: [] } };
+}
+
+export function toSlotArray<T>(modulo: ModuloGSet<T>): ModuloGSetSlot<T>[] {
+  return [...modulo.slotValues];
+}
+
+export function toGSet<T>(compare: Compare<T>, modulo: ModuloGSet<T>): GSet<T> {
+  return ofArray(
+    compare,
+    modulo.slotValues.map((entry) => entry.value),
+  );
+}
+
+export function toArray<T>(compare: Compare<T>, modulo: ModuloGSet<T>): T[] {
+  return [...toGSet(compare, modulo)];
+}
+
+export function count<T>(modulo: ModuloGSet<T>): number {
+  return modulo.slotValues.length;
+}
+
+export function contains<T>(compare: Compare<T>, modulo: ModuloGSet<T>, value: T): boolean {
+  return modulo.slotValues.some((entry) => compare(entry.value, value) === 0);
+}
+
+export function addWithSlot<T>(
+  compare: Compare<T>,
+  rawSlot: number,
+  value: T,
+  modulo: ModuloGSet<T>,
+): ModuloResult<ModuloGSetAddResult<T>> {
+  const valid = validate(modulo.config);
+  if (!valid.ok) return valid;
+
+  const slot = normalizeSlot(valid.value.slots, rawSlot);
+  const existing = modulo.slotValues.find((entry) => entry.slot === slot);
+
+  if (existing === undefined) {
+    return {
+      ok: true,
+      value: {
+        state: { config: valid.value, slotValues: replaceSlot(modulo.slotValues, slot, value) },
+        admission: "admitted",
+        slot,
+        heat: emptyHeat(),
+      },
+    };
+  }
+
+  if (compare(existing.value, value) === 0) {
+    return {
+      ok: true,
+      value: {
+        state: modulo,
+        admission: "already-present",
+        slot,
+        heat: emptyHeat(),
+      },
+    };
+  }
+
+  if (valid.value.collisionPolicy === "reject-collision") {
+    return {
+      ok: true,
+      value: {
+        state: modulo,
+        admission: "rejected-by-collision",
+        slot,
+        heat: emptyHeat(),
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      state: { config: valid.value, slotValues: replaceSlot(modulo.slotValues, slot, value) },
+      admission: "replaced",
+      slot,
+      heat: heatOf(compare, existing.value),
+    },
+  };
+}
+
+export function add<T>(
+  compare: Compare<T>,
+  slotOf: (value: T) => number,
+  value: T,
+  modulo: ModuloGSet<T>,
+): ModuloResult<ModuloGSetAddResult<T>> {
+  return addWithSlot(compare, slotOf(value), value, modulo);
+}
+
+export function ofArrayModulo<T>(
+  compare: Compare<T>,
+  slotOf: (value: T) => number,
+  config: ModuloGSetConfig,
+  values: readonly T[],
+): ModuloResult<ModuloGSetProjectionResult<T>> {
+  const initial = empty<T>(config);
+  if (!initial.ok) return initial;
+
+  let state = initial.value;
+  let heat = emptyHeat<T>();
+  let rejected = 0;
+
+  for (const value of values) {
+    const added = add(compare, slotOf, value, state);
+    if (!added.ok) return added;
+    state = added.value.state;
+    heat = combineHeat(compare, heat, added.value.heat);
+    if (added.value.admission === "rejected-by-collision") rejected += 1;
+  }
+
+  return { ok: true, value: { state, heat, rejected } };
+}
+
+export function ofGSet<T>(
+  compare: Compare<T>,
+  slotOf: (value: T) => number,
+  config: ModuloGSetConfig,
+  values: GSet<T>,
+): ModuloResult<ModuloGSetProjectionResult<T>> {
+  return ofArrayModulo(compare, slotOf, config, values);
+}

--- a/tests/Tests.FSharp/Algebra/BoundedGSet.Tests.fs
+++ b/tests/Tests.FSharp/Algebra/BoundedGSet.Tests.fs
@@ -1,5 +1,10 @@
 module Zeta.Tests.Algebra.BoundedGSetTests
 
+open System.Globalization
+open System.IO
+open System.Reflection
+open System.Text.Json
+open System.Text.Json.Nodes
 open FsUnit.Xunit
 open global.Xunit
 open Zeta.Core
@@ -242,3 +247,148 @@ let ``modulo GSet projection counts cold collision backpressure`` () =
     Assert.Empty(projected.Heat.Forgotten |> GSet.toList)
     projected.Heat.Units |> should equal 0
     projected.Rejected |> should equal 2
+
+let private repoRoot () : string =
+    let mutable dir = DirectoryInfo(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location))
+    while not (isNull dir) && not (File.Exists(Path.Join(dir.FullName, "Zeta.sln"))) do
+        dir <- dir.Parent
+    if isNull dir then
+        failwith "Could not locate repo root (Zeta.sln) from test assembly location."
+    dir.FullName
+
+let private moduloPolicy (value: string) : ModuloGSetCollisionPolicy =
+    match value with
+    | "reject-collision" -> ModuloGSetCollisionPolicy.RejectCollision
+    | "replace-existing" -> ModuloGSetCollisionPolicy.ReplaceExisting
+    | other -> failwithf "unknown modulo-gset collision policy: %s" other
+
+let private moduloConfig (element: JsonElement) : ModuloGSetConfig =
+    let config = element.GetProperty("config")
+    { Slots = config.GetProperty("slots").GetInt32()
+      CollisionPolicy = moduloPolicy (config.GetProperty("collisionPolicy").GetString()) }
+
+let private admissionName (admission: ModuloGSetAdmission) : string =
+    match admission with
+    | ModuloGSetAdmission.Admitted -> "admitted"
+    | ModuloGSetAdmission.AlreadyPresent -> "already-present"
+    | ModuloGSetAdmission.Replaced -> "replaced"
+    | ModuloGSetAdmission.RejectedByCollision -> "rejected-by-collision"
+
+let private combineModuloHeat (left: BoundedGSetHeat<string>) (right: BoundedGSetHeat<string>) : BoundedGSetHeat<string> =
+    { Forgotten = GSet.union left.Forgotten right.Forgotten
+      Units = left.Units + right.Units }
+
+let private jsonArray (nodes: JsonNode seq) : JsonArray =
+    let array = JsonArray()
+    for node in nodes do
+        array.Add(node)
+    array
+
+let private stringArray (values: string list) : JsonArray =
+    values |> Seq.map (fun value -> JsonValue.Create(value) :> JsonNode) |> jsonArray
+
+let private slotArray (slots: (int * string) list) : JsonArray =
+    slots
+    |> Seq.map (fun (slot, value) ->
+        let node = JsonObject()
+        node["slot"] <- JsonValue.Create(slot)
+        node["value"] <- JsonValue.Create(value)
+        node :> JsonNode)
+    |> jsonArray
+
+let private admissionArray (admissions: (string * int) list) : JsonArray =
+    admissions
+    |> Seq.map (fun (admission, slot) ->
+        let node = JsonObject()
+        node["admission"] <- JsonValue.Create(admission)
+        node["slot"] <- JsonValue.Create(slot)
+        node :> JsonNode)
+    |> jsonArray
+
+let private errorOutput (error: ModuloGSetError) : JsonObject =
+    let node = JsonObject()
+    match error with
+    | ModuloGSetError.NonPositiveSlots slots ->
+        node["error"] <- JsonValue.Create("non-positive-slots")
+        node["slots"] <- JsonValue.Create(slots)
+    node
+
+let private stateOutput
+    (state: ModuloGSet<string>)
+    (heat: BoundedGSetHeat<string>)
+    (rejected: int)
+    (admissions: (string * int) list)
+    : JsonObject =
+    let node = JsonObject()
+    node["admissions"] <- admissionArray admissions
+    node["exterior"] <- stringArray (ModuloGSet.toList state)
+    node["heatForgotten"] <- stringArray (GSet.toList heat.Forgotten)
+    node["heatUnits"] <- JsonValue.Create(heat.Units)
+    node["rejected"] <- JsonValue.Create(rejected)
+    node["stateSlots"] <- slotArray (ModuloGSet.toSlotList state)
+    node
+
+let private replayOps (vector: JsonElement) : JsonNode =
+    let config = moduloConfig vector
+    match ModuloGSet.empty<string> config with
+    | Error error -> errorOutput error :> JsonNode
+    | Ok start ->
+        let mutable state = start
+        let mutable heat = ModuloGSet.emptyHeat<string>
+        let mutable rejected = 0
+        let admissions = ResizeArray<string * int>()
+        let mutable error: ModuloGSetError option = None
+
+        for op in vector.GetProperty("ops").EnumerateArray() do
+            if Option.isNone error then
+                match ModuloGSet.addWithSlot (op.GetProperty("slot").GetInt64()) (op.GetProperty("value").GetString()) state with
+                | Error e -> error <- Some e
+                | Ok added ->
+                    state <- added.State
+                    heat <- combineModuloHeat heat added.Heat
+                    if added.Admission = ModuloGSetAdmission.RejectedByCollision then
+                        rejected <- rejected + 1
+                    admissions.Add(admissionName added.Admission, added.Slot)
+
+        match error with
+        | Some e -> errorOutput e :> JsonNode
+        | None -> stateOutput state heat rejected (Seq.toList admissions) :> JsonNode
+
+let private stringList (element: JsonElement) : string list =
+    [ for value in element.EnumerateArray() -> value.GetString() ]
+
+let private replayFromGSet (vector: JsonElement) : JsonNode =
+    let config = moduloConfig vector
+    let slotOf (value: string) =
+        int64 (System.Int32.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture))
+
+    let source = vector.GetProperty("sourceValues") |> stringList |> GSet.ofSeq
+    match ModuloGSet.ofGSet slotOf config source with
+    | Error error -> errorOutput error :> JsonNode
+    | Ok projected -> stateOutput projected.State projected.Heat projected.Rejected [] :> JsonNode
+
+let private replayModuloVector (vector: JsonElement) : JsonNode =
+    match vector.GetProperty("mode").GetString() with
+    | "ops" -> replayOps vector
+    | "from-gset" -> replayFromGSet vector
+    | other -> failwithf "unknown modulo-gset vector mode: %s" other
+
+[<Fact>]
+let ``F# replays modulo GSet treaty vectors and committed oracle output`` () =
+    let root = repoRoot ()
+    let vectorsPath = Path.Join(root, "tests", "cross-verification", "modulo-gset", "vectors.json")
+    let outputPath = Path.Join(root, "tests", "cross-verification", "modulo-gset", "fsharp-output.json")
+
+    use vectorsDoc = JsonDocument.Parse(File.ReadAllText(vectorsPath))
+    use outputDoc = JsonDocument.Parse(File.ReadAllText(outputPath))
+
+    Assert.Equal("hand-port", outputDoc.RootElement.GetProperty("_source").GetString())
+
+    for vector in vectorsDoc.RootElement.GetProperty("vectors").EnumerateArray() do
+        let id = vector.GetProperty("id").GetString()
+        let expected = JsonNode.Parse(vector.GetProperty("expected").GetRawText())
+        let actual = replayModuloVector vector
+        let committed = JsonNode.Parse(outputDoc.RootElement.GetProperty(id).GetRawText())
+
+        Assert.True(JsonNode.DeepEquals(expected, actual), sprintf "computed F# output diverged for %s" id)
+        Assert.True(JsonNode.DeepEquals(expected, committed), sprintf "committed F# output diverged for %s" id)

--- a/tests/cross-verification/modulo-gset/compare.ts
+++ b/tests/cross-verification/modulo-gset/compare.ts
@@ -1,0 +1,8 @@
+import { runNWayDiff } from "../_harness/nway-diff";
+
+process.exit(
+  runNWayDiff({
+    dir: import.meta.dir,
+    minOracles: 2,
+  }),
+);

--- a/tests/cross-verification/modulo-gset/fsharp-output.json
+++ b/tests/cross-verification/modulo-gset/fsharp-output.json
@@ -1,0 +1,76 @@
+{
+  "_source": "hand-port",
+  "reject-collision-keeps-room-cold": {
+    "admissions": [
+      {
+        "admission": "admitted",
+        "slot": 1
+      },
+      {
+        "admission": "rejected-by-collision",
+        "slot": 1
+      },
+      {
+        "admission": "already-present",
+        "slot": 1
+      }
+    ],
+    "exterior": ["a"],
+    "heatForgotten": [],
+    "heatUnits": 0,
+    "rejected": 1,
+    "stateSlots": [
+      {
+        "slot": 1,
+        "value": "a"
+      }
+    ]
+  },
+  "replace-existing-emits-heat": {
+    "admissions": [
+      {
+        "admission": "admitted",
+        "slot": 3
+      },
+      {
+        "admission": "replaced",
+        "slot": 3
+      },
+      {
+        "admission": "already-present",
+        "slot": 3
+      }
+    ],
+    "exterior": ["new"],
+    "heatForgotten": ["old"],
+    "heatUnits": 1,
+    "rejected": 0,
+    "stateSlots": [
+      {
+        "slot": 3,
+        "value": "new"
+      }
+    ]
+  },
+  "gset-source-replays-in-canonical-order": {
+    "admissions": [],
+    "exterior": ["1", "3"],
+    "heatForgotten": ["0"],
+    "heatUnits": 1,
+    "rejected": 0,
+    "stateSlots": [
+      {
+        "slot": 0,
+        "value": "3"
+      },
+      {
+        "slot": 1,
+        "value": "1"
+      }
+    ]
+  },
+  "invalid-slot-count-is-feedback": {
+    "error": "non-positive-slots",
+    "slots": 0
+  }
+}

--- a/tests/cross-verification/modulo-gset/ts-output.json
+++ b/tests/cross-verification/modulo-gset/ts-output.json
@@ -1,0 +1,76 @@
+{
+  "_source": "hand-port",
+  "reject-collision-keeps-room-cold": {
+    "admissions": [
+      {
+        "admission": "admitted",
+        "slot": 1
+      },
+      {
+        "admission": "rejected-by-collision",
+        "slot": 1
+      },
+      {
+        "admission": "already-present",
+        "slot": 1
+      }
+    ],
+    "exterior": ["a"],
+    "heatForgotten": [],
+    "heatUnits": 0,
+    "rejected": 1,
+    "stateSlots": [
+      {
+        "slot": 1,
+        "value": "a"
+      }
+    ]
+  },
+  "replace-existing-emits-heat": {
+    "admissions": [
+      {
+        "admission": "admitted",
+        "slot": 3
+      },
+      {
+        "admission": "replaced",
+        "slot": 3
+      },
+      {
+        "admission": "already-present",
+        "slot": 3
+      }
+    ],
+    "exterior": ["new"],
+    "heatForgotten": ["old"],
+    "heatUnits": 1,
+    "rejected": 0,
+    "stateSlots": [
+      {
+        "slot": 3,
+        "value": "new"
+      }
+    ]
+  },
+  "gset-source-replays-in-canonical-order": {
+    "admissions": [],
+    "exterior": ["1", "3"],
+    "heatForgotten": ["0"],
+    "heatUnits": 1,
+    "rejected": 0,
+    "stateSlots": [
+      {
+        "slot": 0,
+        "value": "3"
+      },
+      {
+        "slot": 1,
+        "value": "1"
+      }
+    ]
+  },
+  "invalid-slot-count-is-feedback": {
+    "error": "non-positive-slots",
+    "slots": 0
+  }
+}

--- a/tests/cross-verification/modulo-gset/vectors.json
+++ b/tests/cross-verification/modulo-gset/vectors.json
@@ -1,0 +1,147 @@
+{
+  "primitive": "modulo-gset",
+  "version": "v1",
+  "description": "ModuloGSet is a finite slot projection of a grow-only set. Plain GSet remains grow-only; this view either backpressures slot collisions cold or replaces the occupant and emits forgotten material as heat.",
+  "vectors": [
+    {
+      "id": "reject-collision-keeps-room-cold",
+      "description": "No-forget mode preserves the existing occupant and counts cold backpressure.",
+      "config": {
+        "slots": 4,
+        "collisionPolicy": "reject-collision"
+      },
+      "mode": "ops",
+      "ops": [
+        {
+          "value": "a",
+          "slot": 1
+        },
+        {
+          "value": "e",
+          "slot": 5
+        },
+        {
+          "value": "a",
+          "slot": -3
+        }
+      ],
+      "expected": {
+        "admissions": [
+          {
+            "admission": "admitted",
+            "slot": 1
+          },
+          {
+            "admission": "rejected-by-collision",
+            "slot": 1
+          },
+          {
+            "admission": "already-present",
+            "slot": 1
+          }
+        ],
+        "exterior": ["a"],
+        "heatForgotten": [],
+        "heatUnits": 0,
+        "rejected": 1,
+        "stateSlots": [
+          {
+            "slot": 1,
+            "value": "a"
+          }
+        ]
+      }
+    },
+    {
+      "id": "replace-existing-emits-heat",
+      "description": "Replacement mode keeps the newest occupant and reports the evicted occupant as heat.",
+      "config": {
+        "slots": 4,
+        "collisionPolicy": "replace-existing"
+      },
+      "mode": "ops",
+      "ops": [
+        {
+          "value": "old",
+          "slot": -1
+        },
+        {
+          "value": "new",
+          "slot": 7
+        },
+        {
+          "value": "new",
+          "slot": 3
+        }
+      ],
+      "expected": {
+        "admissions": [
+          {
+            "admission": "admitted",
+            "slot": 3
+          },
+          {
+            "admission": "replaced",
+            "slot": 3
+          },
+          {
+            "admission": "already-present",
+            "slot": 3
+          }
+        ],
+        "exterior": ["new"],
+        "heatForgotten": ["old"],
+        "heatUnits": 1,
+        "rejected": 0,
+        "stateSlots": [
+          {
+            "slot": 3,
+            "value": "new"
+          }
+        ]
+      }
+    },
+    {
+      "id": "gset-source-replays-in-canonical-order",
+      "description": "Projecting from a GSet consumes canonical GSet order before applying modulo replacement.",
+      "config": {
+        "slots": 3,
+        "collisionPolicy": "replace-existing"
+      },
+      "mode": "from-gset",
+      "slotFunction": "parse-int-mod-slots",
+      "sourceValues": ["3", "0", "1", "0"],
+      "expected": {
+        "admissions": [],
+        "exterior": ["1", "3"],
+        "heatForgotten": ["0"],
+        "heatUnits": 1,
+        "rejected": 0,
+        "stateSlots": [
+          {
+            "slot": 0,
+            "value": "3"
+          },
+          {
+            "slot": 1,
+            "value": "1"
+          }
+        ]
+      }
+    },
+    {
+      "id": "invalid-slot-count-is-feedback",
+      "description": "Invalid slot count returns typed feedback, not an exception.",
+      "config": {
+        "slots": 0,
+        "collisionPolicy": "reject-collision"
+      },
+      "mode": "ops",
+      "ops": [],
+      "expected": {
+        "error": "non-positive-slots",
+        "slots": 0
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

- Added a source-owned TypeScript `ModuloGSet` port under `src/Core.TypeScript/g-set`.
- Added shared `modulo-gset` cross-verification vectors plus TS/F# committed oracle outputs.
- Added an F# treaty replay test so the existing F# implementation and the TS port stay byte-shape aligned.

## Why

Bounded/rolling GSets need an explicit forgetting policy. This locks the first finite-slot projection treaty: no-forget collision backpressure stays cold, replacement emits forgotten material as heat, and invalid slot counts return typed feedback rather than throwing.

## Validation

- `bun test src/Core.TypeScript/g-set/modulo-g-set.test.ts`
- `bun compare.ts` from `tests/cross-verification/modulo-gset`
- `bun src/Core.TypeScript/ci/cross-verify-all.ts`
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter FullyQualifiedName~BoundedGSetTests`
- `bun run preflight:quick`
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test Zeta.sln -c Release`
- `mise exec -- bun test`
- `bun src/Core.TypeScript/hygiene/audit-agencysignature-main-tip.ts --commit HEAD`

Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: Codex
Agent-Model: gpt-5.5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: not-implied-by-credential
Human-Review-Evidence: none
Action-Mode: human-directed
Task: modulo-gset-ts-treaty