### PR TITLE
fix(setup): default profile auto-edit on dev laptops, add .zprofile

### DIFF
--- a/tools/setup/common/profile-edit.sh
+++ b/tools/setup/common/profile-edit.sh
@@ -1,25 +1,22 @@
 #!/usr/bin/env bash
 #
-# tools/setup/common/profile-edit.sh — opt-in auto-edit of shell
-# rc files to source the managed `$HOME/.config/zeta/shellenv.sh`.
+# tools/setup/common/profile-edit.sh — auto-edit shell rc files to source
+# the managed `$HOME/.config/zeta/shellenv.sh`.
 #
-# Default off. Enable with `ZETA_AUTO_EDIT_PROFILES=1` before
-# running install.sh — the rc-file edit is user-visible and
-# should be consent-gated. See GOVERNANCE.md §24 (three-way
-# parity applies here too: dev laptop / CI runner / devcontainer
-# need this the same way).
+# Default ON for dev laptops (install.sh sets ZETA_AUTO_EDIT_PROFILES=1
+# when unset and not CI). Opt out with ZETA_AUTO_EDIT_PROFILES=0.
+# See GOVERNANCE.md §24 (three-way parity: dev laptop / CI / devcontainer).
 #
 # Targets (whichever exist on the machine):
+#   ~/.zprofile      (zsh login shells; macOS Terminal/iTerm login path)
 #   ~/.zshrc         (zsh interactive; macOS default)
 #   ~/.bashrc        (bash interactive; Linux default)
 #   ~/.bash_profile  (bash login; macOS)
 #   ~/.profile       (POSIX fallback; SSH non-interactive)
 #
-# Idempotent. The fenced-marker block is detected on re-run; if
-# the block is already present, the script skips (no duplicate
-# appends). If the block's content has drifted (Zeta regenerated
-# shellenv.sh with a different path, etc.), the script replaces
-# the block in place.
+# Idempotent. The fenced-marker block is detected on re-run; if the block
+# is already present, the script refreshes it in place. Legacy unmarked
+# source lines (pre-marker installs) are left alone — no duplicate append.
 
 set -euo pipefail
 
@@ -31,15 +28,12 @@ MARKER_END='# ---- /zeta shellenv ----'
 SOURCE_LINE='[ -f "$HOME/.config/zeta/shellenv.sh" ] && . "$HOME/.config/zeta/shellenv.sh"'
 
 # ── gate ────────────────────────────────────────────────────────────
-# Default is OFF. User must opt in. This matches Aaron's round-34
-# preference: auto-edit by flag, never by default, never silent.
 if [ "${ZETA_AUTO_EDIT_PROFILES:-0}" != "1" ]; then
   cat <<'EOF'
 ✓ profile-edit: skipped (ZETA_AUTO_EDIT_PROFILES != 1)
 
-  To auto-wire the managed shellenv into your ~/.zshrc /
-  ~/.bashrc / ~/.bash_profile / ~/.profile (whichever exist),
-  re-run with:
+  Dev laptops default to auto-edit. To wire shellenv into rc files, either
+  re-run install.sh (default on non-CI) or set explicitly:
 
       ZETA_AUTO_EDIT_PROFILES=1 tools/setup/install.sh
 
@@ -72,6 +66,8 @@ ensure_block_in_file () {
     ' "$target" > "$tmp"
     mv "$tmp" "$target"
     echo "✓ $target: zeta block refreshed"
+  elif grep -Fq "$SOURCE_LINE" "$target"; then
+    echo "✓ $target: legacy shellenv source present (unmarked); skipping duplicate"
   else
     # Block absent — append.
     {
@@ -82,8 +78,8 @@ ensure_block_in_file () {
 }
 
 # ── apply ──────────────────────────────────────────────────────────
-echo "↓ ZETA_AUTO_EDIT_PROFILES=1 — editing shell rc files..."
-for rc in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.bash_profile" "$HOME/.profile"; do
+echo "↓ profile-edit — wiring managed shellenv into shell rc files..."
+for rc in "$HOME/.zprofile" "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.bash_profile" "$HOME/.profile"; do
   ensure_block_in_file "$rc"
 done
 echo "✓ profile-edit: done. New shells will source the Zeta toolchain."

--- a/tools/setup/common/shellenv.sh
+++ b/tools/setup/common/shellenv.sh
@@ -143,27 +143,25 @@ if [ -n "${GITHUB_ENV:-}" ] && [ -n "${GITHUB_PATH:-}" ]; then
   echo "✓ BASH_ENV + ENV + GITHUB_PATH updated for the remainder of the CI job"
 fi
 
-# Suggest sourcing the file from common shell rc files on first run.
-# We do NOT auto-edit .zshrc / .bashrc — that's a user-visible edit
-# and should be opt-in. The doc tells users how to wire it.
-cat <<'EOF'
+# On dev laptops, install.sh runs profile-edit.sh (default ON, not CI) to
+# append the source line into existing rc files. Under CI the step is
+# skipped — paste manually only when auto-edit is disabled.
+if [ "${ZETA_AUTO_EDIT_PROFILES:-0}" != "1" ]; then
+  cat <<'EOF'
 
-Next step (one-time, local dev only):
-  Paste the line below into all of the following files that
-  exist on your system so every shell variant finds the
-  Zeta toolchain. The block is idempotent — adding it twice
-  is harmless (the `-f` guard skips if the file isn't there).
+Next step (local dev, when profile-edit is disabled):
+  Paste the line below into all of the following files that exist on
+  your system so every shell variant finds the Zeta toolchain:
 
     [ -f "$HOME/.config/zeta/shellenv.sh" ] && . "$HOME/.config/zeta/shellenv.sh"
 
   Target files:
+    ~/.zprofile     (zsh login shells; macOS Terminal login path)
     ~/.zshrc        (zsh interactive shells; macOS default)
     ~/.bashrc       (bash interactive shells; Linux default)
     ~/.bash_profile (bash login shells on macOS)
     ~/.profile      (POSIX fallback; SSH non-interactive)
 
-  Opt-in auto-edit of these files via the install script is
-  BACKLOGged (see docs/BACKLOG.md "Opt-in auto-edit of shell
-  rc files on install"). Until then, paste manually — we
-  deliberately don't touch user rc files without consent.
+  Or re-run with ZETA_AUTO_EDIT_PROFILES=1 (default on dev laptops).
 EOF
+fi

--- a/tools/setup/install.sh
+++ b/tools/setup/install.sh
@@ -67,6 +67,11 @@ SETUP_DIR="$REPO_ROOT/tools/setup"
 if [ -z "${ZETA_HOST_TIER:-}" ] && [ "${GITHUB_ACTIONS:-}" != "true" ]; then
   export ZETA_HOST_TIER=full
 fi
+# Dev laptops: auto-wire shellenv into rc files (profile-edit.sh). CI stays off
+# so runner images are not mutated; opt out locally with ZETA_AUTO_EDIT_PROFILES=0.
+if [ -z "${ZETA_AUTO_EDIT_PROFILES:-}" ] && [ "${GITHUB_ACTIONS:-}" != "true" ]; then
+  export ZETA_AUTO_EDIT_PROFILES=1
+fi
 case ":${MISE_TRUSTED_CONFIG_PATHS:-}:" in
   *:"$REPO_ROOT":*) ;;
   *) export MISE_TRUSTED_CONFIG_PATHS="${MISE_TRUSTED_CONFIG_PATHS:+$MISE_TRUSTED_CONFIG_PATHS:}$REPO_ROOT" ;;


### PR DESCRIPTION
## Summary
- Default `ZETA_AUTO_EDIT_PROFILES=1` on dev laptops (same CI gate as `ZETA_HOST_TIER`; opt out with `ZETA_AUTO_EDIT_PROFILES=0`)
- Add `~/.zprofile` to `profile-edit.sh` targets so macOS login shells source managed shellenv before `.zshrc`
- Skip duplicate append when legacy unmarked shellenv source lines already exist
- Update `shellenv.sh` post-run guidance (remove stale BACKLOGged text)

## Test plan
- [ ] `./tools/setup/install.sh` on macOS — profile-edit appends/refreshes `.zprofile`, skips legacy `.zshrc`
- [ ] `ZETA_AUTO_EDIT_PROFILES=0 ./tools/setup/install.sh` — profile-edit skipped
- [ ] CI macOS/Linux install-sh tests still green (GITHUB_ACTIONS keeps auto-edit off)


Made with [Cursor](https://cursor.com)