### PR TITLE
revert(keys): back out #8926 aaron@machine hybrid key — moving to pure machine/user model

### DIFF
--- a/maintainers/aaron/machines/acehacks-mac-studio.local.pub
+++ b/maintainers/aaron/machines/acehacks-mac-studio.local.pub
@@ -1,1 +1,0 @@
-ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB9F3K3zHAgc4ohAFkYfESG+t7Se3/jziWVM6L+bl1RW aaron@acehacks-mac-studio.local (zeta-device)


### PR DESCRIPTION
Backs out the per-(user×machine) hybrid device key per Aaron's design correction. Keys must be **pure** — user keys (identity) + machine keys (host identity) — with the (user × machine) binding in a **CA cert**, not a `user@machine` hybrid. Hybrid scales O(users×machines) = 30 for 3×10; pure model = O(users+machines) = 13 + certs.

Fully backed out: **revoked** the GitHub key (id 155068851), **deleted** the local private key, **removes** this registration. `machine.ts` rework to pure model + re-key follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)