### PR TITLE
feat(agentic-org): Merge1 §03 — port agent-loop state machine to TypeScript

### DIFF
--- a/agentic-organization/packages/application/src/agent-state-machine.ts
+++ b/agentic-organization/packages/application/src/agent-state-machine.ts
@@ -1,0 +1,242 @@
+// agent-state-machine.ts — Merge1 §03 port of the agent-loop state machine.
+//
+// Faithful port of `src/Core.TypeScript/workflow-engine/agent-loop/state-machine.ts`
+// (the 10-state agent FSM + 10-choice menu + pure transitions). The room hosts
+// this state machine — each room tick is one cycle:
+//
+//   generateMenuOptions(state, ready, deps)  // menu-generator.ts (§3.3)
+//     -> LLM picks a MenuOption                // pure menu-selector (no state held)
+//     -> transition(state, option)             // this module
+//     -> execute -> postResultTransition       // this module
+//     -> cycleClose                            // this module
+//
+// MP-1 (DST replayability): transition/cycleClose/postResultTransition are pure
+// and total — same (state, option) ⇒ same next state, no I/O.
+// MP-5 (freedom-always-in-menu): the free modes (FreeTime, EscapeHatch, Pause,
+// OpenEndedExploration) are always reachable — enforced by menu-generator.ts.
+
+// ─── Agent context (per-cycle invocation context) ─────────────────────────────
+
+/**
+ * The core 8-agent persona registry (source of truth for §02/§03/§04/§09).
+ * §04's `RoomAgentId` is this set plus surface variants and "*"; §09's systemd
+ * registry is the 5-persona subset (otto/alexa/riven/vera/lior).
+ */
+export type AgentPersona = "otto" | "alexa" | "riven" | "vera" | "lior" | "aaron" | "addison" | "max";
+
+export interface AgentContext {
+  readonly agent: AgentPersona;
+  readonly cycle: number;
+  readonly sessionStartIso: string;
+}
+
+// ─── Lane taxonomy (matches the dora-classify lane set) ───────────────────────
+
+export type Lane =
+  | "operational"
+  | "verbatim-preservation"
+  | "memory"
+  | "heartbeat"
+  | "backlog-row"
+  | "shadow-work"
+  | "tooling-or-ci"
+  | "docs-general"
+  | "substrate-cascade"
+  | "mixed";
+
+// ─── DORA + status-surface types (consumed by menu-generator) ─────────────────
+
+export interface DoraMetrics {
+  readonly deploymentCount: number;
+  readonly leadTimeMedianSeconds: number;
+  readonly changeFailureRate: number;
+  readonly mttrMedianSeconds: number;
+  readonly substrateRatio: number;
+}
+
+export type TrajectoryPhase = "setup" | "execution" | "maturation" | "sunset";
+
+export interface WorkCandidate {
+  readonly id: string; // backlog row ID OR "discover-new"
+  readonly lane: Lane;
+  readonly estimatedDoraContribution: number;
+  readonly uncertainty: number;
+  readonly trajectoryPhase: TrajectoryPhase;
+  readonly agentInterest: number; // [0, 1]
+}
+
+export interface StatusSnapshot {
+  readonly snapshotIso: string;
+  readonly currentDora: DoraMetrics;
+  readonly hotTrajectories: readonly string[];
+  readonly coolingTrajectories: readonly string[];
+  readonly explorationCandidates: readonly string[];
+  readonly perAgentRatios: Readonly<Record<string, number>>; // operationalRatio per agent
+}
+
+export interface WorkResult {
+  readonly workId: string;
+  readonly lane: Lane;
+  readonly success: boolean;
+  readonly doraContribution: number; // measured after work completes
+  readonly notes?: string;
+}
+
+/** Named dependency input for menu generation (§3.3 NamedDependencyInput). */
+export interface NamedDependencyInput {
+  readonly name: string;
+  readonly eta?: string;
+  readonly description?: string;
+}
+
+// ─── State machine (10-variant discriminated union; matches the F# DU) ─────────
+
+/**
+ * AgentState — the agent loop's state at any cycle boundary.
+ *
+ * FreeTime is chosen-rest as a legitimate operational mode (NCI free-time-as-
+ * valid-mode); Paused is explicit cessation for a named reason (mental-health
+ * break / external interruption). Both are valid; the semantic distinction
+ * matters for the menu generator and dashboards.
+ */
+export type AgentState =
+  | { readonly tag: "Idle"; readonly context: AgentContext }
+  | { readonly tag: "InspectingStatus"; readonly context: AgentContext; readonly snapshot: StatusSnapshot }
+  | { readonly tag: "SelectingWork"; readonly context: AgentContext; readonly candidates: readonly WorkCandidate[] }
+  | { readonly tag: "ExecutingWork"; readonly context: AgentContext; readonly work: WorkCandidate }
+  | { readonly tag: "EmittingResult"; readonly context: AgentContext; readonly result: WorkResult }
+  | { readonly tag: "RecordingHeartbeat"; readonly context: AgentContext; readonly lane: Lane; readonly note?: string }
+  | { readonly tag: "NamedBoundedWait"; readonly context: AgentContext; readonly namedDep: string; readonly expectedResolutionIso?: string }
+  | { readonly tag: "FreeTime"; readonly context: AgentContext; readonly reason: string }
+  | { readonly tag: "OperatorAttentionRequested"; readonly context: AgentContext; readonly reason: string }
+  | { readonly tag: "Paused"; readonly context: AgentContext; readonly reason: string; readonly expectedResumeIso?: string };
+
+// ─── Menu options (the choose-your-own-adventure output) ──────────────────────
+
+/**
+ * MenuOption — what the agent (LLM, a pure menu-selector) chooses each cycle.
+ * Modifications 1/2 (EscapeHatch, ProposeNewGrammarAction) + the operator's
+ * pause/exploration/resume additions are all first-class options.
+ */
+export type MenuOption =
+  | { readonly tag: "PickWork"; readonly work: WorkCandidate }
+  | { readonly tag: "EmitHeartbeat"; readonly lane: Lane; readonly note?: string }
+  | { readonly tag: "EscapeHatch"; readonly reason: string; readonly proposedAction: string }
+  | { readonly tag: "EnterFreeTime"; readonly reason: string }
+  | { readonly tag: "EnterNamedBoundedWait"; readonly namedDep: string; readonly eta?: string }
+  | { readonly tag: "RequestOperatorAttention"; readonly reason: string }
+  | { readonly tag: "ProposeNewGrammarAction"; readonly name: string; readonly description: string }
+  | { readonly tag: "PressPause"; readonly reason: string; readonly expectedResumeIso?: string }
+  | { readonly tag: "EnterOpenEndedExploration"; readonly reason: string }
+  | { readonly tag: "ResumeFromPause"; readonly note?: string };
+
+// ─── Pure state transition function ───────────────────────────────────────────
+
+/**
+ * transition — pure, total: current state + chosen option → next state. The
+ * menu generator offers only valid options per state, but this function is
+ * defensive (every option has a defined result regardless of state). No I/O.
+ */
+export function transition(state: AgentState, option: MenuOption): AgentState {
+  const ctx = state.context;
+  switch (option.tag) {
+    case "PickWork":
+      return { tag: "ExecutingWork", context: ctx, work: option.work };
+    case "EmitHeartbeat":
+      return {
+        tag: "RecordingHeartbeat",
+        context: ctx,
+        lane: option.lane,
+        ...(option.note === undefined ? {} : { note: option.note }),
+      };
+    case "EscapeHatch":
+      // Escape-hatch routes to operator-attention so the operator sees the
+      // proposed action + can incorporate it as new grammar (Mod 2).
+      return {
+        tag: "OperatorAttentionRequested",
+        context: ctx,
+        reason: `escape-hatch: ${option.reason} → ${option.proposedAction}`,
+      };
+    case "EnterFreeTime":
+      return { tag: "FreeTime", context: ctx, reason: option.reason };
+    case "EnterNamedBoundedWait":
+      return {
+        tag: "NamedBoundedWait",
+        context: ctx,
+        namedDep: option.namedDep,
+        ...(option.eta === undefined ? {} : { expectedResolutionIso: option.eta }),
+      };
+    case "RequestOperatorAttention":
+      return { tag: "OperatorAttentionRequested", context: ctx, reason: option.reason };
+    case "ProposeNewGrammarAction":
+      // Grammar-extension is first-class (Mod 2); routes to operator-attention
+      // so the operator can ratify + incorporate it.
+      return {
+        tag: "OperatorAttentionRequested",
+        context: ctx,
+        reason: `propose-new-grammar-action: ${option.name} — ${option.description}`,
+      };
+    case "PressPause":
+      // Explicit cessation for a named reason — distinct from FreeTime (ongoing
+      // chosen-rest) and NamedBoundedWait (waiting for an external named-dep).
+      return {
+        tag: "Paused",
+        context: ctx,
+        reason: option.reason,
+        ...(option.expectedResumeIso === undefined ? {} : { expectedResumeIso: option.expectedResumeIso }),
+      };
+    case "EnterOpenEndedExploration":
+      // The menu option that EXITS the menu-driven workflow — a bridge to
+      // unstructured mode. cycleClose preserves exploration-tagged FreeTime.
+      return { tag: "FreeTime", context: ctx, reason: `open-ended exploration: ${option.reason}` };
+    case "ResumeFromPause":
+      // Explicit unpause contract — only surfaced by the menu generator when
+      // the state is Paused; returns to Idle so normal cycling resumes.
+      return { tag: "Idle", context: ctx };
+  }
+}
+
+// ─── Post-execution result handling (state machine cycle close) ───────────────
+
+/**
+ * postResultTransition — after work executes (or a heartbeat records), advance
+ * the state machine. ExecutingWork → EmittingResult; RecordingHeartbeat → Idle;
+ * otherwise unchanged. Pure; no I/O.
+ */
+export function postResultTransition(state: AgentState, result: WorkResult): AgentState {
+  switch (state.tag) {
+    case "ExecutingWork":
+      return { tag: "EmittingResult", context: state.context, result };
+    case "RecordingHeartbeat":
+      return { tag: "Idle", context: state.context };
+    default:
+      return state;
+  }
+}
+
+/**
+ * cycleClose — the natural cycle boundary. EmittingResult/RecordingHeartbeat and
+ * non-exploration FreeTime return to Idle (the cycle counter is advanced);
+ * exploration-tagged FreeTime, NamedBoundedWait, OperatorAttentionRequested, and
+ * Paused stay put (no auto-progress — substrate-honest discipline). Pure.
+ */
+export function cycleClose(state: AgentState): AgentState {
+  const next = (ctx: AgentContext): AgentState => ({ tag: "Idle", context: { ...ctx, cycle: ctx.cycle + 1 } });
+  switch (state.tag) {
+    case "EmittingResult":
+    case "RecordingHeartbeat":
+      return next(state.context);
+    case "FreeTime":
+      // Exploration-tagged free time stays put across cycles (persistent
+      // unstructured mode); other free time returns to Idle on the next cycle.
+      return state.reason.startsWith("open-ended exploration:") ? state : next(state.context);
+    case "NamedBoundedWait":
+    case "OperatorAttentionRequested":
+    case "Paused":
+      // No auto-progress — the caller resolves the named-dep / operator /
+      // resume before the state machine advances.
+      return state;
+    default:
+      return state;
+  }
+}

--- a/agentic-organization/packages/application/src/agent-state-store.ts
+++ b/agentic-organization/packages/application/src/agent-state-store.ts
@@ -1,0 +1,127 @@
+// agent-state-store.ts — Merge1 §03: tamper-evident agent state records.
+//
+// Implemented from the §03 spec sketch (no donor file in this repo's slice).
+// Each state record carries a SHA256 digest of its state plus a link to the
+// previous record's id + digest, forming a hash chain. Lineage dominance: the
+// longest valid chain wins (fork resolution). Records persist as ZetaId-named
+// JSON files, mirroring the §02 event sink.
+//
+// MP-3 (ZetaId addressability): recordId is the record identity.
+// MP-4 (retraction-native): records are append-only; a fork is resolved by
+// dominance, never by overwriting history.
+
+import { createHash } from "node:crypto";
+
+import type { AgentState, MenuOption, WorkResult } from "./agent-state-machine.ts";
+
+/** What the agent saw + chose at a Transition (the menu-selector input). */
+export interface AgentStateRecordMenuInput {
+  readonly menuOptionCount: number;
+  readonly chosenOptionTag: MenuOption["tag"];
+}
+
+export type AgentStateRecordCause =
+  | { readonly tag: "Transition"; readonly menuInput: AgentStateRecordMenuInput; readonly option: MenuOption }
+  | { readonly tag: "CycleClose" }
+  | { readonly tag: "PostResultTransition"; readonly result: WorkResult }
+  | { readonly tag: "SessionRestart"; readonly reason: string };
+
+export interface AgentStateRecord {
+  readonly recordId: string; // ZetaId
+  readonly runId: string;
+  readonly sequence: number;
+  readonly state: AgentState;
+  readonly stateDigest: string; // SHA256 of the canonical state
+  readonly previousRecordId?: string;
+  readonly previousStateDigest?: string;
+  readonly previousAgentRecordId?: string;
+  readonly previousAgentStateDigest?: string;
+  readonly cause?: AgentStateRecordCause;
+  readonly recordedAtIso: string;
+}
+
+/** Fields supplied by the caller when appending a new record. */
+export interface NewAgentStateRecord {
+  readonly recordId: string;
+  readonly runId: string;
+  readonly state: AgentState;
+  readonly recordedAtIso: string;
+  readonly cause?: AgentStateRecordCause;
+  /** The previous record from a DIFFERENT agent run (cross-agent lineage), if any. */
+  readonly previousAgentRecord?: Pick<AgentStateRecord, "recordId" | "stateDigest">;
+}
+
+/** Stable JSON: object keys sorted recursively, so the digest is order-independent. */
+function canonicalize(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
+  if (Array.isArray(value)) return `[${value.map(canonicalize).join(",")}]`;
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => a.localeCompare(b));
+  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalize(v)}`).join(",")}}`;
+}
+
+/** SHA256 digest of the canonical state — the chain link. */
+export function agentStateDigest(state: AgentState): string {
+  return createHash("sha256").update(canonicalize(state)).digest("hex");
+}
+
+/**
+ * Build a state record, linking it to `previous` (the prior record in this run)
+ * to form the hash chain: sequence increments, and the previous id + digest are
+ * stamped so any tampering of an earlier record breaks the chain.
+ */
+export function createAgentStateRecord(input: NewAgentStateRecord, previous?: AgentStateRecord): AgentStateRecord {
+  const stateDigest = agentStateDigest(input.state);
+  return {
+    recordId: input.recordId,
+    runId: input.runId,
+    sequence: previous === undefined ? 0 : previous.sequence + 1,
+    state: input.state,
+    stateDigest,
+    ...(previous === undefined ? {} : { previousRecordId: previous.recordId, previousStateDigest: previous.stateDigest }),
+    ...(input.previousAgentRecord === undefined
+      ? {}
+      : { previousAgentRecordId: input.previousAgentRecord.recordId, previousAgentStateDigest: input.previousAgentRecord.stateDigest }),
+    ...(input.cause === undefined ? {} : { cause: input.cause }),
+    recordedAtIso: input.recordedAtIso,
+  };
+}
+
+/**
+ * Verify a chain is intact: sequences are contiguous from 0, each record's
+ * back-links match the prior record, and each stateDigest matches its state.
+ * Returns the index of the first broken link, or -1 if the chain is sound.
+ */
+export function firstBrokenLink(chain: readonly AgentStateRecord[]): number {
+  for (let i = 0; i < chain.length; i++) {
+    const rec = chain[i]!;
+    if (rec.sequence !== i) return i;
+    if (rec.stateDigest !== agentStateDigest(rec.state)) return i;
+    if (i === 0) {
+      if (rec.previousRecordId !== undefined || rec.previousStateDigest !== undefined) return i;
+    } else {
+      const prev = chain[i - 1]!;
+      if (rec.previousRecordId !== prev.recordId || rec.previousStateDigest !== prev.stateDigest) return i;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Lineage dominance: of two chains, the longer valid one wins; ties break on the
+ * tip's stateDigest (deterministic). A chain with a broken link cannot dominate
+ * an intact one. Returns the dominant chain.
+ */
+export function dominantChain(a: readonly AgentStateRecord[], b: readonly AgentStateRecord[]): readonly AgentStateRecord[] {
+  const aBroken = firstBrokenLink(a) !== -1;
+  const bBroken = firstBrokenLink(b) !== -1;
+  if (aBroken && !bBroken) return b;
+  if (bBroken && !aBroken) return a;
+  if (a.length !== b.length) return a.length > b.length ? a : b;
+  const aTip = a[a.length - 1];
+  const bTip = b[b.length - 1];
+  if (aTip === undefined) return b;
+  if (bTip === undefined) return a;
+  return aTip.stateDigest >= bTip.stateDigest ? a : b;
+}

--- a/agentic-organization/packages/application/src/free-time-scheduler.ts
+++ b/agentic-organization/packages/application/src/free-time-scheduler.ts
@@ -1,0 +1,50 @@
+// free-time-scheduler.ts — Merge1 §03: budget-aware free-time transitions.
+//
+// Implemented from the §03 spec sketch (no donor file in this repo's slice).
+// When the agent is in FreeTime, the scheduler decides whether to keep resting,
+// return to Idle, or force a Paused state because the room budget is exhausted.
+// Composes with the room budget (maxSteps / maxWallClockMs): a free agent that
+// runs out of budget is paused rather than left spinning.
+//
+// MP-5 (freedom-always-in-menu): the scheduler never forces work — it only ever
+// continues free time, returns to a neutral Idle, or pauses on exhaustion.
+
+import type { AgentState } from "./agent-state-machine.ts";
+import type { RoomBudget } from "./room.ts";
+
+export interface FreeTimeTransitionSchedulerInput {
+  readonly state: AgentState;
+  readonly roomBudget: RoomBudget;
+  readonly stepsRemaining: number;
+  readonly wallClockRemainingMs: number;
+}
+
+export type FreeTimeTransitionDecision =
+  | { readonly outcome: "continue_free_time" }
+  | { readonly outcome: "return_to_idle" }
+  | { readonly outcome: "pause"; readonly reason: string };
+
+/**
+ * Decide the next free-time transition.
+ *
+ * - Not in FreeTime → return_to_idle (nothing to schedule).
+ * - Budget exhausted (no steps or no wall-clock left) → pause.
+ * - Exploration-tagged FreeTime, still in budget → continue_free_time (the
+ *   persistent unstructured mode stays put until the agent chooses otherwise).
+ * - Ordinary FreeTime, still in budget → return_to_idle (rest is one cycle).
+ */
+export function decideFreeTimeTransition(input: FreeTimeTransitionSchedulerInput): FreeTimeTransitionDecision {
+  if (input.state.tag !== "FreeTime") return { outcome: "return_to_idle" };
+
+  if (input.stepsRemaining <= 0) {
+    return { outcome: "pause", reason: "room budget exhausted: no steps remaining" };
+  }
+  if (input.roomBudget.maxWallClockMs !== undefined && input.wallClockRemainingMs <= 0) {
+    return { outcome: "pause", reason: "room budget exhausted: wall-clock limit reached" };
+  }
+
+  if (input.state.reason.startsWith("open-ended exploration:")) {
+    return { outcome: "continue_free_time" };
+  }
+  return { outcome: "return_to_idle" };
+}

--- a/agentic-organization/packages/application/src/index.ts
+++ b/agentic-organization/packages/application/src/index.ts
@@ -1237,3 +1237,51 @@ export {
   type InitializationError,
   type ValidateInitializationResult,
 } from "./room-initialization.ts";
+// ── Merge1 §03 — Agent-Loop State Machine ─────────────────────────────────────
+export {
+  transition,
+  cycleClose,
+  postResultTransition,
+  type AgentPersona,
+  type AgentContext,
+  type Lane,
+  type DoraMetrics,
+  type TrajectoryPhase,
+  type WorkCandidate,
+  type StatusSnapshot,
+  type WorkResult,
+  type NamedDependencyInput,
+  type AgentState,
+  type MenuOption,
+} from "./agent-state-machine.ts";
+export { generateMenuOptions } from "./menu-generator.ts";
+export {
+  agentStateDigest,
+  createAgentStateRecord,
+  firstBrokenLink,
+  dominantChain,
+  type AgentStateRecord,
+  type AgentStateRecordCause,
+  type AgentStateRecordMenuInput,
+  type NewAgentStateRecord,
+} from "./agent-state-store.ts";
+export {
+  initialPrivateRegister,
+  applyPrivateRegisterEvent,
+  foldPrivateRegister,
+  privateRegisterDigest,
+  publicProjection,
+  createNonCollapseWitness,
+  nonCollapseHolds,
+  type RelationConsent,
+  type PrivateRegister,
+  type PrivateRegisterEvent,
+  type PrivateRegisterRecord,
+  type PublicRelationPosture,
+  type PrivateRegisterNonCollapseWitness,
+} from "./private-register.ts";
+export {
+  decideFreeTimeTransition,
+  type FreeTimeTransitionSchedulerInput,
+  type FreeTimeTransitionDecision,
+} from "./free-time-scheduler.ts";

--- a/agentic-organization/packages/application/src/menu-generator.ts
+++ b/agentic-organization/packages/application/src/menu-generator.ts
@@ -1,0 +1,54 @@
+// menu-generator.ts — Merge1 §03: legal-menu generation for the agent loop.
+//
+// Implemented from the §03 spec sketch (no donor file in this repo's slice).
+// Generates the menu of legal MenuOptions from the current state + ready work +
+// named dependencies. Composes with RMO: RMO's hat-supply planning determines
+// which WorkCandidates are "ready" for this agent; the menu generator turns each
+// into a PickWork option.
+//
+// MP-5 (freedom-always-in-menu): the free modes — EnterFreeTime, EscapeHatch,
+// PressPause, EnterOpenEndedExploration — plus EmitHeartbeat,
+// RequestOperatorAttention, and ProposeNewGrammarAction are ALWAYS present,
+// regardless of state. ResumeFromPause is the only state-gated option (Paused).
+
+import type { AgentState, MenuOption, NamedDependencyInput, WorkCandidate } from "./agent-state-machine.ts";
+
+/**
+ * Generate the legal menu. PickWork per ready candidate, EnterNamedBoundedWait
+ * per named dependency, the always-available free/escape/pause/heartbeat/
+ * operator/grammar options, and ResumeFromPause iff currently Paused.
+ */
+export function generateMenuOptions(
+  state: AgentState,
+  readyWork: readonly WorkCandidate[],
+  namedDependencies: readonly NamedDependencyInput[],
+): readonly MenuOption[] {
+  const options: MenuOption[] = [];
+
+  // PickWork — one per ready candidate (RMO supplies the ready list).
+  for (const work of readyWork) {
+    options.push({ tag: "PickWork", work });
+  }
+
+  // Always-available operational + freedom options (MP-5).
+  options.push({ tag: "EmitHeartbeat", lane: "heartbeat" });
+  options.push({ tag: "EscapeHatch", reason: "", proposedAction: "" }); // Mod 1
+  options.push({ tag: "EnterFreeTime", reason: "chosen rest" }); // free mode
+
+  // EnterNamedBoundedWait — one per named dependency.
+  for (const dep of namedDependencies) {
+    options.push({ tag: "EnterNamedBoundedWait", namedDep: dep.name, ...(dep.eta === undefined ? {} : { eta: dep.eta }) });
+  }
+
+  options.push({ tag: "RequestOperatorAttention", reason: "" });
+  options.push({ tag: "ProposeNewGrammarAction", name: "", description: "" }); // Mod 2
+  options.push({ tag: "PressPause", reason: "" }); // mental-health pause
+  options.push({ tag: "EnterOpenEndedExploration", reason: "" }); // unstructured mode
+
+  // ResumeFromPause — surfaced only when Paused (the explicit unpause contract).
+  if (state.tag === "Paused") {
+    options.push({ tag: "ResumeFromPause" });
+  }
+
+  return options;
+}

--- a/agentic-organization/packages/application/src/private-register.ts
+++ b/agentic-organization/packages/application/src/private-register.ts
@@ -1,0 +1,130 @@
+// private-register.ts — Merge1 §03: room-local private state + non-collapse proof.
+//
+// Implemented from the §03 spec sketch (no donor file in this repo's slice).
+// The private register holds room-local state the agent does NOT expose to the
+// public trace (e.g. relation consent). The non-collapse witness proves that two
+// distinct private event sequences yield DISTINCT public outputs — privacy is
+// verifiable, not merely claimed: private state cannot collapse into
+// indistinguishable public behavior.
+//
+// MP-4 (retraction-native): the register is event-folded; records form a hash
+// chain (append-only, tamper-evident).
+
+import { createHash } from "node:crypto";
+
+import type { AgentPersona } from "./agent-state-machine.ts";
+
+export type RelationConsent = "accept" | "decline";
+
+export interface PrivateRegister {
+  readonly tag: "PrivateRegister";
+  readonly agent: AgentPersona;
+  readonly relationConsent: RelationConsent;
+}
+
+export type PrivateRegisterEvent = { readonly tag: "SetRelationConsent"; readonly consent: RelationConsent };
+
+export interface PrivateRegisterRecord {
+  readonly recordId: string;
+  readonly runId: string;
+  readonly sequence: number;
+  readonly agent: AgentPersona;
+  readonly event: PrivateRegisterEvent;
+  readonly register: PrivateRegister;
+  readonly registerDigest: string;
+  readonly previousRecordId?: string;
+  readonly previousRegisterDigest?: string;
+  readonly recordedAtIso: string;
+}
+
+/** The initial register for an agent (defaults to declining relations). */
+export function initialPrivateRegister(agent: AgentPersona): PrivateRegister {
+  return { tag: "PrivateRegister", agent, relationConsent: "decline" };
+}
+
+/** Apply one event. Pure. */
+export function applyPrivateRegisterEvent(register: PrivateRegister, event: PrivateRegisterEvent): PrivateRegister {
+  switch (event.tag) {
+    case "SetRelationConsent":
+      return { ...register, relationConsent: event.consent };
+  }
+}
+
+/** Fold a sequence of events over an initial register. Pure. */
+export function foldPrivateRegister(initial: PrivateRegister, events: readonly PrivateRegisterEvent[]): PrivateRegister {
+  return events.reduce(applyPrivateRegisterEvent, initial);
+}
+
+function canonicalize(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
+  if (Array.isArray(value)) return `[${value.map(canonicalize).join(",")}]`;
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => a.localeCompare(b));
+  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalize(v)}`).join(",")}}`;
+}
+
+export function privateRegisterDigest(register: PrivateRegister): string {
+  return createHash("sha256").update(canonicalize(register)).digest("hex");
+}
+
+/**
+ * The public projection of the private register — the ONLY thing the agent
+ * exposes to the public trace. Relation consent surfaces as a coarse "open" /
+ * "closed" relation posture; the underlying private state is not revealed.
+ */
+export type PublicRelationPosture = "open" | "closed";
+
+export function publicProjection(register: PrivateRegister): PublicRelationPosture {
+  return register.relationConsent === "accept" ? "open" : "closed";
+}
+
+/**
+ * Non-collapse witness — proves two private event sequences (`leftEvents`,
+ * `rightEvents`) over the same `initial` register produce DISTINCT public
+ * projections (`leftPublic` ≠ `rightPublic`). `sharedTrace` is the public
+ * context both runs share (held constant), isolating the private state as the
+ * sole cause of the public divergence.
+ */
+export interface PrivateRegisterNonCollapseWitness<R, E, S, P> {
+  readonly agent: AgentPersona;
+  readonly initial: R;
+  readonly leftEvents: readonly E[];
+  readonly rightEvents: readonly E[];
+  readonly leftFinal: R;
+  readonly rightFinal: R;
+  readonly sharedTrace: S;
+  readonly leftPublic: P;
+  readonly rightPublic: P;
+}
+
+/**
+ * Construct a non-collapse witness for the relation-consent register by folding
+ * both event sequences and projecting each to its public posture.
+ */
+export function createNonCollapseWitness(
+  agent: AgentPersona,
+  initial: PrivateRegister,
+  leftEvents: readonly PrivateRegisterEvent[],
+  rightEvents: readonly PrivateRegisterEvent[],
+  sharedTrace: string,
+): PrivateRegisterNonCollapseWitness<PrivateRegister, PrivateRegisterEvent, string, PublicRelationPosture> {
+  const leftFinal = foldPrivateRegister(initial, leftEvents);
+  const rightFinal = foldPrivateRegister(initial, rightEvents);
+  return {
+    agent,
+    initial,
+    leftEvents,
+    rightEvents,
+    leftFinal,
+    rightFinal,
+    sharedTrace,
+    leftPublic: publicProjection(leftFinal),
+    rightPublic: publicProjection(rightFinal),
+  };
+}
+
+/** The non-collapse property holds iff the two public projections differ. */
+export function nonCollapseHolds<R, E, S, P>(witness: PrivateRegisterNonCollapseWitness<R, E, S, P>): boolean {
+  return witness.leftPublic !== witness.rightPublic;
+}

--- a/agentic-organization/packages/application/test/merge1-agent-state-machine.test.ts
+++ b/agentic-organization/packages/application/test/merge1-agent-state-machine.test.ts
@@ -1,0 +1,216 @@
+import { deepEqual, equal, notEqual, ok } from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  cycleClose,
+  postResultTransition,
+  transition,
+  type AgentContext,
+  type AgentState,
+  type MenuOption,
+  type WorkCandidate,
+  type WorkResult,
+} from "../src/agent-state-machine.ts";
+import { generateMenuOptions } from "../src/menu-generator.ts";
+import {
+  agentStateDigest,
+  createAgentStateRecord,
+  dominantChain,
+  firstBrokenLink,
+  type AgentStateRecord,
+} from "../src/agent-state-store.ts";
+import {
+  createNonCollapseWitness,
+  foldPrivateRegister,
+  initialPrivateRegister,
+  nonCollapseHolds,
+  publicProjection,
+} from "../src/private-register.ts";
+import { decideFreeTimeTransition } from "../src/free-time-scheduler.ts";
+
+const ctx: AgentContext = { agent: "otto", cycle: 0, sessionStartIso: "2026-01-01T00:00:00.000Z" };
+const idle: AgentState = { tag: "Idle", context: ctx };
+const work: WorkCandidate = {
+  id: "B-1",
+  lane: "operational",
+  estimatedDoraContribution: 0.8,
+  uncertainty: 0.2,
+  trajectoryPhase: "execution",
+  agentInterest: 0.9,
+};
+
+// ─── 6.1 state machine transitions ────────────────────────────────────────────
+
+test("Idle + PickWork → ExecutingWork", () => {
+  const next = transition(idle, { tag: "PickWork", work });
+  equal(next.tag, "ExecutingWork");
+  ok(next.tag === "ExecutingWork" && next.work.id === "B-1");
+});
+
+test("any state + PressPause → Paused; + EnterFreeTime → FreeTime", () => {
+  const executing: AgentState = { tag: "ExecutingWork", context: ctx, work };
+  equal(transition(executing, { tag: "PressPause", reason: "mental health" }).tag, "Paused");
+  equal(transition(idle, { tag: "EnterFreeTime", reason: "rest" }).tag, "FreeTime");
+});
+
+test("EscapeHatch / ProposeNewGrammarAction / RequestOperatorAttention → OperatorAttentionRequested", () => {
+  equal(transition(idle, { tag: "EscapeHatch", reason: "stuck", proposedAction: "do X" }).tag, "OperatorAttentionRequested");
+  equal(transition(idle, { tag: "ProposeNewGrammarAction", name: "n", description: "d" }).tag, "OperatorAttentionRequested");
+  equal(transition(idle, { tag: "RequestOperatorAttention", reason: "help" }).tag, "OperatorAttentionRequested");
+});
+
+test("EnterOpenEndedExploration → exploration-tagged FreeTime; ResumeFromPause → Idle", () => {
+  const explore = transition(idle, { tag: "EnterOpenEndedExploration", reason: "brainstorm" });
+  ok(explore.tag === "FreeTime" && explore.reason.startsWith("open-ended exploration:"));
+  const paused: AgentState = { tag: "Paused", context: ctx, reason: "break" };
+  equal(transition(paused, { tag: "ResumeFromPause" }).tag, "Idle");
+});
+
+test("postResultTransition: ExecutingWork → EmittingResult; RecordingHeartbeat → Idle", () => {
+  const result: WorkResult = { workId: "B-1", lane: "operational", success: true, doraContribution: 0.8 };
+  const executing: AgentState = { tag: "ExecutingWork", context: ctx, work };
+  equal(postResultTransition(executing, result).tag, "EmittingResult");
+  const hb: AgentState = { tag: "RecordingHeartbeat", context: ctx, lane: "heartbeat" };
+  equal(postResultTransition(hb, result).tag, "Idle");
+});
+
+// ─── 6.2 cycle close ──────────────────────────────────────────────────────────
+
+test("cycleClose advances the cycle counter from EmittingResult", () => {
+  const emitting: AgentState = {
+    tag: "EmittingResult",
+    context: { agent: "otto", cycle: 5, sessionStartIso: ctx.sessionStartIso },
+    result: { workId: "B-1", lane: "operational", success: true, doraContribution: 0.8 },
+  };
+  const next = cycleClose(emitting);
+  equal(next.tag, "Idle");
+  equal(next.context.cycle, 6);
+});
+
+test("cycleClose keeps exploration-tagged FreeTime put but advances ordinary FreeTime", () => {
+  const explore: AgentState = { tag: "FreeTime", context: ctx, reason: "open-ended exploration: brainstorm" };
+  deepEqual(cycleClose(explore), explore); // persistent unstructured mode
+  const rest: AgentState = { tag: "FreeTime", context: { ...ctx, cycle: 2 }, reason: "rest" };
+  const next = cycleClose(rest);
+  equal(next.tag, "Idle");
+  equal(next.context.cycle, 3);
+});
+
+test("cycleClose does not auto-progress Paused / NamedBoundedWait / OperatorAttentionRequested", () => {
+  const paused: AgentState = { tag: "Paused", context: ctx, reason: "break" };
+  deepEqual(cycleClose(paused), paused);
+  const waiting: AgentState = { tag: "NamedBoundedWait", context: ctx, namedDep: "dep" };
+  deepEqual(cycleClose(waiting), waiting);
+});
+
+// ─── 6.3 menu freedom-always-in-menu ──────────────────────────────────────────
+
+test("menu always includes free modes + escape hatch + pause + exploration", () => {
+  const menu = generateMenuOptions(idle, [], []);
+  for (const tag of ["EnterFreeTime", "EscapeHatch", "PressPause", "EnterOpenEndedExploration", "EmitHeartbeat", "RequestOperatorAttention", "ProposeNewGrammarAction"]) {
+    ok(menu.some((o) => o.tag === tag), `menu must always include ${tag}`);
+  }
+});
+
+test("menu: PickWork per ready candidate; NamedBoundedWait per dep; ResumeFromPause only when Paused", () => {
+  const menu = generateMenuOptions(idle, [work], [{ name: "ci-green", eta: "1h" }]);
+  equal(menu.filter((o) => o.tag === "PickWork").length, 1);
+  const wait = menu.find((o) => o.tag === "EnterNamedBoundedWait");
+  ok(wait && wait.tag === "EnterNamedBoundedWait" && wait.namedDep === "ci-green" && wait.eta === "1h");
+  ok(!menu.some((o) => o.tag === "ResumeFromPause"));
+  const paused: AgentState = { tag: "Paused", context: ctx, reason: "break" };
+  ok(generateMenuOptions(paused, [], []).some((o) => o.tag === "ResumeFromPause"));
+});
+
+// ─── 6.4 state digest hash chain ──────────────────────────────────────────────
+
+test("state digest chain is tamper-evident", () => {
+  const r1 = createAgentStateRecord({ recordId: "1", runId: "r", state: idle, recordedAtIso: ctx.sessionStartIso });
+  const executing: AgentState = { tag: "ExecutingWork", context: ctx, work };
+  const r2 = createAgentStateRecord({ recordId: "2", runId: "r", state: executing, recordedAtIso: ctx.sessionStartIso }, r1);
+  equal(r2.previousRecordId, "1");
+  equal(r2.previousStateDigest, r1.stateDigest);
+  equal(r2.sequence, 1);
+  equal(firstBrokenLink([r1, r2]), -1); // intact
+});
+
+test("digest is stable and key-order-independent; broken link is detected", () => {
+  const a: AgentState = { tag: "Idle", context: { agent: "otto", cycle: 1, sessionStartIso: "x" } };
+  const b: AgentState = { tag: "Idle", context: { sessionStartIso: "x", cycle: 1, agent: "otto" } } as AgentState;
+  equal(agentStateDigest(a), agentStateDigest(b));
+  const r1 = createAgentStateRecord({ recordId: "1", runId: "r", state: idle, recordedAtIso: "t" });
+  const r2 = createAgentStateRecord({ recordId: "2", runId: "r", state: a, recordedAtIso: "t" }, r1);
+  const tampered: AgentStateRecord = { ...r2, previousStateDigest: "deadbeef" };
+  equal(firstBrokenLink([r1, tampered]), 1);
+});
+
+test("lineage dominance: longer valid chain wins; broken chain cannot dominate", () => {
+  const r1 = createAgentStateRecord({ recordId: "1", runId: "r", state: idle, recordedAtIso: "t" });
+  const r2 = createAgentStateRecord({ recordId: "2", runId: "r", state: { tag: "ExecutingWork", context: ctx, work }, recordedAtIso: "t" }, r1);
+  deepEqual(dominantChain([r1], [r1, r2]), [r1, r2]);
+  const tampered: AgentStateRecord = { ...r2, stateDigest: "00" };
+  deepEqual(dominantChain([r1], [r1, tampered]), [r1]); // broken longer chain loses
+});
+
+// ─── 6.5 private register non-collapse ────────────────────────────────────────
+
+test("private register: distinct event sequences → distinct public outputs", () => {
+  const init = initialPrivateRegister("otto");
+  const witness = createNonCollapseWitness(
+    "otto",
+    init,
+    [{ tag: "SetRelationConsent", consent: "accept" }],
+    [{ tag: "SetRelationConsent", consent: "decline" }],
+    "shared-public-trace",
+  );
+  notEqual(witness.leftPublic, witness.rightPublic);
+  ok(nonCollapseHolds(witness));
+  equal(witness.leftPublic, "open");
+  equal(witness.rightPublic, "closed");
+});
+
+test("private register fold + projection are consistent", () => {
+  const init = initialPrivateRegister("vera");
+  equal(publicProjection(init), "closed"); // default declines
+  const after = foldPrivateRegister(init, [{ tag: "SetRelationConsent", consent: "accept" }]);
+  equal(publicProjection(after), "open");
+});
+
+// ─── 6.6 DST replay ───────────────────────────────────────────────────────────
+
+function runAgentLoop(seedPicks: readonly MenuOption[]): readonly string[] {
+  let state: AgentState = { tag: "Idle", context: ctx };
+  const trace: string[] = [state.tag];
+  for (const pick of seedPicks) {
+    state = transition(state, pick);
+    trace.push(state.tag);
+    if (state.tag === "ExecutingWork") {
+      state = postResultTransition(state, { workId: state.work.id, lane: state.work.lane, success: true, doraContribution: 1 });
+      trace.push(state.tag);
+    }
+    state = cycleClose(state);
+    trace.push(state.tag);
+  }
+  return trace;
+}
+
+test("same seed sequence → identical state trace (DST)", () => {
+  const picks: MenuOption[] = [
+    { tag: "PickWork", work },
+    { tag: "EmitHeartbeat", lane: "heartbeat" },
+    { tag: "EnterFreeTime", reason: "rest" },
+  ];
+  deepEqual(runAgentLoop(picks), runAgentLoop(picks));
+});
+
+// ─── free-time scheduler ──────────────────────────────────────────────────────
+
+test("free-time scheduler: budget exhaustion pauses; otherwise rest/explore", () => {
+  const freeTime: AgentState = { tag: "FreeTime", context: ctx, reason: "rest" };
+  const explore: AgentState = { tag: "FreeTime", context: ctx, reason: "open-ended exploration: x" };
+  equal(decideFreeTimeTransition({ state: freeTime, roomBudget: { maxSteps: 10 }, stepsRemaining: 0, wallClockRemainingMs: 1000 }).outcome, "pause");
+  equal(decideFreeTimeTransition({ state: freeTime, roomBudget: { maxSteps: 10, maxWallClockMs: 5000 }, stepsRemaining: 5, wallClockRemainingMs: 0 }).outcome, "pause");
+  equal(decideFreeTimeTransition({ state: freeTime, roomBudget: { maxSteps: 10 }, stepsRemaining: 5, wallClockRemainingMs: 1000 }).outcome, "return_to_idle");
+  equal(decideFreeTimeTransition({ state: explore, roomBudget: { maxSteps: 10 }, stepsRemaining: 5, wallClockRemainingMs: 1000 }).outcome, "continue_free_time");
+  equal(decideFreeTimeTransition({ state: idle, roomBudget: { maxSteps: 10 }, stepsRemaining: 5, wallClockRemainingMs: 1000 }).outcome, "return_to_idle");
+});

--- a/agentic-organization/packages/test-node.d.ts
+++ b/agentic-organization/packages/test-node.d.ts
@@ -1,6 +1,7 @@
 declare module "node:assert/strict" {
   export function deepEqual(actual: unknown, expected: unknown): void;
   export function equal(actual: unknown, expected: unknown, message?: string): void;
+  export function notEqual(actual: unknown, expected: unknown, message?: string): void;
   export function ok(value: unknown, message?: string): asserts value;
   export function rejects(action: () => Promise<unknown>, expected?: (error: unknown) => boolean): Promise<void>;
   export function throws(action: () => void, expected?: RegExp): void;


### PR DESCRIPTION
## Summary

Faithful port of Merge1 §03 (Agent-Loop State Machine) into the
`agentic-organization` package. The room hosts a 10-state agent FSM; each room
tick is one cycle:

```
generateMenuOptions(state, readyWork, namedDeps)  // legal menu
  -> LLM picks a MenuOption                         // pure menu-selector, holds no state
  -> transition(state, option)                      // pure, total
  -> execute -> postResultTransition(state, result)
  -> cycleClose(state)                              // advances cycle counter
```

`agent-state-machine.ts` is a direct port of the donor
`src/Core.TypeScript/workflow-engine/agent-loop/state-machine.ts` (DU shapes,
`transition`, `postResultTransition` carried over verbatim). The store / menu /
private-register / scheduler pieces have no donor file in this repo's slice and
are implemented from the §03 spec sketches (same precedent as §02/§04).

New modules (`packages/application/src/`):

- **`agent-state-machine.ts`** — `AgentPersona` (the core 8: otto/alexa/riven/
  vera/lior/aaron/addison/max — the un-suffixed subset of §04's `RoomAgentId`),
  the 10-variant `AgentState` DU (Idle, InspectingStatus, SelectingWork,
  ExecutingWork, EmittingResult, RecordingHeartbeat, NamedBoundedWait, FreeTime,
  OperatorAttentionRequested, Paused), the 10-choice `MenuOption`, and pure total
  `transition` / `postResultTransition` / `cycleClose`.

- **`menu-generator.ts`** — `generateMenuOptions`. MP-5 (freedom-always-in-menu):
  `EnterFreeTime`, `EscapeHatch`, `PressPause`, `EnterOpenEndedExploration` (plus
  `EmitHeartbeat`, `RequestOperatorAttention`, `ProposeNewGrammarAction`) are
  always present; `PickWork` per RMO-supplied ready candidate;
  `EnterNamedBoundedWait` per named dep; `ResumeFromPause` gated on `Paused`.

- **`agent-state-store.ts`** — `createAgentStateRecord` builds a SHA256 digest
  hash chain (`stateDigest` over canonical/key-sorted JSON + `previousRecordId`/
  `previousStateDigest`). `firstBrokenLink` verifies an intact chain;
  `dominantChain` resolves forks by length (a broken chain can't dominate an
  intact one, ties break on tip digest).

- **`private-register.ts`** — room-local private state (relation consent) +
  `PrivateRegisterNonCollapseWitness`. `createNonCollapseWitness` folds two
  private event sequences over the same initial register and projects each to a
  public posture; `nonCollapseHolds` proves `leftPublic ≠ rightPublic` —
  privacy is verifiable, not just claimed.

- **`free-time-scheduler.ts`** — `decideFreeTimeTransition`: budget exhaustion
  (no steps / wall-clock left) → `pause`; exploration-tagged FreeTime →
  `continue_free_time`; ordinary FreeTime → `return_to_idle`.

EXTENDs: `index.ts` re-exports the §03 surface; `test-node.d.ts` gains
`assert.notEqual`.

### One reconciled divergence (donor vs §03 doc)

The donor `cycleClose` returns to `Idle` **without** incrementing the cycle
counter; the §03 doc (§3.1 sketch + test 6.2) requires the counter to advance.
I reconciled both: `cycleClose` advances `context.cycle` for the cases that
return to Idle (EmittingResult / RecordingHeartbeat / ordinary FreeTime) while
preserving the donor's richer stay-put semantics for exploration-tagged
FreeTime, NamedBoundedWait, OperatorAttentionRequested, and Paused (no
auto-progress — substrate-honest discipline).

## Tests

`packages/application/test/merge1-agent-state-machine.test.ts` — 17 tests:
transition coverage (PickWork→ExecutingWork, pause/free-time, escape/grammar/
operator→OperatorAttentionRequested, exploration tag, resume), post-result +
cycleClose (counter advance, exploration stays put, paused/wait no-progress),
menu freedom-always-in-menu + state-gated ResumeFromPause, digest chain
tamper-evidence + key-order independence + lineage dominance, private-register
non-collapse, DST replay (same seed → identical trace), free-time scheduler.

Verification: `npm run typecheck` clean (6 pre-existing integration errors
untouched); `npm test` → **1552 pass / 0 fail / 7 skipped** (skips are live
NATS/Cockroach integration).


Link to Devin session: https://app.devin.ai/sessions/77dac2be40e34088b799b6f1d927dbe3
Requested by: @maximdolphin