### PR TITLE
ci(build-ai-cluster-iso): widen phase-3 gate trigger paths to bootstrap inputs (#8760)

### DIFF
--- a/.github/workflows/build-ai-cluster-iso.yml
+++ b/.github/workflows/build-ai-cluster-iso.yml
@@ -54,6 +54,12 @@ on:
       - "src/Core.TypeScript/ci/test-iter-54-install-flow.test.ts"
       - "src/Core.TypeScript/zflash/test-harness/**"
       - "src/Core.TypeScript/installer/zeta-creds-restore.ts"
+      # Added 2026-06-20: the promoted phase-3 gate (QEMU_FIRST_SESSION_PHASE3)
+      # exercises mise bootstrap + the first-session conductor + observe runtime
+      # via zeta-install; without these the gate is skipped on bootstrap-only changes.
+      - ".mise.toml"
+      - "tools/setup/**"
+      - "src/Core.TypeScript/observe/**"
       - ".github/workflows/build-ai-cluster-iso.yml"
   push:
     branches: [main]
@@ -70,6 +76,9 @@ on:
       - "src/Core.TypeScript/ci/test-iter-54-install-flow.test.ts"
       - "src/Core.TypeScript/zflash/test-harness/**"
       - "src/Core.TypeScript/installer/zeta-creds-restore.ts"
+      - ".mise.toml"
+      - "tools/setup/**"
+      - "src/Core.TypeScript/observe/**"
       - ".github/workflows/build-ai-cluster-iso.yml"
   workflow_dispatch:
 


### PR DESCRIPTION
Resolves the remaining half of #8760 (the `lean-proof.yml` half landed in `c94b3802f`).

The promoted phase-3 gate (`QEMU_FIRST_SESSION_PHASE3`) exercises mise bootstrap + the first-session conductor + observe runtime via `zeta-install`, but the trigger `paths:` didn't include those inputs — so the gate was **skipped on bootstrap-only changes**. Adds `.mise.toml`, `tools/setup/**`, `src/Core.TypeScript/observe/**` to both the `pull_request` and `push` path filters.

Exact diff from issue #8760 (Lumen, comment 4761070769). Lumen + an earlier GitHub-App token hit the `workflows`-scope permission wall; applied here via maintainer push. YAML validated (js-yaml).

Closes #8760.

🤖 Generated with [Claude Code](https://claude.com/claude-code)