### PR TITLE
fix(ts): make generated law tests strict-clean

### DIFF
--- a/tests/cross-verification/_harness/codegen-law-tests.ts
+++ b/tests/cross-verification/_harness/codegen-law-tests.ts
@@ -19,7 +19,7 @@
  * Proof lives in Z3/Lean and is referenced by the `proof` field.
  */
 
-import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 interface LawSchema {
@@ -49,7 +49,8 @@ interface InterfaceIr {
 
 export function generateLawTests(ir: InterfaceIr, instanceExpr: string): string {
   const tests = ir.laws.map(law => {
-    const testBody = generateTestBody(law, instanceExpr);
+    const inputBindings = generateInputBindings(law);
+    const testBody = generateTestBody(law);
     const statusComment = law.status === "proven"
       ? `// PROVEN: ${law.proof}`
       : law.status === "conjectured"
@@ -59,7 +60,7 @@ export function generateLawTests(ir: InterfaceIr, instanceExpr: string): string 
     return `  test("${law.id}: ${law.doc ?? law.schema}", () => {
     ${statusComment}
     for (let i = 0; i < N; i++) {
-      const a = gen(), b = gen(), c = gen();
+${inputBindings}
 ${testBody}
     }
   });`;
@@ -81,7 +82,37 @@ ${tests}
 `;
 }
 
-function generateTestBody(law: LawSchema, inst: string): string {
+function generateInputBindings(law: LawSchema): string {
+  const inputs = requiredInputs(law);
+  if (inputs.length === 0) {
+    return "      // No random inputs required for this schema.";
+  }
+
+  return inputs.map(input => `      const ${input} = gen();`).join("\n");
+}
+
+function requiredInputs(law: LawSchema): readonly string[] {
+  switch (law.schema) {
+    case "associative":
+    case "distributive":
+      return ["a", "b", "c"];
+
+    case "commutative":
+      return ["a", "b"];
+
+    case "identity":
+    case "inverse":
+    case "idempotent":
+    case "involutive":
+    case "roundTrip":
+      return ["a"];
+
+    default:
+      return [];
+  }
+}
+
+function generateTestBody(law: LawSchema): string {
   switch (law.schema) {
     case "associative":
       return `      expect(eq(r.${lcFirst(law.op!)}(r.${lcFirst(law.op!)}(a, b), c), r.${lcFirst(law.op!)}(a, r.${lcFirst(law.op!)}(b, c)))).toBe(true);`;
@@ -113,7 +144,7 @@ function generateTestBody(law: LawSchema, inst: string): string {
 }
 
 function lcFirst(s: string): string {
-  return s[0].toLowerCase() + s.slice(1);
+  return s.length === 0 ? s : s.charAt(0).toLowerCase() + s.slice(1);
 }
 
 // ─── Verify law statuses (the CI gate) ──────────────────────────────────
@@ -131,7 +162,7 @@ export function verifyLawStatuses(ir: InterfaceIr, repoRoot: string): LawVerific
       return { id: law.id, status: law.status, proofExists: false };
     }
     // Check if the referenced proof file exists
-    const proofPath = law.proof.split(":")[0]; // "file:test-name" format
+    const proofPath = law.proof.split(":")[0] ?? law.proof; // "file:test-name" format
     try {
       readFileSync(join(repoRoot, proofPath));
       return { id: law.id, status: law.status, proofExists: true, proofPath };

--- a/tests/cross-verification/_harness/generated-semiring-laws.test.ts
+++ b/tests/cross-verification/_harness/generated-semiring-laws.test.ts
@@ -12,7 +12,9 @@ describe("ISemiring — algebraic law property tests (generated)", () => {
   test("add-assoc: Add(Add(a,b),c) = Add(a,Add(b,c))", () => {
     // PROVEN: src/Core.TypeScript/algebra/interfaces.test.ts:add-is-associative
     for (let i = 0; i < N; i++) {
-      const a = gen(), b = gen(), c = gen();
+      const a = gen();
+      const b = gen();
+      const c = gen();
       expect(eq(r.add(r.add(a, b), c), r.add(a, r.add(b, c)))).toBe(true);
     }
   });
@@ -20,7 +22,8 @@ describe("ISemiring — algebraic law property tests (generated)", () => {
   test("add-comm: Add(a,b) = Add(b,a)", () => {
     // PROVEN: src/Core.TypeScript/algebra/interfaces.test.ts:add-is-commutative
     for (let i = 0; i < N; i++) {
-      const a = gen(), b = gen(), c = gen();
+      const a = gen();
+      const b = gen();
       expect(eq(r.add(a, b), r.add(b, a))).toBe(true);
     }
   });
@@ -28,7 +31,7 @@ describe("ISemiring — algebraic law property tests (generated)", () => {
   test("add-identity: Add(a, Zero) = a", () => {
     // PROVEN: src/Core.TypeScript/algebra/interfaces.test.ts:zero-is-additive-identity
     for (let i = 0; i < N; i++) {
-      const a = gen(), b = gen(), c = gen();
+      const a = gen();
       expect(eq(r.add(a, r.zero), a)).toBe(true);
       expect(eq(r.add(r.zero, a), a)).toBe(true);
     }
@@ -37,7 +40,7 @@ describe("ISemiring — algebraic law property tests (generated)", () => {
   test("add-inverse: Add(a, Negate(a)) = Zero", () => {
     // PROVEN: src/Core.TypeScript/algebra/interfaces.test.ts:negate-is-additive-inverse
     for (let i = 0; i < N; i++) {
-      const a = gen(), b = gen(), c = gen();
+      const a = gen();
       expect(eq(r.add(a, r.negate(a)), r.zero)).toBe(true);
     }
   });
@@ -45,7 +48,7 @@ describe("ISemiring — algebraic law property tests (generated)", () => {
   test("mul-identity: Mul(a, One) = a = Mul(One, a)", () => {
     // PROVEN: src/Core.TypeScript/algebra/interfaces.test.ts:one-is-multiplicative-identity
     for (let i = 0; i < N; i++) {
-      const a = gen(), b = gen(), c = gen();
+      const a = gen();
       expect(eq(r.mul(a, r.one), a)).toBe(true);
       expect(eq(r.mul(r.one, a), a)).toBe(true);
     }
@@ -54,7 +57,9 @@ describe("ISemiring — algebraic law property tests (generated)", () => {
   test("mul-distributes-add: Mul(a, Add(b,c)) = Add(Mul(a,b), Mul(a,c))", () => {
     // PROVEN: src/Core.TypeScript/algebra/interfaces.test.ts:mul-distributes-over-add
     for (let i = 0; i < N; i++) {
-      const a = gen(), b = gen(), c = gen();
+      const a = gen();
+      const b = gen();
+      const c = gen();
       expect(eq(r.mul(a, r.add(b, c)), r.add(r.mul(a, b), r.mul(a, c)))).toBe(true);
     }
   });


### PR DESCRIPTION
## Summary

- Fix `codegen-law-tests.ts` under strict TypeScript by removing unused imports/params, making `lcFirst` safe under indexed-access checks, and keeping `proofPath` concrete for exact optional properties.
- Generate only the random inputs each law schema actually uses.
- Regenerate `generated-semiring-laws.test.ts` from the semiring IR so checked-in generated output matches the emitter.

## Validation

- `bun src/Core.TypeScript/lint/lint-typescript.ts`
- `bun test tests/cross-verification/_harness/generated-semiring-laws.test.ts`
- `bun run preflight:quick`
- `bun src/Core.TypeScript/hygiene/audit-agencysignature-main-tip.ts`
