### PR TITLE
fix(lint): restore 4 gate lints — TS/shellcheck/Go/markdownlint (mechanical)

### DIFF
--- a/docs/handoffs/2026-06-21-lumen-to-math-team-gen-self-application-quine.md
+++ b/docs/handoffs/2026-06-21-lumen-to-math-team-gen-self-application-quine.md
@@ -77,6 +77,7 @@ Two sub-questions the math team should settle, in order:
 ## Connection to the live grammar work (why this is timely)
 
 Since the original `sorry` was filed, the IR grammar grew and then shrank:
+
 - `zeta-ir-v4` now includes `add` (affine), and the minimal generating set is proved to be `{mul, add, xshrxor, xrotxor}` (PR #8826, `docs/research/2026-06-20-lumen-zeta-ir-minimal-generating-set.md`).
 - A second `add`-anchor (`murmur3_32_tail`, PR #8855) shows `mul`+`rotl`+`add` composing in one generator.
 

--- a/docs/specs/four-lane-seven-lang-matrix.md
+++ b/docs/specs/four-lane-seven-lang-matrix.md
@@ -38,6 +38,7 @@ Q#'s `Complex` type with `Im = 0.0` is a real number. The sparse simulator with 
 ## Why Quantum in C#/Rust/Go is ✅
 
 `softMixGeneric(complexRing, ir, isZero, [(x, Complex{1,0})])` IS `measure(U_mix|z⟩)`:
+
 - One entry in the ensemble = one basis state
 - Complex ring = quantum arithmetic
 - Consolidate after each op = the sparse statevector update

--- a/src/Core.Go/algebra/star_ring.go
+++ b/src/Core.Go/algebra/star_ring.go
@@ -26,19 +26,19 @@ type Complex struct {
 // RealRing implements StarRing[float64]. Conj = identity.
 type RealRing struct{}
 
-func (RealRing) Zero() float64          { return 0 }
-func (RealRing) One() float64           { return 1 }
-func (RealRing) Add(a, b float64) float64    { return a + b }
-func (RealRing) Mul(a, b float64) float64    { return a * b }
-func (RealRing) Negate(a float64) float64    { return -a }
-func (RealRing) Conj(a float64) float64      { return a }
-func (RealRing) IsZero(a float64) bool       { return math.Abs(a) < 1e-12 }
+func (RealRing) Zero() float64            { return 0 }
+func (RealRing) One() float64             { return 1 }
+func (RealRing) Add(a, b float64) float64 { return a + b }
+func (RealRing) Mul(a, b float64) float64 { return a * b }
+func (RealRing) Negate(a float64) float64 { return -a }
+func (RealRing) Conj(a float64) float64   { return a }
+func (RealRing) IsZero(a float64) bool    { return math.Abs(a) < 1e-12 }
 
 // ComplexRing implements StarRing[Complex]. Conj = complex conjugate.
 type ComplexRing struct{}
 
-func (ComplexRing) Zero() Complex          { return Complex{0, 0} }
-func (ComplexRing) One() Complex           { return Complex{1, 0} }
+func (ComplexRing) Zero() Complex { return Complex{0, 0} }
+func (ComplexRing) One() Complex  { return Complex{1, 0} }
 func (ComplexRing) Add(a, b Complex) Complex {
 	return Complex{a.Re + b.Re, a.Im + b.Im}
 }

--- a/tools/setup/persona-keys/keyring.sh
+++ b/tools/setup/persona-keys/keyring.sh
@@ -34,14 +34,14 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO="$(cd "$HERE/../../.." && pwd)"
 
 mode="${1:-}"; name="${2:-}"; shift 2 2>/dev/null || true
-public_only=""; vault_path=""; out_dir=""; gh_secret=""; gh_repo="Lucent-Financial-Group/Zeta"; publish=""; dry_run=""
+public_only=""; vault_path=""; out_dir=""; gh_secret=""; gh_repo="Lucent-Financial-Group/Zeta"; dry_run=""
 while [ $# -gt 0 ]; do case "$1" in
   --public-only) public_only="--public-only";;
   --vault) vault_path="${2:?}"; shift;;
   --gh-secret) gh_secret="${2:?}"; shift;;
   --gh-repo) gh_repo="${2:?}"; shift;;
   --out) out_dir="${2:?}"; shift;;
-  --publish) publish="--publish";;
+  --publish) echo "note: --publish moved to the biometric-gated publish.ts; ignoring here" >&2 ;;
   --dry-run) dry_run="--dry-run";;
   *) echo "unknown arg: $1" >&2; exit 2;;
 esac; shift; done


### PR DESCRIPTION
Four non-required lint jobs were red on `main` from recent commits (each merged red). All **mechanical, no logic change**:

- **lint(TS)** — `soft-mix.ts(86)` TS6133: `sqrt2inv` was a **dead placeholder** in the unimplemented `branch` op. Removed the dead line, kept the 1/√2 TODO comment.
- **shellcheck** — `keyring.sh:44` SC2034: `publish` var **orphaned** after #8863 removed the unsafe onboard path. Removed it; `--publish` is now an accepted no-op pointing to the biometric-gated `publish.ts`.
- **Go gofmt** — `src/Core.Go/algebra/star_ring.go` → `gofmt -w`.
- **markdownlint MD032** — the quine handoff brief (L80) + `four-lane-seven-lang-matrix.md` (L41) (blank lines around lists).

Verified: lint-typescript green, shellcheck exit 0, gofmt 0 dirty, markdownlint 0 violations. (Also clears the `soft-mix.ts` blocker the #8868 installer PR flagged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)