### PR TITLE
feat(persona-keys): multi-owner machines — multi-principal cert signing + per-machine AuthorizedPrincipals

### DIFF
--- a/full-ai-cluster/nixos/modules/ssh-ca.nix
+++ b/full-ai-cluster/nixos/modules/ssh-ca.nix
@@ -19,6 +19,15 @@
 #   CA pubkey -> Vault SSH secrets engine custody + cert-manager issuance
 #   later (same trust model, upgraded custody).
 #
+# AUTHORIZATION (the identity<->authorization split, decision doc 2026-06-21):
+#   TrustedUserCAKeys says "trust certs the CA signed"; it does NOT by itself
+#   say WHICH users may use THIS machine. That is the per-machine
+#   AuthorizedPrincipalsFile: a list of usernames allowed on this host. The
+#   list is plain DATA (machines/principals.json -> host -> [usernames]); the
+#   (user x machine) pairing lives in that list, NEVER a composite id (the
+#   #8926 / Key-ID NxM lesson). This module reads THIS host's slice of that
+#   data and renders it into a static principals file sshd points at.
+#
 # STATUS — ADDITIVE + INERT (this PR ships the module; it does NOT flip the switch):
 #   * operator-ssh-keys.nix is UNCHANGED and remains the active trust path.
 #   * This module is NOT imported into any node config by this PR.
@@ -29,6 +38,10 @@
 #     it does nothing — `programs.ssh` / sshd config is set ONLY when the
 #     CA pubkey file is present (a `pathExists` guard makes it inert
 #     pre-CA so importing it early cannot break a build).
+#   * AuthorizedPrincipalsFile is set ONLY when machines/principals.json
+#     EXISTS and lists THIS host with >=1 username (a SECOND pathExists +
+#     non-empty guard, the SAME discipline) — absent/empty data -> no
+#     principals line -> no behavior change.
 #
 # ACTIVATION (operator step, NOT this PR):
 #   1. Run the CA generator + commit the CA public key:
@@ -37,10 +50,13 @@
 #   2. Point `caPubFile` below at that committed pubkey (or copy it to a
 #      path under this module's dir) and IMPORT this module in the node's
 #      configuration, then `nixos-rebuild switch`.
+#   3. (Authorization) Add this host to machines/principals.json with the
+#      usernames allowed on it, e.g. { "<host>": ["aaron", "addison"] }, and
+#      commit. The principal names must match the user certs' `-n` principals.
 #
-# Anchors: OpenSSH `sshd_config(5)` TrustedUserCAKeys / `ssh-keygen(1)` -s;
-# OpenSSH PROTOCOL.certkeys; Vault SSH secrets engine + cert-manager
-# (the in-cluster migration target).
+# Anchors: OpenSSH `sshd_config(5)` TrustedUserCAKeys + AuthorizedPrincipalsFile
+# / `ssh-keygen(1)` -s; OpenSSH PROTOCOL.certkeys; Vault SSH secrets engine +
+# cert-manager (the in-cluster migration target; principals source -> IdP later).
 
 { config, lib, pkgs, ... }:
 
@@ -53,14 +69,44 @@ let
   # INERT until the CA pubkey actually exists: importing this module before the
   # operator has generated + committed the CA must not break the build.
   caPresent = builtins.pathExists caPubFile;
+
+  # ── AUTHORIZATION: per-machine authorized-principals (the ownership LIST) ──
+  # The single source of the ownership matrix: host -> [usernames]. Same dir +
+  # change-rate as the machines/<host>.pub registry (a DV2.0 satellite). It is
+  # plain text data (usernames only — NO key material, NO secrets).
+  principalsFile = ../../../machines/principals.json;
+  principalsPresent = builtins.pathExists principalsFile;
+
+  # This node's hostname is the lookup key — a machine knows its OWN host at
+  # eval time, so we render exactly THIS host's list (no Match blocks, no
+  # per-user tokens; one static AuthorizedPrincipalsFile is enough).
+  thisHost = config.networking.hostName;
+
+  principalsData = if principalsPresent then builtins.fromJSON (builtins.readFile principalsFile) else { };
+
+  # The usernames authorized on THIS host (empty if the host is absent / data
+  # absent). Defensive: only string entries; sorted for a byte-stable file.
+  rawPrincipals = principalsData.${thisHost} or [ ];
+  hostPrincipals = lib.sort (a: b: a < b) (lib.filter builtins.isString rawPrincipals);
+  hasPrincipals = principalsPresent && (builtins.length hostPrincipals) > 0;
+
+  # The rendered AuthorizedPrincipalsFile body: one username per line. sshd
+  # ignores blank lines + `#` comments; we emit a header comment + the names.
+  principalsRendered = pkgs.writeText "zeta-authorized-principals-${thisHost}" (''
+    # Zeta per-machine AuthorizedPrincipalsFile for ${thisHost}
+    # Source: machines/principals.json (host -> authorized usernames).
+    # The (user x machine) pairing lives in THIS list, never a composite id.
+  '' + lib.concatStringsSep "\n" hostPrincipals + "\n");
 in
 {
   # When the CA public key is present, anchor sshd's user-cert trust at it:
   # any device key the CA signed into a cert (principal = a node-authorized
   # user) is accepted, with NO per-machine authorizedKeys entry.
   config = lib.mkIf caPresent {
-    services.openssh.extraConfig = lib.mkAfter ''
+    services.openssh.extraConfig = lib.mkAfter (''
       TrustedUserCAKeys ${caPubFile}
-    '';
+    '' + lib.optionalString hasPrincipals ''
+      AuthorizedPrincipalsFile ${principalsRendered}
+    '');
   };
 }

--- a/machines/principals.json
+++ b/machines/principals.json
@@ -1,0 +1,3 @@
+{
+  "acehacks-mac-studio.local": ["aaron"]
+}

--- a/tools/setup/persona-keys/ca-cli.ts
+++ b/tools/setup/persona-keys/ca-cli.ts
@@ -12,8 +12,9 @@
 //   bun ca-cli.ts ca   --ca aaron --dry-run                       # generates NOTHING
 //   bun ca-cli.ts ca   --ca aaron                                 # generate local CA key
 //   bun ca-cli.ts ca   --ca aaron --commit-pub                    # + write CA pubkey to repo (no commit)
-//   bun ca-cli.ts cert --user aaron --machine mymac --dry-run     # signs NOTHING
+//   bun ca-cli.ts cert --user aaron --machine mymac --dry-run     # signs NOTHING (single owner)
 //   bun ca-cli.ts cert --user aaron --machine mymac               # sign that machine's pubkey -> cert
+//   bun ca-cli.ts cert --users aaron,addison --machine d --dry-run # multi-owner plan (NOTHING signed)
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { ensureCa, signMachineCert, realEffects, DEFAULT_CERT_VALIDITY } from "./ca.ts";
@@ -63,15 +64,22 @@ async function main(): Promise<number> {
   }
 
   if (mode === "cert") {
-    const user = opt("--user") ?? "zeta";
     const machineRaw = opt("--machine");
     const machineId = sanitizeHostname(machineRaw ?? "");
     const validity = opt("--validity") ?? DEFAULT_CERT_VALIDITY;
     const dryRun = flag("--dry-run");
     // The device PUBLIC key is the machine.ts registry seam: the USER-INDEPENDENT
-    // `machines/<host>.pub`. This cert (principal=<user>) is the (user × machine) binding.
+    // `machines/<host>.pub`. The cert's principals are the (user × machine) binding.
     const devicePubPath = opt("--device-pub") ?? machinePubPath(repoRoot, machineId);
-    const r = await signMachineCert(fx, { user, machineId, devicePubPath, validity, dryRun, biometricAuth });
+    // AUTHORIZED USER LIST: `--users aaron,addison` for a co-owned machine; `--user aaron` is the
+    // single-owner shorthand. The comma-joined value becomes the cert's `-n` principals; the Key
+    // ID stays machine-only. The (user × machine) pairing lives in the LIST, never a composite id.
+    const usersFlag = opt("--users");
+    const users =
+      usersFlag !== undefined
+        ? usersFlag.split(",").map((u) => u.trim()).filter((u) => u.length > 0)
+        : [opt("--user") ?? "zeta"];
+    const r = await signMachineCert(fx, { users, machineId, devicePubPath, validity, dryRun, biometricAuth });
     if (r.action === "no-ca") {
       console.error(`blocked: no CA private key at ${r.caPrivatePath} — run 'ca-cli.ts ca' first.`);
       return 3;
@@ -83,7 +91,7 @@ async function main(): Promise<number> {
     if (r.dryRun) {
       console.log(`[dry-run] action=${r.action} (NOTHING signed)`);
       console.log(`[dry-run] would sign ${r.devicePubPath}`);
-      console.log(`[dry-run]   -> cert ${r.certPath} (id=${r.certId} principal=${r.principal} validity=${r.validity})`);
+      console.log(`[dry-run]   -> cert ${r.certPath} (id=${r.certId} principals=${r.principal} validity=${r.validity})`);
       return 0;
     }
     if (r.action === "aborted-biometric") {
@@ -93,7 +101,7 @@ async function main(): Promise<number> {
       return 1;
     }
     console.log(`action=${r.action} cert=${r.certPath}`);
-    console.log(`  id=${r.certId} principal=${r.principal} validity=${r.validity}`);
+    console.log(`  id=${r.certId} principals=${r.principal} validity=${r.validity}`);
     // The cert is public — safe to print.
     if (r.certText !== undefined) console.log(r.certText);
     return 0;
@@ -102,7 +110,7 @@ async function main(): Promise<number> {
   console.error(
     "usage:\n" +
       "  bun ca-cli.ts ca   --ca <name> [--dry-run] [--commit-pub]\n" +
-      "  bun ca-cli.ts cert --user <name> --machine <host> [--validity +52w] [--dry-run]",
+      "  bun ca-cli.ts cert (--user <name> | --users a,b) --machine <host> [--validity +52w] [--dry-run]",
   );
   return 2;
 }

--- a/tools/setup/persona-keys/ca.test.ts
+++ b/tools/setup/persona-keys/ca.test.ts
@@ -71,7 +71,7 @@ function fakeEffects(opts?: { genCount?: { n: number }; signCount?: { n: number 
       if (opts?.signCount) opts.signCount.n += 1;
       const out = certPath(req.devicePubPath);
       // Simulate a signed cert — public output only (the CA private is "consumed" by the runner).
-      const cert = `ssh-ed25519-cert-v01@openssh.com AAAAFAKECERT id=${req.certId} principal=${req.principal}\n`;
+      const cert = `ssh-ed25519-cert-v01@openssh.com AAAAFAKECERT id=${req.certId} principal=${req.principals.join(",")}\n`;
       writeFileSync(out, cert);
       return { certPath: out, certText: cert };
     },
@@ -429,6 +429,104 @@ test("REAL ssh-keygen: throwaway CA signs a throwaway device key; cert verifies 
     expect(show.stdout).toContain("tester"); // the principal (-n) — the user×machine pairing lives HERE, not in the Key ID
     expect(show.stdout).not.toContain("tester@mymac"); // guard: the N×M composite Key ID must NOT reappear
     // The cert file is PUBLIC — never carries a private marker.
+    expect(readFileSync(certRes.certPath, "utf8")).not.toMatch(new RegExp(PRIV_MARKER));
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// ── MULTI-PRINCIPAL (multi-owner machine) — the identity↔authorization split, §1 ──────────────
+
+test("multi-principal (fake): users:[aaron,addison] -> joined -n principals; Key ID machine-only", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "zeta-ca-"));
+  try {
+    const fx = fakeEffects();
+    const caPriv = caPrivateKeyPath(tmp);
+    mkdirSync(caPriv.slice(0, caPriv.lastIndexOf("/")), { recursive: true });
+    writeFileSync(caPriv, "FAKE-CA-PRIVATE\n", { mode: 0o600 });
+    const devicePub = join(tmp, "machines", "shared.pub");
+    mkdirSync(devicePub.slice(0, devicePub.lastIndexOf("/")), { recursive: true });
+    writeFileSync(devicePub, "ssh-ed25519 AAAADEVICE shared (zeta-machine)\n");
+
+    const r = await signMachineCert(fx, {
+      users: ["aaron", "addison"],
+      machineId: "shared",
+      devicePubPath: devicePub,
+      home: tmp,
+      biometricAuth: APPROVE,
+    });
+    expect(r.action).toBe("signed");
+    expect(r.principals).toEqual(["aaron", "addison"]); // the structured user LIST
+    expect(r.principal).toBe("aaron,addison"); // the comma-joined -n value
+    expect(r.certId).toBe("shared"); // Key ID is MACHINE-only — no user, no composite
+    // The (user × machine) pairing lives in the principals LIST — never a composite id.
+    expect(r.certId).not.toContain("@");
+    expect(r.certId).not.toContain("aaron");
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("single-user list still works: users:[aaron] == the single-owner path", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "zeta-ca-"));
+  try {
+    const fx = fakeEffects();
+    const caPriv = caPrivateKeyPath(tmp);
+    mkdirSync(caPriv.slice(0, caPriv.lastIndexOf("/")), { recursive: true });
+    writeFileSync(caPriv, "FAKE-CA-PRIVATE\n", { mode: 0o600 });
+    const devicePub = join(tmp, "machines", "solo.pub");
+    mkdirSync(devicePub.slice(0, devicePub.lastIndexOf("/")), { recursive: true });
+    writeFileSync(devicePub, "ssh-ed25519 AAAADEVICE solo (zeta-machine)\n");
+
+    const viaList = await signMachineCert(fx, { users: ["aaron"], machineId: "solo", devicePubPath: devicePub, home: tmp, biometricAuth: APPROVE });
+    expect(viaList.action).toBe("signed");
+    expect(viaList.principals).toEqual(["aaron"]);
+    expect(viaList.principal).toBe("aaron"); // a one-element list joins to a bare username (no comma)
+
+    // The legacy `user` shorthand resolves to the same one-element list.
+    const devicePub2 = join(tmp, "machines", "solo2.pub");
+    writeFileSync(devicePub2, "ssh-ed25519 AAAADEVICE solo2 (zeta-machine)\n");
+    const viaUser = await signMachineCert(fx, { user: "aaron", machineId: "solo2", devicePubPath: devicePub2, home: tmp, biometricAuth: APPROVE });
+    expect(viaUser.principals).toEqual(["aaron"]);
+    expect(viaUser.principal).toBe("aaron");
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("REAL ssh-keygen: a multi-principal cert shows BOTH users + a machine-only Key ID (temp only)", async () => {
+  const probe = spawnSync("ssh-keygen", ["-A", "-?"], { encoding: "utf8" });
+  if (probe.error !== undefined) {
+    return; // no ssh-keygen — conformance covered by the fake-effects tests above
+  }
+  const tmp = mkdtempSync(join(tmpdir(), "zeta-ca-real-multi-"));
+  try {
+    const { realEffects, ensureCa: real, signMachineCert: sign } = await import("./ca.ts");
+    const fx = realEffects();
+    const approve = APPROVE;
+
+    const caRes = await real(fx, { ca: CA, repoRoot: tmp, home: tmp, commitPub: true, biometricAuth: approve });
+    expect(caRes.action).toBe("generated");
+
+    const deviceKey = join(tmp, "device_ed25519");
+    const kg = spawnSync("ssh-keygen", ["-t", "ed25519", "-f", deviceKey, "-N", "", "-C", "shared (zeta-machine)"], { encoding: "utf8" });
+    expect(kg.status).toBe(0);
+    const devicePub = deviceKey + ".pub";
+
+    // Sign with TWO principals (a co-owned machine): aaron + addison.
+    const certRes = await sign(fx, { users: ["aaron", "addison"], machineId: "shared", devicePubPath: devicePub, home: tmp, biometricAuth: approve });
+    expect(certRes.action).toBe("signed");
+
+    const show = spawnSync("ssh-keygen", ["-L", "-f", certRes.certPath], { encoding: "utf8" });
+    expect(show.status).toBe(0);
+    // BOTH principals appear (OpenSSH lists them under "Principals:").
+    expect(show.stdout).toContain("aaron");
+    expect(show.stdout).toContain("addison");
+    // Key ID is the MACHINE alone — never a user@machine composite (the N×M lesson).
+    expect(show.stdout).toContain('Key ID: "shared"');
+    expect(show.stdout).not.toContain("aaron@shared");
+    expect(show.stdout).not.toContain("addison@shared");
+    expect(show.stdout).not.toContain('Key ID: "aaron');
     expect(readFileSync(certRes.certPath, "utf8")).not.toMatch(new RegExp(PRIV_MARKER));
   } finally {
     rmSync(tmp, { recursive: true, force: true });

--- a/tools/setup/persona-keys/ca.ts
+++ b/tools/setup/persona-keys/ca.ts
@@ -79,12 +79,22 @@ export interface SignCertRequest {
   readonly caKeyPath: string;
   /** Path to the per-machine device PUBLIC key to be signed. */
   readonly devicePubPath: string;
-  /** Certificate identity (`-I`) — a human-readable label (e.g. "<user>@<host>"). */
+  /** Certificate identity (`-I`) — a MACHINE-ONLY label (the host id; #8969 made the Key ID
+   *  machine-only — NEVER a `user@machine` composite, the #8926 N×M lesson). */
   readonly certId: string;
-  /** Principal(s) the cert authorizes (`-n`) — the USER the cert binds to (e.g. "aaron"). */
-  readonly principal: string;
+  /** The principals (`-n`) the cert authorizes — the USER LIST it binds to (e.g.
+   *  `["aaron", "addison"]` for a co-owned machine). A single-owner cert is a one-element list.
+   *  The (user × machine) pairing lives HERE, in the list — never in a composite key/id. */
+  readonly principals: readonly string[];
   /** Validity window (`-V`), OpenSSH form (e.g. "+52w"); the rolling-keys discipline. */
   readonly validity: string;
+}
+
+/** Join a user list into the OpenSSH `-n` principals value: comma-separated, no spaces
+ *  (`aaron,addison`). The list IS the authorization-binding; the pairing never becomes a
+ *  composite identifier (the #8926 / Key-ID N×M lesson). */
+export function joinPrincipals(users: readonly string[]): string {
+  return users.join(",");
 }
 
 /** The result of a sign — the written cert path + its (public) text. No private material. */
@@ -233,6 +243,10 @@ export interface CertResult {
   readonly devicePubPath: string;
   readonly certPath: string;
   readonly certId: string;
+  /** The authorized user LIST (the `-n` principals) — `["aaron"]` for a single owner,
+   *  `["aaron","addison"]` for a co-owned machine. The structured form of the binding. */
+  readonly principals: readonly string[];
+  /** The comma-joined principals (`aaron,addison`) — the exact `-n` value, for readouts. */
   readonly principal: string;
   readonly validity: string;
   /** The certificate text, when signed (public — safe to print). Undefined otherwise. */
@@ -265,8 +279,15 @@ export interface CertResult {
 export async function signMachineCert(
   fx: CaEffects,
   opts: {
-    /** The USER the cert binds to (the `-n` principal — trust anchored at the user). */
-    readonly user: string;
+    /** The USER the cert binds to (the `-n` principal — trust anchored at the user). A single
+     *  owner; for a co-owned machine pass `users` instead (this is the one-element shorthand). */
+    readonly user?: string;
+    /** The authorized USER LIST for a (possibly multi-owner) machine — `["aaron","addison"]`.
+     *  Takes precedence over `user`; the comma-joined value becomes the `-n` principals. A
+     *  one-element list is the single-owner path. EXACTLY ONE of `user` / `users` is required;
+     *  `users` must be non-empty. The (user × machine) pairing lives in this LIST — never a
+     *  composite identifier (the #8926 / Key-ID N×M lesson). */
+    readonly users?: readonly string[];
     /** A machine id for the cert identity (`-I`), e.g. the sanitized hostname. */
     readonly machineId: string;
     /** Path to the per-machine device PUBLIC key to sign (the registry `machines/<host>.pub`). */
@@ -281,6 +302,19 @@ export async function signMachineCert(
 ): Promise<CertResult> {
   const caPrivatePath = opts.home === undefined ? caPrivateKeyPath() : caPrivateKeyPath(opts.home);
   const validity = opts.validity ?? DEFAULT_CERT_VALIDITY;
+  // Resolve the authorized user LIST: `users` (multi-owner) wins; else the single `user`. The
+  // (user × machine) binding is this LIST, never a composite id. Fail-closed on a degenerate
+  // request (neither given, or an empty `users`) — we never sign a cert with NO principal.
+  const users: readonly string[] =
+    opts.users !== undefined && opts.users.length > 0
+      ? opts.users
+      : opts.user !== undefined
+        ? [opts.user]
+        : [];
+  if (users.length === 0) {
+    throw new Error("signMachineCert: provide a non-empty `users` list or a single `user`.");
+  }
+  const principal = joinPrincipals(users); // the exact `-n` value (`aaron,addison`)
   // Key ID names the certified SUBJECT = the machine key, so it is the machine id ALONE — NOT
   // `user@machine`. A composite user×machine Key ID is the N×M smell (Aaron, 2026-06-21; same
   // shape as the #8926 hybrid-key error): it would mint a distinct cert per (user, machine) pair
@@ -296,7 +330,8 @@ export async function signMachineCert(
     devicePubPath: opts.devicePubPath,
     certPath: outPath,
     certId,
-    principal: opts.user,
+    principals: users,
+    principal,
     validity,
   };
 
@@ -316,7 +351,7 @@ export async function signMachineCert(
   // BIOMETRIC GATE — fail-closed. A real sign consumes the CA private key; require approval.
   const biometric = await requireBiometric(
     opts.biometricAuth,
-    `Approve: sign cert for machine ${opts.machineId} (principal=${opts.user})`,
+    `Approve: sign cert for machine ${opts.machineId} (principals=${principal})`,
   );
   if (!biometric.ok) {
     return { ...base, dryRun: false, action: "aborted-biometric", biometric };
@@ -326,7 +361,7 @@ export async function signMachineCert(
     caKeyPath: caPrivatePath,
     devicePubPath: opts.devicePubPath,
     certId,
-    principal: opts.user,
+    principals: users,
     validity,
   });
   return { ...base, dryRun: false, action: "signed", certText: out.certText, biometric };
@@ -366,9 +401,10 @@ export function realEffects(): CaEffects {
       return readFileSync(caKeyPath + ".pub", "utf8");
     },
     signCert: (req) => {
-      // ssh-keygen -s <ca> -I <id> -n <principal> -V <validity> <devicePub>
-      // Writes "<devicePub base>-cert.pub" (public). The CA private key is read by ssh-keygen,
-      // never by us; the cert is public output.
+      // ssh-keygen -s <ca> -I <id> -n aaron,addison -V <validity> <devicePub>
+      // The `-n` value is the comma-joined principals LIST (one OpenSSH cert authorizing all
+      // listed users); Key ID (`-I`) is machine-only. Writes "<devicePub base>-cert.pub" (public).
+      // The CA private key is read by ssh-keygen, never by us; the cert is public output.
       const r = spawnSync(
         "ssh-keygen",
         [
@@ -377,7 +413,7 @@ export function realEffects(): CaEffects {
           "-I",
           req.certId,
           "-n",
-          req.principal,
+          joinPrincipals(req.principals),
           "-V",
           req.validity,
           req.devicePubPath,

--- a/tools/setup/persona-keys/onboard.test.ts
+++ b/tools/setup/persona-keys/onboard.test.ts
@@ -305,7 +305,7 @@ function fakeCa(existing: ReadonlySet<string>, opts?: { signCount?: { n: number 
       const out = req.devicePubPath.endsWith(".pub")
         ? req.devicePubPath.slice(0, -4) + "-cert.pub"
         : req.devicePubPath + "-cert.pub";
-      return { certPath: out, certText: `ssh-ed25519-cert-v01@openssh.com AAAAFAKECERT principal=${req.principal}\n` };
+      return { certPath: out, certText: `ssh-ed25519-cert-v01@openssh.com AAAAFAKECERT principal=${req.principals.join(",")}\n` };
     },
   };
 }

--- a/tools/setup/persona-keys/principals.test.ts
+++ b/tools/setup/persona-keys/principals.test.ts
@@ -1,0 +1,93 @@
+// principals.ts conformance — per-machine authorized-principals data + AuthorizedPrincipalsFile
+// rendering (the AUTHORIZATION half of the identity↔authorization split). ALL tests run against
+// a THROWAWAY temp dir; NO secrets are involved (the data is USERNAMES only). NO key-shaped
+// literal appears in this file — the private-key guard string is SPLIT (PRIV_MARKER).
+// Run: bun test principals.test.ts   (from tools/setup/persona-keys)
+import { test, expect } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  principalsDataPath,
+  normalizePrincipals,
+  parsePrincipals,
+  loadPrincipals,
+  renderAuthorizedPrincipals,
+  renderHostAuthorizedPrincipals,
+} from "./principals.ts";
+
+// The private-key marker, assembled at runtime so NO key-shaped literal is in this file.
+const PRIV_MARKER = "PRIVATE" + " " + "KEY";
+
+function writeData(repoRoot: string, obj: unknown): void {
+  const p = principalsDataPath(repoRoot);
+  mkdirSync(p.slice(0, p.lastIndexOf("/")), { recursive: true });
+  writeFileSync(p, JSON.stringify(obj, null, 2) + "\n");
+}
+
+test("normalizePrincipals: trims, drops blanks, de-dups, sorts ORDINAL (byte-stable)", () => {
+  expect(normalizePrincipals(["addison", "aaron", "aaron", "  ", " max "])).toEqual([
+    "aaron",
+    "addison",
+    "max",
+  ]);
+});
+
+test("renderAuthorizedPrincipals: one username per line, trailing newline; lists the right users", () => {
+  const body = renderAuthorizedPrincipals(["addison", "aaron"]);
+  expect(body).toBe("aaron\naddison\n"); // ordinal-sorted
+  expect(body.split("\n").filter((l) => l.length > 0)).toEqual(["aaron", "addison"]);
+});
+
+test("renderAuthorizedPrincipals: INERT when absent — empty list -> empty string (authorizes NObody)", () => {
+  expect(renderAuthorizedPrincipals([])).toBe("");
+});
+
+test("parse/load: a host -> usernames map round-trips; the matrix is the single source", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "zeta-principals-"));
+  try {
+    // The spec matrix: A=aaron, D=aaron+addison, G=all three.
+    writeData(tmp, { A: ["aaron"], D: ["addison", "aaron"], G: ["max", "aaron", "addison"] });
+    const map = loadPrincipals(tmp);
+    expect(map["A"]).toEqual(["aaron"]);
+    expect(map["D"]).toEqual(["aaron", "addison"]); // normalized + sorted
+    expect(map["G"]).toEqual(["aaron", "addison", "max"]);
+    // Per-host render lists exactly that host's users.
+    expect(renderHostAuthorizedPrincipals(map, "D")).toBe("aaron\naddison\n");
+    expect(renderHostAuthorizedPrincipals(map, "A")).toBe("aaron\n");
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("INERT when data file absent: loadPrincipals -> empty map; unknown host -> empty render", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "zeta-principals-"));
+  try {
+    expect(loadPrincipals(tmp)).toEqual({}); // no file -> empty map (no throw, no behavior)
+    const map = loadPrincipals(tmp);
+    expect(renderHostAuthorizedPrincipals(map, "anything")).toBe(""); // absent host -> inert
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("fail-INERT on garbage / non-array entries: never fail-open (no spurious authorization)", () => {
+  expect(parsePrincipals("not json {")).toEqual({}); // invalid JSON -> empty
+  expect(parsePrincipals("[1,2,3]")).toEqual({}); // array, not an object -> empty
+  expect(parsePrincipals("null")).toEqual({});
+  // Non-string entries are dropped, not guessed; a host that nets zero is omitted.
+  expect(parsePrincipals(JSON.stringify({ H: [1, "aaron", null], Z: [] }))).toEqual({ H: ["aaron"] });
+});
+
+test("usernames only — the data carries NO key material (no private marker ever)", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "zeta-principals-"));
+  try {
+    writeData(tmp, { D: ["aaron", "addison"] });
+    const map = loadPrincipals(tmp);
+    const blob = JSON.stringify(map) + renderHostAuthorizedPrincipals(map, "D");
+    expect(blob).not.toMatch(new RegExp(PRIV_MARKER));
+    expect(blob).not.toMatch(new RegExp("BEGIN .*" + PRIV_MARKER));
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});

--- a/tools/setup/persona-keys/principals.ts
+++ b/tools/setup/persona-keys/principals.ts
@@ -1,0 +1,101 @@
+// Zeta per-machine authorized-principals data + AuthorizedPrincipalsFile rendering — the
+// AUTHORIZATION half of the identity↔authorization split (decision doc
+// docs/DECISIONS/2026-06-21-multi-owner-machines-identity-vs-authorization-ssh-ca-bootstrap.md
+// §2 "Authorization = per-machine authorized-principals list").
+//
+// THE MODEL (why this file exists):
+//   IDENTITY is a per-USER cert (`principal=<username>`, ca.ts §1) — "I am aaron." AUTHORIZATION
+//   is a per-MACHINE list of usernames allowed on that host (OpenSSH `AuthorizedPrincipalsFile`).
+//   Ownership is therefore plain DATA — a list of usernames per machine — never a cryptographic
+//   re-binding. Adding a person to a machine = add their username to that machine's list (one
+//   line edit); the fleet is NOT re-keyed. Keys stay O(N+M), not O(N×M).
+//
+//   THE PAIRING LIVES IN THE LIST, NEVER A COMPOSITE ID: a machine maps to a list of bare
+//   usernames; there is NO `user@machine` composite key anywhere (the #8926 / Key-ID N×M lesson,
+//   2026-06-21). The (user × machine) relation is the membership of a username in a host's list.
+//
+// DATA SHAPE (simplest durable + diffable text — no binary; the no-binary-in-proof-lineage rule):
+//   a SINGLE `machines/principals.json` map at repo root (next to the `machines/<host>.pub`
+//   registry — same change-rate, a DV2.0 satellite): { "<host>": ["aaron", "addison"], ... }.
+//   One file, git-diffable, the single source of the ownership matrix. Bare usernames only —
+//   NO key material (it lists who, not what-key); a username is not a secret.
+//
+// SECURITY / INVARIANTS:
+//   * NO secrets — the file lists USERNAMES only (public). No key/seed bytes ever land here.
+//   * INERT WHEN ABSENT — `loadPrincipals` on a missing/empty file yields an EMPTY map; the nix
+//     render is `pathExists`-guarded (ssh-ca.nix) so an absent file changes NO sshd behavior
+//     (same discipline as the existing CA-pubkey guard).
+//   * Ordinal/culture-invariant — usernames are de-duplicated + sorted with ordinal collation
+//     (culture-invariant-by-default rule) so the rendered file is byte-stable across machines.
+//
+// Anchors (Beacon): OpenSSH `AuthorizedPrincipalsFile` / `TrustedUserCAKeys` (`sshd_config(5)`);
+// BLESS-style short-lived SSH certs (Netflix/Facebook); HashiCorp Vault SSH secrets engine +
+// Jetstack cert-manager (the migration target — principals source moves to an identity provider).
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** The ownership matrix: host → the usernames (principals) authorized on that host. A username's
+ *  membership in a host's list IS the (user × machine) authorization — never a composite id. */
+export type PrincipalsMap = Readonly<Record<string, readonly string[]>>;
+
+/** Repo path of the single per-machine principals data file (next to `machines/<host>.pub`). */
+export function principalsDataPath(repoRoot: string): string {
+  return join(repoRoot, "machines", "principals.json");
+}
+
+/** Normalize a username list: trim, drop blanks, de-duplicate, sort ORDINAL (culture-invariant —
+ *  byte-stable across machines, the culture-invariant-by-default rule). Returns a fresh array. */
+export function normalizePrincipals(users: readonly string[]): string[] {
+  const seen = new Set<string>();
+  for (const u of users) {
+    const t = u.trim();
+    if (t.length > 0) seen.add(t);
+  }
+  // Ordinal sort: codepoint order, NOT locale collation (deterministic + byte-lockable).
+  return [...seen].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+}
+
+/** Parse a principals.json blob into a normalized map. Tolerant of an absent/empty/invalid file:
+ *  anything that is not a `{ host: string[] }` object yields an EMPTY map (inert) rather than a
+ *  throw — a missing ownership table must never break a caller (fail-INERT, not fail-open: an
+ *  empty map authorizes NObody). Non-array / non-string entries are skipped, not guessed. */
+export function parsePrincipals(json: string): PrincipalsMap {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(json);
+  } catch {
+    return {};
+  }
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return {};
+  const out: Record<string, readonly string[]> = {};
+  for (const [host, val] of Object.entries(raw as Record<string, unknown>)) {
+    if (!Array.isArray(val)) continue;
+    const users = val.filter((u): u is string => typeof u === "string");
+    const norm = normalizePrincipals(users);
+    if (norm.length > 0) out[host] = norm;
+  }
+  return out;
+}
+
+/** Load the per-machine principals map from `machines/principals.json`. ABSENT ⇒ empty map
+ *  (INERT — exactly the pathExists-guard discipline the nix layer mirrors). Never throws. */
+export function loadPrincipals(repoRoot: string): PrincipalsMap {
+  const p = principalsDataPath(repoRoot);
+  if (!existsSync(p)) return {};
+  return parsePrincipals(readFileSync(p, "utf8"));
+}
+
+/** Render the OpenSSH `AuthorizedPrincipalsFile` CONTENTS for ONE host: one username per line,
+ *  ordinal-sorted, trailing newline. EMPTY list (or unknown host) ⇒ empty string (INERT — no
+ *  principal is authorized, the fail-closed default). This is the exact file sshd reads when
+ *  `AuthorizedPrincipalsFile` points at it. */
+export function renderAuthorizedPrincipals(users: readonly string[]): string {
+  const norm = normalizePrincipals(users);
+  if (norm.length === 0) return "";
+  return norm.map((u) => u).join("\n") + "\n";
+}
+
+/** Render the AuthorizedPrincipals content for `host` from the map (the per-host file body). */
+export function renderHostAuthorizedPrincipals(map: PrincipalsMap, host: string): string {
+  return renderAuthorizedPrincipals(map[host] ?? []);
+}


### PR DESCRIPTION
## What

Builds the **multi-owner machine** slice of the key-onboarding system per the decision doc
`docs/DECISIONS/2026-06-21-multi-owner-machines-identity-vs-authorization-ssh-ca-bootstrap.md`
§"What to build now". Separates **identity** (per-user certs, `principal=username`) from
**authorization** (per-machine list of allowed usernames) so ownership is plain *data* —
**O(N+M)**, not O(N×M). Adding a person later = 1 user cert + edits to the specific machines' lists.

**Security-class — NO auto-merge. Left OPEN for Otto's verify-gate.**

## The four pieces

1. **Multi-principal cert signing** (`ca.ts`) — `signMachineCert` accepts a USER LIST
   (`users: readonly string[]`); `SignCertRequest` carries `principals` joined to `-n aaron,addison`.
   The single-user `user` shorthand still works (a one-element list). **Key ID stays machine-only** —
   the (user × machine) pairing lives in the principals LIST, never a composite identifier (the
   #8926 / Key-ID N×M lesson).
2. **Per-machine principals data** (`machines/principals.json`) — a single diffable text map
   `host -> [usernames]`, the single source of the ownership matrix. Usernames only (no key
   material, no binary). `principals.ts` loads/normalizes (ordinal-sorted, de-duped) + renders.
3. **`ssh-ca.nix` renders `AuthorizedPrincipalsFile`** from that data for THIS host, guarded by a
   `pathExists` + non-empty check — **INERT** when absent (same discipline as the CA-pubkey guard);
   absent/empty -> no principals line -> no behavior change.
4. **Invariants preserved** — `--dry-run` end-to-end inert, one-fingerprint (`sessionBiometric`
   untouched), fail-closed, NO secrets/private keys in git, NO key-shaped literals in tests.

## Proof

- Real `ssh-keygen -L` on a `users:[aaron,addison]` cert:
  ```
  Key ID: "shared"
  Principals:
          aaron
          addison
  ```
  Both principals listed; Key ID is machine-only (no `user@machine`).
- `--dry-run` multi-principal plan: `action=would-sign … id=shared principals=aaron,addison` (NOTHING signed).
- Tests green: `ca.test.ts` + `principals.test.ts` (25/25, incl. real-ssh-keygen round-trips) and
  `onboard`/`setup-machine`/`setup-cluster` (55/55 across touched suites).
- TS lint green (`bun src/Core.TypeScript/lint/lint-typescript.ts`).
- `grep -E "BEGIN.*PRIVATE KEY"` empty on all changed files; only `.pub`-shape/`.json`/`.ts`/`.nix` committed.
- `nix-instantiate` eval confirms: known host -> `["aaron"]` rendered; unknown host -> inert.

> Pre-existing (NOT this PR): 10 `keyring`/`keyset`/`derive` golden-vector/seed-derivation tests fail
> on clean `origin/main` too (verified via stash) — unrelated to this slice.

## Deferred (per spec — Vault/cert-manager's job)

KRL/revocation tooling, rotation automation, host certs, principals-management UI/daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)