### PR TITLE
feat(core): MetaspaceMap — Tier-0 navigable outside (static no-JS SVG, vault warp-links)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -24,6 +24,7 @@
     <Compile Include="CayleyDickson.fs" />
     <Compile Include="Cl3.fs" />
     <Compile Include="Viewport.fs" />
+    <Compile Include="MetaspaceMap.fs" />
     <Compile Include="Fixpoint.fs" />
     <Compile Include="Orbit.fs" />
     <Compile Include="AdinkraCode.fs" />

--- a/src/Core/MetaspaceMap.fs
+++ b/src/Core/MetaspaceMap.fs
@@ -1,0 +1,76 @@
+namespace Zeta.Core
+
+open System
+open System.Globalization
+
+/// **`MetaspaceMap` — the Tier-0 navigable "outside / meta-vault" map (static, no-JS).**
+///
+/// The CSS-only conformance floor of the metaspace navigation
+/// (`docs/research/2026-06-20-metaspace-navigation-physics-engine-2d-viewport-over-3d-clifford-frame-zoom-is-level-traversal.md`):
+/// vaults live at 3D-capable world positions (`Viewport.Vec3`), are projected through a `Viewport.Camera`
+/// to the 2D screen, and render as a **static SVG whose vault markers are `<a href>` warp-links** — so you
+/// can navigate between vaults with **zero JavaScript** (Tier 0). Richer tiers add the live force-directed
+/// physics + pan/zoom camera on top of this same projection.
+///
+/// Pure + deterministic (integer screen coords, `InvariantCulture`, escaped text, no script) ⇒
+/// byte-lockable: the same vaults + camera render the same SVG.
+[<RequireQualifiedAccess>]
+module MetaspaceMap =
+
+    /// A vault as a navigable landmark in the outside: a world position, a label, and the href you warp to
+    /// on click (entering the vault = leaving the outside frame; see the design note's enter = frame-change).
+    type Vault =
+        { Pos: Viewport.Vec3
+          Label: string
+          Href: string }
+
+    let private si (i: int) : string = i.ToString(CultureInfo.InvariantCulture)
+
+    /// Minimal XML/attribute escaping (text + href). No script, so this is the whole surface.
+    let private esc (s: string) : string =
+        s
+            .Replace("&", "&amp;", StringComparison.Ordinal)
+            .Replace("<", "&lt;", StringComparison.Ordinal)
+            .Replace(">", "&gt;", StringComparison.Ordinal)
+            .Replace("\"", "&quot;", StringComparison.Ordinal)
+
+    /// Make a vault landmark.
+    let vault (pos: Viewport.Vec3) (label: string) (href: string) : Vault =
+        { Pos = pos; Label = label; Href = href }
+
+    /// Render the outside as a pure, no-JS SVG of `size`×`size` px. Vaults are projected through `cam`
+    /// (screen origin = viewport center) and drawn as `<a href>`-wrapped markers — clickable warp-links.
+    /// Off-screen vaults (outside the square) are culled. `size` should be positive.
+    let render (size: int) (cam: Viewport.Camera) (vaults: Vault list) : string =
+        let half = size / 2
+
+        // Project a world point to integer screen pixels with the viewport center at (half, half).
+        let toScreen (p: Viewport.Vec3) : int * int =
+            let s = Viewport.project cam p
+            half + int (round s.Sx), half + int (round s.Sy)
+
+        let onScreen (x: int) (y: int) : bool = x >= 0 && x <= size && y >= 0 && y <= size
+
+        let markers =
+            [ for v in vaults do
+                  let x, y = toScreen v.Pos
+                  if onScreen x y then
+                      yield
+                          String.Concat(
+                              "<a xlink:href=\"", esc v.Href, "\" href=\"", esc v.Href, "\">",
+                              "<circle cx=\"", si x, "\" cy=\"", si y,
+                              "\" r=\"10\" fill=\"#3399cc\" stroke=\"#ffffff\" stroke-width=\"1\"/>",
+                              "<text x=\"", si x, "\" y=\"", si (y + 24),
+                              "\" text-anchor=\"middle\" font-family=\"monospace\" font-size=\"12\" fill=\"#cdd6e0\">",
+                              esc v.Label, "</text></a>"
+                          ) ]
+            |> String.concat ""
+
+        String.Concat(
+            "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" ",
+            "width=\"", si size, "\" height=\"", si size, "\" viewBox=\"0 0 ", si size, " ", si size,
+            "\" role=\"img\" aria-label=\"Metaspace — the outside; vaults are warp-links\">",
+            "<rect width=\"", si size, "\" height=\"", si size, "\" fill=\"#0e1116\"/>",
+            markers,
+            "</svg>"
+        )

--- a/tests/Tests.FSharp/Formal/MetaspaceMap.Tests.fs
+++ b/tests/Tests.FSharp/Formal/MetaspaceMap.Tests.fs
@@ -1,0 +1,61 @@
+module Zeta.Tests.Formal.MetaspaceMapTests
+
+open FsCheck.Xunit
+open global.Xunit
+open Zeta.Core
+
+// The Tier-0 navigable metaspace map: vaults at Vec3 → projected via Viewport → static no-JS SVG
+// with <a href> warp-links. The CSS-only conformance floor — navigation works with zero JS.
+
+let private demoVaults : MetaspaceMap.Vault list =
+    [ MetaspaceMap.vault (Viewport.vec3 0.0 0.0 0.0) "home" "/vault/home"
+      MetaspaceMap.vault (Viewport.vec3 30.0 0.0 0.0) "economy" "/vault/economy"
+      MetaspaceMap.vault (Viewport.vec3 0.0 -30.0 0.0) "nursery" "/vault/nursery" ]
+
+[<Fact>]
+let ``renders a self-contained no-JS svg`` () =
+    let svg = MetaspaceMap.render 400 (Viewport.camera 1.0) demoVaults
+    Assert.StartsWith("<svg", svg, System.StringComparison.Ordinal)
+    Assert.Contains("</svg>", svg, System.StringComparison.Ordinal)
+    // Tier-0 floor: NO script anywhere.
+    Assert.DoesNotContain("<script", svg, System.StringComparison.OrdinalIgnoreCase)
+    Assert.DoesNotContain("onclick", svg, System.StringComparison.OrdinalIgnoreCase)
+
+[<Fact>]
+let ``every on-screen vault is an anchor warp-link to its href`` () =
+    let svg = MetaspaceMap.render 400 (Viewport.camera 1.0) demoVaults
+    // each vault centered enough to be on-screen → its href appears in an <a>
+    Assert.Contains("href=\"/vault/home\"", svg, System.StringComparison.Ordinal)
+    Assert.Contains("href=\"/vault/economy\"", svg, System.StringComparison.Ordinal)
+    Assert.Contains("href=\"/vault/nursery\"", svg, System.StringComparison.Ordinal)
+    // anchor count == vault count (all three on-screen at this zoom)
+    let anchors = (svg.Split("<a ").Length) - 1
+    Assert.Equal(3, anchors)
+
+[<Fact>]
+let ``labels are rendered and escaped`` () =
+    let vaults = [ MetaspaceMap.vault (Viewport.vec3 0.0 0.0 0.0) "A & <B>" "/v/x" ]
+    let svg = MetaspaceMap.render 200 (Viewport.camera 1.0) vaults
+    Assert.Contains("A &amp; &lt;B&gt;", svg, System.StringComparison.Ordinal)
+    Assert.DoesNotContain("A & <B>", svg, System.StringComparison.Ordinal)
+
+[<Fact>]
+let ``off-screen vaults are culled (no anchor)`` () =
+    // place a vault far outside the 200px viewport at zoom 1 (world 99999 → screen ~99999+100)
+    let vaults = [ MetaspaceMap.vault (Viewport.vec3 99999.0 0.0 0.0) "faraway" "/v/far" ]
+    let svg = MetaspaceMap.render 200 (Viewport.camera 1.0) vaults
+    Assert.DoesNotContain("/v/far", svg, System.StringComparison.Ordinal)
+
+[<Property>]
+let ``deterministic: same vaults + camera => same svg`` (cxn: int) (czoomn: int) =
+    let cam = Viewport.cameraAt (float (cxn % 50)) 0.0 (1.0 + float (abs (czoomn % 8)))
+    MetaspaceMap.render 400 cam demoVaults = MetaspaceMap.render 400 cam demoVaults
+
+[<Fact>]
+let ``zooming in brings a distant vault on-screen (enter-by-approach)`` () =
+    // a vault outside at zoom 1, but a wider camera (smaller zoom) pulls it into view
+    let vaults = [ MetaspaceMap.vault (Viewport.vec3 300.0 0.0 0.0) "edge" "/v/edge" ]
+    let zoomedOut = MetaspaceMap.render 400 (Viewport.camera 0.1) vaults // 300*0.1=30 → on-screen
+    let zoomedIn = MetaspaceMap.render 400 (Viewport.camera 1.0) vaults // 300*1=300 → off (half=200)
+    Assert.Contains("/v/edge", zoomedOut, System.StringComparison.Ordinal)
+    Assert.DoesNotContain("/v/edge", zoomedIn, System.StringComparison.Ordinal)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -367,6 +367,7 @@
     <Compile Include="Formal/NftCommitBinding.Tests.fs" />
     <Compile Include="Formal/NtpNoninterference.Tests.fs" />
     <Compile Include="Formal/Viewport.Tests.fs" />
+    <Compile Include="Formal/MetaspaceMap.Tests.fs" />
     <Compile Include="Formal/LiveLegs.Tests.fs" />
     <Compile Include="Formal/WikidataGraph.Tests.fs" />
     <Compile Include="Formal/GraphSnapshot.Tests.fs" />


### PR DESCRIPTION
The next metaspace slice (design #8773, built on the `Viewport` floor #8774): the **Tier-0 CSS-only conformance floor** of the "outside / meta-vault" homepage.

Vaults live at 3D-capable world positions (`Viewport.Vec3`), project through a `Viewport.Camera` to the 2D screen, and render as a **static SVG whose vault markers are `<a href>` warp-links** — navigation between vaults with **zero JavaScript**. Richer tiers add live physics + pan/zoom on the *same* projection.

- **`src/Core/MetaspaceMap.fs`** — `Vault {Pos; Label; Href}`; `render (size, cam, vaults)` → pure no-JS SVG (escaped, integer coords, InvariantCulture) — byte-lockable; off-screen vaults culled.
- **`MetaspaceMap.Tests.fs`** — 6 tests, **6/6 green**: self-contained no-JS svg (no `<script>`/`onclick`), every on-screen vault is an `<a href>` warp-link (anchor count == vault count), labels escaped, off-screen culled, deterministic, **zoom brings a distant vault on-screen** (enter-by-approach).

Core **0 warnings / 0 errors**. Next: the force-directed layout step (forces = SocietalDora metrics) to *place* the vaults, then door-graph rooms inside a vault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)