### PR TITLE
feat(core): export room horizon heat

### DIFF
--- a/src/Core/RoomHorizon.fs
+++ b/src/Core/RoomHorizon.fs
@@ -25,6 +25,7 @@ module RoomHorizon =
         | InferenceFeedback of PredictionInference.Feedback
         | VisionFeedback of Vision.GrowthFeedback
         | HorizonFeedback of BoundedGSetError
+        | HeatFeedback of HeatSinkFeedback
 
     type Report<'K, 'S when 'K : comparison> =
         { HorizonBefore: BoundedGSet<'K>
@@ -68,13 +69,16 @@ module RoomHorizon =
         |> List.choose id
 
     /// Emit finite horizon heat through an injected host/room boundary.
-    let emitHeat (sink: IHeatSink) (source: string) (report: Report<'K, 'S>) : Result<unit, HeatSinkFeedback> =
+    let emitHeat (sink: IHeatSink) (source: string) (report: Report<'K, 'S>) : Result<unit, Feedback> =
         let rec loop signatures =
             result {
                 match signatures with
                 | [] -> return ()
                 | signature :: tail ->
-                    do! sink.Emit signature
+                    do!
+                        sink.Emit signature
+                        |> Result.mapError HeatFeedback
+
                     return! loop tail
             }
 
@@ -193,6 +197,20 @@ module RoomHorizon =
             return! reportFromOrdered current tank orderedCandidates
         }
 
+    /// Update and immediately export any finite-horizon heat/backpressure.
+    let updateWithHeat
+        (sink: IHeatSink)
+        (source: string)
+        (current: BoundedGSet<'K>)
+        (tank: SoftThrottle.Tank)
+        (candidates: Candidate<'K, 'S> list)
+        : Result<Report<'K, 'S>, Feedback> =
+        result {
+            let! report = update current tank candidates
+            do! emitHeat sink source report
+            return report
+        }
+
     /// Start from an empty bounded horizon and admit the affordable visible
     /// prefix of candidates.
     let admit
@@ -206,6 +224,20 @@ module RoomHorizon =
                 |> Result.mapError HorizonFeedback
 
             return! update empty tank candidates
+        }
+
+    /// Admit from an empty horizon and immediately export heat/backpressure.
+    let admitWithHeat
+        (sink: IHeatSink)
+        (source: string)
+        (config: BoundedGSetConfig)
+        (tank: SoftThrottle.Tank)
+        (candidates: Candidate<'K, 'S> list)
+        : Result<Report<'K, 'S>, Feedback> =
+        result {
+            let! report = admit config tank candidates
+            do! emitHeat sink source report
+            return report
         }
 
     /// Project exact inference into a finite room view. Posterior truth stays
@@ -238,6 +270,22 @@ module RoomHorizon =
                   Horizon = horizon }
         }
 
+    /// Project inference into the horizon and immediately export horizon heat.
+    let updateInferenceWithHeat
+        (sink: IHeatSink)
+        (source: string)
+        (current: BoundedGSet<'K>)
+        (tank: SoftThrottle.Tank)
+        (keyOf: PredictionInference.Scored<'S> -> 'K)
+        (priorityOf: PredictionInference.Scored<'S> -> PredictionInference.BranchPriority)
+        (inference: PredictionInference.Inference<'S>)
+        : Result<InferenceReport<'K, 'S>, Feedback> =
+        result {
+            let! report = updateInference current tank keyOf priorityOf inference
+            do! emitHeat sink source report.Horizon
+            return report
+        }
+
     /// Start from an empty bounded room view and project exact inference into
     /// the affordable visible prefix.
     let admitInference
@@ -253,4 +301,20 @@ module RoomHorizon =
                 |> Result.mapError HorizonFeedback
 
             return! updateInference empty tank keyOf priorityOf inference
+        }
+
+    /// Project inference from an empty horizon and immediately export heat.
+    let admitInferenceWithHeat
+        (sink: IHeatSink)
+        (source: string)
+        (config: BoundedGSetConfig)
+        (tank: SoftThrottle.Tank)
+        (keyOf: PredictionInference.Scored<'S> -> 'K)
+        (priorityOf: PredictionInference.Scored<'S> -> PredictionInference.BranchPriority)
+        (inference: PredictionInference.Inference<'S>)
+        : Result<InferenceReport<'K, 'S>, Feedback> =
+        result {
+            let! report = admitInference config tank keyOf priorityOf inference
+            do! emitHeat sink source report.Horizon
+            return report
         }

--- a/tests/Tests.FSharp/RoomHorizon.Tests.fs
+++ b/tests/Tests.FSharp/RoomHorizon.Tests.fs
@@ -124,16 +124,30 @@ let ``rolling horizon exports forgetting as host heat`` () =
     Assert.Equal("room-horizon.forgotten", sink.Signatures.[0].Kind)
 
 [<Fact>]
-let ``rolling horizon preserves heat sink backpressure as typed feedback`` () =
+let ``updateWithHeat exports rolling horizon forgetting through injected host port`` () =
     let current =
         BoundedGSet.ofSeq<int> (config 2 BoundedGSetForgetPolicy.ForgetLowest) [ 1; 2 ]
         |> mustOk
         |> fun projection -> projection.State
 
+    let sink = RecordingHeatSink()
+
     let report =
         [ candidate 3 "newer" "C" 1L 1L 1L ]
-        |> RH.update current (SoftThrottle.tank 1.0 0.0)
+        |> RH.updateWithHeat (sink :> IHeatSink) "vision-test" current (SoftThrottle.tank 1.0 0.0)
         |> mustOk
+
+    Assert.Equal<int list>([ 2; 3 ], report.HorizonAfter |> BoundedGSet.toList)
+    Assert.Equal<int list>([ 1 ], report.HorizonHeat.Forgotten |> GSet.toList)
+    Assert.Single(sink.Signatures) |> ignore
+    Assert.Equal("room-horizon.forgotten", sink.Signatures.[0].Kind)
+
+[<Fact>]
+let ``rolling horizon preserves heat sink backpressure as typed feedback`` () =
+    let current =
+        BoundedGSet.ofSeq<int> (config 2 BoundedGSetForgetPolicy.ForgetLowest) [ 1; 2 ]
+        |> mustOk
+        |> fun projection -> projection.State
 
     let sink =
         BoundedHeatSink
@@ -143,9 +157,12 @@ let ``rolling horizon preserves heat sink backpressure as typed feedback`` () =
     let filler = HeatSignature.ofMass "occupied" "heat.fill" 1 1.0 "pre-fill bounded heat sink"
     (sink :> IHeatSink).Emit filler |> mustOk
 
-    match RH.emitHeat (sink :> IHeatSink) "vision-test" report with
-    | Ok () -> Assert.Fail("expected bounded heat sink backpressure")
-    | Error(HeatSinkFeedback.Backpressure(heat, capacity, count)) ->
+    match
+        [ candidate 3 "newer" "C" 1L 1L 1L ]
+        |> RH.updateWithHeat (sink :> IHeatSink) "vision-test" current (SoftThrottle.tank 1.0 0.0)
+    with
+    | Ok _ -> Assert.Fail("expected bounded heat sink backpressure")
+    | Error(RH.HeatFeedback(HeatSinkFeedback.Backpressure(heat, capacity, count))) ->
         Assert.Equal("room-horizon.forgotten", heat.Kind)
         Assert.Equal(1, capacity)
         Assert.Equal(2, count)
@@ -158,9 +175,11 @@ let ``no-forget horizon exports paid finite-view rejection as backpressure heat`
         |> mustOk
         |> fun projection -> projection.State
 
+    let sink = RecordingHeatSink()
+
     let report =
         [ candidate 2 "second" "B" 1L 1L 1L ]
-        |> RH.update current (SoftThrottle.tank 1.0 0.0)
+        |> RH.updateWithHeat (sink :> IHeatSink) "vision-test" current (SoftThrottle.tank 1.0 0.0)
         |> mustOk
 
     Assert.Equal<int list>([ 2 ], report.RejectedByHorizon |> GSet.toList)
@@ -171,6 +190,8 @@ let ``no-forget horizon exports paid finite-view rejection as backpressure heat`
     Assert.Single(signatures) |> ignore
     Assert.Equal("room-horizon.backpressure", signatures.[0].Kind)
     Assert.Equal(1, signatures.[0].Units)
+    Assert.Single(sink.Signatures) |> ignore
+    Assert.Equal("room-horizon.backpressure", sink.Signatures.[0].Kind)
 
 [<Fact>]
 let ``byte-deferred futures stay cold until they enter the room`` () =
@@ -248,3 +269,31 @@ let ``inference projection reports finite horizon rejection after byte admission
     Assert.Equal<int list>([ 2; 3 ], report.Horizon.HorizonAfter |> BoundedGSet.toList)
     Assert.Empty(report.Horizon.RetainedKeys |> GSet.toList)
     Assert.Equal<int list>([ 1 ], report.Horizon.RejectedByHorizon |> GSet.toList)
+
+[<Fact>]
+let ``admitInferenceWithHeat exports finite horizon pressure after exact inference`` () =
+    let inference =
+        [ inferredCandidate "first" "A" 1L 1L 1L
+          inferredCandidate "second" "B" 1L 1L 1L ]
+        |> PI.infer
+        |> mustOk
+
+    let keyOf (scored: PI.Scored<string>) =
+        if scored.Candidate.Label = "first" then 1 else 2
+
+    let sink = RecordingHeatSink()
+
+    let report =
+        RH.admitInferenceWithHeat
+            (sink :> IHeatSink)
+            "vision-test"
+            (config 1 BoundedGSetForgetPolicy.RejectNew)
+            (SoftThrottle.tank 2.0 0.0)
+            keyOf
+            (fun _ -> PI.neutralPriority)
+            inference
+        |> mustOk
+
+    Assert.Equal<int list>([ 2 ], report.Horizon.RejectedByHorizon |> GSet.toList)
+    Assert.Single(sink.Signatures) |> ignore
+    Assert.Equal("room-horizon.backpressure", sink.Signatures.[0].Kind)


### PR DESCRIPTION
## Summary
- Add typed RoomHorizon heat feedback so heat-sink backpressure flows through RoomHorizon.Feedback.
- Add update/admit/inference WithHeat wrappers that mirror RoomAdmission and immediately export finite-horizon heat through an injected sink.
- Extend tests for rolling forgetting, no-forget backpressure, heat-sink saturation, and inference projection heat export.

## Verification
- bun src/Core.TypeScript/hygiene/audit-agencysignature-main-tip.ts --commit HEAD
- dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter "FullyQualifiedName~RoomHorizonTests|FullyQualifiedName~BoundedGSetTests|FullyQualifiedName~RoomAdmissionTests|FullyQualifiedName~RoomBoundaryTests|FullyQualifiedName~RoomRunTests"
- dotnet build -c Release
- dotnet test Zeta.sln -c Release
- bun run preflight:quick

## Note
- One widened build attempt hit transient local csc exit 139 in Core.CSharp.Mediator.Handlers. The isolated project build passed immediately, and the full release build passed on rerun with 0 warnings / 0 errors.
