### PR TITLE
fix(test): make BenPort exact-alloc guard Debug/Release-aware (80/48)

### DIFF
--- a/tests/Tests.FSharp/BenPort.Tests.fs
+++ b/tests/Tests.FSharp/BenPort.Tests.fs
@@ -134,11 +134,17 @@ let ``ZETAID BENCHMARK CASES: discovered, run successfully, and verify exact hea
     Assert.Equal(pack.Sizes.Length, packSamples.Length)
     Assert.Equal(unpack.Sizes.Length, unpackSamples.Length)
     
-    // unpack returns a ZetaObservation record instance (reference type). Exact measured heap
-    // allocation on the pinned net10.0 SDK (10.0.203): 48 bytes. (Was 80; the record's field-type
-    // representation shrank — alloc DROPPED, an improvement, type unchanged + round-trip tests still
-    // pass. This is an exact-value benchmark guard, so it is intentionally runtime-layout-sensitive
-    // and must be re-measured when the SDK or a field type's layout changes.)
-    Assert.Equal(48L, snd unpackSamples.[0])
+    // unpack returns a ZetaObservation record instance (reference type). Its exact heap
+    // allocation is build-configuration-dependent: the F#/JIT layout differs between Debug
+    // and Release, so an unconditional exact golden ping-pongs across environments (sandbox
+    // `dotnet test` defaults to Debug = 80 bytes; CI runs Release = 48 bytes). We assert the
+    // exact value PER configuration via the DEBUG symbol — still an exact guard (catches any
+    // unintended layout change), but honest about the two legitimate runtime layouts.
+#if DEBUG
+    let expectedUnpackAlloc = 80L
+#else
+    let expectedUnpackAlloc = 48L
+#endif
+    Assert.Equal(expectedUnpackAlloc, snd unpackSamples.[0])
 
 


### PR DESCRIPTION
The ZetaObservation unpack alloc golden was ping-ponging across environments because the F#/JIT layout differs between Debug (80B) and Release (48B). PR #8817 flipped it to 48 (CI/Release); sandbox Debug runs measure 80. Rather than pick one, assert the exact value per configuration via #if DEBUG — still an exact regression guard in both configs, matching the repo convention of accounting for Release-specific runtime behavior. Verified passing in both Debug and Release locally.