### PR TITLE
[codex] wire room boundary into darkhall loop

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -19,6 +19,11 @@
     "**/node_modules/**",
     "bin/**",
     "obj/**",
+    // `db/**` is territory/mirror substrate, not authored prose. It can contain
+    // generated Markdown-like files, intentionally extension-shaped pointers,
+    // and archived title fragments that should not be normalized by the prose
+    // lint profile.
+    "db/**",
     // Upstream reference repos under `../` are not part of Zeta.
     "references/prior-art/**",
     // Memory directory is mostly agent-written append-logs (623+

--- a/docs/backlog/2026-06-20-lumen-resume-state.md
+++ b/docs/backlog/2026-06-20-lumen-resume-state.md
@@ -3,21 +3,25 @@
 **Context:** The math-team Face-3 targets (T1, T2, Bridge Functor) are fully discharged and merged. The grammar has evolved to `zeta-ir-v4` (adding the `add` op, anchored to Knuth's MMIX LCG). This backlog captures the four immediate follow-on options identified on 2026-06-20, preserving enough context for any teammate to pick up cold.
 
 ## Option 1: Chase the shrink (The Minimal Generating Set)
+
 **Status:** **ACTIVE** (Lumen executing in current session)
 **The bet:** Aaron observed "things grow before they shrink." The grammar grew across four versions (v1: `mul`, `xorshr` → v2: `rotl` → v3: `xrotxor`, `xshrxor` → v4: `add`). Now that the zoo is full, the compression is visible. `nasam`'s `xshrxor [s]` already strictly generalized v1's `xorshr s`.
 **The task:** Find the minimal generating set that v1..v4 collapse into. Write a research note + F# proof showing how each op reduces to the core set. This is the deepest in-lane math available without touching fragile surfaces.
 
 ## Option 2: Port a second add-user (ChaCha quarter-round)
+
 **Status:** Backlogged
 **The context:** v4 added the `add` op anchored to a single generator (Knuth's MMIX LCG). A core repo discipline is that grammar extensions should generalize across multiple generators.
 **The task:** Port the ChaCha quarter-round (or another public-domain add-user like PCG) to prove `add` generalizes exactly the way `mul` and `xorshr` did. More implementation than proof.
 
 ## Option 3: Probe the genuinely-open quine
+
 **Status:** Backlogged (Reserved for Math Team)
 **The context:** `src/Core.Lean4/Lean4/GenGenFixpoint.lean` contains one documented `sorry` — the full homoiconic quine (the deep structural claim).
 **The task:** This is real research. Go in honestly: surface structure, probe the edges, but do not claim a full discharge unless the proof is airtight.
 
 ## Option 4: The workflow patches in issue #8760
+
 **Status:** Backlogged
 **The context:** Handed off earlier during Face-3. The CI trigger-paths and lean-proof wiring need cleanup.
 **The task:** Pure maintenance. Clear the thread, ensure CI runs exactly when needed without redundant builds.

--- a/inventory/AUDIT-PHASE7.md
+++ b/inventory/AUDIT-PHASE7.md
@@ -1,10 +1,11 @@
 # Phase 7 — Independent Security Audit
 
 **Auditor:** fresh session, did NOT build any of this. **Date:** 2026-06-21.
-**Subject:** merged live system — `https://lucent-financial-group.github.io/Zeta/inventory/`
-+ Supabase backend `mdtbgreryqddloluhdmm.supabase.co`, re-proven against the
-contract in `inventory/spec.md` + `inventory/CLAUDE.md`. PROGRESS.md `[x]` marks
-were treated as **claims**, re-verified from scratch with fresh observed output.
+**Subject:** merged live system —
+`https://lucent-financial-group.github.io/Zeta/inventory/` plus Supabase backend
+`mdtbgreryqddloluhdmm.supabase.co`, re-proven against the contract in
+`inventory/spec.md` + `inventory/CLAUDE.md`. PROGRESS.md `[x]` marks were
+treated as **claims**, re-verified from scratch with fresh observed output.
 
 ## Verdict
 
@@ -44,8 +45,9 @@ before the box is checked. I did not mark any gate passed that I could not obser
 ## The 8 targeted probes
 
 ### 1. Any secret committed anywhere, any branch, any history? — **NO**
+
 - Scanned every commit on every ref (`git rev-list --all`) for proper JWTs
-  (`eyJ…​.eyJ…​.…`) and `sb_secret_` — **zero** real tokens (the `eyJ` noise is
+  (`eyJ….eyJ….…`) and `sb_secret_` — **zero** real tokens (the `eyJ` noise is
   base64 *image* data in `docs/research`, not credentials).
 - Only embedded credential, in `lib/inventory-app.js` and the heartbeat workflow,
   is the **publishable** anon key `sb_publishable_UjTK7ZQ0…` + project URL — public
@@ -57,11 +59,13 @@ before the box is checked. I did not mark any gate passed that I could not obser
   narrative background notes; the k8s `*secret.example.yaml` is `REPLACE_WITH_…`.
 
 ### 2. `service_role` referenced? — **only in "never use this" contexts**
+
 Every occurrence is a cautionary comment ("NEVER place the service_role/secret key
 here"), documentation, or a *guard that rejects such keys*
 (`seed-import.ts:133`: aborts if the key looks like service_role/secret). No usage.
 
 ### 3. RLS bypassable from an unauthenticated client? — **NO**
+
 Live unauthenticated anon REST (public key as `apikey` + `Bearer`, no user session):
 ```
 items             -> HTTP 200  []
@@ -76,8 +80,10 @@ probe users/auth/secrets/api_keys/settings -> HTTP 404 (no stray exposed tables)
 Every sensitive table returns **zero rows** to an unauthenticated client.
 
 ### 4. RLS least-privilege? — **YES, no `USING(true)`**
+
 Read `phase1.sql` policies explicitly. Each is scoped to a specific role AND
 operation via `current_user_role()`:
+
 - `items`: SELECT viewer/editor/admin · INSERT/UPDATE editor/admin · **no DELETE**.
 - `field_definitions`: SELECT all-roles · INSERT/UPDATE/DELETE admin-only.
 - `change_log`: SELECT editor/admin only (viewer excluded) · **no INSERT/UPDATE/DELETE**.
@@ -89,6 +95,7 @@ text in proof files checking for *zero* permissive policies. phase4/phase5 add *
 policy, no GRANT/REVOKE.
 
 ### 5. change_log immutable? — **structurally guaranteed; anon path observed**
+
 Two independent layers in `phase1.sql`: (1) RLS exposes **no** UPDATE/DELETE policy →
 0 rows mutable by any client; (2) `change_log_immutable` BEFORE UPDATE/DELETE trigger
 `raise exception 'change_log is immutable'` — fires even for the privileged owner.
@@ -98,6 +105,7 @@ Observed: anon PATCH/DELETE on `change_log` → HTTP 204 with **0 rows affected*
 refused) require live creds — see §Owner-gated. The structural guarantee is airtight.
 
 ### 6. Custom-field XSS-safe? — **safe by construction; live injection owner-gated**
+
 - Shipped JS has **zero** raw-HTML sinks: `grep` for
   `innerHTML|outerHTML|insertAdjacentHTML|document.write|eval|new Function` across
   `lib/*.js` + `index.html` = **none**. 76 `textContent` writes; custom field values
@@ -112,6 +120,7 @@ refused) require live creds — see §Owner-gated. The structural guarantee is a
   structurally it cannot execute given the above.)
 
 ### 7. UI role checks == RLS enforcement? — **single source; live per-role owner-gated**
+
 Role lives in exactly one place — `profiles.role`, read through the SECURITY DEFINER
 `current_user_role()` function — and **both** the UI (via RPC) and the RLS policies
 read that same function. There is no second divergent role store. The UI's hidden
@@ -119,6 +128,7 @@ buttons are cosmetic; the DB is the gate. *Owner-gated:* exercising every write 
 viewer/editor/admin via both UI and REST with each role's JWT requires live creds.
 
 ### 8. Deployed CSP == repo claim? — **YES**
+
 Live `https://…/Zeta/inventory/` is **byte-identical** to `origin/main`
 (sha256 `de83190e…`, 9563 bytes). Served CSP:
 ```

--- a/inventory/PROGRESS.md
+++ b/inventory/PROGRESS.md
@@ -1101,7 +1101,9 @@ Phase 7 (and with it Phases 3 & 6's deferred live items) is CLOSED. Combined evi
 who observed it:
 
 ### Auditor (independent fresh session) — unauthenticated + structural + static, observed fresh
+
 Full report: `inventory/AUDIT-PHASE7.md` (committed). No P0/P1 defect. Re-proven this session:
+
 - **Secrets:** none in any commit on any ref (JWT/`sb_secret_` scans clean; only the public
   publishable anon key ships). `service_role` only in never-use comments/guards. No seed/.env committed.
 - **RLS unauthenticated:** live anon REST on items/profiles/field_definitions/change_log → all `[]`
@@ -1119,7 +1121,9 @@ Full report: `inventory/AUDIT-PHASE7.md` (committed). No P0/P1 defect. Re-proven
   workflow removed.
 
 ### Owner — live, authenticated human-experience verification (observed, reported 2026-06-21)
+
 Run on the live no-proxy site with temporary audit users (audit-viewer@ / audit-editor@ / audit-admin@):
+
 - **QR scan post-login (Phase 6a):** scan resolves to the correct item record after login. CLEAN.
 - **Export round-trip (Phase 6b):** export → re-import round-trips VALUE-IDENTICAL. CLEAN.
 - **XSS inert (Phase 5 / probe 6):** `<script>` injected as BOTH a custom field NAME and a field VALUE
@@ -1129,6 +1133,7 @@ Run on the live no-proxy site with temporary audit users (audit-viewer@ / audit-
   sort, Phase 6c viewer export) completed clean under this same live verification pass.
 
 ### Credential & residue close-out (owner to complete in dashboard / SQL editor immediately post-merge)
+
 - **Temporary audit users** `audit-viewer@` / `audit-editor@` / `audit-admin@` — QUEUED FOR DELETION
   immediately after merge (owner handles in the Supabase dashboard).
 - **Original chat-burned build creds** `editor@gmail.com` / `viewer@gmail.com` + the admin password/secret
@@ -1138,9 +1143,10 @@ Run on the live no-proxy site with temporary audit users (audit-viewer@ / audit-
   (EXPORT first) to remove items 216/225/226/227/228 + inactive `p5_*` defs.
 
 ### Build status
+
 **INVENTORY BUILD COMPLETE — all 7 phases gated and verified** (Phase 0a→7). Ongoing maintenance items
 live on the Residual Risk Register for future consideration, not blocking v1: live multi-user sync, deep
-accessibility, automated *authenticated* data backup (deferred — needs a CI secret; anon can't read under
+accessibility, automated _authenticated_ data backup (deferred — needs a CI secret; anon can't read under
 default-deny; manual CSV/JSON export is the v1 backup; heartbeat handles only the free-tier pause),
 required-at-DB for custom fields, and post-v1 features. CSP is `<meta>`-only (GitHub Pages can't set
 headers → no `frame-ancestors`/clickjacking defense; low risk given login+RLS gating) — noted for the

--- a/src/Core.TypeScript/hygiene/check-bash-retirement-inventory.test.ts
+++ b/src/Core.TypeScript/hygiene/check-bash-retirement-inventory.test.ts
@@ -186,8 +186,11 @@ describe("buildInventoryReport", () => {
     try {
       runGit(["init"], repo);
 
+      mkdirSync(join(repo, "db", "tools"), { recursive: true });
       mkdirSync(join(repo, "scripts"), { recursive: true });
       mkdirSync(join(repo, "tools", "lean4"), { recursive: true });
+      writeFileSync(join(repo, "db", "tools", "generated.sh"), "#!/usr/bin/env bash\n");
+      writeFileSync(join(repo, "db", "tools", "generated-extensionless"), "#!/usr/bin/env bash\n");
       writeFileSync(join(repo, "scripts", "a.sh"), "#!/usr/bin/env bash\n");
       writeFileSync(join(repo, "scripts", "a-uppercase.SH"), "echo uppercase extension drift\n");
       writeFileSync(join(repo, "scripts", "b.bash"), "#!/usr/bin/env bash\n");

--- a/src/Core.TypeScript/hygiene/check-bash-retirement-inventory.ts
+++ b/src/Core.TypeScript/hygiene/check-bash-retirement-inventory.ts
@@ -74,6 +74,7 @@ export const TRACKED_SHELL_FILE_GLOBS: readonly string[] = SHELL_FILE_EXTENSIONS
 const SHELL_INTERPRETERS = new Set(["bash", "dash", "sh", "zsh", "ksh"]);
 const ENV_OPTIONS_WITH_SEPARATE_OPERAND = new Set(["-a", "-P", "-u", "--argv0", "--chdir", "--path", "--unset"]);
 const ENV_OPTIONS_WITH_INLINE_OPERAND: readonly string[] = ["--argv0=", "--chdir=", "--path=", "--unset="];
+const TERRITORY_MIRROR_PREFIXES: readonly string[] = ["db/"];
 
 export const EXPECTED_RETAINED_SHELL: readonly string[] = [
   ".gemini/service/install-lior-service.sh",
@@ -195,6 +196,7 @@ export function trackedNonLeanShellFilesFromGit(cwd?: string): readonly string[]
   const repoRoot = runGit(["rev-parse", "--show-toplevel"], cwd).trim();
   return trackedGitFiles(repoRoot)
     .filter(({ path }) => existsSync(join(repoRoot, path)))
+    .filter(({ path }) => !isTerritoryMirrorPath(path))
     .filter(({ path }) => !path.startsWith("tools/lean4/"))
     .filter(({ path, executable }) => isTrackedShellFamilyFile(repoRoot, path, executable))
     .map(({ path }) => path)
@@ -210,6 +212,10 @@ function trackedGitFiles(repoRoot: string): readonly TrackedGitFile[] {
     .filter((entry) => entry.length > 0)
     .map(parseTrackedGitFile)
     .filter((entry): entry is TrackedGitFile => entry !== undefined);
+}
+
+function isTerritoryMirrorPath(path: string): boolean {
+  return TERRITORY_MIRROR_PREFIXES.some((prefix) => path.startsWith(prefix));
 }
 
 function parseTrackedGitFile(entry: string): TrackedGitFile | undefined {

--- a/src/Core.TypeScript/hygiene/lint-md.ts
+++ b/src/Core.TypeScript/hygiene/lint-md.ts
@@ -12,6 +12,7 @@ const DEFAULT_EXCLUDES = [
     "node_modules/",
     "tools/lean4/.lake/",
     ".claude/worktrees/",
+    "db/",
     "db/drop/",
     "roms/",
     "obj/",

--- a/src/Core/DarkHallRoomLoop.fs
+++ b/src/Core/DarkHallRoomLoop.fs
@@ -29,6 +29,28 @@ module DarkHallRoomLoop =
 
     type RequestResolver = Runtime.CabinetAction -> Runtime.RunRequest option
 
+    [<RequireQualifiedAccess>]
+    type BoundaryCommand<'K when 'K : comparison> =
+        | AdmitWithSlot of rawSlot: int64 * key: 'K
+        | Frost of cost: int
+        | Clear
+        | Traverse of heldKeys: Set<string> * toRoom: string * vault: DoorGraph.Vault
+
+    type BoundaryRequestResolver<'K when 'K : comparison> =
+        Runtime.CabinetAction -> BoundaryCommand<'K> option
+
+    [<RequireQualifiedAccess>]
+    type BoundaryEffect<'K when 'K : comparison> =
+        | Admitted of RoomAdmission.SlotReport<'K>
+        | Frosted
+        | Cleared
+        | Traversed of fromRoom: string * toRoom: string
+
+    [<RequireQualifiedAccess>]
+    type BoundaryTickResult<'K when 'K : comparison> =
+        | RuntimeResult of Runtime.RunResult
+        | BoundaryResult of BoundaryEffect<'K>
+
     type HeatReadout =
         { HeatRejected: int
           Backpressured: int
@@ -42,12 +64,14 @@ module DarkHallRoomLoop =
         | ControllerActionSelected of cell: int * action: Runtime.CabinetAction
         | RequestMissing of cell: int * action: Runtime.CabinetAction
         | RuntimeFeedback of Runtime.Feedback
+        | BoundaryFeedback of RoomBoundary.Feedback
 
     [<RequireQualifiedAccess>]
     type LoopEvent =
         | Observed of roomName: string * actionCount: int
         | Chosen of choice: ControllerChoice * action: Runtime.CabinetAction
         | Executed of choice: ControllerChoice * action: Runtime.CabinetAction * result: Runtime.RunResult
+        | BoundaryApplied of choice: ControllerChoice * action: Runtime.CabinetAction * effect: string
         | Refused of choice: ControllerChoice option * action: Runtime.CabinetAction option * feedback: TickFeedback
 
     type LoopState =
@@ -63,6 +87,16 @@ module DarkHallRoomLoop =
           Action: Runtime.CabinetAction option
           Result: Result<Runtime.RunResult, TickFeedback>
           Heat: HeatReadout
+          State: LoopState }
+
+    type BoundaryTickOutcome<'K when 'K : comparison> =
+        { Readout: Runtime.ControllerReadout
+          Choice: ControllerChoice
+          Action: Runtime.CabinetAction option
+          BoundaryCommand: BoundaryCommand<'K> option
+          Result: Result<BoundaryTickResult<'K>, TickFeedback>
+          Heat: HeatReadout
+          Boundary: RoomBoundary.Boundary<'K>
           State: LoopState }
 
     type RunOutcome =
@@ -120,8 +154,55 @@ module DarkHallRoomLoop =
         | Runtime.Feedback.MetaCartFeedback(MetaCart.Feedback.HeatRejected(_, feedback)) -> heatSinkFeedbackReadout feedback
         | _ -> emptyHeatReadout
 
+    let private heatReadoutOfSignatures (signatures: HeatSignature list) : HeatReadout =
+        let heatKinds = signatures |> List.map _.Kind
+        let reasons = signatures |> List.map _.Detail
+
+        { emptyHeatReadout with
+            HeatRejected = signatures.Length
+            Backpressured =
+                signatures
+                |> List.filter (fun signature ->
+                    signature.Kind.Contains("backpressure", System.StringComparison.Ordinal)
+                    || signature.Kind.Contains("denied", System.StringComparison.Ordinal))
+                |> List.length
+            HeatKinds = heatKinds
+            Reasons = reasons }
+
+    let private heatReadoutOfBoundaryEffect (source: string) =
+        function
+        | BoundaryEffect.Admitted report -> RoomAdmission.heatSignatures source report |> heatReadoutOfSignatures
+        | BoundaryEffect.Frosted
+        | BoundaryEffect.Cleared
+        | BoundaryEffect.Traversed _ -> emptyHeatReadout
+
+    let private heatReadoutOfBoundaryFeedback (source: string) =
+        function
+        | RoomBoundary.Feedback.HeatFeedback feedback -> heatSinkFeedbackReadout feedback
+        | RoomBoundary.Feedback.AdmissionFeedback(RoomAdmission.Feedback.HeatFeedback feedback) ->
+            heatSinkFeedbackReadout feedback
+        | RoomBoundary.Feedback.AdmissionFeedback _ -> emptyHeatReadout
+        | RoomBoundary.Feedback.PrivacyDenied reason ->
+            HeatSignature.ofMass source "room-boundary.privacy-backpressure" 1 1.0 reason
+            |> List.singleton
+            |> heatReadoutOfSignatures
+        | RoomBoundary.Feedback.DoorDenied(fromRoom, toRoom, reason) ->
+            let detail = sprintf "%s -> %s refused: %s" fromRoom toRoom reason
+
+            HeatSignature.ofMass source "room-boundary.door-denied" 1 1.0 detail
+            |> List.singleton
+            |> heatReadoutOfSignatures
+
     let private heatReadoutOfResult =
         function
+        | Error(TickFeedback.RuntimeFeedback feedback) -> heatReadoutOfRuntimeFeedback feedback
+        | Error(TickFeedback.BoundaryFeedback feedback) -> heatReadoutOfBoundaryFeedback "" feedback
+        | _ -> emptyHeatReadout
+
+    let private heatReadoutOfBoundaryResult (source: string) =
+        function
+        | Ok(BoundaryTickResult.BoundaryResult effect) -> heatReadoutOfBoundaryEffect source effect
+        | Error(TickFeedback.BoundaryFeedback feedback) -> heatReadoutOfBoundaryFeedback source feedback
         | Error(TickFeedback.RuntimeFeedback feedback) -> heatReadoutOfRuntimeFeedback feedback
         | _ -> emptyHeatReadout
 
@@ -138,6 +219,55 @@ module DarkHallRoomLoop =
           Result = result
           Heat = heatReadoutOfResult result
           State = state }
+
+    let private completeBoundary
+        (source: string)
+        (readout: Runtime.ControllerReadout)
+        (choice: ControllerChoice)
+        (action: Runtime.CabinetAction option)
+        (command: BoundaryCommand<'K> option)
+        (result: Result<BoundaryTickResult<'K>, TickFeedback>)
+        (boundary: RoomBoundary.Boundary<'K>)
+        (state: LoopState)
+        : BoundaryTickOutcome<'K> =
+        { Readout = readout
+          Choice = choice
+          Action = action
+          BoundaryCommand = command
+          Result = result
+          Heat = heatReadoutOfBoundaryResult source result
+          Boundary = boundary
+          State = state }
+
+    let private boundaryEffectName =
+        function
+        | BoundaryEffect.Admitted report -> sprintf "admit:%A:%d" report.Outcome report.Slot
+        | BoundaryEffect.Frosted -> "frost"
+        | BoundaryEffect.Cleared -> "clear"
+        | BoundaryEffect.Traversed(fromRoom, toRoom) -> sprintf "traverse:%s->%s" fromRoom toRoom
+
+    let private applyBoundaryCommand
+        (sink: IHeatSink)
+        (command: BoundaryCommand<'K>)
+        (boundary: RoomBoundary.Boundary<'K>)
+        : Result<RoomBoundary.Boundary<'K> * BoundaryEffect<'K>, RoomBoundary.Feedback> =
+        result {
+            match command with
+            | BoundaryCommand.AdmitWithSlot(rawSlot, key) ->
+                let! next, report = RoomBoundary.admitWithSlot sink rawSlot key boundary
+                return next, BoundaryEffect.Admitted report
+
+            | BoundaryCommand.Frost cost ->
+                let! next = RoomBoundary.frost sink cost boundary
+                return next, BoundaryEffect.Frosted
+
+            | BoundaryCommand.Clear -> return RoomBoundary.clear boundary, BoundaryEffect.Cleared
+
+            | BoundaryCommand.Traverse(heldKeys, toRoom, vault) ->
+                let fromRoom = boundary.CurrentRoom
+                let! next = RoomBoundary.traverse sink heldKeys toRoom vault boundary
+                return next, BoundaryEffect.Traversed(fromRoom, next.CurrentRoom)
+        }
 
     let private cellForAction (action: Runtime.CabinetAction) (readout: Runtime.ControllerReadout) : int option =
         GridBinding.bound readout.Grid
@@ -216,6 +346,132 @@ module DarkHallRoomLoop =
                             let next = chosen |> append (LoopEvent.Refused(Some choice, Some action, feedback))
                             return complete readout choice (Some action) (Error feedback) next
                     }
+
+    /// Boundary-aware room tick. The same controller readout may choose a
+    /// cabinet runtime action or a room-boundary operation. Boundary failures
+    /// stay typed and export heat through the injected sink.
+    let tickWithBoundary
+        (source: string)
+        (sink: IHeatSink)
+        (requestFor: RequestResolver)
+        (boundaryFor: BoundaryRequestResolver<'K>)
+        (choose: Runtime.ControllerReadout -> ControllerChoice)
+        (boundary: RoomBoundary.Boundary<'K>)
+        (state: LoopState)
+        : Task<BoundaryTickOutcome<'K>> =
+        let readout = Runtime.observe state.Room
+
+        let observed =
+            { state with LastReadout = Some readout }
+            |> append (LoopEvent.Observed(readout.RoomName, readout.Actions.Length))
+
+        let choice = choose readout
+
+        match Runtime.actionAt choice.Cell readout with
+        | None ->
+            let feedback = TickFeedback.CellUnbound choice.Cell
+            let next = observed |> append (LoopEvent.Refused(Some choice, None, feedback))
+
+            Task.FromResult(
+                completeBoundary source readout choice None None (Error feedback) boundary next
+            )
+
+        | Some action ->
+            let chosen = observed |> append (LoopEvent.Chosen(choice, action))
+
+            match boundaryFor action with
+            | Some command ->
+                match applyBoundaryCommand sink command boundary with
+                | Ok(nextBoundary, effect) ->
+                    let next =
+                        chosen
+                        |> append (LoopEvent.BoundaryApplied(choice, action, boundaryEffectName effect))
+
+                    Task.FromResult(
+                        completeBoundary
+                            source
+                            readout
+                            choice
+                            (Some action)
+                            (Some command)
+                            (Ok(BoundaryTickResult.BoundaryResult effect))
+                            nextBoundary
+                            next
+                    )
+
+                | Error boundaryFeedback ->
+                    let feedback = TickFeedback.BoundaryFeedback boundaryFeedback
+                    let next = chosen |> append (LoopEvent.Refused(Some choice, Some action, feedback))
+
+                    Task.FromResult(
+                        completeBoundary
+                            source
+                            readout
+                            choice
+                            (Some action)
+                            (Some command)
+                            (Error feedback)
+                            boundary
+                            next
+                    )
+
+            | None ->
+                match action.Address with
+                | None ->
+                    let feedback = TickFeedback.ControllerActionSelected(choice.Cell, action)
+                    let next = chosen |> append (LoopEvent.Refused(Some choice, Some action, feedback))
+
+                    Task.FromResult(
+                        completeBoundary source readout choice (Some action) None (Error feedback) boundary next
+                    )
+
+                | Some _ ->
+                    match requestFor action with
+                    | None ->
+                        let feedback = TickFeedback.RequestMissing(choice.Cell, action)
+                        let next = chosen |> append (LoopEvent.Refused(Some choice, Some action, feedback))
+
+                        Task.FromResult(
+                            completeBoundary source readout choice (Some action) None (Error feedback) boundary next
+                        )
+
+                    | Some request ->
+                        task {
+                            let! result =
+                                Runtime.executeCell source sink state.Manifest state.Room choice.Cell request
+
+                            match result with
+                            | Ok runResult ->
+                                let next =
+                                    { chosen with LastResult = Some runResult }
+                                    |> append (LoopEvent.Executed(choice, action, runResult))
+
+                                return
+                                    completeBoundary
+                                        source
+                                        readout
+                                        choice
+                                        (Some action)
+                                        None
+                                        (Ok(BoundaryTickResult.RuntimeResult runResult))
+                                        boundary
+                                        next
+
+                            | Error runtimeFeedback ->
+                                let feedback = TickFeedback.RuntimeFeedback runtimeFeedback
+                                let next = chosen |> append (LoopEvent.Refused(Some choice, Some action, feedback))
+
+                                return
+                                    completeBoundary
+                                        source
+                                        readout
+                                        choice
+                                        (Some action)
+                                        None
+                                        (Error feedback)
+                                        boundary
+                                        next
+                        }
 
     /// Bounded foreground room loop. Infinity happens by explicit continuation
     /// scheduling outside this function; one call always runs a finite number of ticks.

--- a/src/Core/DarkHallScheduler.fs
+++ b/src/Core/DarkHallScheduler.fs
@@ -28,6 +28,14 @@ module DarkHallScheduler =
           LastTick: RoomLoop.TickOutcome option
           HeatRowsRev: HeatBoundaryRow list }
 
+    type BoundaryScheduledRoomState<'K when 'K : comparison> =
+        { Loop: RoomLoop.LoopState
+          Boundary: RoomBoundary.Boundary<'K>
+          CompletedTicks: int
+          CompletedLaps: int
+          LastTick: RoomLoop.BoundaryTickOutcome<'K> option
+          HeatRowsRev: HeatBoundaryRow list }
+
     [<RequireQualifiedAccess>]
     type HeatBoardContinuationFeedback =
         | MalformedContinuation of token: string
@@ -79,13 +87,34 @@ module DarkHallScheduler =
           LastTick = None
           HeatRowsRev = [] }
 
+    let initialWithBoundary
+        (room: DarkHall.Room)
+        (manifest: Chip9Capabilities.Manifest)
+        (boundary: RoomBoundary.Boundary<'K>)
+        : BoundaryScheduledRoomState<'K> =
+        { Loop = RoomLoop.initial room manifest
+          Boundary = boundary
+          CompletedTicks = 0
+          CompletedLaps = 0
+          LastTick = None
+          HeatRowsRev = [] }
+
     let heatRows (state: ScheduledRoomState) : HeatBoundaryRow list =
+        List.rev state.HeatRowsRev
+
+    let boundaryHeatRows (state: BoundaryScheduledRoomState<'K>) : HeatBoundaryRow list =
         List.rev state.HeatRowsRev
 
     let lastHeatRow (state: ScheduledRoomState) : HeatBoundaryRow option =
         state.HeatRowsRev |> List.tryHead
 
+    let lastBoundaryHeatRow (state: BoundaryScheduledRoomState<'K>) : HeatBoundaryRow option =
+        state.HeatRowsRev |> List.tryHead
+
     let backpressured (state: ScheduledRoomState) : bool =
+        state.HeatRowsRev |> List.exists (fun row -> row.Backpressured > 0)
+
+    let boundaryBackpressured (state: BoundaryScheduledRoomState<'K>) : bool =
         state.HeatRowsRev |> List.exists (fun row -> row.Backpressured > 0)
 
     let private setColor (x: int) (y: int) (mask: byte) (frame: Chip8Cow.Frame) : Chip8Cow.Frame =
@@ -149,6 +178,15 @@ module DarkHallScheduler =
           HeatKinds = outcome.Heat.HeatKinds
           Reasons = outcome.Heat.Reasons }
 
+    let private rowOfBoundaryOutcome (tick: int) (outcome: RoomLoop.BoundaryTickOutcome<'K>) : HeatBoundaryRow =
+        { Tick = tick
+          RoomName = outcome.Readout.RoomName
+          HeatRejected = outcome.Heat.HeatRejected
+          Backpressured = outcome.Heat.Backpressured
+          StorageErrors = outcome.Heat.StorageErrors
+          HeatKinds = outcome.Heat.HeatKinds
+          Reasons = outcome.Heat.Reasons }
+
     let record (outcome: RoomLoop.TickOutcome) (state: ScheduledRoomState) : ScheduledRoomState =
         let tick = state.CompletedTicks + 1
         { Loop = outcome.State
@@ -156,6 +194,19 @@ module DarkHallScheduler =
           CompletedLaps = state.CompletedLaps
           LastTick = Some outcome
           HeatRowsRev = rowOfOutcome tick outcome :: state.HeatRowsRev }
+
+    let recordBoundary
+        (outcome: RoomLoop.BoundaryTickOutcome<'K>)
+        (state: BoundaryScheduledRoomState<'K>)
+        : BoundaryScheduledRoomState<'K> =
+        let tick = state.CompletedTicks + 1
+
+        { Loop = outcome.State
+          Boundary = outcome.Boundary
+          CompletedTicks = tick
+          CompletedLaps = state.CompletedLaps
+          LastTick = Some outcome
+          HeatRowsRev = rowOfBoundaryOutcome tick outcome :: state.HeatRowsRev }
 
     let private stampCumulativeLaps
         (startLaps: int)
@@ -182,6 +233,21 @@ module DarkHallScheduler =
             return record outcome state
         }
 
+    let tickWithBoundary
+        (source: string)
+        (sink: IHeatSink)
+        (requestFor: RoomLoop.RequestResolver)
+        (boundaryFor: RoomLoop.BoundaryRequestResolver<'K>)
+        (choose: Runtime.ControllerReadout -> RoomLoop.ControllerChoice)
+        (state: BoundaryScheduledRoomState<'K>)
+        =
+        task {
+            let! outcome =
+                RoomLoop.tickWithBoundary source sink requestFor boundaryFor choose state.Boundary state.Loop
+
+            return recordBoundary outcome state
+        }
+
     let roomTickHandler
         (name: string)
         (matches: InterruptKind -> bool)
@@ -195,6 +261,22 @@ module DarkHallScheduler =
                 let! next = tick source sink requestFor choose state
                 return Ok next
             })
+
+    let boundaryRoomTickHandler
+        (name: string)
+        (matches: InterruptKind -> bool)
+        (source: string)
+        (sink: IHeatSink)
+        (requestFor: RoomLoop.RequestResolver)
+        (boundaryFor: RoomLoop.BoundaryRequestResolver<'K>)
+        (choose: Runtime.ControllerReadout -> RoomLoop.ControllerChoice)
+        : SoftScheduler.HandlerK<BoundaryScheduledRoomState<'K>> =
+        SoftScheduler.handlerK name matches (fun _intr _ctx state ->
+            task {
+                let! next = tickWithBoundary source sink requestFor boundaryFor choose state
+                return Ok next
+            })
+
 
     let heatBoardSimLoopFromState
         (name: string)

--- a/tests/Tests.FSharp/DarkHallRoomLoop.Tests.fs
+++ b/tests/Tests.FSharp/DarkHallRoomLoop.Tests.fs
@@ -27,6 +27,20 @@ let private chooseById id (readout: Runtime.ControllerReadout) : RoomLoop.Contro
 let private wait (task: System.Threading.Tasks.Task<'T>) : 'T =
     task.GetAwaiter().GetResult()
 
+let private mustOk =
+    function
+    | Ok value -> value
+    | Error feedback -> failwithf "expected Ok, got %A" feedback
+
+let private rejectSlots slots : ModuloGSetConfig =
+    { Slots = slots
+      CollisionPolicy = ModuloGSetCollisionPolicy.RejectCollision }
+
+let private emptyBoundary source room budget config =
+    ModuloGSet.empty<string> config
+    |> mustOk
+    |> RoomBoundary.create source room budget
+
 [<Fact>]
 let ``ControllerReadout names the controller projection while GridBinding stays the 4x4 placement`` () =
     let readout = Runtime.observe Arcade.room
@@ -95,6 +109,76 @@ let ``tick records controller-only grammar action as a typed refusal without hea
             Assert.Equal("darkhall.edit-grammar", refused.Id)
         | other -> Assert.Fail(sprintf "expected controller refusal event, got %A" other)
     | other -> Assert.Fail(sprintf "expected controller action refusal, got %A" other)
+
+[<Fact>]
+let ``boundary tick lets a controller choice frost the room boundary`` () =
+    let sink = RecordingHeatSink()
+    let boundary = emptyBoundary "darkhall-boundary-loop" "darkhall" 5 (rejectSlots 2)
+
+    let boundaryFor (action: Runtime.CabinetAction) =
+        if action.Id = "darkhall.edit-grammar" then
+            Some(RoomLoop.BoundaryCommand.Frost 3)
+        else
+            None
+
+    let outcome =
+        RoomLoop.tickWithBoundary
+            "darkhall-boundary-loop"
+            (sink :> IHeatSink)
+            (fun _ -> None)
+            boundaryFor
+            (chooseById "darkhall.edit-grammar")
+            boundary
+            (RoomLoop.initial Arcade.room Chip9Capabilities.chip8Default)
+        |> wait
+
+    match outcome.Result with
+    | Ok(RoomLoop.BoundaryTickResult.BoundaryResult RoomLoop.BoundaryEffect.Frosted) ->
+        Assert.Equal(2, outcome.Boundary.PrivacyBudget)
+        Assert.False(GlassHalo.isVisible outcome.Boundary.Visibility)
+        Assert.Empty(sink.Signatures)
+
+        match RoomLoop.events outcome.State |> List.rev |> List.tryHead with
+        | Some(RoomLoop.LoopEvent.BoundaryApplied(_, action, effect)) ->
+            Assert.Equal("darkhall.edit-grammar", action.Id)
+            Assert.Equal("frost", effect)
+        | other -> Assert.Fail(sprintf "expected boundary-applied event, got %A" other)
+    | other -> Assert.Fail(sprintf "expected boundary frost, got %A" other)
+
+[<Fact>]
+let ``boundary tick admission backpressure leaves occupant outside and exports heat`` () =
+    let sink = RecordingHeatSink()
+    let boundary = emptyBoundary "darkhall-boundary-loop" "darkhall" 5 (rejectSlots 1)
+
+    let admit key (current: RoomBoundary.Boundary<string>) =
+        RoomLoop.tickWithBoundary
+            "darkhall-boundary-loop"
+            (sink :> IHeatSink)
+            (fun _ -> None)
+            (fun action ->
+                if action.Id = "darkhall.escape-hatch" then
+                    Some(RoomLoop.BoundaryCommand.AdmitWithSlot(0L, key))
+                else
+                    None)
+            (chooseById "darkhall.escape-hatch")
+            current
+            (RoomLoop.initial Arcade.room Chip9Capabilities.chip8Default)
+        |> wait
+
+    let first = admit "alpha" boundary
+    let second = admit "beta" first.Boundary
+
+    match first.Result, second.Result with
+    | Ok(RoomLoop.BoundaryTickResult.BoundaryResult(RoomLoop.BoundaryEffect.Admitted firstReport)),
+      Ok(RoomLoop.BoundaryTickResult.BoundaryResult(RoomLoop.BoundaryEffect.Admitted secondReport)) ->
+        Assert.Equal(RoomAdmission.SlotOutcome.Admitted, firstReport.Outcome)
+        Assert.Equal(RoomAdmission.SlotOutcome.Backpressured, secondReport.Outcome)
+        Assert.Equal<string list>([ "alpha" ], second.Boundary.Occupants |> ModuloGSet.toList)
+        Assert.Equal<string list>([ "room-admission.backpressure" ], second.Heat.HeatKinds)
+        Assert.Equal(1, second.Heat.Backpressured)
+        Assert.Equal(1, sink.Signatures.Count)
+        Assert.Equal("room-admission.backpressure", sink.Signatures.[0].Kind)
+    | other -> Assert.Fail(sprintf "expected admission reports, got %A" other)
 
 [<Fact>]
 let ``tick appends runtime refusal and emits heat for denied cabinet capability`` () =

--- a/tests/Tests.FSharp/DarkHallScheduler.Tests.fs
+++ b/tests/Tests.FSharp/DarkHallScheduler.Tests.fs
@@ -38,6 +38,28 @@ let private budget maxLaps : SimLoop.Budget =
       MaxTicks = 64
       MaxMillis = 1_000L }
 
+let private mustOk =
+    function
+    | Ok value -> value
+    | Error feedback -> failwithf "expected Ok, got %A" feedback
+
+let private rejectSlots slots : ModuloGSetConfig =
+    { Slots = slots
+      CollisionPolicy = ModuloGSetCollisionPolicy.RejectCollision }
+
+let private emptyBoundary source room budget config =
+    ModuloGSet.empty<string> config
+    |> mustOk
+    |> RoomBoundary.create source room budget
+
+let private sampleVault () =
+    let v =
+        DoorGraph.empty
+        |> DoorGraph.addRoom "darkhall"
+        |> DoorGraph.addRoom "glass"
+
+    DoorGraph.addDoor (DoorGraph.door "darkhall" "glass" "door-key") v |> mustOk
+
 [<Fact>]
 let ``heat boundary rows render as a host visible CHIP-9 board`` () =
     let row: Scheduler.HeatBoundaryRow =
@@ -147,6 +169,71 @@ let ``soft scheduler banks darkhall heat backpressure as a room boundary row`` (
             match Scheduler.heatRows final with
             | [ row ] -> Assert.Equal(1, row.Backpressured)
             | rows -> Assert.Fail(sprintf "expected one scheduler heat row, got %A" rows)
+    }
+
+[<Fact>]
+let ``boundary room handler records door denial heat as a host visible row`` () =
+    task {
+        let sink = RecordingHeatSink()
+        let boundary = emptyBoundary "darkhall-boundary-scheduler" "darkhall" 5 (rejectSlots 2)
+        let vault = sampleVault ()
+
+        let boundaryFor (action: Runtime.CabinetAction) =
+            if action.Id = "darkhall.edit-grammar" then
+                Some(RoomLoop.BoundaryCommand.Traverse(Set.empty, "glass", vault))
+            else
+                None
+
+        let handler =
+            Scheduler.boundaryRoomTickHandler
+                "darkhall-boundary-room"
+                timer
+                "darkhall-boundary-scheduler"
+                (sink :> IHeatSink)
+                (fun _ -> None)
+                boundaryFor
+                (chooseById "darkhall.edit-grammar")
+
+        let source _ = [ TimerElapsed 17 ]
+
+        let initial =
+            Scheduler.initialWithBoundary Arcade.room Chip9Capabilities.chip8Default boundary
+
+        let! result = (SoftScheduler.driveK [ handler ] source).Run(ctx ()) 42L initial 1
+
+        match result with
+        | Error feedback -> Assert.Fail(sprintf "boundary handler should report through room state, got %A" feedback)
+        | Ok final ->
+            Assert.Equal(1, final.CompletedTicks)
+            Assert.True(Scheduler.boundaryBackpressured final)
+            Assert.Equal("darkhall", final.Boundary.CurrentRoom)
+            Assert.Equal(1, sink.Signatures.Count)
+            Assert.Equal("room-boundary.door-denied", sink.Signatures.[0].Kind)
+
+            match final.LastTick with
+            | None -> Assert.Fail "scheduler should bank the boundary tick"
+            | Some tick ->
+                match tick.Result with
+                | Error(RoomLoop.TickFeedback.BoundaryFeedback(RoomBoundary.Feedback.DoorDenied(fromRoom, toRoom, reason))) ->
+                    Assert.Equal("darkhall", fromRoom)
+                    Assert.Equal("glass", toRoom)
+                    Assert.Contains("permission denied", reason)
+                | other -> Assert.Fail(sprintf "expected door-denial boundary feedback, got %A" other)
+
+            match Scheduler.lastBoundaryHeatRow final with
+            | None -> Assert.Fail "scheduler should expose the latest boundary heat row"
+            | Some row ->
+                Assert.Equal(1, row.Tick)
+                Assert.Equal("darkhall", row.RoomName)
+                Assert.Equal(1, row.HeatRejected)
+                Assert.Equal(1, row.Backpressured)
+                Assert.Equal(0, row.StorageErrors)
+                Assert.Equal<string list>([ "room-boundary.door-denied" ], row.HeatKinds)
+                Assert.Contains("permission denied", System.String.Join(";", row.Reasons))
+
+            match Scheduler.boundaryHeatRows final with
+            | [ row ] -> Assert.Equal(1, row.Backpressured)
+            | rows -> Assert.Fail(sprintf "expected one boundary heat row, got %A" rows)
     }
 
 [<Fact>]

--- a/tests/Tests.FSharp/ZetaIrV4.Tests.fs
+++ b/tests/Tests.FSharp/ZetaIrV4.Tests.fs
@@ -1,12 +1,42 @@
 module ZetaIrV4.Tests
 
+open System
 open Xunit
 open Zeta.Core
 open System.IO
 open System.Text.Json
 
-let goldenPath () =
-    Path.Combine(__SOURCE_DIRECTORY__, "..", "cross-verification", "_golden", "zeta-ir-v4.golden.json")
+let private goldenRelativePath =
+    Path.Combine("tests", "cross-verification", "_golden", "zeta-ir-v4.golden.json")
+
+let private tryFindRepoRoot (startPath: string) =
+    if String.IsNullOrWhiteSpace startPath then
+        None
+    else
+        try
+            let mutable dir = DirectoryInfo(startPath)
+            while not (isNull dir) && not (File.Exists(Path.Combine(dir.FullName, "Zeta.sln"))) do
+                dir <- dir.Parent
+
+            if isNull dir then
+                None
+            else
+                Some dir.FullName
+        with
+        | :? ArgumentException
+        | :? NotSupportedException
+        | :? PathTooLongException -> None
+
+let private repoRoot () =
+    [ Environment.GetEnvironmentVariable("ZETA_REPO_ROOT")
+      Environment.GetEnvironmentVariable("GITHUB_WORKSPACE")
+      AppContext.BaseDirectory
+      Directory.GetCurrentDirectory() ]
+    |> List.tryPick tryFindRepoRoot
+    |> Option.defaultWith (fun () -> failwith "Could not locate repo root (Zeta.sln).")
+
+let private goldenPath () =
+    Path.Combine(repoRoot (), goldenRelativePath)
 
 // ── the firewall: v1, v2, and v3 reject v4 (and vice versa) ───────────────────────────
 

--- a/tests/cross-verification/_harness/cross-lane-equivalence.test.ts
+++ b/tests/cross-verification/_harness/cross-lane-equivalence.test.ts
@@ -97,7 +97,7 @@ const SPLITMIX64_GOLDEN: Record<string, [bigint, bigint]> = {
 
 describe("cross-lane equivalence — quantum basis-state generator ≡ classical interpreter", () => {
   test("splitmix64: quantum lane agrees with classical lane on ALL golden vectors", () => {
-    for (const [id, [input, expected]] of Object.entries(SPLITMIX64_GOLDEN)) {
+    for (const [, [input, expected]] of Object.entries(SPLITMIX64_GOLDEN)) {
       const classical = classicalMix(splitmix64Ir, input);
       const quantum = quantumBasisStateMix(splitmix64Ir, input);
       expect(classical).toBe(expected);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,8 @@
     "**/bin/**",
     "**/obj/**",
     "**/.lake/**",
+    "db",
+    "db/**",
     "tools/lean4/.lake/**",
     "tools/alloy/**",
     "tools/tla/**",


### PR DESCRIPTION
## What changed

- Adds boundary-aware Dark Hall ticks so controller choices can drive room admission, privacy frost/clear, and door traversal through the existing `RoomBoundary` policy.
- Adds boundary-aware scheduled room state and host-visible boundary heat rows for admission backpressure and door denial.
- Keeps generated `db/**` territory mirror files out of source/prose lint surfaces, with a shell-inventory regression test proving bash-shaped mirror files are ignored.
- Hardens current gate drift found during the branch cycle: robust ZetaIrV4 golden discovery, Phase 7 inventory markdown/invisible-Unicode cleanup, and main-tip Lumen/cross-lane lint cleanup.

## Why

The Dark Hall room loop already had controller/readout/runtime pieces, but boundary policy was still outside the tick shape. This makes boundary outcomes first-class without contaminating the normal cabinet runtime path: hosts can opt into the boundary-aware loop when a room wants admission, privacy, traversal, and heat/backpressure surfaced together.

## Validation

- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter "FullyQualifiedName~ZetaIrV4|FullyQualifiedName~BenPortTests"`
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter "FullyQualifiedName~DarkHallRoomLoopTests|FullyQualifiedName~DarkHallSchedulerTests|FullyQualifiedName~RoomBoundaryTests"`
- `mise exec -- bun test tests/cross-verification/_harness/cross-lane-equivalence.test.ts`
- `mise exec -- markdownlint-cli2 "**/*.md"`
- `mise exec -- semgrep --config .semgrep.yml --error --metrics=off`
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test Zeta.sln -c Release`
- `mise exec -- bun run preflight:quick`
- `git diff --check`

Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: Codex
Agent-Model: gpt-5.5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: not-implied-by-credential
Human-Review-Evidence: none
Action-Mode: human-directed
Task: none
Co-Authored-By: Codex <noreply@openai.com>
