### PR TITLE
feat(formal): Z3 QF_BV denotation proofs for IR rows — hand-written splitmix64/fmix32 (C2) + parameterised emitter

### DIFF
--- a/tools/Z3Verify/gen-denotation-splitmix64.smt2
+++ b/tools/Z3Verify/gen-denotation-splitmix64.smt2
@@ -1,0 +1,179 @@
+; ============================================================================
+; gen-denotation-splitmix64.smt2  --  Z3 QF_BV denotation-preservation proof
+;
+;   "the generated code's arithmetic == the hand-written oracle's arithmetic"
+;   proved at the bitvector level, over the WHOLE input domain (not the 10 test
+;   vectors -- all 2^64 splitmix64 inputs and all 2^32 fmix32 inputs).
+;
+; Author: Soraya (formal-verification-expert role), invoked by Otto. C2 of the
+; gen-denotation arc. Reason from our own understanding; do not copy a port.
+;
+; ---------------------------------------------------------------------------
+; WHAT IS BEING PROVED (and why it is not a tautology)
+; ---------------------------------------------------------------------------
+; Two functions are defined per primitive, from TWO INDEPENDENT SOURCES:
+;
+;   *_oracle  -- the hand-written algorithm. Transcribed from the human-authored
+;                port src/Core.CSharp/SplitMix64.cs (Vigna's finaliser) and the
+;                MurmurHash3 fmix32 reference (Appleby). Constants are the named
+;                hex constants the human wrote (GoldenRatio / VignaA / VignaB,
+;                0x85ebca6b / 0xc2b2ae35).
+;
+;   *_interp  -- the GENERATED side: a mechanical unrolled fold of the IR row's
+;                op list, one SMT `let` per IR op, applying the total
+;                interpreter's per-op denotation (mul = wrapping bvmul, xorshr =
+;                z ^ (z >> s), mask = the BV width). The IR rows are:
+;                  tests/cross-verification/splitmix64/_gen/splitmix64.ir.json
+;                    rng.splitmix64@1  zetaId 129c1fac3a48075b481c0f10f30deb06
+;                  tests/cross-verification/fmix32/_gen/fmix32.ir.json
+;                    hash.fmix32@1
+;                The splitmix64 multiplier constants are taken in their STORED
+;                signed-int64 form (DynamicValue.Int is int64) and reinterpreted
+;                here by bvneg(|stored|) -- the exact `fromI64` round-trip the TS
+;                interpreter performs. That reinterpretation is itself discharged
+;                as a checked lemma below, not asserted by comment.
+;
+; The denotation-preservation theorem is:  forall x. oracle(x) = interp(x).
+; In SMT we refute its negation:  assert (not (= (oracle x) (interp x))); the
+; result `unsat` certifies equality over the entire domain. Because the two
+; sides come from independent encodings (named-hex closed form vs IR-op fold
+; over stored-signed constants), `unsat` is a real equivalence result -- it
+; would fail if the IR row, the fromI64 reinterpretation, the op order, the
+; shift widths, or the wrapping semantics disagreed with the oracle.
+;
+; Anchors (Beacon):
+;   - Sebastiano Vigna, "An experimental exploration of Marsaglia's xorshift
+;     generators, scrambled", arXiv:1410.0530 v3 §3 (splitmix64 finaliser);
+;     public-domain reference https://prng.di.unimi.it/splitmix64.c
+;   - Donald Knuth, TAOCP vol.3 §6.4 (the 2^64/phi multiplicative-hash constant)
+;   - Austin Appleby, MurmurHash3 (smhasher) -- fmix32 finaliser
+;   - QF_BV is a decidable theory (Barrett/Tinelli, SMT-LIB 2.6); bvmul is the
+;     mod-2^n product, so wrapping word arithmetic is exact, not modelled.
+;
+; Run:  z3 tools/Z3Verify/gen-denotation-splitmix64.smt2
+; Expected: a column of `unsat` (every theorem/lemma holds), no `sat`.
+; ============================================================================
+
+(set-logic QF_BV)
+(set-info :status unsat)
+
+; ===========================================================================
+; PART 1 -- splitmix64  (64-bit, rng.splitmix64@1)
+; ===========================================================================
+
+; --- oracle constants: the named hex the human wrote in SplitMix64.cs ---
+(define-fun GOLD () (_ BitVec 64) #x9e3779b97f4a7c15)   ; GoldenRatio
+(define-fun VIGA () (_ BitVec 64) #xbf58476d1ce4e5b9)   ; VignaA
+(define-fun VIGB () (_ BitVec 64) #x94d049bb133111eb)   ; VignaB
+
+; --- interp constants: the IR row's STORED signed-int64 k, reinterpreted by
+;     fromI64 == bvneg(|stored|). These literals are the decimal magnitudes that
+;     appear (negated) in splitmix64.ir.json: -7046029254386353131 etc. ---
+(define-fun K0 () (_ BitVec 64) (bvneg (_ bv7046029254386353131 64)))
+(define-fun K1 () (_ BitVec 64) (bvneg (_ bv4658895280553007687 64)))
+(define-fun K2 () (_ BitVec 64) (bvneg (_ bv7723592293110705685 64)))
+
+; LEMMA 1 -- the INT64-domain reinterpretation is exact (fromI64 round-trip).
+; fromI64(stored signed) == the u64 multiplier the oracle names.
+(push)
+(assert (not (and (= K0 GOLD) (= K1 VIGA) (= K2 VIGB))))
+(check-sat)   ; expect: unsat
+(pop)
+
+; --- the hand-written oracle (SplitMix64.Mix shape) ---
+(define-fun sm64_oracle ((x (_ BitVec 64))) (_ BitVec 64)
+  (let ((z0 (bvmul x GOLD)))
+  (let ((z1 (bvmul (bvxor z0 (bvlshr z0 (_ bv30 64))) VIGA)))
+  (let ((z2 (bvmul (bvxor z1 (bvlshr z1 (_ bv27 64))) VIGB)))
+    (bvxor z2 (bvlshr z2 (_ bv31 64)))))))
+
+; --- the generated side: mechanical fold of the IR op list, one let per op ---
+;   ops: [mul k0][xorshr 30][mul k1][xorshr 27][mul k2][xorshr 31]
+(define-fun sm64_interp ((x (_ BitVec 64))) (_ BitVec 64)
+  (let ((s1 (bvmul x K0)))                              ; op 0: mul k0
+  (let ((s2 (bvxor s1 (bvlshr s1 (_ bv30 64)))))       ; op 1: xorshr 30
+  (let ((s3 (bvmul s2 K1)))                             ; op 2: mul k1
+  (let ((s4 (bvxor s3 (bvlshr s3 (_ bv27 64)))))       ; op 3: xorshr 27
+  (let ((s5 (bvmul s4 K2)))                             ; op 4: mul k2
+    (bvxor s5 (bvlshr s5 (_ bv31 64)))))))))            ; op 5: xorshr 31
+
+; THEOREM 1 -- denotation preservation over all 2^64 inputs.
+(push)
+(declare-const x64 (_ BitVec 64))
+(assert (not (= (sm64_oracle x64) (sm64_interp x64))))
+(check-sat)   ; expect: unsat  (oracle == interp for every 64-bit input)
+(pop)
+
+; CONTROL 1 -- positive grounding: refute that the oracle disagrees with the
+; committed canonical vectors. Guards against an "identically-wrong on both
+; sides" encoding (a bug that THEOREM 1 alone could not catch).
+;   mix(0) = 0, mix(1) = 16294208416658607535,
+;   mix(golden=11400714819323198485) = 5878998237028904013
+(push)
+(assert (not (and
+  (= (sm64_oracle (_ bv0 64))                    (_ bv0 64))
+  (= (sm64_oracle (_ bv1 64))                    (_ bv16294208416658607535 64))
+  (= (sm64_oracle (_ bv11400714819323198485 64)) (_ bv5878998237028904013 64)))))
+(check-sat)   ; expect: unsat  (oracle reproduces the byte-locked vectors)
+(pop)
+
+; ===========================================================================
+; PART 2 -- MurmurHash3 fmix32  (32-bit, hash.fmix32@1)
+;   proves the SAME interpreter denotation generalises to a different width.
+; ===========================================================================
+
+; --- oracle constants: named hex from the MurmurHash3 fmix32 reference ---
+(define-fun M0 () (_ BitVec 32) #x85ebca6b)
+(define-fun M1 () (_ BitVec 32) #xc2b2ae35)
+
+; LEMMA 2 -- the IR row's decimal constants equal the oracle's named hex.
+;   fmix32.ir.json carries k = 2246822507, 3266489909 (positive, < 2^31,
+;   no signed reinterpretation needed at width 32).
+(push)
+(assert (not (and (= (_ bv2246822507 32) M0) (= (_ bv3266489909 32) M1))))
+(check-sat)   ; expect: unsat
+(pop)
+
+; --- the hand-written oracle (fmix32 finaliser) ---
+(define-fun fmix32_oracle ((h (_ BitVec 32))) (_ BitVec 32)
+  (let ((a (bvxor h (bvlshr h (_ bv16 32)))))
+  (let ((b (bvmul a M0)))
+  (let ((c (bvxor b (bvlshr b (_ bv13 32)))))
+  (let ((d (bvmul c M1)))
+    (bvxor d (bvlshr d (_ bv16 32))))))))
+
+; --- the generated side: fold of the fmix32 IR op list, one let per op ---
+;   ops: [xorshr 16][mul 2246822507][xorshr 13][mul 3266489909][xorshr 16]
+(define-fun fmix32_interp ((h (_ BitVec 32))) (_ BitVec 32)
+  (let ((s1 (bvxor h (bvlshr h (_ bv16 32)))))         ; op 0: xorshr 16
+  (let ((s2 (bvmul s1 (_ bv2246822507 32))))          ; op 1: mul k0
+  (let ((s3 (bvxor s2 (bvlshr s2 (_ bv13 32)))))      ; op 2: xorshr 13
+  (let ((s4 (bvmul s3 (_ bv3266489909 32))))          ; op 3: mul k1
+    (bvxor s4 (bvlshr s4 (_ bv16 32))))))))            ; op 4: xorshr 16
+
+; THEOREM 2 -- denotation preservation over all 2^32 inputs.
+(push)
+(declare-const h32 (_ BitVec 32))
+(assert (not (= (fmix32_oracle h32) (fmix32_interp h32))))
+(check-sat)   ; expect: unsat  (oracle == interp for every 32-bit input)
+(pop)
+
+; CONTROL 2 -- positive grounding against the committed fmix32 vectors.
+;   fmix32(0) = 0, fmix32(1) = 1364076727, fmix32(255) = 1818482051
+(push)
+(assert (not (and
+  (= (fmix32_oracle (_ bv0 32))   (_ bv0 32))
+  (= (fmix32_oracle (_ bv1 32))   (_ bv1364076727 32))
+  (= (fmix32_oracle (_ bv255 32)) (_ bv1818482051 32)))))
+(check-sat)   ; expect: unsat  (oracle reproduces the byte-locked vectors)
+(pop)
+
+; ============================================================================
+; Six checks, all expected unsat:
+;   LEMMA 1   fromI64 reinterpretation exact (splitmix64 u64 constants)
+;   THEOREM 1 splitmix64 oracle == IR-fold interp, all 2^64 inputs
+;   CONTROL 1 splitmix64 oracle reproduces canonical vectors
+;   LEMMA 2   fmix32 IR constants == oracle constants
+;   THEOREM 2 fmix32 oracle == IR-fold interp, all 2^32 inputs
+;   CONTROL 2 fmix32 oracle reproduces canonical vectors
+; ============================================================================

--- a/tools/Z3Verify/gen-smt2-from-ir.test.ts
+++ b/tools/Z3Verify/gen-smt2-from-ir.test.ts
@@ -1,0 +1,101 @@
+// gen-smt2-from-ir.test.ts — generator-fidelity self-test for the parameterised
+// Z3 QF_BV denotation-proof emitter (gen-smt2-from-ir.ts).
+//
+// WHY THIS EXISTS
+// ---------------
+// gen-smt2-from-ir.ts reads a zeta-ir-v{1,2,3} finaliser row and EMITS the .smt2
+// denotation-preservation proof for it. This test proves the emitter is real, not
+// a green that cannot turn red:
+//   1. it emits a structurally-well-formed proof (balanced parens, the LEMMA /
+//      THEOREM / CONTROL skeleton) for EVERY IR row on the registry;
+//   2. when z3 is on PATH, every emitted proof discharges all-`unsat`
+//      (LEMMA + THEOREM + CONTROL) — the proof is SOUND;
+//   3. CORRUPTING the IR (one constant) makes the emitted proof go `sat` — the
+//      proof is FALSIFIABLE (a green that cannot turn red is a Sybil green).
+//
+// z3 is run opportunistically: if it is absent (some CI runners), legs (2)/(3)
+// soft-skip with a logged note, but the emit + structural legs always run.
+//
+// Run: `bun test tools/Z3Verify/gen-smt2-from-ir.test.ts`
+
+import { expect, test } from "bun:test";
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { parseIrJson, loadVectors, emitSmt2 } from "./gen-smt2-from-ir.ts";
+
+const XV = join(import.meta.dir, "..", "..", "tests", "cross-verification");
+
+// every committed registry row (IR + sibling vectors.yaml byte-lock)
+const ROWS = ["splitmix64", "fmix32", "fmix64", "nasam", "xoshiro256ss"] as const;
+
+const irPathOf = (g: string): string => join(XV, g, "_gen", `${g}.ir.json`);
+
+function parenBalance(s: string): number {
+  let depth = 0;
+  for (const line of s.split("\n")) {
+    const code = line.replace(/;.*$/, ""); // strip line comments
+    for (const ch of code) {
+      if (ch === "(") depth++;
+      else if (ch === ")") depth--;
+    }
+  }
+  return depth;
+}
+
+const z3Available = (() => {
+  const probe = spawnSync("z3", ["--version"], { encoding: "utf8" });
+  return probe.status === 0;
+})();
+
+/** Run z3 on proof text; return the sequence of check-sat verdicts. */
+function z3Verdicts(smt2: string): string[] {
+  const r = spawnSync("z3", ["-in"], { input: smt2, encoding: "utf8" });
+  // (set-info :status ...) makes z3 print an `(error ...)` on a mismatched verdict;
+  // collect the bare sat/unsat/unknown tokens in order.
+  return r.stdout.match(/\b(unsat|sat|unknown)\b/g) ?? [];
+}
+
+for (const g of ROWS) {
+  test(`emits a well-formed proof for ${g}`, () => {
+    const ir = parseIrJson(readFileSync(irPathOf(g), "utf8"));
+    const proof = emitSmt2(ir, loadVectors(irPathOf(g)));
+
+    expect(proof).toContain("(set-logic QF_BV)");
+    expect(proof).toContain("THEOREM");
+    expect(proof).toContain("CONTROL"); // every registry row carries a vectors.yaml
+    expect(parenBalance(proof)).toBe(0); // balanced s-expressions
+  });
+
+  test(`z3 discharges all-unsat for ${g}`, () => {
+    if (!z3Available) {
+      console.warn(`  [skip] z3 not on PATH — soundness leg for ${g} not run`);
+      return;
+    }
+    const ir = parseIrJson(readFileSync(irPathOf(g), "utf8"));
+    const proof = emitSmt2(ir, loadVectors(irPathOf(g)));
+    const verdicts = z3Verdicts(proof);
+    expect(verdicts.length).toBeGreaterThanOrEqual(2); // THEOREM + CONTROL at minimum
+    for (const v of verdicts) expect(v).toBe("unsat");
+  });
+}
+
+test("a corrupted IR makes the proof FALSIFIABLE (CONTROL goes sat)", () => {
+  if (!z3Available) {
+    console.warn("  [skip] z3 not on PATH — falsifiability leg not run");
+    return;
+  }
+  // flip one digit of a splitmix64 multiplier; the byte-lock CONTROL must reject it.
+  const text = readFileSync(irPathOf("splitmix64"), "utf8");
+  const corrupted = text.replace("-7046029254386353131", "-7046029254386353130");
+  expect(corrupted).not.toBe(text);
+  const ir = parseIrJson(corrupted);
+  const proof = emitSmt2(ir, loadVectors(irPathOf("splitmix64")));
+  const verdicts = z3Verdicts(proof);
+  expect(verdicts).toContain("sat"); // at least one check now fails — the green can turn red
+});
+
+// guard: the committed hand-written reference proof still exists alongside the emitter.
+test("hand-written reference proof is present", () => {
+  expect(existsSync(join(import.meta.dir, "gen-denotation-splitmix64.smt2"))).toBe(true);
+});

--- a/tools/Z3Verify/gen-smt2-from-ir.ts
+++ b/tools/Z3Verify/gen-smt2-from-ir.ts
@@ -1,0 +1,370 @@
+/**
+ * gen-smt2-from-ir.ts -- parameterised Z3 QF_BV denotation-preservation proof
+ * generator for the zeta-ir finaliser rows.
+ *
+ *   Reads a zeta-ir-v{1,2,3} artifact (the op-list of a mixer/finaliser) and the
+ *   sibling vectors.yaml byte-lock, and EMITS the .smt2 denotation proof -- the
+ *   same structure as the hand-written gen-denotation-splitmix64.smt2, but
+ *   parameterised over the row. Every new generator that lands on the registry
+ *   gets a machine-checkable denotation proof for free.
+ *
+ *   Author: Soraya (formal-verification-expert role), invoked by Otto. The
+ *   cheap-next-step flagged at the close of C2 (gen-denotation arc). Reason from
+ *   our own understanding; this is not a port.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT THE EMITTED PROOF PROVES (and why it is not a tautology)
+ * ---------------------------------------------------------------------------
+ * The interpreter denotation of each IR op is committed in
+ *   tests/cross-verification/nasam/_gen/gen.ts   (the v3 total interpreter)
+ *   tests/cross-verification/_harness/codegen-from-ir.ts
+ * The emitted proof renders that SAME denotation TWICE, from two INDEPENDENT
+ * SMT encodings, then refutes their disagreement over the WHOLE input domain:
+ *
+ *   *_oracle  -- the REFERENCE encoding. `mul` uses the named-hex u-word literal
+ *                (#x...), so the constant is read as the human writes it.
+ *                `rotl` / `xrotxor` use Z3's PRIMITIVE ((_ rotate_left r) z).
+ *
+ *   *_interp  -- the GENERATED encoding, exactly as the codegen emits it. `mul`
+ *                uses fromI64 == bvneg(|stored signed decimal|) -- the stored
+ *                int64 magnitude reinterpreted to its u-word (the round-trip the
+ *                TS/F#/C#/Rust interpreters perform). `rotl` / `xrotxor` use the
+ *                MANUAL shift-or decomposition (bvor (bvshl z r) (bvlshr z W-r)).
+ *
+ * THEOREM (forall x. oracle(x) = interp(x)) therefore discharges, over every one
+ * of the 2^W inputs and independent of any test vector:
+ *   - that fromI64's signed->unsigned reinterpretation is bit-exact, and
+ *   - that the manual rotate decomposition equals Z3's native rotate.
+ * In SMT we refute the negation; `unsat` certifies equality over the domain.
+ *
+ * CONTROL grounds the generated fold against the sibling vectors.yaml -- the
+ * cross-language (cs/rust/fsharp/python/ts/go) byte-lock. That external oracle is
+ * what makes an "identically-wrong on both encodings" bug observable.
+ *
+ * Honest scope: when a row's ops are all `mul`/`xorshr` with NON-NEGATIVE small
+ * constants (e.g. xoshiro256ss mul-5/mul-9, fmix32), the two encodings coincide
+ * and THEOREM reduces to a reflexive identity -- the load-bearing grounding for
+ * those rows is the CONTROL against vectors.yaml. The emitted header states which
+ * regime the row is in. (A negative `mul` constant or any rotate makes THEOREM
+ * non-trivial: splitmix64, fmix64, nasam, xoshiro's rotl.)
+ *
+ * Anchors (Beacon): QF_BV is decidable (Barrett/Tinelli, SMT-LIB 2.6); bvmul is
+ * the mod-2^n product so wrapping word arithmetic is exact. Per-generator human
+ * anchors live in each vectors.yaml description.
+ *
+ * Usage:
+ *   bun tools/Z3Verify/gen-smt2-from-ir.ts <ir.json> [out.smt2]
+ *     no out path  -> writes <ir-dir>/gen-denotation-<generator>.smt2 and prints it
+ *     out == "-"   -> writes the proof to stdout
+ *
+ * Verify the emitted proof:  z3 <out.smt2>   (expect a column of `unsat`)
+ */
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join, dirname, basename } from "node:path";
+
+// --- IR types (the union of the v1/v2/v3 op grammars) -----------------------
+
+type IrOp =
+  | { readonly op: "mul"; readonly k: bigint } // z := z * k                  (wrapping)
+  | { readonly op: "xorshr"; readonly s: bigint } // z := z ^ (z >>> s)
+  | { readonly op: "rotl"; readonly r: bigint } // z := (z << r) | (z >>> W-r)
+  | { readonly op: "xrotxor"; readonly rs: readonly bigint[] } // z ^= rotl(z,r_i) ^ ...
+  | { readonly op: "xshrxor"; readonly ss: readonly bigint[] }; // z ^= (z>>>s_i) ^ ...
+
+interface ZetaIr {
+  readonly schema: string | undefined;
+  readonly generator: string;
+  readonly version: number;
+  readonly width: bigint;
+  readonly ops: readonly IrOp[];
+}
+
+interface Vector {
+  readonly id: string;
+  readonly x: bigint;
+  readonly result: bigint;
+}
+
+// --- IR parsing (BigInt-safe: JSON.parse loses precision on int64 `k`) -------
+
+export function parseIrJson(text: string): ZetaIr {
+  // Quote every integer that could exceed 2^53 so JSON.parse keeps it exact.
+  const safe = text.replace(/"(k)"\s*:\s*(-?\d+)/g, '"$1":"$2"');
+  const raw = JSON.parse(safe) as {
+    schema?: string;
+    generator?: string;
+    version?: number;
+    width?: number;
+    ops?: unknown[];
+  };
+  if (typeof raw.generator !== "string") throw new Error("IR: missing string `generator`");
+  if (!Array.isArray(raw.ops)) throw new Error("IR: missing `ops` array");
+  const width = BigInt(raw.width ?? 64); // splitmix64's row omits width (u64 default)
+
+  const ops = raw.ops.map((node, i): IrOp => {
+    const o = node as Record<string, unknown>;
+    switch (o.op) {
+      case "mul":
+        return { op: "mul", k: BigInt(o.k as string | number) };
+      case "xorshr":
+        return { op: "xorshr", s: BigInt(o.s as number) };
+      case "rotl":
+        return { op: "rotl", r: BigInt(o.r as number) };
+      case "xrotxor":
+        return { op: "xrotxor", rs: (o.rs as number[]).map((v) => BigInt(v)) };
+      case "xshrxor":
+        return { op: "xshrxor", ss: (o.ss as number[]).map((v) => BigInt(v)) };
+      default:
+        throw new Error(`IR: op #${i} has unknown op "${String(o.op)}"`);
+    }
+  });
+
+  return { schema: raw.schema, generator: raw.generator, version: raw.version ?? 1, width, ops };
+}
+
+// --- vectors.yaml loading (sibling byte-lock; Bun.YAML, as the harness uses) --
+
+export function loadVectors(irPath: string): readonly Vector[] {
+  // ir lives at <dir>/_gen/<name>.ir.json; vectors.yaml is at <dir>/vectors.yaml
+  const genDir = dirname(irPath);
+  const primDir = basename(genDir) === "_gen" ? dirname(genDir) : genDir;
+  const yamlP = join(primDir, "vectors.yaml");
+  if (!existsSync(yamlP)) return [];
+
+  const yaml = (globalThis as { Bun?: { YAML?: { parse(s: string): unknown } } }).Bun?.YAML;
+  if (yaml === undefined) throw new Error(`Bun.YAML unavailable while parsing ${yamlP} (run under bun)`);
+
+  const root = yaml.parse(readFileSync(yamlP, "utf8")) as { vectors?: Record<string, unknown>[] };
+  if (!Array.isArray(root.vectors)) return [];
+
+  const out: Vector[] = [];
+  for (const v of root.vectors) {
+    // a row needs an explicit input `x` AND a canonical `result` to be a control point
+    if (v.x === undefined || v.result === undefined) continue;
+    out.push({ id: String(v.id), x: BigInt(String(v.x)), result: BigInt(String(v.result)) });
+  }
+  return out;
+}
+
+// --- bitvector literal helpers ----------------------------------------------
+
+/** Reduce a (possibly negative) integer to its W-bit two's-complement value. */
+function toWord(n: bigint, width: bigint): bigint {
+  const mod = 1n << width;
+  return ((n % mod) + mod) % mod;
+}
+
+/** A W-bit literal as #x.. hex when W % 4 == 0, else (_ bv<dec> W). */
+function bvHex(n: bigint, width: bigint): string {
+  const w = toWord(n, width);
+  if (width % 4n === 0n) return `#x${w.toString(16).padStart(Number(width) / 4, "0")}`;
+  return `(_ bv${w} ${width})`;
+}
+
+/** A decimal-form W-bit literal, (_ bv<value> W). */
+function bvDec(n: bigint, width: bigint): string {
+  return `(_ bv${toWord(n, width)} ${width})`;
+}
+
+/**
+ * The GENERATED-side constant for a `mul` op, mirroring fromI64 exactly:
+ * a stored-negative int64 reinterprets via bvneg(|stored|); non-negative is direct.
+ */
+function interpMulConst(k: bigint, width: bigint): string {
+  return k < 0n ? `(bvneg (_ bv${-k} ${width}))` : `(_ bv${k} ${width})`;
+}
+
+// --- op renderers: oracle (reference) vs interp (as-codegen-emits) -----------
+
+function rotlManual(z: string, r: bigint, width: bigint): string {
+  const rk = ((r % width) + width) % width;
+  if (rk === 0n) return z;
+  return `(bvor (bvshl ${z} ${bvDec(rk, width)}) (bvlshr ${z} ${bvDec(width - rk, width)}))`;
+}
+
+function rotlNative(z: string, r: bigint, width: bigint): string {
+  const rk = ((r % width) + width) % width;
+  return rk === 0n ? z : `((_ rotate_left ${rk}) ${z})`;
+}
+
+type Side = "oracle" | "interp";
+
+/** Render one op as the SMT expression that maps the previous accumulator `z`. */
+function renderOp(op: IrOp, z: string, width: bigint, side: Side): string {
+  switch (op.op) {
+    case "mul": {
+      const c = side === "oracle" ? bvHex(op.k, width) : interpMulConst(op.k, width);
+      return `(bvmul ${z} ${c})`;
+    }
+    case "xorshr":
+      return `(bvxor ${z} (bvlshr ${z} ${bvDec(op.s, width)}))`;
+    case "rotl":
+      return side === "oracle" ? rotlNative(z, op.r, width) : rotlManual(z, op.r, width);
+    case "xrotxor": {
+      const terms = op.rs.map((r) => (side === "oracle" ? rotlNative(z, r, width) : rotlManual(z, r, width)));
+      return `(bvxor ${z} ${terms.join(" ")})`;
+    }
+    case "xshrxor": {
+      const terms = op.ss.map((s) => `(bvlshr ${z} ${bvDec(s, width)})`);
+      return `(bvxor ${z} ${terms.join(" ")})`;
+    }
+  }
+}
+
+/** A one-line English gloss of an op, for the per-op comment column. */
+function opGloss(op: IrOp): string {
+  switch (op.op) {
+    case "mul":
+      return `mul k=${op.k}`;
+    case "xorshr":
+      return `xorshr s=${op.s}`;
+    case "rotl":
+      return `rotl r=${op.r}`;
+    case "xrotxor":
+      return `xrotxor rs=[${op.rs.join(",")}]`;
+    case "xshrxor":
+      return `xshrxor ss=[${op.ss.join(",")}]`;
+  }
+}
+
+/** Build a nested-let mix function body folding `ops` over the argument `arg`. */
+function emitMixFn(name: string, arg: string, ir: ZetaIr, side: Side): string {
+  const W = ir.width;
+  const lines: string[] = [`(define-fun ${name} ((${arg} (_ BitVec ${W}))) (_ BitVec ${W})`];
+  let cur = arg;
+  const closers = ir.ops.length; // one let per op
+  ir.ops.forEach((op, i) => {
+    const next = `z${i + 1}`;
+    const expr = renderOp(op, cur, W, side);
+    const isLast = i === ir.ops.length - 1;
+    if (isLast) {
+      // final op: produce the body of the innermost let chain directly
+      lines.push(`  (let ((${next} ${expr})) ${next}`);
+    } else {
+      lines.push(`  (let ((${next} ${expr}))                ; op ${i}: ${opGloss(op)}`);
+    }
+    cur = next;
+  });
+  // close all lets + the define-fun
+  lines[lines.length - 1] += ")".repeat(closers) + ")";
+  // append op-N comment to the last line
+  const lastOp = ir.ops[ir.ops.length - 1];
+  if (lastOp) lines[lines.length - 1] += `  ; op ${ir.ops.length - 1}: ${opGloss(lastOp)}`;
+  return lines.join("\n");
+}
+
+// --- whole-proof emission ----------------------------------------------------
+
+export function emitSmt2(ir: ZetaIr, vectors: readonly Vector[]): string {
+  const W = ir.width;
+  const muls = ir.ops.filter((o): o is Extract<IrOp, { op: "mul" }> => o.op === "mul");
+  const negMul = muls.some((m) => m.k < 0n);
+  const hasRot = ir.ops.some((o) => o.op === "rotl" || o.op === "xrotxor");
+  const nonTrivial = negMul || hasRot;
+  const name = ir.generator.replace(/[^A-Za-z0-9]/g, "_");
+
+  const L: string[] = [];
+  L.push("; ============================================================================");
+  L.push(`; gen-denotation-${ir.generator}.smt2  --  Z3 QF_BV denotation-preservation proof`);
+  L.push(";   GENERATED by tools/Z3Verify/gen-smt2-from-ir.ts -- do not hand-edit.");
+  L.push(`;   generator ${ir.generator}@${ir.version}  width=${W}  schema=${ir.schema ?? "(v1)"}`);
+  L.push(";");
+  L.push(";   oracle side : reference encoding (named-hex mul constants; native rotate_left)");
+  L.push(";   interp side : as-codegen encoding (fromI64 = bvneg|stored|; manual rotate)");
+  L.push(
+    `;   THEOREM regime: ${nonTrivial ? "NON-TRIVIAL" : "reflexive"} ` +
+      `(${negMul ? "negative mul constant; " : ""}${hasRot ? "rotation present; " : ""}` +
+      `${nonTrivial ? "" : "all mul constants non-negative, no rotation -> grounding is the CONTROL"})`,
+  );
+  L.push("; ============================================================================");
+  L.push("");
+  L.push("(set-logic QF_BV)");
+  L.push("(set-info :status unsat)");
+  L.push("");
+
+  // LEMMA -- per mul constant, the named-hex oracle literal == the fromI64 interp form.
+  if (muls.length > 0) {
+    L.push("; LEMMA -- each mul constant's fromI64 (bvneg of stored signed decimal) reinterpretation");
+    L.push(";          equals its named-hex u-word literal. Discharges the round-trip per constant,");
+    L.push(";          independent of the fold.");
+    L.push("(push)");
+    const conj = muls.map((m) => `(= ${bvHex(m.k, W)} ${interpMulConst(m.k, W)})`).join("\n  ");
+    L.push(`(assert (not (and\n  ${conj}\n)))`);
+    L.push("(check-sat)   ; expect: unsat");
+    L.push("(pop)");
+    L.push("");
+  }
+
+  // the two independent mix functions
+  L.push("; --- oracle: reference encoding (one let per IR op) ---");
+  L.push(emitMixFn(`${name}_oracle`, "x", ir, "oracle"));
+  L.push("");
+  L.push("; --- interp: generated encoding, exactly as the codegen emits (one let per IR op) ---");
+  L.push(emitMixFn(`${name}_interp`, "x", ir, "interp"));
+  L.push("");
+
+  // THEOREM -- denotation preservation over all 2^W inputs.
+  L.push(`; THEOREM -- oracle == interp over all 2^${W} inputs.`);
+  L.push("(push)");
+  L.push(`(declare-const X (_ BitVec ${W}))`);
+  L.push(`(assert (not (= (${name}_oracle X) (${name}_interp X))))`);
+  L.push("(check-sat)   ; expect: unsat");
+  L.push("(pop)");
+  L.push("");
+
+  // CONTROL -- the generated fold reproduces the vectors.yaml cross-language byte-lock.
+  if (vectors.length > 0) {
+    L.push(`; CONTROL -- the generated fold reproduces the ${vectors.length} committed vectors.yaml`);
+    L.push(";            golden vectors (the cs/rust/fsharp/python/ts/go byte-lock).");
+    L.push("(push)");
+    const conj = vectors
+      .map((v) => `(= (${name}_interp ${bvDec(v.x, W)}) ${bvDec(v.result, W)})  ; ${v.id}`)
+      .join("\n  ");
+    L.push(`(assert (not (and\n  ${conj}\n)))`);
+    L.push("(check-sat)   ; expect: unsat");
+    L.push("(pop)");
+    L.push("");
+  }
+
+  const checks = 1 + (muls.length > 0 ? 1 : 0) + (vectors.length > 0 ? 1 : 0);
+  L.push("; ============================================================================");
+  L.push(`; ${checks} checks, all expected unsat:`);
+  if (muls.length > 0) L.push(";   LEMMA   -- fromI64 reinterpretation exact (per mul constant)");
+  L.push(`;   THEOREM -- ${name}_oracle == ${name}_interp over all 2^${W} inputs`);
+  if (vectors.length > 0) L.push(`;   CONTROL -- generated fold reproduces ${vectors.length} byte-locked vectors`);
+  L.push("; ============================================================================");
+
+  return L.join("\n") + "\n";
+}
+
+// --- CLI --------------------------------------------------------------------
+
+function main(): number {
+  const args = process.argv.slice(2);
+  if (args.length < 1) {
+    console.error("Usage: bun tools/Z3Verify/gen-smt2-from-ir.ts <ir.json> [out.smt2 | -]");
+    return 1;
+  }
+  const irPath = args[0]!;
+  const ir = parseIrJson(readFileSync(irPath, "utf8"));
+  const vectors = loadVectors(irPath);
+  const smt2 = emitSmt2(ir, vectors);
+
+  const outArg = args[1];
+  if (outArg === "-") {
+    process.stdout.write(smt2);
+    return 0;
+  }
+  const outPath = outArg ?? join(dirname(irPath), `gen-denotation-${ir.generator}.smt2`);
+  writeFileSync(outPath, smt2);
+  console.error(
+    `[gen-smt2] ${ir.generator}@${ir.version} (width ${ir.width}, ${ir.ops.length} ops, ` +
+      `${vectors.length} control vectors) -> ${outPath}`,
+  );
+  return 0;
+}
+
+if (import.meta.main) {
+  process.exit(main());
+}


### PR DESCRIPTION
## What

Two commits on the gen-denotation arc (Soraya, formal-verification-expert role, invoked by Otto):

1. **C2 (687ad10)** — hand-written `gen-denotation-splitmix64.smt2`: Z3 QF_BV denotation-preservation for splitmix64 (all 2^64 inputs) + fmix32 (all 2^32), oracle vs IR-fold interp.
2. **Emitter (ab374f1)** — `tools/Z3Verify/gen-smt2-from-ir.ts`: the flagged cheap-next-step. Reads any `zeta-ir-v{1,2,3}` finaliser row + sibling `vectors.yaml` and emits the proof parameterised. **Every new generator on the registry now gets a machine-checkable denotation proof for free.**

## How the emitted proof stays honest

Two **independent** SMT encodings, refuted-on-disagreement over the whole 2^W domain:

| side | `mul` | `rotl` / `xrotxor` |
|---|---|---|
| `oracle` | named-hex u-word `#x...` | Z3 primitive `(_ rotate_left r)` |
| `interp` | `fromI64` = `bvneg(\|stored signed decimal\|)` | manual `(bvor (bvshl) (bvlshr))` |

- **THEOREM** (`oracle == interp`, all inputs) discharges the `fromI64` reinterpretation and the manual-vs-native rotate decomposition.
- **CONTROL** grounds the generated fold against the cross-language (cs/rust/fsharp/python/ts/go) `vectors.yaml` byte-lock — the external oracle that makes an "identically-wrong on both encodings" bug observable.
- **Honest scope**, stated in each emitted header: for all-nonneg-constant, no-rotate rows (fmix32, xoshiro mul-5/9) THEOREM is reflexive and CONTROL carries the load. A negative `mul` or any rotate makes THEOREM non-trivial.

## Verified by execution (not source-reading)

All five registry rows — splitmix64, fmix32, fmix64, nasam, xoshiro256ss — emit proofs that `z3` discharges **all-unsat** (LEMMA + THEOREM + CONTROL). Falsifiable on **both** axes:
- corrupt a `mul` constant → CONTROL flips to `sat`;
- corrupt the manual rotate complement (57→56) → THEOREM flips to `sat`.

`gen-smt2-from-ir.test.ts`: **12/12 green** (emit + structural well-formedness always; z3 soundness + falsifiability legs when z3 is on PATH).

## Design note

Lean by design: the IR is the **hub**, the proof a derived **satellite** regenerated and z3-checked fresh by the test (DV2.0) — no drift-prone stored `.smt2` copies. Use `bun tools/Z3Verify/gen-smt2-from-ir.ts <ir.json> -` to materialise one on demand.

Anchors: QF_BV decidable (Barrett/Tinelli, SMT-LIB 2.6); Vigna arXiv:1410.0530 §3; Knuth TAOCP §6.4; Appleby MurmurHash3; per-generator human anchors in each `vectors.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)