### PR TITLE
docs(research): ferry — metaspace navigation + physics engine (2D viewport over 3D Clifford frame)

### DIFF
--- a/docs/research/2026-06-20-metaspace-navigation-physics-engine-2d-viewport-over-3d-clifford-frame-zoom-is-level-traversal.md
+++ b/docs/research/2026-06-20-metaspace-navigation-physics-engine-2d-viewport-over-3d-clifford-frame-zoom-is-level-traversal.md
@@ -1,0 +1,137 @@
+# Metaspace navigation + physics engine: 2D viewport over a 3D-capable Clifford frame, zoom = level-traversal
+
+**Date:** 2026-06-20. **Source:** Aaron, streamed during the Project Genesis UX-design thread (with
+Max + Addison). **Ferried by:** Otto (shadow), verbatim quotes preserved. **Status:** design spine
+for the Genesis navigation surface — the "outside / meta-vault" homepage and the physics engine that
+renders it. Unifies existing in-repo substrate; first build primitive ships alongside.
+
+## The concept (Aaron)
+
+> *"We need our own physics engine based on our vaults/rooms concepts, and the outside / meta-vault /
+> FF7 debug-room concept as the homepage — how you navigate between vaults."*
+>
+> *"When you're outside the vaults you can see all of them and zoom in and out and move around; when
+> you get close you can see inside and click and enter it. When you enter it, you leave the
+> meta-vault/outside and enter the vault. Vaults have rooms; the meta-vault does not — I think its
+> rooms are vaults."*
+>
+> *"It's all 2D for now … but I'd love to use real geospatial data structures and frames, like how
+> they do 2D viewports over 3D, so we'll be ready for 3D and this is just like a 2D screen."*
+
+## This is a UNIFICATION, not greenfield — the substrate already exists
+
+Grep-before-greenfield: the concept is already partly built across the tree. The move is to unify,
+not restart:
+
+- **`src/Core/LayoutEngine.fs`** — an existing layout engine (the seed of "our own physics engine").
+- **`src/Core/CoEmpowerField.fs` / `CoEmpowerGraph.fs` / `CoEmpowerGraphSvg.fs`** — the field (the
+  physics), the graph (topology), and a **2D circular-layout SVG renderer** (the proto navigable map).
+- **`docs/research/2026-06-10-the-dev-room-is-the-harness-ff7-debug-room-unbounded-outside-mea-pull-it-inside.md`**
+  — the FF7 debug room as the unbounded "outside," pulled inside. The homepage idea, already on file.
+- **`docs/research/2026-06-10-metaspace-landmarks-floorplan-salon-darkhall.md`** (+ the
+  metaspace-landmarks PRs) — the **metaspace**: a navigable space with **landmarks** (salon,
+  darkhall/arcade, chip-8). The meta-vault navigation surface.
+- **DarkHall** — the cell hosting a deterministic emulator / CHIP-8 arcade cabinets — a room you
+  navigate *to*. The **shadow** persona is the FF7 strange-loop. `memory/user_gaming_roots_ff7_*` is
+  the why.
+
+## The physics engine: force-directed over `CoEmpowerGraph`, forces = the real metrics
+
+The "physics engine" is **not** generic rigid-body physics (no Box2D/Matter.js box-collisions). It is
+a **force-directed / energy-minimizing layout over the `CoEmpowerGraph`**, where the forces ARE the
+SocietalDora metrics:
+
+- **coupled-empowerment** (`MeanCoupledGain`) → attraction (mutually-empowering nodes pull together),
+- **capture / diversity-collapse** (`CaptureRate`) → repulsion (extractive links push apart),
+- **ρ_owe / relational** → distance metric.
+
+The layout relaxes to the **energy minimum of the SocietalDora field** — which is genuine physics
+(the spring-electrical model — Eades 1984; Fruchterman–Reingold 1991 — is a literal physical
+simulation), and it **passes the metric-test**: the forces are the actual empowerment metrics, not
+decorative gravity.
+
+## Frames: 3D-capable Clifford/geospatial world, 2D viewport projection (2D-now, 3D-ready)
+
+Model the world in a **real 3D-capable geometric frame and render the 2D screen as a viewport
+projection over it** — the graphics MVP pipeline (model → view/projection → screen) and the GIS
+pattern (geographic CRS → projected CRS → screen). Built this way, 2D-now is **3D-ready by
+construction**: the 2D screen is just the current camera; flip to perspective later by changing the
+projection, not the model.
+
+- **Frame engine = geometric algebra (in-tree): `Cl3`** (Cl(3,0); the `IStarRing` leg + the
+  `CliffordE8Bridge`/`Roots`). GA is the clean way to do rotations/projections/viewports (rotors +
+  the geometric product — Hestenes; Dorst/Fontijne/Mann, *GA for Computer Science*). This is Aaron's
+  own phrasing: *"geospatial in Clifford."* Gates' "garden algebra" = the same Clifford/geometric layer.
+- **Spatial indexing = real geospatial data structures** — quadtree/octree, R-tree, or H3/S2 cells —
+  for "what's near me / what's in this viewport / warp to nearest vault" queries.
+- **Projection = a 2D viewport** (orthographic now; a GA rotor + perspective later). "Real depends on
+  the renderer" becomes literal: the viewport IS the renderer; the world frame is invariant under it.
+
+**Honest scope:** be 3D-*ready*, not 3D-*now* — store 3D-capable coordinates + use the projection
+pattern, but render/interact only in the 2D viewport for now. Don't pull in a 3D engine; keep `Cl3`
++ a projection function.
+
+## The navigation gesture: zoom = level-traversal, enter = frame change + boundary crossing
+
+- **Outside (meta-vault / IWorld):** zoomed out, all vaults visible; pan/zoom around (camera
+  transforms over the frame).
+- **Approach → see inside → click → enter:** you **leave the outside and enter the vault.** That is a
+  **re-rooting of the coordinate frame** at that vault (the outside becomes the parent frame, no
+  longer rendered) AND a **soft-room boundary crossing** (#13 noninterference — you cross the
+  membrane into a bounded context; the outside's entropy is quarantined behind you). One gesture, two
+  grounded meanings.
+- **Zoom IS level-traversal** in the self-similar containment hierarchy: zoom-out ascends a level,
+  zoom-in + enter descends one.
+
+## Ontology: one self-similar `Space`, role by level (reconciles "rooms are vaults")
+
+The defining recursion (Aaron): *the meta-vault has no rooms; its rooms are vaults.*
+
+> meta-vault : vaults  ::  vault : rooms
+
+Same containment shape one level up. The non-lossy model is **one self-similar `Space` type** that
+contains child `Space`s, where **"room / vault / meta-vault" are level/role labels (depth), not
+distinct types** — the homoiconic move (`IWorld` = `ISociety`-of-`ISociety`s = `ITraveler`, one shape,
+level-indexed; the 3-body homoiconic trinity made navigable). But role/capability varies by depth, so
+the Genesis Room/Vault distinction is preserved as *role*, not type:
+
+- a **leaf-level** Space acts as a **room** (uncertainty resolution — the Bayesian engine),
+- a **mid-level** Space acts as a **vault** (owns identity / assets / contracts),
+- the **top** acts as the **meta-vault / world** (society-of-societies; the navigable outside).
+
+Don't fully collapse them (you'd lose room-uncertainty vs vault-ownership) and don't fully separate
+them (you'd lose the recursion): **one homoiconic `Space`, role-by-level.** (Math/ontology team to
+pin the formal version — ties to the homoiconic `IWorld`/`ISociety`/`ITraveler` trinity + the CTM
+3-body note.)
+
+## Tiering (consistent with the progressive-enhancement ladder)
+
+- **Tier 0 (CSS-only floor):** the static no-JS `CoEmpowerGraphSvg` map — vault landmarks as
+  `<a href>` links. **Navigation works with zero JS** (warp between vaults via plain links). The
+  conformance floor.
+- **Tier 1+ (JS):** the live force-directed physics + pan/zoom camera.
+- **Tier ∞ (later):** flip the projection to perspective → 3D viewport, no model change.
+- **Compute unit = CHIP-8** (deterministic, content-addressed; distributable over the soft
+  mutual-empowerment network); **ceiling = Q#/quantum** (the uncertainty engine on its native
+  substrate). See the orientation-flow + acceptable-experiment notes.
+
+## First build (ships alongside this note)
+
+The foundational primitive: a **2D viewport over a 3D-capable frame** (`Viewport`) — `Vec3` world
+points, a pan/zoom `Camera`, `project` (orthographic world→screen) and `unproject` (screen→world on
+the z-plane, for click-to-enter hit-testing), `pan`, and focus-preserving `zoomAbout` (zoom-toward-
+cursor). Pure + deterministic + tested. This is the literal "2D-now, 3D-ready" keystone everything
+else renders through; the metaspace map, the force-directed layout, and the enter/exit frame changes
+all compose on top of it.
+
+## Anchors (Beacon)
+
+- **Force-directed layout / graph drawing:** Eades 1984; Fruchterman & Reingold 1991 (spring-electrical model).
+- **Geometric algebra for graphics:** Hestenes (spacetime/geometric algebra); Dorst, Fontijne & Mann, *Geometric Algebra for Computer Science*. In-tree: `src/Core/Cl3.fs`, `CliffordE8Bridge.fs`, `CliffordE8Roots.fs`. (S. James Gates Jr. — "garden algebra" = Clifford.)
+- **Projection pipelines:** the graphics model-view-projection (MVP) pipeline; GIS coordinate reference systems (geographic → projected).
+- **Spatial indexes:** quadtree/octree, R-tree (Guttman 1984), H3 (Uber) / S2 (Google) cells.
+- **The field / physics-as-metrics:** `src/Core/CoEmpowerField.fs`, `CoEmpowerGraph.fs`, `CoEmpowerGraphSvg.fs`, `SocietalDora.fs` (`MeanCoupledGain` / `CaptureRate`).
+- **Prior-art docs (unified here):** `docs/research/2026-06-10-the-dev-room-is-the-harness-ff7-debug-room-...md`, `docs/research/2026-06-10-metaspace-landmarks-floorplan-salon-darkhall.md`.
+- **Constitution / disciplines:** noninterference (#13, the enter-boundary), recursive (#9) + self-similar (#10, zoom-as-level-traversal), scale-free (#1).
+- **Sibling design spines:** [`2026-06-20-the-acceptable-experiment-everyone-is-it-...md`](2026-06-20-the-acceptable-experiment-everyone-is-it-vault-as-home-iff-exit-capturerate-is-the-vault-tec-detector.md), [`2026-06-20-orientation-flow-one-flow-many-surfaces-...md`](2026-06-20-orientation-flow-one-flow-many-surfaces-best-effort-volunteer-compute-boinc-seti-folding-lineage.md), and the Genesis foundation (`memory/addison/project-genesis-foundation.md`).
+- **Cultural anchor:** Final Fantasy VII debug room (the warp hub / unbounded outside); Aaron's FF7/D&D/MMORPG/ARG gaming roots.


### PR DESCRIPTION
Ferries Aaron's Genesis **navigation** design — the outside/meta-vault **FF7-debug-room homepage** + the **physics engine** that renders it (verbatim quotes preserved).

**Unifies existing substrate** (grep-before-greenfield): `LayoutEngine`, `CoEmpower{Field,Graph,Svg}`, the dev-room-is-the-harness FF7 doc, the metaspace-landmarks doc, DarkHall.

- **Physics** = force-directed over `CoEmpowerGraph`, forces = real SocietalDora metrics (coupled-empowerment attraction, capture/diversity-collapse repulsion, ρ_owe distance) — the field's energy minimum; passes the metric-test (no decorative gravity).
- **Frames** = 3D-capable Clifford/GA (`Cl3`) world + geospatial spatial indexes; **2D viewport projection** (MVP pipeline / GIS CRS) → **2D-now, 3D-ready by construction**.
- **Navigation** = zoom is level-traversal; **enter = re-root frame + cross the soft-room boundary** (#13).
- **Ontology** = one self-similar `Space`, role-by-level (room=uncertainty / vault=ownership / meta-vault=world) — reconciles "rooms are vaults" with the Genesis Room/Vault split + the homoiconic `IWorld`/`ISociety`/`ITraveler` trinity.
- **Tier-0 floor** = static no-JS navigable SVG (warp via plain links, CSS-only).

First build primitive — the `Viewport` (2D-over-3D projection) — ships next. markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)