### PR TITLE
fix(lint): codegen law-tests harness — generator over-declare + dead code

### DIFF
--- a/tests/cross-verification/_harness/codegen-law-tests.ts
+++ b/tests/cross-verification/_harness/codegen-law-tests.ts
@@ -31,6 +31,7 @@ interface LawSchema {
   element?: string;
   inverse?: string;
   identity?: string;
+  over?: string;
   status: "open" | "proven" | "conjectured";
   proof?: string;
   guard?: string; // optional predicate (for tower-level laws)
@@ -86,7 +87,11 @@ ${tests}
 }
 
 function generateInputBindings(law: LawSchema): string {
-  const inputs = requiredInputs(law);
+  // Declare ONLY the inputs the generated body actually references — `requiredInputs`
+  // is per-schema and can over-declare for a specific law, which emits unused-var
+  // (TS6133/6199) lint errors in the generated file. Filter against the body.
+  const body = generateTestBody(law);
+  const inputs = requiredInputs(law).filter((v) => new RegExp(`\\b${v}\\b`).test(body));
   if (inputs.length === 0) {
     return "      // No random inputs required for this schema.";
   }

--- a/tests/cross-verification/_harness/codegen-z3-laws.ts
+++ b/tests/cross-verification/_harness/codegen-z3-laws.ts
@@ -127,7 +127,6 @@ function generateDistributivityCheck(mul: string, add: string): string {
 function generateInvolutiveCheck(op: string): string {
   // For real/int: conj = identity, so conj(conj(a)) = a is trivially true
   // We prove it structurally by asserting it and checking unsat
-  const f = op === "Conj" ? "(- 0 (- 0" : `(${opToSmt(op)} (${opToSmt(op)}`;
   if (op === "Conj") {
     // For real numbers, conj = identity, so conj(conj(a)) = a
     return `; On reals, Conj = identity → trivially involutive\n(assert (not (= a a)))\n`;

--- a/tests/cross-verification/_harness/cross-verify-laws.ts
+++ b/tests/cross-verification/_harness/cross-verify-laws.ts
@@ -81,12 +81,6 @@ func eq(x,y float64) bool { return math.Abs(x-y) < 1e-9 }
 }
 
 function generateCheck(law: LawSchema, lang: "ts" | "py" | "go"): string | null {
-  const eps = lang === "go" ? "eq(" : "Math.abs(";
-  const sub = (expr: string) => {
-    if (lang === "ts") return expr;
-    if (lang === "py") return expr;
-    return expr; // Go uses the same arithmetic ops
-  };
 
   switch (law.schema) {
     case "associative":

--- a/tests/cross-verification/_harness/generated-star-ring-laws.test.ts
+++ b/tests/cross-verification/_harness/generated-star-ring-laws.test.ts
@@ -12,7 +12,7 @@ describe("IStarRing — algebraic law property tests (generated)", () => {
   test("conj-involutive: Conj(Conj(a)) = a", () => {
     // PROVEN: src/Core.TypeScript/algebra/star-ring.test.ts:conj-involution
     for (let i = 0; i < N; i++) {
-      const a = gen(), b = gen(), c = gen();
+      const a = gen();
       expect(eq(r.conj(r.conj(a)), a)).toBe(true);
     }
   });
@@ -20,7 +20,6 @@ describe("IStarRing — algebraic law property tests (generated)", () => {
   test("conj-one: Conj(One) = One", () => {
     // PROVEN: src/Core.TypeScript/algebra/star-ring.test.ts:conj-one
     for (let i = 0; i < N; i++) {
-      const a = gen(), b = gen(), c = gen();
       expect(eq(r.conj(r.one), r.one)).toBe(true);
     }
   });
@@ -28,7 +27,7 @@ describe("IStarRing — algebraic law property tests (generated)", () => {
   test("conj-add-homomorphism: Conj(Add(a,b)) = Add(Conj(a), Conj(b))", () => {
     // PROVEN: src/Core.TypeScript/algebra/star-ring.test.ts:conj-add-hom
     for (let i = 0; i < N; i++) {
-      const a = gen(), b = gen(), c = gen();
+      const a = gen(), b = gen();
       expect(eq(r.conj(r.add(a, b)), r.add(r.conj(a), r.conj(b)))).toBe(true);
     }
   });
@@ -36,7 +35,7 @@ describe("IStarRing — algebraic law property tests (generated)", () => {
   test("conj-mul-antihomomorphism: Conj(Mul(a,b)) = Mul(Conj(b), Conj(a)) [reverses order]", () => {
     // PROVEN: src/Core.TypeScript/algebra/star-ring.test.ts:conj-mul-antihom
     for (let i = 0; i < N; i++) {
-      const a = gen(), b = gen(), c = gen();
+      const a = gen(), b = gen();
       expect(eq(r.conj(r.mul(a, b)), r.mul(r.conj(b), r.conj(a)))).toBe(true);
     }
   });
@@ -45,7 +44,7 @@ describe("IStarRing — algebraic law property tests (generated)", () => {
     // PROVEN: src/Core.TypeScript/algebra/star-ring.test.ts:complex-mul-commutative
     // GUARDED: only holds when level <= complex
     for (let i = 0; i < N; i++) {
-      const a = gen(), b = gen(), c = gen();
+      const a = gen(), b = gen();
       expect(eq(r.mul(a, b), r.mul(b, a))).toBe(true);
     }
   });
@@ -62,7 +61,6 @@ describe("IStarRing — algebraic law property tests (generated)", () => {
   test("norm-multiplicative: |Mul(a,b)|² = |a|²·|b|² — holds for all Cayley-Dickson levels (composition algebra)", () => {
     // PROVEN: src/Core.TypeScript/algebra/star-ring.test.ts:norm-multiplicative
     for (let i = 0; i < N; i++) {
-      const a = gen(), b = gen(), c = gen();
       // |f(a)*f(b)| approx= |f(a*b)| (norm-multiplicativity)
       // Skipped for scalar gen — needs vector/complex input
     }


### PR DESCRIPTION
14 tsc errors in `tests/cross-verification/_harness/` (#8927-era codegen). **Mechanical + generator-correctness, no test-logic change:**
- `codegen-law-tests.ts`: added missing `over?: string` to LawSchema (siblings have it; fixes 4× TS2339) + fixed the **root generator bug** — `generateInputBindings` over-declared all `requiredInputs` even when a law's body used only some; now filters declarations to referenced vars.
- `generated-star-ring-laws.test.ts` (generated by the above): brought in line with the fixed generator (declare-only-used); consistent with a future regen.
- `codegen-z3-laws.ts` / `cross-verify-laws.ts`: removed dead `f` / `eps`+`sub`.

lint(TS) green; generated law tests 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)