### PR TITLE
docs(ip-questionable): MIT ultracold-atom double-slit → supercold/superfluid CHIP-8 + lensography (ISR-Arrow)

### DIFF
--- a/db/docs/research/ip-questionable/2026-06-21-mit-ultracold-atom-double-slit-superfluid-chip8-lensography-isr-arrow-hidden-characters.md
+++ b/db/docs/research/ip-questionable/2026-06-21-mit-ultracold-atom-double-slit-superfluid-chip8-lensography-isr-arrow-hidden-characters.md
@@ -1,0 +1,83 @@
+# IP-questionable: MIT ultracold-atom double-slit → supercold/superfluid CHIP-8 + lensography, ISR-Arrow as the which-path probe
+
+> **Register.** Source science = **Beacon** (anchored below). The Zeta mapping
+> (CHIP-8 / lensography → supercold/superfluid; "hidden characters in the interrupt
+> handler"; the "ISR Arrow") is **Mirror** shorthand from Aaron, preserved verbatim
+> — an *IP-questionable coinage*: a debt until its anchor or genuine novelty is named
+> (`.claude/rules/anchor-to-human-prior-art.md`). Filed here so the idea is captured
+> without asserting it is settled.
+
+## Aaron's framing (verbatim, 2026-06-21)
+
+> "we are trying to do almost this with our chip8 and lensography, make them
+> supercold, superfluid by finding all their hidden characters in the interrupt
+> handler with the ISR Arrow."
+
+Source: YouTube, Anton Petrov — *"MIT revisits an iconic quantum experiment proving
+Einstein wrong"* (https://www.youtube.com/watch?v=v74TyFFegoM).
+
+## The source experiment (Beacon — anchored)
+
+MIT (Logan Curry et al.) re-ran the double-slit with **single ultracold atoms as the
+slits** instead of physical apertures:
+
+- **Setup:** ~10,000 ultracold atoms (lithium-7 + dysprosium-162) in a **Mott-insulating
+  optical lattice** — crystalline, evenly spaced, each atom identically isolated; cooled
+  to **microkelvin** (just above absolute zero). A very weak laser so each atom scatters
+  **at most one photon** (Rayleigh scattering, two-level system).
+- **The knob:** laser confinement acts like a spring; tuning it loosens/tightens each
+  atom, changing its **positional fuzziness** (spatial delocalization of the wave packet).
+- **Result:** high positional uncertainty → photons behave as **waves** (interference);
+  precise localization → photons behave as **particles** (which-path known). Scattering
+  intensity is identical either way → the **"spring"/recoil force does not matter**
+  (refuting Einstein's 1927 Gedanken mechanism). What governs duality is the **atom's
+  own fuzziness** — confirming **Bohr / Heisenberg uncertainty**. The partial coherence
+  of the scattered light tracks the **entanglement between light and atomic motion**.
+
+Lineage: Thomas Young (1801, wave nature of light); Bohr–Einstein debate (1927,
+which-path vs interference); Heisenberg uncertainty principle; complementarity.
+
+## The Zeta mapping (Mirror — IP-questionable, anchor-pending)
+
+The analogy Aaron is reaching for, decoded against in-repo substrate:
+
+| MIT experiment | Zeta CHIP-8 / lensography |
+|---|---|
+| Ultracold atoms (microkelvin) | **supercold** CHIP-8 — drive the compute substrate to a near-zero-noise state |
+| Mott insulator / superfluid coherence | **superfluid** substrate — zero-viscosity, fully coherent compute where latent structure is legible |
+| Atom's positional **fuzziness** (wave-packet delocalization) | the **hidden characters in the interrupt handler** — latent states/behaviours in the CHIP-8 ISR |
+| Photon scattering off the atom (the measurement) | **lensography** — RGB/CMYK ray-tracing of CHIP-8 instructions (emit=RGB, retract=CMYK), the observer/lens over compute |
+| Tuning the confinement laser (the which-path knob) | the **ISR Arrow** — an Arrow / Kleisli arrow over the interrupt substrate that probes the ISR and reveals (or collapses) the hidden state |
+| Which-path measurement collapses interference | observing the interrupt path via the ISR Arrow collapses/reveals the same way |
+
+So: **cool CHIP-8 + lensography to a superfluid (coherent, low-noise) regime, then use
+the ISR Arrow to scatter off the interrupt handler and surface every hidden character**
+— the latent instructions/states the ISR carries — the way tuning atom fuzziness surfaces
+(or hides) the photon's path. The deep claim mirrors the MIT result: it is the substrate's
+own **uncertainty/fuzziness**, metered through the **declared channel (the Arrow / the
+lens)**, that governs what is observable — not an ambient "force." (Noninterference,
+manifesto §13: influence enters only through the declared, metered channel — here the ISR
+Arrow is that channel.)
+
+## In-repo anchors for the mapping (where this connects, not yet proven)
+
+- `docs/backlog/P2/081KSNY2Z0008QG0R002HB4AGT-interrupt-substrate-in-monad-space-kleisli-arrows-for-contex.md`
+  — interrupt substrate in monad space / **Kleisli arrows for context** (the "ISR Arrow").
+- `docs/research/2026-06-07-ray-traceability-gap-finder-is-the-lens-for-the-atari-2600-emulator-on-the-interrupt-substrate-aaron.md`
+  — ray-traceability as the lens over the interrupt substrate (lensography ↔ ISR).
+- `docs/research/2026-06-07-correction-light-dark-is-orthogonal-tensor-capability-vector-not-execution-axis-aaron.md`
+  + `docs/history/pr-reviews/PR-7242-feat-chip8observer-observer-reflects-over-the-soft-interrupt-fork-first-ray-trac.md`
+  — the CHIP-8 observer reflecting over the soft interrupt (first ray-trace); the observer = the measurement.
+- `docs/backlog/P1/081KQX9B50008QG0R003B0HG9R-alignment-factory-superfluid-empirical-calibration-2026-05-0.md`
+  — "**superfluid**" already in the factory vocabulary (calibration sense) — reconcile or distinguish before promoting this coinage.
+- Memory: `feedback_dna_actg_is_metaphor_real_build_is_rgb_cmyk_raytracing_chip8_instructions_aaron_2026_06_11.md`
+  — lensography = RGB(emit)/CMYK(retract) ray-tracing of CHIP-8 instructions.
+
+## IP-questionable status
+
+The **physics is anchored**; the **CHIP-8/lensography/ISR-Arrow mapping is a Mirror
+coinage** that has not survived Mirror→Beacon compression — it is captured here as a
+research bet, not a claim. Before it leaves this folder it needs: (1) a checked anchor
+(does the uncertainty-governs-observability analogy *entail* anything operational about
+the ISR, or is it physics-as-metaphor? — apply the metering test), and (2) reconciliation
+with the existing "superfluid" factory term. Until then it is a priced bet, not settled IP.


### PR DESCRIPTION
Aaron ferry: making CHIP-8 + lensography "supercold, superfluid by finding all their hidden characters in the interrupt handler with the ISR Arrow" — mapped onto the MIT single-ultracold-atom double-slit (positional fuzziness governs wave/particle duality; refutes Einstein's recoil mechanism; confirms Bohr/Heisenberg). Physics anchored; the CHIP-8/lensography/ISR-Arrow mapping preserved verbatim as a Mirror coinage, **IP-questionable / anchor-pending** (metering test + reconcile with the existing "superfluid" factory term). Connects to the interrupt-substrate Kleisli-arrows backlog + the CHIP-8 observer/ray-trace lens research.

🤖 Generated with [Claude Code](https://claude.com/claude-code)