### PR TITLE
docs: Addison's privacy-budget economics — metaspace visibility + funding thesis (TSMC in Time)

### DIFF
--- a/docs/pitch/funding-thesis-tsmc-in-time.md
+++ b/docs/pitch/funding-thesis-tsmc-in-time.md
@@ -89,6 +89,31 @@ The lead is the same as TSMC's: you can see our results (the golden vectors, the
 
 Each step is the TSMC progression: same customers, same interface, better process. Nobody leaves because the upgrade is just a backend swap.
 
+## The economic engine — verification-priced privacy (Addison)
+
+The same property that is the *moat* is also the *network economy*. **Verification is the moat
+(TSMC-precision-in-time); verifiability is also what is free, and opacity is what is priced.** (Economic
+model: Addison, 2026-06-20.)
+
+- **Transparency is free *because* it is verifiable.** A glass (open) vault is content-addressed,
+  inspectable, redundant-with-agreement — the network can trust and reuse it at no premium. This is
+  the **glass halo** default: radical transparency, the same symmetric-observation principle the
+  verification thesis rests on.
+- **Privacy is the earned, *priced* exception.** A **closed vault = closed source = opaque compute the
+  network cannot verify.** Running it on **others' hardware costs privacy budget** — you are asking the
+  network to host compute it cannot see, verify, or reclaim, so the budget **prices that externality**
+  (in practice: dedicated/paid hosting or confidential-compute/attestation — private-yet-attestable).
+- **Own the hardware → private for free.** You **internalize** the cost; "brought your own privacy
+  budget" = your hardware *is* the budget. You are not taxing the network.
+
+Why this is the revenue/sustainability mechanism, not a feature: it is a **metered-resource economy
+that prices the externality of opacity** and makes the verifiable default the cheapest path. It
+**nudges the network toward verifiability** (which compounds the moat), **never forbids privacy** (pay,
+or self-host), and gives the credit economy a principled denominator — **privacy budget** alongside
+compute / storage / bandwidth. The same calibration that makes verification cheap (cross-language
+byte-lock, content-addressing, the oracles) is what makes transparency free and opacity the priced
+exception. Verification is simultaneously the moat *and* the price signal.
+
 ## The ask
 
 Seed funding to sustain the factory while the process calibration compounds. The work IS the moat. Time IS the product. The factory IS TSMC in time.

--- a/docs/research/2026-06-20-metaspace-navigation-physics-engine-2d-viewport-over-3d-clifford-frame-zoom-is-level-traversal.md
+++ b/docs/research/2026-06-20-metaspace-navigation-physics-engine-2d-viewport-over-3d-clifford-frame-zoom-is-level-traversal.md
@@ -191,6 +191,33 @@ which is also why default-*opacity* would have been the Vault-Tec move (hidden-b
 default-transparency-with-earned-privacy is the home. Consent-first (#6) is honored as the *act of
 spending budget to close*, not as withholding by default.
 
+### The economics of opacity — privacy budget prices closed-on-shared-hardware (Addison)
+
+(Addison, 2026-06-20): *a closed vault is like closed source; you have to pay (privacy budget) to run
+it on other people's hardware, because it's not your hardware. If you own the hardware you can be
+private for free — you brought your own privacy budget; you're not paying the network.*
+
+The economic **why** behind the glass-halo default:
+
+- **Closed vault = closed source = opaque compute the network can't verify.** Default transparency is
+  what makes compute *verifiable* (content-addressed, redundant-with-agreement, inspectable — the
+  best-effort-node trust model in the orientation-flow note). Transparency is **free because it is
+  verifiable**; the network can trust and reuse it.
+- **Closed (private) on others' hardware → pay privacy budget.** You're asking the network to host
+  compute it **cannot see, verify, or reclaim** — privacy budget **prices that externality.** In
+  practice "closed on the network" means **dedicated/paid hosting** or **confidential compute /
+  attestation** (TEE/enclave: private-yet-attestable); the budget denominates that premium over the
+  free verifiable default.
+- **Closed on your own hardware → free.** You've **internalized** the cost — "brought your own privacy
+  budget" = your hardware *is* the budget; you're not asking the network to trust-host anything.
+
+Incentive geometry: it **nudges toward transparency** (cheapest, verifiable), **never forbids privacy**
+(pay, or self-host), and the marketplace / open-source / forkability all compose on the glass default
+while closed-source stays a first-class, *priced* option. Cross-links the orientation-flow
+resource-tiering (dependable vs best-effort; content-addressed cache is self-verifying) and the
+Genesis **privacy-budget** resource. This is the economic layer of the privacy/glass-halo model — see
+also the funding thesis ("TSMC in Time"), where it grounds the network economy.
+
 ## Tiering (consistent with the progressive-enhancement ladder)
 
 - **Tier 0 (CSS-only floor):** the static no-JS `CoEmpowerGraphSvg` map — vault landmarks as


### PR DESCRIPTION
**Addison's economic model** (2026-06-20): a closed vault = closed source = opaque compute; running it on others' hardware **costs privacy budget** (the priced externality — dedicated/confidential hosting); **own-hardware = free privacy** (internalized — BYO privacy budget). Transparency is **free because verifiable** (glass halo).

Added to two surfaces, **credited to Addison**:
- **Metaspace note** (visibility section) — an "economics of opacity" subsection + cross-links to the orientation-flow resource-tiering (dependable vs best-effort; content-addressed cache is self-verifying) + the Genesis privacy-budget.
- **Funding thesis ("TSMC in Time")** — a new **"economic engine — verification-priced privacy"** section: **verification is simultaneously the moat AND the price signal.** A metered-resource economy that prices opacity and makes the verifiable default cheapest — the revenue/sustainability mechanism, not a feature; gives the credit economy a principled denominator (privacy budget alongside compute/storage/bandwidth).

markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)