### PR TITLE
fix(gen): repair #8901 self-host codegen — TS compile + lint, restore build-and-test

### DIFF
--- a/docs/trajectories/cross-lang-interfaces/RESUME.md
+++ b/docs/trajectories/cross-lang-interfaces/RESUME.md
@@ -39,10 +39,12 @@ for what's unique (C# variance, Rust lifetimes, Go embedding, Q# functors).
 ## WeakReference as cogen = mix(mix,mix) collection enabler
 
 The weak compiler reference pattern:
+
 - **Strong ref** = "I own this, keep it alive" → classical lane (deterministic, always available)
 - **Weak ref** = "I can reach this, but allow collection" → soft lane (derived, regenerable)
 
 Connection to the gen(gen)=gen architecture:
+
 - The **generator IS the ECC** — if derived code is collected, regenerate it on demand
 - **generate the derivable, keep the irreducible** — WeakRef on generated code, StrongRef on IR
 - `cogen = mix(mix,mix)` — the compiler-generator can reproduce any compiled artifact
@@ -50,6 +52,7 @@ Connection to the gen(gen)=gen architecture:
 - Regeneration = the generator re-specializing the IR when the artifact is needed again
 
 This is `only-the-irreducible-is-primitive` applied to MEMORY MANAGEMENT:
+
 - The IR (irreducible) stays alive (strong ref)
 - The generated code (derivable) is weakly held (can be collected + regenerated)
 - The generator (= ECC = cogen) is the mechanism that makes this safe
@@ -69,6 +72,7 @@ This is `only-the-irreducible-is-primitive` applied to MEMORY MANAGEMENT:
 ## How this connects to the codegen
 
 The interface codegen should emit:
+
 1. **The interface definition** (GCF shape + variance annotations)
 2. **Default implementations** (where the language supports it)
 3. **A WeakRef-wrapped cache** for specialized/generated artifacts
@@ -103,6 +107,7 @@ All 5 steps complete. The interface stack exists in 4 compiled languages (TS/C#/
 the WeakRef cache is operational with no-error-caching safety, and it's wired into soft-mix.
 
 ### What's next (new trajectory: algebraic-codegen-capstone)
+
 1. Self-hosting codegen — IR description of the codegen itself
 2. Clifford lens emission — Cl3/multivectors from IR
 3. Cross-lane cost-parity golden — DumpMachine entry-count = AmplitudeEmu.support

--- a/src/Core.Go/algebra/sparse_quantum_sim.go
+++ b/src/Core.Go/algebra/sparse_quantum_sim.go
@@ -12,7 +12,7 @@ type ComplexAmp struct {
 	Re, Im float64
 }
 
-func (c ComplexAmp) MagnitudeSq() float64 { return c.Re*c.Re + c.Im*c.Im }
+func (c ComplexAmp) MagnitudeSq() float64       { return c.Re*c.Re + c.Im*c.Im }
 func (c ComplexAmp) Scale(s float64) ComplexAmp { return ComplexAmp{c.Re * s, c.Im * s} }
 func (c ComplexAmp) Add(other ComplexAmp) ComplexAmp {
 	return ComplexAmp{c.Re + other.Re, c.Im + other.Im}

--- a/src/Core.TypeScript/algebra/soft-mix.ts
+++ b/src/Core.TypeScript/algebra/soft-mix.ts
@@ -182,8 +182,8 @@ export function createCachedMix(ir: ZetaIrV1): (x: bigint) => bigint {
       width: ir.width,
       ops: ir.ops.map(op => ({
         op: op.op,
-        k_bigint: op.k !== undefined ? String(op.k) : undefined,
-        s: op.s,
+        ...(op.k !== undefined ? { k_bigint: String(op.k) } : {}),
+        ...(op.s !== undefined ? { s: op.s } : {}),
       })),
     };
     const cache = createSpecializationCache(cacheableIr, specialize);

--- a/src/Core.TypeScript/algebra/specialization-cache.test.ts
+++ b/src/Core.TypeScript/algebra/specialization-cache.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { specialize, createSpecializationCache, createSpecializationRegistry, type CacheableIr } from "./specialization-cache";
+import { specialize, createSpecializationCache, createSpecializationRegistry, type CacheableIr, type SpecializedMix } from "./specialization-cache";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 

--- a/src/Core.TypeScript/algebra/specialization-cache.ts
+++ b/src/Core.TypeScript/algebra/specialization-cache.ts
@@ -14,7 +14,6 @@
  *   const result3 = cache.run(input3); // cache miss → regenerates (still correct)
  */
 
-import type { StarRing } from "./star-ring";
 
 // ─── Types ───────────────────────────────────────────────────────────────
 
@@ -95,7 +94,7 @@ export function createSpecializationCache(
   // Weak ref to the specialized function (derivable — can be collected)
   let cachedRef: WeakRef<{ fn: SpecializedMix }> | null = null;
   // FinalizationRegistry to track when GC collects our specialized fn
-  const registry = new FinalizationRegistry<string>((name) => {
+  const registry = new FinalizationRegistry<string>((_name) => {
     stats.regenerations++; // Count GC collections
   });
 

--- a/tests/cross-verification/_harness/codegen-clifford.test.ts
+++ b/tests/cross-verification/_harness/codegen-clifford.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { interpretClifford, emitCliffordTS, type Multivector } from "./codegen-clifford";
+import { interpretClifford, emitCliffordTS } from "./codegen-clifford";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 

--- a/tests/cross-verification/_harness/codegen-clifford.ts
+++ b/tests/cross-verification/_harness/codegen-clifford.ts
@@ -36,8 +36,6 @@ function getK(op: IrOp, width: number): bigint {
  */
 export type Multivector = [number, number, number, number, number, number, number, number];
 
-const ZERO_MV: Multivector = [0, 0, 0, 0, 0, 0, 0, 0];
-
 /** Geometric product in Cl(3,0). Euclidean signature (all squares +1). */
 function geoProduct(a: Multivector, b: Multivector): Multivector {
   const result: Multivector = [0, 0, 0, 0, 0, 0, 0, 0];
@@ -49,7 +47,7 @@ function geoProduct(a: Multivector, b: Multivector): Multivector {
       if (b[j] === 0) continue;
       const mask = i ^ j;
       const sign = reorderSign(i, j);
-      result[mask] += sign * a[i] * b[j];
+      result[mask] = (result[mask] ?? 0) + sign * (a[i] ?? 0) * (b[j] ?? 0);
     }
   }
   return result;
@@ -77,7 +75,7 @@ function popcount(n: number): number {
 function grade(mv: Multivector, k: number): Multivector {
   const result: Multivector = [0, 0, 0, 0, 0, 0, 0, 0];
   for (let i = 0; i < 8; i++) {
-    if (popcount(i) === k) result[i] = mv[i];
+    if (popcount(i) === k) result[i] = mv[i] ?? 0;
   }
   return result;
 }
@@ -118,8 +116,7 @@ export function interpretClifford(ir: ZetaIrV2, input: number): Multivector {
       state = geoProduct(geoProduct(reflector, state), reflector);
     } else if (op.op === "branch") {
       // Branch in Clifford: decompose into even + odd subalgebra
-      const even = grade(state, 0).map((v, i) => v + grade(state, 2)[i]) as Multivector;
-      const odd = grade(state, 1).map((v, i) => v + grade(state, 3)[i]) as Multivector;
+      const even = grade(state, 0).map((v, i) => v + (grade(state, 2)[i] ?? 0)) as Multivector;
       // Keep the even part (quaternionic component)
       state = even;
     }

--- a/tests/cross-verification/_harness/codegen-self-host.ts
+++ b/tests/cross-verification/_harness/codegen-self-host.ts
@@ -14,8 +14,6 @@
  * arithmetic IR, produces the SAME output as the committed codegen.
  */
 
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 
 // ─── The IR of the codegen itself ────────────────────────────────────────
 


### PR DESCRIPTION
PR #8901 (self-hosting codegen) merged red on **6 gate jobs**. This repairs the compile + lint breakage (build-and-test was a **TS-compile cascade**):

- **specialization-cache.test.ts** — import the exported `SpecializedMix` type (TS2304 → bun test couldn't compile → build-and-test failed).
- **soft-mix.ts** — conditional-spread `k_bigint`/`s` (TS2322, exactOptionalPropertyTypes).
- **codegen-clifford.ts** — `?? 0` on provably-present tuple indices (TS2532, noUncheckedIndexedAccess) + drop unused `ZERO_MV`/`odd`.
- **specialization-cache.ts / codegen-clifford.test.ts / codegen-self-host.ts** — drop unused imports / `_name` param.
- **gofmt** Core.Go; **markdownlint** `cross-lang-interfaces/RESUME.md` (MD032).

Verified: lint(TS) green, gofmt 0 dirty, markdownlint clean, previously-broken bun tests **22/0**. No logic change.

**⚠ Flagged, NOT fixed (codegen owner):** `cross-verify` still fails — `tests/cross-verification/{zeta-ir-v2,zset-isa-v2}` have **no oracle** (assert-don't-skip). Needs the per-language oracle outputs (in-flight domain); won't stub a false-passing oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)