### PR TITLE
fix(lint): remove dead eps/sub in cross-verify-laws.ts

### DIFF
--- a/tests/cross-verification/_harness/cross-verify-laws.ts
+++ b/tests/cross-verification/_harness/cross-verify-laws.ts
@@ -81,12 +81,6 @@ func eq(x,y float64) bool { return math.Abs(x-y) < 1e-9 }
 }
 
 function generateCheck(law: LawSchema, lang: "ts" | "py" | "go"): string | null {
-  const eps = lang === "go" ? "eq(" : "Math.abs(";
-  const sub = (expr: string) => {
-    if (lang === "ts") return expr;
-    if (lang === "py") return expr;
-    return expr; // Go uses the same arithmetic ops
-  };
 
   switch (law.schema) {
     case "associative":


### PR DESCRIPTION
The codegen owner fixed the generated star-ring law schemas + over-declare in d196c3e5d; the only residual lint(TS) error was unused `eps`+`sub` in `cross-verify-laws.ts` generateCheck (refactor leftovers). Removed. lint(TS) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)