### PR TITLE
feat(core): compose room and soft heat boundaries

### DIFF
--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -372,6 +372,7 @@
     <Compile Include="DarkHallCabinetRuntime.fs" />
     <Compile Include="DarkHallRoomLoop.fs" />
     <Compile Include="DarkHallScheduler.fs" />
+    <Compile Include="RoomRun.fs" />
     <Compile Include="ReticulumQuantum.fs" />
     <Compile Include="Skadium.fs" />
     <Compile Include="BowlingAlley.fs" />

--- a/src/Core/RoomRun.fs
+++ b/src/Core/RoomRun.fs
@@ -1,0 +1,97 @@
+namespace Zeta.Core
+
+open System.Threading.Tasks
+
+/// Small room-run harnesses that compose production-shaped pieces without
+/// becoming a second runtime. The first slice makes the shared heat boundary
+/// explicit: one injected `IHeatSink` observes both the Dark Hall room boundary
+/// and the soft CHIP-8 lookahead boundary.
+[<RequireQualifiedAccess>]
+module RoomRun =
+
+    module RoomLoop = DarkHallRoomLoop
+    module Runtime = DarkHallCabinetRuntime
+    module Scheduler = DarkHallScheduler
+
+    type BoundaryTickPlan<'K when 'K : comparison> =
+        { HandlerName: string
+          Matches: InterruptKind -> bool
+          SourceName: string
+          RequestFor: RoomLoop.RequestResolver
+          BoundaryFor: RoomLoop.BoundaryRequestResolver<'K>
+          Choose: Runtime.ControllerReadout -> RoomLoop.ControllerChoice
+          Interrupts: SoftScheduler.Source
+          Context: IntrCtx
+          Seed: int64 }
+
+    type SoftDrivePlan =
+        { SourceName: string
+          Value: Chip8Cow.Frame -> float
+          CyclesPerFrame: int
+          Depth: int
+          Width: int
+          Frames: int
+          Start: Chip8Cow.Frame }
+
+    type UnifiedHeatRun<'K when 'K : comparison> =
+        { Room: Scheduler.BoundaryScheduledRoomState<'K>
+          SoftFrame: Chip8Cow.Frame
+          BoundaryHeatRows: Scheduler.HeatBoundaryRow list }
+
+    [<RequireQualifiedAccess>]
+    type UnifiedHeatFeedback<'K when 'K : comparison> =
+        | SchedulerFeedback of InterruptFeedback
+        | SoftDriveFeedback of room: Scheduler.BoundaryScheduledRoomState<'K> * feedback: HeatSinkFeedback
+
+    /// Run one boundary-aware scheduler tick and then one soft-drive window
+    /// through the same heat sink. If the soft lookahead cannot export heat,
+    /// the room state already produced by the boundary tick is returned with
+    /// typed feedback so callers can keep the host-visible transcript.
+    let boundaryTickThenSoftDrive
+        (sink: IHeatSink)
+        (boundaryPlan: BoundaryTickPlan<'K>)
+        (softPlan: SoftDrivePlan)
+        (state: Scheduler.BoundaryScheduledRoomState<'K>)
+        : Task<Result<UnifiedHeatRun<'K>, UnifiedHeatFeedback<'K>>> =
+        task {
+            let handler =
+                Scheduler.boundaryRoomTickHandler
+                    boundaryPlan.HandlerName
+                    boundaryPlan.Matches
+                    boundaryPlan.SourceName
+                    sink
+                    boundaryPlan.RequestFor
+                    boundaryPlan.BoundaryFor
+                    boundaryPlan.Choose
+
+            let! roomResult =
+                (SoftScheduler.driveK [ handler ] boundaryPlan.Interrupts)
+                    .Run
+                    boundaryPlan.Context
+                    boundaryPlan.Seed
+                    state
+                    1
+
+            match roomResult with
+            | Error feedback -> return Error(UnifiedHeatFeedback.SchedulerFeedback feedback)
+            | Ok room ->
+                match
+                    SoftDrive.driveFramesWithHeatSink
+                        softPlan.SourceName
+                        sink
+                        softPlan.Value
+                        softPlan.CyclesPerFrame
+                        softPlan.Depth
+                        softPlan.Width
+                        softPlan.Frames
+                        softPlan.Start
+                with
+                | Ok frame ->
+                    return
+                        Ok
+                            { Room = room
+                              SoftFrame = frame
+                              BoundaryHeatRows = Scheduler.boundaryHeatRows room }
+
+                | Error feedback -> return Error(UnifiedHeatFeedback.SoftDriveFeedback(room, feedback))
+        }

--- a/tests/Tests.FSharp/RoomRun.Tests.fs
+++ b/tests/Tests.FSharp/RoomRun.Tests.fs
@@ -1,0 +1,202 @@
+module Zeta.Tests.RoomRunTests
+
+open System.Diagnostics
+open global.Xunit
+open Zeta.Core
+
+module RoomLoop = DarkHallRoomLoop
+module Runtime = DarkHallCabinetRuntime
+module Scheduler = DarkHallScheduler
+
+let private inputAfterOne =
+    [| 0x60uy; 0x00uy; 0xE0uy; 0x9Euy; 0x60uy; 0x01uy |]
+
+let private noInput =
+    [| 0x6Auy; 0x05uy; 0x7Auy; 0x03uy; 0x60uy; 0x02uy; 0x8Auy; 0x04uy |]
+
+let private ctx () : IntrCtx =
+    { Memetic = "room-run"
+      Prompt = ""
+      Trust = ""
+      Log = ""
+      Otel = ActivityContext() }
+
+let private timer =
+    function
+    | TimerElapsed _ -> true
+    | _ -> false
+
+let private chooseById id (readout: Runtime.ControllerReadout) : RoomLoop.ControllerChoice =
+    let cell =
+        GridBinding.bound readout.Grid
+        |> List.tryFind (fun (_, action) -> action.Id = id)
+        |> Option.map fst
+        |> Option.defaultValue -1
+
+    { Cell = cell
+      Tier = RoomLoop.ChoiceTier.Operator
+      Confidence = 1.0
+      Reason = "test-selected action id" }
+
+let private mustOk =
+    function
+    | Ok value -> value
+    | Error feedback -> failwithf "expected Ok, got %A" feedback
+
+let private rejectSlots slots : ModuloGSetConfig =
+    { Slots = slots
+      CollisionPolicy = ModuloGSetCollisionPolicy.RejectCollision }
+
+let private emptyBoundary source room budget =
+    ModuloGSet.empty<string> (rejectSlots 4)
+    |> mustOk
+    |> RoomBoundary.create source room budget
+
+let private sampleVault () =
+    let v =
+        DoorGraph.empty
+        |> DoorGraph.addRoom "darkhall"
+        |> DoorGraph.addRoom "glass"
+
+    DoorGraph.addDoor (DoorGraph.door "darkhall" "glass" "door-key") v |> mustOk
+
+let private boundaryState boundary =
+    Scheduler.initialWithBoundary Arcade.room Chip9Capabilities.chip8Default boundary
+
+let private boundaryPlan sourceName boundaryFor choose : RoomRun.BoundaryTickPlan<string> =
+    { HandlerName = "room-run-boundary"
+      Matches = timer
+      SourceName = sourceName
+      RequestFor = fun _ -> None
+      BoundaryFor = boundaryFor
+      Choose = choose
+      Interrupts = fun _ -> [ TimerElapsed 17 ]
+      Context = ctx ()
+      Seed = 42L }
+
+let private softPlan sourceName rom width : RoomRun.SoftDrivePlan =
+    { SourceName = sourceName
+      Value = SoftDashboard.sumMemory
+      CyclesPerFrame = 1
+      Depth = 1
+      Width = width
+      Frames = 1
+      Start = Chip8Cow.create 1UL |> Chip8Cow.loadRom rom }
+
+[<Fact>]
+let ``room run exports boundary denial and soft prune heat through one sink`` () =
+    task {
+        let sink = RecordingHeatSink()
+        let boundary = emptyBoundary "room-run-boundary" "darkhall" 5
+        let vault = sampleVault ()
+
+        let plan =
+            boundaryPlan
+                "room-run-boundary"
+                (fun action ->
+                    if action.Id = "darkhall.edit-grammar" then
+                        Some(RoomLoop.BoundaryCommand.Traverse(Set.empty, "glass", vault))
+                    else
+                        None)
+                (chooseById "darkhall.edit-grammar")
+
+        let! result =
+            RoomRun.boundaryTickThenSoftDrive
+                (sink :> IHeatSink)
+                plan
+                (softPlan "room-run-soft" inputAfterOne 1)
+                (boundaryState boundary)
+
+        match result with
+        | Error feedback -> Assert.Fail(sprintf "expected unified room run to complete, got %A" feedback)
+        | Ok run ->
+            Assert.Equal(1, run.Room.CompletedTicks)
+            Assert.True(Scheduler.boundaryBackpressured run.Room)
+            Assert.Equal<string list>(
+                [ "room-boundary.door-denied" ],
+                run.BoundaryHeatRows |> List.collect _.HeatKinds
+            )
+
+            let kinds = sink.Signatures |> Seq.map _.Kind |> Seq.toList
+
+            Assert.Contains("room-boundary.door-denied", kinds)
+            Assert.Contains("soft-emu.prune", kinds)
+            Assert.True(kinds |> List.exists ((=) "room-boundary.door-denied"))
+            Assert.True(kinds |> List.exists ((=) "soft-emu.prune"))
+    }
+
+[<Fact>]
+let ``room run stops on soft heat backpressure with typed feedback and keeps room state`` () =
+    task {
+        let sink =
+            BoundedHeatSink
+                { Capacity = 1
+                  ForgetPolicy = BoundedGSetForgetPolicy.RejectNew }
+
+        let filler = HeatSignature.ofMass "test" "heat.fill" 1 1.0 "occupy bounded heat sink"
+
+        match (sink :> IHeatSink).Emit filler with
+        | Error feedback -> Assert.Fail(sprintf "expected heat sink prefill, got %A" feedback)
+        | Ok() -> ()
+
+        let boundary = emptyBoundary "room-run-boundary" "darkhall" 5
+
+        let plan =
+            boundaryPlan
+                "room-run-boundary"
+                (fun action ->
+                    if action.Id = "darkhall.edit-grammar" then
+                        Some(RoomLoop.BoundaryCommand.Frost 1)
+                    else
+                        None)
+                (chooseById "darkhall.edit-grammar")
+
+        let! result =
+            RoomRun.boundaryTickThenSoftDrive
+                (sink :> IHeatSink)
+                plan
+                (softPlan "room-run-soft" inputAfterOne 1)
+                (boundaryState boundary)
+
+        match result with
+        | Ok _ -> Assert.Fail "soft heat backpressure should stop the run with typed feedback"
+        | Error(RoomRun.UnifiedHeatFeedback.SoftDriveFeedback(room, HeatSinkFeedback.Backpressure(heat, capacity, count))) ->
+            Assert.Equal(1, room.CompletedTicks)
+            Assert.False(Scheduler.boundaryBackpressured room)
+            Assert.Equal("soft-emu.prune", heat.Kind)
+            Assert.Equal("room-run-soft", heat.Source)
+            Assert.Equal(1, capacity)
+            Assert.Equal(2, count)
+            Assert.Equal<HeatSignature list>([ filler ], sink.Stored)
+        | Error feedback -> Assert.Fail(sprintf "unexpected room-run feedback: %A" feedback)
+    }
+
+[<Fact>]
+let ``room run with null heat sink keeps the cold happy path cheap`` () =
+    task {
+        let boundary = emptyBoundary "room-run-boundary" "darkhall" 5
+
+        let plan =
+            boundaryPlan
+                "room-run-boundary"
+                (fun action ->
+                    if action.Id = "darkhall.edit-grammar" then
+                        Some(RoomLoop.BoundaryCommand.Clear)
+                    else
+                        None)
+                (chooseById "darkhall.edit-grammar")
+
+        let! result =
+            RoomRun.boundaryTickThenSoftDrive
+                (NullHeatSink() :> IHeatSink)
+                plan
+                (softPlan "room-run-soft" noInput 64)
+                (boundaryState boundary)
+
+        match result with
+        | Error feedback -> Assert.Fail(sprintf "cold happy path should not need a heat channel, got %A" feedback)
+        | Ok run ->
+            Assert.Equal(1, run.Room.CompletedTicks)
+            Assert.Empty(run.BoundaryHeatRows |> List.collect _.HeatKinds)
+            Assert.Equal(0us, run.SoftFrame.PC % 2us)
+    }

--- a/tests/Tests.FSharp/Tests.FSharp.fsproj
+++ b/tests/Tests.FSharp/Tests.FSharp.fsproj
@@ -147,6 +147,7 @@
     <Compile Include="DarkHallCabinetRuntime.Tests.fs" />
     <Compile Include="DarkHallRoomLoop.Tests.fs" />
     <Compile Include="DarkHallScheduler.Tests.fs" />
+    <Compile Include="RoomRun.Tests.fs" />
     <Compile Include="BowlingAlley.Tests.fs" />
     <Compile Include="Skadium.Tests.fs" />
     <Compile Include="DevRoom.Tests.fs" />


### PR DESCRIPTION
## What changed

- Added `RoomRun`, a small Core harness that composes one boundary-aware Dark Hall scheduler tick and one soft CHIP-8 drive window through the same injected `IHeatSink`.
- Preserves typed feedback when the scheduler fails or when soft-lookahead heat backpressures, including the room state already produced by the boundary tick.
- Added focused tests for shared boundary/soft heat, bounded sink backpressure, and the cold `NullHeatSink` happy path.

## Why

The room framework should feel like test and production share one substrate: simulate, measure, and keep every dropped or refused signal visible as heat. This slice makes the shared heat boundary explicit without turning Q#/Bayesian/soft-drive experiments into a second runtime.

## Validation

- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter "FullyQualifiedName~RoomRunTests|FullyQualifiedName~DarkHallSchedulerTests|FullyQualifiedName~SoftDriveTests"`
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `mise exec -- bun run preflight:quick`
- `mise exec -- semgrep --config .semgrep.yml --error --metrics=off`
- `dotnet test Zeta.sln -c Release`
- `git diff --check`

Agency-Signature-Version: 1
Agent: vera
Agent-Runtime: Codex
Agent-Model: gpt-5.5
Credential-Identity: acehack
Credential-Mode: shared
Human-Review: not-implied-by-credential
Human-Review-Evidence: none
Action-Mode: human-directed
Task: none
Co-Authored-By: Codex <noreply@openai.com>
