### PR TITLE
feat(keys): biometric-gated GitHub PUBLIC-key publish (Touch ID gate, fail-closed)

### DIFF
--- a/tools/setup/persona-keys/publish-cli.ts
+++ b/tools/setup/persona-keys/publish-cli.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env bun
+// Zeta biometric-gated GitHub PUBLIC-key publish CLI — a thin shell around the pure
+// publisher (publish.ts). It reads THIS machine's PUBLIC device key, requires a biometric
+// confirmation (macOS Touch ID via pam_tid; Windows Hello = seam/TODO), and ONLY then
+// uploads the PUBLIC key to GitHub via `gh ssh-key add`. PUBLIC key only — never a secret.
+// `--dry-run` prompts NOTHING and writes NOTHING. See publish.ts for the security invariants.
+//
+// Usage:
+//   bun publish-cli.ts --user aaron                       # Touch ID, then publish this host's pubkey
+//   bun publish-cli.ts --user aaron --host mymac          # explicit hostname for the conventional path
+//   bun publish-cli.ts --user aaron --key path/to/x.pub   # explicit pubkey path
+//   bun publish-cli.ts --user aaron --type signing        # add as a signing key (default: authentication)
+//   bun publish-cli.ts --user aaron --dry-run             # NO biometric prompt, NO GitHub write
+import { dirname, resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
+import { formatResult, hostHostname, publishKey, realEffects, type PublishOptions } from "./publish.ts";
+
+const args = process.argv.slice(2);
+const flag = (n: string): boolean => args.includes(n);
+const opt = (n: string): string | undefined => {
+  const i = args.indexOf(n);
+  return i >= 0 ? args[i + 1] : undefined;
+};
+
+const here = dirname(fileURLToPath(import.meta.url));
+// Repo root: 3 levels up from tools/setup/persona-keys/ (override with --repo-root).
+const repoRoot = opt("--repo-root") ?? resolvePath(here, "..", "..", "..");
+const user = opt("--user");
+const hostname = opt("--host") ?? hostHostname();
+const keyPath = opt("--key");
+const keyTypeArg = opt("--type");
+const dryRun = flag("--dry-run");
+
+function usage(): void {
+  process.stderr.write(
+    "usage: bun publish-cli.ts --user <gh-user> [--host <name>] [--key <pubfile>] " +
+      "[--type authentication|signing] [--dry-run] [--repo-root <path>]\n" +
+      "  Biometric-gated (Touch ID / Windows Hello), fail-closed, PUBLIC key ONLY.\n",
+  );
+}
+
+async function main(): Promise<number> {
+  if (user === undefined || user.trim().length === 0) {
+    usage();
+    process.stderr.write("error: --user <gh-user> is required\n");
+    return 2;
+  }
+  if (keyTypeArg !== undefined && keyTypeArg !== "authentication" && keyTypeArg !== "signing") {
+    usage();
+    process.stderr.write(`error: --type must be 'authentication' or 'signing' (got '${keyTypeArg}')\n`);
+    return 2;
+  }
+  const keyType: "authentication" | "signing" = keyTypeArg === "signing" ? "signing" : "authentication";
+
+  const opts: PublishOptions = {
+    user,
+    repoRoot,
+    hostname,
+    keyType,
+    dryRun,
+    ...(keyPath !== undefined ? { keyPath } : {}),
+  };
+
+  const fx = realEffects();
+  const res = await publishKey(fx, opts);
+  process.stdout.write(formatResult(res) + "\n");
+
+  // Exit code: 0 published / would-publish; 1 aborted (biometric / no key / private material).
+  return res.action === "published" || res.action === "would-publish" ? 0 : 1;
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((e: unknown) => {
+    process.stderr.write((e instanceof Error ? e.message : String(e)) + "\n");
+    process.exit(1);
+  });

--- a/tools/setup/persona-keys/publish.test.ts
+++ b/tools/setup/persona-keys/publish.test.ts
@@ -1,0 +1,193 @@
+// publish.ts conformance — the biometric-gated GitHub PUBLIC-key publisher. EVERY test
+// runs against FIXTURES via the injected PublishEffects — NEVER a real biometric prompt,
+// NEVER a real `gh ssh-key add`, NEVER a network call, NEVER a secret. Proves the security
+// contract: biometric gate FIRST + fail-closed (ghAddKey NOT called when biometric returns
+// false; IS called with the PUBLIC key when true), PUBLIC-key-only refusal, --dry-run does
+// NO prompt + NO write, and the readout shape.
+// Run: bun test publish.test.ts   (from tools/setup/persona-keys)
+import { test, expect } from "bun:test";
+import {
+  detectBiometricPlatform,
+  formatResult,
+  looksPrivate,
+  publicKeyFingerprint,
+  publishKey,
+  publishTitle,
+  type BiometricResult,
+  type PublishEffects,
+} from "./publish.ts";
+
+const PUB = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDwJVbQNiFzUCiOhc aaron@mymac (zeta-device)";
+const PRIVATE_PEM =
+  "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEFAKEFAKE\n-----END OPENSSH PRIVATE KEY-----";
+
+/** A spying fixture door. Records every biometric call + ghAddKey call so a test can
+ *  assert ORDER (biometric before write) and that the write NEVER happens when the gate
+ *  fails. The biometric outcome is whatever `biometric` is set to (fake — no real prompt). */
+function fixtureEffects(opts: {
+  keyText?: string;
+  keyExists?: boolean;
+  biometric: BiometricResult;
+}): {
+  fx: PublishEffects;
+  calls: { biometricPrompts: string[]; ghAdds: { publicKey: string; title: string; keyType: string }[] };
+} {
+  const calls = {
+    biometricPrompts: [] as string[],
+    ghAdds: [] as { publicKey: string; title: string; keyType: string }[],
+  };
+  const fx: PublishEffects = {
+    biometricAuth: async (prompt) => {
+      calls.biometricPrompts.push(prompt);
+      return opts.biometric;
+    },
+    exists: () => opts.keyExists ?? true,
+    readText: () => opts.keyText ?? PUB + "\n",
+    ghAddKey: async ({ publicKey, title, keyType }) => {
+      calls.ghAdds.push({ publicKey, title, keyType });
+    },
+  };
+  return { fx, calls };
+}
+
+test("gated-success: biometric ok:true → ghAddKey IS called with the PUBLIC key + title", async () => {
+  const { fx, calls } = fixtureEffects({ biometric: { ok: true, platform: "macos-touchid" } });
+  const res = await publishKey(fx, { user: "aaron", repoRoot: "/repo", hostname: "mymac" });
+  expect(res.action).toBe("published");
+  expect(calls.biometricPrompts).toHaveLength(1); // gate WAS invoked
+  expect(calls.ghAdds).toHaveLength(1); // write happened
+  expect(calls.ghAdds[0]?.publicKey).toContain("ssh-ed25519");
+  expect(calls.ghAdds[0]?.title).toBe("aaron@mymac (zeta)");
+  expect(calls.ghAdds[0]?.keyType).toBe("authentication");
+});
+
+test("FAIL-CLOSED: biometric ok:false → ghAddKey is NEVER called, publish aborts", async () => {
+  const { fx, calls } = fixtureEffects({
+    biometric: { ok: false, platform: "macos-touchid", reason: "declined" },
+  });
+  const res = await publishKey(fx, { user: "aaron", repoRoot: "/repo", hostname: "mymac" });
+  expect(res.action).toBe("aborted-biometric");
+  expect(calls.biometricPrompts).toHaveLength(1); // gate WAS invoked first
+  expect(calls.ghAdds).toHaveLength(0); // NO GitHub write on biometric failure
+  expect(res.error).toContain("declined");
+});
+
+test("FAIL-CLOSED: unsupported platform (biometric ok:false) → no write", async () => {
+  const { fx, calls } = fixtureEffects({
+    biometric: { ok: false, platform: "unsupported", reason: "no biometric on this host" },
+  });
+  const res = await publishKey(fx, { user: "aaron", repoRoot: "/repo" });
+  expect(res.action).toBe("aborted-biometric");
+  expect(calls.ghAdds).toHaveLength(0);
+});
+
+test("PUBLIC-ONLY: a private-key payload aborts BEFORE the biometric prompt + NO write", async () => {
+  const { fx, calls } = fixtureEffects({
+    keyText: PRIVATE_PEM,
+    biometric: { ok: true, platform: "macos-touchid" }, // even with a passing gate…
+  });
+  const res = await publishKey(fx, { user: "aaron", repoRoot: "/repo", hostname: "mymac" });
+  expect(res.action).toBe("aborted-private-material");
+  expect(calls.biometricPrompts).toHaveLength(0); // never even prompted
+  expect(calls.ghAdds).toHaveLength(0); // never uploaded
+});
+
+test("the uploaded payload NEVER matches /PRIVATE KEY/ (public-only invariant)", async () => {
+  const { fx, calls } = fixtureEffects({ biometric: { ok: true, platform: "macos-touchid" } });
+  await publishKey(fx, { user: "aaron", repoRoot: "/repo", hostname: "mymac" });
+  expect(calls.ghAdds).toHaveLength(1);
+  expect(calls.ghAdds[0]?.publicKey).not.toMatch(/PRIVATE KEY/);
+});
+
+test("aborted-no-key: missing pubkey → abort, no prompt, no write", async () => {
+  const { fx, calls } = fixtureEffects({
+    keyExists: false,
+    biometric: { ok: true, platform: "macos-touchid" },
+  });
+  const res = await publishKey(fx, { user: "aaron", repoRoot: "/repo", hostname: "mymac" });
+  expect(res.action).toBe("aborted-no-key");
+  expect(calls.biometricPrompts).toHaveLength(0);
+  expect(calls.ghAdds).toHaveLength(0);
+});
+
+test("--dry-run: NO biometric prompt, NO GitHub write, reports would-publish", async () => {
+  const { fx, calls } = fixtureEffects({ biometric: { ok: true, platform: "macos-touchid" } });
+  const res = await publishKey(fx, { user: "aaron", repoRoot: "/repo", hostname: "mymac", dryRun: true });
+  expect(res.action).toBe("would-publish");
+  expect(calls.biometricPrompts).toHaveLength(0); // dry-run NEVER prompts
+  expect(calls.ghAdds).toHaveLength(0); // dry-run NEVER writes
+  expect(res.fingerprint).toBeDefined();
+  expect(formatResult(res)).toContain("NO biometric prompt performed");
+  expect(formatResult(res)).toContain("NO GitHub write performed");
+});
+
+test("signing key type flows through to ghAddKey", async () => {
+  const { fx, calls } = fixtureEffects({ biometric: { ok: true, platform: "macos-touchid" } });
+  const res = await publishKey(fx, {
+    user: "aaron",
+    repoRoot: "/repo",
+    hostname: "mymac",
+    keyType: "signing",
+  });
+  expect(res.action).toBe("published");
+  expect(calls.ghAdds[0]?.keyType).toBe("signing");
+});
+
+test("explicit --key path is read instead of the conventional machine path", async () => {
+  const { fx, calls } = fixtureEffects({ biometric: { ok: true, platform: "macos-touchid" } });
+  const res = await publishKey(fx, {
+    user: "aaron",
+    repoRoot: "/repo",
+    hostname: "mymac",
+    keyPath: "/some/explicit/key.pub",
+  });
+  expect(res.keyPath).toBe("/some/explicit/key.pub");
+  expect(res.action).toBe("published");
+  expect(calls.ghAdds).toHaveLength(1);
+});
+
+test("the conventional path is maintainers/<user>/machines/<host>.pub when --key omitted", async () => {
+  const { fx } = fixtureEffects({ biometric: { ok: true, platform: "macos-touchid" } });
+  const res = await publishKey(fx, { user: "aaron", repoRoot: "/repo", hostname: "MyMac.local" });
+  expect(res.keyPath).toBe("/repo/maintainers/aaron/machines/mymac.local.pub");
+});
+
+test("looksPrivate: catches OpenSSH/PEM/PGP private headers, passes a public line", () => {
+  expect(looksPrivate(PRIVATE_PEM)).toBe(true);
+  expect(looksPrivate("-----BEGIN RSA PRIVATE KEY-----\nx\n-----END RSA PRIVATE KEY-----")).toBe(true);
+  expect(looksPrivate("-----BEGIN PGP PRIVATE KEY BLOCK-----\nx")).toBe(true);
+  expect(looksPrivate(PUB)).toBe(false);
+});
+
+test("publishTitle + fingerprint: stable, public-derived, recognizable", () => {
+  expect(publishTitle("aaron", "MyMac.local")).toBe("aaron@mymac.local (zeta)");
+  // fingerprint is deterministic over the public line + never leaks the key bytes verbatim
+  const fp = publicKeyFingerprint(PUB);
+  expect(fp).toMatch(/^key-[0-9a-f]{16}$/);
+  expect(publicKeyFingerprint(PUB)).toBe(fp); // stable
+  expect(fp).not.toContain("AAAAC3"); // not the key blob itself
+});
+
+test("detectBiometricPlatform: darwin→touchid, win32→hello, else→unsupported", () => {
+  expect(detectBiometricPlatform("darwin")).toBe("macos-touchid");
+  expect(detectBiometricPlatform("win32")).toBe("windows-hello");
+  expect(detectBiometricPlatform("linux")).toBe("unsupported");
+});
+
+test("formatResult published readout: shows biometric → ✅ → published <fp> github:<user>", () => {
+  const line = formatResult({
+    dryRun: false,
+    user: "aaron",
+    hostname: "mymac",
+    keyPath: "/repo/maintainers/aaron/machines/mymac.pub",
+    keyType: "authentication",
+    title: "aaron@mymac (zeta)",
+    action: "published",
+    fingerprint: "key-0123456789abcdef",
+    biometric: { ok: true, platform: "macos-touchid" },
+  });
+  expect(line).toContain("biometric");
+  expect(line).toContain("published");
+  expect(line).toContain("github:aaron");
+  expect(line).toContain("key-0123456789abcdef");
+});

--- a/tools/setup/persona-keys/publish.ts
+++ b/tools/setup/persona-keys/publish.ts
@@ -1,0 +1,358 @@
+// Zeta biometric-gated GitHub PUBLIC-key publish — the OUTWARD-WRITE slice of the
+// unified key-onboarding flow (workitem 081KVM1TK3Z08QG0R0002959G6 §"publish to GitHub").
+// Aaron (2026-06-21): *"we need to code this [publish to GitHub] and make sure it uses
+// mac fingerprint / windows hello auth … clean and smooth and automatic."*
+//
+// This slice UPLOADS the per-machine PUBLIC device key (produced by machine.ts and
+// written to maintainers/<user>/machines/<host>.pub) to the operator's GitHub account
+// via `gh ssh-key add` — but ONLY after a biometric confirmation succeeds (fail-closed).
+//
+// SECURITY INVARIANTS (security-sensitive slice — honesty over green):
+//  1. BIOMETRIC GATE FIRST + FAIL-CLOSED — before ANY GitHub write, biometricAuth()
+//     MUST return ok:true. If it returns false / throws / the platform is unsupported,
+//     the publish ABORTS and `gh` is NEVER invoked. There is no `gh` write path that
+//     bypasses the gate. (macOS = Touch ID via pam_tid/sudo, reusing the zflash /
+//     biometric-sudo-handler pattern; Windows Hello = seam-wired, see realEffects.)
+//  2. PUBLIC KEY ONLY — we read, upload, and print ONLY the `.pub` artifact. No seed,
+//     no private key, no CA. The payload is asserted to NOT match /PRIVATE KEY/ before
+//     it crosses the GitHub door — a defense-in-depth refusal, not just a convention.
+//  3. NONINTERFERENCE (manifesto §13) — the biometric prompt, the filesystem read of
+//     the pubkey, and the `gh` invocation enter ONLY through the injected
+//     `PublishEffects` doors. Tests inject fakes (no real prompt, no real network/gh
+//     write); `--dry-run` performs NEITHER a prompt NOR a write. The REAL doors live
+//     only in `realEffects()`.
+//
+// Anchors (Beacon): Touch ID PAM (`pam_tid.so`) biometric sudo — Apple PAM / the
+// repo's biometric-sudo ADR (2026-05-29) + zflash's Touch-ID-gated dd. Windows Hello
+// programmatic consent — `Windows.Security.Credentials.UI.UserConsentVerifier`
+// (Microsoft WinRT). GitHub public-key upload — `gh ssh-key add` (GitHub CLI manual);
+// SSH ed25519 — Bernstein et al. (2011). Physical-presence consent as a write floor —
+// FIDO/WebAuthn user-verification framing.
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir, hostname as osHostname, platform as osPlatform } from "node:os";
+import { join } from "node:path";
+import { publishPubPath, sanitizeHostname } from "./machine.ts";
+
+/** The biometric platforms we know how to gate on. `unsupported` ⇒ fail-closed. */
+export type BiometricPlatform = "macos-touchid" | "windows-hello" | "unsupported";
+
+/** The outcome of a biometric confirmation attempt — never carries a secret. */
+export interface BiometricResult {
+  /** True ONLY if the operator physically confirmed (Touch ID / Windows Hello). */
+  readonly ok: boolean;
+  /** Which mechanism was attempted (for the readout + honest "unsupported" reporting). */
+  readonly platform: BiometricPlatform;
+  /** Present when ok === false — why (unsupported platform, declined, timeout, error). */
+  readonly reason?: string;
+}
+
+/** The doors for ambient influence — the ONLY channel for biometric + filesystem + the
+ *  GitHub write (noninterference §13). Tests/dry-run inject fakes; the CLI injects real. */
+export interface PublishEffects {
+  /** Require a biometric physical-presence confirmation. MUST be called and MUST return
+   *  ok:true before any GitHub write. Reused machinery: Touch ID (pam_tid) on macOS;
+   *  Windows Hello on Windows. NEVER prompts in tests/dry-run (a fake is injected). */
+  readonly biometricAuth: (prompt: string) => Promise<BiometricResult>;
+  /** True iff a path exists (presence-only; never reads secret bytes). */
+  readonly exists: (path: string) => boolean;
+  /** Read a PUBLIC text artifact (the `<host>.pub`). Never used on a private path. */
+  readonly readText: (path: string) => string;
+  /** Upload a PUBLIC key to GitHub (`gh ssh-key add`). The ONLY GitHub-write door.
+   *  Receives the PUBLIC key TEXT (already public-asserted) + a title + the key type. */
+  readonly ghAddKey: (args: {
+    readonly publicKey: string;
+    readonly title: string;
+    readonly keyType: "authentication" | "signing";
+  }) => Promise<void>;
+}
+
+/** Options for a publish run. `keyPath` overrides the conventional machine-pub path. */
+export interface PublishOptions {
+  readonly user: string;
+  readonly repoRoot: string;
+  /** Explicit pubkey path; else maintainers/<user>/machines/<host>.pub is used. */
+  readonly keyPath?: string;
+  /** Hostname override (else the injected hostname). Sanitized for the conventional path. */
+  readonly hostname?: string;
+  /** Add as an authentication key (default) and/or a signing key. */
+  readonly keyType?: "authentication" | "signing";
+  /** When true: NOTHING is prompted and NOTHING is written — reports intent only. */
+  readonly dryRun?: boolean;
+}
+
+/** What a publish run did (or WOULD do, on dry-run). No private material ever appears. */
+export interface PublishResult {
+  readonly dryRun: boolean;
+  readonly user: string;
+  readonly hostname: string;
+  readonly keyPath: string;
+  readonly keyType: "authentication" | "signing";
+  readonly title: string;
+  /** "would-publish" (dry-run) | "published" | "aborted-no-key" | "aborted-biometric"
+   *  | "aborted-private-material". Only "published" implies `gh` was invoked. */
+  readonly action:
+    | "would-publish"
+    | "published"
+    | "aborted-no-key"
+    | "aborted-biometric"
+    | "aborted-private-material";
+  /** The biometric outcome (absent on dry-run — dry-run NEVER prompts). */
+  readonly biometric?: BiometricResult;
+  /** A stable public-derived fingerprint, for the readout. Never the key bytes. */
+  readonly fingerprint?: string;
+  /** Present when the run aborted — the operator-facing reason. */
+  readonly error?: string;
+}
+
+/** Marker substrings that mean "this is private material" — refuse to upload if present.
+ *  Covers OpenSSH + PEM/PKCS#8 private-key headers across formats. */
+const PRIVATE_KEY_MARKERS: readonly string[] = [
+  "PRIVATE KEY",
+  "BEGIN OPENSSH PRIVATE KEY",
+  "BEGIN RSA PRIVATE KEY",
+  "BEGIN EC PRIVATE KEY",
+  "BEGIN DSA PRIVATE KEY",
+  "BEGIN PGP PRIVATE KEY",
+];
+
+/** True iff the text contains ANY private-key marker (case-insensitive defense-in-depth).
+ *  A PUBLIC key line (`ssh-ed25519 AAAA… comment`) never matches. */
+export function looksPrivate(text: string): boolean {
+  const up = text.toUpperCase();
+  return PRIVATE_KEY_MARKERS.some((m) => up.includes(m));
+}
+
+/** The conventional GitHub key title: "<user>@<host> (zeta)" — recognizable + stable. */
+export function publishTitle(user: string, hostname: string): string {
+  return `${user}@${sanitizeHostname(hostname)} (zeta)`;
+}
+
+/** A stable, public-derived fingerprint token of the public-key line (for the readout,
+ *  not for trust). Derived from PUBLIC bytes only; never the key. Computed without
+ *  importing crypto into the pure core, so it stays DST-deterministic + dependency-free. */
+export function publicKeyFingerprint(pubLine: string): string {
+  let h = 0n;
+  const MOD = (1n << 64n) - 59n; // a large 64-bit-ish prime modulus for a stable digest
+  for (let i = 0; i < pubLine.length; i++) {
+    h = (h * 1000003n + BigInt(pubLine.charCodeAt(i))) % MOD;
+  }
+  return `key-${h.toString(16).padStart(16, "0")}`;
+}
+
+/** Resolve the pubkey path: explicit `keyPath` wins; else the conventional machine path. */
+export function resolveKeyPath(opts: PublishOptions, hostname: string): string {
+  return opts.keyPath ?? publishPubPath(opts.repoRoot, opts.user, hostname);
+}
+
+/**
+ * Publish THIS machine's PUBLIC key to GitHub — biometric-gated + fail-closed.
+ *
+ * Order of operations (the security contract):
+ *   1. Resolve + READ the public key. If absent → abort ("aborted-no-key"); no prompt.
+ *   2. Assert it is NOT private material. If it looks private → abort
+ *      ("aborted-private-material"); `gh` is NEVER invoked.
+ *   3. On dry-run: report "would-publish" — NO biometric prompt, NO `gh` write.
+ *   4. BIOMETRIC GATE: call biometricAuth(). If ok !== true → abort
+ *      ("aborted-biometric"); `ghAddKey` is NEVER called.
+ *   5. Only on biometric success: `ghAddKey({ publicKey, title, keyType })`.
+ *
+ * PURE over the injected effects — deterministic + testable, never a real prompt/network.
+ */
+export async function publishKey(fx: PublishEffects, opts: PublishOptions): Promise<PublishResult> {
+  const hostname = sanitizeHostname(opts.hostname ?? "this-host");
+  const keyType = opts.keyType ?? "authentication";
+  const keyPath = resolveKeyPath(opts, hostname);
+  const title = publishTitle(opts.user, hostname);
+  const dryRun = opts.dryRun === true;
+
+  const base = { dryRun, user: opts.user, hostname, keyPath, keyType, title } as const;
+
+  // 1. The public key must exist.
+  if (!fx.exists(keyPath)) {
+    return {
+      ...base,
+      action: "aborted-no-key",
+      error: `no public key at ${keyPath} — run the \`machine\` slice (with --publish) first`,
+    };
+  }
+  const publicKey = fx.readText(keyPath).trim();
+
+  // 2. PUBLIC-ONLY invariant — refuse to upload anything that smells private.
+  if (looksPrivate(publicKey)) {
+    return {
+      ...base,
+      action: "aborted-private-material",
+      error: `${keyPath} contains PRIVATE-key material — refusing to upload (public-only)`,
+    };
+  }
+  const fingerprint = publicKeyFingerprint(publicKey);
+
+  // 3. Dry-run: report intent. NO biometric prompt, NO GitHub write.
+  if (dryRun) {
+    return { ...base, action: "would-publish", fingerprint };
+  }
+
+  // 4. BIOMETRIC GATE — fail-closed. No `gh` path past this point without ok:true.
+  const biometric = await fx.biometricAuth(`Publish ${title} to GitHub`);
+  if (!biometric.ok) {
+    return {
+      ...base,
+      action: "aborted-biometric",
+      biometric,
+      fingerprint,
+      error: `biometric confirmation ${biometric.reason ? `failed: ${biometric.reason}` : "was not granted"} — publish aborted (fail-closed)`,
+    };
+  }
+
+  // 5. Gate passed → upload the PUBLIC key. The ONLY GitHub-write door.
+  await fx.ghAddKey({ publicKey, title, keyType });
+  return { ...base, action: "published", biometric, fingerprint };
+}
+
+/** Clean, "smooth" readout (the operator-facing line). Public-only, safe to print. */
+export function formatResult(res: PublishResult): string {
+  const fp = res.fingerprint ?? "(unknown)";
+  switch (res.action) {
+    case "would-publish":
+      return [
+        `[dry-run] would publish ${fp} to github:${res.user} (${res.keyType})`,
+        `[dry-run] would prompt biometric: "Publish ${res.title} to GitHub"`,
+        "[dry-run] NO biometric prompt performed, NO GitHub write performed.",
+      ].join("\n");
+    case "published":
+      return `🔐 biometric → ✅ → published ${fp} to github:${res.user} (${res.keyType}, "${res.title}")`;
+    case "aborted-biometric":
+      return `🔐 biometric → ❌ → ${res.error ?? "aborted"} (GitHub NOT written)`;
+    case "aborted-no-key":
+      return `aborted: ${res.error ?? "no key"} (no biometric prompt, no GitHub write)`;
+    case "aborted-private-material":
+      return `aborted: ${res.error ?? "private material"} (PUBLIC-only invariant; GitHub NOT written)`;
+  }
+}
+
+// ── REAL effects (CLI-only): the doors that touch the OS / GitHub ───────────────────
+
+/** Detect the biometric platform for the current host. macOS = Touch ID; Windows =
+ *  Windows Hello (seam); everything else = unsupported (fail-closed). */
+export function detectBiometricPlatform(plat: string = osPlatform()): BiometricPlatform {
+  if (plat === "darwin") return "macos-touchid";
+  if (plat === "win32") return "windows-hello";
+  return "unsupported";
+}
+
+/** macOS Touch ID gate — reuse the zflash / biometric-sudo pattern: a no-op `sudo`
+ *  command goes through PAM, and (when `pam_tid.so` is configured per the 2026-05-29
+ *  ADR) prompts Touch ID. We `sudo -k` first to invalidate any cached timestamp so a
+ *  FRESH biometric confirmation is required every publish (no silent timestamp reuse),
+ *  then run `sudo -p '' true`. Success ⇒ the operator physically confirmed.
+ *
+ *  Fail-closed: if `pam_tid.so` is NOT present in /etc/pam.d/sudo we DO NOT fall back to
+ *  a password prompt (that would not be a biometric proof) — we report unsupported so
+ *  the publish aborts. The operator enables Touch-ID-for-sudo per the ADR first. */
+function macTouchIdAuth(prompt: string): BiometricResult {
+  // Require pam_tid to be configured — otherwise `sudo` would gate on a password, which
+  // is NOT the biometric proof this slice promises. Honest fail-closed.
+  let pamHasTouchId = false;
+  try {
+    const pam = readFileSync("/etc/pam.d/sudo", "utf8");
+    pamHasTouchId = /^\s*auth\s+sufficient\s+pam_tid\.so/m.test(pam);
+  } catch {
+    pamHasTouchId = false;
+  }
+  if (!pamHasTouchId) {
+    return {
+      ok: false,
+      platform: "macos-touchid",
+      reason:
+        "Touch ID for sudo is not configured (pam_tid.so absent from /etc/pam.d/sudo). " +
+        "Enable it per docs/DECISIONS/2026-05-29-biometric-sudo-elevation-via-touch-id-pam.md, then retry.",
+    };
+  }
+  // Invalidate cached sudo timestamp so a fresh Touch ID press is required.
+  spawnSync("sudo", ["-k"], { stdio: "ignore" });
+  // `sudo -p ''` suppresses the password-prompt text; pam_tid pops the Touch ID dialog.
+  // stdin is "ignore" so a non-biometric machine fails-closed (no password can be typed)
+  // rather than hanging on a password prompt.
+  process.stderr.write(`🔐 Touch ID: ${prompt}\n`);
+  const r = spawnSync("sudo", ["-p", "", "true"], { stdio: ["ignore", "ignore", "inherit"] });
+  if (r.status === 0) return { ok: true, platform: "macos-touchid" };
+  return {
+    ok: false,
+    platform: "macos-touchid",
+    reason: `Touch ID was declined or failed (sudo status ${r.status ?? "signal"})`,
+  };
+}
+
+/** Windows Hello gate — SEAM (honest-stop, TODO). A clean programmatic Windows Hello
+ *  consent is `Windows.Security.Credentials.UI.UserConsentVerifier.RequestVerificationAsync`,
+ *  reachable from PowerShell via WinRT projection — but that bridge is NOT cleanly
+ *  invokable from this TS CLI today (no WinRT binding shipped here). Rather than fake a
+ *  biometric or weaken the fail-closed gate, this returns unsupported with the wiring
+ *  point named. Wire `RequestVerificationAsync` (or the elevated-UAC/Hello path that
+ *  flash-usb-windows.ts uses for admin elevation) here when the WinRT bridge lands. */
+function windowsHelloAuth(_prompt: string): BiometricResult {
+  return {
+    ok: false,
+    platform: "windows-hello",
+    reason:
+      "Windows Hello programmatic consent is not yet wired from this TS CLI " +
+      "(seam: Windows.Security.Credentials.UI.UserConsentVerifier.RequestVerificationAsync via WinRT/PowerShell). " +
+      "Wire it in publish.ts windowsHelloAuth() before publishing on Windows — fail-closed until then.",
+  };
+}
+
+/** The REAL effects (used by the CLI): the biometric gate per-platform + a filesystem
+ *  read of the PUBLIC key + the real `gh ssh-key add` write. NO secrets, public-only. */
+export function realEffects(): PublishEffects {
+  return {
+    biometricAuth: async (prompt) => {
+      const plat = detectBiometricPlatform();
+      if (plat === "macos-touchid") return macTouchIdAuth(prompt);
+      if (plat === "windows-hello") return windowsHelloAuth(prompt);
+      return {
+        ok: false,
+        platform: "unsupported",
+        reason: `no biometric mechanism on platform '${osPlatform()}' — publish is fail-closed`,
+      };
+    },
+    exists: (p) => existsSync(p),
+    readText: (p) => readFileSync(p, "utf8"),
+    ghAddKey: async ({ publicKey, title, keyType }) => {
+      // Defense-in-depth: NEVER let private material reach the GitHub door, even if a
+      // caller bypassed the core. (The core already asserts this; this is belt + braces.)
+      if (looksPrivate(publicKey)) {
+        throw new Error("refusing to upload PRIVATE-key material to GitHub (public-only invariant)");
+      }
+      // Pass the PUBLIC key on stdin (no key file path, no secret on argv). `gh ssh-key
+      // add -` reads the key from stdin.
+      const r = spawnSync(
+        "gh",
+        ["ssh-key", "add", "-", "--title", title, "--type", keyType],
+        {
+          input: publicKey.endsWith("\n") ? publicKey : publicKey + "\n",
+          encoding: "utf8",
+          stdio: ["pipe", "inherit", "inherit"],
+        },
+      );
+      if (r.status !== 0) {
+        throw new Error(`gh ssh-key add failed (status ${r.status ?? "signal"})`);
+      }
+    },
+  };
+}
+
+/** The host's hostname (the conventional per-machine pub path component). */
+export function hostHostname(): string {
+  return osHostname();
+}
+
+/** The conventional local home (for path resolution parity with machine.ts). */
+export function defaultHome(): string {
+  return homedir();
+}
+
+/** Join helper re-exported so the CLI can build paths without re-importing node:path. */
+export function joinPath(...parts: readonly string[]): string {
+  return join(...parts);
+}


### PR DESCRIPTION
## What

The **outward-write slice** of the unified key-onboarding workitem `081KVM1TK3Z08QG0R0002959G6` (§"publish to GitHub"). Aaron 2026-06-21: *"we need to code this [publish to GitHub] and make sure it uses mac fingerprint / windows hello auth … clean and smooth and automatic."*

`publish.ts` uploads THIS machine's **PUBLIC** device key (produced by `machine.ts` → `maintainers/<user>/machines/<host>.pub`) to GitHub via `gh ssh-key add` — but **only after a biometric confirmation succeeds (fail-closed)**.

Matches the injected-effects seam of the prior slices (`machine.ts` #8847, `github-trust.ts` #8852): a pure core over a `PublishEffects` door, real I/O only in `realEffects()`.

## Biometric gate per platform (reused machinery, not invented)

- **macOS — Touch ID (WIRED).** Reuses the zflash / `biometric-sudo-handler` / 2026-05-29 ADR pattern: `sudo -k` (force a fresh press) then `sudo -p '' true`, gated by `pam_tid.so`. If `pam_tid.so` is **absent** from `/etc/pam.d/sudo` it is **fail-closed** (we do NOT fall back to a password — that is not a biometric proof) and reports the ADR remediation.
- **Windows — Windows Hello (SEAM / honest-stop TODO).** Clean programmatic Hello is `UserConsentVerifier.RequestVerificationAsync` (WinRT), not reachable from this TS CLI today without a WinRT bridge. Rather than fake biometric or weaken the gate, `windowsHelloAuth()` returns `unsupported` (fail-closed) with the exact wiring point named.

## Security invariants (all tested via injected fakes)

- **Biometric FIRST + fail-closed:** `ghAddKey` is **never** reached unless `biometricAuth()` returns `ok:true`. Tests assert `ghAddKey` is NOT called when biometric returns false / platform unsupported, and IS called with the public key when true.
- **PUBLIC key only:** `looksPrivate()` refuses any `/PRIVATE KEY/` payload before the GitHub door (core + `realEffects` belt-and-braces). A test asserts the uploaded payload `not /PRIVATE KEY/`.
- **`--dry-run`** prompts nothing, writes nothing.
- Real `gh ssh-key add` lives **only** in `realEffects()` — never in tests.

## Proof

- `bun publish.test.ts` → **14 pass / 0 fail** (no real prompt, no real gh write).
- `bun src/Core.TypeScript/lint/lint-typescript.ts` → green.
- `--dry-run` verified: prompts nothing, writes nothing, exit 0.

## Wired vs TODO

- macOS Touch ID: **wired**. Windows Hello: **seam + TODO** (WinRT bridge).

## Next slice

The one-command `onboard` orchestrator that chains all slices "clean + smooth + automatic".

🤖 Generated with [Claude Code](https://claude.com/claude-code)