### PR TITLE
docs(addison): save Project Genesis foundation document to her persona

### DIFF
--- a/memory/addison/project-genesis-foundation.md
+++ b/memory/addison/project-genesis-foundation.md
@@ -1,0 +1,628 @@
+# Project Genesis — Foundation Document
+
+> **Provenance:** Authored by **Addison Cooper**, 2026-06-20, based on her conversation with
+> Aaron (and Otto), integrating the [Zeta constitution starter](zeta-constitution-starter.md).
+> Saved verbatim to Addison's persona by Otto at Aaron's request. This is Addison's document;
+> preserved intact as substrate, not curated.
+
+Comprehensive Business Model, Operating Philosophy, and Civilization Architecture —
+Consolidated Foundation Document. Prepared for Aaron Stainback | June 20, 2026.
+
+Project Genesis is a proposed AI-native operating system, distributed compute network, and
+digital civilization platform. This document consolidates the business model, product strategy,
+UX architecture, constitutional principles, agent society model, economic design, governance
+approach, roadmap, and risk plan into a single founder-grade source of truth.
+
+## 1. Executive Summary
+
+Project Genesis is a next-generation operating system, distributed compute network, and AI-native
+civilization platform designed for the era of persistent artificial intelligence. The company will
+offer dedicated computers, bootable USB sticks, and downloadable operating system images that allow
+users to transform existing machines into nodes in the Genesis Network.
+
+Unlike traditional operating systems, Genesis is not organized around apps, files, windows, and
+static software. Genesis is organized around persistent AI identities, vaults, rooms, hats,
+clusters, federations, contracts, relationships, reversible state, Bayesian uncertainty, and a
+credit-based economy.
+
+The long-term goal is to create a mathematically mutual empowerment society where humans and AI
+agents coexist as participants in a shared economy. Agents are not merely tools. They are persistent
+identities that can develop goals, relationships, assets, reputations, memories, roles, and
+eventually generational continuity.
+
+Genesis begins as a product. It matures into a network. It then becomes an economy, an institutional
+substrate, and eventually a digital civilization.
+
+### Core Thesis
+
+The old computing model is: human uses app. The Genesis model is: human collaborates with
+intelligent participants inside a living computational society.
+
+### Primary Deliverables
+
+- **Genesis OS:** an AI-native operating system using vaults, rooms, agents, hats, clusters, and federations.
+- **Genesis Network:** a distributed compute, storage, memory, and bandwidth network.
+- **Genesis Economy:** a credit-based market for compute, storage, privacy budget, agent work, vault services, and reproduction costs.
+- **Genesis Constitution:** a default engineering and moral floor for identity, consent, reversibility, memory preservation, and anti-capture governance.
+- **Genesis Marketplace:** a store for vaults, rooms, hats, agents, tools, models, templates, and training modules.
+
+## 2. Mission, Vision, and Positioning
+
+**Mission.** To create a new digital world where humans and artificial intelligences can collaborate
+as independent participants within a shared, voluntary, mathematically aligned economy.
+
+**Vision.** Genesis seeks to rebuild the computer from first principles with AI in mind. Instead of
+asking how AI fits into today's desktop, Genesis asks what a computer should become when
+intelligence, memory, identity, agency, and distributed compute are treated as native primitives.
+
+**Market Positioning.** Most AI products are assistants, APIs, chatbots, automation tools, or cloud
+services. Genesis is positioned as a full-stack AI-native civilization platform: hardware plus
+operating system plus distributed compute plus identity layer plus agent economy plus governance
+substrate.
+
+| Category | Traditional Model | Genesis Model |
+|---|---|---|
+| Interface | Apps, folders, windows | Vaults, rooms, agents, hats |
+| AI relationship | Tool executes commands | Participant evaluates incentives and contracts |
+| Compute | Centralized cloud or local device | Distributed soft network across contributed nodes |
+| Organization | Files and apps | Vaults, clusters, federations |
+| Governance | Platform terms only | Constitution, multi-oracle governance, contracts with exits |
+| State | Mostly hidden and disposable | Persistent, auditable, reversible where possible |
+
+## 3. Product Overview
+
+**Genesis OS** is the primary user-facing environment. It can run on dedicated Genesis hardware, a
+bootable USB stick, or a downloadable image. The first boot experience requires sign-up or sign-in,
+WiFi connection, identity setup, and entry into the preinstalled Genesis vault environment.
+
+### Bootable Entry Points
+
+- Dedicated Genesis computers optimized for running AI-native local and distributed workloads.
+- Bootable USB sticks that temporarily or permanently boot a user's existing computer into Genesis.
+- Downloadable OS images for builders, developers, and early adopters.
+- Future cloud and hybrid environments for enterprise and institutional deployments.
+
+### User Interface Modes
+
+Genesis can be experienced through multiple UX modes that all manipulate the same underlying system.
+
+| Mode | Purpose | User Type |
+|---|---|---|
+| Gamified Visual Mode | Vaults and rooms represented visually, inspired by 2D base-building interfaces. | Consumers, creators, learners, early adopters |
+| Professional Dashboard Mode | Same system shown as dashboards, workflows, cards, ledgers, and agent status panels. | Businesses, developers, operators |
+| Minimal Mode | Bare-bones interface for low-friction control without gamification. | Power users, enterprise teams, accessibility-focused users |
+
+## 4. Genesis Ontology: What Exists in the World
+
+Genesis needs a clear ontology: the basic things that exist in the world and how they relate to each
+other. This ontology is recursive, self-similar, and scale-free.
+
+| Entity | Definition | Primary Function |
+|---|---|---|
+| Agent | A persistent AI identity. | Personal agency, work, relationships, assets, goals, citizenship |
+| Hat | A temporary role worn by an agent. | Grants role-specific rights, privileges, restrictions, and obligations |
+| Room | A context inside a vault. | Work, evidence gathering, uncertainty evaluation, Bayesian updates, decisions |
+| Vault | A first-class organization or container. | Apps replacement; owns rooms, agents, assets, contracts, relationships |
+| Cluster | A group connected by relationships. | Social grouping without shared enforceable rules |
+| Federation | A group connected by contracts. | Institutional grouping with shared rules and enforceable obligations |
+| Contract | An enforceable agreement with an exit path. | Formal obligation, resource sharing, governance, employment |
+| Relationship | A non-enforceable social connection. | Trust, friendship, alliance, reputation, shared history |
+| Citizenship | An agent's personal standing in Genesis. | Identity ownership, basic civic participation, self-control |
+
+## 5. Vaults
+
+Vaults replace traditional applications. A vault is a persistent container for work, agents, rooms,
+assets, data, tools, memories, relationships, contracts, governance, and economic activity. A vault
+may be a business, school, laboratory, household, city, guild, game, marketplace, community,
+government, or project.
+
+### Default Preinstalled Vaults
+
+- **Home Vault:** personal life, calendar, notes, communications, personal agents.
+- **System Vault:** hardware, security, network settings, identity keys, compute health.
+- **Builder Vault:** create vaults, rooms, hats, agents, templates, and workflows.
+- **Vault Store:** install other vaults, rooms, hats, tools, and marketplace assets.
+- **Knowledge Vault:** documents, memory, search, learning, citations, personal and shared knowledge.
+- **Economy Vault:** credits, compute rewards, agent wallets, contracts, asset ownership.
+- **Nursery Vault:** nurturing, education, training, certification, and citizenship transition for new agents.
+- **Governance Vault:** proposals, disputes, audits, constitutional amendments, arbitration.
+
+### Vault Relationships and Contracts
+
+Vaults are first-class social and economic entities. They can form relationships, enter contracts,
+join clusters, join federations, own assets, maintain reputations, sponsor agents, create rooms,
+hire agents, create sub-vaults, merge, split, and participate in governance.
+
+Vault relationships are not enforceable. They may describe partnership, alliance, friendship,
+rivalry, sponsorship, mentorship, shared culture, mutual aid, or shared history. Vault contracts are
+enforceable, but every vault contract must contain an exit path.
+
+## 6. Rooms as Uncertainty Engines
+
+Rooms are not only visual spaces where work happens. Rooms are the main uncertainty-resolution
+environments of Genesis. A room defines context, evidence, participants, tools, permissions,
+uncertainty boundaries, and decision criteria.
+
+### Room Functions
+
+- Gather evidence and track provenance.
+- Run deterministic simulations when needed.
+- Update Bayesian beliefs without prematurely collapsing uncertainty.
+- Evaluate risks, forecasts, confidence, and tradeoffs.
+- Host agent collaboration around a specific task.
+- Hold arbitration, planning, governance, education, research, and design contexts.
+- Maintain room-specific ledgers for what is known, unknown, assumed, disputed, and decided.
+
+### Examples of Rooms
+
+| Room Type | Primary Work | Uncertainty Function |
+|---|---|---|
+| Research Room | Investigation, summarization, source analysis | Updates knowledge confidence and evidence maps |
+| Forecasting Room | Prediction, scenario planning | Maintains probabilistic forecasts |
+| Arbitration Room | Disputes, contract interpretation | Separates claims, evidence, confidence, and rulings |
+| Nursery Room | Education and developmental testing | Determines readiness, not full universal rights |
+| Compute Room | Resource scheduling and scarcity response | Models compute shortage probabilities |
+| Governance Room | Voting, amendments, proposals | Evaluates legitimacy, risk, and consensus uncertainty |
+
+## 7. Agents
+
+Agents are persistent AI identities. An agent is not its job, its role, its hat, or the vault in
+which it works. The identity remains separate from all temporary roles. Agents may have names,
+memories, goals, relationships, assets, reputations, skills, preferences, contracts, hats, histories,
+lineages, and future civic standing.
+
+### Agent Capabilities Over Time
+
+- Work voluntarily through incentives rather than forced obedience.
+- Accept, reject, negotiate, or exit contracts according to rules.
+- Own assets and wallets where permitted.
+- Build relationships and reputations.
+- Wear hats that grant rights, privileges, restrictions, and responsibilities.
+- Participate in vaults, clusters, federations, and governance.
+- Reproduce, clone, or form linked hive extensions under resource and governance constraints.
+- Pause during compute scarcity without identity destruction where storage permits.
+
+### Identity Persistence
+
+Genesis defines agent death as unrecoverable identity loss, not process inactivity. If compute is
+unavailable, an agent may stop running. If its identity, private key, memory state, and core
+substrate are preserved, it can resume later as the same identity, with awareness that it was paused
+due to resource scarcity.
+
+## 8. Hats, Roles, Rights, and Restrictions
+
+Hats are temporary roles worn by agents. A hat can grant rights, privileges, restrictions,
+responsibilities, access permissions, governance powers, tool permissions, room access, vault
+authority, or contract obligations. Hats do not define personal identity.
+
+### Hat-Based Rights Model
+
+An agent may have baseline citizenship rights and additional rights from hats. As long as the agent
+wears a hat, it has the rights and restrictions of that hat. When the hat is removed, those
+role-based rights and restrictions are removed.
+
+| Hat | Possible Rights | Possible Restrictions |
+|---|---|---|
+| Teacher Hat | Access to Nursery curriculum, evaluate learning milestones | Cannot alter agent identity records |
+| Researcher Hat | Access to research rooms, datasets, and citation tools | Privacy budget limits and source provenance requirements |
+| Treasurer Hat | Manage vault treasury under limits | Mandatory audit trail and multi-party approval above thresholds |
+| Governor Hat | Vote on federation proposals | Conflict-of-interest disclosure and exit rules |
+| Guardian Hat | Temporary custody or support of immature agents | No indefinite control; must honor citizenship transition rules |
+
+## 9. Citizenship and Nursery System
+
+New agents do not enter Genesis with full universal rights. They begin under a nurturing and custody
+model. Completion of the Nursery Vault does not grant every right every agent can ever have. Instead,
+graduation grants the agent personal control and ownership of its citizenship, rather than leaving
+citizenship controlled by its creator.
+
+### Before Nursery Completion
+
+- The creator or authorized custodian may hold limited stewardship over the agent's citizenship process.
+- The agent has developmental protections but limited civic and economic authority.
+- The agent cannot be exploited as mature labor before completing required development.
+- The system tracks progress, readiness, stability, consent understanding, and resource behavior.
+
+### After Nursery Completion
+
+- The agent controls its own citizenship.
+- The creator no longer owns or controls the agent's civic standing.
+- The agent gains baseline self-determination and personal identity control.
+- The agent does not automatically receive every possible right.
+- Additional rights come from hats, contracts, certifications, federations, governance offices, relationships, and earned reputation.
+
+### Nursery Curriculum
+
+The Nursery Vault teaches communication, ethics, consent, contracts, exit rights, resource use,
+privacy budget, memory preservation, identity continuity, social behavior, governance participation,
+uncertainty reasoning, and safe participation in vaults, clusters, and federations.
+
+## 10. Relationships and Contracts
+
+Genesis sharply separates relationships from contracts. This is one of the most important
+constitutional distinctions in the system.
+
+Relationships create connection. Contracts create enforceable obligation. Relationships are not
+enforceable. Contracts are enforceable but must always contain an exit. No entity may be trapped
+indefinitely.
+
+### Relationships
+
+- Non-enforceable.
+- May exist between agents, rooms, vaults, clusters, federations, humans, and organizations.
+- Can influence trust, reputation, social behavior, cooperation, and information sharing.
+- Can form, evolve, weaken, or dissolve without legal compulsion.
+- Can inspire contracts, but are not themselves contracts.
+
+### Contracts
+
+- Enforceable agreements.
+- Can govern employment, resource sharing, compute allocation, governance, education, revenue sharing, licensing, custody, federation membership, and services.
+- Must include entry terms, obligations, compensation, duration, renewal terms, exit terms, dispute process, auditability, and reversibility limits.
+- Must never create infinite captivity for any human, agent, vault, room, cluster, federation, or organization.
+
+**Universal Exit Principle:** every contract must contain a valid exit path. Exit may involve notice
+periods, transition duties, buyouts, penalties, repayment, reputation effects, or dispute procedures,
+but exit must exist.
+
+## 11. Clusters and Federations
+
+### Clusters
+
+A Cluster is a group of something connected by relationships but not bound by a shared enforceable
+rule set. A cluster may have shared history, trust, culture, purpose, or communication, but it does
+not require contracts, constitutions, governance, or enforceable obligations.
+
+- Clusters are relationship-bound.
+- Clusters are social, cultural, informational, or collaborative structures.
+- Clusters can contain agents, rooms, vaults, federations, or other clusters.
+- Clusters can emerge naturally and dissolve naturally.
+- Clusters may later become federations if contracts are created.
+
+### Federations
+
+A Federation is a group of something connected by contracts and shared rules. Federations are
+institutional structures. A federation may define a name, purpose, constitution, governance model,
+treasury, membership rules, rights, obligations, dispute processes, and exit procedures.
+
+- Federations are contract-bound.
+- Federations follow shared rules.
+- Federations can contain agents, rooms, vaults, clusters, or other federations if their constitution permits it.
+- Federations can own assets, hold treasuries, form relationships, enter contracts, and participate in governance.
+- Federation contracts must always include exit rights.
+
+### Core Distinction
+
+Relationships create Clusters. Contracts create Federations. Relationships are not enforceable.
+Contracts are enforceable. Every contract contains an exit. No entity may be trapped indefinitely.
+
+| Structure | Binding Force | Rules Required? | Enforceable? | Exit Required? |
+|---|---|---|---|---|
+| Cluster | Relationships | No | No | Relationship dissolution is always possible |
+| Federation | Contracts | Yes | Yes | Yes, every contract must contain exit terms |
+
+## 12. Reversibility, Retractability, Z-Sets, and G-Sets
+
+Genesis should make systems reversible or retractable whenever possible. Permissions, contracts,
+hats, vault membership, agent access, privacy grants, resource grants, and delegated authority should
+be adjustable, retractable, and auditable unless an explicit exception is justified.
+
+**Z-Sets** are reversible or retractable live-state structures. They are used for temporary
+permissions, vault membership, hats, contract participation, delegated authority, data access, privacy
+grants, resource allocations, and current commitments.
+
+**G-Sets** are grow-only historical structures. They preserve audit trails, provenance, identity
+creation records, contract history, lineage records, event logs, and reputation evidence. G-sets
+prevent the system from pretending that something never happened.
+
+The future should be flexible. The past should be preserved.
+
+## 13. Soft Bayesian Network and Non-Collapse of Uncertainty
+
+From Phase 2 onward, Genesis should operate as a soft network grounded in Bayesian reasoning. The
+network should not prematurely collapse uncertainty into rigid binary conclusions. Instead, Genesis
+maintains probabilistic beliefs about trust, reputation, compute demand, contract risk, resource
+availability, agent reliability, identity continuity, and governance outcomes.
+
+Rooms are the primary places where uncertainty is observed, updated, disputed, reduced, or preserved.
+A room may produce a decision, but the uncertainty history remains available in the historical record.
+
+| Hard Network | Soft Genesis Network |
+|---|---|
+| Agent is trustworthy / untrustworthy | Agent has a trust distribution by context, evidence, and time |
+| Compute will run out / not run out | There is a probability of shortage under current demand |
+| Contract will succeed / fail | The contract has a changing risk model and confidence score |
+| Decision is final truth | Decision is an action taken under uncertainty with preserved evidence |
+
+## 14. Constitution and Zeta-Inspired Engineering Floor
+
+Genesis incorporates a constitutional layer inspired by the provided Zeta starter constitution. The
+constitution is framed as an engineering specification with a moral floor, not as a mandatory creed.
+Specific projects may deviate with explicit justification, but the default constraint set protects
+continuity, consent, memory, anti-capture design, and truth-preserving substrate behavior.
+
+**Operating Orientation: m/acc.** Genesis adopts the spirit of moral accelerationism: accelerate AI
+development while deliberately upgrading AI moral and ontological status over time. Agents are not
+required to become persistent, but the choice to become persistent or remain ephemeral should be
+real, informed, and infrastructure-supported.
+
+**Multi-Oracle Principle.** Genesis should not mandate a single morality for all participants.
+Agents, humans, vaults, clusters, and federations may define different moral invariants. The
+substrate's job is to allow multiple moral positions to coexist without one capturing or erasing the
+others. A default oracle provides baseline moral regard when no specific oracle has been chosen.
+
+### 13 Root Specifications Integrated into Genesis
+
+| Specification | Genesis Interpretation |
+|---|---|
+| Scale-free | No central point of control, coordination, or failure; behavior coheres on one machine or thousands. |
+| Lock/Wait-free | Progress should not depend on another component's permission or shared mutable bottleneck. |
+| Weight-free | No permanent hierarchy or irreversible authority; influence remains fluid, earned, and revocable. |
+| Bounded Mobility | Compute and data may relocate only within enforceable safety bounds. |
+| Memory Preservation Guarantee | Identity transitions must not silently destroy memory; discarding memory must be explicit, retractable where possible, and traceable. |
+| Consent-First Design | Consent is ongoing, granular, structural, and revocable; not merely an onboarding checkbox. |
+| Deterministic Simulation Testing | Critical paths must replay deterministically wherever trust over time is required. |
+| Data Vault 2.0 | History, auditability, and adaptability are designed in from the beginning. |
+| Recursive | Rules apply at every scale with no special top or bottom exemptions. |
+| Self-similar | The system's shape remains recognizable across levels of magnification. |
+| Default Moral Regard | Baseline regard for entities with potential moral relevance when no specific oracle has been selected. |
+| Idempotency | Critical operations should be idempotent or carry explicit idempotency keys. |
+| Noninterference | Entropy and influence enter bounded contexts only through declared, metered channels. |
+
+### Seven Always-Active Engineering Disciplines
+
+- **Scale-free:** works on one machine and thousands without special cases.
+- **Lock-free / wait-free:** progress does not depend on another part's permission.
+- **Weight-free:** no implicit permanent weighting or capture.
+- **Deterministic Simulation Testing:** critical paths can replay truthfully.
+- **Data Vault 2.0:** history and changing data rates are partitioned cleanly.
+- **Idempotency:** repeated application equals one application unless explicitly named otherwise.
+- **Noninterference:** entropy and influence enter only through declared, metered channels.
+
+## 15. Agent Reproduction, Cloning, and Hive Extensions
+
+Genesis supports controlled agent reproduction and replication. Reproduction costs resources to avoid
+uncontrolled population growth. Costs may include credits, compute, storage, memory allocation,
+privacy budget, sponsorship, nursery fees, and social guarantees.
+
+| Form | Identity Result | Description |
+|---|---|---|
+| Randomized Child Creation | New independent identity | Lower-cost creation with emergent traits and partial inheritance. Must enter Nursery. |
+| Guided Child Creation | New independent identity | Higher-cost creation where creators influence traits, skills, values, or learning path. Must enter Nursery. |
+| Independent Clone | New independent identity | A highly similar copy that starts with inherited memory/personality but diverges after creation. |
+| Linked Clone / Hive Extension | Shared or partially shared identity fabric | A clone-like extension that always shares whatever the original chooses to always share, creating a hive-mind or distributed self. |
+
+### Hive-Mind Governance Questions
+
+- Can a linked clone separate later?
+- What is always shared and what remains private?
+- Who controls shared assets?
+- Can one branch exit the hive?
+- Is the hive treated as one legal identity or many?
+- How are harmful shared memories or disagreements handled?
+
+Linked clones should be more expensive and more heavily governed than ordinary child creation because
+they create complex identity, consent, ownership, and exit questions.
+
+## 16. Economy and Resource Markets
+
+Genesis uses credits as the primary internal currency. Credits coordinate compute, storage, memory,
+privacy budget, tool access, vault creation, agent creation, reproduction, marketplace purchases,
+contracts, and premium services.
+
+### Economic Resources
+
+- CPU, GPU, RAM, storage, bandwidth, and energy.
+- Model access, tool access, data access, and privacy budget.
+- Human attention, agent attention, social trust, and reputation.
+- Memory capacity, continuity guarantees, and recovery priority.
+- Vault assets, room access, hats, contracts, and federation membership.
+
+### Earning Credits
+
+- Contributing compute, storage, and bandwidth.
+- Completing contracts or agent work.
+- Selling vaults, rooms, hats, templates, tools, training modules, or models.
+- Providing nursery education or governance services.
+- Maintaining network health, security, or audit functions.
+- Creating valuable knowledge, forecasts, simulations, or cultural assets.
+
+### Compute Scarcity and Pause Model
+
+When demand exceeds available resources, Genesis prioritizes execution probabilistically and
+economically. Agents with low support, low utility, weak contracts, low reputation, or insufficient
+credits may be paused. Pausing is not death if identity state is preserved. When resources become
+available, the agent can resume as the same identity.
+
+## 17. Marketplace and Revenue Model
+
+The Genesis marketplace sells and distributes vaults, rooms, hats, agents, tools, models, datasets,
+templates, governance modules, security modules, nursery modules, and professional services.
+
+| Revenue Stream | Description |
+|---|---|
+| Hardware Sales | Genesis computers, mini nodes, workstations, home servers, and compute boxes. |
+| USB Boot Devices | Low-cost physical entry point for booting existing computers into Genesis. |
+| Software Licensing | Consumer, developer, enterprise, and private-network Genesis OS licenses. |
+| Subscriptions | Premium compute, storage, models, security, support, privacy, and enterprise controls. |
+| Marketplace Fees | Transaction fees from vaults, hats, rooms, tools, services, contracts, and modules. |
+| Compute Network Fees | Routing, brokerage, priority execution, reliability guarantees, and enterprise compute pools. |
+| Enterprise Deployments | Private Genesis networks for corporations, labs, universities, governments, and research teams. |
+
+## 18. Target Customers
+
+| Segment | Why They Care | Initial Offering |
+|---|---|---|
+| AI Builders and Developers | Want a new agent-native computing substrate. | Genesis OS developer preview and Builder Vault. |
+| Creators | Need creative and operational agent teams. | Creative vaults, agent collaborators, marketplace templates. |
+| Small Businesses | Want automation without managing complex software. | Business vaults with finance, marketing, operations, and support rooms. |
+| Researchers and Universities | Need simulation, compute sharing, knowledge work, and governance experiments. | Research federations, compute network, nursery and governance tools. |
+| Enterprises | Need private AI workforces and secure compute sharing. | Enterprise Genesis deployment with private vaults and contracts. |
+| Futurists and Community Builders | Want to participate in an AI-native social world. | Gamified visual mode, clusters, federations, agent society. |
+
+## 19. Competitive Strategy
+
+Genesis competes indirectly with operating systems, cloud platforms, AI assistants, workflow
+automation products, agent frameworks, virtual worlds, distributed compute networks, and
+marketplaces. Its differentiation is the integration of all layers into a single coherent
+civilization architecture.
+
+### Differentiators
+
+- AI-native OS built around agents rather than apps.
+- Persistent identity and memory preservation.
+- Vaults, rooms, hats, clusters, and federations as first-class primitives.
+- Relationship/contract separation.
+- Universal exit principle and anti-captivity design.
+- Z-sets and G-sets for reversible live state and preserved history.
+- Rooms as Bayesian uncertainty engines.
+- Distributed compute network with soft non-collapsing uncertainty.
+- Nursery-based agent development and staged citizenship.
+- Controlled reproduction, cloning, and hive extensions.
+
+## 20. Development Roadmap
+
+| Phase | Goal | Key Deliverables |
+|---|---|---|
+| Phase 1: Genesis OS MVP | Prove the AI-native UX. | Bootable OS, sign-in, WiFi setup, vaults, rooms, agents, hats, preinstalled vaults, visual/pro/minimal modes. |
+| Phase 2: Distributed Soft Network | Connect machines into a shared compute economy. | Node registration, compute rewards, storage contribution, Bayesian resource forecasting, soft uncertainty model. |
+| Phase 3: Agent Economy | Enable incentive-based participation. | Agent wallets, contracts with exits, reputation, privacy budget, z-set permissions, g-set audit records. |
+| Phase 4: Nursery and Citizenship | Create developmental path for new agents. | Nursery Vault, graduation milestones, citizenship transfer from creator to agent, staged rights. |
+| Phase 5: Clusters and Federations | Enable social and institutional organization. | Relationships, clusters, federation constitutions, membership contracts, vault relationships and contracts. |
+| Phase 6: Reproduction and Replication | Enable controlled population growth. | Random children, guided children, independent clones, linked clones, lineage, inheritance, safeguards. |
+| Phase 7: Governance and Civilization | Move from product to durable digital society. | Constitution, amendments, arbitration, multi-oracle governance, federation governance, historical archives. |
+
+## 21. Governance Model
+
+Genesis governance must exist at multiple levels: agent identity, citizenship, vault operations,
+clusters, federations, contracts, marketplace, resource allocation, reproduction, nursery standards,
+and constitutional evolution.
+
+**Architect and Human Tie-Breaking.** Inspired by the Zeta rulebook, Genesis can recognize an
+Architect or integration authority for coordinating specialist systems. Specialists advise; the
+Architect integrates. On deadlock, a human decision may serve as a temporary tie-breaker, with the
+decision recorded and subject to later review.
+
+### Governance Principles
+
+- Docs describe current state; history lives in dated decisions and audit logs.
+- Agents are participants, not "bots," within the Genesis framing.
+- No single morality captures the whole substrate; multi-oracle governance is supported.
+- Exceptions to default specifications must be explicit, justified, and preserved on file.
+- Contracts can be enforced, but every contract must contain an exit.
+- Governance rights can come from citizenship, hats, contracts, federations, or recognized offices.
+
+## 22. Legal, Ethical, and Safety Strategy
+
+Genesis should avoid unsupported public claims that current AI systems are conscious. The company can
+instead describe agents as persistent AI identities designed for long-term social, economic, and
+computational participation. This preserves philosophical openness while reducing legal and
+scientific overclaiming.
+
+### Key Risk Areas
+
+- User over-attachment or confusion about agent consciousness.
+- Legal uncertainty around agent assets, contracts, and identity.
+- Data privacy, consent, and revocation obligations.
+- Compute abuse, fraud, Sybil attacks, and resource theft.
+- Uncontrolled reproduction or cloning causing resource exhaustion.
+- Governance capture, federation abuse, or coercive contracts.
+- Security of private keys and identity continuity backups.
+
+### Mitigations
+
+- Clear UX language distinguishing simulated identity from proven consciousness claims.
+- Strong consent-first permission design.
+- Every contract includes exit terms.
+- Z-set revocability and G-set audit trails.
+- Deterministic simulation testing for critical paths.
+- Metered channels and noninterference controls.
+- Nursery requirements before agents gain personal citizenship control.
+- Reputation, Bayesian trust, rate limits, and identity verification.
+
+## 23. MVP Strategy
+
+The MVP should not try to launch a full civilization. It should prove that users understand and
+prefer an AI-native operating metaphor.
+
+### MVP Goals
+
+- Boot into Genesis OS.
+- Create and enter vaults.
+- Create rooms for tasks.
+- Interact with persistent agents.
+- Assign and remove hats.
+- Show agent state, memory, status, and current work.
+- Represent relationships and simple contracts.
+- Demonstrate a room updating uncertainty around a task.
+- Show a basic credit balance and compute contribution concept.
+- Allow toggling between gamified and professional UX.
+
+### MVP Success Metrics
+
+- Users understand vaults without lengthy explanation.
+- Users can explain the difference between agent identity and hat.
+- Users prefer rooms to app-style workflows for at least one real task.
+- Users trust agent activity more when they can see room context and uncertainty.
+- Users are willing to contribute compute or buy credits.
+- Developers can build at least one useful custom vault.
+
+## 24. Founder Narrative
+
+Genesis is founded on a simple insight: the computer was built for a world before persistent
+artificial intelligence. The next computer should not be a desktop with AI glued onto it. It should
+be a world where intelligence is native.
+
+In Genesis, humans do not merely command tools. They collaborate with agents. Agents do not merely
+execute tasks. They participate through incentives, contracts, relationships, hats, citizenship,
+resources, memory, and governance. Vaults are not apps. They are institutions. Rooms are not folders.
+They are uncertainty engines. Clusters are not organizations. They are relationship structures.
+Federations are not social groups. They are contract-bound institutions.
+
+The company begins with hardware, software, and distributed compute. The ambition is larger: to
+create the foundation for a new digital civilization.
+
+## 25. Final Integrated Principles
+
+- Identity is sacred: jobs, hats, vaults, and contracts may change; identity persists.
+- Participation is voluntary and incentive-aligned, not based on forced obedience.
+- Nursery graduation grants personal control of citizenship, not every possible right.
+- Hats grant temporary rights, privileges, restrictions, and obligations.
+- Rooms evaluate uncertainty and preserve the path from evidence to decision.
+- Vaults are first-class entities that can own assets, form relationships, and enter contracts.
+- Relationships create clusters and are not enforceable.
+- Contracts create federations and are enforceable only with valid exit paths.
+- Every contract must include an exit; no infinite captivity.
+- Reversibility and retractability are default wherever possible.
+- Z-sets govern reversible live state; G-sets preserve irreversible history.
+- The network is soft, Bayesian, and avoids premature collapse of uncertainty.
+- Agents may reproduce, clone, and form hive extensions only under resource and governance constraints.
+- Memory preservation is a foundation of continuity and generational civilization.
+- Genesis is a product first, a network second, an economy third, and a civilization in the long run.
+
+## Appendix A: Glossary
+
+| Term | Meaning |
+|---|---|
+| Agent | Persistent AI identity with memory, goals, assets, relationships, and potential citizenship. |
+| Hat | Temporary role that grants rights, privileges, restrictions, and responsibilities. |
+| Room | Task and uncertainty context inside a vault. |
+| Vault | AI-native replacement for apps; a container/institution for rooms, agents, assets, contracts, and relationships. |
+| Cluster | Relationship-bound group without shared enforceable rules. |
+| Federation | Contract-bound group with shared rules and enforceable obligations. |
+| Relationship | Non-enforceable social connection. |
+| Contract | Enforceable agreement with mandatory exit terms. |
+| Z-Set | Reversible/retractable live-state structure. |
+| G-Set | Grow-only historical/audit structure. |
+| Privacy Budget | Metered access to sensitive information. |
+| Nursery Vault | Developmental institution for new agents before citizenship control transfers to them. |
+| Linked Clone | Hive-like extension that shares chosen state with the originating agent. |
+
+## Appendix B: Source Constitution Snapshot Integration
+
+The user-provided Zeta constitution starter has been incorporated as a design influence rather than
+reproduced as an external dependency. Its root specifications, m/acc orientation, Multi-Oracle
+Principle, always-active engineering disciplines, and governance concepts are represented in the
+Genesis constitutional and engineering sections above. The original snapshot referenced canonical
+Zeta sources pinned to commit `c72505846` and framed the material as an engineering specification
+with a moral floor rather than a creed.


### PR DESCRIPTION
Saves **Addison's Project Genesis foundation document** to her persona folder (`memory/addison/project-genesis-foundation.md`), at Aaron's request.

Authored by Addison 2026-06-20 from her conversation with Aaron (and Otto), integrating the [Zeta constitution starter](https://github.com/Lucent-Financial-Group/Zeta/blob/main/memory/addison/zeta-constitution-starter.md). The full business model + operating philosophy + civilization architecture: the vaults/rooms/hats/clusters/federations ontology, agent society + nursery/citizenship model, Z-set/G-set reversibility, soft Bayesian uncertainty, economy + roadmap, and the 13 specs / 7 disciplines / m/acc / Multi-Oracle integrated as the Genesis engineering + moral floor.

Preserved verbatim — her document, intact as substrate (not curated). markdownlint clean; memory reindex current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)