### PR TITLE
feat(core): GlassHalo — visibility open-by-default, privacy is the EARNED exception

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -26,6 +26,7 @@
     <Compile Include="Viewport.fs" />
     <Compile Include="ForceLayout.fs" />
     <Compile Include="MetaspaceMap.fs" />
+    <Compile Include="GlassHalo.fs" />
     <Compile Include="Fixpoint.fs" />
     <Compile Include="Orbit.fs" />
     <Compile Include="AdinkraCode.fs" />

--- a/src/Core/GlassHalo.fs
+++ b/src/Core/GlassHalo.fs
@@ -1,0 +1,53 @@
+namespace Zeta.Core
+
+/// **`GlassHalo` — visibility is open by default; privacy is the EARNED exception.**
+///
+/// The corrected visibility model (Aaron 2026-06-20; PR #8777 + the Genesis.tsx reconciliation #8784):
+/// **walls are transparent by default (the glass halo / radical transparency)** — *sees everything by
+/// default, opt out.* Privacy is **not** a default you assert; it is a **currency you earn and spend**:
+/// to **frost** a surface (make it opaque) you pay `privacy budget`. This is the opposite of the
+/// opaque-by-default / earned-*access* model (which would be the Vault-Tec move — hidden by default).
+///
+/// It composes with the constitution: consent-first (#6) is honoured as the *act of spending budget to
+/// close*, not as withholding by default; noninterference (#13) meters the crossing; and default
+/// transparency IS the everyone-is-IT symmetric-observation principle (everyone can see ↔ everyone is
+/// observed). Pure + deterministic ⇒ DST-replayable.
+[<RequireQualifiedAccess>]
+module GlassHalo =
+
+    /// A surface's visibility. **Clear is the default.** Frosted is the earned, budget-funded exception
+    /// (`SpentBudget` records what was paid to close it — the metered price of opacity).
+    type Visibility =
+        | Clear
+        | Frosted of SpentBudget: int
+
+    /// The default for every new surface: transparent. (Glass halo — you start visible.)
+    let initial : Visibility = Clear
+
+    /// Is the surface currently see-through? Clear ⇒ yes; Frosted ⇒ no.
+    let isVisible (v: Visibility) : bool =
+        match v with
+        | Clear -> true
+        | Frosted _ -> false
+
+    /// **Frost (opt out of visibility): the earned action.** Costs `cost` privacy budget; succeeds only
+    /// if `available >= cost > 0`. Returns the new `Visibility` and the **remaining** budget. Spending
+    /// zero (or more than you have) is refused — privacy is *earned*, never free or asserted.
+    /// Re-frosting an already-frosted surface is idempotent on visibility (still opaque) but is treated
+    /// as a no-op that neither double-charges nor refunds (you already paid to be private).
+    let frost (cost: int) (available: int) (v: Visibility) : Result<Visibility * int, string> =
+        match v with
+        | Frosted _ -> Ok(v, available) // already private; no double-charge, no refund
+        | Clear ->
+            if cost <= 0 then Error "privacy must be earned: frosting costs a positive privacy budget"
+            elif available < cost then Error "insufficient privacy budget to frost this surface"
+            else Ok(Frosted cost, available - cost)
+
+    /// **Clear (return to transparency): free.** Transparency is the default state, so going back to it
+    /// costs nothing (the paid budget is not refunded — it bought the privacy you had). Idempotent.
+    let clear (v: Visibility) : Visibility = Clear
+
+    /// What an observer may see of a surface, honouring the glass-halo default.
+    /// `content` is shown when Clear; when Frosted, only the `placeholder` (e.g. "🔒 private") is shown.
+    let observe (placeholder: 'a) (content: 'a) (v: Visibility) : 'a =
+        if isVisible v then content else placeholder

--- a/tests/Tests.FSharp/Formal/GlassHalo.Tests.fs
+++ b/tests/Tests.FSharp/Formal/GlassHalo.Tests.fs
@@ -1,0 +1,67 @@
+module Zeta.Tests.Formal.GlassHaloTests
+
+open FsCheck.Xunit
+open global.Xunit
+open Zeta.Core
+
+// The glass-halo visibility model: visible by DEFAULT, privacy is the EARNED exception (spend
+// privacy budget to frost). The load-bearing correction (#8777, #8784) — encoded so it can't
+// re-invert to opaque-by-default.
+
+[<Fact>]
+let ``default is visible (glass halo)`` () =
+    Assert.True(GlassHalo.isVisible GlassHalo.initial)
+    Assert.Equal(GlassHalo.Clear, GlassHalo.initial)
+
+[<Fact>]
+let ``frosting costs budget and makes the surface opaque`` () =
+    match GlassHalo.frost 10 100 GlassHalo.initial with
+    | Ok(v, remaining) ->
+        Assert.False(GlassHalo.isVisible v)
+        Assert.Equal(90, remaining)
+        Assert.Equal(GlassHalo.Frosted 10, v)
+    | Error e -> failwith e
+
+[<Fact>]
+let ``privacy is earned: frosting with zero or negative cost is refused`` () =
+    Assert.True(match GlassHalo.frost 0 100 GlassHalo.initial with Error _ -> true | _ -> false)
+    Assert.True(match GlassHalo.frost -5 100 GlassHalo.initial with Error _ -> true | _ -> false)
+
+[<Fact>]
+let ``insufficient budget cannot buy privacy`` () =
+    Assert.True(match GlassHalo.frost 50 10 GlassHalo.initial with Error _ -> true | _ -> false)
+
+[<Fact>]
+let ``clearing is free and returns to the transparent default`` () =
+    let frosted = GlassHalo.Frosted 10
+    Assert.Equal(GlassHalo.Clear, GlassHalo.clear frosted)
+    Assert.True(GlassHalo.isVisible (GlassHalo.clear frosted))
+
+[<Fact>]
+let ``re-frosting is idempotent: no double-charge, no refund`` () =
+    match GlassHalo.frost 10 100 GlassHalo.initial with
+    | Ok(once, rem1) ->
+        match GlassHalo.frost 10 rem1 once with
+        | Ok(twice, rem2) ->
+            Assert.Equal(once, twice) // still opaque, unchanged
+            Assert.Equal(rem1, rem2) // budget not touched the second time
+        | Error e -> failwith e
+    | Error e -> failwith e
+
+[<Fact>]
+let ``observe shows content when clear, placeholder when frosted`` () =
+    Assert.Equal("secret", GlassHalo.observe "private" "secret" GlassHalo.Clear)
+    Assert.Equal("private", GlassHalo.observe "private" "secret" (GlassHalo.Frosted 10))
+
+[<Property>]
+let ``frosting then clearing is always back to visible, and never overspends`` (cost: int) (avail: int) =
+    let c = 1 + (abs cost % 1000)
+    let a = abs avail % 5000
+    match GlassHalo.frost c a GlassHalo.initial with
+    | Ok(v, remaining) ->
+        // success requires we could afford it; remaining is non-negative and exactly debited
+        remaining >= 0 && remaining = a - c && not (GlassHalo.isVisible v)
+        && GlassHalo.isVisible (GlassHalo.clear v)
+    | Error _ ->
+        // failure only when we couldn't afford it (budget unchanged conceptually)
+        a < c

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -371,6 +371,7 @@
     <Compile Include="Formal/ForceLayout.Tests.fs" />
     <Compile Include="Formal/MetaspaceMap.Tests.fs" />
     <Compile Include="Formal/MetaspaceGraphRender.Tests.fs" />
+    <Compile Include="Formal/GlassHalo.Tests.fs" />
     <Compile Include="Formal/LiveLegs.Tests.fs" />
     <Compile Include="Formal/WikidataGraph.Tests.fs" />
     <Compile Include="Formal/GraphSnapshot.Tests.fs" />


### PR DESCRIPTION
Encodes the corrected visibility model (#8777 + the Genesis.tsx reconciliation #8784) as a **typed primitive so it can't re-invert** to opaque-by-default.

Walls are **`Clear` by default** (the glass halo / radical transparency — *sees everything by default, opt out*); **privacy is a currency you earn and spend** — to **frost** (make opaque) you pay **privacy budget**. The opposite of opaque-by-default / earned-*access* (the Vault-Tec move).

- **`src/Core/GlassHalo.fs`** — `Visibility = Clear | Frosted of SpentBudget`; `initial = Clear`; `isVisible`; `frost (cost, available, v) → Result` (positive cost + sufficient budget required; idempotent re-frost, no double-charge); `clear` (free, back to default); `observe` (content when clear, placeholder when frosted).
- **`GlassHalo.Tests.fs`** — 8 tests, **8/8 green**: default visible, frost costs + opaques, **privacy-is-earned** (zero/negative refused), insufficient budget refused, clear free, re-frost idempotent, observe gates content, property (frost→clear always visible, never overspends).

Composes with consent-first #6 (spending budget to close, not withholding by default), noninterference #13, and the everyone-is-IT symmetric-observation principle. Core **0 warnings / 0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)