### PR TITLE
fix(ts): null-safety in phase7-csp-proof.ts — restore lint(TS) gate (from #8815)

### DIFF
--- a/inventory/proofs/phase7-csp-proof.ts
+++ b/inventory/proofs/phase7-csp-proof.ts
@@ -49,7 +49,7 @@ const csp = (cspMeta?.[1] ?? "").replace(/\s+/g, " ").trim();
 const directives = new Map<string, string[]>();
 for (const part of csp.split(";")) {
   const toks = part.trim().split(/\s+/).filter(Boolean);
-  if (toks.length) directives.set(toks[0].toLowerCase(), toks.slice(1));
+  if (toks.length) directives.set(toks[0]!.toLowerCase(), toks.slice(1));
 }
 const scriptSrc = directives.get("script-src") ?? [];
 const styleSrc = directives.get("style-src") ?? [];
@@ -69,7 +69,7 @@ check("CSP allows no cdn.jsdelivr.net origin", !/cdn\.jsdelivr\.net/i.test(csp))
 const code = html.replace(/<!--[\s\S]*?-->/g, "");
 // Every script tag must carry a src=; none may have an inline body.
 const scriptTags = [...code.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script>/gi)];
-const inlineScripts = scriptTags.filter((m) => !/\bsrc=/.test(m[1]) || m[2].trim() !== "");
+const inlineScripts = scriptTags.filter((m) => !/\bsrc=/.test(m[1]!) || m[2]!.trim() !== "");
 check("no inline script body (all script tags are src=)", inlineScripts.length === 0,
   `${inlineScripts.length} inline script block(s)`);
 
@@ -90,9 +90,9 @@ if (sbTag) {
   const fullTag = sbTag[0];
   const integrity = fullTag.match(/integrity=["'](sha\d+-[^"']+)["']/i)?.[1];
   check("supabase-js script tag has an integrity= (SRI) attribute", integrity !== undefined);
-  check("supabase-js is NOT loaded from an off-origin CDN", !/https?:\/\//.test(sbTag[1]));
+  check("supabase-js is NOT loaded from an off-origin CDN", !/https?:\/\//.test(sbTag[1]!));
   if (integrity) {
-    const sbFile = process.argv[3] ?? resolve(import.meta.dir, "..", sbTag[1]);
+    const sbFile = process.argv[3] ?? resolve(import.meta.dir, "..", sbTag[1]!);
     const bytes = readFileSync(sbFile);
     const want = "sha384-" + createHash("sha384").update(bytes).digest("base64");
     check("SRI integrity matches the vendored file on disk", integrity === want,


### PR DESCRIPTION
#8815 (Phase 7 CSP hardening) shipped `inventory/proofs/phase7-csp-proof.ts` with **5 strict-null errors** (`noUncheckedIndexedAccess`, TS2532/TS2345) failing `lint (TS)` — merged red because lint(TS) is non-required.

**Fix:** non-null assertions on **provably-present** values — `toks[0]!` (under `if (toks.length)`), `m[1]!`/`m[2]!` (regex has 2 capture groups, present on match), `sbTag[1]!` (1 group, narrowed under `if (sbTag)`). **Zero logic change.** Verified `bun src/Core.TypeScript/lint/lint-typescript.ts` → all green.

**Separate reds, flagged not fixed:**
- `lint (bash retirement)` — same #8807 auto-vivify root cause (markdown stubs at `.sh` paths) flagged in #8814/#8817.
- `build-and-test` ZetaIrV4 "byte-for-byte golden" — **failed in CI but passes locally 7/7** on this commit (no byte-diff in log) → suspected flake/CI-env; re-run enqueued, golden **not** touched (it's correct locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)