### PR TITLE
feat(agentic-org): Merge1 §07 — port k8s hat-system to TypeScript

### DIFF
--- a/agentic-organization/packages/application/src/hat-admission.ts
+++ b/agentic-organization/packages/application/src/hat-admission.ts
@@ -1,0 +1,244 @@
+/**
+ * Hat admission policies — the 7 OPA Gatekeeper throttles as pure,
+ * deterministic admission checks.
+ *
+ * Faithful port of
+ * `full-ai-cluster/k8s/applications/hat-system/policies/01..07` (Merge1 §07):
+ *   01 cooldown, 02 max-bindings, 03 conflict-of-interest, 04 quorum,
+ *   05 warmup, 06 max-new-hats, 07 no-supervisor-cycles.
+ *
+ * Each policy is a pure function of the `AdmissionRequest` + `HatPolicy`.
+ * Time arithmetic uses the request's `nowIso` (NOT `Date.now()`) so admission
+ * replays deterministically under DST (MP-1). Decisions are Result-shaped
+ * discriminated unions (MP-7), never exceptions.
+ */
+
+import { isTerminalHatBinding, type HatBinding } from "../../domain/src/hat-binding.ts";
+import type { HatDefinition } from "../../domain/src/hat-definition.ts";
+import type { HatPolicy } from "./hat-policy.ts";
+import type { HatSwap } from "./hat-swap-event.ts";
+
+/** Which admission gate is being requested. */
+export type AdmissionOp =
+  | "create-binding" // a wearer is binding a hat
+  | "promote-active" // a binding is being promoted Warmup → Active
+  | "create-hat"; // a new Hat is being added to the catalog
+
+export interface AdmissionRequest {
+  readonly operation: AdmissionOp;
+  readonly hatId: string;
+  readonly wearerId: string; // SPIFFE-ID analog (matches HatBinding.wearerAgentId)
+  readonly nowIso: string; // deterministic clock (MP-1)
+  readonly existingBindings: readonly HatBinding[];
+  readonly existingHats: readonly HatDefinition[];
+  readonly recentSwaps: readonly HatSwap[];
+  /** quorum cosignatures collected for the binding (04-quorum). */
+  readonly cosignerCount?: number;
+  /** the hat being created/updated, for cycle + novelty checks (06/07). */
+  readonly candidateHat?: HatDefinition;
+  /** when the binding's warmup completes, for promotion gating (05-warmup). */
+  readonly warmupEndsAt?: string;
+  /** ISO timestamps of hats created recently, for the 24h novelty window (06). */
+  readonly recentHatCreations?: readonly string[];
+}
+
+export type AdmissionDecision =
+  | { readonly outcome: "allow" }
+  | { readonly outcome: "deny"; readonly reason: string; readonly throttleName: string };
+
+export interface AdmissionPolicy {
+  readonly name: string;
+  readonly evaluate: (request: AdmissionRequest, policy: HatPolicy) => AdmissionDecision;
+}
+
+const ALLOW: AdmissionDecision = { outcome: "allow" };
+
+function elapsedSeconds(fromIso: string, nowIso: string): number {
+  return (Date.parse(nowIso) - Date.parse(fromIso)) / 1000;
+}
+
+/** 01-cooldown: deny if wearer had a SwapOff for the same hat within cooldownSeconds. */
+export const cooldownPolicy: AdmissionPolicy = {
+  name: "cooldown",
+  evaluate: (req, policy) => {
+    if (req.operation !== "create-binding") return ALLOW;
+    const cooldownSeconds = policy.throttles.cooldownSeconds;
+    const recentSwapOff = req.recentSwaps.find(
+      (s) => s.event === "SwapOff" && s.hat === req.hatId && s.previousWearer?.spiffeID === req.wearerId,
+    );
+    if (recentSwapOff) {
+      const elapsed = elapsedSeconds(recentSwapOff.occurredAt, req.nowIso);
+      if (elapsed < cooldownSeconds) {
+        return { outcome: "deny", reason: `cooldown: ${elapsed}s < ${cooldownSeconds}s`, throttleName: "cooldown" };
+      }
+    }
+    return ALLOW;
+  },
+};
+
+/** 02-max-bindings: deny if wearer's non-terminal bindings reach maxBindingsPerWearer. */
+export const maxBindingsPolicy: AdmissionPolicy = {
+  name: "max-bindings",
+  evaluate: (req, policy) => {
+    if (req.operation !== "create-binding") return ALLOW;
+    const active = req.existingBindings.filter(
+      (b) => b.wearerAgentId === req.wearerId && !isTerminalHatBinding(b),
+    );
+    if (active.length >= policy.throttles.maxBindingsPerWearer) {
+      return {
+        outcome: "deny",
+        reason: `max-bindings: ${active.length} >= ${policy.throttles.maxBindingsPerWearer}`,
+        throttleName: "max-bindings",
+      };
+    }
+    return ALLOW;
+  },
+};
+
+/** 03-conflict-of-interest: deny if wearer holds a hat in the target hat's conflicts set. */
+export const conflictOfInterestPolicy: AdmissionPolicy = {
+  name: "conflict-of-interest",
+  evaluate: (req) => {
+    if (req.operation !== "create-binding") return ALLOW;
+    const targetHat = req.candidateHat ?? req.existingHats.find((h) => h.id === req.hatId);
+    if (!targetHat) return ALLOW;
+    const conflicts = new Set(targetHat.conflictsWithHatIds);
+    const held = req.existingBindings.find(
+      (b) => b.wearerAgentId === req.wearerId && !isTerminalHatBinding(b) && conflicts.has(b.hatId),
+    );
+    if (held) {
+      return {
+        outcome: "deny",
+        reason: `conflict-of-interest: wearer holds conflicting hat ${held.hatId}`,
+        throttleName: "conflict-of-interest",
+      };
+    }
+    return ALLOW;
+  },
+};
+
+/** 04-quorum: deny if the target hat is quorum-gated and lacks enough cosignatures. */
+export const quorumPolicy: AdmissionPolicy = {
+  name: "quorum",
+  evaluate: (req, policy) => {
+    if (req.operation !== "create-binding") return ALLOW;
+    const targetHat = req.candidateHat ?? req.existingHats.find((h) => h.id === req.hatId);
+    if (!targetHat) return ALLOW;
+    const quorumGated = targetHat.quorumSize != null && targetHat.quorumSize > 0;
+    if (!quorumGated) return ALLOW;
+    const required = targetHat.quorumSize ?? policy.throttles.quorumDefaultSize;
+    const signed = req.cosignerCount ?? 0;
+    if (signed < required) {
+      return { outcome: "deny", reason: `quorum: ${signed} < ${required} cosignatures`, throttleName: "quorum" };
+    }
+    return ALLOW;
+  },
+};
+
+/** 05-warmup: deny promoting a binding to Active before its warmup completes. */
+export const warmupPolicy: AdmissionPolicy = {
+  name: "warmup",
+  evaluate: (req) => {
+    if (req.operation !== "promote-active") return ALLOW;
+    if (req.warmupEndsAt && Date.parse(req.nowIso) < Date.parse(req.warmupEndsAt)) {
+      return {
+        outcome: "deny",
+        reason: `warmup: not complete (now ${req.nowIso} < ${req.warmupEndsAt})`,
+        throttleName: "warmup",
+      };
+    }
+    return ALLOW;
+  },
+};
+
+/** 06-max-new-hats: deny creating a Hat when the 24h novelty budget is exhausted. */
+export const maxNewHatsPolicy: AdmissionPolicy = {
+  name: "max-new-hats",
+  evaluate: (req, policy) => {
+    if (req.operation !== "create-hat") return ALLOW;
+    const windowSeconds = 24 * 60 * 60;
+    const recent = (req.recentHatCreations ?? []).filter((iso) => elapsedSeconds(iso, req.nowIso) < windowSeconds);
+    if (recent.length >= policy.throttles.maxNewHatsPerDay) {
+      return {
+        outcome: "deny",
+        reason: `max-new-hats: ${recent.length} >= ${policy.throttles.maxNewHatsPerDay} in 24h`,
+        throttleName: "max-new-hats",
+      };
+    }
+    return ALLOW;
+  },
+};
+
+/**
+ * Detect whether the supervises-DAG (existing hats overlaid with the candidate)
+ * contains any cycle. Returns the offending hat id, or undefined if acyclic.
+ */
+function findSupervisorCycle(hats: ReadonlyMap<string, ReadonlyArray<string>>): string | undefined {
+  const WHITE = 0;
+  const GRAY = 1;
+  const BLACK = 2;
+  const color = new Map<string, number>();
+  for (const id of hats.keys()) color.set(id, WHITE);
+
+  const visit = (id: string): string | undefined => {
+    color.set(id, GRAY);
+    for (const next of hats.get(id) ?? []) {
+      if (!hats.has(next)) continue;
+      const c = color.get(next);
+      if (c === GRAY) return next; // back-edge → cycle
+      if (c === WHITE) {
+        const found = visit(next);
+        if (found) return found;
+      }
+    }
+    color.set(id, BLACK);
+    return undefined;
+  };
+
+  for (const id of hats.keys()) {
+    if (color.get(id) === WHITE) {
+      const found = visit(id);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
+
+/** 07-no-supervisor-cycles: deny a Hat create/update that would cycle the supervises DAG. */
+export const noSupervisorCyclesPolicy: AdmissionPolicy = {
+  name: "no-supervisor-cycles",
+  evaluate: (req) => {
+    if (req.operation !== "create-hat") return ALLOW;
+    const graph = new Map<string, ReadonlyArray<string>>();
+    for (const h of req.existingHats) graph.set(h.id, h.supervisesHatIds);
+    if (req.candidateHat) graph.set(req.candidateHat.id, req.candidateHat.supervisesHatIds);
+    const cycleNode = findSupervisorCycle(graph);
+    if (cycleNode) {
+      return {
+        outcome: "deny",
+        reason: `no-supervisor-cycles: supervises DAG cycles at ${cycleNode}`,
+        throttleName: "no-supervisor-cycles",
+      };
+    }
+    return ALLOW;
+  },
+};
+
+export const ADMISSION_POLICIES: readonly AdmissionPolicy[] = [
+  cooldownPolicy,
+  maxBindingsPolicy,
+  conflictOfInterestPolicy,
+  quorumPolicy,
+  warmupPolicy,
+  maxNewHatsPolicy,
+  noSupervisorCyclesPolicy,
+];
+
+/** Evaluate all admission policies in order; deny if ANY policy denies. */
+export function evaluateAdmission(request: AdmissionRequest, policy: HatPolicy): AdmissionDecision {
+  for (const p of ADMISSION_POLICIES) {
+    const result = p.evaluate(request, policy);
+    if (result.outcome === "deny") return result;
+  }
+  return ALLOW;
+}

--- a/agentic-organization/packages/application/src/hat-policy.ts
+++ b/agentic-organization/packages/application/src/hat-policy.ts
@@ -1,0 +1,41 @@
+/**
+ * HatPolicy — cluster-wide throttle defaults (singleton).
+ *
+ * Faithful port of
+ * `full-ai-cluster/k8s/applications/hat-system/crds/hatpolicy.yaml` (Merge1 §07).
+ * Per-Hat overrides live in `HatDefinition` (warmupSeconds / cooldownSeconds /
+ * quorumSize / conflictsWithHatIds / maxConcurrentAssignments).
+ */
+export interface HatPolicy {
+  readonly throttles: {
+    readonly cooldownSeconds: number; // default 300
+    readonly stickyAttributionSeconds: number; // default 600
+    readonly warmupSeconds: number; // default 180
+    readonly maxBindingsPerWearer: number; // default 3
+    readonly maxNewHatsPerDay: number; // default 5
+    readonly quorumDefaultSize: number; // default 3
+  };
+  readonly swapRetentionDays: number; // default 365
+  readonly tickEmit: {
+    readonly natsSubject: string; // default "zeta.society.hats.ticks"
+    readonly enableLokiStructuredLogs: boolean; // default true
+    readonly enableEvents: boolean; // default true
+  };
+}
+
+export const DEFAULT_HAT_POLICY: HatPolicy = {
+  throttles: {
+    cooldownSeconds: 300,
+    stickyAttributionSeconds: 600,
+    warmupSeconds: 180,
+    maxBindingsPerWearer: 3,
+    maxNewHatsPerDay: 5,
+    quorumDefaultSize: 3,
+  },
+  swapRetentionDays: 365,
+  tickEmit: {
+    natsSubject: "zeta.society.hats.ticks",
+    enableLokiStructuredLogs: true,
+    enableEvents: true,
+  },
+};

--- a/agentic-organization/packages/application/src/hat-status.ts
+++ b/agentic-organization/packages/application/src/hat-status.ts
@@ -1,0 +1,43 @@
+/**
+ * Hat status helpers — reputation accrual on the hat.
+ *
+ * Faithful port of the `Hat.status.reputation` semantics from the K8s Hat CRD
+ * (Merge1 §07 §3.6). Reputation accrues on the hat AND the pairings — never
+ * only the agent. Pure + immutable (returns a new `HatDefinition`).
+ */
+
+import type { HatDefinition, HatStatus } from "../../domain/src/hat-definition.ts";
+
+const EMPTY_STATUS: HatStatus = { reputation: 0, currentWearers: [], lifetimeWearers: 0 };
+
+/** Apply a reputation delta to a hat's status, returning a new hat. */
+export function updateHatReputation(hat: HatDefinition, delta: number): HatDefinition {
+  const current = hat.status ?? EMPTY_STATUS;
+  return {
+    ...hat,
+    status: { ...current, reputation: current.reputation + delta },
+  };
+}
+
+/** Record a new wearer taking the hat: appends to currentWearers, bumps lifetime. */
+export function recordWearerOn(hat: HatDefinition, wearerId: string): HatDefinition {
+  const current = hat.status ?? EMPTY_STATUS;
+  if (current.currentWearers.includes(wearerId)) return hat;
+  return {
+    ...hat,
+    status: {
+      ...current,
+      currentWearers: [...current.currentWearers, wearerId],
+      lifetimeWearers: current.lifetimeWearers + 1,
+    },
+  };
+}
+
+/** Record a wearer leaving the hat: removes from currentWearers (lifetime unchanged). */
+export function recordWearerOff(hat: HatDefinition, wearerId: string): HatDefinition {
+  const current = hat.status ?? EMPTY_STATUS;
+  return {
+    ...hat,
+    status: { ...current, currentWearers: current.currentWearers.filter((w) => w !== wearerId) },
+  };
+}

--- a/agentic-organization/packages/application/src/hat-swap-event.ts
+++ b/agentic-organization/packages/application/src/hat-swap-event.ts
@@ -1,0 +1,57 @@
+/**
+ * HatSwap — append-only tick event for a single hat-binding transition.
+ *
+ * Faithful port of
+ * `full-ai-cluster/k8s/applications/hat-system/crds/hatswap.yaml` (Merge1 §07).
+ * Immutable (MP-4 retraction-native): controllers WRITE one HatSwap per state
+ * transition and NEVER update an existing one. Room telemetry streams these via
+ * the §04 bus to NATS subject `zeta.society.hats.ticks`.
+ */
+
+/** The 7 HatSwap event types (hatswap.yaml `spec.event` enum). */
+export type HatSwapEvent =
+  | "SwapOn" // Binding created and Active
+  | "SwapOff" // Binding deleted or Revoked
+  | "WarmupBegin" // Probation entry
+  | "WarmupEnd" // Probation exit (Active)
+  | "Probation" // Anomaly-triggered authority drop
+  | "QuorumGrant" // Quorum signature collected
+  | "Throttled"; // Throttle denied a binding/swap
+
+export interface HatSwapBindingRef {
+  readonly name: string;
+  readonly namespace: string;
+  readonly uid: string;
+}
+
+export interface HatSwapPreviousWearer {
+  readonly spiffeID: string;
+  readonly revokedAt: string; // ISO-8601
+}
+
+/** A single append-only HatSwap record. */
+export interface HatSwap {
+  readonly id: string; // ZetaId
+  readonly hat: string;
+  readonly wearer: { readonly spiffeID: string };
+  readonly event: HatSwapEvent;
+  readonly occurredAt: string; // ISO-8601
+  readonly reason?: string; // short machine-readable code (e.g. "CooldownActive")
+  readonly message?: string; // human-readable detail
+  readonly bindingRef?: HatSwapBindingRef;
+  readonly throttleName?: string; // which throttle fired, if event === "Throttled"
+  readonly previousWearer?: HatSwapPreviousWearer; // for SwapOn — the prior holder, if any
+}
+
+/**
+ * Append a HatSwap to the event log. Returns a NEW array (append-only —
+ * never mutates an existing record, never reorders). MP-4 retraction-native.
+ */
+export function emitSwap(log: readonly HatSwap[], swap: HatSwap): readonly HatSwap[] {
+  return [...log, swap];
+}
+
+/** Construct a HatSwap record (all fields explicit; deterministic). */
+export function makeHatSwap(input: HatSwap): HatSwap {
+  return input;
+}

--- a/agentic-organization/packages/application/src/index.ts
+++ b/agentic-organization/packages/application/src/index.ts
@@ -1237,3 +1237,28 @@ export {
   type InitializationError,
   type ValidateInitializationResult,
 } from "./room-initialization.ts";
+export {
+  emitSwap,
+  makeHatSwap,
+  type HatSwapEvent,
+  type HatSwap,
+  type HatSwapBindingRef,
+  type HatSwapPreviousWearer,
+} from "./hat-swap-event.ts";
+export { DEFAULT_HAT_POLICY, type HatPolicy } from "./hat-policy.ts";
+export {
+  cooldownPolicy,
+  maxBindingsPolicy,
+  conflictOfInterestPolicy,
+  quorumPolicy,
+  warmupPolicy,
+  maxNewHatsPolicy,
+  noSupervisorCyclesPolicy,
+  ADMISSION_POLICIES,
+  evaluateAdmission,
+  type AdmissionOp,
+  type AdmissionRequest,
+  type AdmissionDecision,
+  type AdmissionPolicy,
+} from "./hat-admission.ts";
+export { updateHatReputation, recordWearerOn, recordWearerOff } from "./hat-status.ts";

--- a/agentic-organization/packages/application/test/merge1-hat-system.test.ts
+++ b/agentic-organization/packages/application/test/merge1-hat-system.test.ts
@@ -1,0 +1,280 @@
+import { equal, ok } from "node:assert/strict";
+import { test } from "node:test";
+
+import { HatBindingPhase, type HatBinding } from "../../domain/src/hat-binding.ts";
+import { HatLevel, RiskLevel, SuccessionPolicy, type HatDefinition } from "../../domain/src/hat-definition.ts";
+import { emitSwap, makeHatSwap, type HatSwap } from "../src/hat-swap-event.ts";
+import { DEFAULT_HAT_POLICY } from "../src/hat-policy.ts";
+import {
+  conflictOfInterestPolicy,
+  cooldownPolicy,
+  evaluateAdmission,
+  maxBindingsPolicy,
+  maxNewHatsPolicy,
+  noSupervisorCyclesPolicy,
+  quorumPolicy,
+  warmupPolicy,
+  type AdmissionRequest,
+} from "../src/hat-admission.ts";
+import { recordWearerOff, recordWearerOn, updateHatReputation } from "../src/hat-status.ts";
+
+const NOW = "2026-06-21T00:00:00.000Z";
+
+function hat(id: string, overrides: Partial<HatDefinition> = {}): HatDefinition {
+  return {
+    id,
+    name: id,
+    departmentId: "engineering",
+    level: HatLevel.IndividualContributor,
+    supervisesHatIds: [],
+    reportsToHatIds: [],
+    conflictsWithHatIds: [],
+    assignableByHatIds: [],
+    allowedToolBundles: [],
+    skills: [],
+    approvalScopes: [],
+    votingScopes: [],
+    memoryScopes: [],
+    credentialScopes: [],
+    documentationScopes: [],
+    lifecycleTransitions: [],
+    requiredEvidence: [],
+    maxConcurrentAssignments: 1,
+    tokenTtlSeconds: 3600,
+    warmupSeconds: 180,
+    cooldownSeconds: 300,
+    successionPolicy: SuccessionPolicy.Rotate,
+    stickyAttribution: false,
+    reputationScope: [],
+    riskLevel: RiskLevel.Low,
+    requiresTwoPersonApproval: false,
+    requiresHumanApproval: false,
+    ...overrides,
+  };
+}
+
+function binding(id: string, hatId: string, wearerAgentId: string, phase: HatBindingPhase): HatBinding {
+  return {
+    id,
+    hatId,
+    organizationId: "org-1",
+    wearerAgentId,
+    phase,
+    boundAt: NOW,
+    warmupEndsAt: NOW,
+    expiresAt: NOW,
+  };
+}
+
+function baseRequest(over: Partial<AdmissionRequest>): AdmissionRequest {
+  return {
+    operation: "create-binding",
+    hatId: "hat-1",
+    wearerId: "agent-a",
+    nowIso: NOW,
+    existingBindings: [],
+    existingHats: [],
+    recentSwaps: [],
+    ...over,
+  };
+}
+
+// --- §6.1 cooldown ----------------------------------------------------------
+
+test("cooldown rejects re-binding within cooldownSeconds", () => {
+  const recentSwaps: HatSwap[] = [
+    {
+      id: "1",
+      hat: "hat-1",
+      wearer: { spiffeID: "agent-a" },
+      event: "SwapOff",
+      occurredAt: "2026-06-20T23:58:20.000Z", // 100s before NOW < 300s cooldown
+      previousWearer: { spiffeID: "agent-a", revokedAt: "" },
+    },
+  ];
+  const result = cooldownPolicy.evaluate(baseRequest({ recentSwaps }), DEFAULT_HAT_POLICY);
+  equal(result.outcome, "deny");
+});
+
+test("cooldown allows re-binding after cooldownSeconds elapse", () => {
+  const recentSwaps: HatSwap[] = [
+    {
+      id: "1",
+      hat: "hat-1",
+      wearer: { spiffeID: "agent-a" },
+      event: "SwapOff",
+      occurredAt: "2026-06-20T23:00:00.000Z", // 3600s before NOW > 300s
+      previousWearer: { spiffeID: "agent-a", revokedAt: "" },
+    },
+  ];
+  const result = cooldownPolicy.evaluate(baseRequest({ recentSwaps }), DEFAULT_HAT_POLICY);
+  equal(result.outcome, "allow");
+});
+
+// --- §6 max-bindings / conflict / quorum / warmup / max-new-hats -----------
+
+test("max-bindings rejects a wearer at the cap", () => {
+  const existingBindings = [
+    binding("b1", "hat-x", "agent-a", HatBindingPhase.Active),
+    binding("b2", "hat-y", "agent-a", HatBindingPhase.Active),
+    binding("b3", "hat-z", "agent-a", HatBindingPhase.Warmup),
+  ];
+  const result = maxBindingsPolicy.evaluate(baseRequest({ existingBindings }), DEFAULT_HAT_POLICY);
+  equal(result.outcome, "deny");
+});
+
+test("max-bindings ignores terminal bindings", () => {
+  const existingBindings = [
+    binding("b1", "hat-x", "agent-a", HatBindingPhase.Revoked),
+    binding("b2", "hat-y", "agent-a", HatBindingPhase.Expired),
+    binding("b3", "hat-z", "agent-a", HatBindingPhase.Released),
+  ];
+  const result = maxBindingsPolicy.evaluate(baseRequest({ existingBindings }), DEFAULT_HAT_POLICY);
+  equal(result.outcome, "allow");
+});
+
+test("conflict-of-interest rejects holding a conflicting hat", () => {
+  const target = hat("hat-1", { conflictsWithHatIds: ["hat-rival"] });
+  const existingBindings = [binding("b1", "hat-rival", "agent-a", HatBindingPhase.Active)];
+  const result = conflictOfInterestPolicy.evaluate(
+    baseRequest({ existingHats: [target], existingBindings }),
+    DEFAULT_HAT_POLICY,
+  );
+  equal(result.outcome, "deny");
+});
+
+test("quorum rejects a gated hat without enough cosignatures", () => {
+  const target = hat("hat-1", { quorumSize: 3 });
+  const result = quorumPolicy.evaluate(baseRequest({ existingHats: [target], cosignerCount: 1 }), DEFAULT_HAT_POLICY);
+  equal(result.outcome, "deny");
+});
+
+test("quorum allows a gated hat with enough cosignatures", () => {
+  const target = hat("hat-1", { quorumSize: 3 });
+  const result = quorumPolicy.evaluate(baseRequest({ existingHats: [target], cosignerCount: 3 }), DEFAULT_HAT_POLICY);
+  equal(result.outcome, "allow");
+});
+
+test("warmup rejects promotion to Active before warmup completes", () => {
+  const result = warmupPolicy.evaluate(
+    baseRequest({ operation: "promote-active", warmupEndsAt: "2026-06-21T00:01:00.000Z" }),
+    DEFAULT_HAT_POLICY,
+  );
+  equal(result.outcome, "deny");
+});
+
+test("max-new-hats rejects exceeding the 24h novelty budget", () => {
+  const recentHatCreations = [
+    "2026-06-20T23:00:00.000Z",
+    "2026-06-20T22:00:00.000Z",
+    "2026-06-20T21:00:00.000Z",
+    "2026-06-20T20:00:00.000Z",
+    "2026-06-20T19:00:00.000Z",
+  ];
+  const result = maxNewHatsPolicy.evaluate(
+    baseRequest({ operation: "create-hat", recentHatCreations }),
+    DEFAULT_HAT_POLICY,
+  );
+  equal(result.outcome, "deny");
+});
+
+// --- §6.2 no supervisor cycles ---------------------------------------------
+
+test("no-supervisor-cycles rejects a supervises cycle", () => {
+  const a = hat("A", { supervisesHatIds: ["B"] });
+  const b = hat("B", { supervisesHatIds: ["A"] }); // cycle!
+  const result = noSupervisorCyclesPolicy.evaluate(
+    baseRequest({ operation: "create-hat", existingHats: [a], candidateHat: b }),
+    DEFAULT_HAT_POLICY,
+  );
+  equal(result.outcome, "deny");
+});
+
+test("no-supervisor-cycles allows an acyclic DAG", () => {
+  const a = hat("A", { supervisesHatIds: ["B"] });
+  const b = hat("B", { supervisesHatIds: ["C"] });
+  const c = hat("C", { supervisesHatIds: [] });
+  const result = noSupervisorCyclesPolicy.evaluate(
+    baseRequest({ operation: "create-hat", existingHats: [a, b], candidateHat: c }),
+    DEFAULT_HAT_POLICY,
+  );
+  equal(result.outcome, "allow");
+});
+
+// --- evaluateAdmission composition -----------------------------------------
+
+test("evaluateAdmission denies if any policy denies (cooldown wins)", () => {
+  const recentSwaps: HatSwap[] = [
+    {
+      id: "1",
+      hat: "hat-1",
+      wearer: { spiffeID: "agent-a" },
+      event: "SwapOff",
+      occurredAt: "2026-06-20T23:58:20.000Z",
+      previousWearer: { spiffeID: "agent-a", revokedAt: "" },
+    },
+  ];
+  const result = evaluateAdmission(baseRequest({ recentSwaps }), DEFAULT_HAT_POLICY);
+  ok(result.outcome === "deny");
+  equal(result.throttleName, "cooldown");
+});
+
+test("evaluateAdmission allows a clean request", () => {
+  const result = evaluateAdmission(baseRequest({}), DEFAULT_HAT_POLICY);
+  equal(result.outcome, "allow");
+});
+
+// --- §6.3 HatSwap append-only ----------------------------------------------
+
+test("HatSwap events are append-only", () => {
+  let log: readonly HatSwap[] = [];
+  log = emitSwap(log, makeHatSwap({ id: "s1", hat: "hat-1", wearer: { spiffeID: "agent-a" }, event: "SwapOn", occurredAt: NOW }));
+  log = emitSwap(log, makeHatSwap({ id: "s2", hat: "hat-1", wearer: { spiffeID: "agent-a" }, event: "SwapOff", occurredAt: NOW }));
+  equal(log.length, 2);
+  equal(log[0]!.event, "SwapOn");
+  equal(log[1]!.event, "SwapOff");
+});
+
+test("emitSwap does not mutate the prior log (retraction-native)", () => {
+  const log0: readonly HatSwap[] = [];
+  const log1 = emitSwap(log0, makeHatSwap({ id: "s1", hat: "h", wearer: { spiffeID: "a" }, event: "SwapOn", occurredAt: NOW }));
+  equal(log0.length, 0);
+  equal(log1.length, 1);
+});
+
+// --- §6.4 reputation accrual -----------------------------------------------
+
+test("reputation accrues on the hat", () => {
+  const h = hat("hat-1", { status: { reputation: 10, currentWearers: [], lifetimeWearers: 1 } });
+  const updated = updateHatReputation(h, 5);
+  equal(updated.status?.reputation, 15);
+});
+
+test("reputation works on a hat with no prior status", () => {
+  const updated = updateHatReputation(hat("hat-1"), 7);
+  equal(updated.status?.reputation, 7);
+});
+
+test("recordWearerOn / recordWearerOff track current wearers + lifetime", () => {
+  let h = recordWearerOn(hat("hat-1"), "agent-a");
+  equal(h.status?.currentWearers.length, 1);
+  equal(h.status?.lifetimeWearers, 1);
+  h = recordWearerOn(h, "agent-b");
+  equal(h.status?.currentWearers.length, 2);
+  equal(h.status?.lifetimeWearers, 2);
+  h = recordWearerOff(h, "agent-a");
+  equal(h.status?.currentWearers.length, 1);
+  equal(h.status?.lifetimeWearers, 2); // lifetime never decreases
+});
+
+// --- §6.5 DST replay of admission ------------------------------------------
+
+test("admission evaluation is deterministic (same inputs → identical decision)", () => {
+  const req = baseRequest({
+    existingBindings: [binding("b1", "hat-x", "agent-a", HatBindingPhase.Active)],
+    existingHats: [hat("hat-1", { conflictsWithHatIds: ["hat-rival"] })],
+  });
+  const r1 = evaluateAdmission(req, DEFAULT_HAT_POLICY);
+  const r2 = evaluateAdmission(req, DEFAULT_HAT_POLICY);
+  equal(JSON.stringify(r1), JSON.stringify(r2));
+});

--- a/agentic-organization/packages/domain/src/hat-definition.ts
+++ b/agentic-organization/packages/domain/src/hat-definition.ts
@@ -93,6 +93,17 @@ export const ReputationScope = {
 
 export type ReputationScope = (typeof ReputationScope)[keyof typeof ReputationScope];
 
+/**
+ * Hat.status — observed runtime state of a hat (port of the K8s Hat CRD
+ * `status` block, Merge1 §07). Reputation accrues on the hat (and pairings),
+ * never only the agent.
+ */
+export type HatStatus = {
+  reputation: number;
+  currentWearers: readonly string[];
+  lifetimeWearers: number;
+};
+
 export type HatDefinition = {
   id: string;
   name: string;
@@ -126,4 +137,6 @@ export type HatDefinition = {
   riskLevel: RiskLevel;
   requiresTwoPersonApproval: boolean;
   requiresHumanApproval: boolean;
+  /** observed runtime state (K8s Hat CRD `status`, Merge1 §07) */
+  status?: HatStatus;
 };


### PR DESCRIPTION
## Summary

Faithful port of Merge1 §07 (K8s Hat-System) from
`full-ai-cluster/k8s/applications/hat-system/` into the `agentic-organization`
package. Lands the HatSwap append-only tick events, the cluster-wide HatPolicy
singleton, the 7 OPA Gatekeeper throttles as pure deterministic admission
policies, and hat-status reputation accrual. Same new-modules-first precedent as
§01/§02/§04/§05 (the deeper domain-type restructure is deferred — see below).

New modules (`packages/application/src/`):

- **`hat-swap-event.ts`** — the 7 `HatSwapEvent` types (`SwapOn`/`SwapOff`/
  `WarmupBegin`/`WarmupEnd`/`Probation`/`QuorumGrant`/`Throttled`) + the `HatSwap`
  record. `emitSwap(log, swap)` is append-only (`[...log, swap]`, never mutates/
  reorders) per MP-4 — controllers WRITE one per transition and never UPDATE.

- **`hat-policy.ts`** — `HatPolicy` + `DEFAULT_HAT_POLICY` (cooldown 300s, sticky
  600s, warmup 180s, maxBindings 3, maxNewHats/day 5, quorum 3, retention 365d,
  NATS subject `zeta.society.hats.ticks`) — direct port of `hatpolicy.yaml`.

- **`hat-admission.ts`** — the 7 OPA Rego throttles re-expressed as pure
  `AdmissionPolicy` functions over `(AdmissionRequest, HatPolicy)`:
  ```
  01 cooldown               recent SwapOff for hat+wearer within cooldownSeconds
  02 max-bindings           wearer's non-terminal bindings >= maxBindingsPerWearer
  03 conflict-of-interest   wearer holds a hat in target.conflictsWithHatIds
  04 quorum                 quorum-gated hat with cosignerCount < quorumSize
  05 warmup                 promote-active before warmupEndsAt
  06 max-new-hats           >= maxNewHatsPerDay hats created in the 24h window
  07 no-supervisor-cycles   3-color DFS over the supervises DAG (existing ∪ candidate)
  ```
  `evaluateAdmission` runs all 7 and denies if any denies. **Time arithmetic uses
  the request's `nowIso`, never `Date.now()`**, so admission replays
  deterministically under DST (MP-1). Decisions are `{ outcome: "allow" } |
  { outcome: "deny"; reason; throttleName }` discriminated unions (MP-7).
  Reuses the existing domain `HatDefinition`/`HatBinding` (which already carry
  `conflictsWithHatIds` / `supervisesHatIds` / `quorumSize` / `isTerminalHatBinding`).

- **`hat-status.ts`** — `updateHatReputation` (accrues on the hat, not only the
  agent) + `recordWearerOn`/`recordWearerOff` (lifetime never decreases); all
  immutable.

Domain (`packages/domain/src/hat-definition.ts`): `HatDefinition` gains an
**optional** `status?: HatStatus` field (`{ reputation, currentWearers,
lifetimeWearers }`) — purely additive, no existing call site reads it.

EXTENDs: `index.ts` re-exports the §07 surface.

**Deferred (integration polish, same precedent as prior sections):** the §07
doc's deeper restructure of `hat-binding.ts` (structured SPIFFE `wearer`,
`cosignedBy[]`, `effectiveAuthority`, `stickyAttributionEndsAt`) and the merge of
the admission policies *into* `hat-guardrails.ts`. The admission policies model
SPIFFE identity via the existing `wearerAgentId` string (opaque id), so behavior
is faithful without the binding-type churn.

## Tests

`packages/application/test/merge1-hat-system.test.ts` — 19 tests: cooldown
(deny inside window / allow after), max-bindings (cap hit / terminal ignored),
conflict-of-interest, quorum (deny/allow), warmup promotion gate, max-new-hats
24h budget, no-supervisor-cycles (cycle denied / DAG allowed), `evaluateAdmission`
composition (cooldown wins, clean allow), HatSwap append-only + non-mutation,
reputation accrual (with/without prior status), wearer on/off lifecycle, and a
DST determinism check.

Verification: `npm run typecheck` clean (6 pre-existing integration errors
untouched); `npm test` → **1554 pass / 0 fail / 7 skipped** (19 new).


Link to Devin session: https://app.devin.ai/sessions/77dac2be40e34088b799b6f1d927dbe3
Requested by: @maximdolphin