### PR TITLE
keys(register): acehacks-mac-studio PURE machine key (user-independent)

### DIFF
--- a/machines/acehacks-mac-studio.local.pub
+++ b/machines/acehacks-mac-studio.local.pub
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMtHx3z2FTFYVlMFzwi2ku3vxI5NS0Jmntec4cir+wxA acehacks-mac-studio.local (zeta-machine)


### PR DESCRIPTION
Re-run under the **pure-key model** (Otto drove, Aaron approved via Touch ID). Replaces the backed-out hybrid `aaron@machine` key (#8926→#8928).

- label = `acehacks-mac-studio.local (zeta-machine)` — **no user baked in**
- registered user-**independent** at `machines/<host>.pub` (shared across users)
- private key local only (umask 077), never committed
- **not** published to any user's GitHub (machine key ≠ user auth key)

The (user × machine) binding is a CA cert (`signMachineCert`, `principal=<user>`) — keeping key management **O(users + machines)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)