### PR TITLE
fix(lint): codegen-spread gate lints — unused imports + RESUME markdownlint

### DIFF
--- a/docs/trajectories/codegen-spread/RESUME.md
+++ b/docs/trajectories/codegen-spread/RESUME.md
@@ -20,10 +20,13 @@ Parent: `gen-gen-self-hosting-bytelock` (shares the IR substrate)
 ## The push order (what's next)
 
 ### 1. ✅ DONE — Ring-generic soft-mix handles v2 ISA ops (TS)
+
 The TS interpreter already has branch/emit/retract/join/merge. On main.
 
 ### 2. NEXT — Golden vectors for ISA ops
+
 Small hand-verified test cases for the ISA ops:
+
 - `branch` on bit 0: one frame → two frames (support doubles)
 - `emit` then `retract` on same key: cancellation (support → 0 on complex ring)
 - `join` (CNOT): conditional bit flip
@@ -32,20 +35,24 @@ Small hand-verified test cases for the ISA ops:
 Commit as `tests/cross-verification/zset-isa-v2/vectors.yaml`.
 
 ### 3. NEXT — Codegen emits ring-generic scripts from v2 IR
+
 Update `codegen-from-ir.ts` to emit scripts that import `StarRing` and use the
 ring-generic interpreter — so a v2 IR with `branch` ops produces code that
 actually forks and interferes in all 7 languages.
 
 ### 4. FUTURE — Self-hosting codegen (gen(gen) operational)
+
 The codegen reads an IR description of itself and emits itself. The IR v2 has
 enough ops to describe interpreter logic (branch for if-statements, join for
 composition). This is Face 3 made operational.
 
 ### 5. FUTURE — Rx query emission (the ZSet lens)
+
 Emit code that expresses the IR as an Rx/observable pipeline (map/filter/merge).
 Produces reactive streaming code in addition to batch scripts.
 
 ### 6. FUTURE — Clifford lens emission
+
 Emit code using the geometric algebra (Cl3, multivectors). The IR ops map to
 geometric product / reflection / grade projection.
 
@@ -73,37 +80,42 @@ geometric product / reflection / grade projection.
 ## Update 2026-06-21 (session end)
 
 ### Done this session
+
 - ✅ codegen-v2-ring: all 7 languages emit ring-generic + benchmark
 - ✅ codegen-specialize: 1st Futamura projection (unrolled = hand-written speed)
 - ✅ v2 ISA golden vectors: 12 tests, 69 assertions
 - ✅ Face 3 FULLY CLOSED (quine discharged by Lumen, independently verified)
 
 ### Performance answer
+
 For deterministic IRs: specialized (unrolled) codegen = hand-written speed (no loop, no switch).
 For branching IRs: interpreter loop required (~1.05x overhead).
 Keep both paths: specialized for hot path, interpreter for generality.
 
 ### Remaining push items (next session)
+
 1. **Interface/type emission** — describe IStarRing as an IR node → emit language-specific interfaces
 2. **Rx pipeline emission** — IR as observable (map/filter/merge operators)
 3. **Auto-harness generation** — codegen emits test + benchmark + golden-vector check per language
 4. **Specialize remaining 5 languages** — extend codegen-specialize to F#/C#/Rust/Go/Q#
 
-
-## Update 2026-06-21 (session end)
+## Update 2026-06-21 (session end, cont.)
 
 ### Done this session
+
 - ✅ codegen-v2-ring: all 7 languages emit ring-generic + benchmark
 - ✅ codegen-specialize: 1st Futamura projection (unrolled = hand-written speed)
 - ✅ v2 ISA golden vectors: 12 tests, 69 assertions
 - ✅ Face 3 FULLY CLOSED (quine discharged by Lumen, independently verified)
 
 ### Performance answer
+
 For deterministic IRs: specialized (unrolled) codegen = hand-written speed (no loop, no switch).
 For branching IRs: interpreter loop required (~1.05x overhead).
 Keep both paths: specialized for hot path, interpreter for generality.
 
 ### Remaining push items (next session)
+
 1. **Interface/type emission** — describe IStarRing as an IR node → emit language-specific interfaces
 2. **Rx pipeline emission** — IR as observable (map/filter/merge operators)
 3. **Auto-harness generation** — codegen emits test + benchmark + golden-vector check per language

--- a/tests/cross-verification/_harness/codegen-specialize.ts
+++ b/tests/cross-verification/_harness/codegen-specialize.ts
@@ -21,7 +21,7 @@
  */
 
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
-import { join, basename } from "node:path";
+import { join } from "node:path";
 
 interface IrOp { op: string; k?: bigint | number; s?: number; bit?: number; control?: number; target?: number; }
 interface ZetaIrV2 { schema: string; generator: string; version: number; width: number; ops: IrOp[]; }

--- a/tests/cross-verification/_harness/codegen-v2-remaining.ts
+++ b/tests/cross-verification/_harness/codegen-v2-remaining.ts
@@ -11,8 +11,6 @@
  * Keep both. Benchmark proves the gap. Test proves equivalence.
  */
 
-import { writeFileSync } from "node:fs";
-import { join } from "node:path";
 
 interface IrOp { op: string; k?: bigint | number; s?: number; bit?: number; control?: number; target?: number; }
 interface ZetaIrV2 { schema: string; generator: string; version: number; width: number; ops: IrOp[]; }

--- a/tests/cross-verification/zset-isa-v2/isa-v2.test.ts
+++ b/tests/cross-verification/zset-isa-v2/isa-v2.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, expect, test } from "bun:test";
 import { softMixGeneric } from "../../../src/Core.TypeScript/algebra/soft-mix";
-import { complexRing, realRing, type Complex, type StarRing, type WEntry } from "../../../src/Core.TypeScript/algebra/star-ring";
+import { complexRing, realRing, type Complex, type WEntry } from "../../../src/Core.TypeScript/algebra/star-ring";
 
 const WIDTH = 4;
 const EPS = 1e-12;


### PR DESCRIPTION
The codegen-spread trajectory merged red on two non-required gate jobs. **Mechanical, no logic change:**
- **lint(TS)** TS6133 unused imports: `codegen-specialize.ts` (`basename`), `codegen-v2-remaining.ts` (`writeFileSync`, `join`), `zset-isa-v2/isa-v2.test.ts` (`StarRing`). Removed.
- **markdownlint**: `codegen-spread/RESUME.md` MD022 (auto-fixed) + MD024 (duplicate heading made unique).

**⚠ Flagged, NOT fixed here (codegen team):** the `cross-verify` job still fails — `tests/cross-verification/zset-isa-v2` has **no oracle** (`compare.ts`/`cross-verify.ts`) because the ISA-v2 cross-language oracle outputs aren't generated yet (only the TS test; per the RESUME, the spread/golden-vectors are "NEXT"). That's in-flight domain work — left for the owner rather than stubbed (a false-passing oracle is worse than none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)