### PR TITLE
feat(core): MetaspaceGraphRender — end-to-end wire (graph → physics → navigable map)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -322,6 +322,7 @@
     <Compile Include="WikidataGraph.fs" />
     <Compile Include="GraphSnapshot.fs" />
     <Compile Include="CoEmpowerGraphSvg.fs" />
+    <Compile Include="MetaspaceGraphRender.fs" />
     <Compile Include="MintPanel.fs" />
     <Compile Include="DemoDashboard.fs" />
     <Compile Include="DemoPipeline.fs" />

--- a/src/Core/MetaspaceGraphRender.fs
+++ b/src/Core/MetaspaceGraphRender.fs
@@ -1,0 +1,68 @@
+namespace Zeta.Core
+
+open System
+
+/// **`MetaspaceGraphRender` — the end-to-end metaspace wire: graph → physics → navigable map.**
+///
+/// Composes the three metaspace slices into one pipeline:
+/// `CoEmpowerGraph` → `ForceLayout.relax` (edge weights = **coupled-empowerment**) → relaxed
+/// `Viewport.Vec3` positions → `MetaspaceMap.render` (Tier-0 no-JS SVG with warp-links). The resting
+/// layout IS the SocietalDora field's energy minimum (forces = the real metrics, not decorative
+/// gravity), and the output is the navigable "outside" you warp through.
+///
+/// Pure + deterministic (circle-seeded initial positions by node index — no RNG; fixed relax
+/// schedule) ⇒ DST-replayable + byte-lockable: same graph + params ⇒ same SVG.
+[<RequireQualifiedAccess>]
+module MetaspaceGraphRender =
+
+    /// Per-edge attraction weight = the **binding** coupled-empowerment of the pair:
+    /// `min(coEmpowerment i→id(j), coEmpowerment j→id(i))` (the SocietalDora `min(self, other)` shape —
+    /// can't be faked by one side). Floored to a small positive so every edge still springs.
+    ///
+    /// **Self-knowledge, not a forcing function (Aaron, 2026-06-20):** a monoculture neighbourhood
+    /// scores *low* on co-empowerment (low diversity ⇒ low `optionSpace`) — but a low score is a
+    /// *known measurement about itself*, NOT a signal to remove or penalize it. Monocultures are
+    /// allowed to exist; that is how a culture finds all the nuance *within* its specificity. The
+    /// floor (`+ 0.25`) makes this concrete in the physics: even a zero-coupled-empowerment edge still
+    /// attracts (the cluster stays laid out together, never expelled) — the score informs, it does not
+    /// coerce. Characterize, don't condemn.
+    let edgeWeight (g: CoEmpowerGraph.Graph) (i: int) (j: int) : float =
+        let ei = CoEmpowerGraph.coEmpowerment g i g.Identity.[j]
+        let ej = CoEmpowerGraph.coEmpowerment g j g.Identity.[i]
+        0.25 + float (min ei ej)
+
+    /// Deterministic initial positions: nodes evenly on a circle (radius from `size`), by index.
+    let private seedPositions (size: int) (n: int) : Viewport.Vec3[] =
+        let r = float (max 1 (size / 3))
+        let m = max 1 n
+        Array.init n (fun i ->
+            let theta = 2.0 * Math.PI * float i / float m
+            Viewport.vec3 (r * cos theta) (r * sin theta) 0.0)
+
+    /// The weighted undirected edge list (i < j) of the graph, weighted by coupled-empowerment.
+    let edges (g: CoEmpowerGraph.Graph) : (int * int * float)[] =
+        [| for i in 0 .. g.N - 1 do
+               for j in g.Adjacency.[i] do
+                   if j > i then
+                       yield (i, j, edgeWeight g i j) |]
+
+    /// Lay the graph out: seed on a circle, then relax under the coupled-empowerment force field.
+    /// Returns one world position per node (the metaspace coordinates).
+    let layout (p: ForceLayout.Params) (size: int) (iters: int) (g: CoEmpowerGraph.Graph) : Viewport.Vec3[] =
+        ForceLayout.relax p iters (edges g) (seedPositions size g.N)
+
+    /// Full pipeline: graph → laid-out, navigable Tier-0 SVG. `labelHref i` supplies each node's
+    /// vault label + warp href. Camera centers the world origin at the viewport center (zoom 1).
+    let render
+        (p: ForceLayout.Params)
+        (size: int)
+        (iters: int)
+        (labelHref: int -> string * string)
+        (g: CoEmpowerGraph.Graph)
+        : string =
+        let positions = layout p size iters g
+        let vaults =
+            [ for i in 0 .. g.N - 1 do
+                  let label, href = labelHref i
+                  yield MetaspaceMap.vault positions.[i] label href ]
+        MetaspaceMap.render size (Viewport.camera 1.0) vaults

--- a/tests/Tests.FSharp/Formal/MetaspaceGraphRender.Tests.fs
+++ b/tests/Tests.FSharp/Formal/MetaspaceGraphRender.Tests.fs
@@ -1,0 +1,61 @@
+module Zeta.Tests.Formal.MetaspaceGraphRenderTests
+
+open FsCheck.Xunit
+open global.Xunit
+open Zeta.Core
+
+module G = Zeta.Core.CoEmpowerGraph
+
+// End-to-end metaspace wire: CoEmpowerGraph → ForceLayout (weights = coupled-empowerment) →
+// MetaspaceMap (Tier-0 no-JS SVG). Closes the loop: a graph in, a navigable laid-out map out.
+
+/// A degree-4 ring of `n` Audience nodes, `kinds` identities (the graph analogue of the grid).
+let private ring (kinds: int) (sd: int) (n: int) : G.Graph =
+    let adj = Array.init n (fun i -> [| (i + n - 2) % n; (i + n - 1) % n; (i + 1) % n; (i + 2) % n |])
+    G.seed kinds sd adj (Array.create n G.Audience)
+
+let private labelHref (i: int) : string * string =
+    sprintf "vault-%d" i, sprintf "/vault/%d" i
+
+[<Fact>]
+let ``graph renders to a navigable no-JS svg with a warp-link per node`` () =
+    let g = ring 3 7 6
+    let svg = MetaspaceGraphRender.render ForceLayout.defaults 600 40 labelHref g
+    Assert.StartsWith("<svg", svg, System.StringComparison.Ordinal)
+    Assert.DoesNotContain("<script", svg, System.StringComparison.OrdinalIgnoreCase)
+    // every node that lands on-screen is an anchor; at least most of the 6 should be visible
+    let anchors = (svg.Split("<a ").Length) - 1
+    Assert.True(anchors >= 1 && anchors <= g.N, $"anchors={anchors} should be in 1..{g.N}")
+
+[<Fact>]
+let ``edge weight is the binding coupled-empowerment (min of both sides), floored positive`` () =
+    let g = ring 3 7 6
+    for (i, j, w) in MetaspaceGraphRender.edges g do
+        let ei = G.coEmpowerment g i g.Identity.[j]
+        let ej = G.coEmpowerment g j g.Identity.[i]
+        Assert.Equal(0.25 + float (min ei ej), w, 9)
+        Assert.True(w > 0.0)
+
+[<Fact>]
+let ``layout returns one world position per node`` () =
+    let g = ring 4 3 8
+    let positions = MetaspaceGraphRender.layout ForceLayout.defaults 600 30 g
+    Assert.Equal(g.N, positions.Length)
+    Assert.True(Array.forall (fun (p: Viewport.Vec3) -> p.Z = 0.0) positions) // 2D-now
+
+[<Property>]
+let ``deterministic: same graph + params => same svg`` (sd: int) =
+    let g = ring 3 (abs sd % 100) 5
+    let a = MetaspaceGraphRender.render ForceLayout.defaults 500 20 labelHref g
+    let b = MetaspaceGraphRender.render ForceLayout.defaults 500 20 labelHref g
+    a = b
+
+[<Fact>]
+let ``laying out reduces the field energy vs the seed circle (the physics ran)`` () =
+    let g = ring 3 7 6
+    let seedPos = MetaspaceGraphRender.layout ForceLayout.defaults 600 0 g // 0 iters = the seed
+    let relaxed = MetaspaceGraphRender.layout ForceLayout.defaults 600 60 g
+    let es = MetaspaceGraphRender.edges g
+    let eSeed = ForceLayout.energy ForceLayout.defaults es seedPos
+    let eRelaxed = ForceLayout.energy ForceLayout.defaults es relaxed
+    Assert.True(eRelaxed < eSeed, $"relaxation should lower energy: seed={eSeed} relaxed={eRelaxed}")

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -369,6 +369,7 @@
     <Compile Include="Formal/Viewport.Tests.fs" />
     <Compile Include="Formal/ForceLayout.Tests.fs" />
     <Compile Include="Formal/MetaspaceMap.Tests.fs" />
+    <Compile Include="Formal/MetaspaceGraphRender.Tests.fs" />
     <Compile Include="Formal/LiveLegs.Tests.fs" />
     <Compile Include="Formal/WikidataGraph.Tests.fs" />
     <Compile Include="Formal/GraphSnapshot.Tests.fs" />


### PR DESCRIPTION
Closes the metaspace loop, composing the three slices into one pipeline:
**`CoEmpowerGraph` → `ForceLayout.relax` (edge weights = coupled-empowerment) → relaxed `Vec3` → `MetaspaceMap.render` (Tier-0 no-JS warp-links).** A graph in, a navigable laid-out map out — the resting layout *is* the SocietalDora field's energy minimum.

- **`src/Core/MetaspaceGraphRender.fs`** — `edgeWeight` (binding `min(coEmp i→id j, coEmp j→id i)`, floored `+0.25`), `edges`, `layout` (circle-seeded + relax, deterministic), `render` (full pipeline; `labelHref` supplies vault label + warp href).
- **`MetaspaceGraphRender.Tests.fs`** — 5 tests, **5/5 green**: graph → no-JS svg with warp-links, edge weight = binding coupled-empowerment, one position per node (z=0, 2D-now), deterministic, **relaxation lowers energy vs the seed** (the physics ran).

**Self-knowledge, not a forcing function** (Aaron): a monoculture scores *low* on co-empowerment but is **allowed to exist** — the score is known self-knowledge, not a removal signal (how a culture finds nuance *within* its specificity). The `+0.25` floor makes it concrete: even a zero-coupled edge still attracts (the cluster stays laid out together, never expelled) — *characterize, don't condemn.*

Core **0 warnings / 0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)