### PR TITLE
feat(csharp): SchemaTsvParser — schema-driven TSV row parsing into typed DynamicValue (live data)

### DIFF
--- a/src/Core.CSharp/SchemaTsvParser.cs
+++ b/src/Core.CSharp/SchemaTsvParser.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Globalization;
+
+namespace Zeta.Core.CSharp;
+
+/// <summary>
+/// Schema-driven TSV row parser — the live-data counterpart to <see cref="SchemaCodegen"/>. Given a
+/// <see cref="TypeSchema"/> (the same IR the codegens consume) and a raw IMDb TSV row, it produces a
+/// typed <see cref="DynamicValue"/> object whose fields are coerced per the schema's neutral types
+/// (<c>int?</c> → Int/Null, <c>bool</c> → Bool from <c>0</c>/<c>1</c>, <c>string</c> → String), with
+/// IMDb's <c>\N</c> null marker mapped to <see cref="DynamicValue.Null"/>. So one schema both
+/// <i>generates</i> the types and <i>parses</i> the rows into them — symmetric and dataset-grounded.
+/// All numeric parsing is <see cref="CultureInfo.InvariantCulture"/>.
+/// </summary>
+public static class SchemaTsvParser
+{
+    /// <summary>Parse one tab-separated row into a typed <see cref="DynamicValue.Object"/> per the schema.</summary>
+    /// <param name="schema">Schema describing field order + neutral types.</param>
+    /// <param name="tsvRow">A tab-separated data row (no header), matching the schema's field count.</param>
+    /// <returns>An object value keyed by schema field name, each cell coerced to its typed shape.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="schema"/> or <paramref name="tsvRow"/> is null.</exception>
+    /// <exception cref="FormatException">Column count mismatches the schema, or a typed cell fails to parse.</exception>
+    public static DynamicValue ParseRow(TypeSchema schema, string tsvRow)
+    {
+        ArgumentNullException.ThrowIfNull(schema);
+        ArgumentNullException.ThrowIfNull(tsvRow);
+
+        string[] cells = tsvRow.Split('\t');
+        if (cells.Length != schema.Fields.Count)
+        {
+            throw new FormatException(
+                $"TSV row has {cells.Length} columns; schema '{schema.TypeName}' expects {schema.Fields.Count}.");
+        }
+
+        var pairs = ImmutableArray.CreateBuilder<KeyValuePair<string, DynamicValue>>(schema.Fields.Count);
+        for (var i = 0; i < schema.Fields.Count; i++)
+        {
+            SchemaField field = schema.Fields[i];
+            pairs.Add(new KeyValuePair<string, DynamicValue>(field.Name, Coerce(field, cells[i])));
+        }
+
+        return new DynamicValue.Object(pairs.ToImmutable());
+    }
+
+    private static DynamicValue Coerce(SchemaField field, string cell)
+    {
+        // IMDb's null marker is the two characters backslash-N.
+        if (string.Equals(cell, "\\N", StringComparison.Ordinal))
+        {
+            return new DynamicValue.Null();
+        }
+
+        string baseType = field.CsType.EndsWith('?') ? field.CsType[..^1] : field.CsType;
+        switch (baseType)
+        {
+            case "string":
+                return new DynamicValue.String(cell);
+            case "bool":
+                return new DynamicValue.Bool(
+                    string.Equals(cell, "1", StringComparison.Ordinal)
+                    || string.Equals(cell, "true", StringComparison.OrdinalIgnoreCase));
+            case "int":
+            case "long":
+                return long.TryParse(cell, NumberStyles.Integer, CultureInfo.InvariantCulture, out long n)
+                    ? new DynamicValue.Int(n)
+                    : throw new FormatException($"field '{field.Name}': '{cell}' is not a valid {baseType}.");
+            case "double":
+                return double.TryParse(cell, NumberStyles.Float, CultureInfo.InvariantCulture, out double d)
+                    ? new DynamicValue.Float(d)
+                    : throw new FormatException($"field '{field.Name}': '{cell}' is not a valid double.");
+            default:
+                throw new NotSupportedException($"field '{field.Name}': unknown type token '{field.CsType}'.");
+        }
+    }
+}

--- a/tests/Tests.CSharp/SchemaTsvParserTests.cs
+++ b/tests/Tests.CSharp/SchemaTsvParserTests.cs
@@ -1,0 +1,58 @@
+using System;
+using Xunit;
+using Zeta.Core.CSharp;
+
+namespace Zeta.Tests.CSharp;
+
+/// <summary>
+/// Tests for <see cref="SchemaTsvParser"/> — the same IMDb schema that generates the types also
+/// parses real TSV rows into typed <see cref="DynamicValue"/> values, with <c>\N</c> → Null.
+/// </summary>
+public class SchemaTsvParserTests
+{
+    private static DynamicValue Field(DynamicValue v, string key) =>
+        DynamicValues.TryField(v, key) ?? throw new InvalidOperationException($"missing field {key}");
+
+    [Fact]
+    public void ParsesRealNameBasicsRowIntoTypedObject()
+    {
+        // Real name.basics shape: nconst, primaryName, birthYear, deathYear, professions, knownForTitles.
+        const string Row = "nm0000001\tFred Astaire\t1899\t1987\tactor,miscellaneous\ttt0072308,tt0050419";
+        DynamicValue v = SchemaTsvParser.ParseRow(ImdbSchemas.NameBasics, Row);
+
+        Assert.Equal("nm0000001", DynamicValues.TryString(Field(v, "Nconst")));
+        Assert.Equal("Fred Astaire", DynamicValues.TryString(Field(v, "PrimaryName")));
+        Assert.Equal((long?)1899, DynamicValues.TryInt(Field(v, "BirthYear")));
+        Assert.Equal((long?)1987, DynamicValues.TryInt(Field(v, "DeathYear")));
+    }
+
+    [Fact]
+    public void MapsImdbNullMarkerToNull()
+    {
+        // Living person → deathYear is the IMDb null marker \N.
+        const string Row = "nm0000002\tLauren Bacall\t1924\t\\N\tactress\ttt0038355";
+        DynamicValue v = SchemaTsvParser.ParseRow(ImdbSchemas.NameBasics, Row);
+
+        Assert.True(DynamicValues.IsNull(Field(v, "DeathYear")));
+        Assert.Equal((long?)1924, DynamicValues.TryInt(Field(v, "BirthYear")));
+    }
+
+    [Fact]
+    public void ParsesBoolAndNullableIntColumns()
+    {
+        // title.basics: tconst, titleType, primaryTitle, originalTitle, isAdult, startYear, endYear, runtimeMinutes, genres.
+        const string Row = "tt0000001\tshort\tCarmencita\tCarmencita\t0\t1894\t\\N\t1\tDocumentary,Short";
+        DynamicValue v = SchemaTsvParser.ParseRow(ImdbSchemas.TitleBasics, Row);
+
+        Assert.Equal((bool?)false, DynamicValues.TryBool(Field(v, "IsAdult")));
+        Assert.Equal((long?)1894, DynamicValues.TryInt(Field(v, "StartYear")));
+        Assert.True(DynamicValues.IsNull(Field(v, "EndYear")));
+        Assert.Equal((long?)1, DynamicValues.TryInt(Field(v, "RuntimeMinutes")));
+    }
+
+    [Fact]
+    public void ThrowsOnColumnCountMismatch()
+    {
+        Assert.Throws<FormatException>(() => SchemaTsvParser.ParseRow(ImdbSchemas.NameBasics, "too\tfew\tcols"));
+    }
+}


### PR DESCRIPTION
The **live-data counterpart** to `SchemaCodegen`: the SAME IMDb schema that generates the *types* now parses real TSV *rows* into typed `DynamicValue` objects.

- Cells coerced per the schema's neutral types — `int?`/`int` → `Int`, `bool` → `Bool` (0/1), `double` → `Float`, `string` → `String` — with IMDb's **`\N`** null marker → `DynamicValue.Null`, all numeric parsing `InvariantCulture`.
- `tests/Tests.CSharp/SchemaTsvParserTests.cs` — 4 tests, **4/4 green**: real `name.basics` row → typed object; `\N` → Null (a living person's `deathYear`); `title.basics` bool + nullable-int columns; column-count mismatch throws (fail-fast).

Completes the round trip: **real IMDb dataset → schema (`FromTsvHeader`) → types (C#/Rust/TS codegen) AND rows (`SchemaTsvParser`) → typed `DynamicValue`.** One schema, symmetric: it both generates the types and parses the data into them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)