### PR TITLE
fix(keys): cert Key ID = machine alone (N+M), not user@machine (N×M)

### DIFF
--- a/tools/setup/persona-keys/ca.test.ts
+++ b/tools/setup/persona-keys/ca.test.ts
@@ -5,8 +5,11 @@
 //
 // PURE-KEY MODEL (Aaron 2026-06-21): the device PUBLIC key signed here is a PURE machine key
 // (host-only label, read from the USER-INDEPENDENT registry `machines/<host>.pub`). THIS cert
-// is the ONLY place the (user × machine) pair is named: `principal=<user>` (`-n`) + a
-// `<user>@<host>` cert IDENTITY (`-I`). The machine key itself carries NO `user@`.
+// is the ONLY place the (user × machine) pair is named — but the pair lives in the PRINCIPAL,
+// not the Key ID: `principal=<user>` (`-n`) carries the user; the cert IDENTITY / Key ID (`-I`)
+// is the `<host>` ALONE (NOT `<user>@<host>` — that composite is the N×M smell, Aaron 2026-06-21).
+// One cert per machine (Key ID=host, principals=authorized users) ⇒ O(N+M). The machine key
+// itself also carries NO `user@`.
 //
 // SECURITY (matched to ca.ts invariants):
 //  * a test asserts NO module output ever matches /PRIVATE KEY/ (the private-leak guard);
@@ -220,7 +223,7 @@ test("cert --dry-run: signs NOTHING when CA + device key present, reports would-
     });
     expect(r.dryRun).toBe(true);
     expect(r.action).toBe("would-sign");
-    expect(r.certId).toBe("tester@mymac");
+    expect(r.certId).toBe("mymac"); // Key ID = machine ALONE (N+M); NOT "tester@mymac" (N×M)
     expect(r.principal).toBe("tester");
     expect(r.validity).toBe(DEFAULT_CERT_VALIDITY);
     expect(signCount.n).toBe(0); // nothing signed
@@ -419,11 +422,12 @@ test("REAL ssh-keygen: throwaway CA signs a throwaway device key; cert verifies 
     expect(existsSync(certRes.certPath)).toBe(true);
 
     // 4. Verify the cert with `ssh-keygen -L` — the (user × machine) binding lives HERE:
-    //    principal=<user> (-n) + a <user>@<host> identity (-I), signed over the PURE machine key.
+    //    principal=<user> (-n) + a <host> Key ID (-I) — NOT <user>@<host>, signed over the PURE machine key.
     const show = spawnSync("ssh-keygen", ["-L", "-f", certRes.certPath], { encoding: "utf8" });
     expect(show.status).toBe(0);
-    expect(show.stdout).toContain("tester@mymac"); // the cert identity (-I) — the pairing
-    expect(show.stdout).toContain("tester"); // the principal (-n) — trust anchored at the user
+    expect(show.stdout).toContain('Key ID: "mymac"'); // the cert identity (-I) = machine ALONE (N+M), NOT user@machine
+    expect(show.stdout).toContain("tester"); // the principal (-n) — the user×machine pairing lives HERE, not in the Key ID
+    expect(show.stdout).not.toContain("tester@mymac"); // guard: the N×M composite Key ID must NOT reappear
     // The cert file is PUBLIC — never carries a private marker.
     expect(readFileSync(certRes.certPath, "utf8")).not.toMatch(new RegExp(PRIV_MARKER));
   } finally {

--- a/tools/setup/persona-keys/ca.ts
+++ b/tools/setup/persona-keys/ca.ts
@@ -281,7 +281,13 @@ export async function signMachineCert(
 ): Promise<CertResult> {
   const caPrivatePath = opts.home === undefined ? caPrivateKeyPath() : caPrivateKeyPath(opts.home);
   const validity = opts.validity ?? DEFAULT_CERT_VALIDITY;
-  const certId = `${opts.user}@${opts.machineId}`;
+  // Key ID names the certified SUBJECT = the machine key, so it is the machine id ALONE — NOT
+  // `user@machine`. A composite user×machine Key ID is the N×M smell (Aaron, 2026-06-21; same
+  // shape as the #8926 hybrid-key error): it would mint a distinct cert per (user, machine) pair
+  // → O(N×M) certs. The user binding lives in the PRINCIPAL (`-n`, below), so one cert per machine
+  // (Key ID = machine, principals = authorized user(s)) keeps it O(N+M). Multi-user on a shared
+  // box = re-sign the one machine cert with more principals (still one cert per machine).
+  const certId = opts.machineId;
   const outPath = certPath(opts.devicePubPath);
   const dryRun = opts.dryRun === true;
 
@@ -310,7 +316,7 @@ export async function signMachineCert(
   // BIOMETRIC GATE — fail-closed. A real sign consumes the CA private key; require approval.
   const biometric = await requireBiometric(
     opts.biometricAuth,
-    `Approve: sign cert for ${opts.user}@${opts.machineId} (principal=${opts.user})`,
+    `Approve: sign cert for machine ${opts.machineId} (principal=${opts.user})`,
   );
   if (!biometric.ok) {
     return { ...base, dryRun: false, action: "aborted-biometric", biometric };


### PR DESCRIPTION
Aaron caught: the cert Key ID was `aaron@acehacks-mac-studio.local` — composite user×machine = N×M smell (same shape as #8926). Fix: `certId = opts.machineId` (Key ID = host alone); the user binding stays in the principal (`-n`). One cert per machine (Key ID=host, principals=users) ⇒ O(N+M). Tests updated to expect the machine-only Key ID + a guard against the composite reappearing. 21/0, lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)