### PR TITLE
feat(setup): one-command, one-fingerprint key onboarding + cross-cluster trust

### DIFF
--- a/.claude/skills/agent-runtime-and-persistence/blueprints/key-onboarding.md
+++ b/.claude/skills/agent-runtime-and-persistence/blueprints/key-onboarding.md
@@ -9,7 +9,7 @@ How an agent sets up identity + access for a maintainer **for** them, under the
 pure-key model. You (the agent) run the commands; the maintainer **approves each
 sensitive step with a biometric** (fail-closed). The human-facing version is
 `tools/setup/persona-keys/ONBOARDING-RUNBOOK.md` — point the maintainer there;
-this blueprint is *your* procedure.
+this blueprint is _your_ procedure.
 
 ## When to use
 
@@ -19,29 +19,52 @@ this blueprint is *your* procedure.
 
 ## The model you are enforcing
 
-Pure keys, **O(users + machines)**: **user key** (identity, `maintainers/<user>/`)
-+ **machine key** (host identity, `machines/<host>.pub`, user-independent) +
+Pure keys, **O(users + machines)**: a **user key** (identity, `maintainers/<user>/`),
+a **machine key** (host identity, `machines/<host>.pub`, user-independent), and a
 **CA cert** (the ONLY place the user×machine pair is named). Nodes trust **one CA
 pubkey** (`TrustedUserCAKeys`). NEVER a `user@machine` hybrid key.
 
-## Procedure — new fork / maintainer (own cluster)
+## Prefer the one-command, one-fingerprint wrappers
+
+Two top-level commands wrap the granular steps; each takes **ONE** biometric approval
+that covers the whole sequence (Aaron 2026-06-21: _"ONE like fingerprint"_). Use these
+by default; fall to the granular steps only for a single isolated action.
+
+- **New machine / maintainer (existing cluster):**
+  `bun tools/setup/persona-keys/setup-machine-cli.ts --user <them>` → ONE Touch ID.
+  Covers status → user-keyring instruction → machine key → trust-resolve →
+  **auto cert-sign if a CA is configured** (no flag). `--dry-run` is inert.
+- **New cluster trust root (+ cross-cluster trust):**
+  `bun tools/setup/persona-keys/setup-cluster-cli.ts --ca <org>` → ONE Touch ID.
+  Generates the CA + **renders** the multi-CA `TrustedUserCAKeys` set. Add a peer
+  cluster's trust with `--trust-peer <peer-ca.pub>` (PUBLIC key only; repeatable) —
+  cross-cluster trust = a node trusts a cert signed by ANY listed CA.
+
+One-approval mechanism: the wrapper builds ONE `sessionBiometric` door (biometric.ts)
+and weaves it into every gated sub-op; the human is prompted at most once and the
+session **replays** that one decision. FAIL-CLOSED: a declined approval poisons the
+session so nothing runs — the per-op gates are never bypassed, just shared.
+
+## Procedure — new fork / maintainer (own cluster) — granular steps
 
 1. **User identity** — the maintainer runs `keyring.sh rotate <them>` (they pick +
    hold the seed; seed shown once, never to git). You do NOT run seed-gen or touch
    the seed. Commit the published `maintainers/<them>/` PUBLIC artifacts.
-2. **CA** — `bun tools/setup/persona-keys/ca-cli.ts ca --ca <org> --commit-pub`
-   → maintainer Touch-IDs. CA private stays local (`~/.config/zeta/ca/`, `umask 077`,
-   never commit); commit only `maintainers/<org>/ssh-ca.pub`.
-3. **Wire trust** — point `TrustedUserCAKeys` at the CA pubkey via
+2. **CA + trust set** — `bun tools/setup/persona-keys/setup-cluster-cli.ts --ca <org>`
+   (one-fingerprint) → maintainer Touch-IDs once. CA private stays local
+   (`~/.config/zeta/ca/`, `umask 077`, never commit); commit only the CA pubkey +
+   the rendered `trusted-user-ca-keys.pub`. (Granular: `ca-cli.ts ca --commit-pub`.)
+3. **Wire trust** — point `TrustedUserCAKeys` at the trust-set file via
    `full-ai-cluster/nixos/modules/ssh-ca.nix` (pathExists-guarded; import to activate).
 
-## Procedure — new dev machine
+## Procedure — new dev machine — granular steps
 
 1. `bun tools/setup/persona-keys/onboard-cli.ts --user <them>` → Touch ID. Generates
    the **pure** machine key (`<host> (zeta-machine)`, no `user@`), private local,
    public at `machines/<host>.pub`. Commit the pubkey. (Dry-run first: `--dry-run`.)
 2. `bun tools/setup/persona-keys/ca-cli.ts cert --user <them> --machine <host>`
    → Touch ID. Mints the cert (`principal=<them>`) binding them to the box.
+   (The one-command `setup-machine-cli.ts` does steps 1–2 under ONE approval.)
 3. If they push from this box: `publish-cli.ts --key <their-user-pub> --user <them>`
    → Touch ID (publishes the USER key, never the machine key).
 
@@ -73,5 +96,7 @@ pubkey** (`TrustedUserCAKeys`). NEVER a `user@machine` hybrid key.
 
 - Human guide: `tools/setup/persona-keys/ONBOARDING-RUNBOOK.md`
 - Tooling: `machine.ts` / `ca.ts` / `onboard.ts` / `publish.ts` / `biometric.ts`
+- One-command wrappers: `setup-machine-cli.ts` / `setup-cluster-cli.ts`
+  (`sessionBiometric` one-approval; `setup-cluster` `--trust-peer` for cross-cluster trust)
 - Rationale (O(users+machines), pure model): PR #8933 · biometric gate: PR #8887
 - Sibling blueprint: `biometric-sudo-handler` (the Touch-ID/PAM gate this relies on)

--- a/tools/setup/persona-keys/ONBOARDING-RUNBOOK.md
+++ b/tools/setup/persona-keys/ONBOARDING-RUNBOOK.md
@@ -23,16 +23,59 @@ committed.
 
 Keys are **pure**, scaling **O(users + machines)** — not O(users × machines):
 
-| Layer | What it is | Where | Names a user? a machine? |
-|---|---|---|---|
-| **User key** | a person's identity (seed-derived, HD `m/44'/1110'/0'/0'`) | `maintainers/<user>/` (keyring) | user only |
-| **Machine key** | a host's identity | `machines/<host>.pub` (user-independent) | machine only |
-| **CA cert** | the **(user × machine) binding** | minted on demand, short-lived | **both** — the ONLY place the pair is named |
+| Layer           | What it is                                                 | Where                                    | Names a user? a machine?                    |
+| --------------- | ---------------------------------------------------------- | ---------------------------------------- | ------------------------------------------- |
+| **User key**    | a person's identity (seed-derived, HD `m/44'/1110'/0'/0'`) | `maintainers/<user>/` (keyring)          | user only                                   |
+| **Machine key** | a host's identity                                          | `machines/<host>.pub` (user-independent) | machine only                                |
+| **CA cert**     | the **(user × machine) binding**                           | minted on demand, short-lived            | **both** — the ONLY place the pair is named |
 
 Nodes trust **one CA public key** (`TrustedUserCAKeys`). The CA signs a cert
 (`principal=<user>` over a machine key) — so 3 users × 10 machines = **13 keys +
-certs**, never 30 hybrid `user@machine` keys. *Never* bake a user into a machine
+certs**, never 30 hybrid `user@machine` keys. _Never_ bake a user into a machine
 key's label; that's the anti-pattern this model exists to avoid.
+
+---
+
+## One command, one fingerprint (the easy path)
+
+The multi-step flows below are wrapped by **two top-level commands**, each gated by
+**ONE** biometric approval that covers the whole sequence (Aaron 2026-06-21: _"should
+be ONE like fingerprint … too many steps and easy to get wrong"_). One Touch ID /
+Windows Hello press up front, then every sub-step runs under that single approval —
+**fail-closed** (decline → nothing runs; the gates are shared, never bypassed).
+
+- **New machine / maintainer on an existing cluster:**
+
+  ```bash
+  bun tools/setup/persona-keys/setup-machine-cli.ts --user <you>     # 🔐 ONE Touch ID
+  # preview with --dry-run (prompts/writes/generates/fetches NOTHING)
+  ```
+
+  One approval covers: status → user-keyring check (instruction if missing) →
+  machine key → trust-resolve → **auto cert-sign if a CA is configured on this host**
+  (no `--sign-with-ca` flag; cleanly skipped when no CA is present).
+
+- **Stand up a new cluster's trust root (+ cross-cluster trust):**
+  ```bash
+  bun tools/setup/persona-keys/setup-cluster-cli.ts --ca <yourorg>   # 🔐 ONE Touch ID
+  # trust a peer cluster's CA too (PUBLIC key only, repeatable):
+  bun tools/setup/persona-keys/setup-cluster-cli.ts --ca <yourorg> --trust-peer <peer-ca.pub>
+  ```
+  One approval generates the CA, then **renders** (never destructively activates) the
+  multi-CA `TrustedUserCAKeys` trust set: this cluster's CA pubkey **plus** any peer
+  CA pubkeys. **Cross-cluster trust** = a node trusts a cert signed by ANY listed CA;
+  add a peer's CA **public** key to trust that peer (the CA private key never leaves
+  its origin host). You commit + import the rendered file; the command never runs
+  `nixos-rebuild`.
+
+These thin wrappers reuse the same modules as the granular steps below
+(`machine.ts`, `ca.ts`, `onboard.ts`, `biometric.ts`) — they add only the
+**one-approval session** (`sessionBiometric`) and the trust-set rendering. The
+granular `ca-cli.ts` / `onboard-cli.ts` paths remain for when you want a single step.
+
+> **Future custody:** these scripts are the **pre-cluster** form. Vault (CA custody)
+> and cert-manager (cert issuance/rotation) take over later — **same trust shape**, an
+> automation/custody upgrade only.
 
 ---
 
@@ -43,25 +86,29 @@ You become your own trust root. ~4 steps; you Touch-ID the CA generation.
 1. **Your user identity (persona keyring).** One seed → all your key types
    (SSH/PGP/Nostr/…), type-separated. Seed is shown once (write it on paper);
    it never touches git.
+
    ```bash
    tools/setup/persona-keys/keyring.sh rotate <you>     # you pick + hold the seed
    # (Otto-bootstrap variant: keyring.sh generate <you>, then rotate to self-custody)
    ```
+
    → publishes your PUBLIC identity to `maintainers/<you>/` (commit it).
 
 2. **Your cluster's SSH CA** (the fleet trust root). Generates a CA keypair;
    private stays local under `umask 077`, only the public key is written.
+
    ```bash
    bun tools/setup/persona-keys/ca-cli.ts ca --ca <yourorg> --commit-pub   # 🔐 Touch ID
    ```
+
    → CA **private** at `~/.config/zeta/ca/ssh_ca_ed25519` (**never commit**);
    CA **public** at `maintainers/<yourorg>/ssh-ca.pub` (commit it — the trust anchor).
-   *Custody:* you hold the CA private now (operator = trust root); Vault takes
+   _Custody:_ you hold the CA private now (operator = trust root); Vault takes
    custody later (same trust shape, automation upgrade only).
 
 3. **Wire the CA into node trust.** Point `TrustedUserCAKeys` at the committed CA
    pubkey via `full-ai-cluster/nixos/modules/ssh-ca.nix` (it's `pathExists`-guarded
-   + inert until the pubkey exists; import it into your node config to activate).
+   and inert until the pubkey exists; import it into your node config to activate).
    Now every node trusts your one CA — no per-machine `authorizedKeys` lists.
 
 4. **Add your users.** Each maintainer runs step 1 (their own keyring). They get
@@ -75,20 +122,24 @@ You become your own trust root. ~4 steps; you Touch-ID the CA generation.
 Run on the new machine. Two Touch-ID taps.
 
 1. **Generate this host's pure machine key** (+ the user×machine presence check).
+
    ```bash
    bun tools/setup/persona-keys/onboard-cli.ts --user <you>          # 🔐 Touch ID
    # preview first with --dry-run (prompts/writes nothing)
    ```
+
    → machine key label `<host> (zeta-machine)` (**no `user@`**); private at
    `~/.config/zeta/machine/id_ed25519` (local, `umask 077`); **public** registered
    at `machines/<host>.pub` (commit it). Note: a machine key is **not** a GitHub
    user key, so it is **not** pushed to anyone's GitHub account.
 
 2. **Bind your user to the machine — sign a cert with the CA.**
+
    ```bash
    bun tools/setup/persona-keys/ca-cli.ts cert --user <you> --machine <host>   # 🔐 Touch ID
    # default validity +52w (the rolling-keys window); override with --validity
    ```
+
    → a `<host>-cert.pub` (`principal=<you>`) — present this with the machine key
    when you SSH. Nodes trust the CA → validate the cert → grant access **as `<you>`**,
    while the key on the wire is the **machine's** (per-machine revocation).
@@ -125,6 +176,9 @@ Run on the new machine. Two Touch-ID taps.
 - Pure-key-model rationale + the O(users+machines) argument: PR #8933.
 - The tooling: `machine.ts` (pure machine key), `ca.ts` (CA + `signMachineCert`),
   `onboard.ts` (the orchestrator), `publish.ts` (biometric GitHub publish),
-  `biometric.ts` (the shared Touch-ID/Hello gate).
+  `biometric.ts` (the shared Touch-ID/Hello gate + `sessionBiometric` one-approval).
+- One-command wrappers: `setup-machine.ts` / `setup-machine-cli.ts` (one-fingerprint
+  machine setup), `setup-cluster.ts` / `setup-cluster-cli.ts` (one-fingerprint cluster
+  trust root + cross-cluster `--trust-peer`).
 - In-cluster future: Vault (CA custody) + cert-manager (issuance/rotation) +
   Headscale (network ACL) — same trust shape, custody/automation upgrade only.

--- a/tools/setup/persona-keys/biometric.test.ts
+++ b/tools/setup/persona-keys/biometric.test.ts
@@ -8,6 +8,7 @@ import { test, expect } from "bun:test";
 import {
   detectBiometricPlatform,
   requireBiometric,
+  sessionBiometric,
   type BiometricAuth,
   type BiometricResult,
 } from "./biometric.ts";
@@ -52,4 +53,57 @@ test("a BiometricResult NEVER carries a secret — it is approval-only", async (
   // Split so this test file contains no contiguous private-key header literal.
   expect(blob).not.toContain("PRIVATE" + " " + "KEY");
   expect(Object.keys(r).sort()).toEqual(["ok", "platform"]);
+});
+
+// ── sessionBiometric — the ONE-FINGERPRINT primitive ──────────────────────────────────────
+
+test("sessionBiometric: prompts the underlying door AT MOST ONCE, replays the decision", async () => {
+  let calls = 0;
+  const underlying: BiometricAuth = async () => {
+    calls += 1;
+    return { ok: true, platform: "macos-touchid" };
+  };
+  const s = sessionBiometric(underlying);
+  // Five sub-ops all approve through the SAME session door.
+  for (let i = 0; i < 5; i++) {
+    const r = await s.door(`Approve: op ${i}`);
+    expect(r.ok).toBe(true);
+  }
+  expect(calls).toBe(1); // the HUMAN was asked exactly once
+  expect(s.underlyingCalls()).toBe(1);
+  expect(s.decision()?.ok).toBe(true);
+});
+
+test("sessionBiometric FAIL-CLOSED: a declined first approval poisons the session (no retry-past-refusal)", async () => {
+  let calls = 0;
+  const underlying: BiometricAuth = async () => {
+    calls += 1;
+    return { ok: false, platform: "macos-touchid", reason: "declined" };
+  };
+  const s = sessionBiometric(underlying);
+  const first = await s.door("Approve: first");
+  expect(first.ok).toBe(false);
+  // A later sub-op CANNOT force a fresh prompt to get past the refusal — it replays ok:false.
+  const second = await s.door("Approve: sneaky retry with a different prompt");
+  expect(second.ok).toBe(false);
+  expect(calls).toBe(1); // still prompted only once — the refusal stands
+  expect(s.underlyingCalls()).toBe(1);
+});
+
+test("sessionBiometric FAIL-CLOSED: no underlying door -> ok:false, prompted at most once", async () => {
+  const s = sessionBiometric(undefined);
+  const r1 = await s.door("Approve: x");
+  const r2 = await s.door("Approve: y");
+  expect(r1.ok).toBe(false);
+  expect(r2.ok).toBe(false);
+  expect(r1.platform).toBe("unsupported");
+  expect(s.underlyingCalls()).toBe(1); // requireBiometric was consulted once, then cached
+});
+
+test("sessionBiometric: a never-called session is zero-approval (NOT a silent bypass)", () => {
+  const underlying: BiometricAuth = async () => ({ ok: true, platform: "macos-touchid" });
+  const s = sessionBiometric(underlying);
+  // Nothing called the door — so nothing was approved (each gated op would fail-closed).
+  expect(s.underlyingCalls()).toBe(0);
+  expect(s.decision()).toBeUndefined();
 });

--- a/tools/setup/persona-keys/biometric.ts
+++ b/tools/setup/persona-keys/biometric.ts
@@ -68,6 +68,55 @@ export async function requireBiometric(
   return auth(prompt);
 }
 
+/** The outcome of a session-approval factory: the wrapped one-prompt door + a probe that
+ *  reports whether the underlying door has been called (the session already decided) and
+ *  what it decided. Lets a top-level command prove "the human gate fired exactly once". */
+export interface SessionGate {
+  /** The wrapped door — prompts the underlying door AT MOST ONCE, then replays its outcome.
+   *  Pass this as the `biometricAuth` to every sub-op so they share the ONE approval. */
+  readonly door: BiometricAuth;
+  /** How many times the UNDERLYING (human-facing) door has been invoked. One-fingerprint
+   *  ⇒ this is 0 (nothing gated ran) or 1 (the single up-front approval). NEVER > 1. */
+  readonly underlyingCalls: () => number;
+  /** The cached session decision, or undefined if the underlying door was never called. */
+  readonly decision: () => BiometricResult | undefined;
+}
+
+/**
+ * SESSION APPROVAL — the one-fingerprint primitive. Wrap an underlying door so the human is
+ * prompted AT MOST ONCE: the first `door(prompt)` call delegates to the underlying door and
+ * caches its outcome; every subsequent call REPLAYS that cached outcome WITHOUT re-prompting.
+ * A top-level command does ONE `requireBiometric(session.door, …)` up front, then passes
+ * `session.door` to every sub-op — so the whole sequence rides on ONE physical approval.
+ *
+ * FAIL-CLOSED + NO BYPASS (security-class):
+ *  - The session is NOT zero-approval: if NOTHING ever calls the door, no gated op runs (each
+ *    sub-op still calls `requireBiometric` and aborts on the absent/declined result).
+ *  - A DECLINED first approval POISONS the session: the cached `ok:false` is replayed to every
+ *    later call, so a sub-op can NEVER "retry past" a refusal. One refusal ⇒ nothing runs.
+ *  - The cache keys ONLY on having-been-called, never on the prompt text — a later sub-op
+ *    cannot smuggle a different prompt to force a fresh approval (that would be re-prompting).
+ *  - It NEVER carries a secret (a BiometricResult is approval-only).
+ *
+ * This is the strange-loop close: the gate completes its approval once, then every later
+ * completion is caught by (folded back into) that one fixed-point decision.
+ */
+export function sessionBiometric(underlying: BiometricAuth | undefined): SessionGate {
+  let calls = 0;
+  let cached: BiometricResult | undefined;
+  const door: BiometricAuth = async (prompt: string): Promise<BiometricResult> => {
+    if (cached !== undefined) return cached; // replay the ONE decision — no re-prompt
+    calls += 1;
+    cached = await requireBiometric(underlying, prompt); // fail-closed if underlying is undefined
+    return cached;
+  };
+  return {
+    door,
+    underlyingCalls: () => calls,
+    decision: () => cached,
+  };
+}
+
 /** Detect the biometric platform for the current host. macOS = Touch ID; Windows =
  *  Windows Hello (seam); everything else = unsupported (fail-closed). */
 export function detectBiometricPlatform(plat: string = osPlatform()): BiometricPlatform {

--- a/tools/setup/persona-keys/setup-cluster-cli.ts
+++ b/tools/setup/persona-keys/setup-cluster-cli.ts
@@ -1,0 +1,119 @@
+#!/usr/bin/env bun
+// Zeta setup-cluster CLI — the ONE-command, ONE-fingerprint entry point for standing up a NEW
+// cluster's trust root, and for cross-cluster trust. A thin shell around the pure orchestrator
+// (setup-cluster.ts → ca.ts). It owns NO key/biometric/seed logic of its own:
+//
+//   * It builds ONE `sessionBiometric` door over the real biometric gate and hands it to
+//     `ensureCa`, so generating the CA keypair takes the operator's Touch ID / Hello ONCE.
+//   * It RENDERS (never destructively activates) the multi-CA `TrustedUserCAKeys` trust set:
+//     this cluster's CA pubkey + any --trust-peer CA pubkeys (cross-cluster trust). PUBLIC
+//     keys only. It writes the rendered trust-set file + the CA pubkey (NOT committed — the
+//     operator commits + imports + nixos-rebuild).
+//   * `--dry-run` prompts NOTHING, generates NOTHING, writes NOTHING.
+//
+// Usage:
+//   bun setup-cluster-cli.ts --ca acme --dry-run                 # plan only — NOTHING is done
+//   bun setup-cluster-cli.ts --ca acme                           # generate CA + render trust set
+//   bun setup-cluster-cli.ts --ca acme --trust-peer peer-ca.pub  # also trust a peer cluster's CA
+//   bun setup-cluster-cli.ts --ca acme --trust-peer a.pub --trust-peer b.pub   # multiple peers
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
+import { realEffects as realCaEffects } from "./ca.ts";
+import { realBiometric, sessionBiometric } from "./biometric.ts";
+import {
+  formatSetupCluster,
+  setupCluster,
+  type PeerCa,
+  type SetupClusterOptions,
+} from "./setup-cluster.ts";
+
+const args = process.argv.slice(2);
+const flag = (n: string): boolean => args.includes(n);
+const opt = (n: string): string | undefined => {
+  const i = args.indexOf(n);
+  return i >= 0 ? args[i + 1] : undefined;
+};
+const allOpts = (n: string): readonly string[] => {
+  const out: string[] = [];
+  for (let i = 0; i < args.length - 1; i++) {
+    if (args[i] === n) {
+      const v = args[i + 1];
+      if (v !== undefined) out.push(v);
+    }
+  }
+  return out;
+};
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = opt("--repo-root") ?? resolvePath(here, "..", "..", "..");
+const ca = opt("--ca");
+const home = opt("--home") ?? homedir();
+const dryRun = flag("--dry-run");
+const peerPaths = allOpts("--trust-peer");
+
+function usage(): void {
+  process.stderr.write(
+    "usage: bun setup-cluster-cli.ts --ca <name> [--trust-peer <peer-ca.pub> ...] " +
+      "[--dry-run] [--repo-root <path>] [--home <path>]\n" +
+      "  ONE command, ONE fingerprint: generate this cluster's CA -> render the multi-CA\n" +
+      "  TrustedUserCAKeys trust set (self CA + any peer CAs) -> print next steps.\n" +
+      "  Cross-cluster trust: --trust-peer adds a PEER cluster's CA PUBLIC key to the trust set.\n" +
+      "  Reuse-only: all key/biometric logic delegated to ca.ts. --dry-run does NOTHING.\n",
+  );
+}
+
+/** Load a peer CA PUBLIC key from a file. PUBLIC keys only — the pure renderer rejects anything
+ *  that does not look like an SSH public key (or that looks private). */
+function loadPeer(path: string): PeerCa {
+  const text = readFileSync(path, "utf8");
+  return { name: basename(path).replace(/\.pub$/, ""), publicKey: text };
+}
+
+async function main(): Promise<number> {
+  if (ca === undefined || ca.trim().length === 0) {
+    usage();
+    process.stderr.write("error: --ca <name> is required\n");
+    return 2;
+  }
+
+  const peers: PeerCa[] = peerPaths.map(loadPeer);
+
+  // ── THE ONE FINGERPRINT ─────────────────────────────────────────────────────────────────
+  // ONE session door over the real biometric gate; ensureCa rides the SAME door so the human is
+  // prompted at most once. FAIL-CLOSED: a declined approval poisons the session → no CA.
+  const session = sessionBiometric(realBiometric());
+
+  const fx = realCaEffects();
+  const opts: SetupClusterOptions = {
+    ca,
+    repoRoot,
+    home,
+    dryRun,
+    ...(peers.length > 0 ? { peers } : {}),
+  };
+
+  const res = await setupCluster(fx, session, opts);
+  process.stdout.write(formatSetupCluster(res) + "\n");
+
+  // On a real run, WRITE the rendered trust-set file (PUBLIC only) next to the CA pubkey so the
+  // operator can commit + import it. NEVER on dry-run. The CA pubkey itself is written by ca.ts
+  // (commitPub). We never git-commit; the operator does.
+  if (!dryRun && res.caResult.action !== "aborted-biometric") {
+    const p = res.rendered.trustedUserCaKeysPath;
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, res.rendered.trustedUserCaKeysFile, { mode: 0o644 });
+    process.stdout.write(`wrote multi-CA trust set -> ${p} (NOT committed; you commit it)\n`);
+  }
+
+  if (res.caResult.action === "aborted-biometric") return 1;
+  return 0;
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((e: unknown) => {
+    process.stderr.write((e instanceof Error ? e.message : String(e)) + "\n");
+    process.exit(1);
+  });

--- a/tools/setup/persona-keys/setup-cluster.test.ts
+++ b/tools/setup/persona-keys/setup-cluster.test.ts
@@ -1,0 +1,145 @@
+// setup-cluster.ts conformance — the ONE-command, ONE-fingerprint cluster trust-root setup +
+// cross-cluster trust. EVERY test uses FIXTURES — NEVER a real biometric prompt, NEVER real
+// keygen, NEVER a real CA/cert, NEVER a secret. Proves:
+//   * one-fingerprint: the HUMAN biometric door fires EXACTLY ONCE to generate the CA;
+//   * FAIL-CLOSED: a declined approval generates NO CA (and the human is prompted once);
+//   * CROSS-CLUSTER TRUST: --trust-peer adds a peer CA PUBLIC key to the rendered multi-CA
+//     TrustedUserCAKeys set; a PRIVATE-looking or non-pubkey peer input is REJECTED;
+//   * --dry-run is inert: NO prompt, NO keygen, NO CA write.
+// Run: bun test setup-cluster.test.ts   (from tools/setup/persona-keys)
+import { test, expect } from "bun:test";
+import type { CaEffects } from "./ca.ts";
+import { sessionBiometric, type BiometricAuth } from "./biometric.ts";
+import {
+  setupCluster,
+  renderTrustSet,
+  looksLikePublicKey,
+  looksLikePrivateKey,
+  formatSetupCluster,
+  type SetupClusterOptions,
+} from "./setup-cluster.ts";
+
+const SELF_CA = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAASELF self-ca";
+const PEER_CA = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAPEER peer-ca";
+
+function countingDoor(ok: boolean): { door: BiometricAuth; prompts: () => string[] } {
+  const prompts: string[] = [];
+  const door: BiometricAuth = async (prompt: string) => {
+    prompts.push(prompt);
+    return ok ? { ok: true, platform: "macos-touchid" } : { ok: false, platform: "macos-touchid", reason: "declined" };
+  };
+  return { door, prompts: () => prompts };
+}
+
+/** A CA effects fixture — counts genCa; returns the self CA pubkey. No real keygen. */
+function caFixture(opts: { exists?: boolean } = {}): { fx: CaEffects; genCalls: () => number; writes: () => string[] } {
+  let genCalls = 0;
+  const writes: string[] = [];
+  const fx: CaEffects = {
+    exists: () => opts.exists === true,
+    readText: () => SELF_CA + "\n",
+    writeText: (p) => {
+      writes.push(p);
+    },
+    mkdirp: () => {},
+    genCa: () => {
+      genCalls += 1;
+      return SELF_CA + "\n";
+    },
+    signCert: () => ({ certPath: "/x-cert.pub", certText: "cert" }),
+  };
+  return { fx, genCalls: () => genCalls, writes: () => writes };
+}
+
+const baseOpts = (over: Partial<SetupClusterOptions> = {}): SetupClusterOptions => ({
+  ca: "acme",
+  repoRoot: "/repo",
+  home: "/home/aaron",
+  ...over,
+});
+
+test("one fingerprint: the HUMAN door fires EXACTLY ONCE to generate the CA", async () => {
+  const { door, prompts } = countingDoor(true);
+  const session = sessionBiometric(door);
+  const f = caFixture({ exists: false });
+
+  const res = await setupCluster(f.fx, session, baseOpts());
+
+  expect(prompts().length).toBe(1);
+  expect(res.biometricApprovals).toBe(1);
+  expect(res.caResult.action).toBe("generated");
+  expect(f.genCalls()).toBe(1);
+  // Self CA is the first (and only) line of the rendered trust set.
+  expect(res.rendered.lines.length).toBe(1);
+  expect(res.rendered.lines[0]?.source).toBe("self");
+});
+
+test("FAIL-CLOSED: a DECLINED approval generates NO CA, prompted once", async () => {
+  const { door, prompts } = countingDoor(false);
+  const session = sessionBiometric(door);
+  const f = caFixture({ exists: false });
+
+  const res = await setupCluster(f.fx, session, baseOpts());
+
+  expect(prompts().length).toBe(1);
+  expect(res.caResult.action).toBe("aborted-biometric");
+  expect(f.genCalls()).toBe(0);
+});
+
+test("cross-cluster trust: --trust-peer adds a peer CA pubkey to the multi-CA trust set", async () => {
+  const { door } = countingDoor(true);
+  const session = sessionBiometric(door);
+  const f = caFixture({ exists: false });
+
+  const res = await setupCluster(
+    f.fx,
+    session,
+    baseOpts({ peers: [{ name: "peer-east", publicKey: PEER_CA }] }),
+  );
+
+  expect(res.rendered.lines.length).toBe(2);
+  expect(res.rendered.lines.map((l) => l.source)).toEqual(["self", "peer-east"]);
+  // The rendered file carries BOTH CA public keys (sshd trusts a cert from either) — federation.
+  expect(res.rendered.trustedUserCaKeysFile).toContain(SELF_CA);
+  expect(res.rendered.trustedUserCaKeysFile).toContain(PEER_CA);
+  // Still ONE approval — the peer add is pure rendering, no extra gate.
+  expect(res.biometricApprovals).toBe(1);
+});
+
+test("renderTrustSet REJECTS a PRIVATE-looking peer input (PUBLIC-only trust set)", () => {
+  const privText = "-----BEGIN OPENSSH " + "PRIVATE" + " " + "KEY-----\nabc\n-----END-----";
+  expect(() => renderTrustSet("/repo", "acme", SELF_CA, [{ name: "bad", publicKey: privText }])).toThrow(
+    /PRIVATE/,
+  );
+});
+
+test("renderTrustSet REJECTS a non-pubkey peer input", () => {
+  expect(() => renderTrustSet("/repo", "acme", SELF_CA, [{ name: "bad", publicKey: "not a key" }])).toThrow(
+    /SSH PUBLIC key/,
+  );
+});
+
+test("looksLikePublicKey / looksLikePrivateKey classify correctly", () => {
+  expect(looksLikePublicKey(SELF_CA)).toBe(true);
+  expect(looksLikePublicKey("ssh-rsa AAAAB3 foo")).toBe(true);
+  expect(looksLikePublicKey("garbage")).toBe(false);
+  expect(looksLikePrivateKey("-----BEGIN RSA " + "PRIVATE" + " " + "KEY-----")).toBe(true);
+  expect(looksLikePrivateKey(SELF_CA)).toBe(false);
+});
+
+test("--dry-run is inert: NO prompt, NO keygen, NO CA write", async () => {
+  const { door, prompts } = countingDoor(true);
+  const session = sessionBiometric(door);
+  const f = caFixture({ exists: false });
+
+  const res = await setupCluster(f.fx, session, baseOpts({ dryRun: true, peers: [{ name: "peer", publicKey: PEER_CA }] }));
+
+  expect(prompts().length).toBe(0);
+  expect(res.biometricApprovals).toBe(0);
+  expect(f.genCalls()).toBe(0);
+  expect(f.writes().length).toBe(0);
+  expect(res.caResult.action).toBe("would-generate");
+  // The plan still renders the trust set (placeholder self CA + the peer) for legibility.
+  expect(res.rendered.lines.length).toBe(2);
+  expect(formatSetupCluster(res)).toContain("DRY RUN");
+});

--- a/tools/setup/persona-keys/setup-cluster.ts
+++ b/tools/setup/persona-keys/setup-cluster.ts
@@ -1,0 +1,290 @@
+// Zeta ONE-FINGERPRINT cluster setup + cross-cluster trust — the top-level "one command, one
+// biometric" entry for standing up a NEW cluster's trust root, and for making clusters trust
+// each other (workitem 081KVM1TK3Z08QG0R0002959G6 §"Trust distribution" + §"Pre-cluster
+// bootstrap"). Aaron (2026-06-21): *"a 2nd one for new clusters; clusters also need to trust
+// each other; all transitions to cert-manager/keyvault later."*
+//
+// WHAT IT IS — a THIN orchestrator over the already-shipped, already-verified ca.ts (`ensureCa`)
+// plus a PURE renderer for the node-side trust set. It adds exactly two things and NO new
+// key/biometric/seed logic:
+//
+//   1. ONE-FINGERPRINT SESSION APPROVAL — ONE up-front `requireBiometric` through a
+//      `sessionBiometric` door (biometric.ts); the SAME session door is handed to `ensureCa`,
+//      so generating the CA keypair takes ONE physical approval. FAIL-CLOSED: a declined
+//      approval poisons the session and NO CA is generated.
+//
+//   2. TRUST-SET RENDERING — it RENDERS (never destructively activates) the value that
+//      sshd's `TrustedUserCAKeys` points at: a `trusted-user-ca-keys.pub` file containing THIS
+//      cluster's CA public key PLUS any PEER cluster CA public keys (cross-cluster trust). The
+//      ssh-ca.nix module then references that ONE file. Multiple trusted CA pubkeys = clusters
+//      trusting each other. We produce the file content + the nix snippet; the operator commits
+//      + imports + `nixos-rebuild` (we never flip the switch).
+//
+// CROSS-CLUSTER TRUST (the model): `TrustedUserCAKeys` accepts a file with MANY CA public keys,
+// one per line — sshd trusts a cert signed by ANY of them. So "cluster A trusts cluster B" = add
+// B's CA PUBLIC key to A's trusted-user-ca-keys file. PUBLIC keys only ever cross; the CA
+// PRIVATE key never leaves its origin host. Bidirectional trust = each side adds the other's CA
+// pubkey. (Migration, no model change: this git-distributed multi-CA trust set → Vault SSH
+// secrets engine custody + cert-manager issuance/rotation later — same trust shape.)
+//
+// SECURITY INVARIANTS (security-class — honesty over green):
+//  - The session is ONE *human* approval, not zero: ensureCa still calls `requireBiometric` and
+//    aborts on a declined/absent result. We never bypass the gate; we share ONE approval.
+//  - NO CA-private / seed handling here — ALL delegated to ca.ts (its `genCa` door writes the
+//    private key locally under umask 077 and returns ONLY the public key).
+//  - PUBLIC keys only ever appear in the rendered trust set / committed artifacts. A peer CA
+//    input is validated to look like an SSH PUBLIC key (and rejected if it looks private).
+//  - `--dry-run` is inert: NO prompt, NO keygen, NO write — the plan (CA + rendered trust set)
+//    is reported only. The session door is NEVER called on dry-run.
+//
+// Noninterference (manifesto §13): every ambient influence (biometric prompt, filesystem, the
+// peer-pubkey inputs) enters ONLY through the injected effects / typed options.
+//
+// Anchors (Beacon): OpenSSH `sshd_config(5)` TrustedUserCAKeys (multi-CA trust file) /
+// `ssh-keygen(1)` -s; OpenSSH PROTOCOL.certkeys. The "many CAs in one trust file = federation"
+// pattern = SSH-CA cross-realm trust prior art (Facebook/Netflix BLESS-style fleets). ed25519
+// CA keys — Bernstein et al. (Ed25519, 2011). Vault SSH secrets engine + cert-manager = the
+// in-cluster migration target (same trust model, upgraded custody).
+
+import { ensureCa, caPublicKeyPath, type CaEffects, type CaResult } from "./ca.ts";
+import { requireBiometric, type BiometricResult, type SessionGate } from "./biometric.ts";
+
+/** A peer cluster's trust input: a label + its CA PUBLIC key text (one SSH pubkey line). */
+export interface PeerCa {
+  /** A human label for the peer cluster (used as a comment in the trust file). */
+  readonly name: string;
+  /** The peer cluster's CA PUBLIC key text (e.g. "ssh-ed25519 AAAA… peer-ca"). PUBLIC only. */
+  readonly publicKey: string;
+}
+
+/** Options for a one-fingerprint cluster setup. `dryRun` is inert. `peers` are peer-cluster CA
+ *  PUBLIC keys to add to this cluster's trust set (cross-cluster trust). */
+export interface SetupClusterOptions {
+  /** The CA identity (the maintainers/<ca>/ subdir; e.g. the cluster/org name). */
+  readonly ca: string;
+  readonly repoRoot: string;
+  readonly home?: string;
+  readonly dryRun?: boolean;
+  /** Peer cluster CA PUBLIC keys to trust (cross-cluster trust). PUBLIC keys only. */
+  readonly peers?: readonly PeerCa[];
+}
+
+/** A single line in the rendered `TrustedUserCAKeys` file — a CA pubkey + which cluster it is. */
+export interface TrustedCaLine {
+  /** "self" for this cluster's own CA, or the peer's name for a peer CA. */
+  readonly source: string;
+  /** The CA PUBLIC key text (one SSH pubkey line, no trailing newline). PUBLIC only. */
+  readonly publicKey: string;
+}
+
+/** The rendered node-side trust set (the value `TrustedUserCAKeys` points at) + the nix snippet
+ *  referencing it. PRODUCED, not activated — the operator commits + imports + rebuilds. */
+export interface RenderedTrustSet {
+  /** The lines (self CA + peer CAs) — the multi-CA trust set. */
+  readonly lines: readonly TrustedCaLine[];
+  /** The full `trusted-user-ca-keys.pub` file content (comment + one CA pubkey per line). */
+  readonly trustedUserCaKeysFile: string;
+  /** Where that file would be committed (next to the self CA pubkey, under maintainers/<ca>/). */
+  readonly trustedUserCaKeysPath: string;
+}
+
+/** The result of a one-fingerprint cluster setup: the CA result + the rendered trust set + the
+ *  one-approval audit fields. */
+export interface SetupClusterResult {
+  readonly dryRun: boolean;
+  readonly ca: string;
+  /** The CA generate/recognise result (delegated to ca.ts). */
+  readonly caResult: CaResult;
+  /** The rendered node-side trust set (self CA + peers) — PRODUCED, never activated. */
+  readonly rendered: RenderedTrustSet;
+  /** Times the underlying (human) biometric door fired. One-fingerprint ⇒ 0 (dry-run / CA
+   *  already exists) or 1 (the single approval for a real CA keygen). NEVER > 1. */
+  readonly biometricApprovals: number;
+  /** The single session decision (undefined if nothing gated ran). No secret. */
+  readonly approval?: BiometricResult;
+}
+
+/** Where the rendered multi-CA `TrustedUserCAKeys` file is committed (next to the self CA pub). */
+export function trustedUserCaKeysPath(repoRoot: string, ca: string): string {
+  // Sits beside maintainers/<ca>/ssh-ca.pub so ssh-ca.nix can reference one stable path.
+  const selfPub = caPublicKeyPath(repoRoot, ca);
+  const dir = selfPub.slice(0, selfPub.lastIndexOf("/"));
+  return `${dir}/trusted-user-ca-keys.pub`;
+}
+
+/** True iff the text looks like an SSH PUBLIC key line (ssh-ed25519 / ssh-rsa / ecdsa-…). */
+export function looksLikePublicKey(text: string): boolean {
+  return /^(ssh-ed25519|ssh-rsa|ecdsa-sha2-nistp\d+|sk-ssh-ed25519@openssh\.com|sk-ecdsa-sha2-nistp\d+@openssh\.com)\s+\S+/m.test(
+    text.trim(),
+  );
+}
+
+/** True iff the text looks like PRIVATE-key material (a defense-in-depth reject for peer input).
+ *  Split header token at runtime so this SOURCE file contains no contiguous private-key literal. */
+export function looksLikePrivateKey(text: string): boolean {
+  const header = "PRIVATE" + " " + "KEY";
+  return text.includes(header) || /^-----BEGIN (OPENSSH|RSA|EC|DSA) /m.test(text);
+}
+
+/**
+ * RENDER the node-side multi-CA trust set: this cluster's CA public key first, then each PEER
+ * cluster's CA public key — the value sshd's `TrustedUserCAKeys` points at. PURE: no IO, no
+ * keygen — just text. Rejects any peer input that does not look like an SSH PUBLIC key, or that
+ * looks PRIVATE (fail-closed; a private key must never enter the trust set).
+ *
+ * The resulting file (one CA pubkey per line) is exactly what sshd reads: a cert signed by ANY
+ * listed CA is accepted → clusters trust each other.
+ */
+export function renderTrustSet(
+  repoRoot: string,
+  ca: string,
+  selfCaPublicKey: string,
+  peers: readonly PeerCa[],
+): RenderedTrustSet {
+  const lines: TrustedCaLine[] = [];
+  const self = selfCaPublicKey.trim();
+  if (self.length > 0) lines.push({ source: "self", publicKey: self });
+  for (const peer of peers) {
+    const pk = peer.publicKey.trim();
+    if (looksLikePrivateKey(pk)) {
+      throw new Error(
+        `peer '${peer.name}': refused — input looks like PRIVATE-key material (trust set is PUBLIC-only)`,
+      );
+    }
+    if (!looksLikePublicKey(pk)) {
+      throw new Error(
+        `peer '${peer.name}': input does not look like an SSH PUBLIC key (expected 'ssh-ed25519 …' / 'ssh-rsa …')`,
+      );
+    }
+    lines.push({ source: peer.name, publicKey: pk });
+  }
+
+  const body = lines
+    .map((l) => `# ${l.source} cluster CA\n${l.publicKey}`)
+    .join("\n");
+  const header =
+    "# Zeta TrustedUserCAKeys — multi-CA trust set (one CA public key per line).\n" +
+    "# sshd accepts a device cert signed by ANY CA listed here → cross-cluster trust.\n" +
+    "# PUBLIC keys only; rendered by setup-cluster (PRODUCED, not activated). Commit + import\n" +
+    "# via ssh-ca.nix, then nixos-rebuild. Migration target: Vault SSH + cert-manager.\n";
+  const file = lines.length > 0 ? `${header}${body}\n` : header;
+
+  return {
+    lines,
+    trustedUserCaKeysFile: file,
+    trustedUserCaKeysPath: trustedUserCaKeysPath(repoRoot, ca),
+  };
+}
+
+/**
+ * Run the one-fingerprint cluster setup: ONE biometric approval up front (through the injected
+ * session gate), then generate this cluster's CA (delegated to ca.ts `ensureCa`, commit-pub),
+ * and RENDER the multi-CA trust set (self CA + any peer CAs). The trust set is PRODUCED — the
+ * operator commits + imports it; we never destructively activate node config.
+ *
+ * On `--dry-run`: NO approval is triggered and ca.ts generates NOTHING; the rendered trust set
+ * uses a placeholder for the (not-yet-generated) self CA so the plan is still legible.
+ *
+ * PURE over the injected effects + session — deterministic + testable against fakes.
+ */
+export async function setupCluster(
+  fx: CaEffects,
+  session: SessionGate,
+  opts: SetupClusterOptions,
+): Promise<SetupClusterResult> {
+  const dryRun = opts.dryRun === true;
+  const peers = opts.peers ?? [];
+
+  // ── ONE-FINGERPRINT APPROVAL (up front) ─────────────────────────────────────────────────
+  // On a real run trigger the SINGLE human approval through the session door; ensureCa is wired
+  // to the SAME door so it replays this one decision (no second prompt). FAIL-CLOSED: a declined
+  // approval poisons the session → ensureCa aborts → no CA. On dry-run we do NOT prompt.
+  if (!dryRun) {
+    await requireBiometric(session.door, `Approve Zeta cluster setup: generate CA for ${opts.ca}`);
+  }
+
+  const caResult = await ensureCa(fx, {
+    ca: opts.ca,
+    repoRoot: opts.repoRoot,
+    commitPub: true,
+    dryRun,
+    biometricAuth: session.door,
+    ...(opts.home !== undefined ? { home: opts.home } : {}),
+  });
+
+  // The self CA pubkey for the trust set: the real one when generated/exists, a placeholder on
+  // dry-run or when an aborted/declined run produced none (so the rendered plan stays legible).
+  const selfPub =
+    caResult.caPublicKey ?? (dryRun ? "ssh-ed25519 <self-CA-public-key-after-generation>" : "");
+  const rendered = renderTrustSet(opts.repoRoot, opts.ca, selfPub, peers);
+
+  const decision = session.decision();
+  return {
+    dryRun,
+    ca: opts.ca,
+    caResult,
+    rendered,
+    biometricApprovals: session.underlyingCalls(),
+    ...(decision !== undefined ? { approval: decision } : {}),
+  };
+}
+
+/** Render the nix snippet that points `TrustedUserCAKeys` at the rendered trust-set file — the
+ *  config the operator imports (additive + inert until imported). PUBLIC paths only. */
+export function renderSshCaNixSnippet(trustedFileRepoRelative: string): string {
+  return [
+    "# Generated by setup-cluster — point sshd at the multi-CA trust set (cross-cluster trust).",
+    "# ADDITIVE + INERT until you import this in a node config and `nixos-rebuild switch`.",
+    "{ lib, ... }:",
+    "let",
+    `  trustedUserCaKeys = ../../../${trustedFileRepoRelative};`,
+    "  present = builtins.pathExists trustedUserCaKeys;",
+    "in {",
+    "  config = lib.mkIf present {",
+    "    services.openssh.extraConfig = lib.mkAfter ''",
+    "      TrustedUserCAKeys ${trustedUserCaKeys}",
+    "    '';",
+    "  };",
+    "}",
+  ].join("\n");
+}
+
+/** Render the operator-facing readout: the CA result + the rendered multi-CA trust set + the
+ *  one-fingerprint confirmation + next steps. Public only — no secrets ever appear. */
+export function formatSetupCluster(res: SetupClusterResult): string {
+  const lines: string[] = [];
+  lines.push(
+    res.dryRun
+      ? `Zeta setup-cluster — DRY RUN (one command; nothing prompted, generated, or written)`
+      : `Zeta setup-cluster — ca=${res.ca} (one fingerprint)`,
+  );
+  // CA step
+  const a = res.caResult.action;
+  lines.push(
+    `  1. [ca] ${a}` +
+      (a === "aborted-biometric"
+        ? ` — biometric ${res.caResult.biometric?.reason ?? "not approved"} (NO CA generated, fail-closed)`
+        : ""),
+  );
+  lines.push(`       CA private key (local only): ${res.caResult.caPrivatePath}`);
+  if (res.caResult.committedPub) {
+    lines.push(`       wrote CA PUBLIC key -> ${res.caResult.caPublicPath} (NOT committed; you commit it)`);
+  } else if (res.dryRun) {
+    lines.push(`       [dry-run] would write CA PUBLIC key -> ${res.caResult.caPublicPath}`);
+  }
+  // Trust set
+  lines.push(`  2. [trust-set] rendered ${res.rendered.lines.length} CA(s): ` +
+    `${res.rendered.lines.map((l) => l.source).join(", ") || "(none)"}`);
+  lines.push(`       -> ${res.rendered.trustedUserCaKeysPath} (PRODUCED, not activated)`);
+  lines.push("");
+  lines.push(
+    res.dryRun
+      ? "Biometric: not invoked (dry-run). On a real run: ONE approval generates the CA."
+      : `Biometric: ${res.biometricApprovals} human approval(s) for the whole run (one-fingerprint).`,
+  );
+  lines.push("Next steps (operator):");
+  lines.push(`  - commit the CA public key + the trusted-user-ca-keys file`);
+  lines.push(`  - point ssh-ca.nix's caPubFile at trusted-user-ca-keys.pub, import it, nixos-rebuild`);
+  lines.push(`  - to trust a peer cluster: re-run with --trust-peer <peer-ca.pub> (PUBLIC key only)`);
+  return lines.join("\n");
+}

--- a/tools/setup/persona-keys/setup-machine-cli.ts
+++ b/tools/setup/persona-keys/setup-machine-cli.ts
@@ -1,0 +1,131 @@
+#!/usr/bin/env bun
+// Zeta setup-machine CLI — the ONE-command, ONE-fingerprint entry point for onboarding a new
+// dev machine / maintainer onto an EXISTING cluster. A thin shell around the pure orchestrator
+// (setup-machine.ts → onboard.ts). It owns NO key/biometric/seed/gh/CA logic of its own:
+//
+//   * It builds ONE `sessionBiometric` door over the real biometric gate, then weaves that
+//     SAME door into EVERY gated sub-effect (machine keygen, cert-sign) — so the operator
+//     presses Touch ID / Windows Hello exactly ONCE for the whole run.
+//   * It auto-detects a configured CA (the CA private key on THIS host) and wires the CA door
+//     ONLY then — so the device cert is auto-signed with no `--sign-with-ca` flag, and the
+//     cert step is cleanly omitted when no CA is present.
+//   * `--dry-run` prompts NOTHING, writes NOTHING, generates NOTHING, fetches NOTHING.
+//
+// Usage:
+//   bun setup-machine-cli.ts --user aaron                 # one command, one fingerprint
+//   bun setup-machine-cli.ts --user aaron --dry-run       # plan only — NOTHING is done
+//   bun setup-machine-cli.ts --user aaron --host mymac    # explicit hostname
+//   bun setup-machine-cli.ts --user aaron --trust octocat --gpg   # also resolve a trust set
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
+import { realEffects as realMachineEffects } from "./machine.ts";
+import { realEffects as realTrustEffects } from "./github-trust.ts";
+import { realEffects as realCaEffects } from "./ca.ts";
+import { caPrivateKeyPath } from "./ca.ts";
+import { realBiometric, sessionBiometric } from "./biometric.ts";
+import { formatSetupMachine, setupMachine, type SetupMachineOptions } from "./setup-machine.ts";
+import type { OnboardEffects } from "./onboard.ts";
+
+const args = process.argv.slice(2);
+const flag = (n: string): boolean => args.includes(n);
+const opt = (n: string): string | undefined => {
+  const i = args.indexOf(n);
+  return i >= 0 ? args[i + 1] : undefined;
+};
+const allOpts = (n: string): readonly string[] => {
+  const out: string[] = [];
+  for (let i = 0; i < args.length - 1; i++) {
+    if (args[i] === n) {
+      const v = args[i + 1];
+      if (v !== undefined) out.push(v);
+    }
+  }
+  return out;
+};
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = opt("--repo-root") ?? resolvePath(here, "..", "..", "..");
+const user = opt("--user");
+const hostname = opt("--host");
+const home = opt("--home") ?? homedir();
+const keyTypeArg = opt("--type");
+const dryRun = flag("--dry-run");
+const includeGpg = flag("--gpg");
+const trustIdentities = allOpts("--trust");
+const certValidity = opt("--cert-validity");
+
+function usage(): void {
+  process.stderr.write(
+    "usage: bun setup-machine-cli.ts --user <name> [--host <name>] [--home <path>] " +
+      "[--type authentication|signing] [--trust <gh-user> ...] [--gpg] [--cert-validity +52w] " +
+      "[--dry-run] [--repo-root <path>]\n" +
+      "  ONE command, ONE fingerprint: status -> user-keyring(instruction) -> machine-key -> " +
+      "trust-resolve -> auto cert-sign (only if a CA is configured on this host).\n" +
+      "  Reuse-only: all key/biometric/seed/CA logic is delegated. --dry-run does NOTHING.\n",
+  );
+}
+
+async function main(): Promise<number> {
+  if (user === undefined || user.trim().length === 0) {
+    usage();
+    process.stderr.write("error: --user <name> is required\n");
+    return 2;
+  }
+  if (keyTypeArg !== undefined && keyTypeArg !== "authentication" && keyTypeArg !== "signing") {
+    usage();
+    process.stderr.write(`error: --type must be 'authentication' or 'signing' (got '${keyTypeArg}')\n`);
+    return 2;
+  }
+  const keyType: "authentication" | "signing" = keyTypeArg === "signing" ? "signing" : "authentication";
+
+  // ── THE ONE FINGERPRINT ─────────────────────────────────────────────────────────────────
+  // Build ONE session door over the real biometric gate. Every gated sub-effect below carries
+  // this SAME door, so the human is prompted at most once; the session replays that one
+  // approval to the rest. FAIL-CLOSED: a declined first approval poisons the session.
+  const session = sessionBiometric(realBiometric());
+
+  // AUTO-CERT: a CA is "configured" on this host iff its private key exists. Probe via ca.ts's
+  // canonical path; wire the CA door ONLY then (so the cert step is omitted cleanly otherwise).
+  const caConfigured = existsSync(caPrivateKeyPath(home));
+
+  const fx: OnboardEffects = {
+    // machine keygen rides the session door (one approval).
+    machine: realMachineEffects(),
+    trust: realTrustEffects(),
+    // The SHARED gate for machine-keygen + cert-sign is the session door (the ONE approval).
+    biometricAuth: session.door,
+    // CA door only when a CA is configured (else the cert step is a clean skip).
+    ...(caConfigured ? { ca: realCaEffects() } : {}),
+  };
+
+  const opts: SetupMachineOptions = {
+    user,
+    repoRoot,
+    home,
+    keyType,
+    dryRun,
+    includeGpg,
+    caConfigured,
+    ...(hostname !== undefined ? { hostname } : {}),
+    ...(trustIdentities.length > 0 ? { trustIdentities } : {}),
+    ...(certValidity !== undefined ? { certValidity } : {}),
+  };
+
+  const res = await setupMachine(fx, session, opts);
+  process.stdout.write(formatSetupMachine(res) + "\n");
+
+  // Hard block iff a gated step was refused (biometric declined on keygen or cert-sign).
+  const hardBlock =
+    res.onboard.machine.action === "aborted-biometric" ||
+    res.onboard.cert?.action === "aborted-biometric";
+  return hardBlock ? 1 : 0;
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((e: unknown) => {
+    process.stderr.write((e instanceof Error ? e.message : String(e)) + "\n");
+    process.exit(1);
+  });

--- a/tools/setup/persona-keys/setup-machine.test.ts
+++ b/tools/setup/persona-keys/setup-machine.test.ts
@@ -1,0 +1,163 @@
+// setup-machine.ts conformance — the ONE-command, ONE-fingerprint machine setup. EVERY test
+// runs against FIXTURES for all sub-modules — NEVER a real biometric prompt, NEVER real keygen,
+// NEVER a real CA/cert, NEVER a network call, NEVER a secret. Proves the one-fingerprint
+// contract (PURE-KEY MODEL: no GitHub publish — the user × machine binding is the CA cert):
+//   * ONE human approval covers the WHOLE sequence (machine keygen + cert-sign) — the
+//     underlying biometric door fires EXACTLY ONCE;
+//   * FAIL-CLOSED — a DECLINED approval poisons the session: NOTHING runs (no key, no cert),
+//     and the human is still prompted only once (no retry-past-refusal);
+//   * AUTO-CERT — when a CA is configured the cert step runs under the SAME one approval; when
+//     not, it is cleanly omitted;
+//   * --dry-run is end-to-end inert: the human door is NEVER called; nothing generated/signed.
+// Run: bun test setup-machine.test.ts   (from tools/setup/persona-keys)
+import { test, expect } from "bun:test";
+import type { MachineEffects } from "./machine.ts";
+import type { GithubTrustEffects } from "./github-trust.ts";
+import type { CaEffects } from "./ca.ts";
+import { sessionBiometric, type BiometricAuth } from "./biometric.ts";
+import type { OnboardEffects } from "./onboard.ts";
+import { setupMachine, formatSetupMachine, type SetupMachineOptions } from "./setup-machine.ts";
+
+const PUB = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDwJVbQNiFzUCiOhc mymac (zeta-machine)";
+const CERT = "ssh-ed25519-cert-v01@openssh.com AAAAI" + "cert-public-text aaron@mymac";
+
+/** A counting underlying biometric door — records every HUMAN-facing prompt so a test can
+ *  assert it fired exactly once (the one-fingerprint property). Returns `ok` per the fixture. */
+function countingDoor(ok: boolean, reason?: string): { door: BiometricAuth; prompts: () => string[] } {
+  const prompts: string[] = [];
+  const door: BiometricAuth = async (prompt: string) => {
+    prompts.push(prompt);
+    return ok
+      ? { ok: true, platform: "macos-touchid" }
+      : { ok: false, platform: "macos-touchid", ...(reason !== undefined ? { reason } : {}) };
+  };
+  return { door, prompts: () => prompts };
+}
+
+/** Build the full OnboardEffects with the SESSION door woven into every gated effect, exactly
+ *  as the CLI does — so the test exercises the real one-approval wiring. */
+function fixture(opts: {
+  sessionDoor: BiometricAuth;
+  caConfigured?: boolean;
+}): { fx: OnboardEffects; genCalls: () => number; signCalls: () => number } {
+  let genCalls = 0;
+  let signCalls = 0;
+
+  const machine: MachineEffects = {
+    hostname: () => "mymac",
+    exists: () => false, // nothing exists yet (fresh box) → keygen path
+    readText: () => PUB + "\n",
+    writeText: () => {},
+    mkdirp: () => {},
+    genEd25519: () => {
+      genCalls += 1;
+      return PUB + "\n";
+    },
+  };
+  const trust: GithubTrustEffects = {
+    exists: () => false,
+    readText: () => "",
+    listDir: () => [],
+    fetchKeys: async () => "",
+    fetchGpg: async () => "",
+  };
+  const ca: CaEffects = {
+    exists: () => true, // CA private + device pubkey present → cert can be signed
+    readText: () => "ssh-ed25519 AAAACA-pub ca\n",
+    writeText: () => {},
+    mkdirp: () => {},
+    genCa: () => "ssh-ed25519 AAAACA-pub ca\n",
+    signCert: () => {
+      signCalls += 1;
+      return { certPath: "/tmp/x-cert.pub", certText: CERT };
+    },
+  };
+
+  const fx: OnboardEffects = {
+    machine,
+    trust,
+    biometricAuth: opts.sessionDoor,
+    ...(opts.caConfigured ? { ca } : {}),
+  };
+  return { fx, genCalls: () => genCalls, signCalls: () => signCalls };
+}
+
+const baseOpts = (over: Partial<SetupMachineOptions> = {}): SetupMachineOptions => ({
+  user: "aaron",
+  repoRoot: "/repo",
+  home: "/home/aaron",
+  caConfigured: false,
+  ...over,
+});
+
+test("one fingerprint: the HUMAN biometric door fires EXACTLY ONCE for the whole run", async () => {
+  const { door, prompts } = countingDoor(true);
+  const session = sessionBiometric(door);
+  const f = fixture({ sessionDoor: session.door, caConfigured: true });
+
+  const res = await setupMachine(f.fx, session, baseOpts({ caConfigured: true }));
+
+  // The single human approval covered keygen + cert-sign.
+  expect(prompts().length).toBe(1);
+  expect(res.biometricApprovals).toBe(1);
+  expect(res.approval?.ok).toBe(true);
+  // Both gated sub-ops actually ran under that one approval.
+  expect(f.genCalls()).toBe(1); // machine keygen
+  expect(f.signCalls()).toBe(1); // cert-sign
+  expect(res.onboard.machine.action).toBe("generated");
+  expect(res.onboard.cert?.action).toBe("signed");
+});
+
+test("FAIL-CLOSED: a DECLINED approval poisons the session — NOTHING runs, prompted once", async () => {
+  const { door, prompts } = countingDoor(false, "declined by operator");
+  const session = sessionBiometric(door);
+  const f = fixture({ sessionDoor: session.door, caConfigured: true });
+
+  const res = await setupMachine(f.fx, session, baseOpts({ caConfigured: true }));
+
+  // The human was prompted exactly once (no retry-past-refusal), and it was a refusal.
+  expect(prompts().length).toBe(1);
+  expect(res.biometricApprovals).toBe(1);
+  expect(res.approval?.ok).toBe(false);
+  // NOTHING ran: no keygen, no cert.
+  expect(f.genCalls()).toBe(0);
+  expect(f.signCalls()).toBe(0);
+  expect(res.onboard.machine.action).toBe("aborted-biometric");
+});
+
+test("auto-cert omitted cleanly when no CA is configured (no flag, no error)", async () => {
+  const { door, prompts } = countingDoor(true);
+  const session = sessionBiometric(door);
+  const f = fixture({ sessionDoor: session.door, caConfigured: false });
+
+  const res = await setupMachine(f.fx, session, baseOpts({ caConfigured: false }));
+
+  expect(prompts().length).toBe(1); // still one approval (the keygen)
+  expect(res.certRequested).toBe(false);
+  expect(res.onboard.cert).toBeUndefined();
+  expect(f.signCalls()).toBe(0);
+  expect(res.onboard.machine.action).toBe("generated");
+});
+
+test("--dry-run is inert: the human door is NEVER called; nothing generated/signed", async () => {
+  const { door, prompts } = countingDoor(true);
+  const session = sessionBiometric(door);
+  const f = fixture({ sessionDoor: session.door, caConfigured: true });
+
+  const res = await setupMachine(f.fx, session, baseOpts({ caConfigured: true, dryRun: true }));
+
+  expect(prompts().length).toBe(0); // NO prompt on dry-run
+  expect(res.biometricApprovals).toBe(0);
+  expect(f.genCalls()).toBe(0);
+  expect(f.signCalls()).toBe(0);
+  expect(res.onboard.dryRun).toBe(true);
+  expect(formatSetupMachine(res)).toContain("DRY RUN");
+});
+
+test("formatSetupMachine reports the one-fingerprint count on a real run", async () => {
+  const { door } = countingDoor(true);
+  const session = sessionBiometric(door);
+  const f = fixture({ sessionDoor: session.door, caConfigured: false });
+  const res = await setupMachine(f.fx, session, baseOpts());
+  expect(formatSetupMachine(res)).toContain("1 human approval(s)");
+});

--- a/tools/setup/persona-keys/setup-machine.ts
+++ b/tools/setup/persona-keys/setup-machine.ts
@@ -1,0 +1,168 @@
+// Zeta ONE-FINGERPRINT machine setup — the top-level "one command, one biometric" payoff
+// for onboarding a new dev machine / maintainer onto an EXISTING cluster (workitem
+// 081KVM1TK3Z08QG0R0002959G6 §"First-run auto-provisioning"). Aaron (2026-06-21):
+// *"should be ONE like fingerprint and then setup new machine/maintainer … too many steps
+// and easy to get wrong."*
+//
+// WHAT IT IS — a THIN orchestrator over the already-shipped, already-verified `onboard.ts`
+// chain (status → user-keyring instruction → machine-key → trust-resolve → OPTIONAL cert-sign).
+// PURE-KEY MODEL (onboard.ts): a machine key is a host identity, NOT a user GitHub auth key, so
+// there is NO GitHub-publish in the chain; the (user × machine) binding is the CA cert. This
+// adds exactly TWO things and NO new key/biometric/seed logic:
+//
+//   1. ONE-FINGERPRINT SESSION APPROVAL — it does ONE up-front `requireBiometric` through a
+//      `sessionBiometric` door (biometric.ts), then hands that SAME session door to every
+//      gated sub-op (machine keygen, cert-sign). The human presses Touch ID ONCE; the session
+//      replays that one approval to the rest of the sequence (NO re-prompts). FAIL-CLOSED: a
+//      declined approval poisons the session, so NOTHING runs.
+//
+//   2. AUTO-CERT — if a CA is configured on this host (the CA private key exists), it sets
+//      `signWithCa` so the freshly-registered machine key is signed into a cert (the user ×
+//      machine binding) with NO extra flag. No CA ⇒ the cert step is simply omitted (a clean
+//      skip, not an error) — exactly the normal case on a box joining a cluster whose CA lives
+//      elsewhere.
+//
+// SECURITY INVARIANTS (security-class — honesty over green):
+//  - The session is ONE *human* approval, not zero: every sub-op still calls `requireBiometric`
+//    and aborts on a declined/absent result. We never bypass a gate; we share ONE approval.
+//  - NO secret / seed / CA-private handling here — ALL delegated to onboard.ts's sub-modules.
+//    A missing user keyring yields an INSTRUCTION (onboard.ts), never a silent seed-gen.
+//  - `--dry-run` is end-to-end inert (threaded into onboard): NO prompt, NO keygen, NO write,
+//    NO network — the session door is NEVER called on dry-run (onboard's dry-run branches skip
+//    every gated op before the door).
+//
+// Noninterference (manifesto §13): every ambient influence (biometric prompt, filesystem, gh,
+// network, the CA-presence probe) enters ONLY through the injected effects — so the whole flow
+// is deterministic + testable against fakes, and the one-approval property is provable.
+//
+// Anchors (Beacon): the onboard.ts chain's anchors hold (ed25519 device keys — Bernstein et al.
+// 2011; Touch ID PAM / Windows Hello UserConsentVerifier; `gh ssh-key add`; OpenSSH SSH-CA).
+// Session approval (one consent covering a bounded op sequence) — the FIDO/WebAuthn
+// user-verification "transaction" model + sudo's timestamp cache, but bounded to ONE run and
+// FAIL-CLOSED rather than time-windowed.
+
+import { onboard, type OnboardEffects, type OnboardOptions, type OnboardResult } from "./onboard.ts";
+import { requireBiometric, type BiometricResult, type SessionGate } from "./biometric.ts";
+
+/** Options for a one-fingerprint machine setup — the operator identity + repo root, plus the
+ *  knobs onboard needs. `dryRun` is end-to-end inert. `caConfigured` is whether THIS host has
+ *  a CA private key (probed by the CLI via ca.ts `caPrivateKeyPath`); when true the cert step
+ *  runs with the SAME session approval, when false it is cleanly omitted. */
+export interface SetupMachineOptions {
+  readonly user: string;
+  readonly repoRoot: string;
+  readonly home?: string;
+  readonly hostname?: string;
+  readonly dryRun?: boolean;
+  readonly trustIdentities?: readonly string[];
+  readonly includeGpg?: boolean;
+  readonly keyType?: "authentication" | "signing";
+  /** Validity window for the auto-signed device cert (OpenSSH `-V`); defaults in ca.ts. */
+  readonly certValidity?: string;
+  /** True iff a CA private key is present on THIS host → auto-sign the device cert (no flag). */
+  readonly caConfigured: boolean;
+}
+
+/** The result of a one-fingerprint setup: the full onboard trace + the proof fields that make
+ *  the one-approval property auditable (how many times the HUMAN gate fired; the one decision). */
+export interface SetupMachineResult {
+  readonly onboard: OnboardResult;
+  /** Times the underlying (human-facing) biometric door fired. One-fingerprint ⇒ 0 (dry-run /
+   *  nothing gated) or 1 (the single approval). NEVER > 1. */
+  readonly biometricApprovals: number;
+  /** The single session decision (undefined if nothing gated ran — e.g. dry-run). No secret. */
+  readonly approval?: BiometricResult;
+  /** True iff the auto-cert step was requested (CA configured + not dry-run pure-skip). */
+  readonly certRequested: boolean;
+}
+
+/**
+ * Run the one-fingerprint machine setup: ONE biometric approval up front (through the injected
+ * session gate), then the full onboard chain with that SAME approval shared by every gated
+ * sub-op, plus auto-cert when a CA is configured.
+ *
+ * The caller (CLI) builds `fx` with the session door already woven into EVERY gated effect
+ * (machine + ca both carry `session.door`), and passes the `session` so this function can (a)
+ * trigger the one up-front approval and (b) report the audit counts. On `--dry-run` the up-front
+ * approval is SKIPPED (nothing will run, so nothing is approved) and onboard runs inert.
+ *
+ * PURE over the injected effects + session — deterministic + testable against fakes.
+ */
+export async function setupMachine(
+  fx: OnboardEffects,
+  session: SessionGate,
+  opts: SetupMachineOptions,
+): Promise<SetupMachineResult> {
+  const dryRun = opts.dryRun === true;
+  const certRequested = opts.caConfigured && !dryRun;
+
+  // ── ONE-FINGERPRINT APPROVAL (up front) ─────────────────────────────────────────────────
+  // On a real run we trigger the SINGLE human approval here, through the session door. Every
+  // gated sub-op below is wired to the SAME session door, so it replays this one decision and
+  // never re-prompts. FAIL-CLOSED: if declined, the cached ok:false flows to every sub-op, so
+  // nothing runs. On --dry-run we do NOT prompt (onboard's dry-run skips every gated op anyway).
+  if (!dryRun) {
+    await requireBiometric(
+      session.door,
+      `Approve Zeta machine setup for ${opts.user} (one approval covers: machine key` +
+        (certRequested ? " + cert-sign)" : ")"),
+    );
+  }
+
+  const onboardOpts: OnboardOptions = {
+    user: opts.user,
+    repoRoot: opts.repoRoot,
+    dryRun,
+    ...(opts.home !== undefined ? { home: opts.home } : {}),
+    ...(opts.hostname !== undefined ? { hostname: opts.hostname } : {}),
+    ...(opts.trustIdentities !== undefined && opts.trustIdentities.length > 0
+      ? { trustIdentities: opts.trustIdentities }
+      : {}),
+    ...(opts.includeGpg !== undefined ? { includeGpg: opts.includeGpg } : {}),
+    ...(opts.keyType !== undefined ? { keyType: opts.keyType } : {}),
+    ...(opts.certValidity !== undefined ? { certValidity: opts.certValidity } : {}),
+    // AUTO-CERT: sign the device key when a CA is configured — no operator flag. onboard runs
+    // the cert step only when BOTH signWithCa is set AND fx.ca is provided (the CLI provides
+    // fx.ca only when the CA exists), so this is a clean skip when no CA is present.
+    ...(opts.caConfigured ? { signWithCa: true } : {}),
+  };
+
+  const res = await onboard(fx, onboardOpts);
+
+  const decision = session.decision();
+  return {
+    onboard: res,
+    biometricApprovals: session.underlyingCalls(),
+    ...(decision !== undefined ? { approval: decision } : {}),
+    certRequested,
+  };
+}
+
+/** Render the operator-facing readout: the full onboard summary + a one-line confirmation of
+ *  the one-fingerprint property (how many times the human gate fired). Public only — no secrets. */
+export function formatSetupMachine(res: SetupMachineResult): string {
+  const lines: string[] = [];
+  lines.push(
+    res.onboard.dryRun
+      ? "Zeta setup-machine — DRY RUN (one command; nothing prompted, generated, written, or fetched)"
+      : `Zeta setup-machine — user=${res.onboard.user}, machine=${res.onboard.hostname} (one fingerprint)`,
+  );
+  res.onboard.steps.forEach((s, i) => {
+    lines.push(`  ${i + 1}. [${s.kind}] ${s.headline}`);
+    for (const dl of s.detail.split("\n")) lines.push(`       ${dl}`);
+  });
+  lines.push("");
+  lines.push(
+    res.onboard.dryRun
+      ? "Biometric: not invoked (dry-run). On a real run: ONE approval covers the whole sequence."
+      : `Biometric: ${res.biometricApprovals} human approval(s) for the whole run (one-fingerprint).`,
+  );
+  const pending = res.onboard.steps.filter((s) => s.pending);
+  if (pending.length === 0) {
+    lines.push("Operator action still required: none.");
+  } else {
+    lines.push(`Operator action still required (${pending.length}):`);
+    pending.forEach((s, i) => lines.push(`  ${i + 1}. [${s.kind}] ${s.detail.split("\n")[0] ?? s.headline}`));
+  }
+  return lines.join("\n");
+}


### PR DESCRIPTION
## What

Two top-level, **one-fingerprint** commands for key onboarding, plus **cross-cluster trust** — collapsing the multi-step flow into ONE command gated by ONE biometric approval (Aaron 2026-06-21: *"should be ONE like fingerprint … too many steps and easy to get wrong … a 2nd one for new clusters; clusters also need to trust each other"*).

### 1. `setup-machine` — new dev machine / maintainer (existing cluster)
`bun tools/setup/persona-keys/setup-machine-cli.ts --user <you>` → **ONE** Touch ID.
Covers: status → user-keyring instruction (if missing) → machine key → trust-resolve → **auto cert-sign if a CA is configured on this host** (no `--sign-with-ca` flag; clean skip when no CA). `--dry-run` inert.

### 2. `setup-cluster` — new cluster trust root (+ cross-cluster trust)
`bun tools/setup/persona-keys/setup-cluster-cli.ts --ca <org>` → **ONE** Touch ID.
Generates the CA (`ensureCa`, commit-pub), then **renders** (never destructively activates) the multi-CA `TrustedUserCAKeys` set + the `ssh-ca.nix` snippet. You commit + import; it never runs `nixos-rebuild`.

### 3. Cross-cluster trust
`--trust-peer <peer-ca.pub>` (repeatable) appends a PEER cluster's CA **public** key to the trust set — sshd trusts a cert signed by ANY listed CA. PUBLIC keys only; private-looking / non-pubkey peer input is rejected fail-closed. The CA private key never leaves its origin host.

## How one-approval works (the crux)

`biometric.ts` gains `sessionBiometric(underlying)`: it wraps a door so the human is prompted **at most once**; later calls **replay** the cached decision (no re-prompt). The wrapper does ONE `requireBiometric` up front and hands the SAME session door to every gated sub-op (machine keygen, cert-sign, CA keygen). **FAIL-CLOSED:** a declined first approval **poisons** the session (no retry-past-refusal); a never-called session is **zero-approval, not a bypass**; it carries no secret. The per-op gates are unchanged — shared, never bypassed.

## Security (security-class — honesty over green)

- One **human** approval per run (not zero), fail-closed — proven by tests: sub-ops invoked with the pre-approved door, the human gate fires **exactly once**, and a declined approval ⇒ **nothing runs**.
- Private keys / seeds / CA-private stay local (umask 077); only public keys + certs are written. **No real keys/CA/certs generated or committed** — tests use fakes / temp dirs.
- No key-shaped literals in changed tests (grep `BEGIN.*PRIVATE KEY` empty; split tokens where needed).
- Reuse-only: `machine.ts` / `ca.ts` / `onboard.ts` unchanged in behavior; new commands add only the session-approval + trust-set rendering.

## Verification

- `bun test` persona-keys: **230/230** green (with `bun` on PATH; the only "failures" in a bare run are `gen.test.ts` subprocess `Bun.spawn(["bun",…])` ENOENT — an environment/PATH artifact, not this change).
- New suites green: `biometric` (sessionBiometric one-prompt + fail-closed), `setup-machine` (one approval covers keygen+cert; declined ⇒ nothing runs; auto-cert skip; dry-run inert), `setup-cluster` (one approval CA; cross-cluster trust set; private/non-pubkey peer rejected; dry-run inert).
- `bun src/Core.TypeScript/lint/lint-typescript.ts` green; markdownlint + prettier clean on docs.
- `--dry-run` verified inert end-to-end (no artifacts on disk).

## Docs

`ONBOARDING-RUNBOOK.md` + the `key-onboarding` blueprint updated to the one-command flow; the cert-manager/Vault future is noted (these are the pre-cluster form; Vault custody + cert-manager issuance take over later — same trust shape).

## Note for the verify-gate

**PR left OPEN — do not auto-merge** (Otto verify-gates this security-class change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)