### PR TITLE
feat(codegen): shared .zetaschema.json single-source IR — one file, every oracle

### DIFF
--- a/schemas/imdb/name-basics.zetaschema.json
+++ b/schemas/imdb/name-basics.zetaschema.json
@@ -1,0 +1,12 @@
+{
+  "namespace": "Zeta.Generated.Imdb",
+  "typeName": "ImdbName",
+  "fields": [
+    { "name": "Nconst", "csType": "string" },
+    { "name": "PrimaryName", "csType": "string" },
+    { "name": "BirthYear", "csType": "int?" },
+    { "name": "DeathYear", "csType": "int?" },
+    { "name": "PrimaryProfession", "csType": "string" },
+    { "name": "KnownForTitles", "csType": "string" }
+  ]
+}

--- a/schemas/imdb/title-basics.zetaschema.json
+++ b/schemas/imdb/title-basics.zetaschema.json
@@ -1,0 +1,15 @@
+{
+  "namespace": "Zeta.Generated.Imdb",
+  "typeName": "ImdbTitle",
+  "fields": [
+    { "name": "Tconst", "csType": "string" },
+    { "name": "TitleType", "csType": "string" },
+    { "name": "PrimaryTitle", "csType": "string" },
+    { "name": "OriginalTitle", "csType": "string" },
+    { "name": "IsAdult", "csType": "bool" },
+    { "name": "StartYear", "csType": "int?" },
+    { "name": "EndYear", "csType": "int?" },
+    { "name": "RuntimeMinutes", "csType": "int?" },
+    { "name": "Genres", "csType": "string" }
+  ]
+}

--- a/schemas/imdb/title-principals.zetaschema.json
+++ b/schemas/imdb/title-principals.zetaschema.json
@@ -1,0 +1,12 @@
+{
+  "namespace": "Zeta.Generated.Imdb",
+  "typeName": "ImdbPrincipal",
+  "fields": [
+    { "name": "Tconst", "csType": "string" },
+    { "name": "Ordering", "csType": "int" },
+    { "name": "Nconst", "csType": "string" },
+    { "name": "Category", "csType": "string" },
+    { "name": "Job", "csType": "string" },
+    { "name": "Characters", "csType": "string" }
+  ]
+}

--- a/src/Core.CSharp/SchemaJson.cs
+++ b/src/Core.CSharp/SchemaJson.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+
+namespace Zeta.Core.CSharp;
+
+/// <summary>
+/// Serialize / parse a <see cref="TypeSchema"/> as a <c>.zetaschema.json</c> file — the shared,
+/// language-neutral IR file that every codegen leg consumes from ONE source of truth: the C#
+/// <see cref="SchemaCodegen"/> / <see cref="RustSchemaCodegen"/>, the TypeScript leg, and the
+/// Roslyn source generator (approach A) all read this same format
+/// (<c>{ "namespace", "typeName", "fields": [ { "name", "csType" } ] }</c>).
+/// <para>
+/// <see cref="ToJson"/> emits a deterministic, byte-stable layout (2-space indent, explicit
+/// <c>\n</c>) so committed schema files are diffable + byte-lockable; <see cref="FromJson"/>
+/// parses tolerantly via <c>System.Text.Json</c>.
+/// </para>
+/// </summary>
+public static class SchemaJson
+{
+    /// <summary>Serialize a schema to the canonical, byte-stable <c>.zetaschema.json</c> text.</summary>
+    /// <param name="schema">The schema (IR) to serialize.</param>
+    /// <returns>Deterministic JSON with a trailing newline.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="schema"/> is null.</exception>
+    public static string ToJson(TypeSchema schema)
+    {
+        ArgumentNullException.ThrowIfNull(schema);
+
+        var sb = new StringBuilder();
+        sb.Append("{\n");
+        sb.Append("  \"namespace\": ").Append(JsonString(schema.Namespace)).Append(",\n");
+        sb.Append("  \"typeName\": ").Append(JsonString(schema.TypeName)).Append(",\n");
+        sb.Append("  \"fields\": [\n");
+        for (var i = 0; i < schema.Fields.Count; i++)
+        {
+            SchemaField field = schema.Fields[i];
+            sb.Append("    { \"name\": ").Append(JsonString(field.Name))
+              .Append(", \"csType\": ").Append(JsonString(field.CsType)).Append(" }");
+            sb.Append(i < schema.Fields.Count - 1 ? ",\n" : "\n");
+        }
+
+        sb.Append("  ]\n");
+        sb.Append("}\n");
+        return sb.ToString();
+    }
+
+    /// <summary>Parse a <c>.zetaschema.json</c> document into a <see cref="TypeSchema"/>.</summary>
+    /// <param name="json">The schema JSON text.</param>
+    /// <returns>The parsed schema.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="json"/> is null.</exception>
+    /// <exception cref="FormatException">A required property is missing or malformed.</exception>
+    public static TypeSchema FromJson(string json)
+    {
+        ArgumentNullException.ThrowIfNull(json);
+
+        using var doc = JsonDocument.Parse(json);
+        JsonElement root = doc.RootElement;
+
+        string ns = RequireString(root, "namespace");
+        string typeName = RequireString(root, "typeName");
+
+        if (!root.TryGetProperty("fields", out JsonElement fieldsEl) || fieldsEl.ValueKind != JsonValueKind.Array)
+        {
+            throw new FormatException("zetaschema: missing or non-array 'fields'.");
+        }
+
+        var fields = new List<SchemaField>(fieldsEl.GetArrayLength());
+        foreach (JsonElement f in fieldsEl.EnumerateArray())
+        {
+            fields.Add(new SchemaField(RequireString(f, "name"), RequireString(f, "csType")));
+        }
+
+        return new TypeSchema(ns, typeName, fields);
+    }
+
+    private static string RequireString(JsonElement el, string name)
+    {
+        if (!el.TryGetProperty(name, out JsonElement prop) || prop.ValueKind != JsonValueKind.String)
+        {
+            throw new FormatException($"zetaschema: missing or non-string '{name}'.");
+        }
+
+        return prop.GetString() ?? throw new FormatException($"zetaschema: null '{name}'.");
+    }
+
+    private static string JsonString(string value) => JsonSerializer.Serialize(value);
+}

--- a/src/Core.TypeScript/schema-codegen/schema-codegen.test.ts
+++ b/src/Core.TypeScript/schema-codegen/schema-codegen.test.ts
@@ -1,5 +1,25 @@
 import { test, expect } from "bun:test";
-import { generate, type TypeSchema } from "./schema-codegen";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { generate, loadSchema, type TypeSchema } from "./schema-codegen";
+
+// Shared single-source IR: the TS leg reads the SAME committed schemas/imdb/*.zetaschema.json
+// that the C# / Rust / Roslyn legs read. One file, every oracle.
+const sharedImdbNamePath = join(import.meta.dir, "../../../schemas/imdb/name-basics.zetaschema.json");
+
+test("loads the shared committed .zetaschema.json and generates the real IMDb interface", () => {
+  const schema = loadSchema(readFileSync(sharedImdbNamePath, "utf8"));
+  expect(schema.typeName).toBe("ImdbName");
+  const ts = generate(schema);
+  expect(ts).toContain("export interface ImdbName {");
+  expect(ts).toContain("nconst: string;");
+  expect(ts).toContain("birthYear: number | null;");
+  expect(ts).toContain("knownForTitles: string;");
+});
+
+test("loadSchema rejects a malformed schema", () => {
+  expect(() => loadSchema('{ "namespace": "X", "typeName": "Y" }')).toThrow();
+});
 
 // TypeScript leg of "one IR, a typed surface per oracle": the SAME TypeSchema the C#
 // SchemaCodegen renders to a record and the Rust RustSchemaCodegen renders to a struct

--- a/src/Core.TypeScript/schema-codegen/schema-codegen.ts
+++ b/src/Core.TypeScript/schema-codegen/schema-codegen.ts
@@ -33,6 +33,38 @@ const TS_TYPES: Readonly<Record<string, string>> = {
   "double?": "number | null",
 };
 
+/**
+ * Parse a shared `.zetaschema.json` IR file (the single source of truth all codegen legs read:
+ * C#, Rust, this TS leg, and the Roslyn generator). Validates the structure and narrows the
+ * `unknown` JSON to a {@link TypeSchema}.
+ */
+export function loadSchema(json: string): TypeSchema {
+  const raw: unknown = JSON.parse(json);
+  if (typeof raw !== "object" || raw === null) {
+    throw new Error("zetaschema: root must be an object");
+  }
+  const obj = raw as Record<string, unknown>;
+  const namespace = obj["namespace"];
+  const typeName = obj["typeName"];
+  const fieldsRaw = obj["fields"];
+  if (typeof namespace !== "string" || typeof typeName !== "string" || !Array.isArray(fieldsRaw)) {
+    throw new Error("zetaschema: missing or malformed namespace/typeName/fields");
+  }
+  const fields: SchemaField[] = fieldsRaw.map((f: unknown): SchemaField => {
+    if (typeof f !== "object" || f === null) {
+      throw new Error("zetaschema: each field must be an object");
+    }
+    const fo = f as Record<string, unknown>;
+    const name = fo["name"];
+    const csType = fo["csType"];
+    if (typeof name !== "string" || typeof csType !== "string") {
+      throw new Error("zetaschema: each field needs string name + csType");
+    }
+    return { name, csType };
+  });
+  return { namespace, typeName, fields };
+}
+
 /** PascalCase identifier to camelCase (e.g. `BirthYear` → `birthYear`, `Nconst` → `nconst`). */
 function toCamelCase(name: string): string {
   if (name.length === 0) {

--- a/tests/Tests.CSharp/SchemaJsonTests.cs
+++ b/tests/Tests.CSharp/SchemaJsonTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.IO;
+using Xunit;
+using Zeta.Core.CSharp;
+
+namespace Zeta.Tests.CSharp;
+
+/// <summary>
+/// Tests for <see cref="SchemaJson"/> and the committed shared <c>.zetaschema.json</c> IR files —
+/// one source of truth consumed by every codegen leg. The committed files are golden-locked to
+/// <see cref="ImdbSchemas"/> so the file and the code-defined schema can never drift.
+/// </summary>
+public class SchemaJsonTests
+{
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(Path.GetDirectoryName(typeof(SchemaJsonTests).Assembly.Location)!);
+        while (dir is not null && !File.Exists(Path.Join(dir.FullName, "Zeta.sln")))
+        {
+            dir = dir.Parent;
+        }
+
+        return dir?.FullName ?? throw new InvalidOperationException("Could not locate repo root (Zeta.sln).");
+    }
+
+    private static string SchemaFile(string name) =>
+        File.ReadAllText(Path.Join(RepoRoot(), "schemas", "imdb", name));
+
+    [Theory]
+    [InlineData("name-basics.zetaschema.json")]
+    [InlineData("title-basics.zetaschema.json")]
+    [InlineData("title-principals.zetaschema.json")]
+    public void CommittedFileRoundTripsThroughFromJsonAndToJson(string file)
+    {
+        string text = SchemaFile(file);
+        TypeSchema schema = SchemaJson.FromJson(text);
+        // ToJson is byte-stable, so re-serializing the parsed schema reproduces the committed file.
+        Assert.Equal(text, SchemaJson.ToJson(schema));
+    }
+
+    [Fact]
+    public void CommittedNameBasicsIsGoldenLockedToImdbSchemas()
+    {
+        // The committed file MUST equal the code-defined schema — single source of truth, no drift.
+        Assert.Equal(SchemaFile("name-basics.zetaschema.json"), SchemaJson.ToJson(ImdbSchemas.NameBasics));
+        Assert.Equal(SchemaFile("title-basics.zetaschema.json"), SchemaJson.ToJson(ImdbSchemas.TitleBasics));
+        Assert.Equal(SchemaFile("title-principals.zetaschema.json"), SchemaJson.ToJson(ImdbSchemas.TitlePrincipals));
+    }
+
+    [Fact]
+    public void LoadedSchemaFeedsCSharpAndRustCodegen()
+    {
+        // The shared IR file → the same typed surfaces the in-code schema produces.
+        TypeSchema fromFile = SchemaJson.FromJson(SchemaFile("name-basics.zetaschema.json"));
+        Assert.Contains(
+            "public sealed record ImdbName(string Nconst, string PrimaryName, int? BirthYear, int? DeathYear, string PrimaryProfession, string KnownForTitles);",
+            SchemaCodegen.Generate(fromFile),
+            StringComparison.Ordinal);
+        Assert.Contains("pub birth_year: Option<i32>,", RustSchemaCodegen.Generate(fromFile), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FromJsonRejectsMissingFields()
+    {
+        Assert.Throws<FormatException>(() => SchemaJson.FromJson("{ \"namespace\": \"X\", \"typeName\": \"Y\" }"));
+    }
+}


### PR DESCRIPTION
The **keystone** that unifies the codegen story: one committed, language-neutral `.zetaschema.json` IR file consumed by **all** legs — C# `SchemaCodegen`, Rust `RustSchemaCodegen`, the TS leg, and the Roslyn generator (which already reads this format). Grounded in the real IMDb dataset.

- **`src/Core.CSharp/SchemaJson.cs`** — `ToJson` (deterministic, byte-stable) + `FromJson` (tolerant parse).
- **`schemas/imdb/{name-basics,title-basics,title-principals}.zetaschema.json`** — the real IMDb schemas as committed shared IR files.
- **`tests/Tests.CSharp/SchemaJsonTests.cs`** (6 tests): committed files round-trip; **golden-locked to `ImdbSchemas`** (file == code, no drift); loaded file → C# record + Rust struct; rejects malformed input.
- **TS** `loadSchema(json)` + a test loading the **same** committed `name-basics` file → TS interface.

C# **6/6** + TS **7/7** green; `tsc` clean. One IR file now drives four generators across three languages, grounded in real IMDb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)