### PR TITLE
feat(keys): trust-set installer MECHANISM — render resolver set into operator-ssh-keys (gated --write, default OFF)

### DIFF
--- a/tools/setup/persona-keys/install-trust-cli.ts
+++ b/tools/setup/persona-keys/install-trust-cli.ts
@@ -1,0 +1,132 @@
+// Zeta GitHub TEMP-TRUST-ROOT installer CLI — a thin shell that REUSES the read-only
+// resolver (github-trust.ts) to PRODUCE the trust set, then RENDERS it into the
+// `operator-ssh-keys` node-config format (install-trust.ts). `--dry-run`/`--emit` print
+// to stdout and write NOTHING; `--write` is gated + default OFF (operator-gated trust
+// POLICY). This CLI NEVER fetches/resolves on its own — resolution is github-trust.ts's
+// door — and NEVER touches a secret (public keys only). Workitem 081KVM1TK3Z08QG0R0002959G6.
+//
+//   *** TEMP TRUST ROOT (GitHub) — migrate to cert-manager/Vault + Headscale when
+//       clusters are redundant. ***
+//
+// Usage:
+//   bun install-trust-cli.ts --user aaron --dry-run             # NO network; reports intent, writes nothing
+//   bun install-trust-cli.ts --user aaron --emit                # fetch (resolver) + print rendered config to stdout
+//   bun install-trust-cli.ts --user aaron --emit --format nix-array
+//   bun install-trust-cli.ts --user aaron --write --out <path>  # GATED write THROUGH the effects door (default OFF)
+import { dirname, resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  realEffects as githubTrustEffects,
+  resolveIdentities,
+  resolveTrustSet,
+} from "./github-trust.ts";
+import {
+  defaultOperatorKeysTxtPath,
+  installTrust,
+  realEffects as installEffects,
+  renderOperatorSshKeys,
+  type RenderFormat,
+} from "./install-trust.ts";
+
+const args = process.argv.slice(2);
+const flag = (n: string): boolean => args.includes(n);
+const opt = (n: string): string | undefined => {
+  const i = args.indexOf(n);
+  return i >= 0 ? args[i + 1] : undefined;
+};
+const allOpts = (n: string): readonly string[] => {
+  const out: string[] = [];
+  for (let i = 0; i < args.length - 1; i++) {
+    if (args[i] === n) {
+      const v = args[i + 1];
+      if (v !== undefined) out.push(v);
+    }
+  }
+  return out;
+};
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = opt("--repo-root") ?? resolvePath(here, "..", "..", "..");
+const explicitUsers = allOpts("--user");
+const allowlistPath = opt("--allowlist");
+const includeGpg = flag("--gpg"); // signing trust (resolver-side); not rendered into ssh keys
+const dryRun = flag("--dry-run");
+const emit = flag("--emit");
+const doWrite = flag("--write");
+const force = flag("--force");
+const formatArg = opt("--format");
+const outPath = opt("--out");
+
+function parseFormat(v: string | undefined): RenderFormat {
+  if (v === "nix-array") return "nix-array";
+  return "txt";
+}
+
+async function main(): Promise<number> {
+  const format = parseFormat(formatArg);
+
+  // REUSE the resolver's identity sourcing + read-only effects. No re-implemented sourcing.
+  const ghFx = githubTrustEffects();
+  const idRes = resolveIdentities(ghFx, {
+    repoRoot,
+    ...(explicitUsers.length > 0 ? { identities: explicitUsers } : {}),
+    ...(allowlistPath !== undefined ? { allowlistPath } : {}),
+  });
+  if (idRes.rejected.length > 0) {
+    console.error(`rejected invalid GitHub usernames: ${idRes.rejected.join(", ")}`);
+  }
+  console.error(`identity source: ${idRes.sourceKind}`);
+
+  if (idRes.identities.length === 0) {
+    console.error("no trusted identities resolved — pass --user, add an allowlist, or populate maintainers/.");
+    return 2;
+  }
+
+  // REUSE resolveTrustSet to PRODUCE the trust set. On --dry-run NO network is performed.
+  const res = await resolveTrustSet(ghFx, { identities: idRes.identities, includeGpg, dryRun });
+
+  if (res.dryRun) {
+    console.error(`*** ${"TEMP TRUST ROOT"} (GitHub) — dry-run: NO network, NO write. ***`);
+    console.error(`would resolve: ${res.identities.join(", ")}`);
+    console.error(`would render: operator-ssh-keys (${format}) — and write NOTHING (dry-run).`);
+    return 0;
+  }
+
+  const anyError = res.perIdentity.some((p) => p.status === "error");
+
+  if (!doWrite) {
+    // --emit / default: print the rendered config to stdout. Writes NOTHING.
+    const rendered = renderOperatorSshKeys(res, { format });
+    if (emit || !doWrite) {
+      process.stdout.write(rendered);
+    }
+    console.error(`rendered ${res.trustSet.length} authorized-keys line(s) to stdout (NOT installed).`);
+    if (anyError) {
+      console.error("one or more identities failed to resolve (see per-identity status).");
+      return 1;
+    }
+    return 0;
+  }
+
+  // GATED write path (--write). Default OFF; reaching here required an explicit --write.
+  if (anyError) {
+    console.error("refusing to WRITE a trust set with resolution errors — fix resolution first.");
+    return 1;
+  }
+  const target = outPath ?? defaultOperatorKeysTxtPath(repoRoot);
+  const installFx = installEffects();
+  const result = installTrust(installFx, res, { targetPath: target, format, write: true, force });
+  if (result.wrote) {
+    console.error(`WROTE ${result.bytes} byte(s) to ${result.path} (TEMP TRUST ROOT — operator-gated trust policy).`);
+    return 0;
+  }
+  console.error(`did NOT write: ${result.refusedReason ?? "unknown"}`);
+  return 1;
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((e: unknown) => {
+    console.error(e instanceof Error ? e.message : String(e));
+    process.exit(1);
+  });

--- a/tools/setup/persona-keys/install-trust.test.ts
+++ b/tools/setup/persona-keys/install-trust.test.ts
@@ -1,0 +1,175 @@
+// install-trust.ts conformance — the GitHub TEMP-TRUST-ROOT installer MECHANISM. EVERY
+// test runs against FIXTURE TrustResolution values + temp dirs — NEVER live network,
+// NEVER a real operator-ssh-keys write, NEVER a secret. Proves: the render is pure +
+// deterministic, each entry is annotated by source, the TEMP-TRUST-ROOT banner is present,
+// the rendered output is PUBLIC-ONLY (no private material), --dry-run/render-only writes
+// nothing, and the gated --write goes ONLY through the injected effects door (temp dir),
+// refusing to clobber without force.
+// Run: bun test install-trust.test.ts   (from tools/setup/persona-keys)
+import { test, expect } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { TEMP_TRUST_ROOT_BANNER, type TrustResolution } from "./github-trust.ts";
+import {
+  defaultOperatorKeysTxtPath,
+  installTrust,
+  isPublicOnly,
+  renderOperatorSshKeys,
+  type InstallTrustEffects,
+} from "./install-trust.ts";
+
+const ED = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDwJVbQNiFzUCiOhc aaron@lucent.financial";
+const RSA = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQ octocat@github";
+
+/** Build a fixture TrustResolution (as the resolver would PRODUCE) without any network. */
+function fixtureResolution(entries: readonly { source: string; key: string }[]): TrustResolution {
+  return {
+    dryRun: false,
+    includeGpg: false,
+    identities: [...new Set(entries.map((e) => e.source))],
+    perIdentity: [],
+    trustSet: entries.map((e) => ({ source: e.source, key: e.key, algo: e.key.split(/\s+/, 1)[0] ?? "" })),
+    gpgBlocks: [],
+  };
+}
+
+/** A FIXTURE effects door: records writes in-memory; only touches the real FS through the
+ *  temp paths the test passes. fetchCount-style assertion is unnecessary (no fetch door). */
+function recordingEffects(opts?: { existingPaths?: readonly string[] }): {
+  fx: InstallTrustEffects;
+  writes: { path: string; contents: string }[];
+} {
+  const writes: { path: string; contents: string }[] = [];
+  const existing = new Set(opts?.existingPaths ?? []);
+  const fx: InstallTrustEffects = {
+    writeText: (path, contents) => {
+      writes.push({ path, contents });
+      existing.add(path);
+    },
+    exists: (path) => existing.has(path),
+  };
+  return { fx, writes };
+}
+
+test("renderOperatorSshKeys: txt form annotates each key by source + carries the TEMP banner", () => {
+  const res = fixtureResolution([
+    { source: "aaron", key: ED },
+    { source: "octocat", key: RSA },
+  ]);
+  const out = renderOperatorSshKeys(res);
+  expect(out).toContain(TEMP_TRUST_ROOT_BANNER);
+  expect(out).toContain("generated from the GitHub temp-trust-root resolver");
+  expect(out).toContain("TEMP until Vault/cert-manager + Headscale");
+  expect(out).toContain("# source: gh:aaron");
+  expect(out).toContain("# source: gh:octocat");
+  expect(out).toContain(ED);
+  expect(out).toContain(RSA);
+  // each pubkey line follows its source comment
+  const lines = out.split("\n");
+  const aaronIdx = lines.indexOf("# source: gh:aaron");
+  expect(lines[aaronIdx + 1]).toBe(ED);
+});
+
+test("renderOperatorSshKeys: deterministic — same input renders byte-identical output", () => {
+  const res = fixtureResolution([{ source: "aaron", key: ED }]);
+  expect(renderOperatorSshKeys(res)).toBe(renderOperatorSshKeys(res));
+});
+
+test("renderOperatorSshKeys: nix-array form emits the authorizedKeys.keys array", () => {
+  const res = fixtureResolution([{ source: "aaron", key: ED }]);
+  const out = renderOperatorSshKeys(res, { format: "nix-array" });
+  expect(out).toContain("users.users.zeta.openssh.authorizedKeys.keys = [");
+  expect(out).toContain("# source: gh:aaron");
+  expect(out).toContain(`"${ED}"`);
+  expect(out).toContain("];");
+});
+
+test("renderOperatorSshKeys: empty trust set still renders a valid banner-only file", () => {
+  const res = fixtureResolution([]);
+  const out = renderOperatorSshKeys(res);
+  expect(out).toContain(TEMP_TRUST_ROOT_BANNER);
+  expect(out).toContain("(none)");
+  expect(isPublicOnly(out)).toBe(true);
+});
+
+test("rendered output is PUBLIC-ONLY — never contains private-key material", () => {
+  const res = fixtureResolution([
+    { source: "aaron", key: ED },
+    { source: "octocat", key: RSA },
+  ]);
+  const out = renderOperatorSshKeys(res);
+  // Assemble the forbidden marker at runtime — no contiguous private-key literal in source.
+  const marker = "BEGIN OPENSSH " + "PRIVATE" + " KEY";
+  expect(out).not.toContain(marker);
+  expect(out).not.toContain("PRIVATE" + " KEY");
+  expect(isPublicOnly(out)).toBe(true);
+});
+
+test("isPublicOnly: refuses text that carries private-key material", () => {
+  const tainted = "ssh-ed25519 AAAA ok\n-----" + "BEGIN " + "PRIVATE" + " KEY" + "-----\n";
+  expect(isPublicOnly(tainted)).toBe(false);
+});
+
+test("installTrust: default (write OFF) renders but writes NOTHING through the door", () => {
+  const res = fixtureResolution([{ source: "aaron", key: ED }]);
+  const { fx, writes } = recordingEffects();
+  const result = installTrust(fx, res, { targetPath: "/tmp/should-not-be-written.txt" });
+  expect(result.wrote).toBe(false);
+  expect(result.refusedReason).toContain("write not requested");
+  expect(writes.length).toBe(0);
+});
+
+test("installTrust: gated --write goes ONLY through the injected door (recorded, no real FS)", () => {
+  const res = fixtureResolution([{ source: "aaron", key: ED }]);
+  const { fx, writes } = recordingEffects();
+  const target = "/tmp/install-trust-record-only.txt";
+  const result = installTrust(fx, res, { targetPath: target, write: true });
+  expect(result.wrote).toBe(true);
+  expect(writes.length).toBe(1);
+  expect(writes[0]?.path).toBe(target);
+  expect(writes[0]?.contents).toContain(ED);
+  expect(writes[0]?.contents).toContain(TEMP_TRUST_ROOT_BANNER);
+  // and the recorded write performed NO real filesystem mutation
+  expect(existsSync(target)).toBe(false);
+});
+
+test("installTrust: refuses to clobber an existing target without force", () => {
+  const res = fixtureResolution([{ source: "aaron", key: ED }]);
+  const target = "/tmp/already-here.txt";
+  const { fx, writes } = recordingEffects({ existingPaths: [target] });
+  const refused = installTrust(fx, res, { targetPath: target, write: true });
+  expect(refused.wrote).toBe(false);
+  expect(refused.refusedReason).toContain("target exists");
+  expect(writes.length).toBe(0);
+  // with force it overwrites
+  const forced = installTrust(fx, res, { targetPath: target, write: true, force: true });
+  expect(forced.wrote).toBe(true);
+  expect(writes.length).toBe(1);
+});
+
+test("installTrust: REAL write only touches a temp dir (hermetic, never operator-ssh-keys)", () => {
+  const dir = mkdtempSync(join(tmpdir(), "install-trust-"));
+  try {
+    const target = join(dir, "operator-ssh-keys.txt");
+    const res = fixtureResolution([{ source: "aaron", key: ED }]);
+    // real effects-shaped door, scoped to the temp dir
+    const fx: InstallTrustEffects = {
+      writeText: (p, c) => writeFileSync(p, c, "utf8"),
+      exists: (p) => existsSync(p),
+    };
+    const result = installTrust(fx, res, { targetPath: target, write: true });
+    expect(result.wrote).toBe(true);
+    const written = readFileSync(target, "utf8");
+    expect(written).toContain(ED);
+    expect(written).toContain("# source: gh:aaron");
+    expect(isPublicOnly(written)).toBe(true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("defaultOperatorKeysTxtPath: points at the node-config operator-ssh-keys.txt", () => {
+  const p = defaultOperatorKeysTxtPath("/repo");
+  expect(p).toBe("/repo/full-ai-cluster/nixos/modules/operator-ssh-keys.txt");
+});

--- a/tools/setup/persona-keys/install-trust.ts
+++ b/tools/setup/persona-keys/install-trust.ts
@@ -1,0 +1,186 @@
+// Zeta GitHub TEMP-TRUST-ROOT installer MECHANISM — the renderer that turns the
+// read-only resolver's authorized-keys trust set (github-trust.ts → TrustResolution)
+// into the node-config `operator-ssh-keys` format, and (gated, default OFF) writes it
+// into the node's operator-ssh-keys.txt. Workitem 081KVM1TK3Z08QG0R0002959G6
+// §"installer mechanism".
+//
+// >>> TEMP TRUST ROOT (GitHub) — migrate to cert-manager/Vault + Headscale when
+//     clusters are redundant. <<<
+//
+// SECURITY INVARIANTS (security-sensitive slice — honesty over green):
+//  1. RESOLUTION IS NOT RE-IMPLEMENTED. This module consumes a `TrustResolution`
+//     PRODUCED by github-trust.ts (`resolveTrustSet`). It never fetches, never resolves,
+//     never touches the network. It RENDERS (pure) and optionally WRITES (gated).
+//  2. PUBLIC KEYS ONLY. The trust set is OpenSSH public-key lines. No secret, no seed,
+//     no private key, no CA passes through here. The renderer cannot emit private
+//     material (a test asserts the rendered output carries no private-key marker).
+//  3. WRITE IS OPERATOR-GATED + DEFAULT OFF. `renderOperatorSshKeys` is pure and always
+//     safe. `--dry-run`/`--emit` print to stdout and write NOTHING. `--write` is the only
+//     path that touches the filesystem, it is OFF unless explicitly requested, and even
+//     then it routes through the injected `InstallTrustEffects.writeText` door — so tests
+//     write to temp dirs, never to the real operator-ssh-keys path. Installing a SPECIFIC
+//     trust set is a trust-POLICY decision; this slice ships the MECHANISM only.
+//
+// Noninterference (manifesto §13): the filesystem WRITE enters ONLY through the injected
+// `InstallTrustEffects` door — so the pure render path is deterministic and every test is
+// hermetic (temp dirs / fixtures), NEVER a real node-config write.
+//
+// Anchors (Beacon): OpenSSH `sshd(8)` AUTHORIZED_KEYS file format (one pubkey per line,
+// `#` comments ignored); the sibling `operator-ssh-keys.nix` reads `operator-ssh-keys.txt`
+// via `builtins.readFile` then `lib.splitString "\n"` + filters comment/blank lines
+// (so the `.txt` list IS the node trust). Nix string-injection avoidance (#5086): pubkey
+// content is DATA read from a file, never a Nix string literal — the renderer targets the
+// `.txt` file for exactly that reason.
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { TEMP_TRUST_ROOT_BANNER, type TrustResolution } from "./github-trust.ts";
+
+/** The door for the ONLY ambient effect this module has — a filesystem write
+ *  (noninterference §13). Tests inject a temp-dir writer; the CLI injects the real one.
+ *  There is intentionally NO read/fetch door here: resolution is github-trust.ts's job. */
+export interface InstallTrustEffects {
+  /** Write text to a path (the gated `--write` path). The ONLY effect door. */
+  readonly writeText: (path: string, contents: string) => void;
+  /** True iff a path exists (used to refuse clobbering without an explicit force). */
+  readonly exists: (path: string) => boolean;
+}
+
+/** The two render targets: the `.txt` operator-keys list (what the nix module reads), or
+ *  the inline nix `authorizedKeys.keys = [ ... ]` array (a legacy/alternate shape). The
+ *  `.txt` form is canonical (#5086: pubkey content is DATA, not a Nix string literal). */
+export type RenderFormat = "txt" | "nix-array";
+
+/** Result of a (gated) write: the path written + byte length, for an auditable readout. */
+export interface InstallResult {
+  readonly wrote: boolean;
+  readonly path: string;
+  readonly bytes: number;
+  /** Set when a write was REFUSED (e.g. target exists, no force) — wrote === false. */
+  readonly refusedReason?: string;
+}
+
+/** The default node-config target the installer renders FOR. Relative to repo root. */
+export function defaultOperatorKeysTxtPath(repoRoot: string): string {
+  return `${repoRoot}/full-ai-cluster/nixos/modules/operator-ssh-keys.txt`;
+}
+
+/** A stable header banner stamped into every rendered artifact: the TEMP-TRUST-ROOT
+ *  warning + provenance (generated from the resolver) + a do-not-edit note. Deterministic
+ *  (no timestamp) so renders are byte-stable + DST-replayable. */
+function headerLines(res: TrustResolution, commentPrefix: string): readonly string[] {
+  return [
+    `${commentPrefix} ${TEMP_TRUST_ROOT_BANNER}`,
+    `${commentPrefix} generated from the GitHub temp-trust-root resolver (github-trust.ts) —`,
+    `${commentPrefix} TEMP until Vault/cert-manager + Headscale. Do not edit by hand.`,
+    `${commentPrefix} resolved from GitHub public .keys for: ${res.identities.join(", ") || "(none)"}`,
+    `${commentPrefix} trust set: ${res.trustSet.length} unique authorized-keys line(s) — PUBLIC keys only.`,
+  ];
+}
+
+/**
+ * Render the resolver's authorized-keys trust set into the `operator-ssh-keys` node-config
+ * format. PURE + deterministic: same `TrustResolution` → byte-identical string, no clock,
+ * no network, no filesystem. Each entry is annotated with its source GitHub identity.
+ *
+ * - `format: "txt"` (default) → the sibling-of-`operator-ssh-keys.nix` `.txt` list: a
+ *   header banner, then per key a `# source: gh:<user>` comment + the verbatim pubkey line.
+ *   This is the file `operator-ssh-keys.nix` reads via `builtins.readFile`.
+ * - `format: "nix-array"` → an inline `users.users.zeta.openssh.authorizedKeys.keys = [ … ]`
+ *   array (each key a quoted string with a leading source comment). Alternate shape.
+ *
+ * NEVER emits private material — the input is public-key lines only.
+ */
+export function renderOperatorSshKeys(
+  res: TrustResolution,
+  opts?: { readonly format?: RenderFormat },
+): string {
+  const format = opts?.format ?? "txt";
+  if (format === "nix-array") return renderNixArray(res);
+  return renderTxt(res);
+}
+
+/** Render the canonical `.txt` operator-keys list. */
+function renderTxt(res: TrustResolution): string {
+  const out: string[] = [...headerLines(res, "#"), ""];
+  for (const e of res.trustSet) {
+    out.push(`# source: gh:${e.source}`);
+    out.push(e.key);
+  }
+  return out.join("\n") + "\n";
+}
+
+/** Escape a pubkey line for safe inclusion as a Nix double-quoted string literal. Pubkeys
+ *  are base64 + a comment so this is normally a no-op, but we escape `\`, `"`, and `${`
+ *  defensively (#5086 string-injection class). */
+function nixEscape(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\$\{/g, "\\${");
+}
+
+/** Render the inline nix `authorizedKeys.keys = [ … ]` array shape (alternate). */
+function renderNixArray(res: TrustResolution): string {
+  const out: string[] = [...headerLines(res, "#"), "", "{", "  users.users.zeta.openssh.authorizedKeys.keys = ["];
+  for (const e of res.trustSet) {
+    out.push(`    # source: gh:${e.source}`);
+    out.push(`    "${nixEscape(e.key)}"`);
+  }
+  out.push("  ];", "}");
+  return out.join("\n") + "\n";
+}
+
+/** Guard: a rendered artifact must contain NO private-key material. The marker token is
+ *  assembled at runtime (no contiguous private-key literal in this source). Returns true
+ *  iff the text is clean (public only). Used by the write path as a last-line refusal. */
+export function isPublicOnly(rendered: string): boolean {
+  // Assemble the marker at runtime so this source has no contiguous private-key literal.
+  const marker = "PRIVATE" + " KEY";
+  return !rendered.includes(marker);
+}
+
+/**
+ * The GATED write path (default OFF). Renders the trust set and — only when `write: true`
+ * — writes it to `targetPath` THROUGH the injected effects door. Refuses to write private
+ * material (isPublicOnly guard) and, unless `force`, refuses to clobber an existing file.
+ *
+ * IMPORTANT: this is the MECHANISM. The CLI does not pass `write: true` unless `--write`
+ * is explicitly given, and this PR ships no real installed trust set. Tests pass a temp
+ * path + a temp-dir `writeText` — never the real operator-ssh-keys path.
+ */
+export function installTrust(
+  fx: InstallTrustEffects,
+  res: TrustResolution,
+  opts: {
+    readonly targetPath: string;
+    readonly format?: RenderFormat;
+    readonly write?: boolean;
+    readonly force?: boolean;
+  },
+): InstallResult {
+  const rendered = renderOperatorSshKeys(res, opts.format !== undefined ? { format: opts.format } : {});
+  if (!isPublicOnly(rendered)) {
+    // Belt-and-suspenders: should be impossible (input is public keys), but never write
+    // anything that looks like private material.
+    return { wrote: false, path: opts.targetPath, bytes: 0, refusedReason: "rendered output contained private-key material" };
+  }
+  if (opts.write !== true) {
+    return { wrote: false, path: opts.targetPath, bytes: Buffer.byteLength(rendered, "utf8"), refusedReason: "write not requested (--write OFF)" };
+  }
+  if (opts.force !== true && fx.exists(opts.targetPath)) {
+    return { wrote: false, path: opts.targetPath, bytes: Buffer.byteLength(rendered, "utf8"), refusedReason: `target exists (pass force to overwrite): ${opts.targetPath}` };
+  }
+  fx.writeText(opts.targetPath, rendered);
+  return { wrote: true, path: opts.targetPath, bytes: Buffer.byteLength(rendered, "utf8") };
+}
+
+/** The REAL effects (used by the CLI): a plain filesystem write + exists check. NO network,
+ *  NO auth, NO secrets, NO read of any private path. Resolution is github-trust.ts's door. */
+export function realEffects(): InstallTrustEffects {
+  return {
+    writeText: (p, contents) => writeFileSync(p, contents, "utf8"),
+    exists: (p) => existsSync(p),
+  };
+}
+
+/** Read a previously-rendered artifact back (CLI `--diff` convenience to compare against a
+ *  target). Plain public read; never a private path. */
+export function readExisting(path: string): string | undefined {
+  return existsSync(path) ? readFileSync(path, "utf8") : undefined;
+}


### PR DESCRIPTION
## What

The `github-trust.ts` resolver (#8852) PRODUCES an authorized-keys trust set, but nothing INSTALLS it into the node config. This slice ships the installer **MECHANISM** — a pure renderer plus a gated (default OFF) writer. Workitem `081KVM1TK3Z08QG0R0002959G6`.

**Security-class — honesty over green. DO NOT auto-merge; left OPEN for Otto's verify-gate.**

## Deliverable

- **`tools/setup/persona-keys/install-trust.ts`**
  - `renderOperatorSshKeys(trustSet, {format}) -> string` — PURE + deterministic. Renders the resolver's trust set into the `operator-ssh-keys` format: `"txt"` (the list `operator-ssh-keys.nix` reads via `builtins.readFile`) or `"nix-array"`. Each entry annotated with its source `gh:<user>`; a TEMP-TRUST-ROOT header banner ("generated from the GitHub temp-trust-root resolver — TEMP until Vault/cert-manager + Headscale").
  - `installTrust(fx, res, opts)` — the **GATED** write path, **default OFF**. Writes ONLY through the injected `InstallTrustEffects.writeText` door (noninterference §13), refuses to clobber without `force`, and refuses any private-key material (`isPublicOnly` guard, marker assembled at runtime).
- **`tools/setup/persona-keys/install-trust-cli.ts`** — REUSES `github-trust.ts` (`resolveIdentities` + `resolveTrustSet`) to PRODUCE the set; `install-trust` only renders/writes. `--dry-run` does NO network + writes nothing; `--emit` prints rendered config to stdout (writes nothing); `--write` is gated, default OFF.
- **`tools/setup/persona-keys/install-trust.test.ts`** — 11 tests against FIXTURE `TrustResolution` + temp dirs.

## Reuse / security confirmation

- **No re-implemented fetch/resolution** — resolution stays `github-trust.ts`'s door; this module only RENDERS + (optionally) WRITES.
- **No secrets** — public keys only; a test asserts the rendered output carries no private-key marker.
- **Ships the MECHANISM only** — does NOT commit a real installed trust set (installing a SPECIFIC set is an operator-gated trust-POLICY decision). **No change to `full-ai-cluster/nixos/modules/operator-ssh-keys.*`.**

## Gate

- `bun install-trust.test.ts` → 11/11 green (fixtures + temp dirs, no real write)
- `tsc` on the new files clean (the one repo lint error is **pre-existing** in `src/Core.TypeScript/algebra/soft-mix.ts`, untouched here)
- `--dry-run` / `--emit` write nothing (verified)
- `grep -E "BEGIN.*PRIVATE KEY" install-trust.test.ts` → empty
- No `operator-ssh-keys.{nix,txt}` change

🤖 Generated with [Claude Code](https://claude.com/claude-code)