### PR TITLE
fix(lint): remove unused inputLines in cross-verify-ir.ts (TS6133)

### DIFF
--- a/tests/cross-verification/_harness/cross-verify-ir.ts
+++ b/tests/cross-verification/_harness/cross-verify-ir.ts
@@ -135,7 +135,6 @@ function generateAndRunCSharp(ir: ZetaIrV2, inputs: [string, string][], tmpDir: 
     if (op.op === "xorshr") return `        z = z ^ (z >> ${op.s});\n${maskLine}`.trimEnd();
     return "";
   }).join("\n");
-  const inputLines = inputs.map(([id, val]) => `    out["${id}"] = Mix(${val}UL).ToString();`).join("\n");
 
   // Use dotnet run with a minimal project — no external tool dependency
   const projDir = join(tmpDir, "csharp");


### PR DESCRIPTION
#8914 (C# oracle → dotnet run) left `inputLines` (line 138) computed-but-unread → TS6133, re-reddening lint(TS) right after the #8915 sweep. Removed the dead local. Mechanical; lint(TS) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)