### PR TITLE
backlog(workitem): unified key onboarding — per-persona + per-machine, one generator

### DIFF
--- a/workitems/081KVM1TK3Z08QG0R0002959G6-unified-key-onboarding-one-generator-per-persona-per-machine.md
+++ b/workitems/081KVM1TK3Z08QG0R0002959G6-unified-key-onboarding-one-generator-per-persona-per-machine.md
@@ -1,0 +1,83 @@
+---
+id: 081KVM1TK3Z08QG0R0002959G6
+type: task
+state: backlog
+priority: P1
+slug: unified-key-onboarding-one-generator-per-persona-per-machine
+title: "Unified key onboarding — one generator, per-persona + per-machine keys, for new contributors and agents"
+created: 2026-06-21T02:58:14.783Z
+depends_on: []
+composes_with: ["081KSGS9H0008QG0R002T3BJ2R"]
+---
+
+# Unified key onboarding — one generator, per-persona + per-machine keys, for new contributors and agents
+
+<!-- Work-item body. ZetaId-keyed (conflict-free, time-sortable). "Backlog" is a
+     STATE = this folder; completion moves the file to workitems/done/YYYY/MM/.
+     Identity is the zetaid prefix — resolve cross-refs by `081KVM1TK3Z08QG0R0002959G6-*.md` glob. -->
+
+## Why this exists (Aaron, 2026-06-20)
+
+The key/identity setup is **scattered** across several surfaces, and a discrepancy audit (Otto,
+2026-06-20) found **three unreconciled SSH keys** for the same operator:
+
+1. **ad-hoc local** `~/.ssh/id_ed25519` (`SHA256:XxMOZ…`, `aaron_bond@yahoo.com`) — what zflash injects
+   into a flashed USB ESP at flash time;
+2. **registered persona/PKI** (`SHA256:7DS+…`, HD-derived) in `maintainers/aaron/keyring-public.json`;
+3. **published operator** key (`aaron@lucent.financial`) in `maintainers/aaron/ssh-pubkeys.txt` +
+   `full-ai-cluster/nixos/modules/operator-ssh-keys.txt` (baked into every node, pub. 2026-06-09).
+
+These don't match → a freshly-flashed node trusts the ad-hoc key, not the canonical identity.
+**Goal:** ONE easy generator so new contributors AND agents can set up keys, with **per-persona vs
+per-machine made explicit** and known — no more floating ad-hoc keys.
+
+## The two axes (the core model)
+
+- **Per-PERSONA (identity, machine-independent):** seed-derived along HD paths
+  (`m/44'/1110'/0'/0'` ssh, `…/1111'` pgp, `…/1237'` nostr, eth/btc/sol), the **rolling 4×4 keyset
+  ("two of every key type" for rotation)**, registered as the persona's public trust roots in
+  `maintainers/<persona>/keyring-public.json` + `ssh-pubkeys.txt`. Same identity on every machine;
+  rotatable. Applies to humans (aaron, addison) AND agents (otto, amara, ani, alexa) identically.
+- **Per-MACHINE (device, persona-bound):** a device key (derived per-machine for SSH from the PKI base,
+  or a per-host keypair) that identifies the **machine**, traceable to its persona — what zflash
+  injects + `operator-ssh-keys` bakes into node trust. This is the layer that was being filled ad-hoc.
+
+## What to combine (the scattered pieces today)
+
+- **Generator:** `tools/setup/persona-keys/` — `gen.ts` / `derive.ts` / `keyset.ts` / `keyring.sh` /
+  `keyring-4x4.ts` (the 4×4 rolling layout) + `keyring.rotate.test.ts` + `keyring.dst1000.test.ts` +
+  golden vectors (seed → all keys, deterministic, DST-replayable).
+- **Registry/publish:** `maintainers/<persona>/{keyring-public.json, ssh-pubkeys.txt, gpg-pubkey.asc}`.
+- **Node trust:** `full-ai-cluster/nixos/modules/operator-ssh-keys.{nix,txt}` + `keyring-dst1000.yml`.
+- **Provisioning:** zflash ESP pubkey injection (`src/Core.TypeScript/zflash/cli.ts`) + `install.sh`
+  (`tools/setup/`) — should pull the *derived/published* key, not an ad-hoc `id_ed25519`.
+
+## Canonical-email cleanup (Aaron, 2026-06-20)
+
+- **`aaron@lucent.financial` is now the canonical operator email** (working) — and it is **already the
+  published key** in `ssh-pubkeys.txt` / `operator-ssh-keys.txt`. So the reconciliation is: **retire /
+  re-point the ad-hoc `aaron_bond@yahoo.com` `id_ed25519`** (the floating one) onto the canonical
+  `aaron@lucent.financial` identity (either derive it via the persona-keys generator, or publish the
+  intended device key under `aaron@lucent.financial`).
+- **Optional:** standardize git author identity (`git config user.email`) → `aaron@lucent.financial`
+  so commit attribution matches the keyring identity. (Operator's call — identity change.)
+
+## Scope (design-first; KEYS ARE SECRET — operator-run)
+
+1. **Design the unified flow**: one command (extend `keyring.sh` / a `zeta keys onboard`) that, from a
+   seed, (a) derives the persona keyset (4×4 rolling), (b) writes the public trust roots to
+   `maintainers/<persona>/`, (c) derives/registers the per-machine key, (d) feeds zflash + node trust —
+   with a clear `whoami`-style readout of "this key = persona X on machine Y."
+2. **Reconcile the existing 3-key state** for aaron onto `aaron@lucent.financial` (cleanup).
+3. **One flow for humans + agents** (personas otto/amara/ani/alexa already have keyrings — same path).
+
+*Honest scope:* this touches **seeds/secrets** — Otto/agents do NOT run the key generation or hold
+seeds; the deliverable is the unified-flow design + the reconciliation plan. Generation + the git/email
+change are operator-run.
+
+## Composition
+
+- `composes_with` `081KSGS9H0008QG0R002T3BJ2R` (iter-4 ssh-key + hashedpassword substrate for cluster
+  bring-up).
+- Relates to: the zflash TS/FS iso-usb consolidation (UX note 2026-06-20) and the MCU/ESP32 fleet item
+  `081KVM04R4T08QG0R003AZ0E6K` (those nodes also need the per-machine key story).


### PR DESCRIPTION
Aaron: combine the scattered key/identity pieces into **one easy generator** for new contributors + agents, with **per-persona vs per-machine** explicit.

Motivated by the 2026-06-20 discrepancy audit — **3 unreconciled SSH keys** for the same operator: ad-hoc local `id_ed25519` (`aaron_bond@yahoo.com`, what zflash injects), registered PKI (`7DS+…`, keyring-public.json), published operator (`aaron@lucent.financial`, baked into nodes).

New workitem `081KVM1TK3Z08QG0R0002959G6` (P1). Captures:
- **Two axes:** per-**persona** (seed-derived HD `4×4` rolling keyset → `maintainers/<persona>/keyring-public.json`) vs per-**machine** (device key for zflash / node-trust).
- **Pieces to combine:** `tools/setup/persona-keys/` (gen/derive/keyset/keyring-4x4/rotate) + the `maintainers/<persona>/` registry + `operator-ssh-keys` node trust + zflash + `install.sh`.
- **Canonical-email cleanup:** `aaron@lucent.financial` is now canonical (already the published key) → retire/re-point the ad-hoc yahoo `id_ed25519`; optionally standardize `git config user.email`.
- **One flow for humans + agents** (otto/amara/ani/alexa keyrings, same path). Design-first + operator-run (seeds/secrets — agents don't hold seeds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)