### PR TITLE
keys(register): aaron's acehacks-mac-studio device key (per-machine, public)

### DIFF
--- a/maintainers/aaron/machines/acehacks-mac-studio.local.pub
+++ b/maintainers/aaron/machines/acehacks-mac-studio.local.pub
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB9F3K3zHAgc4ohAFkYfESG+t7Se3/jziWVM6L+bl1RW aaron@acehacks-mac-studio.local (zeta-device)


### PR DESCRIPTION
First real run of the **agent-run / operator-approved** onboard flow — Otto drove, Aaron approved via **Touch ID** (×2: device-key gen + GitHub publish). Generated this host's ed25519 device key (private stays local under `~/.config/zeta/machine`, umask 077), published the **public** key to github:aaron, and registers it here in `maintainers/`.

Per-MACHINE device key for the (aaron × acehacks-mac-studio) pair — distinct from aaron's persona keyring. **Public key only**; private never committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)