### PR TITLE
feat(setup): 1Password in desired-state — brew-cask manifest + generic cask loop

### DIFF
--- a/tools/setup/macos.sh
+++ b/tools/setup/macos.sh
@@ -117,6 +117,35 @@ if [ -f "$BREW_MANIFEST" ]; then
 fi
 echo "✓ brew packages up to date"
 
+# ── 3b. Brew CASKS (from manifests/brew-cask) ───────────────────────
+# Casks are a separate brew namespace (`--cask` / `brew list --cask`), so they get
+# their own declarative manifest + loop (mirrors the formula loop above, tier-aware).
+CASK_MANIFEST="$SETUP_DIR/manifests/brew-cask"
+if [ -f "$CASK_MANIFEST" ]; then
+  CASKS="$(awk '
+    { sub(/#.*$/, ""); gsub(/^[[:space:]]+|[[:space:]]+$/, "") }
+    NF > 0 { print }
+  ' "$CASK_MANIFEST")"
+  if [ -n "$CASKS" ]; then
+    echo "↓ installing brew casks from $(basename "$CASK_MANIFEST")..."
+    printf '%s\n' "$CASKS" | while IFS= read -r cask_line; do
+      required_tier="$(zeta_tier_of_line "$cask_line")"
+      cask="$(zeta_strip_tier "$cask_line" | awk '{print $1}')"
+      [ -z "$cask" ] && continue
+      if ! zeta_tier_allows "$required_tier"; then
+        echo "→ $cask skipped: requires tier=$required_tier, host is $ZETA_HOST_TIER ($ZETA_HOST_TIER_SOURCE)"
+        continue
+      fi
+      if brew list --cask "$cask" >/dev/null 2>&1; then
+        brew upgrade --cask "$cask" >/dev/null 2>&1 || true
+      else
+        brew install --cask "$cask"
+      fi
+    done
+  fi
+fi
+echo "✓ brew casks up to date"
+
 # Tap, trust, and install the official cvc5 cask (custom tap for macOS)
 if ! command -v cvc5 >/dev/null 2>&1; then
   echo "↓ tapping and installing cvc5..."

--- a/tools/setup/manifests/brew-cask
+++ b/tools/setup/manifests/brew-cask
@@ -1,0 +1,19 @@
+# macOS Homebrew CASKS — GUI apps + cask-distributed CLIs, installed by
+# tools/setup/macos.sh (`brew install --cask`). Formulae live in manifests/brew.
+# Add a cask by appending a line. Comments start with `#`. Tier tags (tier=slim|
+# standard|full) are honored exactly as in manifests/brew.
+#
+# Why a separate manifest: casks are `brew install --cask` + `brew list --cask`
+# (a different namespace than formulae). The formula loop in macos.sh uses
+# `brew list --formula`, so casks need their own declarative list + loop.
+
+# Secret / private-key custody (Aaron 2026-06-21 — "add 1password to our deps
+# desired state"). The private-key-custody lane: 1Password holds CA + machine
+# keys; its SSH agent SIGNS without exposing private bytes (same non-extractable
+# property as Vault/Secure Enclave), and `op` + service accounts give scoped,
+# least-privilege agent access. The bootstrap of the Vault + cert-manager model
+# (decision doc 2026-06-21-multi-owner-machines-…; backlog 081KVNMFYS8…).
+# Verified (dep-pin-search-first, brew 2026-06-21): cask `1password` 8.12.24 ✓,
+# cask `1password-cli` 2.34.1 ✓. brew default version; idempotent (skips if present).
+1password      # the desktop app — operator sign-in + the 1Password SSH agent
+1password-cli  # `op` — scoped service-account / CLI access for agent secret retrieval


### PR DESCRIPTION
Aaron 2026-06-21: add 1Password to deps desired-state. Adds a generic cask manifest (manifests/brew-cask) + a cask install loop in macos.sh (the install had only a cvc5 one-off). Seeded with `1password` (app + SSH agent) + `1password-cli` (`op`). The private-key-custody bootstrap lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)