### PR TITLE
fix: wire orphans into builds + fill interface gaps (review response)

### DIFF
--- a/src/Core.Go/algebra/interfaces_test.go
+++ b/src/Core.Go/algebra/interfaces_test.go
@@ -1,0 +1,59 @@
+package algebra
+
+import "testing"
+
+func TestAdditiveGroupIdentity(t *testing.T) {
+	g := AdditiveGroupInt64{}
+	if g.Combine(5, g.Identity()) != 5 {
+		t.Error("identity should be neutral")
+	}
+	if g.Combine(g.Identity(), 5) != 5 {
+		t.Error("identity should be neutral (left)")
+	}
+}
+
+func TestAdditiveGroupInverse(t *testing.T) {
+	g := AdditiveGroupInt64{}
+	if g.Combine(7, g.Inverse(7)) != g.Identity() {
+		t.Error("inverse should undo combine")
+	}
+}
+
+func TestAdditiveGroupAssociativity(t *testing.T) {
+	g := AdditiveGroupInt64{}
+	if g.Combine(g.Combine(1, 2), 3) != g.Combine(1, g.Combine(2, 3)) {
+		t.Error("combine should be associative")
+	}
+}
+
+func TestMaxSemilatticeJoin(t *testing.T) {
+	l := MaxSemilatticeInt64{}
+	if l.Join(3, 7) != 7 {
+		t.Error("join should be max")
+	}
+	if l.Join(7, 3) != 7 {
+		t.Error("join should be commutative")
+	}
+}
+
+func TestMaxSemilatticeIdempotent(t *testing.T) {
+	l := MaxSemilatticeInt64{}
+	if l.Join(5, 5) != 5 {
+		t.Error("join should be idempotent")
+	}
+}
+
+func TestSetUnionMonoid(t *testing.T) {
+	m := SetUnionMonoid[string]{}
+	empty := m.Identity()
+	if len(empty) != 0 {
+		t.Error("identity should be empty set")
+	}
+
+	a := map[string]bool{"x": true, "y": true}
+	b := map[string]bool{"y": true, "z": true}
+	c := m.Combine(a, b)
+	if len(c) != 3 || !c["x"] || !c["y"] || !c["z"] {
+		t.Error("combine should be union")
+	}
+}

--- a/src/Core.QSharp.ReferenceOracle/AlgebraInterfaces.qs
+++ b/src/Core.QSharp.ReferenceOracle/AlgebraInterfaces.qs
@@ -42,6 +42,22 @@ namespace Zeta.Algebra {
     /// Group inverse.
     function GroupInverse(a : Int) : Int { return -a; }
 
+    // ─── IMonoid ────────────────────────────────────────────────────────
+
+    /// Monoid identity (additive: 0).
+    function MonoidIdentity() : Int { return 0; }
+
+    /// Monoid combine (associative, not necessarily invertible).
+    function MonoidCombine(a : Int, b : Int) : Int { return a + b; }
+
+    // ─── ICodec ─────────────────────────────────────────────────────────
+
+    /// Encode: Int → Int[] (trivial codec: wrap in single-element array).
+    function CodecEncode(a : Int) : Int[] { return [a]; }
+
+    /// Decode: Int[] → Int (extract single element).
+    function CodecDecode(b : Int[]) : Int { return b[0]; }
+
     // ─── ILattice ───────────────────────────────────────────────────────
 
     /// Join (max for integer lattice).

--- a/src/Core.Rust.Observe/src/lib.rs
+++ b/src/Core.Rust.Observe/src/lib.rs
@@ -16,9 +16,13 @@
 //! ("not flying blind") and letting serde drop-in-replace ours.
 
 pub mod algebra;
+pub mod algebra_interfaces;
 pub mod json;
 pub mod json_reader;
 pub mod observe_json;
+pub mod sparse_quantum_sim;
+pub mod specialization_cache;
+pub mod star_ring;
 pub mod types;
 
 pub use algebra::{fold, replay, simulate};

--- a/src/Core.Rust.Observe/src/sparse_quantum_sim.rs
+++ b/src/Core.Rust.Observe/src/sparse_quantum_sim.rs
@@ -161,9 +161,13 @@ mod tests {
     fn measure_returns_correct_value_for_deterministic_input() {
         let mut sim = SparseQuantumSim::new(64);
         sim.initialize(1);
-        // Apply splitmix64-like ops
+        // Apply full splitmix64 pipeline (all 6 ops)
         sim.apply_mul(0x9E3779B97F4A7C15);
         sim.apply_xorshr(30);
+        sim.apply_mul(0xBF58476D1CE4E5B9);
+        sim.apply_xorshr(27);
+        sim.apply_mul(0x94D049BB133111EB);
+        sim.apply_xorshr(31);
         // Support should still be 1 (all permutations)
         assert_eq!(sim.support(), 1);
         // The result should be the splitmix64 golden for input=1

--- a/src/Core/AlgebraInterfaces.fs
+++ b/src/Core/AlgebraInterfaces.fs
@@ -1,57 +1,10 @@
 namespace Zeta.Core
 
-/// The full algebraic interface stack for F# (complements CayleyDickson.fs IStarRing).
-/// IStarRing/ISemiring already live in CayleyDickson.fs. These add the rest.
+/// Additional algebraic instances for F# (the interfaces themselves live in
+/// Zeta.Core.Abstractions — ISemiring, IStarRing, IGroup, IMonoid, ISemilattice).
+/// This file provides F#-idiomatic object-expression instances.
 
-/// Group: identity + combine + inverse. Minimal structure for undo/retract.
-[<Interface>]
-type IGroup<'T> =
-    abstract member Identity: 'T
-    abstract member Combine: 'T * 'T -> 'T
-    abstract member Inverse: 'T -> 'T
-
-/// Monoid: identity + combine. No inverse. The CRDT merge floor.
-[<Interface>]
-type IMonoid<'T> =
-    abstract member Identity: 'T
-    abstract member Combine: 'T * 'T -> 'T
-
-/// Join-semilattice: idempotent, commutative, associative join.
-[<Interface>]
-type IJoinSemilattice<'T> =
-    abstract member Join: 'T * 'T -> 'T
-
-/// Full lattice: join (LUB) + meet (GLB).
-[<Interface>]
-type ILattice<'T> =
-    inherit IJoinSemilattice<'T>
-    abstract member Meet: 'T * 'T -> 'T
-
-/// Codec: encode/decode pair. The serialization contract.
-[<Interface>]
-type ICodec<'TDomain, 'TWire> =
-    abstract member Encode: 'TDomain -> 'TWire
-    abstract member Decode: 'TWire -> 'TDomain
-
-/// Read-only port (covariant — can widen output).
-[<Interface>]
-type IReadPort<'T> =
-    abstract member Read: unit -> 'T
-
-/// Write-only port (contravariant — can narrow input).
-[<Interface>]
-type IWritePort<'T> =
-    abstract member Write: 'T -> unit
-
-/// Hexagonal port: read + write. Invariant on T.
-[<Interface>]
-type IPort<'T> =
-    inherit IReadPort<'T>
-    inherit IWritePort<'T>
-
-// ─── Instances ───────────────────────────────────────────────────────────
-
-/// Additive group over float.
+/// Additive group over float (implements C#'s IGroup<float>).
 module AdditiveGroupFloat =
     let instance: IGroup<float> =
         { new IGroup<float> with
@@ -59,8 +12,16 @@ module AdditiveGroupFloat =
             member _.Combine(a, b) = a + b
             member _.Inverse a = -a }
 
-/// Max join-semilattice over float.
+/// Max semilattice over float (implements C#'s ISemilattice<float>).
 module MaxSemilattice =
-    let instance: IJoinSemilattice<float> =
-        { new IJoinSemilattice<float> with
-            member _.Join(a, b) = max a b }
+    let instance: ISemilattice<float> =
+        { new ISemilattice<float> with
+            member _.Identity = System.Double.NegativeInfinity
+            member _.Combine(a, b) = max a b }
+
+/// Float monoid under addition (implements C#'s IMonoid<float>).
+module AdditiveMonoidFloat =
+    let instance: IMonoid<float> =
+        { new IMonoid<float> with
+            member _.Identity = 0.0
+            member _.Combine(a, b) = a + b }

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -22,6 +22,8 @@
     <Compile Include="PolicyKind.fs" />
     <Compile Include="RetryPolicy.fs" />
     <Compile Include="CayleyDickson.fs" />
+    <Compile Include="AlgebraInterfaces.fs" />
+    <Compile Include="SpecializationCache.fs" />
     <Compile Include="Cl3.fs" />
     <Compile Include="Viewport.fs" />
     <Compile Include="ForceLayout.fs" />

--- a/tests/cross-verification/zeta-ir-v2/interfaces/port.ir.json
+++ b/tests/cross-verification/zeta-ir-v2/interfaces/port.ir.json
@@ -1,0 +1,15 @@
+{
+  "schema": "zeta-ir-v2-interface",
+  "name": "IPort",
+  "typeParams": [{ "name": "T", "variance": "invariant" }],
+  "doc": "Hexagonal port: the boundary between domain and infrastructure. Read + Write.",
+  "members": [
+    { "name": "Read", "kind": "method", "params": [], "returns": "T", "doc": "Read the current value from the port." },
+    { "name": "Write", "kind": "method", "params": [{"name": "value", "type": "T"}], "returns": "void", "doc": "Write a value to the port." }
+  ],
+  "laws": [
+    "Read after Write: Write(v); Read() = v",
+    "Write is total: never throws on valid T",
+    "Read may block: implementation-specific (sync or async)"
+  ]
+}


### PR DESCRIPTION
Responds to the deep review findings:

1. ✅ Rust: 4 modules wired → cargo test 19/19 pass
2. ✅ F#: wired into .fsproj → dotnet build clean
3. ✅ Q#: IMonoid + ICodec added (7/7)
4. ✅ Go: law tests added → go test passes
5. ✅ port.ir.json added

Honest gaps documented in commit message.