### PR TITLE
[codex] add room boundary policy

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -195,6 +195,7 @@
     <Compile Include="Heat.fs" />
     <Compile Include="RoomHorizon.fs" />
     <Compile Include="RoomAdmission.fs" />
+    <Compile Include="RoomBoundary.fs" />
     <Compile Include="Query.fs" />
     <Compile Include="Injection.fs" />
     <Compile Include="InjectionExt.fs" />

--- a/src/Core/RoomBoundary.fs
+++ b/src/Core/RoomBoundary.fs
@@ -1,0 +1,116 @@
+namespace Zeta.Core
+
+/// A room boundary composes finite admission, visibility, door traversal, and
+/// host-facing heat without becoming a runtime of its own.
+[<RequireQualifiedAccess>]
+module RoomBoundary =
+
+    type Boundary<'K when 'K : comparison> =
+        { Source: string
+          Occupants: ModuloGSet<'K>
+          Visibility: GlassHalo.Visibility
+          PrivacyBudget: int
+          CurrentRoom: string }
+
+    [<RequireQualifiedAccess>]
+    type Feedback =
+        | AdmissionFeedback of RoomAdmission.Feedback
+        | PrivacyDenied of reason: string
+        | DoorDenied of fromRoom: string * toRoom: string * reason: string
+        | HeatFeedback of HeatSinkFeedback
+
+    let create
+        (source: string)
+        (currentRoom: string)
+        (privacyBudget: int)
+        (occupants: ModuloGSet<'K>)
+        : Boundary<'K> =
+        { Source = source
+          Occupants = occupants
+          Visibility = GlassHalo.initial
+          PrivacyBudget = max 0 privacyBudget
+          CurrentRoom = currentRoom }
+
+    let private admissionFeedback =
+        function
+        | RoomAdmission.Feedback.HeatFeedback feedback -> Feedback.HeatFeedback feedback
+        | feedback -> Feedback.AdmissionFeedback feedback
+
+    let private emitRefusalHeat
+        (sink: IHeatSink)
+        (source: string)
+        (kind: string)
+        (detail: string)
+        : Result<unit, Feedback> =
+        let heat = HeatSignature.ofMass source kind 1 1.0 detail
+        sink.Emit heat |> Result.mapError Feedback.HeatFeedback
+
+    let private privacyDenied
+        (sink: IHeatSink)
+        (source: string)
+        (reason: string)
+        : Result<'T, Feedback> =
+        result {
+            do! emitRefusalHeat sink source "room-boundary.privacy-backpressure" reason
+            return! Error(Feedback.PrivacyDenied reason)
+        }
+
+    let private doorDenied
+        (sink: IHeatSink)
+        (source: string)
+        (fromRoom: string)
+        (toRoom: string)
+        (reason: string)
+        : Result<'T, Feedback> =
+        result {
+            let detail = sprintf "%s -> %s refused: %s" fromRoom toRoom reason
+            do! emitRefusalHeat sink source "room-boundary.door-denied" detail
+            return! Error(Feedback.DoorDenied(fromRoom, toRoom, reason))
+        }
+
+    /// Admit one occupant through the finite room view and export any heat.
+    let admitWithSlot
+        (sink: IHeatSink)
+        (rawSlot: int64)
+        (key: 'K)
+        (boundary: Boundary<'K>)
+        : Result<Boundary<'K> * RoomAdmission.SlotReport<'K>, Feedback> =
+        result {
+            let! report =
+                RoomAdmission.admitWithHeat sink boundary.Source rawSlot key boundary.Occupants
+                |> Result.mapError admissionFeedback
+
+            return { boundary with Occupants = report.After }, report
+        }
+
+    /// Spend earned privacy budget to frost the boundary.
+    let frost
+        (sink: IHeatSink)
+        (cost: int)
+        (boundary: Boundary<'K>)
+        : Result<Boundary<'K>, Feedback> =
+        match GlassHalo.frost cost boundary.PrivacyBudget boundary.Visibility with
+        | Ok(visibility, remaining) ->
+            Ok { boundary with Visibility = visibility; PrivacyBudget = remaining }
+        | Error reason -> privacyDenied sink boundary.Source reason
+
+    /// Return the boundary to the clear default. This does not refund spent
+    /// privacy budget; that budget bought the private interval that already ran.
+    let clear (boundary: Boundary<'K>) : Boundary<'K> =
+        { boundary with Visibility = GlassHalo.clear boundary.Visibility }
+
+    let observe (placeholder: 'A) (content: 'A) (boundary: Boundary<'K>) : 'A =
+        GlassHalo.observe placeholder content boundary.Visibility
+
+    /// Traverse one declared door. Permission failures and missing doors are
+    /// typed refusals and also exported as heat for host/debug visibility.
+    let traverse
+        (sink: IHeatSink)
+        (heldKeys: Set<string>)
+        (toRoom: string)
+        (vault: DoorGraph.Vault)
+        (boundary: Boundary<'K>)
+        : Result<Boundary<'K>, Feedback> =
+        match DoorGraph.traverse heldKeys boundary.CurrentRoom toRoom vault with
+        | Ok destination -> Ok { boundary with CurrentRoom = destination }
+        | Error reason -> doorDenied sink boundary.Source boundary.CurrentRoom toRoom reason

--- a/tests/Tests.FSharp/RoomBoundary.Tests.fs
+++ b/tests/Tests.FSharp/RoomBoundary.Tests.fs
@@ -1,0 +1,140 @@
+module Zeta.Tests.RoomBoundaryTests
+
+open global.Xunit
+open Zeta.Core
+
+module RB = RoomBoundary
+module RA = RoomAdmission
+
+let private mustOk =
+    function
+    | Ok value -> value
+    | Error feedback -> failwithf "expected Ok, got %A" feedback
+
+let private rejectSlots slots : ModuloGSetConfig =
+    { Slots = slots
+      CollisionPolicy = ModuloGSetCollisionPolicy.RejectCollision }
+
+let private replaceSlots slots : ModuloGSetConfig =
+    { Slots = slots
+      CollisionPolicy = ModuloGSetCollisionPolicy.ReplaceExisting }
+
+let private emptyBoundary source room budget config =
+    ModuloGSet.empty<string> config
+    |> mustOk
+    |> RB.create source room budget
+
+let private sampleVault () =
+    let v =
+        DoorGraph.empty
+        |> DoorGraph.addRoom "arcade"
+        |> DoorGraph.addRoom "glass"
+
+    DoorGraph.addDoor (DoorGraph.door "arcade" "glass" "door-key") v |> mustOk
+
+[<Fact>]
+let ``admission collision stays no-forget and emits room backpressure heat`` () =
+    let sink = RecordingHeatSink()
+    let start = emptyBoundary "experience-room" "arcade" 10 (rejectSlots 1)
+
+    let first, firstReport =
+        RB.admitWithSlot (sink :> IHeatSink) 0L "alpha" start |> mustOk
+
+    let second, secondReport =
+        RB.admitWithSlot (sink :> IHeatSink) 1L "beta" first |> mustOk
+
+    Assert.Equal(RA.SlotOutcome.Admitted, firstReport.Outcome)
+    Assert.Equal(RA.SlotOutcome.Backpressured, secondReport.Outcome)
+    Assert.Equal<string list>([ "alpha" ], second.Occupants |> ModuloGSet.toList)
+    Assert.Equal<string list>([ "beta" ], secondReport.Backpressured |> GSet.toList)
+    Assert.Equal(1, sink.Signatures.Count)
+    Assert.Equal("room-admission.backpressure", sink.Signatures.[0].Kind)
+
+[<Fact>]
+let ``admission replacement exports forgotten occupant heat`` () =
+    let sink = RecordingHeatSink()
+    let start = emptyBoundary "experience-room" "arcade" 10 (replaceSlots 1)
+
+    let first, _ =
+        RB.admitWithSlot (sink :> IHeatSink) 0L "old" start |> mustOk
+
+    let second, report =
+        RB.admitWithSlot (sink :> IHeatSink) 1L "new" first |> mustOk
+
+    Assert.Equal(RA.SlotOutcome.Replaced, report.Outcome)
+    Assert.Equal<string list>([ "new" ], second.Occupants |> ModuloGSet.toList)
+    Assert.Equal<string list>([ "old" ], report.Heat.Forgotten |> GSet.toList)
+    Assert.Equal(1, sink.Signatures.Count)
+    Assert.Equal("room-admission.forgotten", sink.Signatures.[0].Kind)
+
+[<Fact>]
+let ``frost spends privacy budget and observe hides content`` () =
+    let sink = RecordingHeatSink()
+    let start = emptyBoundary "experience-room" "arcade" 7 (rejectSlots 2)
+
+    let frosted = RB.frost (sink :> IHeatSink) 5 start |> mustOk
+
+    Assert.Equal(2, frosted.PrivacyBudget)
+    Assert.False(GlassHalo.isVisible frosted.Visibility)
+    Assert.Equal("private", RB.observe "private" "payload" frosted)
+    Assert.Equal("payload", frosted |> RB.clear |> RB.observe "private" "payload")
+    Assert.Empty(sink.Signatures)
+
+[<Fact>]
+let ``insufficient privacy budget is typed and emits refusal heat`` () =
+    let sink = RecordingHeatSink()
+    let start = emptyBoundary "experience-room" "arcade" 2 (rejectSlots 2)
+
+    match RB.frost (sink :> IHeatSink) 5 start with
+    | Error(RB.Feedback.PrivacyDenied reason) ->
+        Assert.Contains("insufficient privacy budget", reason)
+        Assert.Equal(1, sink.Signatures.Count)
+        Assert.Equal("room-boundary.privacy-backpressure", sink.Signatures.[0].Kind)
+    | other -> Assert.Fail(sprintf "expected privacy denial, got %A" other)
+
+[<Fact>]
+let ``door traversal denial is typed and emits refusal heat`` () =
+    let sink = RecordingHeatSink()
+    let boundary = emptyBoundary "experience-room" "arcade" 10 (rejectSlots 2)
+    let vault = sampleVault ()
+
+    match RB.traverse (sink :> IHeatSink) Set.empty "glass" vault boundary with
+    | Error(RB.Feedback.DoorDenied(fromRoom, toRoom, reason)) ->
+        Assert.Equal("arcade", fromRoom)
+        Assert.Equal("glass", toRoom)
+        Assert.Contains("permission denied", reason)
+        Assert.Equal(1, sink.Signatures.Count)
+        Assert.Equal("room-boundary.door-denied", sink.Signatures.[0].Kind)
+    | other -> Assert.Fail(sprintf "expected door denial, got %A" other)
+
+[<Fact>]
+let ``door traversal with key moves the boundary room without heat`` () =
+    let sink = RecordingHeatSink()
+    let boundary = emptyBoundary "experience-room" "arcade" 10 (rejectSlots 2)
+    let vault = sampleVault ()
+
+    let next =
+        RB.traverse (sink :> IHeatSink) (Set.ofList [ "door-key" ]) "glass" vault boundary
+        |> mustOk
+
+    Assert.Equal("glass", next.CurrentRoom)
+    Assert.Empty(sink.Signatures)
+
+[<Fact>]
+let ``refusal heat sink backpressure is typed`` () =
+    let sink =
+        BoundedHeatSink
+            { Capacity = 1
+              ForgetPolicy = BoundedGSetForgetPolicy.RejectNew }
+
+    let filler = HeatSignature.ofMass "test" "heat.fill" 1 1.0 "occupy bounded heat sink"
+    (sink :> IHeatSink).Emit filler |> mustOk
+
+    let start = emptyBoundary "experience-room" "arcade" 2 (rejectSlots 2)
+
+    match RB.frost (sink :> IHeatSink) 5 start with
+    | Error(RB.Feedback.HeatFeedback(HeatSinkFeedback.Backpressure(heat, capacity, count))) ->
+        Assert.Equal("room-boundary.privacy-backpressure", heat.Kind)
+        Assert.Equal(1, capacity)
+        Assert.Equal(2, count)
+    | other -> Assert.Fail(sprintf "expected heat feedback, got %A" other)

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -159,6 +159,7 @@
     <Compile Include="PredictionScheduler.Tests.fs" />
     <Compile Include="RoomHorizon.Tests.fs" />
     <Compile Include="RoomAdmission.Tests.fs" />
+    <Compile Include="RoomBoundary.Tests.fs" />
     <Compile Include="RecordedSource.Tests.fs" />
     <Compile Include="SoftIsr.Tests.fs" />
     <Compile Include="SimFramework.Tests.fs" />


### PR DESCRIPTION
Adds `RoomBoundary` as the small source-owned connector over `RoomAdmission`, `GlassHalo`, `DoorGraph`, and `IHeatSink`.

The new boundary gives rooms one typed surface for finite admission, earned privacy frosting, permission-gated traversal, and host-visible heat on refusal/backpressure. It does not become a runtime: admission algebra, visibility, traversal, and heat remain owned by their existing modules.

Validation:
- dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter FullyQualifiedName~RoomBoundaryTests
- dotnet format --verify-no-changes
- bun run preflight:quick
- git diff --check
- dotnet build -c Release
- dotnet test Zeta.sln -c Release
- bun src/Core.TypeScript/hygiene/audit-agencysignature-main-tip.ts --commit HEAD

Co-Authored-By: Codex <noreply@openai.com>
Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: Codex
Agent-Model: gpt-5.5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: not-implied-by-credential
Human-Review-Evidence: none
Action-Mode: human-directed
Task: none
