### PR TITLE
[codex] add room admission heat policy

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -192,6 +192,7 @@
     <Compile Include="PredictionScheduler.fs" />
     <Compile Include="Heat.fs" />
     <Compile Include="RoomHorizon.fs" />
+    <Compile Include="RoomAdmission.fs" />
     <Compile Include="Query.fs" />
     <Compile Include="Injection.fs" />
     <Compile Include="InjectionExt.fs" />

--- a/src/Core/RoomAdmission.fs
+++ b/src/Core/RoomAdmission.fs
@@ -1,0 +1,128 @@
+namespace Zeta.Core
+
+/// Room-facing admission policy for finite exterior views.
+///
+/// `ModuloGSet` owns the algebraic finite-slot projection. This module names
+/// the room boundary semantics around it: no-forget collision becomes
+/// backpressure, replacement emits forgotten occupants as heat, and both flow
+/// through the same injected heat sink used by DarkHall/CHIP rooms.
+[<RequireQualifiedAccess>]
+module RoomAdmission =
+
+    [<RequireQualifiedAccess>]
+    type SlotOutcome =
+        | Admitted
+        | AlreadyPresent
+        | Replaced
+        | Backpressured
+
+    [<RequireQualifiedAccess>]
+    type Feedback =
+        | SlotFeedback of ModuloGSetError
+        | HeatFeedback of HeatSinkFeedback
+
+    type SlotReport<'K when 'K : comparison> =
+        { Before: ModuloGSet<'K>
+          After: ModuloGSet<'K>
+          Key: 'K
+          Slot: int
+          Outcome: SlotOutcome
+          Backpressured: GSet<'K>
+          Heat: BoundedGSetHeat<'K> }
+
+    let private positiveSignature (source: string) (kind: string) (units: int) (detail: string) : HeatSignature option =
+        if units <= 0 then
+            None
+        else
+            Some(HeatSignature.ofMass source kind units (float units) detail)
+
+    let private outcomeOf =
+        function
+        | ModuloGSetAdmission.Admitted -> SlotOutcome.Admitted
+        | ModuloGSetAdmission.AlreadyPresent -> SlotOutcome.AlreadyPresent
+        | ModuloGSetAdmission.Replaced -> SlotOutcome.Replaced
+        | ModuloGSetAdmission.RejectedByCollision -> SlotOutcome.Backpressured
+
+    let private backpressured (key: 'K) =
+        function
+        | ModuloGSetAdmission.RejectedByCollision -> GSet.singleton key
+        | ModuloGSetAdmission.Admitted
+        | ModuloGSetAdmission.AlreadyPresent
+        | ModuloGSetAdmission.Replaced -> GSet.empty
+
+    /// Admit one key into a finite modulo-slot room view.
+    let admitWithSlot
+        (rawSlot: int64)
+        (key: 'K)
+        (current: ModuloGSet<'K>)
+        : Result<SlotReport<'K>, Feedback> =
+        result {
+            let! added =
+                ModuloGSet.addWithSlot rawSlot key current
+                |> Result.mapError Feedback.SlotFeedback
+
+            return
+                { Before = current
+                  After = added.State
+                  Key = key
+                  Slot = added.Slot
+                  Outcome = outcomeOf added.Admission
+                  Backpressured = backpressured key added.Admission
+                  Heat = added.Heat }
+        }
+
+    /// Admit one key using a caller-owned slot function.
+    let admit
+        (slotOf: 'K -> int64)
+        (key: 'K)
+        (current: ModuloGSet<'K>)
+        : Result<SlotReport<'K>, Feedback> =
+        admitWithSlot (slotOf key) key current
+
+    /// Host-facing heat signatures for finite room admission.
+    ///
+    /// Algebraic `ModuloGSet` rejection stays cold; room admission can still
+    /// expose an explicit backpressure signature so the scheduler/debugger sees
+    /// why a paid candidate could not enter the finite exterior view.
+    let heatSignatures (source: string) (report: SlotReport<'K>) : HeatSignature list =
+        [ BoundedHeat.signature
+              source
+              "room-admission.forgotten"
+              (sprintf "finite room admission forgot occupant at slot=%d" report.Slot)
+              report.Heat
+          positiveSignature
+              source
+              "room-admission.backpressure"
+              (GSet.count report.Backpressured)
+              (sprintf "finite room admission rejected candidate at slot=%d" report.Slot) ]
+        |> List.choose id
+
+    /// Emit room-admission heat through an injected host/room boundary.
+    let emitHeat (sink: IHeatSink) (source: string) (report: SlotReport<'K>) : Result<unit, Feedback> =
+        let rec loop signatures =
+            result {
+                match signatures with
+                | [] -> return ()
+                | signature :: tail ->
+                    do!
+                        sink.Emit signature
+                        |> Result.mapError Feedback.HeatFeedback
+
+                    return! loop tail
+            }
+
+        report |> heatSignatures source |> loop
+
+    /// Admit and immediately export any generated heat/backpressure signal.
+    let admitWithHeat
+        (sink: IHeatSink)
+        (source: string)
+        (rawSlot: int64)
+        (key: 'K)
+        (current: ModuloGSet<'K>)
+        : Result<SlotReport<'K>, Feedback> =
+        result {
+            let! report = admitWithSlot rawSlot key current
+            do! emitHeat sink source report
+            return report
+        }

--- a/tests/Tests.FSharp/RoomAdmission.Tests.fs
+++ b/tests/Tests.FSharp/RoomAdmission.Tests.fs
@@ -1,0 +1,92 @@
+module Zeta.Tests.RoomAdmissionTests
+
+open global.Xunit
+open Zeta.Core
+
+module RA = RoomAdmission
+
+let private mustOk =
+    function
+    | Ok value -> value
+    | Error feedback -> failwithf "expected Ok, got %A" feedback
+
+let private rejectSlots slots : ModuloGSetConfig =
+    { Slots = slots
+      CollisionPolicy = ModuloGSetCollisionPolicy.RejectCollision }
+
+let private replaceSlots slots : ModuloGSetConfig =
+    { Slots = slots
+      CollisionPolicy = ModuloGSetCollisionPolicy.ReplaceExisting }
+
+let private emptyModulo config =
+    ModuloGSet.empty<string> config |> mustOk
+
+[<Fact>]
+let ``no-forget modulo collision becomes room backpressure without forgetting`` () =
+    let start = emptyModulo (rejectSlots 2)
+    let first = RA.admitWithSlot 1L "alpha" start |> mustOk
+    let second = RA.admitWithSlot 3L "beta" first.After |> mustOk
+
+    Assert.Equal(RA.SlotOutcome.Admitted, first.Outcome)
+    Assert.Equal(RA.SlotOutcome.Backpressured, second.Outcome)
+    Assert.Equal(1, second.Slot)
+    Assert.Equal<string list>([ "alpha" ], second.After |> ModuloGSet.toList)
+    Assert.Equal<string list>([ "beta" ], second.Backpressured |> GSet.toList)
+    Assert.Empty(second.Heat.Forgotten |> GSet.toList)
+    Assert.Equal(0, second.Heat.Units)
+
+    let signatures = RA.heatSignatures "chip9-room" second
+
+    Assert.Single(signatures) |> ignore
+    Assert.Equal("room-admission.backpressure", signatures.[0].Kind)
+    Assert.Equal(1, signatures.[0].Units)
+
+[<Fact>]
+let ``replacement emits forgotten occupant as room heat`` () =
+    let start = emptyModulo (replaceSlots 2)
+    let first = RA.admitWithSlot 1L "old" start |> mustOk
+    let second = RA.admitWithSlot 3L "new" first.After |> mustOk
+
+    Assert.Equal(RA.SlotOutcome.Replaced, second.Outcome)
+    Assert.Equal<string list>([ "new" ], second.After |> ModuloGSet.toList)
+    Assert.Empty(second.Backpressured |> GSet.toList)
+    Assert.Equal<string list>([ "old" ], second.Heat.Forgotten |> GSet.toList)
+    Assert.Equal(1, second.Heat.Units)
+
+    let signatures = RA.heatSignatures "chip9-room" second
+
+    Assert.Single(signatures) |> ignore
+    Assert.Equal("room-admission.forgotten", signatures.[0].Kind)
+    Assert.Equal(1, signatures.[0].Units)
+
+[<Fact>]
+let ``admitWithHeat exports room backpressure through the injected sink`` () =
+    let sink = RecordingHeatSink()
+    let start = emptyModulo (rejectSlots 1)
+    let first = RA.admitWithHeat (sink :> IHeatSink) "chip8-room" 0L "one" start |> mustOk
+    let second = RA.admitWithHeat (sink :> IHeatSink) "chip8-room" 1L "two" first.After |> mustOk
+
+    Assert.Equal(RA.SlotOutcome.Backpressured, second.Outcome)
+    Assert.Equal(1, sink.Signatures.Count)
+    Assert.Equal("room-admission.backpressure", sink.Signatures.[0].Kind)
+    Assert.Equal(1, sink.Signatures.[0].Units)
+
+[<Fact>]
+let ``admitWithHeat preserves heat sink backpressure as typed feedback`` () =
+    let sink =
+        BoundedHeatSink
+            { Capacity = 1
+              ForgetPolicy = BoundedGSetForgetPolicy.RejectNew }
+
+    let filler = HeatSignature.ofMass "test" "heat.fill" 1 1.0 "occupy bounded heat sink"
+    (sink :> IHeatSink).Emit filler |> mustOk
+
+    let start = emptyModulo (replaceSlots 1)
+    let first = RA.admitWithSlot 0L "old" start |> mustOk
+
+    match RA.admitWithHeat (sink :> IHeatSink) "chip8-room" 1L "new" first.After with
+    | Error(RA.Feedback.HeatFeedback(HeatSinkFeedback.Backpressure(heat, capacity, count))) ->
+        Assert.Equal("room-admission.forgotten", heat.Kind)
+        Assert.Equal(1, capacity)
+        Assert.Equal(2, count)
+    | other -> Assert.Fail(sprintf "expected heat sink backpressure, got %A" other)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -158,6 +158,7 @@
     <Compile Include="PredictionInference.Tests.fs" />
     <Compile Include="PredictionScheduler.Tests.fs" />
     <Compile Include="RoomHorizon.Tests.fs" />
+    <Compile Include="RoomAdmission.Tests.fs" />
     <Compile Include="RecordedSource.Tests.fs" />
     <Compile Include="SoftIsr.Tests.fs" />
     <Compile Include="SimFramework.Tests.fs" />


### PR DESCRIPTION
Adds a room-facing admission policy over ModuloGSet so finite rooms can report no-forget collision backpressure and replacement heat through the same injected heat sink pattern used by DarkHall and CHIP room code.

The algebraic ModuloGSet still owns finite-slot state. RoomAdmission names the room boundary outcome, exposes backpressured keys as a GSet, and exports heat signatures for forgotten occupants or explicit room admission pressure without using exceptions.

Validation:
- dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter FullyQualifiedName~RoomAdmissionTests
- git diff --check
- dotnet format --verify-no-changes
- dotnet build -c Release
- dotnet test Zeta.sln -c Release
- bun run preflight:quick
- bun src/Core.TypeScript/hygiene/audit-agencysignature-main-tip.ts --commit HEAD

Co-Authored-By: Codex <noreply@openai.com>
Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: Codex
Agent-Model: gpt-5.5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: not-implied-by-credential
Human-Review-Evidence: none
Action-Mode: human-directed
Task: none
