### PR TITLE
feat(core): ForceLayout — the metaspace physics engine (force-directed, forces = metrics)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -24,6 +24,7 @@
     <Compile Include="CayleyDickson.fs" />
     <Compile Include="Cl3.fs" />
     <Compile Include="Viewport.fs" />
+    <Compile Include="ForceLayout.fs" />
     <Compile Include="MetaspaceMap.fs" />
     <Compile Include="Fixpoint.fs" />
     <Compile Include="Orbit.fs" />

--- a/src/Core/ForceLayout.fs
+++ b/src/Core/ForceLayout.fs
@@ -1,0 +1,104 @@
+namespace Zeta.Core
+
+/// **`ForceLayout` — the metaspace physics engine: a force-directed (spring-electrical) layout.**
+///
+/// Relaxes node positions (`Viewport.Vec3`, in the z=0 plane for 2D-now) toward the energy minimum of
+/// a force field (Eades 1984; Fruchterman–Reingold 1991 — a literal physical simulation). Two forces:
+/// **attraction** along graph edges (a spring pulling connected nodes together) and **repulsion**
+/// between every pair (an electrical charge pushing them apart). The metaspace wires these to the real
+/// SocietalDora metrics — **attraction = coupled-empowerment, repulsion = capture/diversity-collapse**
+/// (see the design note) — so the resting layout IS the field's energy minimum, not decorative gravity.
+/// The module is the pure physics; the metric-wiring (edge weights) is the caller's.
+///
+/// Pure + deterministic (no RNG, no ambient state) ⇒ DST-replayable + byte-lockable: same positions +
+/// edges + params ⇒ same step. Repulsion is softened (`+ epsilon`) so coincident nodes don't blow up.
+[<RequireQualifiedAccess>]
+module ForceLayout =
+
+    /// Tuning for one relaxation step.
+    type Params =
+        { /// Ideal edge length (the spring's rest length `k`).
+          IdealLength: float
+          /// Repulsion strength (electrical constant).
+          Repulsion: float
+          /// Attraction strength (spring constant) along edges.
+          Attraction: float
+          /// Step size (how far a node moves per displacement unit), and the per-step cap (`MaxStep`).
+          Step: float
+          MaxStep: float }
+
+    /// Sensible defaults for a screen-scale layout.
+    let defaults : Params =
+        { IdealLength = 50.0; Repulsion = 1.0; Attraction = 1.0; Step = 0.1; MaxStep = 10.0 }
+
+    let private epsilon = 1e-6
+
+    /// One Fruchterman–Reingold relaxation step over `positions` with undirected `edges`
+    /// `(i, j, weight)` (weight scales attraction — e.g. coupled-empowerment). Returns new positions;
+    /// length preserved. Operates in the x/y plane (z carried through unchanged) for the 2D viewport.
+    let step (p: Params) (edges: (int * int * float)[]) (positions: Viewport.Vec3[]) : Viewport.Vec3[] =
+        let n = positions.Length
+        let dispX = Array.zeroCreate<float> n
+        let dispY = Array.zeroCreate<float> n
+
+        // Repulsion: every distinct pair pushes apart, ~ k^2 / distance.
+        for i in 0 .. n - 1 do
+            for j in i + 1 .. n - 1 do
+                let dx = positions.[i].X - positions.[j].X
+                let dy = positions.[i].Y - positions.[j].Y
+                let dist = sqrt (dx * dx + dy * dy) + epsilon
+                let force = p.Repulsion * p.IdealLength * p.IdealLength / (dist * dist)
+                let ux, uy = dx / dist, dy / dist
+                dispX.[i] <- dispX.[i] + ux * force
+                dispY.[i] <- dispY.[i] + uy * force
+                dispX.[j] <- dispX.[j] - ux * force
+                dispY.[j] <- dispY.[j] - uy * force
+
+        // Attraction: each edge pulls its endpoints together, ~ weight * dist^2 / k.
+        for (i, j, w) in edges do
+            if i >= 0 && i < n && j >= 0 && j < n && i <> j then
+                let dx = positions.[i].X - positions.[j].X
+                let dy = positions.[i].Y - positions.[j].Y
+                let dist = sqrt (dx * dx + dy * dy) + epsilon
+                let force = p.Attraction * w * dist * dist / p.IdealLength
+                let ux, uy = dx / dist, dy / dist
+                dispX.[i] <- dispX.[i] - ux * force
+                dispY.[i] <- dispY.[i] - uy * force
+                dispX.[j] <- dispX.[j] + ux * force
+                dispY.[j] <- dispY.[j] + uy * force
+
+        // Apply, capping the per-step move (cooling/stability).
+        Array.init n (fun i ->
+            let mvx = dispX.[i] * p.Step
+            let mvy = dispY.[i] * p.Step
+            let mag = sqrt (mvx * mvx + mvy * mvy)
+            let scale = if mag > p.MaxStep then p.MaxStep / mag else 1.0
+            { positions.[i] with
+                X = positions.[i].X + mvx * scale
+                Y = positions.[i].Y + mvy * scale })
+
+    /// Run `iters` relaxation steps (a fixed schedule — deterministic; no random restarts).
+    let relax (p: Params) (iters: int) (edges: (int * int * float)[]) (positions: Viewport.Vec3[]) : Viewport.Vec3[] =
+        let mutable acc = positions
+        for _ in 1 .. iters do
+            acc <- step p edges acc
+        acc
+
+    /// Total layout energy: spring + repulsion potential. Strictly decreases toward the rest state
+    /// under relaxation (the metric the layout minimizes) — used to assert convergence.
+    let energy (p: Params) (edges: (int * int * float)[]) (positions: Viewport.Vec3[]) : float =
+        let n = positions.Length
+        let mutable e = 0.0
+        for i in 0 .. n - 1 do
+            for j in i + 1 .. n - 1 do
+                let dx = positions.[i].X - positions.[j].X
+                let dy = positions.[i].Y - positions.[j].Y
+                let dist = sqrt (dx * dx + dy * dy) + epsilon
+                e <- e + p.Repulsion * p.IdealLength * p.IdealLength / dist // repulsion potential
+        for (i, j, w) in edges do
+            if i >= 0 && i < n && j >= 0 && j < n && i <> j then
+                let dx = positions.[i].X - positions.[j].X
+                let dy = positions.[i].Y - positions.[j].Y
+                let dist = sqrt (dx * dx + dy * dy)
+                e <- e + p.Attraction * w * dist * dist * dist / (3.0 * p.IdealLength) // spring potential
+        e

--- a/tests/Tests.FSharp/Formal/ForceLayout.Tests.fs
+++ b/tests/Tests.FSharp/Formal/ForceLayout.Tests.fs
@@ -1,0 +1,63 @@
+module Zeta.Tests.Formal.ForceLayoutTests
+
+open FsCheck.Xunit
+open global.Xunit
+open Zeta.Core
+
+// The metaspace physics engine: force-directed (spring-electrical) layout. The load-bearing
+// property is convergence — relaxation monotonically reduces the field energy toward the rest
+// state (the SocietalDora energy minimum the metaspace lays out to).
+
+let private v (x: float) (y: float) : Viewport.Vec3 = Viewport.vec3 x y 0.0
+
+let private dist (a: Viewport.Vec3) (b: Viewport.Vec3) : float =
+    sqrt ((a.X - b.X) ** 2.0 + (a.Y - b.Y) ** 2.0)
+
+[<Fact>]
+let ``relaxation reduces total energy (converges to the field minimum)`` () =
+    // a 4-node path 0-1-2-3 started in a poor (collinear, cramped) layout
+    let positions = [| v 0.0 0.0; v 1.0 0.0; v 2.0 0.0; v 3.0 0.0 |]
+    let edges = [| (0, 1, 1.0); (1, 2, 1.0); (2, 3, 1.0) |]
+    let before = ForceLayout.energy ForceLayout.defaults edges positions
+    let after = ForceLayout.energy ForceLayout.defaults edges (ForceLayout.relax ForceLayout.defaults 50 edges positions)
+    Assert.True(after < before, $"energy should drop: before={before} after={after}")
+
+[<Fact>]
+let ``two unconnected nodes repel — they end farther apart`` () =
+    let positions = [| v 0.0 0.0; v 1.0 0.0 |]
+    let relaxed = ForceLayout.relax ForceLayout.defaults 20 [||] positions
+    Assert.True(dist relaxed.[0] relaxed.[1] > dist positions.[0] positions.[1])
+
+[<Fact>]
+let ``a connected pair flung far apart is pulled back toward the ideal length`` () =
+    let p = ForceLayout.defaults // IdealLength = 50
+    let positions = [| v 0.0 0.0; v 500.0 0.0 |] // way past ideal
+    let edges = [| (0, 1, 1.0) |]
+    let relaxed = ForceLayout.relax p 100 edges positions
+    Assert.True(dist relaxed.[0] relaxed.[1] < dist positions.[0] positions.[1], "spring should contract an over-stretched edge")
+
+[<Property>]
+let ``a step preserves node count and the z-plane (2D-now)`` (seed: int) =
+    // small deterministic layout derived from the seed (no RNG)
+    let n = 3 + (abs seed % 5)
+    let positions = Array.init n (fun i -> v (float (i * 7 % 40)) (float (i * 13 % 40)))
+    let edges = [| for i in 0 .. n - 2 -> (i, i + 1, 1.0) |]
+    let stepped = ForceLayout.step ForceLayout.defaults edges positions
+    stepped.Length = n && Array.forall (fun (q: Viewport.Vec3) -> q.Z = 0.0) stepped
+
+[<Property>]
+let ``relaxation is deterministic (same input => same output)`` (iters: int) =
+    let k = 1 + (abs iters % 30)
+    let positions = [| v 0.0 0.0; v 10.0 5.0; v 3.0 20.0; v 25.0 25.0 |]
+    let edges = [| (0, 1, 1.0); (1, 2, 2.0); (2, 3, 1.0); (3, 0, 1.0) |]
+    let a = ForceLayout.relax ForceLayout.defaults k edges positions
+    let b = ForceLayout.relax ForceLayout.defaults k edges positions
+    Array.forall2 (fun (x: Viewport.Vec3) (y: Viewport.Vec3) -> x.X = y.X && x.Y = y.Y && x.Z = y.Z) a b
+
+[<Fact>]
+let ``higher edge weight (more coupled-empowerment) pulls a pair closer than a weak edge`` () =
+    let p = ForceLayout.defaults
+    let start () = [| v 0.0 0.0; v 200.0 0.0 |]
+    let strong = ForceLayout.relax p 80 [| (0, 1, 4.0) |] (start ())
+    let weak = ForceLayout.relax p 80 [| (0, 1, 0.5) |] (start ())
+    Assert.True(dist strong.[0] strong.[1] < dist weak.[0] weak.[1], "stronger coupling => tighter rest distance")

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -367,6 +367,7 @@
     <Compile Include="Formal/NftCommitBinding.Tests.fs" />
     <Compile Include="Formal/NtpNoninterference.Tests.fs" />
     <Compile Include="Formal/Viewport.Tests.fs" />
+    <Compile Include="Formal/ForceLayout.Tests.fs" />
     <Compile Include="Formal/MetaspaceMap.Tests.fs" />
     <Compile Include="Formal/LiveLegs.Tests.fs" />
     <Compile Include="Formal/WikidataGraph.Tests.fs" />


### PR DESCRIPTION
The **physics proper** (design #8773), on the `Viewport` floor: a pure, deterministic **Fruchterman–Reingold spring-electrical layout** that relaxes node positions (`Viewport.Vec3`, z=0 plane for 2D-now) toward the field's **energy minimum**.

Edges **attract** (spring, weight-scaled); all pairs **repel** (electrical). The metaspace wires **attraction = coupled-empowerment, repulsion = capture/diversity-collapse** (SocietalDora) — so the resting layout *is* the field minimum, not decorative gravity (passes the metric-test). The module is the pure physics; the metric-wiring (edge weights) is the caller's.

- **`src/Core/ForceLayout.fs`** — `Params`/`defaults`; `step` (one FR relaxation), `relax` (fixed iteration schedule — deterministic, no random restarts), `energy` (the potential the layout minimizes). Softened repulsion (`+epsilon`).
- **`ForceLayout.Tests.fs`** — 6 tests, **6/6 green**: **relaxation reduces energy** (converges), unconnected nodes repel apart, an over-stretched edge contracts, step preserves node count + z-plane (2D-now), relaxation deterministic, **higher edge weight (more coupled-empowerment) ⇒ tighter rest distance**.

Core **0 warnings / 0 errors**. Next: feed `CoEmpowerGraph` adjacency + SocietalDora weights into `relax`, render relaxed positions through `MetaspaceMap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)