### PR TITLE
feat(agentic-org): Merge1 §06 — port formal verification to TypeScript

### DIFF
--- a/agentic-organization/packages/application/src/formal-verification-port.ts
+++ b/agentic-organization/packages/application/src/formal-verification-port.ts
@@ -1,0 +1,87 @@
+/**
+ * Formal-verification seam — TLA+/TLC + Alloy model-checker port.
+ *
+ * Faithful port of `src/Core.TypeScript/formal-verification/run-tlc.ts`
+ * (Merge1 §06). The room gains an optional `formalVerification` seam: real =
+ * shell to TLC/Alloy; mock = cached/pass results for DST replay (MP-1). All
+ * outcomes are discriminated-union Results (MP-7), never exceptions.
+ */
+
+/** The curated TLA+ spec catalogue (port of run-tlc.ts CATALOGUE). */
+export const CATALOGUE: readonly string[] = [
+  "SmokeCheck",
+  "TickMonotonicity",
+  "OperatorLifecycleRace",
+  "TransactionInterleaving",
+  "TwoPCSink",
+  "InfoTheoreticSharder",
+  "RecursiveCountingLFP",
+  "FeatureFlagsResolution",
+  "SocietyEmergence",
+  "SocietyRuntimeRefinement",
+  "DbspSpec",
+  "CircuitRegistration",
+  "SpineAsyncProtocol",
+];
+
+/**
+ * TLC exit-code taxonomy (run-tlc.ts `ExitCode`):
+ *   0 success · 1 invariant violation · 2 toolchain error · 3 usage error.
+ */
+export type TlaVerificationResult =
+  | { readonly outcome: "pass"; readonly specName: string; readonly durationMs: number }
+  | { readonly outcome: "fail"; readonly specName: string; readonly invariant: string; readonly counterexample: string }
+  | { readonly outcome: "toolchain_error"; readonly reason: string }
+  | { readonly outcome: "usage_error"; readonly reason: string };
+
+export type AlloyVerificationResult =
+  | { readonly outcome: "pass"; readonly modelName: string; readonly durationMs: number }
+  | { readonly outcome: "fail"; readonly modelName: string; readonly counterexample: string }
+  | { readonly outcome: "toolchain_error"; readonly reason: string };
+
+export type ToolchainStatus =
+  | { readonly ready: true; readonly javaVersion: string; readonly tlaVersion: string }
+  | { readonly ready: false; readonly reason: string };
+
+/** The room's formal-verification seam. */
+export interface FormalVerificationPort {
+  /** Run TLA+/TLC on a spec. */
+  runTla(specName: string): Promise<TlaVerificationResult>;
+  /** Run Alloy on a model. */
+  runAlloy(modelName: string): Promise<AlloyVerificationResult>;
+  /** Check toolchain readiness (java + tla2tools.jar). */
+  checkToolchain(): Promise<ToolchainStatus>;
+  /** List available specs in the catalogue. */
+  listSpecs(): readonly string[];
+}
+
+/**
+ * Mock formal-verification port for DST. Deterministic: same inputs → same
+ * outputs (no clock, no spawn). A spec not present in `cachedResults` passes
+ * with `durationMs: 0`. Unknown specs (not in the catalogue) surface a
+ * `usage_error` so a catalogue drift is caught.
+ */
+export function createMockFormalVerification(
+  cachedResults?: ReadonlyMap<string, TlaVerificationResult>,
+): FormalVerificationPort {
+  const known = new Set(CATALOGUE);
+  return {
+    runTla(specName: string): Promise<TlaVerificationResult> {
+      const cached = cachedResults?.get(specName);
+      if (cached) return Promise.resolve(cached);
+      if (!known.has(specName)) {
+        return Promise.resolve({ outcome: "usage_error", reason: `unknown spec: ${specName}` });
+      }
+      return Promise.resolve({ outcome: "pass", specName, durationMs: 0 });
+    },
+    runAlloy(modelName: string): Promise<AlloyVerificationResult> {
+      return Promise.resolve({ outcome: "pass", modelName, durationMs: 0 });
+    },
+    checkToolchain(): Promise<ToolchainStatus> {
+      return Promise.resolve({ ready: true, javaVersion: "mock", tlaVersion: "mock" });
+    },
+    listSpecs(): readonly string[] {
+      return [...CATALOGUE];
+    },
+  };
+}

--- a/agentic-organization/packages/application/src/index.ts
+++ b/agentic-organization/packages/application/src/index.ts
@@ -1237,3 +1237,29 @@ export {
   type InitializationError,
   type ValidateInitializationResult,
 } from "./room-initialization.ts";
+export {
+  CATALOGUE,
+  createMockFormalVerification,
+  type FormalVerificationPort,
+  type TlaVerificationResult,
+  type AlloyVerificationResult,
+  type ToolchainStatus,
+} from "./formal-verification-port.ts";
+export {
+  finiteSocietyClosureCertificate,
+  validateFiniteSocietyClosureCertificate,
+  type DirectedEdge,
+  type FiniteSocietyClosureStep,
+  type FiniteSocietyClosureCertificate,
+  type FiniteSocietyClosureValidation,
+} from "./society-closure-certificate.ts";
+export {
+  evaluateSoakGate,
+  DEFAULT_MIN_TICKS,
+  DEFAULT_MIN_SOAK_MS,
+  DEFAULT_REQUIRED_SPECS,
+  DEFAULT_SOAK_GATE_CRITERIA,
+  type SoakGateCriteria,
+  type SoakGateInput,
+  type SoakGateResult,
+} from "./review-gate-soak.ts";

--- a/agentic-organization/packages/application/src/review-gate-soak.ts
+++ b/agentic-organization/packages/application/src/review-gate-soak.ts
@@ -1,0 +1,88 @@
+/**
+ * Soak review gate — promotion gate requiring ≥100 ticks / ≥24h soak plus
+ * required TLA+ specs and (when federated) a society-closure certificate.
+ *
+ * Faithful port of the Merge1 §06 review-gate upgrade. Pure + deterministic
+ * (MP-1): the caller supplies `ticksSurvived` / `soakMs` / spec results, so the
+ * gate replays identically. Result-shaped decision (MP-7).
+ */
+
+import type { TlaVerificationResult } from "./formal-verification-port.ts";
+import {
+  validateFiniteSocietyClosureCertificate,
+  type FiniteSocietyClosureCertificate,
+} from "./society-closure-certificate.ts";
+
+export const DEFAULT_MIN_TICKS = 100;
+export const DEFAULT_MIN_SOAK_MS = 86_400_000; // 24h
+export const DEFAULT_REQUIRED_SPECS: readonly string[] = ["SocietyEmergence", "SocietyRuntimeRefinement"];
+
+export type SoakGateCriteria = {
+  /** Minimum ticks the room must survive before promotion. */
+  readonly minTicks: number;
+  /** Minimum wall-clock duration before promotion. */
+  readonly minSoakMs: number;
+  /** TLA+ specs that must pass. */
+  readonly requiredSpecs: readonly string[];
+};
+
+export const DEFAULT_SOAK_GATE_CRITERIA: SoakGateCriteria = {
+  minTicks: DEFAULT_MIN_TICKS,
+  minSoakMs: DEFAULT_MIN_SOAK_MS,
+  requiredSpecs: DEFAULT_REQUIRED_SPECS,
+};
+
+export type SoakGateInput = {
+  readonly ticksSurvived: number;
+  readonly soakMs: number;
+  readonly criteria: SoakGateCriteria;
+  /** TLA+ results keyed by spec name (e.g. from a FormalVerificationPort). */
+  readonly specResults?: ReadonlyMap<string, TlaVerificationResult>;
+  /** Society-closure certificate, required only when the room is federated. */
+  readonly closureCertificate?: FiniteSocietyClosureCertificate;
+};
+
+export type SoakGateResult =
+  | {
+      readonly outcome: "promoted";
+      readonly criteria: SoakGateCriteria;
+      readonly ticksSurvived: number;
+      readonly soakMs: number;
+    }
+  | { readonly outcome: "blocked"; readonly reason: string; readonly missingCriteria: readonly string[] };
+
+/** Evaluate the soak gate. Promotes only when EVERY criterion is met. */
+export function evaluateSoakGate(input: SoakGateInput): SoakGateResult {
+  const missing: string[] = [];
+
+  if (input.ticksSurvived < input.criteria.minTicks) {
+    missing.push(`ticks ${input.ticksSurvived} < ${input.criteria.minTicks}`);
+  }
+  if (input.soakMs < input.criteria.minSoakMs) {
+    missing.push(`soak ${input.soakMs}ms < ${input.criteria.minSoakMs}ms`);
+  }
+  for (const spec of input.criteria.requiredSpecs) {
+    const result = input.specResults?.get(spec);
+    if (!result) {
+      missing.push(`spec ${spec}: not run`);
+    } else if (result.outcome !== "pass") {
+      missing.push(`spec ${spec}: ${result.outcome}`);
+    }
+  }
+  if (input.closureCertificate) {
+    const validation = validateFiniteSocietyClosureCertificate(input.closureCertificate);
+    if (!validation.ok) {
+      missing.push(`closure certificate invalid: ${validation.reason}`);
+    }
+  }
+
+  if (missing.length > 0) {
+    return { outcome: "blocked", reason: missing.join("; "), missingCriteria: missing };
+  }
+  return {
+    outcome: "promoted",
+    criteria: input.criteria,
+    ticksSurvived: input.ticksSurvived,
+    soakMs: input.soakMs,
+  };
+}

--- a/agentic-organization/packages/application/src/society-closure-certificate.ts
+++ b/agentic-organization/packages/application/src/society-closure-certificate.ts
@@ -1,0 +1,109 @@
+/**
+ * Finite-society closure certificate.
+ *
+ * Faithful port of `tools/formal-verification/society-finite-closure.ts`
+ * (Merge1 §06). Proves that a finite society of N agents forms a complete graph
+ * via pairwise bidirectional relations: for each unordered pair {a, b} the
+ * federation adds the two directed edges a->b and b->a. After all C(N,2) pairs
+ * are processed the graph has N*(N-1) directed edges — the formal guarantee
+ * behind "harmonious division" (aperiodic proximity, full connectivity).
+ *
+ * Pure + deterministic (MP-1). Validation is Result-shaped (MP-7).
+ */
+
+export type DirectedEdge = `${string}->${string}`;
+
+export type FiniteSocietyClosureStep = {
+  readonly pair: readonly [string, string];
+  readonly addedEdges: readonly [DirectedEdge, DirectedEdge];
+  readonly edgeCountAfter: number;
+};
+
+export type FiniteSocietyClosureCertificate = {
+  readonly agents: readonly string[];
+  readonly unorderedPairCount: number;
+  readonly steps: readonly FiniteSocietyClosureStep[];
+  readonly finalEdges: readonly DirectedEdge[];
+};
+
+export type FiniteSocietyClosureValidation =
+  | {
+      readonly ok: true;
+      readonly agentCount: number;
+      readonly unorderedPairCount: number;
+      readonly directedEdgeCount: number;
+    }
+  | { readonly ok: false; readonly reason: string };
+
+function directedEdge(from: string, to: string): DirectedEdge {
+  return `${from}->${to}`;
+}
+
+/** C(n, 2) = n*(n-1)/2 — the number of unordered pairs of n agents. */
+function unorderedPairs(n: number): number {
+  return (n * (n - 1)) / 2;
+}
+
+/**
+ * Build the closure certificate for a finite society. Agents are deduplicated
+ * (preserving first-seen order) so the certificate is canonical. Each unordered
+ * pair contributes one step adding its two directed edges, in a deterministic
+ * lexicographic-by-index order.
+ */
+export function finiteSocietyClosureCertificate(
+  agents: readonly string[],
+): FiniteSocietyClosureCertificate {
+  const unique: string[] = [];
+  const seen = new Set<string>();
+  for (const a of agents) {
+    if (!seen.has(a)) {
+      seen.add(a);
+      unique.push(a);
+    }
+  }
+
+  const steps: FiniteSocietyClosureStep[] = [];
+  const finalEdges: DirectedEdge[] = [];
+  for (let i = 0; i < unique.length; i++) {
+    for (let j = i + 1; j < unique.length; j++) {
+      const a = unique[i]!;
+      const b = unique[j]!;
+      const addedEdges: readonly [DirectedEdge, DirectedEdge] = [directedEdge(a, b), directedEdge(b, a)];
+      finalEdges.push(addedEdges[0], addedEdges[1]);
+      steps.push({ pair: [a, b], addedEdges, edgeCountAfter: finalEdges.length });
+    }
+  }
+
+  return {
+    agents: unique,
+    unorderedPairCount: unorderedPairs(unique.length),
+    steps,
+    finalEdges,
+  };
+}
+
+/**
+ * Validate a closure certificate: the pair count, step count, and directed-edge
+ * count must all be internally consistent with a complete bidirectional graph.
+ */
+export function validateFiniteSocietyClosureCertificate(
+  certificate: FiniteSocietyClosureCertificate,
+): FiniteSocietyClosureValidation {
+  const n = certificate.agents.length;
+  const expectedPairs = unorderedPairs(n);
+  if (certificate.unorderedPairCount !== expectedPairs) {
+    return { ok: false, reason: `unorderedPairCount ${certificate.unorderedPairCount} != C(${n},2)=${expectedPairs}` };
+  }
+  if (certificate.steps.length !== expectedPairs) {
+    return { ok: false, reason: `steps ${certificate.steps.length} != ${expectedPairs}` };
+  }
+  const expectedEdges = n * (n - 1);
+  if (certificate.finalEdges.length !== expectedEdges) {
+    return { ok: false, reason: `finalEdges ${certificate.finalEdges.length} != ${expectedEdges}` };
+  }
+  const distinct = new Set(certificate.finalEdges);
+  if (distinct.size !== expectedEdges) {
+    return { ok: false, reason: `finalEdges contains duplicates (${distinct.size} distinct of ${expectedEdges})` };
+  }
+  return { ok: true, agentCount: n, unorderedPairCount: expectedPairs, directedEdgeCount: expectedEdges };
+}

--- a/agentic-organization/packages/application/test/merge1-formal-verification.test.ts
+++ b/agentic-organization/packages/application/test/merge1-formal-verification.test.ts
@@ -1,0 +1,163 @@
+import { deepEqual, equal, ok } from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  CATALOGUE,
+  createMockFormalVerification,
+  type TlaVerificationResult,
+} from "../src/formal-verification-port.ts";
+import {
+  finiteSocietyClosureCertificate,
+  validateFiniteSocietyClosureCertificate,
+} from "../src/society-closure-certificate.ts";
+import {
+  DEFAULT_MIN_SOAK_MS,
+  DEFAULT_MIN_TICKS,
+  evaluateSoakGate,
+  type SoakGateCriteria,
+} from "../src/review-gate-soak.ts";
+
+// --- §6.1 society closure certificate --------------------------------------
+
+test("3 agents → 3 pairs → 6 directed edges", () => {
+  const cert = finiteSocietyClosureCertificate(["a", "b", "c"]);
+  equal(cert.unorderedPairCount, 3);
+  equal(cert.finalEdges.length, 6);
+  equal(cert.steps.length, 3);
+  const validation = validateFiniteSocietyClosureCertificate(cert);
+  equal(validation.ok, true);
+});
+
+test("closure certificate edges are bidirectional + distinct", () => {
+  const cert = finiteSocietyClosureCertificate(["a", "b"]);
+  deepEqual([...cert.finalEdges].sort(), ["a->b", "b->a"]);
+  equal(new Set(cert.finalEdges).size, 2);
+});
+
+test("closure certificate deduplicates agents (canonical)", () => {
+  const cert = finiteSocietyClosureCertificate(["a", "b", "a", "c", "b"]);
+  deepEqual(cert.agents, ["a", "b", "c"]);
+  equal(cert.unorderedPairCount, 3);
+});
+
+test("singleton / empty society has no edges", () => {
+  equal(finiteSocietyClosureCertificate(["a"]).finalEdges.length, 0);
+  equal(finiteSocietyClosureCertificate([]).finalEdges.length, 0);
+});
+
+test("validation rejects a tampered edge count", () => {
+  const cert = finiteSocietyClosureCertificate(["a", "b", "c"]);
+  const tampered = { ...cert, finalEdges: cert.finalEdges.slice(0, 4) };
+  const validation = validateFiniteSocietyClosureCertificate(tampered);
+  ok(validation.ok === false);
+});
+
+// --- §6.2 mock formal verification (DST) -----------------------------------
+
+test("mock FV port is deterministic", async () => {
+  const fv = createMockFormalVerification();
+  const r1 = await fv.runTla("SocietyEmergence");
+  const r2 = await fv.runTla("SocietyEmergence");
+  deepEqual(r1, r2);
+  equal(r1.outcome, "pass");
+});
+
+test("mock FV returns cached results when supplied", async () => {
+  const cached = new Map<string, TlaVerificationResult>([
+    ["TickMonotonicity", { outcome: "fail", specName: "TickMonotonicity", invariant: "Mono", counterexample: "cx" }],
+  ]);
+  const fv = createMockFormalVerification(cached);
+  const r = await fv.runTla("TickMonotonicity");
+  equal(r.outcome, "fail");
+});
+
+test("mock FV flags an unknown spec (catalogue drift)", async () => {
+  const fv = createMockFormalVerification();
+  const r = await fv.runTla("NotARealSpec");
+  equal(r.outcome, "usage_error");
+});
+
+test("catalogue lists 13 specs and is exposed via listSpecs", () => {
+  equal(CATALOGUE.length, 13);
+  deepEqual(createMockFormalVerification().listSpecs(), [...CATALOGUE]);
+});
+
+// --- §6.3 review gate soak test --------------------------------------------
+
+const NO_SPEC_CRITERIA: SoakGateCriteria = {
+  minTicks: DEFAULT_MIN_TICKS,
+  minSoakMs: DEFAULT_MIN_SOAK_MS,
+  requiredSpecs: [],
+};
+
+test("room with <100 ticks is blocked", () => {
+  const result = evaluateSoakGate({ ticksSurvived: 50, soakMs: 3_600_000, criteria: NO_SPEC_CRITERIA });
+  equal(result.outcome, "blocked");
+});
+
+test("room meeting ticks + soak + no specs is promoted", () => {
+  const result = evaluateSoakGate({
+    ticksSurvived: 100,
+    soakMs: DEFAULT_MIN_SOAK_MS,
+    criteria: NO_SPEC_CRITERIA,
+  });
+  equal(result.outcome, "promoted");
+});
+
+test("review gate blocks when a required spec did not pass", () => {
+  const specResults = new Map<string, TlaVerificationResult>([
+    ["SocietyEmergence", { outcome: "pass", specName: "SocietyEmergence", durationMs: 1 }],
+    ["SocietyRuntimeRefinement", { outcome: "fail", specName: "SocietyRuntimeRefinement", invariant: "I", counterexample: "cx" }],
+  ]);
+  const result = evaluateSoakGate({
+    ticksSurvived: 200,
+    soakMs: DEFAULT_MIN_SOAK_MS,
+    criteria: { minTicks: 100, minSoakMs: DEFAULT_MIN_SOAK_MS, requiredSpecs: ["SocietyEmergence", "SocietyRuntimeRefinement"] },
+    specResults,
+  });
+  ok(result.outcome === "blocked");
+  ok(result.missingCriteria.some((m) => m.includes("SocietyRuntimeRefinement")));
+});
+
+test("review gate blocks when a required spec was not run", () => {
+  const result = evaluateSoakGate({
+    ticksSurvived: 200,
+    soakMs: DEFAULT_MIN_SOAK_MS,
+    criteria: { minTicks: 100, minSoakMs: DEFAULT_MIN_SOAK_MS, requiredSpecs: ["SocietyEmergence"] },
+  });
+  equal(result.outcome, "blocked");
+});
+
+test("review gate blocks on an invalid closure certificate", () => {
+  const cert = finiteSocietyClosureCertificate(["a", "b", "c"]);
+  const tampered = { ...cert, finalEdges: cert.finalEdges.slice(0, 2) };
+  const result = evaluateSoakGate({
+    ticksSurvived: 200,
+    soakMs: DEFAULT_MIN_SOAK_MS,
+    criteria: NO_SPEC_CRITERIA,
+    closureCertificate: tampered,
+  });
+  equal(result.outcome, "blocked");
+});
+
+test("review gate promotes a fully-federated room", () => {
+  const cert = finiteSocietyClosureCertificate(["a", "b", "c"]);
+  const specResults = new Map<string, TlaVerificationResult>([
+    ["SocietyEmergence", { outcome: "pass", specName: "SocietyEmergence", durationMs: 1 }],
+  ]);
+  const result = evaluateSoakGate({
+    ticksSurvived: 100,
+    soakMs: DEFAULT_MIN_SOAK_MS,
+    criteria: { minTicks: 100, minSoakMs: DEFAULT_MIN_SOAK_MS, requiredSpecs: ["SocietyEmergence"] },
+    specResults,
+    closureCertificate: cert,
+  });
+  equal(result.outcome, "promoted");
+});
+
+// --- determinism (MP-1) -----------------------------------------------------
+
+test("review gate evaluation is deterministic", () => {
+  const input = { ticksSurvived: 50, soakMs: 100, criteria: NO_SPEC_CRITERIA };
+  deepEqual(evaluateSoakGate(input), evaluateSoakGate(input));
+});


### PR DESCRIPTION
## Summary

Faithful port of Merge1 §06 (Formal Verification) from
`src/Core.TypeScript/formal-verification/` + the §06 doc sketches into
`agentic-organization`. Lands the TLA+/TLC + Alloy model-checker seam, the
finite-society closure certificate (the formal guarantee behind "harmonious
division"), and the soak-test promotion gate. New-modules-first, same precedent
as §01/§02/§04/§05/§07.

New modules (`packages/application/src/`):

- **`formal-verification-port.ts`** — `FormalVerificationPort` seam
  (`runTla` / `runAlloy` / `checkToolchain` / `listSpecs`) + the 13-spec
  `CATALOGUE` (port of `run-tlc.ts`). Results are discriminated unions mirroring
  TLC's exit taxonomy (`pass` / `fail{invariant,counterexample}` /
  `toolchain_error` / `usage_error`) — Result-over-exception (MP-7).
  `createMockFormalVerification` is deterministic for DST (MP-1): same inputs →
  same outputs, optional cached results, and a spec **not** in the catalogue
  surfaces `usage_error` so catalogue drift is caught.

- **`society-closure-certificate.ts`** — `finiteSocietyClosureCertificate(agents)`
  + `validateFiniteSocietyClosureCertificate(cert)`. Proves a finite society of N
  agents forms a complete bidirectional graph:
  ```
  C(N,2) unordered pairs  →  each adds  a->b, b->a  →  N*(N-1) directed edges
  ```
  Agents are deduplicated (first-seen order) so the certificate is canonical;
  validation checks pair-count, step-count, edge-count, and distinctness.

- **`review-gate-soak.ts`** — `evaluateSoakGate`: promotes only when **all** of
  ≥100 ticks (`DEFAULT_MIN_TICKS`), ≥24h soak (`DEFAULT_MIN_SOAK_MS`), the
  required TLA+ specs (default `SocietyEmergence` + `SocietyRuntimeRefinement`)
  pass, and — when federated — the closure certificate validates; otherwise
  `blocked` with `missingCriteria`. Pure/deterministic (caller supplies
  ticks/soak/spec results). Named `SoakGate*` / `evaluateSoakGate` to avoid
  collision with the existing `review-gate.ts` `evaluateReviewGate`.

EXTEND: `index.ts` re-exports the §06 surface.

**Deferred (integration polish, same precedent as prior sections):** the §06
doc's deeper EXTENDs of `conformance.ts` (TLA+-backed violation detection) and
the hat-guardrails OPA merge (the 7 OPA policies already landed in §07 as
`hat-admission.ts`). The seam + certificate + soak gate are the load-bearing new
surface.

## Tests

`packages/application/test/merge1-formal-verification.test.ts` — 16 tests:
closure certificate (3→6 edges, bidirectional+distinct, agent dedup, singleton/
empty, tamper rejection), mock FV (determinism, cached results, unknown-spec
drift, 13-spec catalogue), soak gate (blocked <100 ticks, promoted on full
criteria, blocked on failed/unrun required spec, blocked on invalid closure cert,
fully-federated promotion), and a determinism check.

Verification: `npm run typecheck` clean (6 pre-existing integration errors
untouched); `npm test` → **1551 pass / 0 fail / 7 skipped** (16 new).


Link to Devin session: https://app.devin.ai/sessions/77dac2be40e34088b799b6f1d927dbe3
Requested by: @maximdolphin