### PR TITLE
fix(setup): widen curl retry window for release downloads

### DIFF
--- a/.github/workflows/build-ai-cluster-iso.yml
+++ b/.github/workflows/build-ai-cluster-iso.yml
@@ -97,7 +97,13 @@ jobs:
   build:
     name: build-iso
     runs-on: ubuntu-24.04
-    timeout-minutes: ${{ github.event_name == 'workflow_dispatch' && 240 || 90 }}
+    # Cold-cache PR runs can exceed the old 90-minute budget while still
+    # actively compiling Nix dependencies in `Build installer ISO` (run
+    # 27902283517, 2026-06-21, cancelled at 90m during texinfo/binutils
+    # builds). Keep manual dispatch roomier for hardware-oriented debugging,
+    # and give PR/push enough budget to finish a real cold build instead of
+    # cancelling useful work at the boundary.
+    timeout-minutes: ${{ github.event_name == 'workflow_dispatch' && 240 || 180 }}
     permissions:
       contents: read
       # B-0853.1 cosign keyless OIDC — sigstore/Fulcio CA mints a short-lived

--- a/src/Core.TypeScript/ci/windows-install-ps1-smoke.js
+++ b/src/Core.TypeScript/ci/windows-install-ps1-smoke.js
@@ -31,7 +31,8 @@ export function miseProvidesTool(miseListOutput, tool) {
         .map((l) => l.trim())
         .some((l) => new RegExp(`(^|\\s)${tool}(\\s|@|$)`).test(l));
 }
-/** Pure: parse tools/setup/manifests/agent-clis. */
+export const AGENT_CLI_MANIFEST_RELATIVE_PATH = ["tools", "setup", "manifests", "from-bun-global"];
+/** Pure: parse tools/setup/manifests/from-bun-global. */
 export function parseAgentCliManifest(text) {
     return text
         .split(/\r?\n/)
@@ -106,19 +107,20 @@ function main() {
     }
     try {
         const g = execFileSync("mise", ["exec", "--", "bun", "pm", "ls", "-g"], { encoding: "utf8" });
-        const manifestPath = join(repoRoot(), "tools", "setup", "manifests", "agent-clis");
+        const manifestPath = join(repoRoot(), ...AGENT_CLI_MANIFEST_RELATIVE_PATH);
         const entries = parseAgentCliManifest(readFileSync(manifestPath, "utf8"));
         for (const entry of entries) {
             if (bunGlobalOutputContainsPackage(g, entry.packageId)) {
-                pass(`${entry.packageId} installed (bun --global via manifests/agent-clis)`);
+                pass(`${entry.packageId} installed (bun --global via manifests/from-bun-global)`);
             }
             else {
                 fail(`${entry.packageId} not in bun global packages`);
             }
         }
     }
-    catch {
-        fail("could not check bun global packages");
+    catch (error) {
+        const reason = error instanceof Error ? `: ${error.message}` : "";
+        fail(`could not check bun global packages${reason}`);
     }
     if (mode === "desktop") {
         try {

--- a/src/Core.TypeScript/ci/windows-install-ps1-smoke.test.js
+++ b/src/Core.TypeScript/ci/windows-install-ps1-smoke.test.js
@@ -1,7 +1,7 @@
 import { test, expect } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { taskHasDurationAndNextRun, miseProvidesTool, parseAgentCliManifest, bunGlobalOutputContainsPackage, SHARED_COMMANDS, CONTAINER_SKIPS, } from "./windows-install-ps1-smoke";
+import { AGENT_CLI_MANIFEST_RELATIVE_PATH, taskHasDurationAndNextRun, miseProvidesTool, parseAgentCliManifest, bunGlobalOutputContainsPackage, SHARED_COMMANDS, CONTAINER_SKIPS, } from "./windows-install-ps1-smoke";
 test("taskHasDurationAndNextRun: healthy task (Repetition Duration + populated Next Run)", () => {
     const xml = "<Repetition><Interval>PT1M</Interval><Duration>P3650D</Duration></Repetition>";
     const v = "Next Run Time:                        5/30/2026 11:00:00 AM";
@@ -37,6 +37,11 @@ test("agent CLI manifest parser keeps package id plus expected binary metadata",
         { packageId: "@anthropic-ai/claude-code", binary: "claude" },
         { packageId: "@openai/codex", binary: "codex" },
     ]);
+});
+test("agent CLI smoke reads the canonical bun-global manifest", () => {
+    const repoRoot = join(import.meta.dir, "..", "..", "..");
+    const manifest = readFileSync(join(repoRoot, ...AGENT_CLI_MANIFEST_RELATIVE_PATH), "utf8");
+    expect(parseAgentCliManifest(manifest).map((entry) => entry.packageId)).toContain("@openai/codex");
 });
 test("bun global package detection accepts scoped id or unscoped package name", () => {
     expect(bunGlobalOutputContainsPackage("@openai/codex@1.2.3", "@openai/codex")).toBe(true);

--- a/src/Core.TypeScript/ci/windows-install-ps1-smoke.test.ts
+++ b/src/Core.TypeScript/ci/windows-install-ps1-smoke.test.ts
@@ -2,6 +2,7 @@ import { test, expect } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
+  AGENT_CLI_MANIFEST_RELATIVE_PATH,
   taskHasDurationAndNextRun,
   miseProvidesTool,
   parseAgentCliManifest,
@@ -50,6 +51,12 @@ test("agent CLI manifest parser keeps package id plus expected binary metadata",
     { packageId: "@anthropic-ai/claude-code", binary: "claude" },
     { packageId: "@openai/codex", binary: "codex" },
   ]);
+});
+
+test("agent CLI smoke reads the canonical bun-global manifest", () => {
+  const repoRoot = join(import.meta.dir, "..", "..", "..");
+  const manifest = readFileSync(join(repoRoot, ...AGENT_CLI_MANIFEST_RELATIVE_PATH), "utf8");
+  expect(parseAgentCliManifest(manifest).map((entry) => entry.packageId)).toContain("@openai/codex");
 });
 
 test("bun global package detection accepts scoped id or unscoped package name", () => {

--- a/src/Core.TypeScript/ci/windows-install-ps1-smoke.ts
+++ b/src/Core.TypeScript/ci/windows-install-ps1-smoke.ts
@@ -44,6 +44,8 @@ export interface AgentCliManifestEntry {
   readonly binary?: string;
 }
 
+export const AGENT_CLI_MANIFEST_RELATIVE_PATH = ["tools", "setup", "manifests", "from-bun-global"] as const;
+
 /** Pure: parse tools/setup/manifests/from-bun-global. */
 export function parseAgentCliManifest(text: string): AgentCliManifestEntry[] {
   return text
@@ -126,7 +128,7 @@ function main(): void {
 
   try {
     const g = execFileSync("mise", ["exec", "--", "bun", "pm", "ls", "-g"], { encoding: "utf8" });
-    const manifestPath = join(repoRoot(), "tools", "setup", "manifests", "agent-clis");
+    const manifestPath = join(repoRoot(), ...AGENT_CLI_MANIFEST_RELATIVE_PATH);
     const entries = parseAgentCliManifest(readFileSync(manifestPath, "utf8"));
     for (const entry of entries) {
       if (bunGlobalOutputContainsPackage(g, entry.packageId)) {
@@ -135,8 +137,9 @@ function main(): void {
         fail(`${entry.packageId} not in bun global packages`);
       }
     }
-  } catch {
-    fail("could not check bun global packages");
+  } catch (error) {
+    const reason = error instanceof Error ? `: ${error.message}` : "";
+    fail(`could not check bun global packages${reason}`);
   }
 
   if (mode === "desktop") {

--- a/tools/setup/common/curl-fetch.sh
+++ b/tools/setup/common/curl-fetch.sh
@@ -4,10 +4,11 @@
 # fetching URLs during install.
 #
 # One helper:
-#   - curl_fetch        — file-output downloads. `--retry 5`
-#                         + `--retry-all-errors` (safe because
-#                         curl restarts the file from scratch
-#                         on retry).
+#   - curl_fetch        — file-output downloads. retry defaults:
+#                         12 retries, 10-second delay, 300-second cap
+#                         + `--retry-all-errors` + a multi-minute
+#                         retry window (safe because curl restarts
+#                         the file from scratch on retry).
 #
 # All upstream-installer call sites (Homebrew, mise, elan)
 # now use the download-to-temp + verify + exec pattern via
@@ -62,12 +63,17 @@
 #
 # RETRY POLICY (rationale)
 # ========================
-#   --retry 5            — up to 5 retries (6 total attempts
-#                          including the initial try, per
-#                          curl(1)). Empirically covers the
-#                          upstream 5xx blips this install
-#                          path has hit.
-#   --retry-delay 2      — 2-second base delay between retries.
+#   --retry N            — default 12 retries (13 total attempts
+#                          including the initial try, per curl(1)).
+#                          The old 5-retry/2-second envelope
+#                          exhausted in ~12s during a GitHub
+#                          release 500 burst on 2026-06-21.
+#   --retry-delay N      — default 10 seconds between retries, long
+#                          enough to ride through short CDN/release
+#                          edge outages without rerunning CI.
+#   --retry-max-time N   — default 300 seconds, an upper bound so
+#                          a truly down upstream still fails instead
+#                          of hanging a job indefinitely.
 #   --retry-all-errors   — (file-output only) retry on ALL
 #                          transient errors including HTTP
 #                          5xx without `Retry-After`. Curl's
@@ -131,7 +137,14 @@ _curl_fetch_supports_retry_all_errors() {
 # keeps the connect/DNS/408/429/5xx-with-Retry-After retry behaviour
 # that bare --retry already provides.
 curl_fetch() {
-  local -a retry_args=(--retry 5 --retry-delay 2)
+  local retry_count="${ZETA_CURL_RETRY_COUNT:-12}"
+  local retry_delay_seconds="${ZETA_CURL_RETRY_DELAY_SECONDS:-10}"
+  local retry_max_time_seconds="${ZETA_CURL_RETRY_MAX_TIME_SECONDS:-300}"
+  local -a retry_args=(
+    --retry "$retry_count"
+    --retry-delay "$retry_delay_seconds"
+    --retry-max-time "$retry_max_time_seconds"
+  )
   if _curl_fetch_supports_retry_all_errors; then
     retry_args+=(--retry-all-errors)
   fi


### PR DESCRIPTION
## Summary
- widen the shared curl_fetch retry envelope from a short 5-retry/2-second window to a bounded multi-minute retry budget
- keep the retry policy configurable with ZETA_CURL_RETRY_COUNT, ZETA_CURL_RETRY_DELAY_SECONDS, and ZETA_CURL_RETRY_MAX_TIME_SECONDS
- point the Windows install smoke at the canonical tools/setup/manifests/from-bun-global manifest instead of the retired agent-clis path
- add a local unit guard that opens the canonical bun-global manifest so future manifest path drift fails before the Docker shield
- raise the x64 AI-cluster ISO PR/push timeout from 90 to 180 minutes after a cold build cancelled at 90 minutes while still compiling Nix dependencies

## Root cause
Current main gate failed before semgrep ran. The failing job hit repeated HTTP 500s while tools/setup/install.sh downloaded the pinned mise release tarball. The existing common curl helper retried, but exhausted its approximate 12-second window.

After the retry fix, the Windows Docker install shield surfaced a separate stale-path bug: the installer used tools/setup/manifests/from-bun-global, but the smoke verifier still read tools/setup/manifests/agent-clis.

The rerun then reached the AI-cluster ISO workflow and proved another independent CI issue: x64 build-iso cancelled at the 90-minute PR job budget while still actively compiling Nix dependencies in Build installer ISO.

## Validation
- bash -n tools/setup/common/curl-fetch.sh
- shellcheck tools/setup/common/curl-fetch.sh
- curl_fetch file URL smoke with small retry overrides
- bun test src/Core.TypeScript/ci/windows-install-ps1-smoke.test.ts
- bun src/Core.TypeScript/lint/lint-typescript.ts
- bun run preflight:quick
- git diff --check

Agency-Signature-Version: 1
Agent: Vera
Agent-Runtime: Codex
Agent-Model: GPT-5.5
Credential-Identity: zeta-vera
Credential-Mode: delegated
Human-Review: not-requested
Action-Mode: foreground
Task: fix-installer-ci-flakes
Co-Authored-By: Codex <noreply@openai.com>
