### PR TITLE
feat(keys): unify ONE biometric-approval gate over every sensitive key-onboarding op (agent-run, operator-approved)

### DIFF
--- a/tools/setup/persona-keys/biometric.test.ts
+++ b/tools/setup/persona-keys/biometric.test.ts
@@ -1,0 +1,55 @@
+// biometric.ts conformance — the SHARED operator-approval gate that ca.ts / machine.ts /
+// publish.ts all run their sensitive ops through. EVERY test uses a FAKE door (no real Touch
+// ID / Windows Hello, no `sudo`, no network). Proves: the platform detector; `requireBiometric`
+// is FAIL-CLOSED when no door is injected (the "agent forgot to wire the gate" case) and
+// delegates to the door otherwise; a result NEVER carries a secret.
+// Run: bun test biometric.test.ts   (from tools/setup/persona-keys)
+import { test, expect } from "bun:test";
+import {
+  detectBiometricPlatform,
+  requireBiometric,
+  type BiometricAuth,
+  type BiometricResult,
+} from "./biometric.ts";
+
+test("detectBiometricPlatform: darwin→touchid, win32→hello, else→unsupported", () => {
+  expect(detectBiometricPlatform("darwin")).toBe("macos-touchid");
+  expect(detectBiometricPlatform("win32")).toBe("windows-hello");
+  expect(detectBiometricPlatform("linux")).toBe("unsupported");
+});
+
+test("requireBiometric: NO door provided -> ok:false, unsupported (FAIL-CLOSED by default)", async () => {
+  const r = await requireBiometric(undefined, "Approve: anything");
+  expect(r.ok).toBe(false);
+  expect(r.platform).toBe("unsupported");
+  expect(r.reason).toContain("fail-closed");
+});
+
+test("requireBiometric: delegates to the injected door + forwards the prompt", async () => {
+  const prompts: string[] = [];
+  const door: BiometricAuth = async (prompt) => {
+    prompts.push(prompt);
+    return { ok: true, platform: "macos-touchid" };
+  };
+  const r = await requireBiometric(door, "Approve: generate device key for mymac");
+  expect(r.ok).toBe(true);
+  expect(prompts).toEqual(["Approve: generate device key for mymac"]);
+});
+
+test("requireBiometric: a declining door yields ok:false (the gate honors the operator)", async () => {
+  const door: BiometricAuth = async () => ({ ok: false, platform: "macos-touchid", reason: "declined" });
+  const r = await requireBiometric(door, "Approve: sign cert");
+  expect(r.ok).toBe(false);
+  expect(r.reason).toBe("declined");
+});
+
+test("a BiometricResult NEVER carries a secret — it is approval-only", async () => {
+  const door: BiometricAuth = async () => ({ ok: true, platform: "macos-touchid" });
+  const r: BiometricResult = await requireBiometric(door, "Approve: x");
+  // The shape has only ok / platform / reason — assert no key/seed-bearing field leaked in.
+  const blob = JSON.stringify(r);
+  expect(blob).not.toContain("ssh-ed25519");
+  // Split so this test file contains no contiguous private-key header literal.
+  expect(blob).not.toContain("PRIVATE" + " " + "KEY");
+  expect(Object.keys(r).sort()).toEqual(["ok", "platform"]);
+});

--- a/tools/setup/persona-keys/biometric.ts
+++ b/tools/setup/persona-keys/biometric.ts
@@ -1,0 +1,154 @@
+// Zeta SHARED biometric-approval gate — the ONE physical-presence approval primitive that
+// every sensitive key-onboarding op runs through (workitem 081KVM1TK3Z08QG0R0002959G6
+// §"agent-run, operator-approved"). Aaron (2026-06-21): *"nothing is operator run, only
+// operator approved with hello/biometrics … i'll have you run what you need to for setup."*
+//
+// The AGENT executes every step (keygen / sign / publish); the HUMAN's Touch ID / Windows
+// Hello is the AUTHORIZATION at each sensitive gate. This module is the lift-out of the
+// biometric primitive that publish.ts (#8859) originally owned — extracted here so ca.ts,
+// machine.ts, and publish.ts share ONE gate, not three copies of the Touch-ID logic.
+//
+// SECURITY INVARIANTS (security-class — honesty over green):
+//  1. FAIL-CLOSED — the gate returns `ok:true` ONLY when the operator physically confirmed.
+//     Absent biometric (no pam_tid / declined / unsupported platform / error) ⇒ `ok:false`.
+//     A caller MUST abort its sensitive action on `ok:false`; this module never performs the
+//     sensitive action itself — it only reports approval.
+//  2. NEVER carries a secret — a `BiometricResult` has no key/seed bytes; it is approval-only.
+//  3. NONINTERFERENCE (manifesto §13) — the biometric prompt enters a caller ONLY through an
+//     injected `biometricAuth(prompt)` door. Tests inject a FAKE (no real prompt); the CLI
+//     injects `realBiometric()`. `--dry-run` callers must not call the door at all.
+//
+// Anchors (Beacon): Touch ID PAM (`pam_tid.so`) biometric sudo — Apple PAM / the repo's
+// biometric-sudo ADR (docs/DECISIONS/2026-05-29-biometric-sudo-elevation-via-touch-id-pam.md)
+// + zflash's Touch-ID-gated dd. Windows Hello programmatic consent —
+// `Windows.Security.Credentials.UI.UserConsentVerifier.RequestVerificationAsync` (Microsoft
+// WinRT). Physical-presence consent as an action floor — FIDO/WebAuthn user-verification.
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { platform as osPlatform } from "node:os";
+
+/** The biometric platforms we know how to gate on. `unsupported` ⇒ fail-closed. */
+export type BiometricPlatform = "macos-touchid" | "windows-hello" | "unsupported";
+
+/** The outcome of a biometric confirmation attempt — never carries a secret. */
+export interface BiometricResult {
+  /** True ONLY if the operator physically confirmed (Touch ID / Windows Hello). */
+  readonly ok: boolean;
+  /** Which mechanism was attempted (for the readout + honest "unsupported" reporting). */
+  readonly platform: BiometricPlatform;
+  /** Present when ok === false — why (unsupported platform, declined, timeout, error). */
+  readonly reason?: string;
+}
+
+/** The injectable biometric door — the ONLY channel for the physical-presence prompt
+ *  (noninterference §13). A sensitive op takes this and MUST get `ok:true` before acting.
+ *  Tests inject a fake; the CLI injects `realBiometric()`; `--dry-run` never calls it. */
+export type BiometricAuth = (prompt: string) => Promise<BiometricResult>;
+
+/**
+ * Require an operator approval through the SHARED gate — the one helper every sensitive op
+ * calls right before its real action. FAIL-CLOSED by construction: if NO door was injected
+ * (`auth === undefined`), this returns `{ ok:false, platform:"unsupported" }` — so a caller
+ * that forgot to wire the gate aborts rather than silently acting. Otherwise it delegates to
+ * the injected door. NEVER carries a secret.
+ */
+export async function requireBiometric(
+  auth: BiometricAuth | undefined,
+  prompt: string,
+): Promise<BiometricResult> {
+  if (auth === undefined) {
+    return {
+      ok: false,
+      platform: "unsupported",
+      reason:
+        "no biometric approval door was provided — fail-closed (the sensitive action is " +
+        "agent-run but operator-APPROVED; wire the biometric gate before running it).",
+    };
+  }
+  return auth(prompt);
+}
+
+/** Detect the biometric platform for the current host. macOS = Touch ID; Windows =
+ *  Windows Hello (seam); everything else = unsupported (fail-closed). */
+export function detectBiometricPlatform(plat: string = osPlatform()): BiometricPlatform {
+  if (plat === "darwin") return "macos-touchid";
+  if (plat === "win32") return "windows-hello";
+  return "unsupported";
+}
+
+/** macOS Touch ID gate — reuse the zflash / biometric-sudo pattern: a no-op `sudo`
+ *  command goes through PAM, and (when `pam_tid.so` is configured per the 2026-05-29
+ *  ADR) prompts Touch ID. We `sudo -k` first to invalidate any cached timestamp so a
+ *  FRESH biometric confirmation is required every time (no silent timestamp reuse), then
+ *  run `sudo -p '' true`. Success ⇒ the operator physically confirmed.
+ *
+ *  Fail-closed: if `pam_tid.so` is NOT present in /etc/pam.d/sudo we DO NOT fall back to
+ *  a password prompt (that would not be a biometric proof) — we report unsupported so the
+ *  caller aborts. The operator enables Touch-ID-for-sudo per the ADR first. */
+function macTouchIdAuth(prompt: string): BiometricResult {
+  // Require pam_tid to be configured — otherwise `sudo` would gate on a password, which
+  // is NOT the biometric proof this gate promises. Honest fail-closed.
+  let pamHasTouchId = false;
+  try {
+    const pam = readFileSync("/etc/pam.d/sudo", "utf8");
+    pamHasTouchId = /^\s*auth\s+sufficient\s+pam_tid\.so/m.test(pam);
+  } catch {
+    pamHasTouchId = false;
+  }
+  if (!pamHasTouchId) {
+    return {
+      ok: false,
+      platform: "macos-touchid",
+      reason:
+        "Touch ID for sudo is not configured (pam_tid.so absent from /etc/pam.d/sudo). " +
+        "Enable it per docs/DECISIONS/2026-05-29-biometric-sudo-elevation-via-touch-id-pam.md, then retry.",
+    };
+  }
+  // Invalidate cached sudo timestamp so a fresh Touch ID press is required.
+  spawnSync("sudo", ["-k"], { stdio: "ignore" });
+  // `sudo -p ''` suppresses the password-prompt text; pam_tid pops the Touch ID dialog.
+  // stdin is "ignore" so a non-biometric machine fails-closed (no password can be typed)
+  // rather than hanging on a password prompt.
+  process.stderr.write(`🔐 Touch ID: ${prompt}\n`);
+  const r = spawnSync("sudo", ["-p", "", "true"], { stdio: ["ignore", "ignore", "inherit"] });
+  if (r.status === 0) return { ok: true, platform: "macos-touchid" };
+  return {
+    ok: false,
+    platform: "macos-touchid",
+    reason: `Touch ID was declined or failed (sudo status ${r.status ?? "signal"})`,
+  };
+}
+
+/** Windows Hello gate — SEAM (honest-stop, TODO). A clean programmatic Windows Hello
+ *  consent is `Windows.Security.Credentials.UI.UserConsentVerifier.RequestVerificationAsync`,
+ *  reachable from PowerShell via WinRT projection — but that bridge is NOT cleanly invokable
+ *  from this TS CLI today (no WinRT binding shipped here). Rather than fake a biometric or
+ *  weaken the fail-closed gate, this returns unsupported with the wiring point named. Wire
+ *  `RequestVerificationAsync` (or the elevated-UAC/Hello path that flash-usb-windows.ts uses
+ *  for admin elevation) here when the WinRT bridge lands. */
+function windowsHelloAuth(_prompt: string): BiometricResult {
+  return {
+    ok: false,
+    platform: "windows-hello",
+    reason:
+      "Windows Hello programmatic consent is not yet wired from this TS CLI " +
+      "(seam: Windows.Security.Credentials.UI.UserConsentVerifier.RequestVerificationAsync via WinRT/PowerShell). " +
+      "Wire it in biometric.ts windowsHelloAuth() before running on Windows — fail-closed until then.",
+  };
+}
+
+/** The REAL biometric door (CLI-only): the per-platform physical-presence gate. macOS =
+ *  Touch ID via pam_tid; Windows = Windows Hello (seam); everything else = unsupported
+ *  (fail-closed). NEVER carries a secret — it returns approval only. */
+export function realBiometric(): BiometricAuth {
+  return async (prompt: string): Promise<BiometricResult> => {
+    const plat = detectBiometricPlatform();
+    if (plat === "macos-touchid") return macTouchIdAuth(prompt);
+    if (plat === "windows-hello") return windowsHelloAuth(prompt);
+    return {
+      ok: false,
+      platform: "unsupported",
+      reason: `no biometric mechanism on platform '${osPlatform()}' — fail-closed (no approval)`,
+    };
+  };
+}

--- a/tools/setup/persona-keys/ca-cli.ts
+++ b/tools/setup/persona-keys/ca-cli.ts
@@ -18,6 +18,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { ensureCa, signMachineCert, realEffects, DEFAULT_CERT_VALIDITY } from "./ca.ts";
 import { publishPubPath, sanitizeHostname } from "./machine.ts";
+import { realBiometric } from "./biometric.ts";
 
 const args = process.argv.slice(2);
 const mode = args[0];
@@ -31,59 +32,83 @@ const opt = (n: string) => {
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = opt("--repo-root") ?? resolve(here, "..", "..", "..");
 const fx = realEffects();
+// AGENT-RUN, OPERATOR-APPROVED: the shared biometric gate is the operator's authorization
+// for the real keygen/sign path (fail-closed). Dry-run never invokes it.
+const biometricAuth = realBiometric();
 
-if (mode === "ca") {
-  const ca = opt("--ca") ?? "zeta";
-  const dryRun = flag("--dry-run");
-  const commitPub = flag("--commit-pub");
-  const r = ensureCa(fx, { ca, repoRoot, dryRun, commitPub });
-  if (r.dryRun) {
-    console.log(`[dry-run] action=${r.action} (NOTHING generated or written)`);
-    console.log(`[dry-run] would write CA private key to: ${r.caPrivatePath}`);
-    if (commitPub) console.log(`[dry-run] would write CA PUBLIC key to: ${r.caPublicPath}`);
-    process.exit(0);
+async function main(): Promise<number> {
+  if (mode === "ca") {
+    const ca = opt("--ca") ?? "zeta";
+    const dryRun = flag("--dry-run");
+    const commitPub = flag("--commit-pub");
+    const r = await ensureCa(fx, { ca, repoRoot, dryRun, commitPub, biometricAuth });
+    if (r.dryRun) {
+      console.log(`[dry-run] action=${r.action} (NOTHING generated or written)`);
+      console.log(`[dry-run] would write CA private key to: ${r.caPrivatePath}`);
+      if (commitPub) console.log(`[dry-run] would write CA PUBLIC key to: ${r.caPublicPath}`);
+      return 0;
+    }
+    if (r.action === "aborted-biometric") {
+      console.error(
+        `blocked: biometric ${r.biometric?.reason ?? "not approved"} — NO CA key generated (fail-closed).`,
+      );
+      return 1;
+    }
+    console.log(`action=${r.action} ca=${ca}`);
+    console.log(`CA private key (local only): ${r.caPrivatePath}`);
+    if (r.committedPub) console.log(`wrote CA PUBLIC key -> ${r.caPublicPath} (NOT committed; you commit it)`);
+    // Printing the CA PUBLIC key is safe (it is the git-distributed trust root).
+    if (r.caPublicKey !== undefined) console.log(r.caPublicKey);
+    return 0;
   }
-  console.log(`action=${r.action} ca=${ca}`);
-  console.log(`CA private key (local only): ${r.caPrivatePath}`);
-  if (r.committedPub) console.log(`wrote CA PUBLIC key -> ${r.caPublicPath} (NOT committed; you commit it)`);
-  // Printing the CA PUBLIC key is safe (it is the git-distributed trust root).
-  if (r.caPublicKey !== undefined) console.log(r.caPublicKey);
-  process.exit(0);
+
+  if (mode === "cert") {
+    const user = opt("--user") ?? "zeta";
+    const machineRaw = opt("--machine");
+    const machineId = sanitizeHostname(machineRaw ?? "");
+    const validity = opt("--validity") ?? DEFAULT_CERT_VALIDITY;
+    const dryRun = flag("--dry-run");
+    // The device PUBLIC key is the machine.ts publish seam: maintainers/<user>/machines/<host>.pub.
+    const devicePubPath = opt("--device-pub") ?? publishPubPath(repoRoot, user, machineId);
+    const r = await signMachineCert(fx, { user, machineId, devicePubPath, validity, dryRun, biometricAuth });
+    if (r.action === "no-ca") {
+      console.error(`blocked: no CA private key at ${r.caPrivatePath} — run 'ca-cli.ts ca' first.`);
+      return 3;
+    }
+    if (r.action === "no-device-key") {
+      console.error(`blocked: no device pubkey at ${r.devicePubPath} — run machine-cli.ts machine --publish first.`);
+      return 3;
+    }
+    if (r.dryRun) {
+      console.log(`[dry-run] action=${r.action} (NOTHING signed)`);
+      console.log(`[dry-run] would sign ${r.devicePubPath}`);
+      console.log(`[dry-run]   -> cert ${r.certPath} (id=${r.certId} principal=${r.principal} validity=${r.validity})`);
+      return 0;
+    }
+    if (r.action === "aborted-biometric") {
+      console.error(
+        `blocked: biometric ${r.biometric?.reason ?? "not approved"} — NO cert signed (fail-closed).`,
+      );
+      return 1;
+    }
+    console.log(`action=${r.action} cert=${r.certPath}`);
+    console.log(`  id=${r.certId} principal=${r.principal} validity=${r.validity}`);
+    // The cert is public — safe to print.
+    if (r.certText !== undefined) console.log(r.certText);
+    return 0;
+  }
+
+  console.error(
+    "usage:\n" +
+      "  bun ca-cli.ts ca   --ca <name> [--dry-run] [--commit-pub]\n" +
+      "  bun ca-cli.ts cert --user <name> --machine <host> [--validity +52w] [--dry-run]",
+  );
+  return 2;
 }
 
-if (mode === "cert") {
-  const user = opt("--user") ?? "zeta";
-  const machineRaw = opt("--machine");
-  const machineId = sanitizeHostname(machineRaw ?? "");
-  const validity = opt("--validity") ?? DEFAULT_CERT_VALIDITY;
-  const dryRun = flag("--dry-run");
-  // The device PUBLIC key is the machine.ts publish seam: maintainers/<user>/machines/<host>.pub.
-  const devicePubPath = opt("--device-pub") ?? publishPubPath(repoRoot, user, machineId);
-  const r = signMachineCert(fx, { user, machineId, devicePubPath, validity, dryRun });
-  if (r.action === "no-ca") {
-    console.error(`blocked: no CA private key at ${r.caPrivatePath} — run 'ca-cli.ts ca' first.`);
-    process.exit(3);
-  }
-  if (r.action === "no-device-key") {
-    console.error(`blocked: no device pubkey at ${r.devicePubPath} — run machine-cli.ts machine --publish first.`);
-    process.exit(3);
-  }
-  if (r.dryRun) {
-    console.log(`[dry-run] action=${r.action} (NOTHING signed)`);
-    console.log(`[dry-run] would sign ${r.devicePubPath}`);
-    console.log(`[dry-run]   -> cert ${r.certPath} (id=${r.certId} principal=${r.principal} validity=${r.validity})`);
-    process.exit(0);
-  }
-  console.log(`action=${r.action} cert=${r.certPath}`);
-  console.log(`  id=${r.certId} principal=${r.principal} validity=${r.validity}`);
-  // The cert is public — safe to print.
-  if (r.certText !== undefined) console.log(r.certText);
-  process.exit(0);
-}
-
-console.error(
-  "usage:\n" +
-    "  bun ca-cli.ts ca   --ca <name> [--dry-run] [--commit-pub]\n" +
-    "  bun ca-cli.ts cert --user <name> --machine <host> [--validity +52w] [--dry-run]",
-);
-process.exit(2);
+main()
+  .then((code) => process.exit(code))
+  .catch((e: unknown) => {
+    process.stderr.write((e instanceof Error ? e.message : String(e)) + "\n");
+    process.exit(1);
+  });

--- a/tools/setup/persona-keys/ca.test.ts
+++ b/tools/setup/persona-keys/ca.test.ts
@@ -24,9 +24,23 @@ import {
   DEFAULT_CERT_VALIDITY,
   type CaEffects,
 } from "./ca.ts";
+import type { BiometricAuth, BiometricResult } from "./biometric.ts";
 
 // The private-key marker, assembled at runtime so NO key-shaped literal is in this file.
 const PRIV_MARKER = "PRIVATE" + " " + "KEY";
+
+// A FAKE biometric door (no real Touch ID / Hello). `ok` controls approval; a `calls` array
+// records every prompt so a test can assert the gate WAS invoked + fail-closed semantics.
+function fakeBiometric(ok: boolean, calls?: string[]): BiometricAuth {
+  return async (prompt: string): Promise<BiometricResult> => {
+    if (calls) calls.push(prompt);
+    return ok
+      ? { ok: true, platform: "macos-touchid" }
+      : { ok: false, platform: "macos-touchid", reason: "declined" };
+  };
+}
+// A passing approval, the default for the happy-path tests below.
+const APPROVE = fakeBiometric(true);
 
 // A deterministic fake: never shells out, never touches a secret. genCa/signCert write
 // FAKE public artifacts to a real temp filesystem and return public text only.
@@ -59,16 +73,25 @@ function fakeEffects(opts?: { genCount?: { n: number }; signCount?: { n: number 
 const CA = "tester";
 const USER = "tester";
 
-test("ca --dry-run: generates NOTHING, writes NOTHING, reports would-generate", () => {
+test("ca --dry-run: generates NOTHING, writes NOTHING, reports would-generate (never prompts)", async () => {
   const tmp = mkdtempSync(join(tmpdir(), "zeta-ca-"));
   try {
     const genCount = { n: 0 };
+    const prompts: string[] = [];
     const fx = fakeEffects({ genCount });
-    const r = ensureCa(fx, { ca: CA, repoRoot: tmp, home: tmp, dryRun: true, commitPub: true });
+    const r = await ensureCa(fx, {
+      ca: CA,
+      repoRoot: tmp,
+      home: tmp,
+      dryRun: true,
+      commitPub: true,
+      biometricAuth: fakeBiometric(true, prompts),
+    });
     expect(r.dryRun).toBe(true);
     expect(r.action).toBe("would-generate");
     expect(r.committedPub).toBe(false);
     expect(genCount.n).toBe(0); // nothing generated
+    expect(prompts).toHaveLength(0); // dry-run NEVER prompts
     expect(existsSync(r.caPrivatePath)).toBe(false); // nothing written
     expect(existsSync(r.caPublicPath)).toBe(false); // no ssh-ca.pub written
   } finally {
@@ -76,11 +99,11 @@ test("ca --dry-run: generates NOTHING, writes NOTHING, reports would-generate", 
   }
 });
 
-test("ca: generates the CA (fake) and commits ONLY the PUBLIC key; private never published", () => {
+test("ca: generates the CA (fake) and commits ONLY the PUBLIC key; private never published", async () => {
   const tmp = mkdtempSync(join(tmpdir(), "zeta-ca-"));
   try {
     const fx = fakeEffects();
-    const r = ensureCa(fx, { ca: CA, repoRoot: tmp, home: tmp, commitPub: true });
+    const r = await ensureCa(fx, { ca: CA, repoRoot: tmp, home: tmp, commitPub: true, biometricAuth: APPROVE });
     expect(r.action).toBe("generated");
     expect(r.committedPub).toBe(true);
     // the committed path holds ONLY the public key — no private bytes anywhere in it
@@ -98,28 +121,30 @@ test("ca: generates the CA (fake) and commits ONLY the PUBLIC key; private never
   }
 });
 
-test("ca: idempotent — a second run is a no-op ('exists'), does not regenerate", () => {
+test("ca: idempotent — a second run is a no-op ('exists'), does not regenerate", async () => {
   const tmp = mkdtempSync(join(tmpdir(), "zeta-ca-"));
   try {
     const genCount = { n: 0 };
+    const secondPrompts: string[] = [];
     const fx = fakeEffects({ genCount });
-    const first = ensureCa(fx, { ca: CA, repoRoot: tmp, home: tmp });
+    const first = await ensureCa(fx, { ca: CA, repoRoot: tmp, home: tmp, biometricAuth: APPROVE });
     expect(first.action).toBe("generated");
     expect(genCount.n).toBe(1);
-    const second = ensureCa(fx, { ca: CA, repoRoot: tmp, home: tmp });
+    const second = await ensureCa(fx, { ca: CA, repoRoot: tmp, home: tmp, biometricAuth: fakeBiometric(true, secondPrompts) });
     expect(second.action).toBe("exists"); // idempotent: apply-N == apply-once effect
     expect(genCount.n).toBe(1); // NOT regenerated
+    expect(secondPrompts).toHaveLength(0); // the idempotent no-op does NOT prompt (no keygen)
     expect(second.caPublicKey).toBe(first.caPublicKey); // same public key returned
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }
 });
 
-test("ca: without --commit-pub, writes NO ssh-ca.pub to the repo", () => {
+test("ca: without --commit-pub, writes NO ssh-ca.pub to the repo", async () => {
   const tmp = mkdtempSync(join(tmpdir(), "zeta-ca-"));
   try {
     const fx = fakeEffects();
-    const r = ensureCa(fx, { ca: CA, repoRoot: tmp, home: tmp });
+    const r = await ensureCa(fx, { ca: CA, repoRoot: tmp, home: tmp, biometricAuth: APPROVE });
     expect(r.action).toBe("generated");
     expect(r.committedPub).toBe(false);
     expect(existsSync(caPublicKeyPath(tmp, CA))).toBe(false); // nothing landed in the repo
@@ -128,10 +153,49 @@ test("ca: without --commit-pub, writes NO ssh-ca.pub to the repo", () => {
   }
 });
 
-test("cert --dry-run: signs NOTHING when CA + device key present, reports would-sign", () => {
+test("FAIL-CLOSED (ca-gen): biometric declined -> genCa NEVER called, NO CA, aborted-biometric", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "zeta-ca-"));
+  try {
+    const genCount = { n: 0 };
+    const prompts: string[] = [];
+    const fx = fakeEffects({ genCount });
+    const r = await ensureCa(fx, {
+      ca: CA,
+      repoRoot: tmp,
+      home: tmp,
+      commitPub: true,
+      biometricAuth: fakeBiometric(false, prompts),
+    });
+    expect(r.action).toBe("aborted-biometric");
+    expect(prompts).toHaveLength(1); // the gate WAS invoked
+    expect(genCount.n).toBe(0); // the CA keygen door was NEVER called
+    expect(r.committedPub).toBe(false);
+    expect(existsSync(r.caPrivatePath)).toBe(false); // nothing written
+    expect(existsSync(r.caPublicPath)).toBe(false); // no ssh-ca.pub committed
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("FAIL-CLOSED (ca-gen): NO biometric door provided -> genCa NEVER runs (default fail-closed)", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "zeta-ca-"));
+  try {
+    const genCount = { n: 0 };
+    const fx = fakeEffects({ genCount });
+    // No biometricAuth wired — requireBiometric returns ok:false (fail-closed).
+    const r = await ensureCa(fx, { ca: CA, repoRoot: tmp, home: tmp });
+    expect(r.action).toBe("aborted-biometric");
+    expect(genCount.n).toBe(0); // never generated without an approval door
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("cert --dry-run: signs NOTHING when CA + device key present, reports would-sign (never prompts)", async () => {
   const tmp = mkdtempSync(join(tmpdir(), "zeta-ca-"));
   try {
     const signCount = { n: 0 };
+    const prompts: string[] = [];
     const fx = fakeEffects({ signCount });
     // Pretend the CA + a device pubkey both exist.
     const caPriv = caPrivateKeyPath(tmp);
@@ -141,38 +205,54 @@ test("cert --dry-run: signs NOTHING when CA + device key present, reports would-
     mkdirSync(devicePub.slice(0, devicePub.lastIndexOf("/")), { recursive: true });
     writeFileSync(devicePub, "ssh-ed25519 AAAADEVICE tester@mymac\n");
 
-    const r = signMachineCert(fx, { user: USER, machineId: "mymac", devicePubPath: devicePub, home: tmp, dryRun: true });
+    const r = await signMachineCert(fx, {
+      user: USER,
+      machineId: "mymac",
+      devicePubPath: devicePub,
+      home: tmp,
+      dryRun: true,
+      biometricAuth: fakeBiometric(true, prompts),
+    });
     expect(r.dryRun).toBe(true);
     expect(r.action).toBe("would-sign");
     expect(r.certId).toBe("tester@mymac");
     expect(r.principal).toBe("tester");
     expect(r.validity).toBe(DEFAULT_CERT_VALIDITY);
     expect(signCount.n).toBe(0); // nothing signed
+    expect(prompts).toHaveLength(0); // dry-run NEVER prompts
     expect(existsSync(r.certPath)).toBe(false); // no cert written
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }
 });
 
-test("cert: fail-closed when CA absent -> no-ca (signs nothing)", () => {
+test("cert: fail-closed when CA absent -> no-ca (signs nothing, never prompts)", async () => {
   const tmp = mkdtempSync(join(tmpdir(), "zeta-ca-"));
   try {
     const signCount = { n: 0 };
+    const prompts: string[] = [];
     const fx = fakeEffects({ signCount });
     const devicePub = join(tmp, "maintainers", USER, "machines", "mymac.pub");
     mkdirSync(devicePub.slice(0, devicePub.lastIndexOf("/")), { recursive: true });
     writeFileSync(devicePub, "ssh-ed25519 AAAADEVICE tester@mymac\n");
     // No CA private key written.
-    const r = signMachineCert(fx, { user: USER, machineId: "mymac", devicePubPath: devicePub, home: tmp });
+    const r = await signMachineCert(fx, {
+      user: USER,
+      machineId: "mymac",
+      devicePubPath: devicePub,
+      home: tmp,
+      biometricAuth: fakeBiometric(true, prompts),
+    });
     expect(r.action).toBe("no-ca");
     expect(signCount.n).toBe(0);
+    expect(prompts).toHaveLength(0); // a clean skip never prompts (no sensitive action)
     expect(r.certText).toBeUndefined();
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }
 });
 
-test("cert: fail-closed when device key absent -> no-device-key (signs nothing)", () => {
+test("cert: fail-closed when device key absent -> no-device-key (signs nothing)", async () => {
   const tmp = mkdtempSync(join(tmpdir(), "zeta-ca-"));
   try {
     const signCount = { n: 0 };
@@ -182,7 +262,7 @@ test("cert: fail-closed when device key absent -> no-device-key (signs nothing)"
     writeFileSync(caPriv, "FAKE-CA-PRIVATE\n", { mode: 0o600 });
     // No device pubkey written.
     const devicePub = join(tmp, "maintainers", USER, "machines", "absent.pub");
-    const r = signMachineCert(fx, { user: USER, machineId: "absent", devicePubPath: devicePub, home: tmp });
+    const r = await signMachineCert(fx, { user: USER, machineId: "absent", devicePubPath: devicePub, home: tmp, biometricAuth: APPROVE });
     expect(r.action).toBe("no-device-key");
     expect(signCount.n).toBe(0);
   } finally {
@@ -190,7 +270,57 @@ test("cert: fail-closed when device key absent -> no-device-key (signs nothing)"
   }
 });
 
-test("cert: signs (fake) into a -cert.pub; cert text is public, has no private marker", () => {
+test("FAIL-CLOSED (cert-sign): biometric declined -> signCert NEVER called, NO cert, aborted-biometric", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "zeta-ca-"));
+  try {
+    const signCount = { n: 0 };
+    const prompts: string[] = [];
+    const fx = fakeEffects({ signCount });
+    const caPriv = caPrivateKeyPath(tmp);
+    mkdirSync(caPriv.slice(0, caPriv.lastIndexOf("/")), { recursive: true });
+    writeFileSync(caPriv, "FAKE-CA-PRIVATE\n", { mode: 0o600 });
+    const devicePub = join(tmp, "maintainers", USER, "machines", "mymac.pub");
+    mkdirSync(devicePub.slice(0, devicePub.lastIndexOf("/")), { recursive: true });
+    writeFileSync(devicePub, "ssh-ed25519 AAAADEVICE tester@mymac\n");
+
+    const r = await signMachineCert(fx, {
+      user: USER,
+      machineId: "mymac",
+      devicePubPath: devicePub,
+      home: tmp,
+      biometricAuth: fakeBiometric(false, prompts),
+    });
+    expect(r.action).toBe("aborted-biometric");
+    expect(prompts).toHaveLength(1); // the gate WAS invoked (CA + device present)
+    expect(signCount.n).toBe(0); // the sign door was NEVER called
+    expect(r.certText).toBeUndefined();
+    expect(existsSync(certPath(devicePub))).toBe(false); // no cert written
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("FAIL-CLOSED (cert-sign): NO biometric door -> signCert NEVER runs (default fail-closed)", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "zeta-ca-"));
+  try {
+    const signCount = { n: 0 };
+    const fx = fakeEffects({ signCount });
+    const caPriv = caPrivateKeyPath(tmp);
+    mkdirSync(caPriv.slice(0, caPriv.lastIndexOf("/")), { recursive: true });
+    writeFileSync(caPriv, "FAKE-CA-PRIVATE\n", { mode: 0o600 });
+    const devicePub = join(tmp, "maintainers", USER, "machines", "mymac.pub");
+    mkdirSync(devicePub.slice(0, devicePub.lastIndexOf("/")), { recursive: true });
+    writeFileSync(devicePub, "ssh-ed25519 AAAADEVICE tester@mymac\n");
+    // No biometricAuth wired — fail-closed.
+    const r = await signMachineCert(fx, { user: USER, machineId: "mymac", devicePubPath: devicePub, home: tmp });
+    expect(r.action).toBe("aborted-biometric");
+    expect(signCount.n).toBe(0);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("cert: signs (fake) into a -cert.pub; cert text is public, has no private marker", async () => {
   const tmp = mkdtempSync(join(tmpdir(), "zeta-ca-"));
   try {
     const fx = fakeEffects();
@@ -201,7 +331,7 @@ test("cert: signs (fake) into a -cert.pub; cert text is public, has no private m
     mkdirSync(devicePub.slice(0, devicePub.lastIndexOf("/")), { recursive: true });
     writeFileSync(devicePub, "ssh-ed25519 AAAADEVICE tester@mymac\n");
 
-    const r = signMachineCert(fx, { user: USER, machineId: "mymac", devicePubPath: devicePub, home: tmp });
+    const r = await signMachineCert(fx, { user: USER, machineId: "mymac", devicePubPath: devicePub, home: tmp, biometricAuth: APPROVE });
     expect(r.action).toBe("signed");
     expect(r.certPath).toBe(certPath(devicePub));
     expect(existsSync(r.certPath)).toBe(true);
@@ -218,15 +348,15 @@ test("certPath: derives <base>-cert.pub from a device pubkey path", () => {
   expect(certPath("/x/mymac")).toBe("/x/mymac-cert.pub"); // tolerant if no .pub suffix
 });
 
-test("PRIVATE-LEAK GUARD: no module output (paths/keys/cert) ever contains a private marker", () => {
+test("PRIVATE-LEAK GUARD: no module output (paths/keys/cert) ever contains a private marker", async () => {
   const tmp = mkdtempSync(join(tmpdir(), "zeta-ca-"));
   try {
     const fx = fakeEffects();
-    const ca = ensureCa(fx, { ca: CA, repoRoot: tmp, home: tmp, commitPub: true });
+    const ca = await ensureCa(fx, { ca: CA, repoRoot: tmp, home: tmp, commitPub: true, biometricAuth: APPROVE });
     const devicePub = join(tmp, "maintainers", USER, "machines", "mymac.pub");
     mkdirSync(devicePub.slice(0, devicePub.lastIndexOf("/")), { recursive: true });
     writeFileSync(devicePub, "ssh-ed25519 AAAADEVICE tester@mymac\n");
-    const cert = signMachineCert(fx, { user: USER, machineId: "mymac", devicePubPath: devicePub, home: tmp });
+    const cert = await signMachineCert(fx, { user: USER, machineId: "mymac", devicePubPath: devicePub, home: tmp, biometricAuth: APPROVE });
     // Stringify EVERY field the module returns — none may carry a private marker.
     const blob = JSON.stringify(ca) + JSON.stringify(cert);
     expect(blob).not.toMatch(new RegExp(PRIV_MARKER));
@@ -249,9 +379,12 @@ test("REAL ssh-keygen: throwaway CA signs a throwaway device key; cert verifies 
   try {
     const { realEffects, ensureCa: real, signMachineCert: sign, caPrivateKeyPath: caPath } = await import("./ca.ts");
     const fx = realEffects();
+    // A FAKE biometric (approve) so the round-trip never needs a real Touch ID prompt — the
+    // gate is exercised against the fake; the keygen/sign are the real ssh-keygen.
+    const approve = APPROVE;
 
     // 1. Generate a THROWAWAY CA (home pinned to temp → CA private stays inside temp).
-    const caRes = real(fx, { ca: CA, repoRoot: tmp, home: tmp, commitPub: true });
+    const caRes = await real(fx, { ca: CA, repoRoot: tmp, home: tmp, commitPub: true, biometricAuth: approve });
     expect(caRes.action).toBe("generated");
     const caPriv = caPath(tmp);
     expect(caPriv.startsWith(tmp)).toBe(true); // CA private key is inside the temp dir
@@ -272,8 +405,8 @@ test("REAL ssh-keygen: throwaway CA signs a throwaway device key; cert verifies 
     const devicePub = deviceKey + ".pub";
     expect(existsSync(devicePub)).toBe(true);
 
-    // 3. Sign the device PUBLIC key into a cert with the throwaway CA.
-    const certRes = sign(fx, { user: USER, machineId: "mymac", devicePubPath: devicePub, home: tmp });
+    // 3. Sign the device PUBLIC key into a cert with the throwaway CA (biometric-approved).
+    const certRes = await sign(fx, { user: USER, machineId: "mymac", devicePubPath: devicePub, home: tmp, biometricAuth: approve });
     expect(certRes.action).toBe("signed");
     expect(existsSync(certRes.certPath)).toBe(true);
 

--- a/tools/setup/persona-keys/ca.ts
+++ b/tools/setup/persona-keys/ca.ts
@@ -39,6 +39,11 @@ import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+// SHARED biometric-approval gate — the agent EXECUTES keygen/sign; the operator's Touch ID /
+// Windows Hello is the AUTHORIZATION (Aaron 2026-06-21). Both sensitive ops (generate CA key,
+// sign a cert with the CA private key) are gated FAIL-CLOSED behind a biometric confirm.
+import { requireBiometric, type BiometricAuth, type BiometricResult } from "./biometric.ts";
+export type { BiometricAuth, BiometricResult } from "./biometric.ts";
 
 /** The host-environment doors — the ONLY channel for ambient influence (noninterference).
  *  Every door is PUBLIC-safe by construction: `genCa`/`signCert` return only public text,
@@ -115,8 +120,9 @@ export function certPath(devicePubPath: string): string {
 /** What a `ca` (generate-CA) run did (or, with dryRun, WOULD do). No private material here. */
 export interface CaResult {
   readonly dryRun: boolean;
-  /** "generated" | "exists" (idempotent: an existing CA is a no-op) | "would-generate". */
-  readonly action: "generated" | "exists" | "would-generate";
+  /** "generated" | "exists" (idempotent: an existing CA is a no-op) | "would-generate"
+   *  | "aborted-biometric" (the operator did NOT approve → fail-closed, NOTHING generated). */
+  readonly action: "generated" | "exists" | "would-generate" | "aborted-biometric";
   /** Local path the CA PRIVATE key lives at (never its contents). */
   readonly caPrivatePath: string;
   /** Repo path the CA PUBLIC key would/did get written to (when `commitPub`). */
@@ -125,19 +131,32 @@ export interface CaResult {
   readonly caPublicKey?: string;
   /** True iff we wrote the CA public key to the repo path (never true on dry-run). */
   readonly committedPub: boolean;
+  /** The biometric approval outcome (present only when the gate was invoked — i.e. a real
+   *  keygen was attempted; absent on dry-run, on the idempotent `exists` no-op, and never
+   *  carries a secret). */
+  readonly biometric?: BiometricResult;
 }
 
 /**
- * Generate (or, idempotently, recognise) the SSH CA keypair — OPERATOR-RUN.
- * Generates ONLY a CA keypair via the injected `genCa` door (private written locally under
- * umask 077 by the runner; only the PUBLIC key returned). With `commitPub`, writes ONLY the
- * CA PUBLIC key to maintainers/<ca>/ssh-ca.pub (this module does NOT commit to git).
+ * Generate (or, idempotently, recognise) the SSH CA keypair — AGENT-RUN, OPERATOR-APPROVED.
+ * The agent EXECUTES the keygen; a biometric confirm (Touch ID / Windows Hello) is the
+ * operator's AUTHORIZATION. Generates ONLY a CA keypair via the injected `genCa` door (private
+ * written locally under umask 077 by the runner; only the PUBLIC key returned). With
+ * `commitPub`, writes ONLY the CA PUBLIC key to maintainers/<ca>/ssh-ca.pub (no git commit).
  *
+ * BIOMETRIC GATE + FAIL-CLOSED: when a real keygen is about to happen (the CA does NOT already
+ * exist and it is not a dry-run), `biometricAuth()` MUST return ok:true first. On ok:false the
+ * run aborts ("aborted-biometric") and `genCa` is NEVER invoked — NO CA key is created. The
+ * idempotent `exists` no-op (no private material created) and `--dry-run` (creates nothing) do
+ * NOT prompt.
+ *
+ * @param biometricAuth the SHARED approval gate (biometric.ts). Tests inject a fake; the CLI
+ *                      injects `realBiometric()`. Required only for the real-keygen path.
  * @param commitPub when true, write the CA PUBLIC key to the repo path (the operator then
  *                  commits it; the CA public key is the git-distributed trust root).
- * @param dryRun    when true, NOTHING is generated or written — returns "would-generate".
+ * @param dryRun    when true, NOTHING is generated, written, or prompted — "would-generate".
  */
-export function ensureCa(
+export async function ensureCa(
   fx: CaEffects,
   opts: {
     /** The CA identity (the maintainers/<ca>/ subdir; e.g. the operator persona). */
@@ -146,8 +165,10 @@ export function ensureCa(
     readonly home?: string;
     readonly commitPub?: boolean;
     readonly dryRun?: boolean;
+    /** SHARED biometric approval door — required for the real keygen path (fail-closed). */
+    readonly biometricAuth?: BiometricAuth;
   },
-): CaResult {
+): Promise<CaResult> {
   const caPrivatePath = opts.home === undefined ? caPrivateKeyPath() : caPrivateKeyPath(opts.home);
   const caPublicPath = caPublicKeyPath(opts.repoRoot, opts.ca);
   const dryRun = opts.dryRun === true;
@@ -166,29 +187,48 @@ export function ensureCa(
 
   let caPublicKey: string;
   let action: CaResult["action"];
+  let biometric: BiometricResult | undefined;
   if (alreadyExists) {
-    // Idempotent: an existing CA is a no-op. Read back its PUBLIC half only.
+    // Idempotent: an existing CA is a no-op (no private material created → no gate). Read
+    // back its PUBLIC half only.
     caPublicKey = fx.readText(caPrivatePath + ".pub").trim();
     action = "exists";
   } else {
+    // BIOMETRIC GATE — fail-closed. A real keygen creates private material; require approval.
+    biometric = await requireBiometric(
+      opts.biometricAuth,
+      `Approve: generate SSH CA keypair for ${opts.ca}`,
+    );
+    if (!biometric.ok) {
+      return {
+        dryRun: false,
+        action: "aborted-biometric",
+        caPrivatePath,
+        caPublicPath,
+        committedPub: false,
+        biometric,
+      };
+    }
     caPublicKey = fx.genCa(caPrivatePath, `${opts.ca} (zeta-ssh-ca)`).trim();
     action = "generated";
   }
 
+  const bio = biometric !== undefined ? { biometric } : {};
   if (wantCommit) {
     fx.mkdirp(dirOf(caPublicPath));
     fx.writeText(caPublicPath, caPublicKey.endsWith("\n") ? caPublicKey : caPublicKey + "\n");
-    return { dryRun: false, action, caPrivatePath, caPublicPath, caPublicKey, committedPub: true };
+    return { dryRun: false, action, caPrivatePath, caPublicPath, caPublicKey, committedPub: true, ...bio };
   }
 
-  return { dryRun: false, action, caPrivatePath, caPublicPath, caPublicKey, committedPub: false };
+  return { dryRun: false, action, caPrivatePath, caPublicPath, caPublicKey, committedPub: false, ...bio };
 }
 
 /** What a `cert` (sign-device-key) run did (or, with dryRun, WOULD do). Public only. */
 export interface CertResult {
   readonly dryRun: boolean;
-  /** "signed" | "would-sign" | "no-ca" (CA private absent) | "no-device-key" (pubkey absent). */
-  readonly action: "signed" | "would-sign" | "no-ca" | "no-device-key";
+  /** "signed" | "would-sign" | "no-ca" (CA private absent) | "no-device-key" (pubkey absent)
+   *  | "aborted-biometric" (operator did NOT approve → fail-closed, NOTHING signed). */
+  readonly action: "signed" | "would-sign" | "no-ca" | "no-device-key" | "aborted-biometric";
   readonly caPrivatePath: string;
   readonly devicePubPath: string;
   readonly certPath: string;
@@ -197,18 +237,30 @@ export interface CertResult {
   readonly validity: string;
   /** The certificate text, when signed (public — safe to print). Undefined otherwise. */
   readonly certText?: string;
+  /** The biometric approval outcome (present only when the gate was invoked — i.e. a real
+   *  sign was attempted; absent on dry-run + clean skips; never carries a secret). */
+  readonly biometric?: BiometricResult;
 }
 
 /**
  * Sign a per-machine device PUBLIC key into a certificate (`principal=<user>` + machine id +
- * a validity window) via the injected `signCert` door (ssh-keygen -s under the hood). The CA
- * private key is consumed by the runner; it is never read into this process.
+ * a validity window) via the injected `signCert` door (ssh-keygen -s under the hood) — AGENT-RUN,
+ * OPERATOR-APPROVED. The agent EXECUTES the sign; a biometric confirm is the operator's
+ * AUTHORIZATION (signing CONSUMES the CA private key, so it must be approved). The CA private
+ * key is consumed by the runner; it is never read into this process.
  *
  * Reads the machine's PUBLIC key from `devicePubPath` (the machine.ts publish seam —
  * maintainers/<user>/machines/<host>.pub). Fail-closed: a missing CA or device key returns a
- * typed `no-ca` / `no-device-key` (no partial work). `--dry-run` signs NOTHING.
+ * typed `no-ca` / `no-device-key` (no partial work) and NEVER prompts. `--dry-run` signs
+ * NOTHING and never prompts.
+ *
+ * BIOMETRIC GATE + FAIL-CLOSED: when a real sign is about to happen (CA + device key present,
+ * not dry-run), `biometricAuth()` MUST return ok:true first. On ok:false the run aborts
+ * ("aborted-biometric") and `signCert` is NEVER invoked — NO cert is produced.
+ *
+ * @param biometricAuth the SHARED approval gate (biometric.ts). Required for the real-sign path.
  */
-export function signMachineCert(
+export async function signMachineCert(
   fx: CaEffects,
   opts: {
     /** The USER the cert binds to (the `-n` principal — trust anchored at the user). */
@@ -221,8 +273,10 @@ export function signMachineCert(
     /** Validity window (OpenSSH `-V` form). Defaults to DEFAULT_CERT_VALIDITY. */
     readonly validity?: string;
     readonly dryRun?: boolean;
+    /** SHARED biometric approval door — required for the real sign path (fail-closed). */
+    readonly biometricAuth?: BiometricAuth;
   },
-): CertResult {
+): Promise<CertResult> {
   const caPrivatePath = opts.home === undefined ? caPrivateKeyPath() : caPrivateKeyPath(opts.home);
   const validity = opts.validity ?? DEFAULT_CERT_VALIDITY;
   const certId = `${opts.user}@${opts.machineId}`;
@@ -238,8 +292,8 @@ export function signMachineCert(
     validity,
   };
 
-  // Fail-closed presence checks (BEFORE any work) — a missing CA or device key is a typed
-  // no-op, never a partial sign. (Checked even on dry-run so the plan is honest.)
+  // Fail-closed presence checks (BEFORE any work, BEFORE any prompt) — a missing CA or device
+  // key is a typed no-op, never a partial sign. (Checked even on dry-run so the plan is honest.)
   if (!fx.exists(caPrivatePath)) {
     return { ...base, dryRun, action: "no-ca" };
   }
@@ -251,6 +305,15 @@ export function signMachineCert(
     return { ...base, dryRun: true, action: "would-sign" };
   }
 
+  // BIOMETRIC GATE — fail-closed. A real sign consumes the CA private key; require approval.
+  const biometric = await requireBiometric(
+    opts.biometricAuth,
+    `Approve: sign cert for ${opts.user}@${opts.machineId} (principal=${opts.user})`,
+  );
+  if (!biometric.ok) {
+    return { ...base, dryRun: false, action: "aborted-biometric", biometric };
+  }
+
   const out = fx.signCert({
     caKeyPath: caPrivatePath,
     devicePubPath: opts.devicePubPath,
@@ -258,7 +321,7 @@ export function signMachineCert(
     principal: opts.user,
     validity,
   });
-  return { ...base, dryRun: false, action: "signed", certText: out.certText };
+  return { ...base, dryRun: false, action: "signed", certText: out.certText, biometric };
 }
 
 function dirOf(p: string): string {

--- a/tools/setup/persona-keys/machine-cli.ts
+++ b/tools/setup/persona-keys/machine-cli.ts
@@ -14,6 +14,7 @@
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { checkPresence, ensureMachineKey, formatStatus, realEffects } from "./machine.ts";
+import { realBiometric } from "./biometric.ts";
 
 const args = process.argv.slice(2);
 const mode = args[0];
@@ -29,32 +30,49 @@ const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = opt("--repo-root") ?? resolve(here, "..", "..", "..");
 const fx = realEffects();
 
-if (mode === "status" || mode === "whoami") {
-  const s = checkPresence(fx, { user, repoRoot });
-  console.log(formatStatus(s));
-  console.log(`  user keyring: ${s.userKeyringPath}`);
-  console.log(`  device key (local, private): ${s.devicePrivatePath}`);
-  console.log(`  device pubkey (publish path): ${s.devicePublicPath}`);
-  process.exit(0);
-}
-
-if (mode === "machine") {
-  const dryRun = flag("--dry-run");
-  const publish = flag("--publish");
-  const r = ensureMachineKey(fx, { user, repoRoot, publish, dryRun });
-  if (r.dryRun) {
-    console.log(`[dry-run] action=${r.action} (NOTHING generated or written)`);
-    console.log(`[dry-run] would write private key to: ${r.devicePrivatePath}`);
-    if (publish) console.log(`[dry-run] would write PUBLIC key to: ${r.devicePublicPath}`);
-    process.exit(0);
+async function main(): Promise<number> {
+  if (mode === "status" || mode === "whoami") {
+    const s = checkPresence(fx, { user, repoRoot });
+    console.log(formatStatus(s));
+    console.log(`  user keyring: ${s.userKeyringPath}`);
+    console.log(`  device key (local, private): ${s.devicePrivatePath}`);
+    console.log(`  device pubkey (publish path): ${s.devicePublicPath}`);
+    return 0;
   }
-  console.log(`action=${r.action} hostname=${r.hostname}`);
-  console.log(`private key (local only): ${r.devicePrivatePath}`);
-  if (r.published) console.log(`published PUBLIC key -> ${r.devicePublicPath} (NOT committed)`);
-  // Printing the PUBLIC key is safe (it is the publishable trust artifact).
-  if (r.publicKey !== undefined) console.log(r.publicKey);
-  process.exit(0);
+
+  if (mode === "machine") {
+    const dryRun = flag("--dry-run");
+    const publish = flag("--publish");
+    // AGENT-RUN, OPERATOR-APPROVED: the shared biometric gate authorizes the real keygen
+    // (fail-closed). Dry-run never invokes it.
+    const r = await ensureMachineKey(fx, { user, repoRoot, publish, dryRun, biometricAuth: realBiometric() });
+    if (r.dryRun) {
+      console.log(`[dry-run] action=${r.action} (NOTHING generated or written)`);
+      console.log(`[dry-run] would write private key to: ${r.devicePrivatePath}`);
+      if (publish) console.log(`[dry-run] would write PUBLIC key to: ${r.devicePublicPath}`);
+      return 0;
+    }
+    if (r.action === "aborted-biometric") {
+      console.error(
+        `blocked: biometric ${r.biometric?.reason ?? "not approved"} — NO device key generated (fail-closed).`,
+      );
+      return 1;
+    }
+    console.log(`action=${r.action} hostname=${r.hostname}`);
+    console.log(`private key (local only): ${r.devicePrivatePath}`);
+    if (r.published) console.log(`published PUBLIC key -> ${r.devicePublicPath} (NOT committed)`);
+    // Printing the PUBLIC key is safe (it is the publishable trust artifact).
+    if (r.publicKey !== undefined) console.log(r.publicKey);
+    return 0;
+  }
+
+  console.error("usage: bun machine-cli.ts <status|whoami|machine> --user <name> [--dry-run] [--publish]");
+  return 2;
 }
 
-console.error("usage: bun machine-cli.ts <status|whoami|machine> --user <name> [--dry-run] [--publish]");
-process.exit(2);
+main()
+  .then((code) => process.exit(code))
+  .catch((e: unknown) => {
+    process.stderr.write((e instanceof Error ? e.message : String(e)) + "\n");
+    process.exit(1);
+  });

--- a/tools/setup/persona-keys/machine.test.ts
+++ b/tools/setup/persona-keys/machine.test.ts
@@ -17,6 +17,20 @@ import {
   userKeyringPublicPath,
   type MachineEffects,
 } from "./machine.ts";
+import type { BiometricAuth, BiometricResult } from "./biometric.ts";
+
+// A FAKE biometric door (no real Touch ID / Hello). `ok` controls approval; a `calls` array
+// records every prompt so a test can assert the gate WAS invoked + fail-closed semantics.
+function fakeBiometric(ok: boolean, calls?: string[]): BiometricAuth {
+  return async (prompt: string): Promise<BiometricResult> => {
+    if (calls) calls.push(prompt);
+    return ok
+      ? { ok: true, platform: "macos-touchid" }
+      : { ok: false, platform: "macos-touchid", reason: "declined" };
+  };
+}
+// A passing approval, the default for the happy-path tests below.
+const APPROVE = fakeBiometric(true);
 
 // A fully in-memory-ish fake: deterministic fake key generation, real temp filesystem
 // for the public-artifact writes. The fake NEVER shells out and NEVER touches secrets.
@@ -71,16 +85,25 @@ test("status: detects an existing user keyring + machine key independently (two-
   }
 });
 
-test("--dry-run generates NOTHING and reports would-generate", () => {
+test("--dry-run generates NOTHING and reports would-generate (and never prompts)", async () => {
   const tmp = mkdtempSync(join(tmpdir(), "zeta-machine-"));
   try {
     const genCount = { n: 0 };
+    const prompts: string[] = [];
     const fx = fakeEffects("dev-box-3", { genCount });
-    const r = ensureMachineKey(fx, { user: "tester", repoRoot: tmp, home: tmp, dryRun: true, publish: true });
+    const r = await ensureMachineKey(fx, {
+      user: "tester",
+      repoRoot: tmp,
+      home: tmp,
+      dryRun: true,
+      publish: true,
+      biometricAuth: fakeBiometric(true, prompts),
+    });
     expect(r.dryRun).toBe(true);
     expect(r.action).toBe("would-generate");
     expect(r.published).toBe(false);
     expect(genCount.n).toBe(0); // nothing generated
+    expect(prompts).toHaveLength(0); // dry-run NEVER prompts
     expect(existsSync(r.devicePrivatePath)).toBe(false); // nothing written
     expect(existsSync(r.devicePublicPath)).toBe(false);
   } finally {
@@ -88,11 +111,11 @@ test("--dry-run generates NOTHING and reports would-generate", () => {
   }
 });
 
-test("machine: generates a device key (fake) and publishes ONLY the public half; private never published", () => {
+test("machine: generates a device key (fake) and publishes ONLY the public half; private never published", async () => {
   const tmp = mkdtempSync(join(tmpdir(), "zeta-machine-"));
   try {
     const fx = fakeEffects("dev-box-4");
-    const r = ensureMachineKey(fx, { user: "tester", repoRoot: tmp, home: tmp, publish: true });
+    const r = await ensureMachineKey(fx, { user: "tester", repoRoot: tmp, home: tmp, publish: true, biometricAuth: APPROVE });
     expect(r.action).toBe("generated");
     expect(r.published).toBe(true);
     // the PUBLISH path holds ONLY the public key — no private bytes anywhere in it
@@ -101,7 +124,8 @@ test("machine: generates a device key (fake) and publishes ONLY the public half;
     const published = readFileSync(publishedPath, "utf8");
     expect(published).toContain("ssh-ed25519");
     expect(published).not.toContain("PRIVATE");
-    expect(published).not.toMatch(/BEGIN .*PRIVATE KEY/);
+    // The marker is assembled at runtime so NO key-shaped header literal appears in this file.
+    expect(published).not.toMatch(new RegExp("BEGIN .*" + "PRIVATE" + " " + "KEY"));
     // the private key file stays at the LOCAL path, NOT under maintainers/
     expect(r.devicePrivatePath.includes("maintainers")).toBe(false);
   } finally {
@@ -109,18 +133,63 @@ test("machine: generates a device key (fake) and publishes ONLY the public half;
   }
 });
 
-test("machine: idempotent — a second run is a no-op ('exists'), does not regenerate", () => {
+test("machine: idempotent — a second run is a no-op ('exists'), does not regenerate", async () => {
   const tmp = mkdtempSync(join(tmpdir(), "zeta-machine-"));
   try {
     const genCount = { n: 0 };
+    const secondPrompts: string[] = [];
     const fx = fakeEffects("dev-box-5", { genCount });
-    const first = ensureMachineKey(fx, { user: "tester", repoRoot: tmp, home: tmp });
+    const first = await ensureMachineKey(fx, { user: "tester", repoRoot: tmp, home: tmp, biometricAuth: APPROVE });
     expect(first.action).toBe("generated");
     expect(genCount.n).toBe(1);
-    const second = ensureMachineKey(fx, { user: "tester", repoRoot: tmp, home: tmp });
+    const second = await ensureMachineKey(fx, {
+      user: "tester",
+      repoRoot: tmp,
+      home: tmp,
+      biometricAuth: fakeBiometric(true, secondPrompts),
+    });
     expect(second.action).toBe("exists"); // idempotent: apply-N == apply-once effect
     expect(genCount.n).toBe(1); // NOT regenerated
+    expect(secondPrompts).toHaveLength(0); // the idempotent no-op does NOT prompt (no keygen)
     expect(second.publicKey).toBe(first.publicKey); // same public key returned
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("FAIL-CLOSED: biometric declined -> genEd25519 NEVER called, NO key, aborted-biometric", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "zeta-machine-"));
+  try {
+    const genCount = { n: 0 };
+    const prompts: string[] = [];
+    const fx = fakeEffects("dev-box-deny", { genCount });
+    const r = await ensureMachineKey(fx, {
+      user: "tester",
+      repoRoot: tmp,
+      home: tmp,
+      publish: true,
+      biometricAuth: fakeBiometric(false, prompts),
+    });
+    expect(r.action).toBe("aborted-biometric");
+    expect(prompts).toHaveLength(1); // the gate WAS invoked
+    expect(genCount.n).toBe(0); // the keygen door was NEVER called
+    expect(r.published).toBe(false);
+    expect(existsSync(r.devicePrivatePath)).toBe(false); // nothing written
+    expect(existsSync(r.devicePublicPath)).toBe(false); // no public artifact either
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("FAIL-CLOSED: NO biometric door provided -> keygen NEVER runs (default fail-closed)", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "zeta-machine-"));
+  try {
+    const genCount = { n: 0 };
+    const fx = fakeEffects("dev-box-nodoor", { genCount });
+    // No biometricAuth wired at all — requireBiometric returns ok:false (fail-closed).
+    const r = await ensureMachineKey(fx, { user: "tester", repoRoot: tmp, home: tmp });
+    expect(r.action).toBe("aborted-biometric");
+    expect(genCount.n).toBe(0); // never generated without an approval door
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }
@@ -145,8 +214,10 @@ test("real ssh-keygen into a temp dir produces a valid ed25519 pubkey, private s
   try {
     const { realEffects, ensureMachineKey: ensure, deviceKeyPath } = await import("./machine.ts");
     const fx = realEffects();
-    // pin HOME to the temp dir so the REAL device path resolves inside temp, never ~/.ssh
-    const r = ensure(fx, { user: "tester", repoRoot: tmp, home: tmp, publish: true });
+    // pin HOME to the temp dir so the REAL device path resolves inside temp, never ~/.ssh.
+    // A FAKE biometric (approve) so this test never needs a real Touch ID prompt — the gate
+    // is exercised against the fake; the keygen itself is the real ssh-keygen.
+    const r = await ensure(fx, { user: "tester", repoRoot: tmp, home: tmp, publish: true, biometricAuth: APPROVE });
     expect(r.action).toBe("generated");
     const priv = deviceKeyPath(tmp);
     expect(priv.startsWith(tmp)).toBe(true); // private key is inside the temp dir

--- a/tools/setup/persona-keys/machine.ts
+++ b/tools/setup/persona-keys/machine.ts
@@ -26,6 +26,11 @@ import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir, hostname as osHostname } from "node:os";
 import { join } from "node:path";
+// SHARED biometric-approval gate — the agent EXECUTES the device-key generation; the
+// operator's Touch ID / Windows Hello is the AUTHORIZATION (Aaron 2026-06-21). Key generation
+// creates private material, so it is gated FAIL-CLOSED behind a biometric confirm.
+import { requireBiometric, type BiometricAuth, type BiometricResult } from "./biometric.ts";
+export type { BiometricAuth, BiometricResult } from "./biometric.ts";
 
 /** The host-environment doors — the ONLY channel for ambient influence (noninterference). */
 export interface MachineEffects {
@@ -118,25 +123,37 @@ export interface MachineResult {
   readonly hostname: string;
   readonly devicePrivatePath: string;
   readonly devicePublicPath: string;
-  /** "generated" | "exists" (idempotent: an existing key is a no-op) | "would-generate" (dry-run). */
-  readonly action: "generated" | "exists" | "would-generate";
+  /** "generated" | "exists" (idempotent: an existing key is a no-op) | "would-generate" (dry-run)
+   *  | "aborted-biometric" (operator did NOT approve → fail-closed, NO key generated). */
+  readonly action: "generated" | "exists" | "would-generate" | "aborted-biometric";
   /** The PUBLIC key text, when present/generated (safe to print/publish). Undefined on pure dry-run. */
   readonly publicKey?: string;
   /** True iff we wrote the public key to the publish path (never true on dry-run). */
   readonly published: boolean;
+  /** The biometric approval outcome (present only when the gate was invoked — i.e. a real
+   *  keygen was attempted; absent on dry-run + the idempotent `exists` no-op; no secret). */
+  readonly biometric?: BiometricResult;
 }
 
 /**
- * Generate (or, idempotently, recognise) THIS machine's per-host ed25519 device key.
- * Generates ONLY a device keypair — no seed, no CA, no persona key. The private key
- * is written locally by ssh-keygen under umask 077 (the runner's job); ONLY the
- * public key is read back and (optionally) written to the publish path.
+ * Generate (or, idempotently, recognise) THIS machine's per-host ed25519 device key —
+ * AGENT-RUN, OPERATOR-APPROVED. The agent EXECUTES the keygen; a biometric confirm (Touch ID /
+ * Windows Hello) is the operator's AUTHORIZATION. Generates ONLY a device keypair — no seed,
+ * no CA, no persona key. The private key is written locally by ssh-keygen under umask 077 (the
+ * runner's job); ONLY the public key is read back and (optionally) written to the publish path.
  *
+ * BIOMETRIC GATE + FAIL-CLOSED: when a real keygen is about to happen (the device key does NOT
+ * already exist and it is not a dry-run), `biometricAuth()` MUST return ok:true first. On
+ * ok:false the run aborts ("aborted-biometric") and `genEd25519` is NEVER invoked — NO key is
+ * created and NO public artifact is written. The idempotent `exists` no-op (no private material
+ * created) and `--dry-run` (creates nothing) do NOT prompt.
+ *
+ * @param biometricAuth the SHARED approval gate (biometric.ts). Required for the real-keygen path.
  * @param publish  when true, copy the PUBLIC key into maintainers/<user>/machines/.
  *                 (This PR does NOT commit; the caller/operator decides whether to commit.)
- * @param dryRun   when true, NOTHING is generated or written — returns "would-generate".
+ * @param dryRun   when true, NOTHING is generated, written, or prompted — "would-generate".
  */
-export function ensureMachineKey(
+export async function ensureMachineKey(
   fx: MachineEffects,
   opts: {
     readonly user: string;
@@ -144,8 +161,10 @@ export function ensureMachineKey(
     readonly home?: string;
     readonly publish?: boolean;
     readonly dryRun?: boolean;
+    /** SHARED biometric approval door — required for the real keygen path (fail-closed). */
+    readonly biometricAuth?: BiometricAuth;
   },
-): MachineResult {
+): Promise<MachineResult> {
   const hostname = sanitizeHostname(fx.hostname());
   const devicePrivatePath = opts.home === undefined ? deviceKeyPath() : deviceKeyPath(opts.home);
   const devicePublicPath = publishPubPath(opts.repoRoot, opts.user, hostname);
@@ -166,22 +185,41 @@ export function ensureMachineKey(
 
   let publicKey: string;
   let action: MachineResult["action"];
+  let biometric: BiometricResult | undefined;
   if (alreadyExists) {
-    // Idempotent: an existing device key is a no-op. Read back its PUBLIC half only.
+    // Idempotent: an existing device key is a no-op (no private material created → no gate).
+    // Read back its PUBLIC half only.
     publicKey = fx.readText(devicePrivatePath + ".pub").trim();
     action = "exists";
   } else {
+    // BIOMETRIC GATE — fail-closed. A real keygen creates private material; require approval.
+    biometric = await requireBiometric(
+      opts.biometricAuth,
+      `Approve: generate device key for ${hostname}`,
+    );
+    if (!biometric.ok) {
+      return {
+        dryRun: false,
+        hostname,
+        devicePrivatePath,
+        devicePublicPath,
+        action: "aborted-biometric",
+        published: false,
+        biometric,
+      };
+    }
     publicKey = fx.genEd25519(devicePrivatePath, `${opts.user}@${hostname} (zeta-device)`).trim();
     action = "generated";
   }
 
+  const bio = biometric !== undefined ? { biometric } : {};
   if (wantPublish) {
     fx.mkdirp(dirOf(devicePublicPath));
     fx.writeText(devicePublicPath, publicKey.endsWith("\n") ? publicKey : publicKey + "\n");
-    return { dryRun: false, hostname, devicePrivatePath, devicePublicPath, action, publicKey, published: true };
+    return { dryRun: false, hostname, devicePrivatePath, devicePublicPath, action, publicKey, published: true, ...bio };
   }
 
-  return { dryRun: false, hostname, devicePrivatePath, devicePublicPath, action, publicKey, published: false };
+  return { dryRun: false, hostname, devicePrivatePath, devicePublicPath, action, publicKey, published: false, ...bio };
 }
 
 function dirOf(p: string): string {

--- a/tools/setup/persona-keys/onboard-cli.ts
+++ b/tools/setup/persona-keys/onboard-cli.ts
@@ -21,6 +21,7 @@ import { realEffects as realMachineEffects } from "./machine.ts";
 import { realEffects as realPublishEffects } from "./publish.ts";
 import { realEffects as realTrustEffects } from "./github-trust.ts";
 import { realEffects as realCaEffects } from "./ca.ts";
+import { realBiometric } from "./biometric.ts";
 import { formatOnboard, onboard, type OnboardEffects, type OnboardOptions } from "./onboard.ts";
 
 const args = process.argv.slice(2);
@@ -82,6 +83,10 @@ async function main(): Promise<number> {
     machine: realMachineEffects(),
     publish: realPublishEffects(),
     trust: realTrustEffects(),
+    // The SHARED biometric gate — the operator's authorization for the agent-run keygen +
+    // cert-sign steps (fail-closed). The publish step uses publish's own gate. Dry-run never
+    // invokes any of them.
+    biometricAuth: realBiometric(),
     // The CA door is wired ONLY when the operator opts into the cert tie-in. Absent the flag
     // the cert step never runs (and a missing CA private key skips cleanly inside ca.ts).
     ...(signWithCa ? { ca: realCaEffects() } : {}),

--- a/tools/setup/persona-keys/onboard.test.ts
+++ b/tools/setup/persona-keys/onboard.test.ts
@@ -28,6 +28,9 @@ function fixture(opts: {
   pubText?: string;
   /** The biometric outcome publish.ts will see (fake — no real Touch ID / Hello). */
   biometric?: BiometricResult;
+  /** The biometric outcome the SHARED gate (machine-keygen + cert-sign) will see. Defaults
+   *  to approve. Set ok:false to exercise the keygen/sign fail-closed paths via the chain. */
+  sharedBiometric?: BiometricResult;
   /** GitHub `.keys` bodies per identity (public lines), for the trust resolve step. */
   ghKeys?: Record<string, string>;
   /** maintainers/ subdir names the trust resolver may source identities from. */
@@ -37,12 +40,14 @@ function fixture(opts: {
   order: string[];
   ghAdds: { publicKey: string; title: string; keyType: string }[];
   biometricPrompts: string[];
+  sharedPrompts: string[];
   genCalls: string[];
   fetchedUsers: string[];
 } {
   const order: string[] = [];
   const ghAdds: { publicKey: string; title: string; keyType: string }[] = [];
   const biometricPrompts: string[] = [];
+  const sharedPrompts: string[] = [];
   const genCalls: string[] = [];
   const fetchedUsers: string[] = [];
   const existing = opts.existing ?? new Set<string>();
@@ -101,7 +106,24 @@ function fixture(opts: {
     },
   };
 
-  return { fx: { machine, publish, trust }, order, ghAdds, biometricPrompts, genCalls, fetchedUsers };
+  // The SHARED biometric door — the ONE gate the agent-run keygen + cert-sign steps go
+  // through (the operator's approval). Defaults to approve; tests can set ok:false to
+  // exercise the chain's keygen/sign fail-closed paths. Records its own prompts.
+  const biometricAuth = async (prompt: string): Promise<BiometricResult> => {
+    sharedPrompts.push(prompt);
+    order.push("shared.biometricAuth");
+    return opts.sharedBiometric ?? { ok: true, platform: "macos-touchid" };
+  };
+
+  return {
+    fx: { machine, publish, trust, biometricAuth },
+    order,
+    ghAdds,
+    biometricPrompts,
+    sharedPrompts,
+    genCalls,
+    fetchedUsers,
+  };
 }
 
 /** The conventional paths machine.ts builds (so fixtures can mark them present/absent). */
@@ -164,6 +186,31 @@ test("MISSING user keyring -> INSTRUCTION (keyring.sh), NEVER a silent seed-gen"
   // (genEd25519) is for the per-MACHINE device key — and here the machine key already
   // existed, so even that was a no-op. No seed-gen path exists in the orchestrator at all.
   expect(genCalls).toHaveLength(0);
+});
+
+test("CHAIN keygen gated: device key ABSENT + shared approve -> keygen runs after a shared prompt", async () => {
+  // device key absent (→ keygen), machine pub present so publish reaches the gate too.
+  const { fx, genCalls, sharedPrompts } = fixture({
+    existing: new Set([userKeyringPath, machinePubPath]),
+  });
+  const res = await onboard(fx, { user: USER, repoRoot: REPO, home: HOME });
+  expect(res.machine.action).toBe("generated");
+  expect(genCalls).toHaveLength(1); // keygen ran
+  expect(sharedPrompts).toHaveLength(1); // ONLY after a shared biometric approval
+  expect(sharedPrompts[0]).toContain("generate device key");
+});
+
+test("CHAIN FAIL-CLOSED (keygen): device ABSENT + shared DECLINE -> genEd25519 NEVER runs, blocked", async () => {
+  const { fx, genCalls, sharedPrompts } = fixture({
+    existing: new Set([userKeyringPath, machinePubPath]),
+    sharedBiometric: { ok: false, platform: "macos-touchid", reason: "declined" },
+  });
+  const res = await onboard(fx, { user: USER, repoRoot: REPO, home: HOME });
+  expect(res.machine.action).toBe("aborted-biometric");
+  expect(sharedPrompts).toHaveLength(1); // gate invoked
+  expect(genCalls).toHaveLength(0); // but NO keygen — fail-closed
+  const mStep = res.steps.find((s) => s.kind === "machine-key");
+  expect(mStep?.headline).toBe("blocked");
 });
 
 test("--dry-run: NO biometric prompt, NO gh write, NO keygen, NO network", async () => {
@@ -337,6 +384,23 @@ test("CA tie-in: CA + device key present -> cert-sign signs the device key (prin
   expect(signCount.n).toBe(1);
   // the cert text is public (a cert) — no private marker.
   expect(res.cert?.certText).not.toContain("PRIVATE" + " " + "KEY");
+});
+
+test("CA tie-in FAIL-CLOSED: CA + device present but shared DECLINE -> signCert NEVER runs, blocked", async () => {
+  const signCount = { n: 0 };
+  const { fx } = fixture({
+    existing: new Set([userKeyringPath, devicePrivatePath, machinePubPath]),
+    sharedBiometric: { ok: false, platform: "macos-touchid", reason: "declined" },
+  });
+  const fxWithCa: OnboardEffects = {
+    ...fx,
+    ca: fakeCa(new Set([caPrivatePath, machinePubPath]), { signCount }),
+  };
+  const res = await onboard(fxWithCa, { user: USER, repoRoot: REPO, home: HOME, signWithCa: true });
+  const certStep = res.steps.find((s) => s.kind === "cert-sign");
+  expect(certStep?.headline).toBe("blocked");
+  expect(res.cert?.action).toBe("aborted-biometric");
+  expect(signCount.n).toBe(0); // NO sign — fail-closed
 });
 
 test("CA tie-in: --dry-run does NOT sign (would-sign), even with CA + device present", async () => {

--- a/tools/setup/persona-keys/onboard.ts
+++ b/tools/setup/persona-keys/onboard.ts
@@ -49,6 +49,7 @@ import type { GithubTrustEffects, TrustResolution } from "./github-trust.ts";
 import { resolveIdentities, resolveTrustSet } from "./github-trust.ts";
 import type { CaEffects, CertResult } from "./ca.ts";
 import { signMachineCert } from "./ca.ts";
+import type { BiometricAuth } from "./biometric.ts";
 
 /** The sub-module effects bundles — the ONLY doors for ambient influence. Tests inject
  *  fakes; the CLI injects each module's `realEffects()`. The orchestrator never touches the
@@ -61,6 +62,11 @@ export interface OnboardEffects {
   readonly trust: GithubTrustEffects;
   /** OPTIONAL CA door — enables the gated, flash-time cert-sign tie-in (delegates to ca.ts). */
   readonly ca?: CaEffects;
+  /** The SHARED biometric approval door — the ONE gate every sensitive op runs through
+   *  (machine-key generation, cert sign). The PUBLISH step uses its own `publish.biometricAuth`
+   *  (publish.ts owns that gate). When absent, the gated keygen/sign ops fail-closed (no key /
+   *  no cert). Tests inject a fake; the CLI injects `realBiometric()`. */
+  readonly biometricAuth?: BiometricAuth;
 }
 
 /** Options for an onboard run — the operator identity + repo root, plus the knobs each
@@ -200,10 +206,12 @@ export async function onboard(fx: OnboardEffects, opts: OnboardOptions): Promise
   // Delegated: machine.ts owns ssh-keygen + umask + the public-only read-back. We pass
   // publish:false here (this slice's "publish to GitHub" is the separate biometric-gated
   // step 4, not the maintainers/ pubkey-file write). Idempotent: an existing key is a no-op.
-  const machine = ensureMachineKey(fx.machine, {
+  // Gated: the agent runs the keygen, the operator's biometric is the approval (shared door).
+  const machine = await ensureMachineKey(fx.machine, {
     user: opts.user,
     repoRoot: opts.repoRoot,
     ...(home !== undefined ? { home } : {}),
+    ...(fx.biometricAuth !== undefined ? { biometricAuth: fx.biometricAuth } : {}),
     dryRun,
   });
   steps.push({
@@ -213,13 +221,17 @@ export async function onboard(fx: OnboardEffects, opts: OnboardOptions): Promise
         ? "created"
         : machine.action === "would-generate"
           ? "would-create"
-          : "present",
+          : machine.action === "aborted-biometric"
+            ? "blocked"
+            : "present",
     detail:
       machine.action === "exists"
         ? `device key already present (local, private) at ${machine.devicePrivatePath} — no action.`
         : machine.action === "would-generate"
           ? `[dry-run] would generate this host's device key at ${machine.devicePrivatePath} (NOTHING generated).`
-          : `generated this host's device key at ${machine.devicePrivatePath} (private, local, umask 077).`,
+          : machine.action === "aborted-biometric"
+            ? `blocked: biometric ${machine.biometric?.reason ? `failed: ${machine.biometric.reason}` : "not approved"} — NO device key generated (fail-closed).`
+            : `generated this host's device key at ${machine.devicePrivatePath} (private, local, umask 077).`,
     pending: false,
   });
 
@@ -283,12 +295,15 @@ export async function onboard(fx: OnboardEffects, opts: OnboardOptions): Promise
   // beyond ca.ts's own `would-sign` (dryRun is threaded through).
   let cert: CertResult | undefined;
   if (opts.signWithCa === true && fx.ca !== undefined) {
-    const certRes = signMachineCert(fx.ca, {
+    // Gated: the agent runs ssh-keygen -s, the operator's biometric is the approval. Signing
+    // consumes the CA private key, so it is fail-closed behind the shared gate.
+    const certRes = await signMachineCert(fx.ca, {
       user: opts.user,
       machineId: hostname,
       devicePubPath: publishPubPath(opts.repoRoot, opts.user, hostname),
       ...(home !== undefined ? { home } : {}),
       ...(opts.certValidity !== undefined ? { validity: opts.certValidity } : {}),
+      ...(fx.biometricAuth !== undefined ? { biometricAuth: fx.biometricAuth } : {}),
       dryRun,
     });
     cert = certRes;
@@ -299,7 +314,9 @@ export async function onboard(fx: OnboardEffects, opts: OnboardOptions): Promise
           ? "signed"
           : certRes.action === "would-sign"
             ? "would-sign"
-            : "skipped",
+            : certRes.action === "aborted-biometric"
+              ? "blocked"
+              : "skipped",
       detail: certStepDetail(certRes),
       // No-CA / no-device-key are clean skips (operator may add a CA later); never block.
       pending: false,
@@ -324,6 +341,8 @@ function certStepDetail(res: CertResult): string {
       return `skipped: no CA configured (no CA private key at ${res.caPrivatePath}) — present a bare key, sign later.`;
     case "no-device-key":
       return `skipped: no device pubkey at ${res.devicePubPath} — run the machine step (with --publish) first.`;
+    case "aborted-biometric":
+      return `blocked: biometric ${res.biometric?.reason ? `failed: ${res.biometric.reason}` : "not approved"} — NO cert signed (fail-closed).`;
   }
 }
 

--- a/tools/setup/persona-keys/publish.ts
+++ b/tools/setup/persona-keys/publish.ts
@@ -30,21 +30,26 @@
 // FIDO/WebAuthn user-verification framing.
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
-import { homedir, hostname as osHostname, platform as osPlatform } from "node:os";
+import { homedir, hostname as osHostname } from "node:os";
 import { join } from "node:path";
 import { publishPubPath, sanitizeHostname } from "./machine.ts";
+// The biometric gate is the SHARED primitive in biometric.ts (lifted out of this module so
+// ca.ts / machine.ts / publish.ts all share ONE gate, not three copies of the Touch-ID
+// logic). publish.ts re-exports the types + detector for back-compat with its existing
+// importers (CLI + tests); the implementation now lives in biometric.ts.
+import {
+  detectBiometricPlatform as detectBiometricPlatformShared,
+  realBiometric,
+  type BiometricPlatform,
+  type BiometricResult,
+} from "./biometric.ts";
 
-/** The biometric platforms we know how to gate on. `unsupported` ⇒ fail-closed. */
-export type BiometricPlatform = "macos-touchid" | "windows-hello" | "unsupported";
+export type { BiometricPlatform, BiometricResult } from "./biometric.ts";
 
-/** The outcome of a biometric confirmation attempt — never carries a secret. */
-export interface BiometricResult {
-  /** True ONLY if the operator physically confirmed (Touch ID / Windows Hello). */
-  readonly ok: boolean;
-  /** Which mechanism was attempted (for the readout + honest "unsupported" reporting). */
-  readonly platform: BiometricPlatform;
-  /** Present when ok === false — why (unsupported platform, declined, timeout, error). */
-  readonly reason?: string;
+/** Re-exported for back-compat with publish.ts's existing importers (CLI + tests). The
+ *  implementation lives in the shared biometric.ts. */
+export function detectBiometricPlatform(plat?: string): BiometricPlatform {
+  return plat === undefined ? detectBiometricPlatformShared() : detectBiometricPlatformShared(plat);
 }
 
 /** The doors for ambient influence — the ONLY channel for biometric + filesystem + the
@@ -233,89 +238,12 @@ export function formatResult(res: PublishResult): string {
 
 // ── REAL effects (CLI-only): the doors that touch the OS / GitHub ───────────────────
 
-/** Detect the biometric platform for the current host. macOS = Touch ID; Windows =
- *  Windows Hello (seam); everything else = unsupported (fail-closed). */
-export function detectBiometricPlatform(plat: string = osPlatform()): BiometricPlatform {
-  if (plat === "darwin") return "macos-touchid";
-  if (plat === "win32") return "windows-hello";
-  return "unsupported";
-}
-
-/** macOS Touch ID gate — reuse the zflash / biometric-sudo pattern: a no-op `sudo`
- *  command goes through PAM, and (when `pam_tid.so` is configured per the 2026-05-29
- *  ADR) prompts Touch ID. We `sudo -k` first to invalidate any cached timestamp so a
- *  FRESH biometric confirmation is required every publish (no silent timestamp reuse),
- *  then run `sudo -p '' true`. Success ⇒ the operator physically confirmed.
- *
- *  Fail-closed: if `pam_tid.so` is NOT present in /etc/pam.d/sudo we DO NOT fall back to
- *  a password prompt (that would not be a biometric proof) — we report unsupported so
- *  the publish aborts. The operator enables Touch-ID-for-sudo per the ADR first. */
-function macTouchIdAuth(prompt: string): BiometricResult {
-  // Require pam_tid to be configured — otherwise `sudo` would gate on a password, which
-  // is NOT the biometric proof this slice promises. Honest fail-closed.
-  let pamHasTouchId = false;
-  try {
-    const pam = readFileSync("/etc/pam.d/sudo", "utf8");
-    pamHasTouchId = /^\s*auth\s+sufficient\s+pam_tid\.so/m.test(pam);
-  } catch {
-    pamHasTouchId = false;
-  }
-  if (!pamHasTouchId) {
-    return {
-      ok: false,
-      platform: "macos-touchid",
-      reason:
-        "Touch ID for sudo is not configured (pam_tid.so absent from /etc/pam.d/sudo). " +
-        "Enable it per docs/DECISIONS/2026-05-29-biometric-sudo-elevation-via-touch-id-pam.md, then retry.",
-    };
-  }
-  // Invalidate cached sudo timestamp so a fresh Touch ID press is required.
-  spawnSync("sudo", ["-k"], { stdio: "ignore" });
-  // `sudo -p ''` suppresses the password-prompt text; pam_tid pops the Touch ID dialog.
-  // stdin is "ignore" so a non-biometric machine fails-closed (no password can be typed)
-  // rather than hanging on a password prompt.
-  process.stderr.write(`🔐 Touch ID: ${prompt}\n`);
-  const r = spawnSync("sudo", ["-p", "", "true"], { stdio: ["ignore", "ignore", "inherit"] });
-  if (r.status === 0) return { ok: true, platform: "macos-touchid" };
-  return {
-    ok: false,
-    platform: "macos-touchid",
-    reason: `Touch ID was declined or failed (sudo status ${r.status ?? "signal"})`,
-  };
-}
-
-/** Windows Hello gate — SEAM (honest-stop, TODO). A clean programmatic Windows Hello
- *  consent is `Windows.Security.Credentials.UI.UserConsentVerifier.RequestVerificationAsync`,
- *  reachable from PowerShell via WinRT projection — but that bridge is NOT cleanly
- *  invokable from this TS CLI today (no WinRT binding shipped here). Rather than fake a
- *  biometric or weaken the fail-closed gate, this returns unsupported with the wiring
- *  point named. Wire `RequestVerificationAsync` (or the elevated-UAC/Hello path that
- *  flash-usb-windows.ts uses for admin elevation) here when the WinRT bridge lands. */
-function windowsHelloAuth(_prompt: string): BiometricResult {
-  return {
-    ok: false,
-    platform: "windows-hello",
-    reason:
-      "Windows Hello programmatic consent is not yet wired from this TS CLI " +
-      "(seam: Windows.Security.Credentials.UI.UserConsentVerifier.RequestVerificationAsync via WinRT/PowerShell). " +
-      "Wire it in publish.ts windowsHelloAuth() before publishing on Windows — fail-closed until then.",
-  };
-}
-
-/** The REAL effects (used by the CLI): the biometric gate per-platform + a filesystem
- *  read of the PUBLIC key + the real `gh ssh-key add` write. NO secrets, public-only. */
+/** The REAL effects (used by the CLI): the SHARED biometric gate (biometric.ts) + a
+ *  filesystem read of the PUBLIC key + the real `gh ssh-key add` write. NO secrets,
+ *  public-only. The biometric door is `realBiometric()` — the one gate every op shares. */
 export function realEffects(): PublishEffects {
   return {
-    biometricAuth: async (prompt) => {
-      const plat = detectBiometricPlatform();
-      if (plat === "macos-touchid") return macTouchIdAuth(prompt);
-      if (plat === "windows-hello") return windowsHelloAuth(prompt);
-      return {
-        ok: false,
-        platform: "unsupported",
-        reason: `no biometric mechanism on platform '${osPlatform()}' — publish is fail-closed`,
-      };
-    },
+    biometricAuth: realBiometric(),
     exists: (p) => existsSync(p),
     readText: (p) => readFileSync(p, "utf8"),
     ghAddKey: async ({ publicKey, title, keyType }) => {


### PR DESCRIPTION
## What

Makes the whole key-onboarding setup **agent-run, operator-approved-via-biometric** (Aaron 2026-06-21: *"nothing is operator run, only operator approved with hello/biometrics … i'll have you run what you need to for setup"*). The agent **executes** every step (keygen / sign / publish); the human's **Touch ID / Windows Hello** is the **authorization** at each sensitive gate. **Fail-closed everywhere.**

## The one shared gate

- **`biometric.ts` (NEW)** — the shared approval primitive **lifted out of `publish.ts` (#8859)**: `detectBiometricPlatform`, the macOS Touch-ID (`pam_tid` / `sudo -k`) + Windows-Hello seam, `realBiometric()`, the injectable `BiometricAuth` door, `BiometricResult`/`BiometricPlatform` types, and `requireBiometric(auth, prompt)` — **fail-closed by construction** (no door injected ⇒ `ok:false`). One gate, not three copies of the Touch-ID logic.

## Each op now gated (with its approval prompt)

| Op | Function | Prompt | Fail-closed proof |
|---|---|---|---|
| CA keygen | `ca.ts ensureCa` (now async) | `Approve: generate SSH CA keypair for <ca>` | `genCa` NOT invoked on biometric-false |
| Cert sign | `ca.ts signMachineCert` (now async) | `Approve: sign cert for <user>@<machine> (principal=<user>)` | `signCert` NOT invoked on biometric-false |
| Device keygen | `machine.ts ensureMachineKey` (now async) | `Approve: generate device key for <machine>` | `genEd25519` NOT invoked on biometric-false |
| Publish | `publish.ts publishKey` (unchanged) | `Publish <title> to GitHub` | `ghAddKey` NOT invoked on biometric-false |

- **`publish.ts`** — refactored to **import** the shared gate (no behavior change; its 14 tests still pass).
- **`onboard.ts`** — threads the **one** shared door through the chain; keygen + cert-sign gated, status / trust-resolve read-only (no gate). Reuse-only, orchestration unchanged.
- **CLIs** (`ca-cli` / `machine-cli` / `onboard-cli`) — `await` + inject `realBiometric()`.

## Gate (all green)

- **Full persona-keys suite green: 107/107** (was 93; +14) incl. real `ssh-keygen` round-trips.
- **Per-op fail-closed tests** assert the underlying action (`genCa` / `signCert` / `genEd25519` / `ghAddKey`) is **NOT invoked** on biometric-false — for **each** gated op, via **both** a declining door and a missing door.
- `--dry-run` **prompts nothing + does nothing** for ca / cert / machine / onboard (verified inert: no artifacts written).
- `grep -E "BEGIN.*PRIVATE KEY"` **empty** across all changed test files.
- **No real CA/keys generated or committed** (working tree shows only the 12 source/test files).
- The 3 remaining repo-wide `tsc` lint errors are **PRE-EXISTING on `origin/main`** (`tests/cross-verification/_harness/*` from #8882/#8883) — **NOT introduced here**; **zero** persona-keys/biometric lint errors.

## Security-class

Left **OPEN for Otto's verify-gate** — **NOT auto-merged**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)