### PR TITLE
fix(ts): restore lint(TS) gate — #8807 shipped TS errors (markdown-stub .ts + unused bindings)

### DIFF
--- a/src/Core.TypeScript/backlog/auto-vivify.test.ts
+++ b/src/Core.TypeScript/backlog/auto-vivify.test.ts
@@ -1,7 +1,5 @@
 import { test, expect } from "bun:test";
-import { join } from "node:path";
-import { writeFileSync, unlinkSync, existsSync } from "node:fs";
-import { extractPointers, extractZetaId, resolvePointer, processAll } from "./auto-vivify";
+import { extractPointers, extractZetaId, resolvePointer } from "./auto-vivify";
 
 test("extractPointers finds wikilinks, markdown links, and backticks correctly", () => {
   const text = `

--- a/src/Core.TypeScript/backlog/auto-vivify.ts
+++ b/src/Core.TypeScript/backlog/auto-vivify.ts
@@ -16,7 +16,7 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, statSync, watch } from "node:fs";
 import { dirname, join, normalize, relative, basename } from "node:path";
 import { pack, DEFAULT_ENV } from "../zeta-id/zeta-id";
-import { format, isCanonical } from "../zeta-id/encoding";
+import { format } from "../zeta-id/encoding";
 import { Category, Chromosome, Firefly, type ZetaObservation } from "../zeta-id/types";
 
 const REPO_ROOT = normalize(join(__dirname, "..", "..", ".."));
@@ -293,7 +293,7 @@ export function resolvePointer(cleanTarget: string, fromFile: string): ResolvedT
 }
 
 // Generate stub content based on type
-function getStubContent(resolved: ResolvedTarget, cleanTarget: string): string {
+function getStubContent(resolved: ResolvedTarget, _cleanTarget: string): string {
   const name = basename(resolved.resolvedPath, ".md").replace(/^_-|-_$/g, "");
   const createdIso = new Date().toISOString();
 
@@ -484,7 +484,7 @@ function main(): number {
       const dirPath = join(REPO_ROOT, surface);
       if (!isDir(dirPath)) continue;
 
-      watch(dirPath, { recursive: true }, (event, filename) => {
+      watch(dirPath, { recursive: true }, (_event, filename) => {
         if (filename && filename.endsWith(".md")) {
           console.log(`Change detected in ${surface}/${filename}. Running auto-vivifier...`);
           try {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -43,6 +43,7 @@
     "full-ai-cluster/portal/web",
     "full-ai-cluster/portal/web/**",
     "src/Core.TypeScript/qsharp-oracle/**",
-    "src/Core.TypeScript/cursor/**"
+    "src/Core.TypeScript/cursor/**",
+    "db/tools/backlog/new-workitem.ts"
   ]
 }


### PR DESCRIPTION
The `lint (TS)` gate (`tsc --noEmit`, **non-required** so it merged red) was failing on `main` from **#8807** (auto-vivify dangling MD pointers). Two causes, both fixed:

1. **`db/tools/backlog/new-workitem.ts` is a markdown stub at a `.ts` path** — the auto-vivifier wrote a `# new-workitem.ts/ …` placeholder there → `tsc` TS1127 "Invalid character" + parse cascade. **Stopgap:** excluded from `tsconfig` (it's a vivified placeholder, not TypeScript — `new-workitem.ts` is a planned-but-unbuilt B-0956 tool). **Root cause (flag for #8807's owner):** the auto-vivifier should write stubs as `.md` sidecars or valid-TS, not markdown at a `.ts` path — every future dangling `.ts` reference will re-break `tsc`. Remove the exclude when the real tool is built.

2. **`auto-vivify.{ts,test.ts}` had 6 unused bindings** (TS6133/TS6192): removed 4 dead imports + `_`-prefixed 2 genuinely-unused params. **Behavior-preserving** — `auto-vivify --check` still clean, its **3 tests still pass**. *Flag:* the test imports `processAll` + fs helpers but exercises none — the main path looks under-tested (owner's call).

Verified locally: `bun src/Core.TypeScript/lint/lint-typescript.ts` → **all green**; auto-vivify `--check` clean; tests **3/3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)