### PR TITLE
feat(keys): per-MACHINE device key + (user × machine) status — safe slice of unified onboarding

### DIFF
--- a/tools/setup/persona-keys/README.md
+++ b/tools/setup/persona-keys/README.md
@@ -50,6 +50,41 @@ the markov/homeostat chains. So:
 3. **Public artifacts are safe to publish** — pubkeys / addresses / npub go to
    `maintainers/<name>/` and are committed to `main`.
 
+## Per-MACHINE device key + (user × machine) status — `machine.ts` / `machine-cli.ts`
+
+The keyring above is the **per-PERSONA** identity (one seed → all key types, same on
+every machine). A **per-MACHINE** key is different: a per-host ed25519 device keypair
+(NOT seed-derived) that identifies *this dev machine*, traceable to its persona. This
+is the first SAFE slice of the unified onboarding item
+(`081KVM1TK3Z08QG0R0002959G6`) — read-mostly, secret-conservative.
+
+- **`status` / `whoami` (READ-ONLY, generates nothing):** the workitem's two-part
+  presence check — is the **user keyring** present and is **this dev machine's**
+  device key present, checked **independently** (you flash from many dev machines, so
+  the user key is often set up while a new flasher box's key is not):
+
+  ```bash
+  bun machine-cli.ts status --user aaron
+  # user=aaron present=y, machine=<host> key present=n, machine key published=n
+  ```
+
+- **`machine` (generate the per-MACHINE device key ONLY):** generates a standard
+  `ssh-keygen -t ed25519` device keypair if absent (idempotent — a second run is a
+  no-op). The **private** key stays local under `~/.config/zeta/machine/` (`umask
+  077`); `--publish` writes **only the PUBLIC** key to
+  `maintainers/<user>/machines/<host>.pub`. `--dry-run` generates nothing.
+
+  ```bash
+  bun machine-cli.ts machine --user aaron --dry-run   # prints plan, generates NOTHING
+  bun machine-cli.ts machine --user aaron --publish   # local device key + public to repo (NOT committed)
+  ```
+
+**Security invariants (same as the seed keyring):** no seed / CA / persona key is
+generated here — only a per-host device keypair; the private key never touches
+argv / stdout / git; only public keys/fingerprints are published. **Out of scope
+(LATER slices):** the SSH-CA (sign per-machine certs), the GitHub pubkey upload, and
+cluster node-trust injection — this slice does NOT build key-upload or CA-signing.
+
 ## Two storage modes (Aaron 2026-06-09)
 
 - **Equipment mode (cluster):** private bits → **Vault** (`--vault zeta/personas/otto`).

--- a/tools/setup/persona-keys/machine-cli.ts
+++ b/tools/setup/persona-keys/machine-cli.ts
@@ -1,0 +1,60 @@
+// Zeta machine/status CLI — a thin shell around the pure oracle (machine.ts).
+// Two modes, both SAFE:
+//   status  (READ-ONLY)  — the two-part (user × machine) presence check, no generation.
+//   machine (GATED)      — generate THIS machine's per-host ed25519 device key (only),
+//                          private stays local under umask 077; --publish writes ONLY the
+//                          public key to maintainers/<user>/machines/<host>.pub (no commit).
+// SECURITY: no seed/CA/persona key generated; no secret to argv/stdout/git. See machine.ts.
+//
+// Usage:
+//   bun machine-cli.ts status  --user aaron
+//   bun machine-cli.ts machine --user aaron --dry-run        # generates NOTHING
+//   bun machine-cli.ts machine --user aaron                  # generate local device key
+//   bun machine-cli.ts machine --user aaron --publish        # + write public key to repo (no commit)
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { checkPresence, ensureMachineKey, formatStatus, realEffects } from "./machine.ts";
+
+const args = process.argv.slice(2);
+const mode = args[0];
+const flag = (n: string) => args.includes(n);
+const opt = (n: string) => {
+  const i = args.indexOf(n);
+  return i >= 0 ? args[i + 1] : undefined;
+};
+
+const user = opt("--user") ?? "zeta";
+// Repo root: 3 levels up from tools/setup/persona-keys/ (override with --repo-root for tests).
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = opt("--repo-root") ?? resolve(here, "..", "..", "..");
+const fx = realEffects();
+
+if (mode === "status" || mode === "whoami") {
+  const s = checkPresence(fx, { user, repoRoot });
+  console.log(formatStatus(s));
+  console.log(`  user keyring: ${s.userKeyringPath}`);
+  console.log(`  device key (local, private): ${s.devicePrivatePath}`);
+  console.log(`  device pubkey (publish path): ${s.devicePublicPath}`);
+  process.exit(0);
+}
+
+if (mode === "machine") {
+  const dryRun = flag("--dry-run");
+  const publish = flag("--publish");
+  const r = ensureMachineKey(fx, { user, repoRoot, publish, dryRun });
+  if (r.dryRun) {
+    console.log(`[dry-run] action=${r.action} (NOTHING generated or written)`);
+    console.log(`[dry-run] would write private key to: ${r.devicePrivatePath}`);
+    if (publish) console.log(`[dry-run] would write PUBLIC key to: ${r.devicePublicPath}`);
+    process.exit(0);
+  }
+  console.log(`action=${r.action} hostname=${r.hostname}`);
+  console.log(`private key (local only): ${r.devicePrivatePath}`);
+  if (r.published) console.log(`published PUBLIC key -> ${r.devicePublicPath} (NOT committed)`);
+  // Printing the PUBLIC key is safe (it is the publishable trust artifact).
+  if (r.publicKey !== undefined) console.log(r.publicKey);
+  process.exit(0);
+}
+
+console.error("usage: bun machine-cli.ts <status|whoami|machine> --user <name> [--dry-run] [--publish]");
+process.exit(2);

--- a/tools/setup/persona-keys/machine.test.ts
+++ b/tools/setup/persona-keys/machine.test.ts
@@ -1,0 +1,165 @@
+// machine.ts conformance — the two-part (user × machine) presence check + the gated
+// device-key generation. ALL tests run against a THROWAWAY temp dir via injected
+// effects (or mktemp -d for the real-ssh-keygen path) — NEVER real ~/.ssh, NEVER real
+// maintainer paths, NEVER committing a generated key. Conformance/structure only.
+// Run: bun test machine.test.ts   (from tools/setup/persona-keys)
+import { test, expect } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  checkPresence,
+  ensureMachineKey,
+  formatStatus,
+  publishPubPath,
+  sanitizeHostname,
+  userKeyringPublicPath,
+  type MachineEffects,
+} from "./machine.ts";
+
+// A fully in-memory-ish fake: deterministic fake key generation, real temp filesystem
+// for the public-artifact writes. The fake NEVER shells out and NEVER touches secrets.
+function fakeEffects(host: string, opts?: { genCount?: { n: number } }): MachineEffects {
+  return {
+    hostname: () => host,
+    exists: (p) => existsSync(p),
+    readText: (p) => readFileSync(p, "utf8"),
+    writeText: (p, c) => writeFileSync(p, c),
+    mkdirp: (p) => mkdirSync(p, { recursive: true }),
+    genEd25519: (keyPath, comment) => {
+      if (opts?.genCount) opts.genCount.n += 1;
+      // Simulate ssh-keygen: write a (fake) private + public file locally.
+      mkdirSync(keyPath.slice(0, keyPath.lastIndexOf("/")), { recursive: true });
+      writeFileSync(keyPath, "FAKE-PRIVATE-DO-NOT-USE\n", { mode: 0o600 });
+      const pub = `ssh-ed25519 AAAAFAKEPUBKEY ${comment}\n`;
+      writeFileSync(keyPath + ".pub", pub);
+      return pub;
+    },
+  };
+}
+
+test("status: both absent -> userKeyPresent=n, machine key present=n (READ-ONLY, generates nothing)", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "zeta-machine-"));
+  try {
+    const fx = fakeEffects("dev-box-1");
+    const s = checkPresence(fx, { user: "tester", repoRoot: tmp, home: tmp });
+    expect(s.userKeyPresent).toBe(false);
+    expect(s.machineKeyPresentLocal).toBe(false);
+    expect(s.machineKeyPublished).toBe(false);
+    expect(formatStatus(s)).toContain("user=tester present=n");
+    expect(formatStatus(s)).toContain("machine=dev-box-1 key present=n");
+    // pure inspection: no files were created
+    expect(existsSync(s.devicePrivatePath)).toBe(false);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("status: detects an existing user keyring + machine key independently (two-axis)", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "zeta-machine-"));
+  try {
+    // user key present, machine key NOT (the common 'new flasher box' case from the workitem)
+    mkdirSync(join(tmp, "maintainers", "tester"), { recursive: true });
+    writeFileSync(userKeyringPublicPath(tmp, "tester"), JSON.stringify({ user: "tester" }));
+    const fx = fakeEffects("dev-box-2");
+    const s = checkPresence(fx, { user: "tester", repoRoot: tmp, home: tmp });
+    expect(s.userKeyPresent).toBe(true);
+    expect(s.machineKeyPresentLocal).toBe(false); // independent: user set up, this machine not
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("--dry-run generates NOTHING and reports would-generate", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "zeta-machine-"));
+  try {
+    const genCount = { n: 0 };
+    const fx = fakeEffects("dev-box-3", { genCount });
+    const r = ensureMachineKey(fx, { user: "tester", repoRoot: tmp, home: tmp, dryRun: true, publish: true });
+    expect(r.dryRun).toBe(true);
+    expect(r.action).toBe("would-generate");
+    expect(r.published).toBe(false);
+    expect(genCount.n).toBe(0); // nothing generated
+    expect(existsSync(r.devicePrivatePath)).toBe(false); // nothing written
+    expect(existsSync(r.devicePublicPath)).toBe(false);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("machine: generates a device key (fake) and publishes ONLY the public half; private never published", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "zeta-machine-"));
+  try {
+    const fx = fakeEffects("dev-box-4");
+    const r = ensureMachineKey(fx, { user: "tester", repoRoot: tmp, home: tmp, publish: true });
+    expect(r.action).toBe("generated");
+    expect(r.published).toBe(true);
+    // the PUBLISH path holds ONLY the public key — no private bytes anywhere in it
+    const publishedPath = publishPubPath(tmp, "tester", "dev-box-4");
+    expect(existsSync(publishedPath)).toBe(true);
+    const published = readFileSync(publishedPath, "utf8");
+    expect(published).toContain("ssh-ed25519");
+    expect(published).not.toContain("PRIVATE");
+    expect(published).not.toMatch(/BEGIN .*PRIVATE KEY/);
+    // the private key file stays at the LOCAL path, NOT under maintainers/
+    expect(r.devicePrivatePath.includes("maintainers")).toBe(false);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("machine: idempotent — a second run is a no-op ('exists'), does not regenerate", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "zeta-machine-"));
+  try {
+    const genCount = { n: 0 };
+    const fx = fakeEffects("dev-box-5", { genCount });
+    const first = ensureMachineKey(fx, { user: "tester", repoRoot: tmp, home: tmp });
+    expect(first.action).toBe("generated");
+    expect(genCount.n).toBe(1);
+    const second = ensureMachineKey(fx, { user: "tester", repoRoot: tmp, home: tmp });
+    expect(second.action).toBe("exists"); // idempotent: apply-N == apply-once effect
+    expect(genCount.n).toBe(1); // NOT regenerated
+    expect(second.publicKey).toBe(first.publicKey); // same public key returned
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("sanitizeHostname: filesystem-safe, ordinal-stable, never empty", () => {
+  expect(sanitizeHostname("Dev Box!.local")).toBe("dev-box-.local");
+  expect(sanitizeHostname("  ")).toBe("unknown-host");
+  expect(sanitizeHostname("aaron-MBP")).toBe("aaron-mbp");
+});
+
+// REAL ssh-keygen, but ONLY into a throwaway temp dir (never ~/.ssh, never committed).
+// Proves the production seam actually produces a valid ed25519 pubkey and that the
+// private key never leaves the local temp path. Skips cleanly if ssh-keygen absent.
+test("real ssh-keygen into a temp dir produces a valid ed25519 pubkey, private stays local", async () => {
+  const probe = spawnSync("ssh-keygen", ["-A", "-?"], { encoding: "utf8" });
+  const haveSshKeygen = probe.error === undefined;
+  if (!haveSshKeygen) {
+    return; // environment without ssh-keygen — conformance covered by the fake-effects tests
+  }
+  const tmp = mkdtempSync(join(tmpdir(), "zeta-machine-real-"));
+  try {
+    const { realEffects, ensureMachineKey: ensure, deviceKeyPath } = await import("./machine.ts");
+    const fx = realEffects();
+    // pin HOME to the temp dir so the REAL device path resolves inside temp, never ~/.ssh
+    const r = ensure(fx, { user: "tester", repoRoot: tmp, home: tmp, publish: true });
+    expect(r.action).toBe("generated");
+    const priv = deviceKeyPath(tmp);
+    expect(priv.startsWith(tmp)).toBe(true); // private key is inside the temp dir
+    expect(existsSync(priv)).toBe(true);
+    expect(existsSync(priv + ".pub")).toBe(true);
+    // private key is not group/other readable (umask 077 honored by ssh-keygen)
+    const mode = statSync(priv).mode & 0o077;
+    expect(mode).toBe(0);
+    // published artifact is the PUBLIC key only
+    const published = readFileSync(publishPubPath(tmp, "tester", fx.hostname()), "utf8");
+    expect(published).toContain("ssh-ed25519");
+    expect(published).not.toMatch(/PRIVATE/);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});

--- a/tools/setup/persona-keys/machine.ts
+++ b/tools/setup/persona-keys/machine.ts
@@ -1,0 +1,222 @@
+// Zeta per-MACHINE device key + two-part (user × machine) presence check — the
+// SAFE, read-mostly slice of the unified key-onboarding flow (workitem
+// 081KVM1TK3Z08QG0R0002959G6 §"Two-part presence check"). PURE oracle + a single
+// gated side-effect (generate ONE per-host ed25519 device key via ssh-keygen).
+//
+// SECURITY INVARIANTS (matched to the persona-keys README §"Security invariants"):
+//  1. NO seed / NO CA key / NO persona key is generated here — ONLY a per-host
+//     ed25519 device keypair (NOT seed-derived: each machine has its own key).
+//  2. The private key NEVER touches argv / stdout / git. ssh-keygen writes it to a
+//     local file under umask 077; only the PUBLIC key (`<path>.pub`) is read back
+//     for publishing. We never print or return private bytes.
+//  3. Public artifacts only are published — the device PUBLIC key goes to
+//     `maintainers/<user>/machines/<hostname>.pub`. This module SUPPORTS writing it;
+//     it does NOT commit. Upload-to-GitHub / SSH-CA signing / cluster trust are
+//     LATER slices (explicitly out of scope here).
+//
+// Noninterference (manifesto §13): the host environment (hostname, filesystem,
+// ssh-keygen runner) enters ONLY through the injected `MachineEffects` — so the
+// presence check + dry-run are deterministic and testable against a temp dir,
+// never the real ~/.ssh or real maintainer paths.
+//
+// Anchors (Beacon): ed25519 device keys — Bernstein et al. (Ed25519, 2011);
+// OpenSSH `ssh-keygen(1)`. Two-axis identity (user × machine) — the workitem's
+// per-PERSONA vs per-MACHINE model. Type-separated keys — persona-keys README.
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir, hostname as osHostname } from "node:os";
+import { join } from "node:path";
+
+/** The host-environment doors — the ONLY channel for ambient influence (noninterference). */
+export interface MachineEffects {
+  /** This dev machine's hostname (the per-machine identity component). */
+  readonly hostname: () => string;
+  /** True iff a path exists (used for presence checks — never reads contents of secrets). */
+  readonly exists: (path: string) => boolean;
+  /** Read a PUBLIC text artifact (pubkey / public keyring). Never used on private paths. */
+  readonly readText: (path: string) => string;
+  /** Write a PUBLIC text artifact (the published `<hostname>.pub`). */
+  readonly writeText: (path: string, content: string) => void;
+  /** Create a directory (recursive). */
+  readonly mkdirp: (path: string) => void;
+  /** Generate an ed25519 keypair at `keyPath` (private) + `keyPath.pub` (public).
+   *  Returns the PUBLIC key text only — the private bytes never cross this boundary. */
+  readonly genEd25519: (keyPath: string, comment: string) => string;
+}
+
+/** Where this dev machine's PRIVATE device key lives locally (never published, never committed). */
+export function deviceKeyPath(home: string = homedir()): string {
+  return join(home, ".config", "zeta", "machine", "id_ed25519");
+}
+
+/** Where this machine's PUBLIC device key is published under the operator's maintainer dir. */
+export function publishPubPath(repoRoot: string, user: string, hostname: string): string {
+  return join(repoRoot, "maintainers", user, "machines", `${sanitizeHostname(hostname)}.pub`);
+}
+
+/** The operator's persona keyring public registry (the "user key present?" probe). */
+export function userKeyringPublicPath(repoRoot: string, user: string): string {
+  return join(repoRoot, "maintainers", user, "keyring-public.json");
+}
+
+/** Hostnames become filenames — keep them filesystem-safe + ordinal-stable (culture-invariant). */
+export function sanitizeHostname(hostname: string): string {
+  const cleaned = hostname.trim().toLowerCase().replace(/[^a-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+  return cleaned.length > 0 ? cleaned : "unknown-host";
+}
+
+/** Result of the two-part presence check (workitem §"Two-part presence check"). */
+export interface PresenceStatus {
+  readonly user: string;
+  readonly hostname: string;
+  /** Is this operator's persona keyring registered (user identity present)? */
+  readonly userKeyPresent: boolean;
+  /** Is THIS dev machine's device private key present locally? */
+  readonly machineKeyPresentLocal: boolean;
+  /** Is THIS dev machine's device PUBLIC key published under maintainers/<user>/machines/? */
+  readonly machineKeyPublished: boolean;
+  readonly userKeyringPath: string;
+  readonly devicePrivatePath: string;
+  readonly devicePublicPath: string;
+}
+
+/** READ-ONLY two-part check: user keyring present? this machine's device key present?
+ *  Pure over the injected effects — inspects existence only, never reads secret bytes. */
+export function checkPresence(
+  fx: MachineEffects,
+  opts: { readonly user: string; readonly repoRoot: string; readonly home?: string },
+): PresenceStatus {
+  const hostname = sanitizeHostname(fx.hostname());
+  const userKeyringPath = userKeyringPublicPath(opts.repoRoot, opts.user);
+  const devicePrivatePath = opts.home === undefined ? deviceKeyPath() : deviceKeyPath(opts.home);
+  const devicePublicPath = publishPubPath(opts.repoRoot, opts.user, hostname);
+  return {
+    user: opts.user,
+    hostname,
+    userKeyPresent: fx.exists(userKeyringPath),
+    machineKeyPresentLocal: fx.exists(devicePrivatePath),
+    machineKeyPublished: fx.exists(devicePublicPath),
+    userKeyringPath,
+    devicePrivatePath,
+    devicePublicPath,
+  };
+}
+
+/** Human-readable readout: "user=<persona> present=<y/n>, machine=<hostname> key present=<y/n>". */
+export function formatStatus(s: PresenceStatus): string {
+  const yn = (b: boolean) => (b ? "y" : "n");
+  return [
+    `user=${s.user} present=${yn(s.userKeyPresent)}`,
+    `machine=${s.hostname} key present=${yn(s.machineKeyPresentLocal)}`,
+    `machine key published=${yn(s.machineKeyPublished)}`,
+  ].join(", ");
+}
+
+/** What a `machine` run did (or, with dryRun, WOULD do). No private material ever appears here. */
+export interface MachineResult {
+  readonly dryRun: boolean;
+  readonly hostname: string;
+  readonly devicePrivatePath: string;
+  readonly devicePublicPath: string;
+  /** "generated" | "exists" (idempotent: an existing key is a no-op) | "would-generate" (dry-run). */
+  readonly action: "generated" | "exists" | "would-generate";
+  /** The PUBLIC key text, when present/generated (safe to print/publish). Undefined on pure dry-run. */
+  readonly publicKey?: string;
+  /** True iff we wrote the public key to the publish path (never true on dry-run). */
+  readonly published: boolean;
+}
+
+/**
+ * Generate (or, idempotently, recognise) THIS machine's per-host ed25519 device key.
+ * Generates ONLY a device keypair — no seed, no CA, no persona key. The private key
+ * is written locally by ssh-keygen under umask 077 (the runner's job); ONLY the
+ * public key is read back and (optionally) written to the publish path.
+ *
+ * @param publish  when true, copy the PUBLIC key into maintainers/<user>/machines/.
+ *                 (This PR does NOT commit; the caller/operator decides whether to commit.)
+ * @param dryRun   when true, NOTHING is generated or written — returns "would-generate".
+ */
+export function ensureMachineKey(
+  fx: MachineEffects,
+  opts: {
+    readonly user: string;
+    readonly repoRoot: string;
+    readonly home?: string;
+    readonly publish?: boolean;
+    readonly dryRun?: boolean;
+  },
+): MachineResult {
+  const hostname = sanitizeHostname(fx.hostname());
+  const devicePrivatePath = opts.home === undefined ? deviceKeyPath() : deviceKeyPath(opts.home);
+  const devicePublicPath = publishPubPath(opts.repoRoot, opts.user, hostname);
+  const dryRun = opts.dryRun === true;
+  const wantPublish = opts.publish === true;
+  const alreadyExists = fx.exists(devicePrivatePath);
+
+  if (dryRun) {
+    return {
+      dryRun: true,
+      hostname,
+      devicePrivatePath,
+      devicePublicPath,
+      action: alreadyExists ? "exists" : "would-generate",
+      published: false,
+    };
+  }
+
+  let publicKey: string;
+  let action: MachineResult["action"];
+  if (alreadyExists) {
+    // Idempotent: an existing device key is a no-op. Read back its PUBLIC half only.
+    publicKey = fx.readText(devicePrivatePath + ".pub").trim();
+    action = "exists";
+  } else {
+    publicKey = fx.genEd25519(devicePrivatePath, `${opts.user}@${hostname} (zeta-device)`).trim();
+    action = "generated";
+  }
+
+  if (wantPublish) {
+    fx.mkdirp(dirOf(devicePublicPath));
+    fx.writeText(devicePublicPath, publicKey.endsWith("\n") ? publicKey : publicKey + "\n");
+    return { dryRun: false, hostname, devicePrivatePath, devicePublicPath, action, publicKey, published: true };
+  }
+
+  return { dryRun: false, hostname, devicePrivatePath, devicePublicPath, action, publicKey, published: false };
+}
+
+function dirOf(p: string): string {
+  const i = p.lastIndexOf("/");
+  return i >= 0 ? p.slice(0, i) : ".";
+}
+
+/** The REAL host effects (used by the CLI). ssh-keygen generates in-process; the
+ *  private key file is created under umask 077 by ssh-keygen — never read by us. */
+export function realEffects(): MachineEffects {
+  return {
+    hostname: () => osHostname(),
+    exists: (p) => existsSync(p),
+    readText: (p) => readFileSync(p, "utf8"),
+    writeText: (p, c) => writeFileSync(p, c, { mode: 0o644 }),
+    mkdirp: (p) => mkdirSync(p, { recursive: true }),
+    genEd25519: (keyPath, comment) => {
+      mkdirSync(dirOf(keyPath), { recursive: true, mode: 0o700 });
+      const prevUmask = process.umask(0o077); // private key must not be group/other readable
+      try {
+        // ssh-keygen generates the key itself — no secret on argv. -N "" = no passphrase
+        // (standard for an unattended device key); the private file stays local (umask 077).
+        const r = spawnSync(
+          "ssh-keygen",
+          ["-t", "ed25519", "-f", keyPath, "-N", "", "-C", comment],
+          { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+        );
+        if (r.status !== 0) {
+          throw new Error(`ssh-keygen failed (status ${r.status ?? "signal"}): ${r.stderr ?? ""}`);
+        }
+      } finally {
+        process.umask(prevUmask);
+      }
+      // Read back ONLY the public half.
+      return readFileSync(keyPath + ".pub", "utf8");
+    },
+  };
+}


### PR DESCRIPTION
First **SAFE, read-mostly** slice of the unified key-onboarding workitem `081KVM1TK3Z08QG0R0002959G6`. Extends the existing per-PERSONA keyring tooling (`tools/setup/persona-keys/`) with the **per-MACHINE** axis. **No seeds / CA / persona keys are generated here** — only a per-host device keypair, and only when explicitly run.

## What

- **`machine.ts`** — pure oracle + one gated side-effect:
  - `checkPresence` / `formatStatus` — **READ-ONLY** two-part `(user × machine)` presence check (workitem §"Two-part presence check"): is the **user keyring** present? is **this dev machine's** device key present? Checked **independently** (the workitem's "new flasher box" case — user key set up, this machine's key not).
  - `ensureMachineKey` — generate **only** a per-host **ed25519** device keypair via `ssh-keygen` when absent; **idempotent** (a second run reports `exists`, does not regenerate). `--dry-run` generates nothing.
- **`machine-cli.ts`** — `status`/`whoami` + `machine` modes (thin shell, mirrors `gen.ts`).
- **`machine.test.ts`** — conformance against a throwaway `mktemp -d` via injected effects, plus a real-`ssh-keygen`-into-temp test (never `~/.ssh`, never committed).
- **README** — new section documenting modes + matched security invariants.

## How secrets are handled (invariants matched to the persona-keys README)

- NO seed, NO CA key, NO persona key — only a per-host device keypair.
- Private key never to argv / stdout / git: `ssh-keygen` writes it locally under `umask 077` (`~/.config/zeta/machine/`); only the **PUBLIC** key is read back.
- Only PUBLIC keys published (`maintainers/<user>/machines/<host>.pub`); the code **supports** publishing, this PR does **not** commit a generated key.
- Noninterference (manifesto §13): host env (hostname, fs, ssh-keygen) enters **only** via injected `MachineEffects` — so status + dry-run are deterministic and temp-dir-testable.

## Out of scope (LATER slices — explicitly NOT built here)

SSH-CA cert signing, GitHub pubkey upload, cluster node-trust injection.

## Gate

- `bun machine.test.ts` green (7/7, temp dir, no real keys); full persona-keys suite **29/29** (no regression).
- `bun src/Core.TypeScript/lint/lint-typescript.ts` green; markdownlint clean.
- `--dry-run` verified: generates **nothing** (no `~/.config/zeta/machine/` created).
- **No real keys / CA / seeds generated or committed** (git status: 3 new `.ts` files + README only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)