### PR TITLE
feat(core): Viewport — 2D viewport over a 3D-capable frame (metaspace navigation keystone)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -23,6 +23,7 @@
     <Compile Include="RetryPolicy.fs" />
     <Compile Include="CayleyDickson.fs" />
     <Compile Include="Cl3.fs" />
+    <Compile Include="Viewport.fs" />
     <Compile Include="Fixpoint.fs" />
     <Compile Include="Orbit.fs" />
     <Compile Include="AdinkraCode.fs" />

--- a/src/Core/Viewport.fs
+++ b/src/Core/Viewport.fs
@@ -1,0 +1,60 @@
+namespace Zeta.Core
+
+/// **2D viewport over a 3D-capable world frame** — the projection floor of the metaspace navigation
+/// (the "outside / meta-vault" homepage; see
+/// `docs/research/2026-06-20-metaspace-navigation-physics-engine-2d-viewport-over-3d-clifford-frame-zoom-is-level-traversal.md`).
+///
+/// Positions live in a 3D frame (`Vec3`, Cl3-compatible) so the model is **3D-READY**; the current
+/// render projects **orthographically** to a 2D screen (`Vec2`) through a pan/zoom `Camera`. This is
+/// the graphics MVP pipeline (model → view/projection → screen) and the GIS pattern (geographic CRS
+/// → projected CRS → screen): **2D-now, 3D-ready by construction** — flip to perspective later by
+/// changing `project` (using `Z`), not the model. "Real depends on the renderer": the `Camera` IS
+/// the renderer; the world frame is invariant under it.
+///
+/// Pure + deterministic (no ambient state, no culture-sensitive ops) — DST-replayable and composable
+/// under the metaspace force-directed layout + enter/exit frame changes.
+[<RequireQualifiedAccess>]
+module Viewport =
+
+    /// A point in the 3D world frame. Orthographic render uses `X`,`Y`; `Z` is reserved for depth /
+    /// the future perspective projection (kept so the model is 3D-ready).
+    type Vec3 = { X: float; Y: float; Z: float }
+
+    /// A point on the 2D screen (world units × zoom, relative to the camera center).
+    type Vec2 = { Sx: float; Sy: float }
+
+    /// The camera: world-space center (pan) and `Zoom` (screen units per world unit, `> 0`).
+    type Camera = { CenterX: float; CenterY: float; Zoom: float }
+
+    /// A 3D world point.
+    let vec3 (x: float) (y: float) (z: float) : Vec3 = { X = x; Y = y; Z = z }
+
+    /// A camera centered at the origin with the given zoom.
+    let camera (zoom: float) : Camera = { CenterX = 0.0; CenterY = 0.0; Zoom = zoom }
+
+    /// A camera centered at `(cx, cy)` in world space with the given zoom.
+    let cameraAt (cx: float) (cy: float) (zoom: float) : Camera = { CenterX = cx; CenterY = cy; Zoom = zoom }
+
+    /// Orthographic world → screen: `(worldXY − center) × zoom`. (Perspective later folds in `Z`.)
+    let project (cam: Camera) (p: Vec3) : Vec2 =
+        { Sx = (p.X - cam.CenterX) * cam.Zoom
+          Sy = (p.Y - cam.CenterY) * cam.Zoom }
+
+    /// Inverse on the `z = 0` plane: screen → world — for click-to-enter hit-testing. Requires
+    /// `cam.Zoom <> 0`.
+    let unproject (cam: Camera) (s: Vec2) : Vec3 =
+        { X = s.Sx / cam.Zoom + cam.CenterX
+          Y = s.Sy / cam.Zoom + cam.CenterY
+          Z = 0.0 }
+
+    /// Pan the camera by a world-space delta.
+    let pan (dx: float) (dy: float) (cam: Camera) : Camera =
+        { cam with CenterX = cam.CenterX + dx; CenterY = cam.CenterY + dy }
+
+    /// Zoom by `factor` (`> 1` zooms in) **about a world-space focus** — the "zoom toward the cursor"
+    /// gesture: the focus point stays fixed on screen across the zoom. Adjusts the center so
+    /// `project (zoomAbout focus factor cam) focus = project cam focus`.
+    let zoomAbout (focus: Vec3) (factor: float) (cam: Camera) : Camera =
+        { Zoom = cam.Zoom * factor
+          CenterX = focus.X - (focus.X - cam.CenterX) / factor
+          CenterY = focus.Y - (focus.Y - cam.CenterY) / factor }

--- a/tests/Tests.FSharp/Formal/Viewport.Tests.fs
+++ b/tests/Tests.FSharp/Formal/Viewport.Tests.fs
@@ -1,0 +1,63 @@
+module Zeta.Tests.Formal.ViewportTests
+
+open FsCheck.Xunit
+open global.Xunit
+open Zeta.Core
+
+// The 2D-viewport-over-3D-frame primitive (metaspace navigation floor): project / unproject /
+// pan / zoomAbout. 2D-now, 3D-ready — the projection laws that let the same world frame render to
+// a 2D screen and (later) a 3D viewport without model change.
+
+/// Relative+absolute tolerance (orthographic project/unproject is FP, magnitude-scaled).
+let private approx (a: float) (b: float) : bool = abs (a - b) <= 1e-6 * (1.0 + abs a + abs b)
+
+/// Strictly-positive, not-tiny zoom from a generated int.
+let private zoomOf (n: int) : float = 1.0 + float (abs (n % 1000))
+
+/// Bounded exact-float coordinate from a generated int (keeps the FP round-trip stable).
+let private coord (n: int) : float = float (n % 100000)
+
+[<Property>]
+let ``project sends the camera center to the screen origin`` (cx: int) (cy: int) (z: int) (zn: int) =
+    let cam = Viewport.cameraAt (coord cx) (coord cy) (zoomOf zn)
+    let s = Viewport.project cam (Viewport.vec3 cam.CenterX cam.CenterY (coord z))
+    approx s.Sx 0.0 && approx s.Sy 0.0
+
+[<Property>]
+let ``unproject inverts project on the z=0 plane (click-to-enter hit-test)`` (x: int) (y: int) (cx: int) (cy: int) (zn: int) =
+    let cam = Viewport.cameraAt (coord cx) (coord cy) (zoomOf zn)
+    let p = Viewport.vec3 (coord x) (coord y) 0.0
+    let back = Viewport.unproject cam (Viewport.project cam p)
+    approx back.X p.X && approx back.Y p.Y && approx back.Z 0.0
+
+[<Property>]
+let ``zoomAbout keeps the focus point fixed on screen (zoom toward cursor)`` (fx: int) (fy: int) (cx: int) (cy: int) (zn: int) (fn: int) =
+    let cam = Viewport.cameraAt (coord cx) (coord cy) (zoomOf zn)
+    let focus = Viewport.vec3 (coord fx) (coord fy) 0.0
+    let factor = 1.0 + float (abs (fn % 50)) // factor >= 1, strictly nonzero
+    let before = Viewport.project cam focus
+    let after = Viewport.project (Viewport.zoomAbout focus factor cam) focus
+    approx before.Sx after.Sx && approx before.Sy after.Sy
+
+[<Property>]
+let ``pan is invertible`` (dx: int) (dy: int) (cx: int) (cy: int) (zn: int) =
+    let cam = Viewport.cameraAt (coord cx) (coord cy) (zoomOf zn)
+    let ddx = coord dx
+    let ddy = coord dy
+    let back = Viewport.pan (-ddx) (-ddy) (Viewport.pan ddx ddy cam)
+    approx back.CenterX cam.CenterX && approx back.CenterY cam.CenterY
+
+[<Fact>]
+let ``zoom scales screen distance by the zoom factor`` () =
+    let cam = Viewport.camera 2.0
+    let s = Viewport.project cam (Viewport.vec3 1.0 0.0 0.0)
+    Assert.Equal(2.0, s.Sx, 9)
+    Assert.Equal(0.0, s.Sy, 9)
+
+[<Fact>]
+let ``zoomAbout the origin with the origin centered only scales zoom`` () =
+    let cam = Viewport.camera 1.0
+    let zoomed = Viewport.zoomAbout (Viewport.vec3 0.0 0.0 0.0) 3.0 cam
+    Assert.Equal(3.0, zoomed.Zoom, 9)
+    Assert.Equal(0.0, zoomed.CenterX, 9)
+    Assert.Equal(0.0, zoomed.CenterY, 9)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -366,6 +366,7 @@
     <Compile Include="Formal/CostarZSet.Tests.fs" />
     <Compile Include="Formal/NftCommitBinding.Tests.fs" />
     <Compile Include="Formal/NtpNoninterference.Tests.fs" />
+    <Compile Include="Formal/Viewport.Tests.fs" />
     <Compile Include="Formal/LiveLegs.Tests.fs" />
     <Compile Include="Formal/WikidataGraph.Tests.fs" />
     <Compile Include="Formal/GraphSnapshot.Tests.fs" />


### PR DESCRIPTION
The **first build** of the metaspace navigation (design ferry #8773): the projection floor — **2D-now, 3D-ready by construction.**

Positions live in a 3D frame (`Vec3`, Cl3-compatible); the current render projects **orthographically** to a 2D screen (`Vec2`) through a pan/zoom `Camera` — the graphics MVP pipeline / GIS CRS pattern. Flip to perspective later by changing `project` (using `Z`), not the model.

- **`src/Core/Viewport.fs`** — `Vec3`/`Vec2`/`Camera`; `project` (world→screen), `unproject` (screen→world on `z=0`, for **click-to-enter hit-testing**), `pan`, `zoomAbout` (focus-preserving **zoom-toward-cursor**). Pure + deterministic — DST-replayable; the force-directed layout + enter/exit frame changes compose on top.
- **`Viewport.Tests.fs`** — 6 tests, **6/6 green**: center→origin, `unproject` inverts `project` on the z-plane, `zoomAbout` keeps the focus fixed on screen, `pan` invertible, zoom scales screen distance.

Core **0 warnings / 0 errors**. Next slices: place vaults at `Vec3` + render the Tier-0 static SVG metaspace map (warp links), then the force-directed layout (forces = SocietalDora metrics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)