### PR TITLE
fix(rust): add missing dev-deps for experience_cross_verify (serde derive + sha256)

### DIFF
--- a/src/Core.Rust.Algebra/Cargo.toml
+++ b/src/Core.Rust.Algebra/Cargo.toml
@@ -20,6 +20,8 @@ zeta-core-merkle = { path = "../Core.Rust.Merkle", default-features = false }
 
 [dev-dependencies]
 serde_json = "1"
+serde = { version = "1", features = ["derive"] }
+zeta-core-sha256 = { path = "../Core.Rust.Sha256" }
 zeta-core-yaml = { path = "../Core.Rust.Yaml" }
 
 [lints.rust]


### PR DESCRIPTION
Fixes the `lint (Rust)` gate failure on `main`: `Core.Rust.Algebra`'s `experience_cross_verify` test (added by #8791) uses `serde::Serialize` (derive) + `zeta_core_sha256::sha256_hex`, but dev-dependencies only had `serde_json` — so the test **failed to compile** (E0432 unresolved imports + E0277), exiting clippy with code 101. Merged red because `lint (Rust)` is non-required.

**Fix:** add the two missing **dev-dependencies** — `serde = { version = "1", features = ["derive"] }` + `zeta-core-sha256 = { path = "../Core.Rust.Sha256" }`. **Dev-only** — the production algebra stays zero-dependency (supply-chain doctrine intact). Verified locally: `cargo test --test experience_cross_verify` → compiles + **1/1 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)