### PR TITLE
fix(ts): cover star-ring generated law schemas

### DIFF
--- a/tests/cross-verification/_harness/codegen-law-tests.ts
+++ b/tests/cross-verification/_harness/codegen-law-tests.ts
@@ -28,6 +28,7 @@ interface LawSchema {
   op?: string;
   mul?: string;
   add?: string;
+  over?: string;
   element?: string;
   inverse?: string;
   identity?: string;
@@ -101,6 +102,8 @@ function requiredInputs(law: LawSchema): readonly string[] {
       return ["a", "b", "c"];
 
     case "commutative":
+    case "homomorphism":
+    case "antihomomorphism":
       return ["a", "b"];
 
     case "identity":
@@ -109,6 +112,10 @@ function requiredInputs(law: LawSchema): readonly string[] {
     case "involutive":
     case "roundTrip":
       return ["a"];
+
+    case "fixpoint":
+    case "multiplicative":
+      return [];
 
     default:
       return [];

--- a/tests/cross-verification/_harness/codegen-z3-laws.ts
+++ b/tests/cross-verification/_harness/codegen-z3-laws.ts
@@ -127,7 +127,6 @@ function generateDistributivityCheck(mul: string, add: string): string {
 function generateInvolutiveCheck(op: string): string {
   // For real/int: conj = identity, so conj(conj(a)) = a is trivially true
   // We prove it structurally by asserting it and checking unsat
-  const f = op === "Conj" ? "(- 0 (- 0" : `(${opToSmt(op)} (${opToSmt(op)}`;
   if (op === "Conj") {
     // For real numbers, conj = identity, so conj(conj(a)) = a
     return `; On reals, Conj = identity → trivially involutive\n(assert (not (= a a)))\n`;

--- a/tests/cross-verification/_harness/generated-star-ring-laws.test.ts
+++ b/tests/cross-verification/_harness/generated-star-ring-laws.test.ts
@@ -12,7 +12,7 @@ describe("IStarRing — algebraic law property tests (generated)", () => {
   test("conj-involutive: Conj(Conj(a)) = a", () => {
     // PROVEN: src/Core.TypeScript/algebra/star-ring.test.ts:conj-involution
     for (let i = 0; i < N; i++) {
-      const a = gen(), b = gen(), c = gen();
+      const a = gen();
       expect(eq(r.conj(r.conj(a)), a)).toBe(true);
     }
   });
@@ -20,7 +20,7 @@ describe("IStarRing — algebraic law property tests (generated)", () => {
   test("conj-one: Conj(One) = One", () => {
     // PROVEN: src/Core.TypeScript/algebra/star-ring.test.ts:conj-one
     for (let i = 0; i < N; i++) {
-      const a = gen(), b = gen(), c = gen();
+      // No random inputs required for this schema.
       expect(eq(r.conj(r.one), r.one)).toBe(true);
     }
   });
@@ -28,7 +28,8 @@ describe("IStarRing — algebraic law property tests (generated)", () => {
   test("conj-add-homomorphism: Conj(Add(a,b)) = Add(Conj(a), Conj(b))", () => {
     // PROVEN: src/Core.TypeScript/algebra/star-ring.test.ts:conj-add-hom
     for (let i = 0; i < N; i++) {
-      const a = gen(), b = gen(), c = gen();
+      const a = gen();
+      const b = gen();
       expect(eq(r.conj(r.add(a, b)), r.add(r.conj(a), r.conj(b)))).toBe(true);
     }
   });
@@ -36,7 +37,8 @@ describe("IStarRing — algebraic law property tests (generated)", () => {
   test("conj-mul-antihomomorphism: Conj(Mul(a,b)) = Mul(Conj(b), Conj(a)) [reverses order]", () => {
     // PROVEN: src/Core.TypeScript/algebra/star-ring.test.ts:conj-mul-antihom
     for (let i = 0; i < N; i++) {
-      const a = gen(), b = gen(), c = gen();
+      const a = gen();
+      const b = gen();
       expect(eq(r.conj(r.mul(a, b)), r.mul(r.conj(b), r.conj(a)))).toBe(true);
     }
   });
@@ -45,7 +47,8 @@ describe("IStarRing — algebraic law property tests (generated)", () => {
     // PROVEN: src/Core.TypeScript/algebra/star-ring.test.ts:complex-mul-commutative
     // GUARDED: only holds when level <= complex
     for (let i = 0; i < N; i++) {
-      const a = gen(), b = gen(), c = gen();
+      const a = gen();
+      const b = gen();
       expect(eq(r.mul(a, b), r.mul(b, a))).toBe(true);
     }
   });
@@ -54,7 +57,9 @@ describe("IStarRing — algebraic law property tests (generated)", () => {
     // PROVEN: src/Core.TypeScript/algebra/star-ring.test.ts:quaternion-mul-associative
     // GUARDED: only holds when level <= quaternion
     for (let i = 0; i < N; i++) {
-      const a = gen(), b = gen(), c = gen();
+      const a = gen();
+      const b = gen();
+      const c = gen();
       expect(eq(r.mul(r.mul(a, b), c), r.mul(a, r.mul(b, c)))).toBe(true);
     }
   });
@@ -62,7 +67,7 @@ describe("IStarRing — algebraic law property tests (generated)", () => {
   test("norm-multiplicative: |Mul(a,b)|² = |a|²·|b|² — holds for all Cayley-Dickson levels (composition algebra)", () => {
     // PROVEN: src/Core.TypeScript/algebra/star-ring.test.ts:norm-multiplicative
     for (let i = 0; i < N; i++) {
-      const a = gen(), b = gen(), c = gen();
+      // No random inputs required for this schema.
       // |f(a)*f(b)| approx= |f(a*b)| (norm-multiplicativity)
       // Skipped for scalar gen — needs vector/complex input
     }


### PR DESCRIPTION
## Summary

- Add `over` to the structured law generator schema for homomorphism/antihomomorphism laws.
- Teach generated law input planning which star-ring schemas need `a,b`, which need `a,b,c`, and which need no scalar inputs.
- Regenerate the star-ring law property test and remove a dead local from the Z3 obligation generator.

## Validation

- `bun src/Core.TypeScript/lint/lint-typescript.ts`
- `bun test tests/cross-verification/_harness/generated-semiring-laws.test.ts tests/cross-verification/_harness/generated-star-ring-laws.test.ts`
- `bun run preflight:quick`
- `bun src/Core.TypeScript/hygiene/audit-agencysignature-main-tip.ts`
