### PR TITLE
feat(csharp): ImdbSchemas — wire the TypeSchema IR to the real IMDb dataset (grounding)

### DIFF
--- a/src/Core.CSharp/ImdbSchemas.cs
+++ b/src/Core.CSharp/ImdbSchemas.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+
+namespace Zeta.Core.CSharp;
+
+/// <summary>
+/// The real IMDb non-commercial dataset schemas, as zeta <see cref="TypeSchema"/> values — the
+/// grounding step ("everything grows from IMDb and Wikipedia"). Each schema is derived from the
+/// actual IMDb TSV column header via <see cref="FromTsvHeader"/> with IMDb's documented column
+/// types, so the generated C# / Rust / TS surfaces reflect the real dataset, not a toy. IMDb
+/// columns are camelCase; the neutral field names are PascalCase (the codegen baseline), and each
+/// codegen re-idiomizes (C# PascalCase records, Rust <c>snake_case</c> structs, TS camelCase
+/// interfaces). The subset <c>ImdbDataset.fs</c> currently parses (Nconst, PrimaryName; Tconst,
+/// Category) is a subset of these full schemas.
+/// </summary>
+public static class ImdbSchemas
+{
+    private const string Ns = "Zeta.Generated.Imdb";
+
+    private static readonly string[] NameBasicsColumns =
+        ["nconst", "primaryName", "birthYear", "deathYear", "primaryProfession", "knownForTitles"];
+
+    private static readonly string[] TitleBasicsColumns =
+        ["tconst", "titleType", "primaryTitle", "originalTitle", "isAdult", "startYear", "endYear", "runtimeMinutes", "genres"];
+
+    private static readonly string[] TitlePrincipalsColumns =
+        ["tconst", "ordering", "nconst", "category", "job", "characters"];
+
+    /// <summary>
+    /// Build a <see cref="TypeSchema"/> from a real TSV header's columns — the IR driven by the
+    /// dataset itself. Each column becomes a field (name PascalCased to the neutral baseline);
+    /// its type comes from <paramref name="typeHints"/> or falls back to <paramref name="defaultType"/>
+    /// (TSV is text, so unhinted columns are <c>string</c>).
+    /// </summary>
+    /// <param name="ns">Target namespace for the emitted type.</param>
+    /// <param name="typeName">Emitted type name (PascalCase).</param>
+    /// <param name="headerColumns">The dataset's actual column names (camelCase, from the TSV header row).</param>
+    /// <param name="typeHints">Column-name → neutral type token; columns absent here use <paramref name="defaultType"/>.</param>
+    /// <param name="defaultType">Neutral type token for columns without a hint.</param>
+    /// <returns>A schema whose fields mirror the dataset's columns in order.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="headerColumns"/> or <paramref name="typeHints"/> is null.</exception>
+    public static TypeSchema FromTsvHeader(
+        string ns,
+        string typeName,
+        IReadOnlyList<string> headerColumns,
+        IReadOnlyDictionary<string, string> typeHints,
+        string defaultType = "string")
+    {
+        ArgumentNullException.ThrowIfNull(headerColumns);
+        ArgumentNullException.ThrowIfNull(typeHints);
+
+        var fields = new List<SchemaField>(headerColumns.Count);
+        foreach (string column in headerColumns)
+        {
+            string csType = typeHints.TryGetValue(column, out string? hint) ? hint : defaultType;
+            fields.Add(new SchemaField(Pascalize(column), csType));
+        }
+
+        return new TypeSchema(ns, typeName, fields);
+    }
+
+    /// <summary><c>name.basics.tsv</c> — people: nconst, primaryName, birth/death years, professions, known-for titles.</summary>
+    public static TypeSchema NameBasics { get; } = FromTsvHeader(
+        Ns,
+        "ImdbName",
+        NameBasicsColumns,
+        new Dictionary<string, string>(StringComparer.Ordinal) { ["birthYear"] = "int?", ["deathYear"] = "int?" });
+
+    /// <summary><c>title.basics.tsv</c> — works: tconst, types, titles, adult flag, years, runtime, genres.</summary>
+    public static TypeSchema TitleBasics { get; } = FromTsvHeader(
+        Ns,
+        "ImdbTitle",
+        TitleBasicsColumns,
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["isAdult"] = "bool",
+            ["startYear"] = "int?",
+            ["endYear"] = "int?",
+            ["runtimeMinutes"] = "int?",
+        });
+
+    /// <summary><c>title.principals.tsv</c> — credited contributions: title, ordering, person, category, job, characters.</summary>
+    public static TypeSchema TitlePrincipals { get; } = FromTsvHeader(
+        Ns,
+        "ImdbPrincipal",
+        TitlePrincipalsColumns,
+        new Dictionary<string, string>(StringComparer.Ordinal) { ["ordering"] = "int" });
+
+    /// <summary>camelCase IMDb column to PascalCase neutral field name (e.g. <c>primaryName</c> → <c>PrimaryName</c>).</summary>
+    private static string Pascalize(string column) =>
+        column.Length == 0 ? column : char.ToUpperInvariant(column[0]) + column[1..];
+}

--- a/tests/Tests.CSharp/ImdbSchemasTests.cs
+++ b/tests/Tests.CSharp/ImdbSchemasTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+using Zeta.Core.CSharp;
+
+namespace Zeta.Tests.CSharp;
+
+/// <summary>
+/// Tests for <see cref="ImdbSchemas"/> — the IR grounded in the real IMDb dataset. The schema is
+/// derived from the actual TSV header, then the same schema renders to C# / Rust surfaces.
+/// </summary>
+public class ImdbSchemasTests
+{
+    [Fact]
+    public void FromTsvHeaderDerivesSchemaFromRealHeaderLine()
+    {
+        // The actual name.basics.tsv header row, split on tab — the IR driven by the dataset.
+        string[] header = "nconst\tprimaryName\tbirthYear\tdeathYear\tprimaryProfession\tknownForTitles".Split('\t');
+        TypeSchema schema = ImdbSchemas.FromTsvHeader(
+            "Zeta.Generated.Imdb",
+            "ImdbName",
+            header,
+            new Dictionary<string, string>(StringComparer.Ordinal) { ["birthYear"] = "int?", ["deathYear"] = "int?" });
+
+        Assert.Equal("ImdbName", schema.TypeName);
+        Assert.Equal(6, schema.Fields.Count);
+        Assert.Equal("PrimaryName", schema.Fields[1].Name);
+        Assert.Equal("int?", schema.Fields[2].CsType);
+        Assert.Equal("KnownForTitles", schema.Fields[5].Name);
+    }
+
+    [Fact]
+    public void RealNameBasicsGeneratesCSharpRecordWithRealColumns()
+    {
+        string cs = SchemaCodegen.Generate(ImdbSchemas.NameBasics);
+        Assert.Contains(
+            "public sealed record ImdbName(string Nconst, string PrimaryName, int? BirthYear, int? DeathYear, string PrimaryProfession, string KnownForTitles);",
+            cs,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RealNameBasicsGeneratesRustStructWithIdioms()
+    {
+        string rust = RustSchemaCodegen.Generate(ImdbSchemas.NameBasics);
+        Assert.Contains("pub birth_year: Option<i32>,", rust, StringComparison.Ordinal);
+        Assert.Contains("pub known_for_titles: String,", rust, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TitleBasicsAndPrincipalsAreGrounded()
+    {
+        Assert.Contains("public sealed record ImdbTitle(", SchemaCodegen.Generate(ImdbSchemas.TitleBasics), StringComparison.Ordinal);
+        Assert.Contains("bool IsAdult", SchemaCodegen.Generate(ImdbSchemas.TitleBasics), StringComparison.Ordinal);
+        Assert.Contains("int Ordering", SchemaCodegen.Generate(ImdbSchemas.TitlePrincipals), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AlignsWithImdbDatasetParsedSubset()
+    {
+        // ImdbDataset.fs parses a subset (Nconst, PrimaryName) — both must exist in the full real schema.
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        foreach (SchemaField field in ImdbSchemas.NameBasics.Fields)
+        {
+            names.Add(field.Name);
+        }
+
+        Assert.Contains("Nconst", names);
+        Assert.Contains("PrimaryName", names);
+    }
+}


### PR DESCRIPTION
**"Everything grows from IMDb and Wikipedia"** — grounds the codegen IR in the **real IMDb non-commercial dataset** instead of a toy schema.

- **`FromTsvHeader`** derives a `TypeSchema` directly from a dataset's actual TSV column header + IMDb's documented types — *the IR driven by the data*.
- Canonical schemas for the real files: **`name.basics`** → `ImdbName`, **`title.basics`** → `ImdbTitle`, **`title.principals`** → `ImdbPrincipal`, with real columns + types (`birthYear`/`deathYear` → `int?`, `isAdult` → `bool`, `ordering` → `int`, …).
- IMDb columns are camelCase; neutral field names PascalCase; each codegen re-idiomizes (C# PascalCase / Rust `snake_case` / TS camelCase).

`tests/Tests.CSharp/ImdbSchemasTests.cs` — 5 tests, **5/5 green**: `FromTsvHeader` derives from the real `name.basics` header; real `NameBasics` → C# record (6 real columns) + Rust struct (`birth_year: Option<i32>`, `known_for_titles: String`); `TitleBasics`/`Principals` grounded; aligns with the `ImdbDataset.fs` parsed subset (`Nconst`, `PrimaryName` ⊂ full schema).

Now the cross-lang trio (C#/Rust/TS — #8755/#8759/#8762) emits the **real** IMDb entity types from one dataset-derived IR. Future: emit a shared `.zetaschema.json` so the TS + Roslyn legs consume the same real schema file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)