### PR TITLE
fix(test): BenPort exact-alloc golden 80→48 — restore build-and-test (all platforms)

### DIFF
--- a/tests/Tests.FSharp/BenPort.Tests.fs
+++ b/tests/Tests.FSharp/BenPort.Tests.fs
@@ -134,7 +134,11 @@ let ``ZETAID BENCHMARK CASES: discovered, run successfully, and verify exact hea
     Assert.Equal(pack.Sizes.Length, packSamples.Length)
     Assert.Equal(unpack.Sizes.Length, unpackSamples.Length)
     
-    // unpack returns a ZetaObservation record instance (reference type), which allocates exactly 80 bytes on net10.0!
-    Assert.Equal(80L, snd unpackSamples.[0])
+    // unpack returns a ZetaObservation record instance (reference type). Exact measured heap
+    // allocation on the pinned net10.0 SDK (10.0.203): 48 bytes. (Was 80; the record's field-type
+    // representation shrank — alloc DROPPED, an improvement, type unchanged + round-trip tests still
+    // pass. This is an exact-value benchmark guard, so it is intentionally runtime-layout-sensitive
+    // and must be re-measured when the SDK or a field type's layout changes.)
+    Assert.Equal(48L, snd unpackSamples.[0])
 
 


### PR DESCRIPTION
`build-and-test` was failing on **all 5 platforms** at `BenPort.Tests.fs:138` — the "verify exact heap allocation" guard asserted `ZetaObservation` unpack allocates **80 bytes**, now it's **48** (`Expected: 80, Actual: 48`). Pre-existing (red since #8807, masked by gate-run cancellations); **not** caused by recent docs/lean/ts commits.

**Diagnosis:** reproduced locally on the **pinned SDK** (dotnet 10.0.203, matches `global.json`) → exactly 48. `ZetaObservation` is **unchanged** (Types.fs:185, last touched #8109); a field-type representation shrank so the record's heap footprint **dropped** 80→48 — an *improvement* (alloc decreasing, not a regression; round-trip/cross-verify tests still pass). The exact-alloc golden was stale.

**Fix:** update the golden to the measured current value (`48L`) + a comment that it's intentionally runtime-layout-sensitive. BenPort locally **3/3** (1 skip).

**Separate red, flagged not fixed (for the #8807 owner):** the gate's `lint (bash retirement inventory)` job is also red from the **same #8807 auto-vivify root cause** as the lint(TS) fix #8814 — it wrote **markdown stubs at code-extension paths**: `db/common/host-tier.sh` + `db/tools/setup/common/sync-upstreams.sh` are 3-line markdown stubs, not bash. Can't be honestly stopgapped (allowlisting markdown-as-bash lies; deleting re-dangles the source `.md` refs → auto-vivify recreates). **Real fix:** `auto-vivify.ts` should skip code-extension targets or write `.md` sidecars (it keeps the target's extension but always emits markdown). Owner's policy call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)