### PR TITLE
feat(keys): reuse-only `onboard` orchestrator — chains machine/publish/github-trust, no gate bypass

### DIFF
--- a/src/Core.TypeScript/zflash/cli.ts
+++ b/src/Core.TypeScript/zflash/cli.ts
@@ -75,8 +75,14 @@ import {
   parseUuidFromDiskutilInfo,
   resolveZetaTestInfraPubkeyFromZflashModule,
 } from "./lib.ts";
-import { deviceKeyPath } from "../../../tools/setup/persona-keys/machine.ts";
-import { onboardUserAndMachine, realEffects as realOnboardEffects, localKeyringPath } from "../../../tools/setup/persona-keys/onboard.ts";
+import {
+  deviceKeyPath,
+  userKeyringPublicPath,
+  realEffects as realMachineEffects,
+} from "../../../tools/setup/persona-keys/machine.ts";
+import { realEffects as realPublishEffects } from "../../../tools/setup/persona-keys/publish.ts";
+import { realEffects as realTrustEffects } from "../../../tools/setup/persona-keys/github-trust.ts";
+import { onboard, formatOnboard } from "../../../tools/setup/persona-keys/onboard.ts";
 
 const ISO_GLOB_PREFIX = "zeta-installer-";
 const DEFAULT_SSH_KEY = join(homedir(), ".ssh", "id_ed25519.pub");
@@ -1136,44 +1142,50 @@ async function main() {
       const repoRoot = findRepoRoot() || ".";
       const home = homedir();
       
-      const localKeyring = localKeyringPath(user, home);
+      const userKeyringPublic = userKeyringPublicPath(repoRoot, user);
       const localMachineKey = deviceKeyPath(home);
-      
-      const userKeyringExists = existsSync(localKeyring);
+
+      const userKeyringExists = existsSync(userKeyringPublic);
       const machineKeyExists = existsSync(localMachineKey);
-      
+
       if (!userKeyringExists || !machineKeyExists) {
         process.stdout.write(`\nzflash: detected missing user keyring or machine key for user '${user}'.\n`);
-        process.stdout.write(`Starting inline onboarding flow...\n\n`);
+        process.stdout.write(`Starting inline onboarding flow (reuse-only orchestrator)...\n\n`);
         try {
-          await onboardUserAndMachine(realOnboardEffects(), {
-            user,
-            repoRoot,
-            home,
-            publish: true,
-          });
-        } catch (err: any) {
-          bail(1, `Onboarding failed: ${err.message}`);
+          // Delegate to the reuse-only orchestrator: it ensures THIS host's device key,
+          // PRINTS the keyring.sh instruction if the user keyring is missing (it does NOT
+          // run seed-gen — seed custody is the operator's), and goes THROUGH publish.ts's
+          // biometric gate for the GitHub publish. No secret/seed handling lives here.
+          const res = await onboard(
+            {
+              machine: realMachineEffects(),
+              publish: realPublishEffects(),
+              trust: realTrustEffects(),
+            },
+            { user, repoRoot, home, keyType: "authentication" },
+          );
+          process.stdout.write(formatOnboard(res) + "\n\n");
+        } catch (err: unknown) {
+          bail(1, `Onboarding failed: ${err instanceof Error ? err.message : String(err)}`);
         }
       }
 
-      // Generate the union of the machine's public key and the user's public key
+      // Generate the union of the machine's public key and the user's PUBLISHED public key.
+      // We read ONLY public trust roots — the machine pubkey file and the operator's
+      // maintainers/<user>/ssh-pubkeys.txt (the public trust registry) — never a private
+      // keyring JSON (the orchestrator no longer materializes secrets locally).
       const machinePubPath = deviceKeyPath(home) + ".pub";
-      const localKeyringAfter = localKeyringPath(user, home);
-      
+      const userSshPubPath = join(repoRoot, "maintainers", user, "ssh-pubkeys.txt");
+
       let combinedContent = "";
       if (existsSync(machinePubPath)) {
         combinedContent += readFileSync(machinePubPath, "utf8").trim() + "\n";
       }
-      if (existsSync(localKeyringAfter)) {
-        try {
-          const keyring = JSON.parse(readFileSync(localKeyringAfter, "utf8"));
-          if (keyring.ssh?.public) {
-            combinedContent += keyring.ssh.public.trim() + "\n";
-          }
-        } catch { /* ignore */ }
+      if (existsSync(userSshPubPath)) {
+        const userPub = readFileSync(userSshPubPath, "utf8").trim();
+        if (userPub) combinedContent += userPub + "\n";
       }
-      
+
       if (combinedContent.trim()) {
         tempPubkeyPath = join(tmpdir(), `zeta-combined-${user}.pub`);
         writeFileSync(tempPubkeyPath, combinedContent, { mode: 0o644 });

--- a/tools/setup/persona-keys/keyring.sh
+++ b/tools/setup/persona-keys/keyring.sh
@@ -53,11 +53,14 @@ command -v bun >/dev/null || { echo "bun required (closed over in install.sh)"; 
 [ -d "$HERE/node_modules" ] || (cd "$HERE" && bun install >/dev/null)
 
 if [ "$mode" = "onboard" ]; then
+  # Reuse-only orchestrator: chains status -> user-keyring(instruction) -> machine-key ->
+  # publish(biometric-gated, via publish.ts) -> trust-resolve. It NEVER runs seed-gen (a
+  # missing user keyring prints the keyring.sh generate|rotate instruction); the GitHub
+  # publish always goes THROUGH publish.ts's biometric gate (no --publish toggle, no bypass).
   extra_args=()
-  [ -n "$publish" ] && extra_args+=("--publish")
   [ -n "$dry_run" ] && extra_args+=("--dry-run")
   [ -n "$out_dir" ] && extra_args+=("--repo-root" "$out_dir")
-  bun "$HERE/onboard.ts" --user "$name" "${extra_args[@]}"
+  bun "$HERE/onboard-cli.ts" --user "$name" "${extra_args[@]}"
   exit 0
 fi
 

--- a/tools/setup/persona-keys/onboard-cli.ts
+++ b/tools/setup/persona-keys/onboard-cli.ts
@@ -1,0 +1,108 @@
+#!/usr/bin/env bun
+// Zeta key-onboarding ORCHESTRATOR CLI — a thin shell around the pure orchestrator
+// (onboard.ts). It wires the THREE sub-modules' REAL effects (machine / publish /
+// github-trust) and runs the end-to-end first-run flow with a clean numbered readout.
+//
+// The CLI contains NO secret/biometric/gh/seed logic of its own — every door comes from a
+// sub-module's `realEffects()`. The biometric gate lives in publish.ts and is never
+// bypassed; a missing user keyring prints the `keyring.sh` instruction (no seed-gen here).
+// `--dry-run` prompts NOTHING, writes NOTHING, generates NOTHING, fetches NOTHING.
+//
+// Usage:
+//   bun onboard-cli.ts --user aaron                      # full first-run flow (this host)
+//   bun onboard-cli.ts --user aaron --dry-run            # plan only — NOTHING is done
+//   bun onboard-cli.ts --user aaron --host mymac         # explicit hostname
+//   bun onboard-cli.ts --user aaron --type signing       # publish as a signing key
+//   bun onboard-cli.ts --user aaron --trust octocat --trust torvalds --gpg   # trust set
+import { homedir } from "node:os";
+import { dirname, resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
+import { realEffects as realMachineEffects } from "./machine.ts";
+import { realEffects as realPublishEffects } from "./publish.ts";
+import { realEffects as realTrustEffects } from "./github-trust.ts";
+import { formatOnboard, onboard, type OnboardEffects, type OnboardOptions } from "./onboard.ts";
+
+const args = process.argv.slice(2);
+const flag = (n: string): boolean => args.includes(n);
+const opt = (n: string): string | undefined => {
+  const i = args.indexOf(n);
+  return i >= 0 ? args[i + 1] : undefined;
+};
+/** Collect ALL values for a repeatable option (e.g. --trust a --trust b). */
+const allOpts = (n: string): readonly string[] => {
+  const out: string[] = [];
+  for (let i = 0; i < args.length - 1; i++) {
+    if (args[i] === n) {
+      const v = args[i + 1];
+      if (v !== undefined) out.push(v);
+    }
+  }
+  return out;
+};
+
+const here = dirname(fileURLToPath(import.meta.url));
+// Repo root: 3 levels up from tools/setup/persona-keys/ (override with --repo-root).
+const repoRoot = opt("--repo-root") ?? resolvePath(here, "..", "..", "..");
+const user = opt("--user");
+const hostname = opt("--host");
+const home = opt("--home") ?? homedir();
+const keyTypeArg = opt("--type");
+const dryRun = flag("--dry-run");
+const includeGpg = flag("--gpg");
+const trustIdentities = allOpts("--trust");
+
+function usage(): void {
+  process.stderr.write(
+    "usage: bun onboard-cli.ts --user <name> [--host <name>] [--home <path>] " +
+      "[--type authentication|signing] [--trust <gh-user> ...] [--gpg] [--dry-run] [--repo-root <path>]\n" +
+      "  Chains: status -> user-keyring(instruction) -> machine-key -> publish(biometric-gated) -> trust-resolve.\n" +
+      "  Reuse-only: no secret/biometric/gh/seed logic here — all delegated. --dry-run does NOTHING.\n",
+  );
+}
+
+async function main(): Promise<number> {
+  if (user === undefined || user.trim().length === 0) {
+    usage();
+    process.stderr.write("error: --user <name> is required\n");
+    return 2;
+  }
+  if (keyTypeArg !== undefined && keyTypeArg !== "authentication" && keyTypeArg !== "signing") {
+    usage();
+    process.stderr.write(`error: --type must be 'authentication' or 'signing' (got '${keyTypeArg}')\n`);
+    return 2;
+  }
+  const keyType: "authentication" | "signing" = keyTypeArg === "signing" ? "signing" : "authentication";
+
+  const fx: OnboardEffects = {
+    machine: realMachineEffects(),
+    publish: realPublishEffects(),
+    trust: realTrustEffects(),
+  };
+
+  const opts: OnboardOptions = {
+    user,
+    repoRoot,
+    home,
+    keyType,
+    dryRun,
+    includeGpg,
+    ...(hostname !== undefined ? { hostname } : {}),
+    ...(trustIdentities.length > 0 ? { trustIdentities } : {}),
+  };
+
+  const res = await onboard(fx, opts);
+  process.stdout.write(formatOnboard(res) + "\n");
+
+  // Exit code: 0 unless the publish step was a hard, non-recoverable block (biometric
+  // declined / private material). A would-publish (dry-run) or no-key is informational.
+  const hardBlock =
+    res.publish.action === "aborted-biometric" || res.publish.action === "aborted-private-material";
+  return hardBlock ? 1 : 0;
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((e: unknown) => {
+    process.stderr.write((e instanceof Error ? e.message : String(e)) + "\n");
+    process.exit(1);
+  });

--- a/tools/setup/persona-keys/onboard.test.ts
+++ b/tools/setup/persona-keys/onboard.test.ts
@@ -1,241 +1,273 @@
+// onboard.ts conformance — the key-onboarding ORCHESTRATOR that CHAINS machine.ts +
+// publish.ts + github-trust.ts. EVERY test runs against FIXTURES injected for ALL THREE
+// sub-modules — NEVER a real biometric prompt, NEVER a real `gh`, NEVER real keygen,
+// NEVER a network call, NEVER a secret. Proves the orchestration contract:
+//   * step ORDER: status -> (user-keyring) -> machine-key -> PUBLISH (only via publish.ts's
+//     gate, recorded after the prior steps) -> trust-resolve;
+//   * a MISSING user keyring yields an INSTRUCTION (the keyring.sh step), NOT a silent
+//     seed-gen — and the orchestrator never derives/generates a seed;
+//   * --dry-run is end-to-end inert: no biometric prompt, no gh write, no keygen, no fetch;
+//   * the publish step goes THROUGH publish.ts (the gate is enforced there, never bypassed).
+// Run: bun test onboard.test.ts   (from tools/setup/persona-keys)
 import { test, expect } from "bun:test";
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join, dirname } from "node:path";
-import { onboardUserAndMachine, localKeyringPath, type OnboardEffects } from "./onboard.ts";
-import { userKeyringPublicPath, deviceKeyPath } from "./machine.ts";
+import type { MachineEffects } from "./machine.ts";
+import type { BiometricResult, PublishEffects } from "./publish.ts";
+import type { GithubTrustEffects } from "./github-trust.ts";
+import { keyringInstruction, onboard, formatOnboard, type OnboardEffects } from "./onboard.ts";
 
-function fakeOnboardEffects(opts: {
-  hostname: string;
-  answers: Record<string, string>;
-  ghAuthed: boolean;
-  ghUsername?: string;
-  gitUsername?: string;
-  gitEmail?: string;
-  sshKeysRegistered?: string[];
-  gpgKeysRegistered?: string[];
-  askLog?: string[];
-  ghLog?: string[];
-}): OnboardEffects {
-  const askLog = opts.askLog || [];
-  const ghLog = opts.ghLog || [];
-  
-  return {
-    machine: {
-      hostname: () => opts.hostname,
-      exists: (p) => existsSync(p),
-      readText: (p) => readFileSync(p, "utf8"),
-      writeText: (p, c) => writeFileSync(p, c),
-      mkdirp: (p) => mkdirSync(p, { recursive: true }),
-      genEd25519: (keyPath, comment) => {
-        mkdirSync(dirname(keyPath), { recursive: true });
-        writeFileSync(keyPath, "FAKE-PRIVATE-DEVICE-KEY\n", { mode: 0o600 });
-        const pub = `ssh-ed25519 AAAAFAKEPUBKEY ${comment}\n`;
-        writeFileSync(keyPath + ".pub", pub);
-        return pub;
-      },
+const PUB = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDwJVbQNiFzUCiOhc aaron@mymac (zeta-device)";
+
+/** A spying triple-fixture: machine + publish + trust doors, with a shared call-ORDER log
+ *  so a test can assert the chain (status read → machine ensure → biometric → gh add →
+ *  trust fetch). No door does anything real — no keygen, no prompt, no gh, no network. */
+function fixture(opts: {
+  /** Files that "exist" (presence probes). Keyed by the EXACT path machine.ts builds. */
+  existing?: ReadonlySet<string>;
+  /** Pubkey text returned by readText (public only — never a secret in the fixture). */
+  pubText?: string;
+  /** The biometric outcome publish.ts will see (fake — no real Touch ID / Hello). */
+  biometric?: BiometricResult;
+  /** GitHub `.keys` bodies per identity (public lines), for the trust resolve step. */
+  ghKeys?: Record<string, string>;
+  /** maintainers/ subdir names the trust resolver may source identities from. */
+  maintainers?: readonly string[];
+}): {
+  fx: OnboardEffects;
+  order: string[];
+  ghAdds: { publicKey: string; title: string; keyType: string }[];
+  biometricPrompts: string[];
+  genCalls: string[];
+  fetchedUsers: string[];
+} {
+  const order: string[] = [];
+  const ghAdds: { publicKey: string; title: string; keyType: string }[] = [];
+  const biometricPrompts: string[] = [];
+  const genCalls: string[] = [];
+  const fetchedUsers: string[] = [];
+  const existing = opts.existing ?? new Set<string>();
+  const pubText = opts.pubText ?? PUB + "\n";
+
+  const machine: MachineEffects = {
+    hostname: () => "mymac",
+    exists: (p) => {
+      order.push(`machine.exists:${p}`);
+      return existing.has(p);
     },
-    ask: async (query) => {
-      askLog.push(query);
-      for (const [k, v] of Object.entries(opts.answers)) {
-        if (query.toLowerCase().includes(k.toLowerCase())) return v;
-      }
-      return "";
+    readText: () => pubText,
+    writeText: () => {
+      order.push("machine.writeText");
     },
-    askHidden: async (query) => {
-      askLog.push(query);
-      for (const [k, v] of Object.entries(opts.answers)) {
-        if (query.toLowerCase().includes(k.toLowerCase())) return v;
-      }
-      return "";
+    mkdirp: () => {
+      order.push("machine.mkdirp");
     },
-    ghAuthStatus: () => {
-      const res: { ok: boolean; username?: string } = { ok: opts.ghAuthed };
-      if (opts.ghUsername !== undefined) {
-        res.username = opts.ghUsername;
-      }
-      return res;
+    genEd25519: (keyPath) => {
+      // The ONLY keygen door — recorded so a test can assert dry-run NEVER calls it.
+      genCalls.push(keyPath);
+      order.push(`machine.genEd25519:${keyPath}`);
+      return PUB + "\n";
     },
-    ghAuthLogin: () => {
-      ghLog.push("gh auth login");
-      opts.ghAuthed = true;
-      opts.ghUsername = "tester-gh";
-      return true;
-    },
-    ghAuthSetupGit: () => {
-      ghLog.push("gh auth setup-git");
-      return true;
-    },
-    ghSshKeyList: () => {
-      return (opts.sshKeysRegistered || []).join("\n");
-    },
-    ghSshKeyAdd: (keyPath, title) => {
-      ghLog.push(`gh ssh-key add ${keyPath} --title ${title}`);
-      const pubkey = readFileSync(keyPath, "utf8").trim();
-      const cleanPub = pubkey.split(" ")[1] || pubkey;
-      opts.sshKeysRegistered = opts.sshKeysRegistered || [];
-      opts.sshKeysRegistered.push(cleanPub);
-      return true;
-    },
-    ghGpgKeyList: () => {
-      return (opts.gpgKeysRegistered || []).join("\n");
-    },
-    ghGpgKeyAdd: (keyPath, title) => {
-      ghLog.push(`gh gpg-key add ${keyPath} --title ${title}`);
-      opts.gpgKeysRegistered = opts.gpgKeysRegistered || [];
-      opts.gpgKeysRegistered.push("A3E5D79B1100FF11"); // fake keyId
-      return true;
-    },
-    getGitUser: () => {
-      const res: { name?: string; email?: string } = {};
-      if (opts.gitUsername !== undefined) {
-        res.name = opts.gitUsername;
-      }
-      if (opts.gitEmail !== undefined) {
-        res.email = opts.gitEmail;
-      }
-      return res;
-    }
   };
+
+  const publish: PublishEffects = {
+    biometricAuth: async (prompt) => {
+      biometricPrompts.push(prompt);
+      order.push("publish.biometricAuth");
+      return opts.biometric ?? { ok: true, platform: "macos-touchid" };
+    },
+    exists: (p) => {
+      order.push(`publish.exists:${p}`);
+      return existing.has(p);
+    },
+    readText: () => pubText,
+    ghAddKey: async ({ publicKey, title, keyType }) => {
+      ghAdds.push({ publicKey, title, keyType });
+      order.push("publish.ghAddKey");
+    },
+  };
+
+  const trust: GithubTrustEffects = {
+    fetchKeys: async (user) => {
+      fetchedUsers.push(user);
+      order.push(`trust.fetchKeys:${user}`);
+      return opts.ghKeys?.[user] ?? "";
+    },
+    fetchGpg: async () => "",
+    readText: () => "",
+    exists: (p) => existing.has(p),
+    listDir: (p) => {
+      order.push(`trust.listDir:${p}`);
+      return opts.maintainers ?? [];
+    },
+  };
+
+  return { fx: { machine, publish, trust }, order, ghAdds, biometricPrompts, genCalls, fetchedUsers };
 }
 
-test("onboard: idempotent when both user and machine keys are present", async () => {
-  const tmp = mkdtempSync(join(tmpdir(), "zeta-onboard-"));
-  try {
-    const user = "tester";
-    const hostname = "test-host-1";
-    
-    // Setup pre-existing local user keyring
-    const localKeyPath = localKeyringPath(user, tmp);
-    mkdirSync(dirname(localKeyPath), { recursive: true });
-    writeFileSync(localKeyPath, JSON.stringify({
-      user,
-      ssh: { public: "ssh-ed25519 AAAATESTERUSERPUBKEY tester@lucent.financial", fingerprint: "fp" },
-      pgp: { keyId: "A3E5D79B1100FF11", public: "GPG-PUBKEY" }
-    }));
-    
-    // Setup repo user keyring
-    const repoPublic = userKeyringPublicPath(tmp, user);
-    mkdirSync(dirname(repoPublic), { recursive: true });
-    writeFileSync(repoPublic, JSON.stringify({ user }));
-    
-    // Setup pre-existing local machine key
-    const localMacKey = deviceKeyPath(tmp);
-    mkdirSync(dirname(localMacKey), { recursive: true });
-    writeFileSync(localMacKey, "FAKE-PRIVATE");
-    writeFileSync(localMacKey + ".pub", "ssh-ed25519 AAAAFAKEMACHINEKEY comment");
-    
-    // Setup repo machine key
-    const repoMacPub = join(tmp, "maintainers", user, "machines", `${hostname}.pub`);
-    mkdirSync(dirname(repoMacPub), { recursive: true });
-    writeFileSync(repoMacPub, "ssh-ed25519 AAAAFAKEMACHINEKEY comment");
-    
-    const askLog: string[] = [];
-    const ghLog: string[] = [];
-    const fx = fakeOnboardEffects({
-      hostname,
-      answers: {},
-      ghAuthed: true,
-      ghUsername: "tester-gh",
-      sshKeysRegistered: ["AAAATESTERUSERPUBKEY"],
-      gpgKeysRegistered: ["A3E5D79B1100FF11"],
-      askLog,
-      ghLog
-    });
-    
-    await onboardUserAndMachine(fx, { user, repoRoot: tmp, home: tmp, publish: true });
-    
-    // Should verify keys and require zero interactive prompts
-    expect(askLog.length).toBe(0);
-  } finally {
-    rmSync(tmp, { recursive: true, force: true });
-  }
+/** The conventional paths machine.ts builds (so fixtures can mark them present/absent). */
+const REPO = "/repo";
+const USER = "aaron";
+const userKeyringPath = `${REPO}/maintainers/${USER}/keyring-public.json`;
+const devicePrivatePath = "/home/aaron/.config/zeta/machine/id_ed25519";
+const machinePubPath = `${REPO}/maintainers/${USER}/machines/mymac.pub`;
+const HOME = "/home/aaron";
+
+test("CHAIN ORDER: status -> machine ensure -> biometric -> ghAddKey -> trust fetch", async () => {
+  const { fx, order, ghAdds, biometricPrompts } = fixture({
+    existing: new Set([userKeyringPath, devicePrivatePath, machinePubPath]),
+    ghKeys: { octocat: PUB },
+  });
+  const res = await onboard(fx, { user: USER, repoRoot: REPO, home: HOME, trustIdentities: ["octocat"] });
+
+  // Five steps, in the contract order.
+  expect(res.steps.map((s) => s.kind)).toEqual([
+    "status",
+    "user-keyring",
+    "machine-key",
+    "publish",
+    "trust-resolve",
+  ]);
+  // The biometric prompt happened (gate invoked via publish.ts) and BEFORE the gh write.
+  expect(biometricPrompts).toHaveLength(1);
+  const idxBio = order.indexOf("publish.biometricAuth");
+  const idxAdd = order.indexOf("publish.ghAddKey");
+  expect(idxBio).toBeGreaterThanOrEqual(0);
+  expect(idxAdd).toBeGreaterThan(idxBio); // gh write only AFTER the biometric
+  // And the publish happened only after the machine-key presence read.
+  const idxMachineProbe = order.findIndex((o) => o.startsWith("machine.exists:" + devicePrivatePath));
+  expect(idxMachineProbe).toBeGreaterThanOrEqual(0);
+  expect(idxBio).toBeGreaterThan(idxMachineProbe);
+  // The trust fetch came last (after the publish gh write).
+  const idxFetch = order.indexOf("trust.fetchKeys:octocat");
+  expect(idxFetch).toBeGreaterThan(idxAdd);
+
+  expect(ghAdds).toHaveLength(1);
+  expect(ghAdds[0]?.publicKey).toContain("ssh-ed25519");
+  expect(res.publish.action).toBe("published");
 });
 
-test("onboard: missing user keyring triggers interactive import", async () => {
-  const tmp = mkdtempSync(join(tmpdir(), "zeta-onboard-"));
-  try {
-    const user = "tester";
-    const hostname = "test-host-2";
-    
-    // Fake seed phrase
-    const goldenMnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art";
-    
-    // Pre-exist repo keyring
-    const repoPublic = userKeyringPublicPath(tmp, user);
-    mkdirSync(dirname(repoPublic), { recursive: true });
-    writeFileSync(repoPublic, JSON.stringify({ user }));
-    
-    // Machine key already exists
-    const localMacKey = deviceKeyPath(tmp);
-    mkdirSync(dirname(localMacKey), { recursive: true });
-    writeFileSync(localMacKey, "FAKE-PRIVATE");
-    writeFileSync(localMacKey + ".pub", "ssh-ed25519 AAAAFAKEMACHINEKEY comment");
-    const repoMacPub = join(tmp, "maintainers", user, "machines", `${hostname}.pub`);
-    mkdirSync(dirname(repoMacPub), { recursive: true });
-    writeFileSync(repoMacPub, "ssh-ed25519 AAAAFAKEMACHINEKEY comment");
-    
-    const askLog: string[] = [];
-    const fx = fakeOnboardEffects({
-      hostname,
-      answers: {
-        "restore": "y",
-        "paste seed": goldenMnemonic
-      },
-      ghAuthed: true,
-      ghUsername: "tester-gh",
-      askLog
-    });
-    
-    await onboardUserAndMachine(fx, { user, repoRoot: tmp, home: tmp, publish: true });
-    
-    const localKeyPath = localKeyringPath(user, tmp);
-    expect(existsSync(localKeyPath)).toBe(true);
-    
-    const keyring = JSON.parse(readFileSync(localKeyPath, "utf8"));
-    expect(keyring.user).toBe(user);
-    expect(keyring.mnemonic).toBe(goldenMnemonic);
-  } finally {
-    rmSync(tmp, { recursive: true, force: true });
-  }
+test("MISSING user keyring -> INSTRUCTION (keyring.sh), NEVER a silent seed-gen", async () => {
+  // user keyring absent; machine key present so we isolate the user-keyring behavior.
+  const { fx, genCalls } = fixture({
+    existing: new Set([devicePrivatePath, machinePubPath]),
+  });
+  const res = await onboard(fx, { user: USER, repoRoot: REPO, home: HOME });
+
+  const userStep = res.steps.find((s) => s.kind === "user-keyring");
+  expect(userStep?.headline).toBe("instruction");
+  expect(userStep?.pending).toBe(true);
+  // The instruction names the keyring.sh generate|rotate step — the operator runs it.
+  expect(userStep?.detail).toContain("keyring.sh generate aaron");
+  expect(userStep?.detail).toContain("keyring.sh rotate");
+  expect(userStep?.detail).toContain("seed custody is yours");
+  // CRITICAL: the orchestrator did NOT generate a USER seed/keyring. The only keygen door
+  // (genEd25519) is for the per-MACHINE device key — and here the machine key already
+  // existed, so even that was a no-op. No seed-gen path exists in the orchestrator at all.
+  expect(genCalls).toHaveLength(0);
 });
 
-test("onboard: missing machine key generates key and publishes public half", async () => {
-  const tmp = mkdtempSync(join(tmpdir(), "zeta-onboard-"));
-  try {
-    const user = "tester";
-    const hostname = "test-host-3";
-    
-    // Setup pre-existing user keyring
-    const localKeyPath = localKeyringPath(user, tmp);
-    mkdirSync(dirname(localKeyPath), { recursive: true });
-    writeFileSync(localKeyPath, JSON.stringify({
-      user,
-      ssh: { public: "ssh-ed25519 AAAATESTERUSERPUBKEY tester@lucent.financial", fingerprint: "fp" },
-      pgp: { keyId: "A3E5D79B1100FF11", public: "GPG-PUBKEY" }
-    }));
-    const repoPublic = userKeyringPublicPath(tmp, user);
-    mkdirSync(dirname(repoPublic), { recursive: true });
-    writeFileSync(repoPublic, JSON.stringify({ user }));
-    
-    const fx = fakeOnboardEffects({
-      hostname,
-      answers: {},
-      ghAuthed: true,
-      ghUsername: "tester-gh",
-      sshKeysRegistered: ["AAAATESTERUSERPUBKEY"]
-    });
-    
-    await onboardUserAndMachine(fx, { user, repoRoot: tmp, home: tmp, publish: true });
-    
-    const localMacKey = deviceKeyPath(tmp);
-    expect(existsSync(localMacKey)).toBe(true);
-    expect(existsSync(localMacKey + ".pub")).toBe(true);
-    
-    const repoMacPub = join(tmp, "maintainers", user, "machines", `${hostname}.pub`);
-    expect(existsSync(repoMacPub)).toBe(true);
-    expect(readFileSync(repoMacPub, "utf8")).toContain("ssh-ed25519 AAAAFAKEPUBKEY");
-  } finally {
-    rmSync(tmp, { recursive: true, force: true });
-  }
+test("--dry-run: NO biometric prompt, NO gh write, NO keygen, NO network", async () => {
+  // user keyring + device key absent (→ would-create), but the machine pub IS present so
+  // the publish step reaches would-publish — dry-run must still do NONE of it (no prompt,
+  // no write, no keygen, no fetch). (publish.ts aborts pre-dry-run only when the pub is
+  // absent; with it present, dry-run is the meaningful would-publish path.)
+  const { fx, biometricPrompts, ghAdds, genCalls, fetchedUsers } = fixture({
+    existing: new Set([machinePubPath]),
+    ghKeys: { octocat: PUB },
+  });
+  const res = await onboard(fx, {
+    user: USER,
+    repoRoot: REPO,
+    home: HOME,
+    dryRun: true,
+    trustIdentities: ["octocat"],
+  });
+
+  expect(res.dryRun).toBe(true);
+  expect(biometricPrompts).toHaveLength(0); // no prompt
+  expect(ghAdds).toHaveLength(0); // no GitHub write
+  expect(genCalls).toHaveLength(0); // no keygen
+  expect(fetchedUsers).toHaveLength(0); // no network fetch
+  // The readout reports intent, not action.
+  expect(res.machine.action).toBe("would-generate");
+  expect(res.publish.action).toBe("would-publish");
+  expect(res.trust.dryRun).toBe(true);
+  const out = formatOnboard(res);
+  expect(out).toContain("DRY RUN");
+  expect(out).toContain("would");
+});
+
+test("FAIL-CLOSED via publish.ts: biometric declined -> NO gh write, step blocked", async () => {
+  const { fx, ghAdds, biometricPrompts } = fixture({
+    existing: new Set([userKeyringPath, devicePrivatePath, machinePubPath]),
+    biometric: { ok: false, platform: "macos-touchid", reason: "declined" },
+  });
+  const res = await onboard(fx, { user: USER, repoRoot: REPO, home: HOME });
+
+  expect(biometricPrompts).toHaveLength(1); // gate invoked
+  expect(ghAdds).toHaveLength(0); // but NO write — fail-closed (enforced by publish.ts)
+  const pubStep = res.steps.find((s) => s.kind === "publish");
+  expect(pubStep?.headline).toBe("blocked");
+  expect(res.publish.action).toBe("aborted-biometric");
+});
+
+test("publish goes THROUGH publish.ts: no-key abort never prompts, never writes", async () => {
+  // machine pub absent → publish.ts aborts BEFORE the prompt (publish.ts's own contract).
+  const { fx, ghAdds, biometricPrompts } = fixture({
+    existing: new Set([userKeyringPath, devicePrivatePath]), // note: no machinePubPath
+  });
+  const res = await onboard(fx, { user: USER, repoRoot: REPO, home: HOME });
+
+  expect(res.publish.action).toBe("aborted-no-key");
+  expect(biometricPrompts).toHaveLength(0); // publish.ts aborts pre-prompt
+  expect(ghAdds).toHaveLength(0);
+  const pubStep = res.steps.find((s) => s.kind === "publish");
+  expect(pubStep?.pending).toBe(true); // operator must run machine step first
+});
+
+test("idempotent: all present -> created NOTHING, machine key is a no-op", async () => {
+  const { fx, genCalls } = fixture({
+    existing: new Set([userKeyringPath, devicePrivatePath, machinePubPath]),
+  });
+  const res = await onboard(fx, { user: USER, repoRoot: REPO, home: HOME });
+
+  expect(res.machine.action).toBe("exists"); // no regeneration
+  expect(genCalls).toHaveLength(0); // genEd25519 never called
+  const userStep = res.steps.find((s) => s.kind === "user-keyring");
+  expect(userStep?.headline).toBe("present");
+});
+
+test("trust-resolve delegates to github-trust: fetches the explicit identities", async () => {
+  const { fx, fetchedUsers } = fixture({
+    existing: new Set([userKeyringPath, devicePrivatePath, machinePubPath]),
+    ghKeys: { octocat: PUB, torvalds: PUB },
+  });
+  const res = await onboard(fx, {
+    user: USER,
+    repoRoot: REPO,
+    home: HOME,
+    trustIdentities: ["octocat", "torvalds"],
+  });
+  expect(fetchedUsers.sort()).toEqual(["octocat", "torvalds"]);
+  // PUB is identical for both → de-duped to 1 by github-trust (idempotent collapse).
+  expect(res.trust.trustSet).toHaveLength(1);
+});
+
+test("keyringInstruction: names generate-then-rotate + seed-custody, no secret", () => {
+  const inst = keyringInstruction("ophelia");
+  expect(inst).toContain("keyring.sh generate ophelia");
+  expect(inst).toContain("keyring.sh rotate");
+  expect(inst).toContain("seed custody is yours");
+  // It is an INSTRUCTION string only — it carries no key/seed material.
+  expect(inst).not.toContain("ssh-ed25519");
+});
+
+test("formatOnboard: numbered readout + an operator-action list when pending exists", async () => {
+  // user keyring missing → 1 pending (instruction); dry-run publish → another pending.
+  const { fx } = fixture({ existing: new Set<string>() });
+  const res = await onboard(fx, { user: USER, repoRoot: REPO, home: HOME, dryRun: true });
+  const out = formatOnboard(res);
+  expect(out).toContain("1. [status]");
+  expect(out).toContain("2. [user-keyring]");
+  expect(out).toContain("5. [trust-resolve]");
+  expect(out).toContain("Operator action still required");
 });

--- a/tools/setup/persona-keys/onboard.ts
+++ b/tools/setup/persona-keys/onboard.ts
@@ -1,469 +1,304 @@
-import { homedir } from "node:os";
-import { join, dirname, resolve } from "node:path";
-import { spawnSync } from "node:child_process";
-import * as readline from "node:readline/promises";
-import { Writable } from "node:stream";
-import { fileURLToPath } from "node:url";
+// Zeta key-onboarding ORCHESTRATOR — the one-command "clean + smooth + automatic"
+// payoff slice of the unified key-onboarding flow (workitem 081KVM1TK3Z08QG0R0002959G6
+// §"First-run auto-provisioning" + §"Trust distribution"). Aaron (2026-06-21):
+// *"clean and smooth and automatic."*
+//
+// This module CHAINS three already-shipped, already-verified sub-modules end-to-end and
+// produces a clean per-step readout. It is a COORDINATOR, not an implementor:
+//
+//   1. STATUS        — machine.ts  `checkPresence`     (the two-part user × machine probe)
+//   2. USER KEYRING  — keyring.sh INSTRUCTION ONLY     (seed custody is human-held; the
+//                       orchestrator PRINTS the exact `keyring.sh generate|rotate` step,
+//                       it NEVER runs seed-gen — the seed never crosses this boundary)
+//   3. MACHINE KEY   — machine.ts  `ensureMachineKey`  (this host's device key)
+//   4. PUBLISH       — publish.ts  `publishKey`        (biometric-gated, fail-closed,
+//                       PUBLIC-only — the orchestrator goes THROUGH the gate, never around)
+//   5. TRUST RESOLVE — github-trust.ts `resolveTrustSet` (produce/print the trust set)
+//   6. READOUT       — a clean numbered summary of present / created / operator-still-to-do.
+//
+// SECURITY INVARIANTS (security-sensitive slice — honesty over green):
+//  1. NO secret handling, NO biometric logic, NO `gh` logic, NO seed-gen lives here. ALL
+//     of it is DELEGATED to the sub-modules through their injected-effects doors. The
+//     orchestrator contains nothing that could emit, derive, or print private material —
+//     it never imports the seed/keyring derivation (derive.ts / bip39) at all.
+//  2. The PUBLISH step MUST go through publish.ts `publishKey` — the biometric gate is
+//     never bypassed and there is NO direct `gh` call here. (publish.ts is fail-closed;
+//     the orchestrator only calls it and narrates the typed result.)
+//  3. A MISSING user keyring yields an INSTRUCTION, never a silent seed-gen. Seed custody
+//     is the operator's; the orchestrator instructs (`keyring.sh generate|rotate`), it
+//     does not run `keyring.sh` and never touches a mnemonic.
+//  4. `--dry-run` is end-to-end: no prompts, no writes, no keygen, no network — the plan
+//     is printed and NOTHING is done. Each delegated call receives `dryRun: true`.
+//
+// Noninterference (manifesto §13): every ambient influence (hostname, filesystem,
+// biometric prompt, `gh` write, GitHub fetch) enters ONLY through the three injected
+// sub-module effects bundles — so the whole flow is deterministic + testable against
+// fakes, and `--dry-run` is provably side-effect-free.
+//
+// Anchors (Beacon): the chained modules' own anchors hold — ed25519 device keys
+// (Bernstein et al. 2011), Touch ID PAM (`pam_tid.so`) / Windows Hello UserConsentVerifier,
+// `gh ssh-key add` (GitHub CLI), GitHub `.keys`/`.gpg` public endpoints + `ssh-import-id`
+// (Canonical), SSH authorized_keys (`sshd(8)`). Orchestration as a thin coordinator over
+// idempotent steps — the workitem's "one command … idempotent (re-running … is a no-op)".
 
-import { deriveKeyring, freshMnemonic } from "./derive.ts";
-import { validateMnemonic } from "@scure/bip39";
-import { wordlist } from "@scure/bip39/wordlists/english.js";
-import {
-  deviceKeyPath,
-  publishPubPath,
-  userKeyringPublicPath,
-  sanitizeHostname,
-  ensureMachineKey,
-  realEffects as realMachineEffects,
-  type MachineEffects
-} from "./machine.ts";
+import type { MachineEffects, MachineResult, PresenceStatus } from "./machine.ts";
+import { checkPresence, ensureMachineKey, publishPubPath, sanitizeHostname } from "./machine.ts";
+import type { PublishEffects, PublishResult } from "./publish.ts";
+import { publishKey } from "./publish.ts";
+import type { GithubTrustEffects, TrustResolution } from "./github-trust.ts";
+import { resolveIdentities, resolveTrustSet } from "./github-trust.ts";
 
-/** Injected effects interface for Onboarding (enables noninterference/testing). */
+/** The three sub-module effects bundles — the ONLY doors for ambient influence. Tests
+ *  inject fakes for all three; the CLI injects each module's `realEffects()`. The
+ *  orchestrator never touches the OS / network / a secret except through these. */
 export interface OnboardEffects {
   readonly machine: MachineEffects;
-  readonly ask: (query: string) => Promise<string>;
-  readonly askHidden: (query: string) => Promise<string>;
-  readonly ghAuthStatus: () => { ok: boolean; username?: string };
-  readonly ghAuthLogin: () => boolean;
-  readonly ghAuthSetupGit: () => boolean;
-  readonly ghSshKeyList: () => string;
-  readonly ghSshKeyAdd: (keyPath: string, title: string) => boolean;
-  readonly ghGpgKeyList: () => string;
-  readonly ghGpgKeyAdd: (keyPath: string, title: string) => boolean;
-  readonly getGitUser: () => { name?: string; email?: string };
+  readonly publish: PublishEffects;
+  readonly trust: GithubTrustEffects;
 }
 
+/** Options for an onboard run — the operator identity + repo root, plus the knobs each
+ *  delegated step needs. `dryRun` is end-to-end (every sub-call gets `dryRun: true`). */
 export interface OnboardOptions {
+  /** The operator/persona identity (the user component of user × machine). */
   readonly user: string;
+  /** Repo root (where maintainers/<user>/… trust roots live). */
   readonly repoRoot: string;
-  readonly home: string;
-  readonly publish?: boolean;
+  /** Local home override (for the device-key path; defaults to the host home). */
+  readonly home?: string;
+  /** Hostname override (else the injected machine hostname). */
+  readonly hostname?: string;
+  /** End-to-end dry-run: NO prompts, NO writes, NO keygen, NO network. Plan only. */
   readonly dryRun?: boolean;
+  /** Trust identities to resolve (else sourced from allowlist / maintainers/ by github-trust). */
+  readonly trustIdentities?: readonly string[];
+  /** Include GPG/signing trust in the resolve step. */
+  readonly includeGpg?: boolean;
+  /** Publish key type (default authentication). */
+  readonly keyType?: "authentication" | "signing";
 }
 
-export function localKeyringPath(user: string, home: string): string {
-  return join(home, ".config", "zeta", `keyring-${user}.json`);
+/** The kind of a single orchestrated step (for the numbered readout). */
+export type StepKind = "status" | "user-keyring" | "machine-key" | "publish" | "trust-resolve";
+
+/** A single step's outcome — what it found / did / would do, plus an operator-facing note.
+ *  `pending` flags work the OPERATOR must still do (seed-gen, the gated biometric confirm). */
+export interface OnboardStep {
+  readonly kind: StepKind;
+  /** A short, stable headline for this step ("present" / "created" / "instruction" / …). */
+  readonly headline: string;
+  /** The human-readable detail line (safe to print — public only, no secrets). */
+  readonly detail: string;
+  /** True iff this step needs operator action that the orchestrator cannot/should-not do. */
+  readonly pending: boolean;
 }
 
-export async function onboardUserAndMachine(
-  fx: OnboardEffects,
-  opts: OnboardOptions
-): Promise<void> {
-  const userPublicPath = userKeyringPublicPath(opts.repoRoot, opts.user);
-  const userPrivatePath = localKeyringPath(opts.user, opts.home);
-  
-  const userPublicExists = fx.machine.exists(userPublicPath);
-  const userPrivateExists = fx.machine.exists(userPrivatePath);
-  
-  let userKeyringData: any = null;
-  let choice = "";
-
-  if (userPrivateExists) {
-    try {
-      const raw = fx.machine.readText(userPrivatePath);
-      userKeyringData = JSON.parse(raw);
-    } catch (e) {
-      console.warn(`Warning: failed to read/parse local private keyring at ${userPrivatePath}:`, e);
-    }
-  }
-
-  if (userPrivateExists && userPublicExists) {
-    console.log(`User keyring for '${opts.user}' already exists locally and in repository.`);
-  } else if (!userPrivateExists && userPublicExists) {
-    console.log(`User keyring for '${opts.user}' exists in repository, but private keys are missing locally.`);
-    const restoreChoice = await fx.ask(`Restore private keys by importing your existing seed phrase? [Y/n]: `);
-    if (restoreChoice.trim().toLowerCase() !== "n") {
-      const seed = await fx.askHidden(`Paste seed phrase for '${opts.user}' (hidden): `);
-      const trimmedSeed = seed.trim();
-      if (!validateMnemonic(trimmedSeed, wordlist)) {
-        throw new Error("Invalid seed phrase. Cannot restore user keyring.");
-      }
-      const { full } = deriveKeyring(trimmedSeed, opts.user);
-      userKeyringData = full;
-      if (!opts.dryRun) {
-        fx.machine.mkdirp(dirname(userPrivatePath));
-        const prevUmask = process.umask(0o077);
-        try {
-          fx.machine.writeText(userPrivatePath, JSON.stringify(full, null, 2));
-        } finally {
-          process.umask(prevUmask);
-        }
-        console.log(`Successfully restored local private keys to ${userPrivatePath}`);
-      } else {
-        console.log(`[dry-run] Would write private keys to ${userPrivatePath}`);
-      }
-    } else {
-      console.log("Restoration skipped. Note: you cannot push signed commits or authenticate without private keys.");
-    }
-  } else {
-    // Both absent OR only private exists but public absent
-    if (!userPrivateExists) {
-      console.log(`User keyring for '${opts.user}' is missing.`);
-      const onboardChoice = await fx.ask(`Create new persona keyring? [G]enerate a new seed / [I]mport an existing one / [S]kip: `);
-      choice = onboardChoice.trim().toLowerCase();
-      let seed = "";
-      if (choice === "g") {
-        seed = freshMnemonic();
-        console.log("\n============================================================");
-        console.log("  YOUR SEED PHRASE — write it on PAPER now (24 words):");
-        console.log("============================================================");
-        console.log(`  ${seed}`);
-        console.log("\n  This is the ONLY thing that recovers ALL your keys + funds.");
-        console.log("  * Stamp it on METAL (fireproof/waterproof) — or paper — in 2 safe places.");
-        console.log("  * Do NOT photograph it, screenshot it, or paste it anywhere digital/online.");
-        console.log("  * No one (not even Otto) can recover it for you if lost.");
-        console.log("============================================================");
-        
-        let confirmed = false;
-        while (!confirmed) {
-          const ack = await fx.ask("  Type SAVED once it is written down: ");
-          if (ack.trim() === "SAVED") {
-            confirmed = true;
-          } else {
-            console.log("  Not confirmed (expected SAVED). Let's try again.");
-          }
-        }
-      } else if (choice === "i") {
-        const inp = await fx.askHidden(`Paste seed phrase for '${opts.user}' (hidden): `);
-        seed = inp.trim();
-        if (!validateMnemonic(seed, wordlist)) {
-          throw new Error("Invalid seed phrase.");
-        }
-      } else {
-        console.log("Skipping user keyring setup.");
-      }
-
-      if (seed) {
-        const { full } = deriveKeyring(seed, opts.user);
-        userKeyringData = full;
-        if (!opts.dryRun) {
-          fx.machine.mkdirp(dirname(userPrivatePath));
-          const prevUmask = process.umask(0o077);
-          try {
-            fx.machine.writeText(userPrivatePath, JSON.stringify(full, null, 2));
-          } finally {
-            process.umask(prevUmask);
-          }
-          console.log(`Wrote local private keys to ${userPrivatePath}`);
-        } else {
-          console.log(`[dry-run] Would write private keys to ${userPrivatePath}`);
-        }
-      }
-    }
-
-    // Write public files to maintainers/<user>/
-    if (userKeyringData && (opts.publish || opts.dryRun)) {
-      const dest = join(opts.repoRoot, "maintainers", opts.user);
-      if (!opts.dryRun) {
-        fx.machine.mkdirp(dest);
-        
-        // Write ssh-pubkeys.txt
-        const sshPub = userKeyringData.ssh.public.trim();
-        fx.machine.writeText(join(dest, "ssh-pubkeys.txt"), `${sshPub}  ${opts.user}@lucent.financial\n`);
-        
-        // Write gpg-pubkey.asc
-        fx.machine.writeText(join(dest, "gpg-pubkey.asc"), userKeyringData.pgp.public);
-        
-        // Write keyring-public.json
-        const pubMetadata = {
-          user: opts.user,
-          status: !userPrivateExists && choice === "g" ? "bootstrap-test" : "self-custody",
-          ssh_fingerprint: userKeyringData.ssh.fingerprint,
-          pgp: {
-            keyId: userKeyringData.pgp.keyId,
-            fingerprint: userKeyringData.pgp.fingerprint
-          },
-          nostr_npub: userKeyringData.nostr.npub,
-          eth: userKeyringData.eth.address,
-          btc: userKeyringData.btc.address,
-          sol: userKeyringData.sol.address,
-          paths: {
-            ssh: userKeyringData.ssh.path,
-            pgp: userKeyringData.pgp.path,
-            nostr: userKeyringData.nostr.path,
-            eth: userKeyringData.eth.path,
-            btc: userKeyringData.btc.path,
-            sol: userKeyringData.sol.path
-          },
-          anchors: {
-            github: null,
-            fido_webauthn: null,
-            note: "human anchor: GitHub (first trust root) + FIDO/WebAuthn/Windows Hello; recorded at rotate/anchor time"
-          }
-        };
-        fx.machine.writeText(join(dest, "keyring-public.json"), JSON.stringify(pubMetadata, null, 2) + "\n");
-        console.log(`Wrote public trust roots to ${dest}`);
-      } else {
-        console.log(`[dry-run] Would write public trust roots to ${dest}`);
-      }
-    }
-  }
-
-  // Machine Onboarding
-  const hostname = sanitizeHostname(fx.machine.hostname());
-  const devPrivatePath = deviceKeyPath(opts.home);
-  const devPublicPath = publishPubPath(opts.repoRoot, opts.user, hostname);
-  
-  const machinePrivateExists = fx.machine.exists(devPrivatePath);
-  const machinePublicExists = fx.machine.exists(devPublicPath);
-  
-  if (machinePrivateExists && machinePublicExists) {
-    console.log(`Machine key for host '${hostname}' already exists locally and is published.`);
-  } else {
-    console.log(`Machine key for host '${hostname}' is missing or not published.`);
-    if (!opts.dryRun) {
-      const machineOpts: { user: string; repoRoot: string; home?: string; publish?: boolean } = {
-        user: opts.user,
-        repoRoot: opts.repoRoot,
-        home: opts.home,
-      };
-      if (opts.publish !== undefined) {
-        machineOpts.publish = opts.publish;
-      }
-      const r = ensureMachineKey(fx.machine, machineOpts);
-      console.log(`Machine key setup: action=${r.action} hostname=${r.hostname}`);
-      if (r.published) {
-        console.log(`Published machine public key to ${devPublicPath}`);
-      }
-    } else {
-      console.log(`[dry-run] Would ensure machine key at ${devPrivatePath} and publish to ${devPublicPath}`);
-    }
-  }
-
-  // GitHub integration
-  console.log("\nChecking GitHub configuration...");
-  const auth = fx.ghAuthStatus();
-  if (!auth.ok) {
-    console.log("GitHub CLI is not authenticated.");
-    const ghChoice = await fx.ask("Authenticate with GitHub now? [Y/n]: ");
-    if (ghChoice.trim().toLowerCase() !== "n") {
-      const success = fx.ghAuthLogin();
-      if (!success) {
-        console.warn("Warning: GitHub authentication failed or cancelled.");
-      }
-    }
-  }
-
-  const authSecond = fx.ghAuthStatus();
-  if (authSecond.ok) {
-    console.log(`Logged in to GitHub as @${authSecond.username}.`);
-    
-    const setupGitSuccess = fx.ghAuthSetupGit();
-    if (setupGitSuccess) {
-      console.log("Configured GitHub credential helper for Git.");
-    }
-    
-    let userSshPub = "";
-    if (userKeyringData) {
-      userSshPub = userKeyringData.ssh.public.trim();
-    } else {
-      const sshPubPath = join(opts.repoRoot, "maintainers", opts.user, "ssh-pubkeys.txt");
-      if (fx.machine.exists(sshPubPath)) {
-        userSshPub = fx.machine.readText(sshPubPath).trim();
-      }
-    }
-
-    if (userSshPub) {
-      const sshKeys = fx.ghSshKeyList();
-      const cleanPub = userSshPub.split(" ")[1];
-      if (cleanPub && sshKeys.includes(cleanPub)) {
-        console.log("SSH public key is already registered on GitHub.");
-      } else {
-        console.log("SSH public key is not registered on GitHub.");
-        const addSshChoice = await fx.ask("Register user SSH public key on GitHub? [Y/n]: ");
-        if (addSshChoice.trim().toLowerCase() !== "n") {
-          const tempPath = join(opts.repoRoot, "maintainers", opts.user, "ssh-pubkeys.txt");
-          if (!opts.dryRun && fx.machine.exists(tempPath)) {
-            const added = fx.ghSshKeyAdd(tempPath, `zeta-ssh-${opts.user}`);
-            if (added) console.log("Successfully added SSH key to GitHub.");
-          } else if (opts.dryRun) {
-            console.log(`[dry-run] Would add SSH public key to GitHub with title "zeta-ssh-${opts.user}"`);
-          }
-        }
-      }
-    }
-
-    let userGpgPub = "";
-    if (userKeyringData) {
-      userGpgPub = userKeyringData.pgp.public.trim();
-    } else {
-      const gpgPubPath = join(opts.repoRoot, "maintainers", opts.user, "gpg-pubkey.asc");
-      if (fx.machine.exists(gpgPubPath)) {
-        userGpgPub = fx.machine.readText(gpgPubPath).trim();
-      }
-    }
-
-    if (userGpgPub) {
-      const gpgKeys = fx.ghGpgKeyList();
-      // Match using the PGP key ID
-      let keyId = "";
-      if (userKeyringData) {
-        keyId = userKeyringData.pgp.keyId.toUpperCase();
-      } else {
-        const pubJsonPath = join(opts.repoRoot, "maintainers", opts.user, "keyring-public.json");
-        if (fx.machine.exists(pubJsonPath)) {
-          try {
-            const m = JSON.parse(fx.machine.readText(pubJsonPath));
-            keyId = m.pgp?.keyId?.toUpperCase() || "";
-          } catch { /* ignore */ }
-        }
-      }
-
-      if (keyId && gpgKeys.toUpperCase().includes(keyId)) {
-        console.log("GPG/PGP public signing key is already registered on GitHub.");
-      } else {
-        console.log("GPG/PGP public signing key is not registered on GitHub.");
-        const addGpgChoice = await fx.ask("Register GPG signing key on GitHub? [Y/n]: ");
-        if (addGpgChoice.trim().toLowerCase() !== "n") {
-          const tempGpgPath = join(opts.repoRoot, "maintainers", opts.user, "gpg-pubkey.asc");
-          if (!opts.dryRun && fx.machine.exists(tempGpgPath)) {
-            const added = fx.ghGpgKeyAdd(tempGpgPath, `zeta-gpg-${opts.user}`);
-            if (added) console.log("Successfully added GPG key to GitHub.");
-          } else if (opts.dryRun) {
-            console.log(`[dry-run] Would add GPG key to GitHub with title "zeta-gpg-${opts.user}"`);
-          }
-        }
-      }
-    }
-  } else {
-    console.log("GitHub integration skipped (not authenticated).");
-  }
-
-  console.log("\n============================================================");
-  console.log("  ONBOARDING SUMMARY");
-  console.log("============================================================");
-  console.log(`  Persona User: ${opts.user}`);
-  console.log(`  Dev Machine:  ${hostname}`);
-  console.log(`  User Key:     ${userPrivateExists ? "Local Private present" : "Local Private MISSING"} · ${userPublicExists ? "Repo Public present" : "Repo Public MISSING"}`);
-  console.log(`  Machine Key:  ${machinePrivateExists ? "Local Private present" : "Local Private MISSING"} · ${machinePublicExists ? "Repo Public present" : "Repo Public MISSING"}`);
-  console.log(`  GitHub Auth:  ${authSecond.ok ? `Connected (@${authSecond.username})` : "Disconnected"}`);
-  console.log("============================================================");
+/** The full onboard result: the per-step trace + the typed sub-results (for assertions). */
+export interface OnboardResult {
+  readonly dryRun: boolean;
+  readonly user: string;
+  readonly hostname: string;
+  readonly steps: readonly OnboardStep[];
+  /** The two-part presence status from step 1 (machine.ts). */
+  readonly presence: PresenceStatus;
+  /** The machine-key step's typed result (machine.ts). */
+  readonly machine: MachineResult;
+  /** The publish step's typed result (delegated to publish.ts — gate enforced there). */
+  readonly publish: PublishResult;
+  /** The trust-resolve step's typed result (delegated to github-trust.ts). */
+  readonly trust: TrustResolution;
 }
 
-/** The REAL environment effects wrapper. */
-export function realEffects(): OnboardEffects {
-  return {
-    machine: realMachineEffects(),
-    ask: async (query) => {
-      const rl = readline.createInterface({
-        input: process.stdin,
-        output: process.stdout,
-      });
-      const answer = await rl.question(query);
-      rl.close();
-      return answer;
-    },
-    askHidden: async (query) => {
-      let muted = false;
-      const mutableStdout = new Writable({
-        write(chunk, encoding, callback) {
-          if (!muted) {
-            process.stdout.write(chunk, encoding);
-          }
-          callback();
-        }
-      });
-      const rl = readline.createInterface({
-        input: process.stdin,
-        output: mutableStdout,
-        terminal: true
-      });
-      const answerPromise = rl.question(query);
-      muted = true;
-      const answer = await answerPromise;
-      muted = false;
-      rl.close();
-      process.stdout.write("\n");
-      return answer;
-    },
-    ghAuthStatus: () => {
-      try {
-        const r = spawnSync("gh", ["auth", "status"], { encoding: "utf8" });
-        const output = (r.stdout ?? "") + (r.stderr ?? "");
-        const match = output.match(/Logged in to github\.com account ([a-zA-Z0-9-_]+)/) ||
-                      output.match(/Logged in to github\.com as ([a-zA-Z0-9-_]+)/);
-        if (match && match[1]) {
-          return { ok: true, username: match[1] };
-        }
-        return { ok: false };
-      } catch {
-        return { ok: false };
-      }
-    },
-    ghAuthLogin: () => {
-      const r = spawnSync("gh", ["auth", "login"], { stdio: "inherit" });
-      return r.status === 0;
-    },
-    ghAuthSetupGit: () => {
-      const r = spawnSync("gh", ["auth", "setup-git"], { stdio: "inherit" });
-      return r.status === 0;
-    },
-    ghSshKeyList: () => {
-      try {
-        const r = spawnSync("gh", ["ssh-key", "list"], { encoding: "utf8" });
-        return r.stdout ?? "";
-      } catch {
-        return "";
-      }
-    },
-    ghSshKeyAdd: (keyPath, title) => {
-      const r = spawnSync("gh", ["ssh-key", "add", keyPath, "--title", title], { stdio: "inherit" });
-      return r.status === 0;
-    },
-    ghGpgKeyList: () => {
-      try {
-        const r = spawnSync("gh", ["gpg-key", "list"], { encoding: "utf8" });
-        return r.stdout ?? "";
-      } catch {
-        return "";
-      }
-    },
-    ghGpgKeyAdd: (keyPath, title) => {
-      const r = spawnSync("gh", ["gpg-key", "add", keyPath, "--title", title], { stdio: "inherit" });
-      return r.status === 0;
-    },
-    getGitUser: () => {
-      try {
-        const name = spawnSync("git", ["config", "user.name"], { encoding: "utf8" }).stdout?.trim();
-        const email = spawnSync("git", ["config", "user.email"], { encoding: "utf8" }).stdout?.trim();
-        return { name, email };
-      } catch {
-        return {};
-      }
-    }
-  };
+/** The exact `keyring.sh` instruction the operator must run when the user keyring is
+ *  missing. GENERATE-THEN-ROTATE per the keyring.sh blueprint (Aaron 2026-06-09): Otto
+ *  runs `generate` (does the hard bits), then the operator runs `rotate` to take a seed
+ *  they pick and hold. The orchestrator NEVER runs this — seed custody is the human's. */
+export function keyringInstruction(user: string): string {
+  return [
+    `the user keyring for '${user}' is MISSING — seed custody is yours, so the orchestrator`,
+    "will NOT generate it. Run the seed-gen step yourself (GENERATE-THEN-ROTATE blueprint):",
+    `    tools/setup/persona-keys/keyring.sh generate ${user} --out maintainers/${user}`,
+    `    tools/setup/persona-keys/keyring.sh rotate   ${user} --out maintainers/${user}`,
+    "  (`generate` does the hard bits fast; `rotate` lets you pick + write down a seed you hold.)",
+  ].join("\n");
 }
 
-// Simple CLI runner
-if (import.meta.main) {
-  const args = process.argv.slice(2);
-  const flag = (n: string) => args.includes(n);
-  const opt = (n: string) => { const i = args.indexOf(n); return i >= 0 ? args[i + 1] : undefined; };
-  
-  const fx = realEffects();
-  
-  // Resolve user
-  let user = opt("--user");
-  if (!user) {
-    const gitInfo = fx.getGitUser();
-    if (gitInfo.name) {
-      // Lowercase, space to hyphen
-      user = gitInfo.name.trim().toLowerCase().replace(/[^a-z0-9._-]+/g, "-");
-    } else {
-      user = process.env.USER || "zeta";
-    }
-  }
-  
-  const here = dirname(fileURLToPath(import.meta.url));
-  const repoRoot = opt("--repo-root") ?? resolve(here, "..", "..", "..");
-  const home = opt("--home") ?? homedir();
-  const publish = flag("--publish");
-  const dryRun = flag("--dry-run");
-  
-  onboardUserAndMachine(fx, { user, repoRoot, home, publish, dryRun })
-    .then(() => process.exit(0))
-    .catch((err) => {
-      console.error("Onboarding failed:", err.message);
-      process.exit(1);
+/**
+ * Run the end-to-end first-run onboarding flow as a CHAIN over the three sub-modules.
+ *
+ * Order is the security contract: STATUS → (user-keyring instruction if missing) →
+ * MACHINE-KEY → PUBLISH (biometric-gated, only after the prior steps) → TRUST-RESOLVE.
+ * Every effect is delegated; the orchestrator adds no secret/biometric/gh/seed logic.
+ *
+ * On `dryRun`: every delegated call receives `dryRun: true`, so NOTHING is prompted,
+ * written, generated, or fetched — the readout reports intent only.
+ *
+ * PURE over the injected `OnboardEffects` — deterministic + testable against fakes.
+ */
+export async function onboard(fx: OnboardEffects, opts: OnboardOptions): Promise<OnboardResult> {
+  const dryRun = opts.dryRun === true;
+  const home = opts.home;
+  const keyType = opts.keyType ?? "authentication";
+  const steps: OnboardStep[] = [];
+
+  // ── Step 1: STATUS — the two-part (user × machine) presence check (machine.ts) ──────
+  const presence = checkPresence(fx.machine, {
+    user: opts.user,
+    repoRoot: opts.repoRoot,
+    ...(home !== undefined ? { home } : {}),
+  });
+  const hostname = opts.hostname !== undefined ? sanitizeHostname(opts.hostname) : presence.hostname;
+  steps.push({
+    kind: "status",
+    headline: "status",
+    detail:
+      `user=${opts.user} keyring ${presence.userKeyPresent ? "PRESENT" : "MISSING"}; ` +
+      `machine=${hostname} device key ${presence.machineKeyPresentLocal ? "PRESENT" : "MISSING"}` +
+      ` (published=${presence.machineKeyPublished ? "y" : "n"})`,
+    pending: false,
+  });
+
+  // ── Step 2: USER KEYRING — INSTRUCTION ONLY when missing (NEVER a silent seed-gen) ──
+  if (presence.userKeyPresent) {
+    steps.push({
+      kind: "user-keyring",
+      headline: "present",
+      detail: `user keyring already registered at ${presence.userKeyringPath} — no action.`,
+      pending: false,
     });
+  } else {
+    // Missing → emit the operator INSTRUCTION; do NOT run keyring.sh / touch a seed.
+    steps.push({
+      kind: "user-keyring",
+      headline: "instruction",
+      detail: keyringInstruction(opts.user),
+      pending: true, // operator must run the seed-gen themselves
+    });
+  }
+
+  // ── Step 3: MACHINE KEY — generate this host's device key if missing (machine.ts) ───
+  // Delegated: machine.ts owns ssh-keygen + umask + the public-only read-back. We pass
+  // publish:false here (this slice's "publish to GitHub" is the separate biometric-gated
+  // step 4, not the maintainers/ pubkey-file write). Idempotent: an existing key is a no-op.
+  const machine = ensureMachineKey(fx.machine, {
+    user: opts.user,
+    repoRoot: opts.repoRoot,
+    ...(home !== undefined ? { home } : {}),
+    dryRun,
+  });
+  steps.push({
+    kind: "machine-key",
+    headline:
+      machine.action === "generated"
+        ? "created"
+        : machine.action === "would-generate"
+          ? "would-create"
+          : "present",
+    detail:
+      machine.action === "exists"
+        ? `device key already present (local, private) at ${machine.devicePrivatePath} — no action.`
+        : machine.action === "would-generate"
+          ? `[dry-run] would generate this host's device key at ${machine.devicePrivatePath} (NOTHING generated).`
+          : `generated this host's device key at ${machine.devicePrivatePath} (private, local, umask 077).`,
+    pending: false,
+  });
+
+  // ── Step 4: PUBLISH — biometric-gated, PUBLIC-only (publish.ts owns the gate) ────────
+  // The orchestrator goes THROUGH publish.ts `publishKey`; it never invokes `gh` or a
+  // biometric prompt itself. The conventional pubkey path is machine.ts's publishPubPath.
+  const pubPath = publishPubPath(opts.repoRoot, opts.user, hostname);
+  const publish = await publishKey(fx.publish, {
+    user: opts.user,
+    repoRoot: opts.repoRoot,
+    hostname,
+    keyType,
+    keyPath: pubPath,
+    dryRun,
+  });
+  steps.push({
+    kind: "publish",
+    headline:
+      publish.action === "published"
+        ? "published"
+        : publish.action === "would-publish"
+          ? "would-publish"
+          : "blocked",
+    detail: publishStepDetail(publish),
+    // Pending iff the operator must still confirm the biometric (would-publish), or a
+    // recoverable abort needs operator action (no-key → run machine step first).
+    pending: publish.action === "would-publish" || publish.action === "aborted-no-key",
+  });
+
+  // ── Step 5: TRUST RESOLVE — produce/print the trust set (github-trust.ts) ────────────
+  // Delegated read-only resolve. Identities are sourced by github-trust (explicit arg /
+  // allowlist / maintainers dirs). On dry-run NO network is touched (the module enforces it).
+  const idRes = resolveIdentities(fx.trust, {
+    repoRoot: opts.repoRoot,
+    ...(opts.trustIdentities !== undefined && opts.trustIdentities.length > 0
+      ? { identities: opts.trustIdentities }
+      : {}),
+  });
+  const trust = await resolveTrustSet(fx.trust, {
+    identities: idRes.identities,
+    ...(opts.includeGpg !== undefined ? { includeGpg: opts.includeGpg } : {}),
+    dryRun,
+  });
+  steps.push({
+    kind: "trust-resolve",
+    headline: trust.dryRun ? "would-resolve" : "resolved",
+    detail: trust.dryRun
+      ? `[dry-run] would resolve trust set for ${idRes.identities.length} identit(ies)` +
+        ` (${idRes.sourceKind}): ${idRes.identities.join(", ") || "(none)"} — NO network.`
+      : `resolved trust set: ${trust.trustSet.length} authorized-keys line(s) from` +
+        ` ${idRes.identities.length} identit(ies) (${idRes.sourceKind}) — PRODUCED, not installed.`,
+    pending: false,
+  });
+
+  return { dryRun, user: opts.user, hostname, steps, presence, machine, publish, trust };
+}
+
+/** The operator-facing detail line for the publish step (mirrors publish.ts's outcomes
+ *  without re-implementing any of its logic — it only narrates the typed result). */
+function publishStepDetail(res: PublishResult): string {
+  switch (res.action) {
+    case "would-publish":
+      return (
+        `[dry-run] would publish ${res.fingerprint ?? "(key)"} to github:${res.user} (${res.keyType}) ` +
+        "AFTER a biometric confirm — NO prompt + NO GitHub write performed."
+      );
+    case "published":
+      return `biometric -> ok -> published ${res.fingerprint ?? "(key)"} to github:${res.user} (${res.keyType}).`;
+    case "aborted-biometric":
+      return `blocked: ${res.error ?? "biometric not granted"} (GitHub NOT written — fail-closed).`;
+    case "aborted-no-key":
+      return `blocked: no public key to publish — run the machine step (with --publish) first.`;
+    case "aborted-private-material":
+      return `blocked: refused PRIVATE-key material (PUBLIC-only invariant; GitHub NOT written).`;
+  }
+}
+
+/** Render the clean numbered readout (step 6). A per-step summary + a trailing
+ *  "operator must still do" list of the pending items (seed-gen, gated biometric confirm).
+ *  Safe to print: public only, no secrets ever appear. */
+export function formatOnboard(res: OnboardResult): string {
+  const lines: string[] = [];
+  lines.push(
+    res.dryRun
+      ? `Zeta key onboarding — DRY RUN (nothing prompted, written, generated, or fetched)`
+      : `Zeta key onboarding — user=${res.user}, machine=${res.hostname}`,
+  );
+  res.steps.forEach((s, i) => {
+    lines.push(`  ${i + 1}. [${s.kind}] ${s.headline}`);
+    for (const dl of s.detail.split("\n")) lines.push(`       ${dl}`);
+  });
+
+  const pending = res.steps.filter((s) => s.pending);
+  lines.push("");
+  if (pending.length === 0) {
+    lines.push("Operator action still required: none.");
+  } else {
+    lines.push(`Operator action still required (${pending.length}):`);
+    pending.forEach((s, i) => lines.push(`  ${i + 1}. [${s.kind}] ${s.detail.split("\n")[0] ?? s.headline}`));
+  }
+  return lines.join("\n");
 }


### PR DESCRIPTION
## What

The one-command **`onboard` orchestrator** — the "clean + smooth + automatic" payoff slice of the unified key-onboarding workitem `081KVM1TK3Z08QG0R0002959G6`. **Security-class change — honesty over green. DO NOT auto-merge — Otto runs the verify-gate before merge.**

This **replaces** the prior `onboard.ts` (#8860), which handled seeds in-process (`freshMnemonic`/`deriveKeyring`, printed the seed phrase, wrote private keys) and reimplemented `gh ssh-key add`/`gh gpg-key add` with **no biometric gate** — uploading keys to GitHub *around* `publish.ts`. That is exactly the gate-bypass + secret-handling this slice must not do. The new orchestrator is a thin coordinator that **delegates every effect**.

## The chained flow (reuse-only)

`onboard()` is pure over an injected `OnboardEffects` triple (machine + publish + trust):

1. **status** — `machine.ts checkPresence` (two-part user × machine probe)
2. **user-keyring** — INSTRUCTION ONLY when missing: prints the exact `keyring.sh generate|rotate` step. **Never runs seed-gen, never imports `derive.ts`/bip39, never touches a mnemonic.**
3. **machine-key** — `machine.ts ensureMachineKey` (this host's device key)
4. **publish** — `publish.ts publishKey`: biometric-gated, fail-closed, PUBLIC-only. The orchestrator goes **through** the gate, never around — there is **no `gh` call here**.
5. **trust-resolve** — `github-trust.ts resolveTrustSet` (produce/print the trust set)
6. **readout** — clean numbered summary of present / created / operator-still-to-do.

## Reuse + delegation confirmation

- No secret/biometric/`gh`/seed logic in `onboard.ts` or `onboard-cli.ts` — `grep` for `derive.ts|bip39|freshMnemonic|deriveKeyring|spawnSync|"gh"|mnemonic` matches **only in comments** documenting their deliberate absence.
- Publish goes **through** `publish.ts publishKey`; the biometric gate is enforced there and is never bypassed.
- `keyring.sh onboard` now dispatches to `onboard-cli.ts` (dropped the `--publish` toggle — publish always goes through the gate).
- `zflash/cli.ts` auto-provision updated to the reuse-only orchestrator; reads **only public trust roots** (machine pub + `maintainers/<user>/ssh-pubkeys.txt`), never a private keyring JSON.

## Gate results

- `bun onboard.test.ts` — **9/9 green** (fakes for all three sub-module effects; no real biometric/gh/keygen/network).
- `bun src/Core.TypeScript/lint/lint-typescript.ts` — **green** (tsc + prettier + style).
- `--dry-run` verified inert against temp dirs — **zero files written**, no prompt, no network.
- `grep -E "BEGIN.*PRIVATE KEY" onboard.test.ts` — **empty** (key-shaped literal split per #8860 lesson).
- Full persona-keys suite 66/66; zflash lib/esp-inject 61/61.

## Tests assert (the contract)

- Chain **order**: biometric before `gh` write; publish after the machine-key probe.
- Missing user keyring → **INSTRUCTION** (not silent seed-gen); `genEd25519` never called for a user seed.
- `--dry-run` does **nothing** (no prompt/write/keygen/fetch).
- Fail-closed via `publish.ts`: biometric declined → no `gh` write.

## Merge

**Open, NOT merged.** Otto runs the security-verify-gate transition (build/tests/lint + grep for key-shaped literals + the no-gate-bypass read) and merges after verifying — per the security-verify-gate-is-a-DU-transition discipline. No auto-merge armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)