### PR TITLE
fix(gate-lint): mechanical multi-language gate-lint sweep (codegen red-merge cleanup)

### DIFF
--- a/src/Core.Python/algebra/specialization_cache.py
+++ b/src/Core.Python/algebra/specialization_cache.py
@@ -13,10 +13,11 @@ Usage:
     # ... GC may collect the specialized function ...
     result3 = cache.run(input3)  # miss → regenerates (still correct)
 """
+
 from __future__ import annotations
 import weakref
 from typing import TypeVar, Generic, Callable, Optional
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 T = TypeVar("T")
 U = TypeVar("U")
@@ -25,6 +26,7 @@ U = TypeVar("U")
 @dataclass
 class CacheStats:
     """Observable statistics for the specialization cache."""
+
     hits: int = 0
     misses: int = 0
     errors: int = 0
@@ -83,6 +85,7 @@ class SpecializationCache(Generic[T, U]):
 
 # ─── Convenience: specialized mix cache from IR ───────────────────────────
 
+
 def create_mix_cache(
     ir_ops: list,
     width: int,
@@ -102,12 +105,14 @@ def create_mix_cache(
             elif op["op"] == "xorshr":
                 s = op["s"]
                 steps.append(lambda z, s=s: (z ^ (z >> s)) & mask)
+
         # Return the pipeline as a single function
         def mix(x: int) -> int:
             z = x & mask
             for step in steps:
                 z = step(z)
             return z
+
         return mix
 
     return SpecializationCache(specialize)

--- a/src/Core.Rust.Observe/src/algebra_interfaces.rs
+++ b/src/Core.Rust.Observe/src/algebra_interfaces.rs
@@ -67,9 +67,15 @@ pub struct AdditiveGroupI64;
 impl Group for AdditiveGroupI64 {
     type Element = i64;
 
-    fn identity(&self) -> i64 { 0 }
-    fn combine(&self, a: i64, b: i64) -> i64 { a.wrapping_add(b) }
-    fn inverse(&self, a: i64) -> i64 { a.wrapping_neg() }
+    fn identity(&self) -> i64 {
+        0
+    }
+    fn combine(&self, a: i64, b: i64) -> i64 {
+        a.wrapping_add(b)
+    }
+    fn inverse(&self, a: i64) -> i64 {
+        a.wrapping_neg()
+    }
 }
 
 /// Max join-semilattice over i64.
@@ -78,7 +84,9 @@ pub struct MaxLatticeI64;
 impl JoinSemilattice for MaxLatticeI64 {
     type Element = i64;
 
-    fn join(&self, a: i64, b: i64) -> i64 { a.max(b) }
+    fn join(&self, a: i64, b: i64) -> i64 {
+        a.max(b)
+    }
 }
 
 /// JSON codec (String ↔ serde_json::Value — conceptual, no serde dep here).
@@ -88,8 +96,12 @@ impl Codec for JsonStringCodec {
     type Domain = String;
     type Wire = Vec<u8>;
 
-    fn encode(&self, a: &String) -> Vec<u8> { a.as_bytes().to_vec() }
-    fn decode(&self, b: &Vec<u8>) -> String { String::from_utf8_lossy(b).into_owned() }
+    fn encode(&self, a: &String) -> Vec<u8> {
+        a.as_bytes().to_vec()
+    }
+    fn decode(&self, b: &Vec<u8>) -> String {
+        String::from_utf8_lossy(b).into_owned()
+    }
 }
 
 #[cfg(test)]

--- a/src/Core.Rust.Observe/src/sparse_quantum_sim.rs
+++ b/src/Core.Rust.Observe/src/sparse_quantum_sim.rs
@@ -22,14 +22,20 @@ impl Complex {
     }
 
     pub fn scale(self, s: f64) -> Self {
-        Self { re: self.re * s, im: self.im * s }
+        Self {
+            re: self.re * s,
+            im: self.im * s,
+        }
     }
 }
 
 impl std::ops::Add for Complex {
     type Output = Self;
     fn add(self, rhs: Self) -> Self {
-        Self { re: self.re + rhs.re, im: self.im + rhs.im }
+        Self {
+            re: self.re + rhs.re,
+            im: self.im + rhs.im,
+        }
     }
 }
 
@@ -45,8 +51,16 @@ pub struct SparseQuantumSim {
 
 impl SparseQuantumSim {
     pub fn new(width: u32) -> Self {
-        let mask = if width >= 64 { u64::MAX } else { (1u64 << width) - 1 };
-        Self { state: HashMap::new(), width, mask }
+        let mask = if width >= 64 {
+            u64::MAX
+        } else {
+            (1u64 << width) - 1
+        };
+        Self {
+            state: HashMap::new(),
+            width,
+            mask,
+        }
     }
 
     /// Number of basis states with nonzero amplitude.
@@ -107,7 +121,11 @@ impl SparseQuantumSim {
         let mut next = HashMap::with_capacity(self.state.len());
         for (&key, &amp) in &self.state {
             let control_set = (key >> control) & 1 == 1;
-            let new_key = if control_set { (key ^ (1u64 << target)) & self.mask } else { key };
+            let new_key = if control_set {
+                (key ^ (1u64 << target)) & self.mask
+            } else {
+                key
+            };
             let entry = next.entry(new_key).or_insert(Complex::ZERO);
             *entry = *entry + amp;
         }
@@ -117,15 +135,22 @@ impl SparseQuantumSim {
 
     /// Measure: collapse to one basis state (Born rule).
     pub fn measure(&self) -> u64 {
-        if self.state.is_empty() { return 0; }
-        if self.state.len() == 1 { return *self.state.keys().next().unwrap(); }
+        if self.state.is_empty() {
+            return 0;
+        }
+        if self.state.len() == 1 {
+            return *self.state.keys().next().unwrap();
+        }
         // For deterministic paths this always returns the single state
         *self.state.keys().next().unwrap()
     }
 
     /// Get amplitude for a specific basis state.
     pub fn get_amplitude(&self, basis_state: u64) -> Complex {
-        self.state.get(&(basis_state & self.mask)).copied().unwrap_or(Complex::ZERO)
+        self.state
+            .get(&(basis_state & self.mask))
+            .copied()
+            .unwrap_or(Complex::ZERO)
     }
 
     fn prune(state: &mut HashMap<u64, Complex>) {

--- a/src/Core.Rust.Observe/src/specialization_cache.rs
+++ b/src/Core.Rust.Observe/src/specialization_cache.rs
@@ -5,7 +5,10 @@
 // When all strong refs are dropped, the specialized function is deallocated.
 // Next call regenerates it from the IR.
 
-use std::sync::{Arc, Weak, atomic::{AtomicU64, Ordering}};
+use std::sync::{
+    Arc, Weak,
+    atomic::{AtomicU64, Ordering},
+};
 
 /// Stats for the specialization cache.
 #[derive(Debug, Default)]
@@ -108,8 +111,11 @@ mod tests {
         let cc = call_count.clone();
         let mut cache = SpecializationCache::new(move || {
             let n = cc.fetch_add(1, Ordering::Relaxed);
-            if n == 0 { Err("transient".into()) }
-            else { Ok(|x: u64| x * 2) }
+            if n == 0 {
+                Err("transient".into())
+            } else {
+                Ok(|x: u64| x * 2)
+            }
         });
 
         // First call: error

--- a/src/Core.Rust.Observe/src/star_ring.rs
+++ b/src/Core.Rust.Observe/src/star_ring.rs
@@ -17,13 +17,27 @@ pub trait StarRing: Clone + PartialEq {
 
 /// Real numbers (f64) as a *-ring. Conj = identity.
 impl StarRing for f64 {
-    fn zero() -> Self { 0.0 }
-    fn one() -> Self { 1.0 }
-    fn add(a: &Self, b: &Self) -> Self { a + b }
-    fn mul(a: &Self, b: &Self) -> Self { a * b }
-    fn negate(a: &Self) -> Self { -a }
-    fn conj(a: &Self) -> Self { *a }
-    fn is_zero(a: &Self) -> bool { a.abs() < 1e-12 }
+    fn zero() -> Self {
+        0.0
+    }
+    fn one() -> Self {
+        1.0
+    }
+    fn add(a: &Self, b: &Self) -> Self {
+        a + b
+    }
+    fn mul(a: &Self, b: &Self) -> Self {
+        a * b
+    }
+    fn negate(a: &Self) -> Self {
+        -a
+    }
+    fn conj(a: &Self) -> Self {
+        *a
+    }
+    fn is_zero(a: &Self) -> bool {
+        a.abs() < 1e-12
+    }
 }
 
 /// Complex number (re + im*i).
@@ -34,18 +48,39 @@ pub struct Complex {
 }
 
 impl StarRing for Complex {
-    fn zero() -> Self { Complex { re: 0.0, im: 0.0 } }
-    fn one() -> Self { Complex { re: 1.0, im: 0.0 } }
-    fn add(a: &Self, b: &Self) -> Self { Complex { re: a.re + b.re, im: a.im + b.im } }
+    fn zero() -> Self {
+        Complex { re: 0.0, im: 0.0 }
+    }
+    fn one() -> Self {
+        Complex { re: 1.0, im: 0.0 }
+    }
+    fn add(a: &Self, b: &Self) -> Self {
+        Complex {
+            re: a.re + b.re,
+            im: a.im + b.im,
+        }
+    }
     fn mul(a: &Self, b: &Self) -> Self {
         Complex {
             re: a.re * b.re - a.im * b.im,
             im: a.re * b.im + a.im * b.re,
         }
     }
-    fn negate(a: &Self) -> Self { Complex { re: -a.re, im: -a.im } }
-    fn conj(a: &Self) -> Self { Complex { re: a.re, im: -a.im } }
-    fn is_zero(a: &Self) -> bool { a.re * a.re + a.im * a.im < 1e-12 }
+    fn negate(a: &Self) -> Self {
+        Complex {
+            re: -a.re,
+            im: -a.im,
+        }
+    }
+    fn conj(a: &Self) -> Self {
+        Complex {
+            re: a.re,
+            im: -a.im,
+        }
+    }
+    fn is_zero(a: &Self) -> bool {
+        a.re * a.re + a.im * a.im < 1e-12
+    }
 }
 
 /// A weighted entry: (key, weight) where weight is from a *-ring.
@@ -66,33 +101,62 @@ pub fn consolidate<W: StarRing>(entries: Vec<WEntry<W>>) -> Vec<WEntry<W>> {
             grouped.push(entry);
         }
     }
-    grouped.into_iter().filter(|g| !W::is_zero(&g.weight)).collect()
+    grouped
+        .into_iter()
+        .filter(|g| !W::is_zero(&g.weight))
+        .collect()
 }
 
 /// Soft mix: fold IR ops over a weighted ensemble. Ring-generic.
 /// Each op can FORK frames (1→N for branching ops). Support grows only
 /// by actual uncertainty, not by register width. For mul/xorshr (permutations),
 /// each frame maps 1→1 (no growth). The "grows in bits by uncertainty" property.
-pub fn soft_mix<W: StarRing>(ops: &[(& str, u64)], width: u32, input: Vec<WEntry<W>>) -> Vec<WEntry<W>> {
-    let mask: u64 = if width >= 64 { u64::MAX } else { (1u64 << width) - 1 };
+pub fn soft_mix<W: StarRing>(
+    ops: &[(&str, u64)],
+    width: u32,
+    input: Vec<WEntry<W>>,
+) -> Vec<WEntry<W>> {
+    let mask: u64 = if width >= 64 {
+        u64::MAX
+    } else {
+        (1u64 << width) - 1
+    };
     let mut ensemble = input;
     for &(op, val) in ops {
         // flatMap: each frame can produce multiple output frames (fork).
         // mul/xorshr: deterministic (1→1). branch: 1→2 (grows by 1 bit of uncertainty).
-        ensemble = ensemble.into_iter().flat_map(|e| {
-            match op {
-                "mul" => vec![WEntry { key: e.key.wrapping_mul(val) & mask, weight: e.weight }],
-                "xorshr" => vec![WEntry { key: (e.key ^ (e.key >> val)) & mask, weight: e.weight }],
-                "branch" => {
-                    // Fork: two frames, each with the original weight (to be scaled by 1/√2 later)
-                    vec![
-                        WEntry { key: e.key & mask, weight: e.weight.clone() },
-                        WEntry { key: (e.key ^ (1u64 << val)) & mask, weight: e.weight },
-                    ]
-                },
-                _ => vec![WEntry { key: e.key, weight: e.weight }],
-            }
-        }).collect();
+        ensemble = ensemble
+            .into_iter()
+            .flat_map(|e| {
+                match op {
+                    "mul" => vec![WEntry {
+                        key: e.key.wrapping_mul(val) & mask,
+                        weight: e.weight,
+                    }],
+                    "xorshr" => vec![WEntry {
+                        key: (e.key ^ (e.key >> val)) & mask,
+                        weight: e.weight,
+                    }],
+                    "branch" => {
+                        // Fork: two frames, each with the original weight (to be scaled by 1/√2 later)
+                        vec![
+                            WEntry {
+                                key: e.key & mask,
+                                weight: e.weight.clone(),
+                            },
+                            WEntry {
+                                key: (e.key ^ (1u64 << val)) & mask,
+                                weight: e.weight,
+                            },
+                        ]
+                    }
+                    _ => vec![WEntry {
+                        key: e.key,
+                        weight: e.weight,
+                    }],
+                }
+            })
+            .collect();
         ensemble = consolidate(ensemble);
     }
     ensemble

--- a/src/Core.TypeScript/hygiene/check-bash-retirement-inventory.ts
+++ b/src/Core.TypeScript/hygiene/check-bash-retirement-inventory.ts
@@ -93,6 +93,7 @@ export const EXPECTED_RETAINED_SHELL: readonly string[] = [
   "tools/setup/common/one-liner-tools.sh",
   "tools/setup/common/profile-edit.sh",
   "tools/setup/common/python-tools.sh",
+  "tools/setup/common/qdk.sh",
   "tools/setup/common/quantum.sh",
   "tools/setup/common/repo-bins.sh",
   "tools/setup/common/shellenv.sh",
@@ -136,6 +137,10 @@ export const RETAINED_SHELL_CATEGORY_BY_FILE: Readonly<Record<string, RetainedSh
   "tools/setup/common/one-liner-tools.sh": "setup/bootstrap",
   "tools/setup/common/profile-edit.sh": "setup/bootstrap",
   "tools/setup/common/python-tools.sh": "setup/bootstrap",
+  // qdk.sh installs the modern Q# Development Kit (qsharp 1.x pip package) — a
+  // quantum-toolchain installer alongside quantum.sh, retained shell at the
+  // pre-Bun setup edge (added with #8909, inventory entry missed at merge).
+  "tools/setup/common/qdk.sh": "setup/bootstrap",
   "tools/setup/common/quantum.sh": "setup/bootstrap",
   "tools/setup/common/repo-bins.sh": "setup/bootstrap",
   "tools/setup/common/shellenv.sh": "setup/bootstrap",

--- a/tests/cross-verification/_harness/cross-verify-ir.ts
+++ b/tests/cross-verification/_harness/cross-verify-ir.ts
@@ -88,7 +88,6 @@ sys.stdout.write(json.dumps(out))`;
 }
 
 function generateAndRunGo(ir: ZetaIrV2, inputs: [string, string][], tmpDir: string): OracleResult {
-  const mask = ir.width >= 64 ? "" : `\tz = z & ${(1n << BigInt(ir.width)) - 1n}`;
   const body = ir.ops.map(op => {
     if (op.op === "mul") {
       const line = `\tz = z * ${getK(op, ir.width)}`;


### PR DESCRIPTION
Mechanical multi-language gate-lint sweep. The codegen trajectory landed several PRs that merged red on non-required gate jobs; this restores them. **Mechanical fixes only — no logic/behavior change. Honesty over green.**

## Fixed (mechanical)

| Gate | Fix | Confirm |
|---|---|---|
| **lint(TS)** | Removed unused `mask` local in `generateAndRunGo` (`tests/cross-verification/_harness/cross-verify-ir.ts:91`, TS6133). The Go body inlines the width mask per-op; the local was dead. | `lint-typescript.ts` green |
| **build-and-test (×2)** | Cascade from the TS error (tsc exit 2 → bun test couldn't compile). Cleared by the TS fix. | `bun test tests/cross-verification/` → **165 pass / 0 fail** |
| **lint(Python)** | Removed unused `field` import in `algebra/specialization_cache.py` (ruff F401), then `ruff format` re-flow for the PEP8 blank-line drift the removal caused. | `lint-python.ts` green (ruff check + ruff format --check + mypy) |
| **lint(Rust) fmt** | `cargo fmt` on `Core.Rust.Observe` (4 files, whitespace only). | `cargo fmt --check` green on the crate |
| **lint(bash hygiene)** | Added `tools/setup/common/qdk.sh` to the retained-shell inventory + `setup/bootstrap` category. | guard OK (setup/bootstrap 24, host-service 2, nixos 3) |

### The bash file decision (judgment, per the brief)
`qdk.sh` is the modern Q# Development Kit (qsharp 1.x pip package) installer, added with **#8909** alongside the existing `quantum.sh`. It is a legitimate pre-Bun setup-edge installer whose inventory/allowlist entry was simply **missed at merge** — not a stray/scratch script. Correct fix is to **retain it** (add to the allowlist), not delete it.

## NOT fixed — flagged, not stubbed

- **lint(Rust) clippy on `Core.Rust.Observe` stays RED.** The `cargo fmt` failure ran first in CI and short-circuited, masking clippy. After the fmt fix, the crate is independently red: **47 `missing_docs`** (`Cargo.toml [lints.rust] missing_docs="warn"` + lint script `-- -D warnings`), **`field width is never read`** (`sparse_quantum_sim.rs:48`), and one **`collapsible_if`** (`specialization_cache.rs:56`). All originate from #8900/#8908. These need doc-comment authorship + a field-removal/`#[allow]` decision — **NOT mechanical**, so left for the codegen owner. (The fmt fix is kept regardless: it's a correct, independent gate finding and a prerequisite.)
- **cross-verify `zeta-ir-v2` / `zset-isa-v2` "no oracle"** (assert-don't-skip) — needs per-language oracle OUTPUTS from the in-flight codegen domain. **Not stubbed**: a false-passing `compare.ts`/`cross-verify.ts` is worse than honest red. Codegen owner's remaining gap.

## Guardrails honored
- No logic/behavior change; unused-removal + formatter runs + allowlist addition only.
- `grep -E "BEGIN.*PRIVATE KEY"` over all touched files = empty.
- All git/edits via the isolated worktree; shared checkout untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)