### PR TITLE
feat(algebra): StarRing<T> — *-ring interface + Cayley-Dickson tower (TS)

### DIFF
--- a/src/Core.TypeScript/algebra/star-ring.test.ts
+++ b/src/Core.TypeScript/algebra/star-ring.test.ts
@@ -1,0 +1,204 @@
+/**
+ * star-ring.test.ts — verify the *-ring interface + instances + Cayley-Dickson tower.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  realRing,
+  complexRing,
+  doubled,
+  quaternionRing,
+  consolidate,
+  type Complex,
+  type StarRing,
+  type WEntry,
+} from "./star-ring";
+
+// ─── Ring law helpers ────────────────────────────────────────────────────────
+
+function checkRingLaws<T>(name: string, ring: StarRing<T>, eq: (a: T, b: T) => boolean, samples: T[]) {
+  describe(`${name} — ring laws`, () => {
+    test("zero is additive identity", () => {
+      for (const a of samples) {
+        expect(eq(ring.add(a, ring.zero), a)).toBe(true);
+        expect(eq(ring.add(ring.zero, a), a)).toBe(true);
+      }
+    });
+
+    test("one is multiplicative identity", () => {
+      for (const a of samples) {
+        expect(eq(ring.mul(a, ring.one), a)).toBe(true);
+        expect(eq(ring.mul(ring.one, a), a)).toBe(true);
+      }
+    });
+
+    test("additive inverse: a + (-a) = 0", () => {
+      for (const a of samples) {
+        expect(eq(ring.add(a, ring.negate(a)), ring.zero)).toBe(true);
+      }
+    });
+
+    test("conj(conj(a)) = a (involution)", () => {
+      for (const a of samples) {
+        expect(eq(ring.conj(ring.conj(a)), a)).toBe(true);
+      }
+    });
+
+    test("conj(one) = one", () => {
+      expect(eq(ring.conj(ring.one), ring.one)).toBe(true);
+    });
+  });
+}
+
+// ─── Real ring ───────────────────────────────────────────────────────────────
+
+const realEq = (a: number, b: number) => Math.abs(a - b) < 1e-10;
+const realSamples = [0, 1, -1, 2.5, -3.7, 0.001];
+
+checkRingLaws("real", realRing, realEq, realSamples);
+
+// ─── Complex ring ────────────────────────────────────────────────────────────
+
+const cEq = (a: Complex, b: Complex) => Math.abs(a.re - b.re) < 1e-10 && Math.abs(a.im - b.im) < 1e-10;
+const cSamples: Complex[] = [
+  { re: 0, im: 0 }, { re: 1, im: 0 }, { re: 0, im: 1 },
+  { re: -1, im: 0 }, { re: 3, im: -2 }, { re: 0.5, im: 0.5 },
+];
+
+checkRingLaws("complex", complexRing, cEq, cSamples);
+
+describe("complex — specific properties", () => {
+  test("i² = -1", () => {
+    const i: Complex = { re: 0, im: 1 };
+    const iSq = complexRing.mul(i, i);
+    expect(cEq(iSq, { re: -1, im: 0 })).toBe(true);
+  });
+
+  test("conj(a+bi) = a-bi", () => {
+    const z: Complex = { re: 3, im: 4 };
+    const c = complexRing.conj(z);
+    expect(c.re).toBe(3);
+    expect(c.im).toBe(-4);
+  });
+
+  test("|z|² = z * conj(z) is real and non-negative", () => {
+    const z: Complex = { re: 3, im: 4 };
+    const normSq = complexRing.mul(z, complexRing.conj(z));
+    expect(normSq.im).toBeCloseTo(0, 10);
+    expect(normSq.re).toBeCloseTo(25, 10); // 3² + 4² = 25
+  });
+});
+
+// ─── Cayley-Dickson doubling ─────────────────────────────────────────────────
+
+describe("Cayley-Dickson doubled(real) ≅ complex", () => {
+  const dReal = doubled(realRing);
+  const dEq = (a: { real: number; imag: number }, b: { real: number; imag: number }) =>
+    Math.abs(a.real - b.real) < 1e-10 && Math.abs(a.imag - b.imag) < 1e-10;
+
+  test("(0,1)*(0,1) = (-1,0) — i² = -1", () => {
+    const i = { real: 0, imag: 1 };
+    const iSq = dReal.mul(i, i);
+    expect(dEq(iSq, { real: -1, imag: 0 })).toBe(true);
+  });
+
+  test("doubled(real) agrees with complexRing on multiplication", () => {
+    // (a+bi)*(c+di) should agree in both representations
+    const a: Complex = { re: 2, im: 3 };
+    const b: Complex = { re: 1, im: -1 };
+    const cResult = complexRing.mul(a, b);
+
+    const da = { real: 2, imag: 3 };
+    const db = { real: 1, imag: -1 };
+    const dResult = dReal.mul(da, db);
+
+    expect(Math.abs(cResult.re - dResult.real)).toBeLessThan(1e-10);
+    expect(Math.abs(cResult.im - dResult.imag)).toBeLessThan(1e-10);
+  });
+});
+
+describe("quaternion ring (doubled(complex))", () => {
+  test("quaternion multiplication is non-commutative", () => {
+    // i*j ≠ j*i in quaternions
+    const i = { real: { re: 0, im: 1 }, imag: { re: 0, im: 0 } };
+    const j = { real: { re: 0, im: 0 }, imag: { re: 1, im: 0 } };
+    const ij = quaternionRing.mul(i, j);
+    const ji = quaternionRing.mul(j, i);
+    // ij ≠ ji (non-commutative)
+    const eq = (a: typeof ij, b: typeof ji) =>
+      Math.abs(a.real.re - b.real.re) < 1e-10 &&
+      Math.abs(a.real.im - b.real.im) < 1e-10 &&
+      Math.abs(a.imag.re - b.imag.re) < 1e-10 &&
+      Math.abs(a.imag.im - b.imag.im) < 1e-10;
+    expect(eq(ij, ji)).toBe(false); // non-commutative!
+  });
+
+  test("quaternion: ij = -ji (anticommutative)", () => {
+    const i = { real: { re: 0, im: 1 }, imag: { re: 0, im: 0 } };
+    const j = { real: { re: 0, im: 0 }, imag: { re: 1, im: 0 } };
+    const ij = quaternionRing.mul(i, j);
+    const ji = quaternionRing.mul(j, i);
+    const negJi = quaternionRing.negate(ji);
+    const eq = Math.abs(ij.real.re - negJi.real.re) < 1e-10 &&
+      Math.abs(ij.real.im - negJi.real.im) < 1e-10 &&
+      Math.abs(ij.imag.re - negJi.imag.re) < 1e-10 &&
+      Math.abs(ij.imag.im - negJi.imag.im) < 1e-10;
+    expect(eq).toBe(true); // ij = -ji
+  });
+});
+
+// ─── Consolidate (the merge operation, generic over ring) ────────────────────
+
+describe("consolidate — ring-generic merge", () => {
+  const magSq = (z: Complex) => z.re * z.re + z.im * z.im;
+  const isZeroC = (z: Complex) => magSq(z) < 1e-12;
+  const isZeroR = (w: number) => Math.abs(w) < 1e-12;
+
+  test("complex: opposite-phase entries cancel (destructive interference)", () => {
+    const entries: WEntry<string, Complex>[] = [
+      { key: "a", weight: { re: 0.5, im: 0 } },
+      { key: "a", weight: { re: -0.5, im: 0 } },
+    ];
+    const result = consolidate(complexRing, isZeroC, entries);
+    expect(result.length).toBe(0); // cancelled!
+  });
+
+  test("complex: same-phase entries reinforce (constructive interference)", () => {
+    const entries: WEntry<string, Complex>[] = [
+      { key: "a", weight: { re: 0.3, im: 0.4 } },
+      { key: "a", weight: { re: 0.3, im: 0.4 } },
+    ];
+    const result = consolidate(complexRing, isZeroC, entries);
+    expect(result.length).toBe(1);
+    expect(result[0]!.weight.re).toBeCloseTo(0.6, 10);
+    expect(result[0]!.weight.im).toBeCloseTo(0.8, 10);
+  });
+
+  test("real: same-key entries always reinforce (no cancellation on positive)", () => {
+    const entries: WEntry<string, number>[] = [
+      { key: "a", weight: 0.3 },
+      { key: "a", weight: 0.7 },
+    ];
+    const result = consolidate(realRing, isZeroR, entries);
+    expect(result.length).toBe(1);
+    expect(result[0]!.weight).toBeCloseTo(1.0, 10);
+  });
+
+  test("real: opposite-sign entries DO cancel (retraction)", () => {
+    const entries: WEntry<string, number>[] = [
+      { key: "a", weight: 1.0 },
+      { key: "a", weight: -1.0 },
+    ];
+    const result = consolidate(realRing, isZeroR, entries);
+    expect(result.length).toBe(0); // retracted!
+  });
+
+  test("different keys are independent (no cross-interference)", () => {
+    const entries: WEntry<string, Complex>[] = [
+      { key: "a", weight: { re: 1, im: 0 } },
+      { key: "b", weight: { re: 1, im: 0 } },
+    ];
+    const result = consolidate(complexRing, isZeroC, entries);
+    expect(result.length).toBe(2);
+  });
+});

--- a/src/Core.TypeScript/algebra/star-ring.ts
+++ b/src/Core.TypeScript/algebra/star-ring.ts
@@ -1,0 +1,162 @@
+/**
+ * src/Core.TypeScript/algebra/star-ring.ts — the *-ring interface (IStarRing port).
+ *
+ * A *-ring (star-ring) is a ring with an involution (conjugation). This is the
+ * minimal algebraic interface that makes the soft lanes work generically:
+ *
+ *   - Real weights (Bayesian): conj = identity, the ring is commutative
+ *   - Complex amplitudes (Quantum): conj = complex conjugate, enables interference
+ *   - Quaternion (future): conj = quaternion conjugate, non-commutative
+ *
+ * The same code works over any StarRing instance — swap the ring, change the
+ * physics. This is the TS port of F#'s `IStarRing<'A>` from `CayleyDickson.fs`.
+ *
+ * Composes with:
+ *   - src/Core/CayleyDickson.fs (F# source of truth: IStarRing, Doubled.algebra)
+ *   - src/Core/ImaginaryStack (complex/quaternion/octonion instances)
+ *   - src/Core/WSet.fs (consolidate + apply use the ring)
+ *   - docs/specs/soft-lane-codegen-numeric-interfaces.md (the design spec)
+ */
+
+// ─── The StarRing interface ──────────────────────────────────────────────────
+
+/**
+ * A *-ring: a ring (Zero, One, Add, Mul, Negate) plus an involution (Conj).
+ * Dictionary-passing style (same as F#'s object expression pattern).
+ * Carries NO state — pure operations.
+ */
+export interface StarRing<T> {
+  readonly zero: T;
+  readonly one: T;
+  add(a: T, b: T): T;
+  mul(a: T, b: T): T;
+  negate(a: T): T;
+  conj(a: T): T;
+}
+
+// ─── Complex number type ─────────────────────────────────────────────────────
+
+export interface Complex {
+  readonly re: number;
+  readonly im: number;
+}
+
+// ─── Real algebra (IStarRing<float>) ─────────────────────────────────────────
+
+export const realRing: StarRing<number> = {
+  zero: 0,
+  one: 1,
+  add: (a, b) => a + b,
+  mul: (a, b) => a * b,
+  negate: (a) => -a,
+  conj: (a) => a, // real conjugation = identity
+};
+
+// ─── Complex algebra (IStarRing<Complex>) ────────────────────────────────────
+
+export const complexRing: StarRing<Complex> = {
+  zero: { re: 0, im: 0 },
+  one: { re: 1, im: 0 },
+  add: (a, b) => ({ re: a.re + b.re, im: a.im + b.im }),
+  mul: (a, b) => ({
+    re: a.re * b.re - a.im * b.im,
+    im: a.re * b.im + a.im * b.re,
+  }),
+  negate: (a) => ({ re: -a.re, im: -a.im }),
+  conj: (a) => ({ re: a.re, im: -a.im }), // complex conjugation
+};
+
+// ─── Cayley-Dickson doubling (Doubled.algebra port) ──────────────────────────
+
+export interface Doubled<T> {
+  readonly real: T;
+  readonly imag: T;
+}
+
+/**
+ * The Cayley-Dickson construction: given an IStarRing<A>, produce IStarRing<Doubled<A>>.
+ * This IS the tower: Real → Complex → Quaternion → Octonion → ...
+ *
+ * Multiplication: (a,b)*(c,d) = (a*c - conj(d)*b, d*a + b*conj(c))
+ * Conjugation: conj(a,b) = (conj(a), -b)
+ */
+export function doubled<T>(inner: StarRing<T>): StarRing<Doubled<T>> {
+  return {
+    zero: { real: inner.zero, imag: inner.zero },
+    one: { real: inner.one, imag: inner.zero },
+    add: (a, b) => ({
+      real: inner.add(a.real, b.real),
+      imag: inner.add(a.imag, b.imag),
+    }),
+    mul: (a, b) => ({
+      // (a,b)*(c,d) = (a*c - conj(d)*b, d*a + b*conj(c))
+      real: inner.add(
+        inner.mul(a.real, b.real),
+        inner.negate(inner.mul(inner.conj(b.imag), a.imag)),
+      ),
+      imag: inner.add(
+        inner.mul(b.imag, a.real),
+        inner.mul(a.imag, inner.conj(b.real)),
+      ),
+    }),
+    negate: (a) => ({
+      real: inner.negate(a.real),
+      imag: inner.negate(a.imag),
+    }),
+    conj: (a) => ({
+      real: inner.conj(a.real),
+      imag: inner.negate(a.imag),
+    }),
+  };
+}
+
+// ─── The imaginary stack (pre-computed instances) ─────────────────────────────
+
+/** Complex = Doubled<Real> — same as ImaginaryStack.complex in F# */
+export const complexFromDoubled: StarRing<Doubled<number>> = doubled(realRing);
+
+/** Quaternion = Doubled<Complex> */
+export type Quaternion = Doubled<Complex>;
+export const quaternionRing: StarRing<Quaternion> = doubled(complexRing);
+
+/** Octonion = Doubled<Quaternion> */
+export type Octonion = Doubled<Quaternion>;
+export const octonionRing: StarRing<Octonion> = doubled(quaternionRing);
+
+// ─── Weighted set operations (generic over ring) ─────────────────────────────
+
+export interface WEntry<K, W> {
+  readonly key: K;
+  readonly weight: W;
+}
+
+/**
+ * Consolidate: sum weights of identical keys under ring.add, drop zeros.
+ * This is where interference happens — opposite-weight entries cancel.
+ * Generic over the ring: real weights → no cancel on positive; complex → phase cancel.
+ */
+export function consolidate<K, W>(
+  ring: StarRing<W>,
+  isZero: (w: W) => boolean,
+  entries: readonly WEntry<K, W>[],
+  keyEq: (a: K, b: K) => boolean = (a, b) => a === b,
+): WEntry<K, W>[] {
+  const grouped: { key: K; weight: W }[] = [];
+  for (const entry of entries) {
+    const existing = grouped.find((g) => keyEq(g.key, entry.key));
+    if (existing) {
+      existing.weight = ring.add(existing.weight, entry.weight);
+    } else {
+      grouped.push({ key: entry.key, weight: entry.weight });
+    }
+  }
+  return grouped.filter((g) => !isZero(g.weight));
+}
+
+/**
+ * Norm-squared: conj(w) * w. For complex: |z|² = re² + im². For real: w².
+ * Used to determine "is this weight effectively zero."
+ */
+export function normSq<W>(ring: StarRing<W>, w: W): W {
+  return ring.mul(ring.conj(w), w);
+}


### PR DESCRIPTION
The numeric algebra foundation for ring-generic soft-lane codegen.

- StarRing<T> interface (port of F#'s IStarRing<'A>)
- Real, Complex, Quaternion, Octonion instances via Cayley-Dickson doubling
- co
Ports F#'s IStarRing<'A> to TypeScript:
-ing = change physics)
- 22 tests, 92 assertions (ring laws + CD tower + interference/retraction)

Next: wire this into the soft-lane codegen so generated code uses the algebra.