### PR TITLE
keys(ca): register the zeta shared SSH CA public key (fleet trust root)

### DIFF
--- a/maintainers/zeta/ssh-ca.pub
+++ b/maintainers/zeta/ssh-ca.pub
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICF4kCpscog4Otk+klS56pEl1cnL3RGf0N1GwyXGZj8i zeta (zeta-ssh-ca)


### PR DESCRIPTION
Generated the **zeta shared SSH CA** (Otto drove, Aaron approved via Touch ID). The fleet trust root: nodes trust this ONE CA pubkey (`TrustedUserCAKeys`), and it signs per-(user×machine) certs — keeping key management **O(users + machines)**.

- CA **private**: local only (`~/.config/zeta/ca/`, umask 077), **never committed**. Aaron holds it (operator = trust root) → Vault later.
- CA **public** (this file): the committed trust anchor → `ssh-ca.nix TrustedUserCAKeys`.
- Choice: `zeta` shared CA (N-trust-1), not per-user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)