### PR TITLE
feat(core): project horizon heat onto darkhall board

### DIFF
--- a/docs/handoffs/2026-06-21-lumen-to-math-team-gen-self-application-quine.md
+++ b/docs/handoffs/2026-06-21-lumen-to-math-team-gen-self-application-quine.md
@@ -77,6 +77,7 @@ Two sub-questions the math team should settle, in order:
 ## Connection to the live grammar work (why this is timely)
 
 Since the original `sorry` was filed, the IR grammar grew and then shrank:
+
 - `zeta-ir-v4` now includes `add` (affine), and the minimal generating set is proved to be `{mul, add, xshrxor, xrotxor}` (PR #8826, `docs/research/2026-06-20-lumen-zeta-ir-minimal-generating-set.md`).
 - A second `add`-anchor (`murmur3_32_tail`, PR #8855) shows `mul`+`rotl`+`add` composing in one generator.
 

--- a/docs/specs/four-lane-seven-lang-matrix.md
+++ b/docs/specs/four-lane-seven-lang-matrix.md
@@ -38,6 +38,7 @@ Q#'s `Complex` type with `Im = 0.0` is a real number. The sparse simulator with 
 ## Why Quantum in C#/Rust/Go is ✅
 
 `softMixGeneric(complexRing, ir, isZero, [(x, Complex{1,0})])` IS `measure(U_mix|z⟩)`:
+
 - One entry in the ensemble = one basis state
 - Complex ring = quantum arithmetic
 - Consolidate after each op = the sparse statevector update

--- a/docs/specs/zeta-ir-v2-isa-ops.md
+++ b/docs/specs/zeta-ir-v2-isa-ops.md
@@ -74,6 +74,7 @@ case "retract":
 ## The Rx/query view (Aaron's observation)
 
 The ISA ops ARE reactive queries over two ZSets:
+
 - **Frame ZSet A** (current state): keys = possible states, weights = amplitudes
 - **Frame ZSet B** (after op): keys = transformed states, weights = transformed amplitudes
 - **Each op**: A query that maps ZSet A → ZSet B
@@ -97,7 +98,8 @@ This is DBSP's `D[op]` (the incremental version of the op) applied to the ZSet s
 
 One JSON schema. One `flatMap → consolidate` interpreter. One `StarRing` interface.
 The lens is selected by which ring instance you inject:
+
 - `realRing` → classical/Bayesian view
-- `complexRing` → quantum/amplitude view  
+- `complexRing` → quantum/amplitude view
 - `cl3Ring` → Clifford/geometric view (future)
 - The IR is its own meta-description (gen(gen)=gen)

--- a/src/Core.TypeScript/algebra/soft-mix.ts
+++ b/src/Core.TypeScript/algebra/soft-mix.ts
@@ -81,8 +81,9 @@ function applyOp<W>(
       const newKey = (entry.key ^ (entry.key >> BigInt(op.s!))) & MASK;
       return [{ key: newKey, weight: entry.weight }];
     } else if (op.op === "branch") {
-      // Fork: two frames — bit flipped vs not (the H gate / Hadamard).
-      // Support grows by 1 bit of uncertainty.
+      // Fork: two frames, bit flipped vs not.
+      // Support grows by 1 bit of uncertainty; ring-specific split weights
+      // are a separate policy.
       const bit = BigInt(op.s ?? (op as any).bit ?? 0);
       return [
         { key: entry.key, weight: entry.weight },

--- a/src/Core/DarkHallScheduler.fs
+++ b/src/Core/DarkHallScheduler.fs
@@ -169,6 +169,41 @@ module DarkHallScheduler =
     let renderHeatBoardForState (seed: uint64) (state: ScheduledRoomState) : string list =
         state |> heatRows |> renderHeatBoard seed
 
+    let private heatReadoutOfSignatures (signatures: HeatSignature list) : RoomLoop.HeatReadout =
+        { HeatRejected = signatures.Length
+          Backpressured =
+            signatures
+            |> List.filter (fun signature ->
+                signature.Kind.Contains("backpressure", System.StringComparison.Ordinal)
+                || signature.Kind.Contains("denied", System.StringComparison.Ordinal))
+            |> List.length
+          StorageErrors = 0
+          HeatKinds = signatures |> List.map _.Kind
+          Reasons = signatures |> List.map _.Detail }
+
+    /// Project a finite prediction horizon into the same host-visible heat row
+    /// used by Dark Hall/CHIP room execution. The horizon is not a runtime:
+    /// attention may order futures, but this row only reports materialized
+    /// forgetting and paid finite-view backpressure.
+    let heatRowOfHorizonReport
+        (tick: int)
+        (roomName: string)
+        (source: string)
+        (report: RoomHorizon.Report<'K, 'S>)
+        : HeatBoundaryRow =
+        let heat =
+            report
+            |> RoomHorizon.heatSignatures source
+            |> heatReadoutOfSignatures
+
+        { Tick = tick
+          RoomName = roomName
+          HeatRejected = heat.HeatRejected
+          Backpressured = heat.Backpressured
+          StorageErrors = heat.StorageErrors
+          HeatKinds = heat.HeatKinds
+          Reasons = heat.Reasons }
+
     let private rowOfOutcome (tick: int) (outcome: RoomLoop.TickOutcome) : HeatBoundaryRow =
         { Tick = tick
           RoomName = outcome.Readout.RoomName

--- a/tests/Tests.FSharp/DarkHallScheduler.Tests.fs
+++ b/tests/Tests.FSharp/DarkHallScheduler.Tests.fs
@@ -8,6 +8,8 @@ open Zeta.Core
 module Runtime = DarkHallCabinetRuntime
 module RoomLoop = DarkHallRoomLoop
 module Scheduler = DarkHallScheduler
+module RH = RoomHorizon
+module PS = ProbabilitySemiring
 
 let private ctx () : IntrCtx =
     { Memetic = "darkhall-scheduler"
@@ -51,6 +53,26 @@ let private emptyBoundary source room budget config =
     ModuloGSet.empty<string> config
     |> mustOk
     |> RoomBoundary.create source room budget
+
+let private horizonConfig capacity policy : BoundedGSetConfig =
+    { Capacity = capacity
+      ForgetPolicy = policy }
+
+let private horizonCost bytes : Vision.BranchCost =
+    { SpaceBytes = bytes
+      TimeTicks = 0
+      BytesPerTick = 0L
+      UncertaintyResolutionBits = 0 }
+
+let private horizonCandidate key label state bytes : RH.Candidate<int, string> =
+    { Key = key
+      Branch =
+        { Label = label
+          State = state
+          Cost = horizonCost bytes }
+      Priority =
+        { Attention = PS.one
+          Gravity = PS.one } }
 
 let private sampleVault () =
     let v =
@@ -97,6 +119,58 @@ let ``heat boundary rows render as a host visible CHIP-9 board`` () =
     Assert.Equal("0", firstDisplayRow.Substring(33, 1))
     Assert.Equal("44", firstDisplayRow.Substring(48, 2))
     Assert.Equal("0", firstDisplayRow.Substring(50, 1))
+
+[<Fact>]
+let ``room horizon forgetting renders on the DarkHall heat board`` () =
+    let current =
+        BoundedGSet.ofSeq<int> (horizonConfig 2 BoundedGSetForgetPolicy.ForgetLowest) [ 1; 2 ]
+        |> mustOk
+        |> fun projection -> projection.State
+
+    let report =
+        [ horizonCandidate 3 "newer" "C" 1L ]
+        |> RH.update current (SoftThrottle.tank 1.0 0.0)
+        |> mustOk
+
+    let row = Scheduler.heatRowOfHorizonReport 11 "darkhall" "darkhall-horizon" report
+
+    Assert.Equal(11, row.Tick)
+    Assert.Equal("darkhall", row.RoomName)
+    Assert.Equal(1, row.HeatRejected)
+    Assert.Equal(0, row.Backpressured)
+    Assert.Equal<string list>([ "room-horizon.forgotten" ], row.HeatKinds)
+    Assert.Contains("forgot materialized keys", System.String.Join(";", row.Reasons))
+
+    let frame = Scheduler.heatBoardFrame 99UL [ row ]
+
+    Assert.Equal(1uy, Chip8Cow.colorAt 0 0 frame)
+    Assert.Equal(0uy, Chip8Cow.colorAt 16 0 frame)
+    Assert.Equal(4uy, Chip8Cow.colorAt 48 0 frame)
+
+[<Fact>]
+let ``room horizon no-forget backpressure renders on the DarkHall heat board`` () =
+    let current =
+        BoundedGSet.ofSeq<int> (horizonConfig 1 BoundedGSetForgetPolicy.RejectNew) [ 1 ]
+        |> mustOk
+        |> fun projection -> projection.State
+
+    let report =
+        [ horizonCandidate 2 "second" "B" 1L ]
+        |> RH.update current (SoftThrottle.tank 1.0 0.0)
+        |> mustOk
+
+    let row = Scheduler.heatRowOfHorizonReport 12 "darkhall" "darkhall-horizon" report
+
+    Assert.Equal(1, row.HeatRejected)
+    Assert.Equal(1, row.Backpressured)
+    Assert.Equal<string list>([ "room-horizon.backpressure" ], row.HeatKinds)
+    Assert.Contains("paid futures could not enter", System.String.Join(";", row.Reasons))
+
+    let frame = Scheduler.heatBoardFrame 99UL [ row ]
+
+    Assert.Equal(1uy, Chip8Cow.colorAt 0 0 frame)
+    Assert.Equal(3uy, Chip8Cow.colorAt 16 0 frame)
+    Assert.Equal(4uy, Chip8Cow.colorAt 48 0 frame)
 
 [<Fact>]
 let ``soft scheduler banks darkhall heat backpressure as a room boundary row`` () =


### PR DESCRIPTION
## Summary
- Project `RoomHorizon.Report` into `DarkHallScheduler.HeatBoundaryRow` so finite-horizon forgetting and no-forget backpressure render on the existing CHIP-9 heat board.
- Add tests that verify `room-horizon.forgotten` and `room-horizon.backpressure` drive the red/backpressure/kind lanes.
- Clear fresh-main quick preflight fallout: markdownlint MD032 blank lines and an unused soft-mix branch placeholder, while preserving support-growth semantics.

## Verification
- `PATH="/Users/acehack/.bun/bin:$PATH" bun src/Core.TypeScript/hygiene/audit-agencysignature-main-tip.ts --max 2 --branch HEAD`
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter "FullyQualifiedName~DarkHallSchedulerTests|FullyQualifiedName~RoomHorizonTests"`
- `PATH="/Users/acehack/.bun/bin:$PATH" bun test src/Core.TypeScript/algebra/soft-mix.test.ts`
- `dotnet build -c Release`
- `PATH="/Users/acehack/.bun/bin:$PATH" bun run preflight:quick`
- `dotnet test Zeta.sln -c Release`

## Notes
- Local shell did not have `bun` on PATH, but `/Users/acehack/.bun/bin/bun` is installed. I ran Bun gates with that directory prepended to PATH so package scripts can resolve nested `bun` calls.
- Local quick preflight still skips Go because the local Go toolchain is unavailable; CI covers it.
