### PR TITLE
feat(algebra): StarRing ports — C#, Rust, Go (soft-lane full matrix)

### DIFF
--- a/src/Core.Abstractions/SoftMix.cs
+++ b/src/Core.Abstractions/SoftMix.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Zeta.Core;
+
+/// <summary>
+/// Ring-generic soft-mix interpreter: folds IR ops over a weighted ensemble.
+/// The ring IS the physics — swap it, change the behavior:
+///   - real (double) → Bayesian (no interference)
+///   - complex → Quantum (interference/cancellation)
+///   - quaternion → future (non-commutative)
+///
+/// Port of src/Core.TypeScript/algebra/soft-mix.ts and src/Core/WSet.fs consolidate.
+/// </summary>
+public static class SoftMix
+{
+    /// <summary>A weighted entry: (key, weight) from a *-ring.</summary>
+    public record struct WEntry<TWeight>(ulong Key, TWeight Weight);
+
+    /// <summary>An IR operation (mul or xorshr).</summary>
+    public record struct IrOp(string Kind, ulong Val);
+
+    /// <summary>
+    /// Consolidate: sum weights of identical keys via ring.Add, drop zeros.
+    /// This is where interference (complex) or mixture (real) happens.
+    /// </summary>
+    public static IList<WEntry<TWeight>> Consolidate<TWeight>(
+        IStarRing<TWeight> ring,
+        IList<WEntry<TWeight>> entries,
+        System.Func<TWeight, bool> isZero)
+    {
+        var grouped = new List<WEntry<TWeight>>();
+        foreach (var entry in entries)
+        {
+            var idx = grouped.FindIndex(g => g.Key == entry.Key);
+            if (idx >= 0)
+            {
+                grouped[idx] = new WEntry<TWeight>(entry.Key, ring.Add(grouped[idx].Weight, entry.Weight));
+            }
+            else
+            {
+                grouped.Add(entry);
+            }
+        }
+        return grouped.Where(g => !isZero(g.Weight)).ToList();
+    }
+
+    /// <summary>
+    /// Ring-generic soft mix: fold all IR ops over the ensemble.
+    /// One function — works for any IStarRing instance.
+    /// </summary>
+    public static IList<WEntry<TWeight>> Mix<TWeight>(
+        IStarRing<TWeight> ring,
+        IReadOnlyList<IrOp> ops,
+        int width,
+        IList<WEntry<TWeight>> input,
+        System.Func<TWeight, bool> isZero)
+    {
+        ulong mask = width >= 64 ? ulong.MaxValue : (1UL << width) - 1;
+        var ensemble = input.ToList();
+
+        foreach (var op in ops)
+        {
+            ensemble = ensemble.Select(e =>
+            {
+                ulong newKey = op.Kind switch
+                {
+                    "mul" => (e.Key * op.Val) & mask,
+                    "xorshr" => (e.Key ^ (e.Key >> (int)op.Val)) & mask,
+                    _ => e.Key,
+                };
+                return new WEntry<TWeight>(newKey, e.Weight);
+            }).ToList();
+
+            ensemble = Consolidate(ring, ensemble, isZero).ToList();
+        }
+
+        return ensemble;
+    }
+}

--- a/src/Core.Go/algebra/star_ring.go
+++ b/src/Core.Go/algebra/star_ring.go
@@ -1,0 +1,118 @@
+// Package algebra provides the *-ring interface and instances.
+//
+// A *-ring: a ring (Zero, One, Add, Mul, Negate) plus an involution (Conj).
+// The soft-lane interpreter is generic over this interface — swap the instance,
+// change the physics (real → Bayesian, complex → quantum).
+package algebra
+
+import "math"
+
+// StarRing is the *-ring interface: Zero/One/Add/Mul/Negate + Conj.
+type StarRing[T any] interface {
+	Zero() T
+	One() T
+	Add(a, b T) T
+	Mul(a, b T) T
+	Negate(a T) T
+	Conj(a T) T
+	IsZero(a T) bool
+}
+
+// Complex represents a complex number (re + im*i).
+type Complex struct {
+	Re, Im float64
+}
+
+// RealRing implements StarRing[float64]. Conj = identity.
+type RealRing struct{}
+
+func (RealRing) Zero() float64          { return 0 }
+func (RealRing) One() float64           { return 1 }
+func (RealRing) Add(a, b float64) float64    { return a + b }
+func (RealRing) Mul(a, b float64) float64    { return a * b }
+func (RealRing) Negate(a float64) float64    { return -a }
+func (RealRing) Conj(a float64) float64      { return a }
+func (RealRing) IsZero(a float64) bool       { return math.Abs(a) < 1e-12 }
+
+// ComplexRing implements StarRing[Complex]. Conj = complex conjugate.
+type ComplexRing struct{}
+
+func (ComplexRing) Zero() Complex          { return Complex{0, 0} }
+func (ComplexRing) One() Complex           { return Complex{1, 0} }
+func (ComplexRing) Add(a, b Complex) Complex {
+	return Complex{a.Re + b.Re, a.Im + b.Im}
+}
+func (ComplexRing) Mul(a, b Complex) Complex {
+	return Complex{a.Re*b.Re - a.Im*b.Im, a.Re*b.Im + a.Im*b.Re}
+}
+func (ComplexRing) Negate(a Complex) Complex { return Complex{-a.Re, -a.Im} }
+func (ComplexRing) Conj(a Complex) Complex   { return Complex{a.Re, -a.Im} }
+func (ComplexRing) IsZero(a Complex) bool {
+	return a.Re*a.Re+a.Im*a.Im < 1e-12
+}
+
+// WEntry is a weighted entry: (key, weight) where weight is from a *-ring.
+type WEntry[W any] struct {
+	Key    uint64
+	Weight W
+}
+
+// Consolidate sums weights of identical keys, drops zeros.
+// This is where interference (complex) or mixture (real) happens.
+func Consolidate[W any](ring StarRing[W], entries []WEntry[W]) []WEntry[W] {
+	grouped := make([]WEntry[W], 0, len(entries))
+	for _, e := range entries {
+		found := false
+		for i := range grouped {
+			if grouped[i].Key == e.Key {
+				grouped[i].Weight = ring.Add(grouped[i].Weight, e.Weight)
+				found = true
+				break
+			}
+		}
+		if !found {
+			grouped = append(grouped, WEntry[W]{Key: e.Key, Weight: e.Weight})
+		}
+	}
+	result := make([]WEntry[W], 0, len(grouped))
+	for _, g := range grouped {
+		if !ring.IsZero(g.Weight) {
+			result = append(result, g)
+		}
+	}
+	return result
+}
+
+// Op represents one IR operation.
+type Op struct {
+	Kind string // "mul" or "xorshr"
+	Val  uint64 // multiplier constant or shift amount
+}
+
+// SoftMix folds IR ops over a weighted ensemble. Ring-generic.
+func SoftMix[W any](ring StarRing[W], ops []Op, width int, input []WEntry[W]) []WEntry[W] {
+	var mask uint64
+	if width >= 64 {
+		mask = ^uint64(0)
+	} else {
+		mask = (1 << width) - 1
+	}
+	ensemble := input
+	for _, op := range ops {
+		stepped := make([]WEntry[W], len(ensemble))
+		for i, e := range ensemble {
+			var newKey uint64
+			switch op.Kind {
+			case "mul":
+				newKey = (e.Key * op.Val) & mask
+			case "xorshr":
+				newKey = (e.Key ^ (e.Key >> op.Val)) & mask
+			default:
+				newKey = e.Key
+			}
+			stepped[i] = WEntry[W]{Key: newKey, Weight: e.Weight}
+		}
+		ensemble = Consolidate(ring, stepped)
+	}
+	return ensemble
+}

--- a/src/Core.Rust.Observe/src/star_ring.rs
+++ b/src/Core.Rust.Observe/src/star_ring.rs
@@ -1,0 +1,88 @@
+//! star_ring.rs — the *-ring trait + instances (port of IStarRing<T>).
+//!
+//! A *-ring: a ring (zero, one, add, mul, negate) plus an involution (conj).
+//! The soft-lane interpreter is generic over this trait — swap the instance,
+//! change the physics (real → Bayesian, complex → quantum, quaternion → future).
+
+/// The *-ring trait: Zero/One/Add/Mul/Negate + Conj (involution).
+pub trait StarRing: Clone + PartialEq {
+    fn zero() -> Self;
+    fn one() -> Self;
+    fn add(a: &Self, b: &Self) -> Self;
+    fn mul(a: &Self, b: &Self) -> Self;
+    fn negate(a: &Self) -> Self;
+    fn conj(a: &Self) -> Self;
+    fn is_zero(a: &Self) -> bool;
+}
+
+/// Real numbers (f64) as a *-ring. Conj = identity.
+impl StarRing for f64 {
+    fn zero() -> Self { 0.0 }
+    fn one() -> Self { 1.0 }
+    fn add(a: &Self, b: &Self) -> Self { a + b }
+    fn mul(a: &Self, b: &Self) -> Self { a * b }
+    fn negate(a: &Self) -> Self { -a }
+    fn conj(a: &Self) -> Self { *a }
+    fn is_zero(a: &Self) -> bool { a.abs() < 1e-12 }
+}
+
+/// Complex number (re + im*i).
+#[derive(Clone, PartialEq, Debug)]
+pub struct Complex {
+    pub re: f64,
+    pub im: f64,
+}
+
+impl StarRing for Complex {
+    fn zero() -> Self { Complex { re: 0.0, im: 0.0 } }
+    fn one() -> Self { Complex { re: 1.0, im: 0.0 } }
+    fn add(a: &Self, b: &Self) -> Self { Complex { re: a.re + b.re, im: a.im + b.im } }
+    fn mul(a: &Self, b: &Self) -> Self {
+        Complex {
+            re: a.re * b.re - a.im * b.im,
+            im: a.re * b.im + a.im * b.re,
+        }
+    }
+    fn negate(a: &Self) -> Self { Complex { re: -a.re, im: -a.im } }
+    fn conj(a: &Self) -> Self { Complex { re: a.re, im: -a.im } }
+    fn is_zero(a: &Self) -> bool { a.re * a.re + a.im * a.im < 1e-12 }
+}
+
+/// A weighted entry: (key, weight) where weight is from a *-ring.
+#[derive(Clone)]
+pub struct WEntry<W: StarRing> {
+    pub key: u64,
+    pub weight: W,
+}
+
+/// Consolidate: sum weights of identical keys, drop zeros.
+/// This is where interference (complex) or mixture (real) happens.
+pub fn consolidate<W: StarRing>(entries: Vec<WEntry<W>>) -> Vec<WEntry<W>> {
+    let mut grouped: Vec<WEntry<W>> = Vec::new();
+    for entry in entries {
+        if let Some(existing) = grouped.iter_mut().find(|g| g.key == entry.key) {
+            existing.weight = W::add(&existing.weight, &entry.weight);
+        } else {
+            grouped.push(entry);
+        }
+    }
+    grouped.into_iter().filter(|g| !W::is_zero(&g.weight)).collect()
+}
+
+/// Soft mix: fold IR ops over a weighted ensemble. Ring-generic.
+pub fn soft_mix<W: StarRing>(ops: &[(& str, u64)], width: u32, input: Vec<WEntry<W>>) -> Vec<WEntry<W>> {
+    let mask: u64 = if width >= 64 { u64::MAX } else { (1u64 << width) - 1 };
+    let mut ensemble = input;
+    for &(op, val) in ops {
+        ensemble = ensemble.into_iter().map(|e| {
+            let new_key = match op {
+                "mul" => e.key.wrapping_mul(val) & mask,
+                "xorshr" => (e.key ^ (e.key >> val)) & mask,
+                _ => e.key,
+            };
+            WEntry { key: new_key, weight: e.weight }
+        }).collect();
+        ensemble = consolidate(ensemble);
+    }
+    ensemble
+}


### PR DESCRIPTION
Three-language port of the ring-generic soft-mix interpreter. C# uses existing IStarRing<T>. Rust defines StarRing trait. Go uses generics.

Combined with TS + F# + Python already on main: the soft lanes now have ring-generic implementations in 6/7 target languages.