### PR TITLE
feat(core): DoorGraph — rooms connected by permission-gated doors (the vault interior)

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -27,6 +27,7 @@
     <Compile Include="ForceLayout.fs" />
     <Compile Include="MetaspaceMap.fs" />
     <Compile Include="GlassHalo.fs" />
+    <Compile Include="DoorGraph.fs" />
     <Compile Include="Fixpoint.fs" />
     <Compile Include="Orbit.fs" />
     <Compile Include="AdinkraCode.fs" />

--- a/src/Core/DoorGraph.fs
+++ b/src/Core/DoorGraph.fs
@@ -1,0 +1,72 @@
+namespace Zeta.Core
+
+/// **`DoorGraph` — rooms connected by doors (the vault interior; #8775 door model).**
+///
+/// The *inside* counterpart to the metaspace outside-map. Within a vault, **rooms are leaves**
+/// (rooms can't contain rooms — bounded downward) and a room may have **multiple doors to other rooms
+/// in the same vault**, so the rooms form a **graph** (nodes = rooms, edges = doors), not a nesting
+/// tree. A **door is a first-class portal = a declared, metered channel (#13 noninterference)**: you
+/// move between rooms ONLY through doors, and traversal is **permission-gated** (consent-first #6) —
+/// which also keeps the Universal Exit Principle (a room with a door out is a room you can leave).
+///
+/// Pure + deterministic ⇒ DST-replayable. Permission gating is an injected predicate (the only door),
+/// so no ambient authority leaks in.
+[<RequireQualifiedAccess>]
+module DoorGraph =
+
+    /// A door: a directed portal `From → To` between two rooms (by id), with a permission `Key` that a
+    /// traverser must hold. Bidirectional connections are two doors (a room you can enter you can also
+    /// be left — but each direction is independently gated).
+    type Door =
+        { From: string
+          To: string
+          Key: string }
+
+    /// A vault interior: its room ids (the leaves) and the doors among them.
+    type Vault =
+        { Rooms: string list
+          Doors: Door list }
+
+    /// Build a door (directed, permission-gated).
+    let door (from: string) (to': string) (key: string) : Door =
+        { From = from; To = to'; Key = key }
+
+    /// An empty vault interior.
+    let empty : Vault = { Rooms = []; Doors = [] }
+
+    /// Add a room (a leaf). Idempotent — a room already present is not duplicated.
+    let addRoom (room: string) (v: Vault) : Vault =
+        if List.contains room v.Rooms then v else { v with Rooms = room :: v.Rooms }
+
+    /// Add a door — but ONLY between rooms that exist in THIS vault (doors stay intra-vault; the
+    /// outside-map handles vault↔vault). Returns Error if either endpoint is absent or it self-loops.
+    let addDoor (d: Door) (v: Vault) : Result<Vault, string> =
+        if d.From = d.To then Error "a door cannot connect a room to itself"
+        elif not (List.contains d.From v.Rooms) then Error $"door source room '{d.From}' is not in this vault"
+        elif not (List.contains d.To v.Rooms) then Error $"door target room '{d.To}' is not in this vault"
+        else Ok { v with Doors = d :: v.Doors }
+
+    /// The doors leading OUT of `room` (its lateral exits within the vault).
+    let exits (room: string) (v: Vault) : Door list =
+        v.Doors |> List.filter (fun d -> d.From = room)
+
+    /// **Universal Exit Principle:** every room has at least one door out. Returns the rooms that
+    /// VIOLATE it (no exit) — empty list ⇒ no room is a trap.
+    let roomsWithoutExit (v: Vault) : string list =
+        v.Rooms |> List.filter (fun r -> List.isEmpty (exits r v))
+
+    /// **Traverse a door (the metered crossing):** succeeds only if a door `from → to` exists AND the
+    /// traverser's `heldKeys` include that door's `Key` (permission-gated, consent-first #6). Returns
+    /// the destination room id. The `heldKeys` set is the only door for authority — no ambient grant.
+    let traverse (heldKeys: Set<string>) (from: string) (to': string) (v: Vault) : Result<string, string> =
+        match v.Doors |> List.tryFind (fun d -> d.From = from && d.To = to') with
+        | None -> Error $"no door from '{from}' to '{to'}'"
+        | Some d ->
+            if Set.contains d.Key heldKeys then Ok to'
+            else Error $"permission denied: door '{from}→{to'}' requires key '{d.Key}'"
+
+    /// Can this traverser reach `to'` from `from` in one metered step (door exists + key held)?
+    let canTraverse (heldKeys: Set<string>) (from: string) (to': string) (v: Vault) : bool =
+        match traverse heldKeys from to' v with
+        | Ok _ -> true
+        | Error _ -> false

--- a/tests/Tests.FSharp/Formal/DoorGraph.Tests.fs
+++ b/tests/Tests.FSharp/Formal/DoorGraph.Tests.fs
@@ -1,0 +1,74 @@
+module Zeta.Tests.Formal.DoorGraphTests
+
+open FsCheck.Xunit
+open global.Xunit
+open Zeta.Core
+
+// The door model (#8775): rooms = leaves, doors = first-class permission-gated portals (#13 metered
+// channels), Universal Exit Principle (a room with a door out is a room you can leave).
+
+/// A small vault: keys → triage → forecast, with a back door triage → keys.
+let private sample () =
+    let v =
+        DoorGraph.empty
+        |> DoorGraph.addRoom "keys"
+        |> DoorGraph.addRoom "triage"
+        |> DoorGraph.addRoom "forecast"
+    let v = match DoorGraph.addDoor (DoorGraph.door "keys" "triage" "k1") v with Ok x -> x | Error e -> failwith e
+    let v = match DoorGraph.addDoor (DoorGraph.door "triage" "forecast" "k2") v with Ok x -> x | Error e -> failwith e
+    let v = match DoorGraph.addDoor (DoorGraph.door "triage" "keys" "k1") v with Ok x -> x | Error e -> failwith e
+    v
+
+[<Fact>]
+let ``addRoom is idempotent`` () =
+    let v = DoorGraph.empty |> DoorGraph.addRoom "a" |> DoorGraph.addRoom "a"
+    Assert.Equal(1, v.Rooms.Length)
+
+[<Fact>]
+let ``a door only connects rooms that exist in this vault (intra-vault)`` () =
+    let v = DoorGraph.empty |> DoorGraph.addRoom "a"
+    Assert.True(match DoorGraph.addDoor (DoorGraph.door "a" "ghost" "k") v with Error _ -> true | _ -> false)
+    Assert.True(match DoorGraph.addDoor (DoorGraph.door "ghost" "a" "k") v with Error _ -> true | _ -> false)
+
+[<Fact>]
+let ``a door cannot self-loop (a room is not contained in itself)`` () =
+    let v = DoorGraph.empty |> DoorGraph.addRoom "a"
+    Assert.True(match DoorGraph.addDoor (DoorGraph.door "a" "a" "k") v with Error _ -> true | _ -> false)
+
+[<Fact>]
+let ``traverse is permission-gated: needs the door's key`` () =
+    let v = sample ()
+    // hold k1 → can go keys→triage; cannot go triage→forecast (needs k2)
+    Assert.Equal(Ok "triage", DoorGraph.traverse (Set.ofList [ "k1" ]) "keys" "triage" v)
+    Assert.True(match DoorGraph.traverse (Set.ofList [ "k1" ]) "triage" "forecast" v with Error _ -> true | _ -> false)
+    // hold both → can go triage→forecast
+    Assert.Equal(Ok "forecast", DoorGraph.traverse (Set.ofList [ "k1"; "k2" ]) "triage" "forecast" v)
+
+[<Fact>]
+let ``traverse fails when no door exists (no teleporting)`` () =
+    let v = sample ()
+    // there is no direct keys→forecast door
+    Assert.True(match DoorGraph.traverse (Set.ofList [ "k1"; "k2" ]) "keys" "forecast" v with Error _ -> true | _ -> false)
+
+[<Fact>]
+let ``exits lists a room's lateral doors`` () =
+    let v = sample ()
+    let triageExits = DoorGraph.exits "triage" v |> List.map (fun d -> d.To) |> List.sort
+    Assert.Equal<string list>([ "forecast"; "keys" ], triageExits)
+    Assert.Equal<string list>([ "triage" ], DoorGraph.exits "keys" v |> List.map (fun d -> d.To))
+
+[<Fact>]
+let ``Universal Exit Principle: a room with no door out is flagged (a trap)`` () =
+    let v = sample () // forecast has no outgoing door
+    Assert.Equal<string list>([ "forecast" ], DoorGraph.roomsWithoutExit v)
+    // give forecast a way back → no traps
+    let v2 = match DoorGraph.addDoor (DoorGraph.door "forecast" "triage" "k2") v with Ok x -> x | Error e -> failwith e
+    Assert.True(List.isEmpty (DoorGraph.roomsWithoutExit v2))
+
+[<Property>]
+let ``canTraverse holds iff a door exists and its key is held`` (hasKey: bool) =
+    let v =
+        DoorGraph.empty |> DoorGraph.addRoom "a" |> DoorGraph.addRoom "b"
+        |> (fun g -> match DoorGraph.addDoor (DoorGraph.door "a" "b" "secret") g with Ok x -> x | Error e -> failwith e)
+    let keys = if hasKey then Set.ofList [ "secret" ] else Set.empty
+    DoorGraph.canTraverse keys "a" "b" v = hasKey

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -372,6 +372,7 @@
     <Compile Include="Formal/MetaspaceMap.Tests.fs" />
     <Compile Include="Formal/MetaspaceGraphRender.Tests.fs" />
     <Compile Include="Formal/GlassHalo.Tests.fs" />
+    <Compile Include="Formal/DoorGraph.Tests.fs" />
     <Compile Include="Formal/LiveLegs.Tests.fs" />
     <Compile Include="Formal/WikidataGraph.Tests.fs" />
     <Compile Include="Formal/GraphSnapshot.Tests.fs" />


### PR DESCRIPTION
The **last metaspace spine piece** (door model #8775): the *inside* counterpart to the outside-map.

Within a vault, **rooms are leaves** (rooms can't contain rooms) and a room may have **multiple doors to other rooms in the same vault** → rooms form a **graph**. A **door is a first-class portal = a declared, metered channel (#13)**: you move between rooms ONLY through doors; traversal is **permission-gated** (consent-first #6, injected `heldKeys` — the only door for authority); and the **Universal Exit Principle** is checkable (a room with a door out is a room you can leave).

- **`src/Core/DoorGraph.fs`** — `Door {From;To;Key}`; `Vault {Rooms;Doors}`; `addRoom` (idempotent), `addDoor` (intra-vault only, no self-loop), `exits`, `roomsWithoutExit` (flags traps), `traverse` (door must exist **and** key held — no teleporting), `canTraverse`.
- **`DoorGraph.Tests.fs`** — 8 tests, **8/8 green**: addRoom idempotent, doors intra-vault only, no self-loop, traverse permission-gated, no teleport without a door, exits listing, **Universal Exit Principle flags a trap**, property (canTraverse iff door+key held).

Core **0/0**. Completes the metaspace spine: `Viewport` · `MetaspaceMap` · `ForceLayout` · `MetaspaceGraphRender` · `GlassHalo` · `DoorGraph`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)