### PR TITLE
Prove normalizer incompleteness via counterexamples

### DIFF
--- a/docs/research/2026-06-21-lumen-zeta-ir-normalizer-incompleteness.md
+++ b/docs/research/2026-06-21-lumen-zeta-ir-normalizer-incompleteness.md
@@ -1,0 +1,57 @@
+# Research Note: Incompleteness of the Zeta IR Normalizer
+
+**Date:** 2026-06-21
+**Author:** Manus AI
+**Component:** `Zeta.Core.ZetaIrNormalizer`
+
+## Key Recommendation
+**The Zeta IR Normalizer is SOUND but INCOMPLETE.** It is not a decision procedure for program equivalence. We must not rely on structural equality of normalized IRs (`normalize A == normalize B`) to determine if two generators compute the same function.
+
+## 1. The Completeness Question
+The `ZetaIrNormalizer` successfully lowers the 6-op `zeta-ir-v4` grammar into the 4-op minimal generating set (`{mul, add, xshrxor, xrotxor}`). We have formally verified (via Lean 4 and FsCheck) that this lowering is **sound** (preserves denotation), **idempotent**, and **closed** over the core four.
+
+The natural next question is **completeness**: does the normalizer serve as a canonical decision procedure for IR equivalence? Formally, if two IR programs $A$ and $B$ compute the exact same function over `UInt64` (i.e., $\forall x, \text{eval}(A, x) = \text{eval}(B, x)$), do they normalize to the exact same structural IR list?
+
+$$\forall A, B \in \text{Ir}. (\forall x, \text{eval}(A, x) = \text{eval}(B, x)) \implies \text{normalize}(A) = \text{normalize}(B)$$
+
+## 2. The Verdict: Incomplete
+The normalizer is **provably incomplete**. The theorem above is false.
+
+The current `normalizeOp` function operates strictly point-wise—it lowers individual operations in isolation without inspecting the surrounding program structure. It performs no algebraic simplification, fusion, or term rewriting across sequence boundaries.
+
+Because the grammar admits multiple ways to construct identical algebraic functions using sequences of core operations, we can easily construct equivalent programs that normalize to distinct structures.
+
+### Counterexample 1: Multiplication Composition
+The simplest counterexample exploits the associativity of multiplication in the ring $\mathbb{Z}/2^W\mathbb{Z}$.
+
+* **Program A:** `[Mul 2, Mul 3]`
+* **Program B:** `[Mul 6]`
+
+Both programs compute $f(x) = x \times 6 \pmod{2^W}$.
+Because `Mul` is already a core-four operation, the normalizer preserves both programs exactly as written:
+* `normalize(A)` = `[Mul 2, Mul 3]`
+* `normalize(B)` = `[Mul 6]`
+
+The normal forms are structurally unequal despite strict functional equivalence.
+
+### Counterexample 2: Rotation Algebra
+A second counterexample exploits the algebraic structure of bitwise rotation.
+
+* **Program A:** `[Rotl 1, Rotl 2]`
+* **Program B:** `[Rotl 3]`
+
+Both programs compute a total left-rotation by 3 bits.
+The normalizer lowers `Rotl r` to `XRotXor [0, r]`:
+* `normalize(A)` = `[XRotXor [0, 1], XRotXor [0, 2]]`
+* `normalize(B)` = `[XRotXor [0, 3]]`
+
+Again, the normal forms are distinct.
+
+## 3. Conclusion and Architectural Boundaries
+The incompleteness is not a flaw in the normalizer, but a deliberate architectural boundary. 
+
+The normalizer's job is **vocabulary reduction** (6 ops $\to$ 4 ops), not **algebraic simplification**. Building a true canonical normal form for program equivalence would require a full term-rewriting engine capable of flattening all affine and linear transformations over $\mathbb{F}_2$ and $\mathbb{Z}/2^W\mathbb{Z}$.
+
+For downstream consumers (compilers, optimizers, Lean targets):
+1. **You CAN** rely on `normalize` to strip `xorshr` and `rotl` from the vocabulary, guaranteeing you only need to implement 4 operations.
+2. **You CANNOT** rely on `normalize(A) == normalize(B)` to deduplicate generators or prove functional equivalence. Equivalency checking remains the domain of SMT solvers (like the existing Z3 harness) or exhaustive search.

--- a/tests/Tests.FSharp/ZetaIrNormalizer.Tests.fs
+++ b/tests/Tests.FSharp/ZetaIrNormalizer.Tests.fs
@@ -65,3 +65,35 @@ module NormalizerProperties =
             ],
             norm.Ops
         )
+
+    [<Fact>]
+    let ``normalize is incomplete: equivalent programs can have distinct normal forms (mul composition)`` () =
+        let progA = { ZetaIrV4.Generator = "A"; ZetaIrV4.Version = 1; ZetaIrV4.Width = 64; ZetaIrV4.Ops = [ZetaIrV4.Mul 2L; ZetaIrV4.Mul 3L] }
+        let progB = { ZetaIrV4.Generator = "B"; ZetaIrV4.Version = 1; ZetaIrV4.Width = 64; ZetaIrV4.Ops = [ZetaIrV4.Mul 6L] }
+        
+        // They are functionally equivalent over uint64
+        let evalA x = (x * 2UL) * 3UL
+        let evalB x = x * 6UL
+        for i in 0UL .. 100UL do
+            Assert.Equal(evalA i, evalB i)
+            
+        // But their normal forms are distinct
+        let normA = normalize progA
+        let normB = normalize progB
+        Assert.NotEqual<ZetaIrV4.Op list>(normA.Ops, normB.Ops)
+
+    [<Fact>]
+    let ``normalize is incomplete: equivalent programs can have distinct normal forms (rotation algebra)`` () =
+        let progA = { ZetaIrV4.Generator = "A"; ZetaIrV4.Version = 1; ZetaIrV4.Width = 64; ZetaIrV4.Ops = [ZetaIrV4.Rotl 1L; ZetaIrV4.Rotl 2L] }
+        let progB = { ZetaIrV4.Generator = "B"; ZetaIrV4.Version = 1; ZetaIrV4.Width = 64; ZetaIrV4.Ops = [ZetaIrV4.Rotl 3L] }
+        
+        // They are functionally equivalent over uint64
+        let evalA x = evalOp64 (ZetaIrV4.Rotl 2L) (evalOp64 (ZetaIrV4.Rotl 1L) x)
+        let evalB x = evalOp64 (ZetaIrV4.Rotl 3L) x
+        for i in [0UL; 1UL; 2UL; 42UL; 100UL; 0xFFFFFFFFFFFFFFFFUL] do
+            Assert.Equal(evalA i, evalB i)
+            
+        // But their normal forms are distinct
+        let normA = normalize progA
+        let normB = normalize progB
+        Assert.NotEqual<ZetaIrV4.Op list>(normA.Ops, normB.Ops)


### PR DESCRIPTION
Resolves the completeness question: the normalizer is sound but incomplete. It does not decide IR equivalence. Added F# tests with concrete counterexamples (mul composition, rotation algebra) and a research note.