### PR TITLE
fix(lint): interfaces.test.ts unused type imports (TS6133)

### DIFF
--- a/src/Core.TypeScript/algebra/interfaces.test.ts
+++ b/src/Core.TypeScript/algebra/interfaces.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect } from "bun:test";
 import {
   numberSemiring, additiveGroup, maxLattice, boolOrLattice,
   setUnionMonoid, jsonCodec,
-  type ISemiring, type IGroup, type IMonoid, type ILattice, type ICodec,
+  type ISemiring,
 } from "./interfaces";
 
 describe("ISemiring<number> — ring laws", () => {


### PR DESCRIPTION
Removed 4 unused type imports (`IGroup`/`IMonoid`/`ILattice`/`ICodec`) from `algebra/interfaces.test.ts` re-reddening lint(TS). Mechanical, no test-logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)