### PR TITLE
feat(agentic-org): Merge1 §09 — port agent runtime (systemd) to TypeScript

### DIFF
--- a/agentic-organization/packages/application/src/agent-persona-registry.ts
+++ b/agentic-organization/packages/application/src/agent-persona-registry.ts
@@ -1,0 +1,87 @@
+/**
+ * Agent persona registry — port of
+ * `full-ai-cluster/nixos/modules/zeta-ai-agent.nix` `personas` let-binding
+ * (Merge1 §09).
+ *
+ * The systemd persona registry (≥3 vendor-diverse AI agents, each
+ * independently restartable, mutually reparable, cluster-reparable from outside
+ * the failure domain) becomes the room agent persona registry. Each room is
+ * initialized with one or more personas; a persona's `binary` + `invocationArgs`
+ * become the room's agent invocation contract.
+ *
+ * Vendor diversity is load-bearing: ≥3 distinct vendors give outage resilience
+ * AND self-modification safety (a BFT margin when one vendor update breaks ≥1
+ * agent — see mutual-repair.ts).
+ *
+ * NOTE (donor↔doc reconciliation): the §09 doc sketch lists lior as
+ * `binary: "gemini"`. The donor nix (the source of truth) ships lior as
+ * `binary: "agy"` (Antigravity CLI, `-p` flag) per B-0850.3d. We port the
+ * donor's actual values.
+ */
+
+export interface AgentPersonaConfig {
+  readonly name: string;
+  readonly vendor: string;
+  /** Non-interactive CLI binary (resolved from the persona's vendor toolchain). */
+  readonly binary: string;
+  /** Per-vendor non-interactive invocation args (e.g. Claude `--print`, Codex `exec`). */
+  readonly invocationArgs: readonly string[];
+  readonly description: string;
+}
+
+/**
+ * The canonical persona registry — 5 vendor-diverse AI agents.
+ * Port of `zeta-ai-agent.nix` `personas`.
+ */
+export const PERSONA_REGISTRY: Readonly<Record<string, AgentPersonaConfig>> = {
+  otto: {
+    name: "otto",
+    vendor: "anthropic",
+    binary: "claude",
+    invocationArgs: ["--print", "<<autonomous-loop>>"],
+    description: "Otto AI agent — Claude Code (Anthropic)",
+  },
+  alexa: {
+    name: "alexa",
+    vendor: "alibaba-qwen",
+    binary: "kiro",
+    invocationArgs: [],
+    description: "Alexa AI agent — Kiro (Qwen Coder)",
+  },
+  riven: {
+    name: "riven",
+    vendor: "xai-grok",
+    binary: "grok",
+    invocationArgs: [],
+    description: "Riven AI agent — Grok / Grok-Build (xAI)",
+  },
+  vera: {
+    name: "vera",
+    vendor: "openai",
+    binary: "codex",
+    invocationArgs: ["exec", "<<autonomous-loop>>"],
+    description: "Vera AI agent — Codex (OpenAI)",
+  },
+  lior: {
+    name: "lior",
+    vendor: "google-gemini",
+    binary: "agy",
+    invocationArgs: ["-p", "<<autonomous-loop>>"],
+    description: "Lior AI agent — Antigravity CLI (Google)",
+  },
+} as const;
+
+/** Get a persona config by name. */
+export function getPersona(name: string): AgentPersonaConfig | undefined {
+  return PERSONA_REGISTRY[name];
+}
+
+/** List all personas, in a deterministic (name-sorted) order for DST replay. */
+export function listPersonas(): readonly AgentPersonaConfig[] {
+  return Object.values(PERSONA_REGISTRY).sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+}
+
+/** Distinct vendors represented in the registry (the BFT diversity surface). */
+export function distinctVendors(): readonly string[] {
+  return [...new Set(listPersonas().map((p) => p.vendor))].sort();
+}

--- a/agentic-organization/packages/application/src/index.ts
+++ b/agentic-organization/packages/application/src/index.ts
@@ -1204,3 +1204,36 @@ export {
   type BootstrapResult,
   type ScryptParams,
 } from "./credential-bootstrap.ts";
+export {
+  PERSONA_REGISTRY,
+  getPersona,
+  listPersonas,
+  distinctVendors,
+  type AgentPersonaConfig,
+} from "./agent-persona-registry.ts";
+export {
+  DEFAULT_ROOM_LIFECYCLE,
+  buildRoomLifecycle,
+  renderAgentUnit,
+  type RoomLifecycleConfig,
+  type RenderedAgentUnit,
+} from "./systemd-runtime-adapter.ts";
+export {
+  MIN_PEERS_FOR_BFT,
+  canAttemptRepair,
+  countHealthy,
+  createMockMutualRepair,
+  type MutualRepairPort,
+  type HealthStatus,
+  type RepairResult,
+  type MockMutualRepairOptions,
+} from "./mutual-repair.ts";
+export {
+  classifyProvisioningValues,
+  validateRoomInitializationConfig,
+  type RoomInitializationConfig,
+  type ProvisioningValueClass,
+  type ClassifiedProvisioningValue,
+  type InitializationError,
+  type ValidateInitializationResult,
+} from "./room-initialization.ts";

--- a/agentic-organization/packages/application/src/mutual-repair.ts
+++ b/agentic-organization/packages/application/src/mutual-repair.ts
@@ -1,0 +1,93 @@
+/**
+ * Mutual repair — port of the mutual-repair concept in
+ * `full-ai-cluster/nixos/modules/zeta-ai-agent.nix` (Merge1 §09).
+ *
+ * ≥3 vendor-diverse AI agents can fix each other AND the cluster when it is
+ * down. Vendor diversity provides outage resilience AND self-modification safety
+ * (a ≥3 floor gives a BFT margin when one vendor update breaks ≥1 agent). When a
+ * room detects a peer is unhealthy it can attempt repair via `MutualRepairPort`;
+ * the BFT quorum stops a single broken agent from cascading.
+ *
+ * The port is a seam (MP-2): a real adapter would shell to systemd / kubectl; the
+ * mock is in-process + deterministic for DST (MP-1). Outcomes are Result-shaped
+ * discriminated unions (MP-7), never thrown.
+ */
+
+export type HealthStatus =
+  | { readonly healthy: true; readonly lastTickAt: string }
+  | { readonly healthy: false; readonly reason: string; readonly lastTickAt?: string };
+
+export type RepairResult =
+  | { readonly outcome: "repaired"; readonly action: string }
+  | { readonly outcome: "repair_failed"; readonly reason: string }
+  | { readonly outcome: "peer_not_found"; readonly peerRoomId: string };
+
+export interface MutualRepairPort {
+  /** Check whether a peer room is healthy. */
+  checkPeerHealth(peerRoomId: string): Promise<HealthStatus>;
+  /** Attempt to repair a peer room (restart its agent, fix its config). */
+  repairPeer(peerRoomId: string): Promise<RepairResult>;
+  /** Attempt to repair the cluster from outside the failure domain. */
+  repairCluster(): Promise<RepairResult>;
+}
+
+/** BFT quorum: at least 3 healthy peers needed before attempting mutual repair. */
+export const MIN_PEERS_FOR_BFT = 3;
+
+/** Can we attempt mutual repair? Need ≥3 healthy peers (BFT margin). */
+export function canAttemptRepair(healthStatuses: readonly HealthStatus[]): boolean {
+  return countHealthy(healthStatuses) >= MIN_PEERS_FOR_BFT;
+}
+
+/** Number of healthy peers in a set of statuses. */
+export function countHealthy(healthStatuses: readonly HealthStatus[]): number {
+  return healthStatuses.filter((s) => s.healthy).length;
+}
+
+export type MockMutualRepairOptions = {
+  /** Peer rooms considered healthy; everything else is reported unhealthy. */
+  readonly healthyPeers?: readonly string[];
+  /** Peers known to the federation (unknown peers → peer_not_found). */
+  readonly knownPeers?: readonly string[];
+  /** Whether a repair attempt succeeds. */
+  readonly repairSucceeds?: boolean;
+  /** Whether a cluster repair attempt succeeds. */
+  readonly clusterRepairSucceeds?: boolean;
+  /** Fixed timestamp for deterministic health reports. */
+  readonly nowIso?: string;
+};
+
+/** Deterministic in-process mutual-repair adapter for DST. */
+export function createMockMutualRepair(options: MockMutualRepairOptions = {}): MutualRepairPort {
+  const healthy = new Set(options.healthyPeers ?? []);
+  const known = new Set(options.knownPeers ?? options.healthyPeers ?? []);
+  const repairSucceeds = options.repairSucceeds ?? true;
+  const clusterRepairSucceeds = options.clusterRepairSucceeds ?? true;
+  const nowIso = options.nowIso ?? "2026-01-01T00:00:00.000Z";
+  return {
+    checkPeerHealth(peerRoomId: string): Promise<HealthStatus> {
+      return Promise.resolve(
+        healthy.has(peerRoomId)
+          ? { healthy: true, lastTickAt: nowIso }
+          : { healthy: false, reason: "no recent tick", lastTickAt: nowIso },
+      );
+    },
+    repairPeer(peerRoomId: string): Promise<RepairResult> {
+      if (!known.has(peerRoomId)) {
+        return Promise.resolve({ outcome: "peer_not_found", peerRoomId });
+      }
+      return Promise.resolve(
+        repairSucceeds
+          ? { outcome: "repaired", action: `restarted ${peerRoomId}` }
+          : { outcome: "repair_failed", reason: "restart did not bring peer healthy" },
+      );
+    },
+    repairCluster(): Promise<RepairResult> {
+      return Promise.resolve(
+        clusterRepairSucceeds
+          ? { outcome: "repaired", action: "reconciled cluster from outside failure domain" }
+          : { outcome: "repair_failed", reason: "cluster unreachable" },
+      );
+    },
+  };
+}

--- a/agentic-organization/packages/application/src/room-initialization.ts
+++ b/agentic-organization/packages/application/src/room-initialization.ts
@@ -1,0 +1,80 @@
+/**
+ * Room initialization — port of `full-ai-cluster/PROVISIONING.md`
+ * "6 values per box" cookie-cutter provisioning (Merge1 §09).
+ *
+ * Each room is initialized with 6 configuration values, split by content class
+ * (mirroring §08 `RestoredCredential.contentClass`):
+ *   1. Node hostname               — public_identifier
+ *   2. Operator SSH pubkey         — public_identifier
+ *   3. zeta user password (hash)   — secret_material
+ *   4. WiFi credentials            — secret_material
+ *   5. Cluster join token          — secret_material
+ *   6. Agent vendor API keys       — secret_material
+ *
+ * Secret material is injected via the credential proxy (§08) and never visible
+ * to the agent. This module provides the config shape + pure, testable
+ * classification / validation; the full `initializeRoom` (restore credentials →
+ * create SPIFFE identity → real room → self-register) is deferred to the §04/§08
+ * integration layer (transport + credential bootstrap + createRealRoom), matching
+ * the new-modules-first precedent of the prior sections.
+ */
+
+export interface RoomInitializationConfig {
+  readonly hostname: string;
+  readonly operatorSshPubkey: string;
+  // Secret material — injected via the credential proxy, never visible to the agent.
+  readonly zetaUserPasswordHash: string;
+  readonly wifiCredentials?: { readonly ssid: string; readonly psk: string };
+  readonly clusterJoinToken?: string;
+  readonly vendorApiKeys?: Readonly<Record<string, string>>;
+}
+
+export type ProvisioningValueClass = "public_identifier" | "secret_material";
+
+export type ClassifiedProvisioningValue = {
+  readonly field: string;
+  readonly contentClass: ProvisioningValueClass;
+  readonly present: boolean;
+};
+
+/**
+ * Classify the 6 provisioning values into public vs secret (pure). Used to drive
+ * which values go to the credential proxy (secret) vs which may be logged /
+ * exposed to the agent (public).
+ */
+export function classifyProvisioningValues(config: RoomInitializationConfig): readonly ClassifiedProvisioningValue[] {
+  return [
+    { field: "hostname", contentClass: "public_identifier", present: config.hostname !== "" },
+    { field: "operatorSshPubkey", contentClass: "public_identifier", present: config.operatorSshPubkey !== "" },
+    { field: "zetaUserPasswordHash", contentClass: "secret_material", present: config.zetaUserPasswordHash !== "" },
+    { field: "wifiCredentials", contentClass: "secret_material", present: config.wifiCredentials !== undefined },
+    { field: "clusterJoinToken", contentClass: "secret_material", present: config.clusterJoinToken !== undefined },
+    { field: "vendorApiKeys", contentClass: "secret_material", present: config.vendorApiKeys !== undefined },
+  ];
+}
+
+export type InitializationError =
+  | { readonly kind: "missing_hostname" }
+  | { readonly kind: "missing_operator_pubkey" }
+  | { readonly kind: "missing_password_hash" };
+
+export type ValidateInitializationResult =
+  | { readonly outcome: "ok"; readonly value: RoomInitializationConfig }
+  | { readonly outcome: "feedback"; readonly error: InitializationError };
+
+/**
+ * Validate the minimum required provisioning values (the 3 always-required
+ * fields). Result-shaped (MP-7), never thrown.
+ */
+export function validateRoomInitializationConfig(config: RoomInitializationConfig): ValidateInitializationResult {
+  if (config.hostname === "") {
+    return { outcome: "feedback", error: { kind: "missing_hostname" } };
+  }
+  if (config.operatorSshPubkey === "") {
+    return { outcome: "feedback", error: { kind: "missing_operator_pubkey" } };
+  }
+  if (config.zetaUserPasswordHash === "") {
+    return { outcome: "feedback", error: { kind: "missing_password_hash" } };
+  }
+  return { outcome: "ok", value: config };
+}

--- a/agentic-organization/packages/application/src/systemd-runtime-adapter.ts
+++ b/agentic-organization/packages/application/src/systemd-runtime-adapter.ts
@@ -1,0 +1,84 @@
+/**
+ * Systemd runtime adapter — port of
+ * `full-ai-cluster/nixos/modules/zeta-ai-agent.nix` `makeAgentService`
+ * (Merge1 §09).
+ *
+ * The systemd service config (restart policy, RestartSec, memory + CPU limits,
+ * tick interval, network-not-cluster dependency) becomes room lifecycle
+ * parameters. `RoomBudget` (maxSteps / maxWallClockMs) maps onto the memory +
+ * CPU limits; the tick interval becomes the room's step frequency.
+ *
+ * The donor deliberately depends on `network-online.target` and NOT on
+ * `k3s.service` so an agent runs regardless of cluster state and can repair the
+ * cluster when it is broken — modelled here by `independentOfCluster`.
+ */
+
+import type { AgentPersonaConfig } from "./agent-persona-registry.ts";
+
+export interface RoomLifecycleConfig {
+  /** "always" = restart on any exit; "on-failure" = only on non-zero exit; "no" = never. */
+  readonly restartPolicy: "always" | "on-failure" | "no";
+  /** Seconds between restart attempts (systemd RestartSec). */
+  readonly restartSec: number;
+  /** Memory limit in bytes (systemd MemoryMax). */
+  readonly memoryLimitBytes: number;
+  /** CPU quota as a percentage of one core (systemd CPUQuota). */
+  readonly cpuQuotaPercent: number;
+  /** Tick interval in seconds — how often the agent loop runs. */
+  readonly tickIntervalSec: number;
+  /** Whether the room runs regardless of cluster state (mutual repair). */
+  readonly independentOfCluster: boolean;
+}
+
+export const DEFAULT_ROOM_LIFECYCLE: RoomLifecycleConfig = {
+  restartPolicy: "always",
+  restartSec: 5,
+  memoryLimitBytes: 2 * 1024 * 1024 * 1024, // 2 GiB
+  cpuQuotaPercent: 100,
+  tickIntervalSec: 60,
+  independentOfCluster: true,
+};
+
+/** Build a room lifecycle config from a persona config + optional overrides. */
+export function buildRoomLifecycle(
+  persona: AgentPersonaConfig,
+  overrides?: Partial<RoomLifecycleConfig>,
+): RoomLifecycleConfig {
+  void persona; // persona currently selects no per-vendor lifecycle deltas; reserved for future tuning
+  return { ...DEFAULT_ROOM_LIFECYCLE, ...overrides };
+}
+
+/**
+ * A rendered systemd-style unit description for a persona (the structured shape
+ * `makeAgentService` produces). Pure + deterministic so the unit contract can be
+ * asserted in tests without touching a real init system.
+ */
+export type RenderedAgentUnit = {
+  readonly description: string;
+  readonly after: readonly string[];
+  readonly wants: readonly string[];
+  readonly wantedBy: readonly string[];
+  readonly serviceType: "simple";
+  readonly restart: "always" | "on-failure" | "no";
+  readonly restartSec: number;
+  readonly memoryMax: number;
+  readonly cpuQuota: number;
+  readonly execStart: readonly string[];
+};
+
+/** Render the systemd-style unit for a persona under a lifecycle config (pure). */
+export function renderAgentUnit(persona: AgentPersonaConfig, lifecycle: RoomLifecycleConfig): RenderedAgentUnit {
+  return {
+    description: `${persona.description} (${persona.vendor})`,
+    // Deliberately NOT after k3s/cluster — only network — so the agent can repair the cluster.
+    after: ["network-online.target"],
+    wants: ["network-online.target"],
+    wantedBy: ["multi-user.target"],
+    serviceType: "simple",
+    restart: lifecycle.restartPolicy,
+    restartSec: lifecycle.restartSec,
+    memoryMax: lifecycle.memoryLimitBytes,
+    cpuQuota: lifecycle.cpuQuotaPercent,
+    execStart: [persona.binary, ...persona.invocationArgs],
+  };
+}

--- a/agentic-organization/packages/application/test/merge1-agent-runtime.test.ts
+++ b/agentic-organization/packages/application/test/merge1-agent-runtime.test.ts
@@ -1,0 +1,146 @@
+import { deepEqual, equal, ok } from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  PERSONA_REGISTRY,
+  distinctVendors,
+  getPersona,
+  listPersonas,
+} from "../src/agent-persona-registry.ts";
+import {
+  DEFAULT_ROOM_LIFECYCLE,
+  buildRoomLifecycle,
+  renderAgentUnit,
+} from "../src/systemd-runtime-adapter.ts";
+import {
+  MIN_PEERS_FOR_BFT,
+  canAttemptRepair,
+  countHealthy,
+  createMockMutualRepair,
+  type HealthStatus,
+} from "../src/mutual-repair.ts";
+import {
+  classifyProvisioningValues,
+  validateRoomInitializationConfig,
+  type RoomInitializationConfig,
+} from "../src/room-initialization.ts";
+
+// --- §6.1 persona registry --------------------------------------------------
+
+test("persona registry has ≥3 vendor-diverse agents", () => {
+  const personas = listPersonas();
+  ok(personas.length >= 3);
+  ok(distinctVendors().length >= 3); // BFT diversity floor
+});
+
+test("listPersonas is deterministically ordered (DST replay)", () => {
+  deepEqual(
+    listPersonas().map((p) => p.name),
+    ["alexa", "lior", "otto", "riven", "vera"],
+  );
+});
+
+test("getPersona returns the donor invocation contract", () => {
+  equal(getPersona("otto")?.binary, "claude");
+  deepEqual(getPersona("otto")?.invocationArgs, ["--print", "<<autonomous-loop>>"]);
+  // donor source of truth: lior ships `agy` (Antigravity CLI), not `gemini`
+  equal(getPersona("lior")?.binary, "agy");
+  equal(getPersona("nope"), undefined);
+});
+
+test("every persona has a distinct binary", () => {
+  const binaries = listPersonas().map((p) => p.binary);
+  equal(new Set(binaries).size, binaries.length);
+});
+
+// --- §6.2 room lifecycle config ---------------------------------------------
+
+test("room lifecycle defaults to always-restart, cluster-independent", () => {
+  const lifecycle = buildRoomLifecycle(PERSONA_REGISTRY.otto!);
+  equal(lifecycle.restartPolicy, "always");
+  equal(lifecycle.independentOfCluster, true);
+  deepEqual(lifecycle, DEFAULT_ROOM_LIFECYCLE);
+});
+
+test("buildRoomLifecycle applies overrides", () => {
+  const lifecycle = buildRoomLifecycle(PERSONA_REGISTRY.otto!, { tickIntervalSec: 1, restartPolicy: "on-failure" });
+  equal(lifecycle.tickIntervalSec, 1);
+  equal(lifecycle.restartPolicy, "on-failure");
+  equal(lifecycle.restartSec, DEFAULT_ROOM_LIFECYCLE.restartSec); // untouched
+});
+
+test("renderAgentUnit depends on network, NOT the cluster", () => {
+  const unit = renderAgentUnit(PERSONA_REGISTRY.vera!, DEFAULT_ROOM_LIFECYCLE);
+  deepEqual(unit.after, ["network-online.target"]);
+  ok(!unit.after.some((d) => d.includes("k3s") || d.includes("k8s")));
+  deepEqual(unit.execStart, ["codex", "exec", "<<autonomous-loop>>"]);
+  equal(unit.restart, "always");
+  equal(unit.serviceType, "simple");
+});
+
+// --- §6.3 mutual repair BFT quorum ------------------------------------------
+
+const healthy: HealthStatus = { healthy: true, lastTickAt: "2026-01-01T00:00:00.000Z" };
+const unhealthy: HealthStatus = { healthy: false, reason: "no tick" };
+
+test("need ≥3 healthy peers for mutual repair", () => {
+  equal(MIN_PEERS_FOR_BFT, 3);
+  ok(!canAttemptRepair([healthy, unhealthy]));
+  ok(!canAttemptRepair([healthy, healthy]));
+  ok(canAttemptRepair([healthy, healthy, healthy]));
+  equal(countHealthy([healthy, unhealthy, healthy]), 2);
+});
+
+test("mock mutual repair reports peer health deterministically", async () => {
+  const repair = createMockMutualRepair({ healthyPeers: ["room-a"], nowIso: "2026-02-02T00:00:00.000Z" });
+  const a = await repair.checkPeerHealth("room-a");
+  ok(a.healthy && a.lastTickAt === "2026-02-02T00:00:00.000Z");
+  const b = await repair.checkPeerHealth("room-b");
+  ok(!b.healthy);
+});
+
+test("mock mutual repair: repair peer / unknown peer / cluster (Result-shaped)", async () => {
+  const repair = createMockMutualRepair({ knownPeers: ["room-a"], repairSucceeds: true });
+  const ok1 = await repair.repairPeer("room-a");
+  equal(ok1.outcome, "repaired");
+  const missing = await repair.repairPeer("room-x");
+  ok(missing.outcome === "peer_not_found" && missing.peerRoomId === "room-x");
+  const cluster = await repair.repairCluster();
+  equal(cluster.outcome, "repaired");
+
+  const failing = createMockMutualRepair({ knownPeers: ["room-a"], repairSucceeds: false, clusterRepairSucceeds: false });
+  equal((await failing.repairPeer("room-a")).outcome, "repair_failed");
+  equal((await failing.repairCluster()).outcome, "repair_failed");
+});
+
+// --- §6.6 room initialization (6-value provisioning) ------------------------
+
+const MIN_CONFIG: RoomInitializationConfig = {
+  hostname: "node-1",
+  operatorSshPubkey: "ssh-ed25519 AAAA",
+  zetaUserPasswordHash: "$6$abc",
+};
+
+test("provisioning values are classified public vs secret", () => {
+  const classified = classifyProvisioningValues({
+    ...MIN_CONFIG,
+    clusterJoinToken: "tok",
+    vendorApiKeys: { anthropic: "sk-..." },
+  });
+  const publicFields = classified.filter((c) => c.contentClass === "public_identifier").map((c) => c.field);
+  deepEqual(publicFields, ["hostname", "operatorSshPubkey"]);
+  // password / wifi / token / api keys are all secret
+  ok(classified.find((c) => c.field === "zetaUserPasswordHash")?.contentClass === "secret_material");
+  ok(classified.find((c) => c.field === "wifiCredentials")?.present === false);
+  ok(classified.find((c) => c.field === "clusterJoinToken")?.present === true);
+});
+
+test("validateRoomInitializationConfig requires the 3 mandatory fields", () => {
+  equal(validateRoomInitializationConfig(MIN_CONFIG).outcome, "ok");
+  const noHost = validateRoomInitializationConfig({ ...MIN_CONFIG, hostname: "" });
+  ok(noHost.outcome === "feedback" && noHost.error.kind === "missing_hostname");
+  const noKey = validateRoomInitializationConfig({ ...MIN_CONFIG, operatorSshPubkey: "" });
+  ok(noKey.outcome === "feedback" && noKey.error.kind === "missing_operator_pubkey");
+  const noPass = validateRoomInitializationConfig({ ...MIN_CONFIG, zetaUserPasswordHash: "" });
+  ok(noPass.outcome === "feedback" && noPass.error.kind === "missing_password_hash");
+});


### PR DESCRIPTION
## Summary

Final Merge1 section. Faithful port of the systemd-based agent runtime from
`full-ai-cluster/` into `agentic-organization`. The systemd persona registry
becomes room agent personas, the service lifecycle becomes room lifecycle
parameters, mutual repair becomes room-federation recovery, and the installer's
"6 values per box" provisioning becomes room initialization. New-modules-first,
same precedent as §01–§08.

New modules (`packages/application/src/`):

- **`agent-persona-registry.ts`** — port of `zeta-ai-agent.nix` `personas`.
  5 vendor-diverse personas (otto/alexa/riven/vera/lior); each persona's
  `binary` + `invocationArgs` is the room's agent invocation contract.
  `listPersonas` is name-sorted (DST replay); `distinctVendors` exposes the BFT
  diversity surface.
  ```ts
  PERSONA_REGISTRY.otto // { vendor: "anthropic", binary: "claude",
                        //   invocationArgs: ["--print", "<<autonomous-loop>>"] }
  ```

- **`systemd-runtime-adapter.ts`** — port of `makeAgentService`.
  `RoomLifecycleConfig` (restart policy, `RestartSec`, memory/CPU limits, tick
  interval, `independentOfCluster`), `DEFAULT_ROOM_LIFECYCLE`,
  `buildRoomLifecycle`, and a pure `renderAgentUnit` that asserts the donor's
  load-bearing invariant: `after = ["network-online.target"]` and **not** k3s, so
  an agent runs (and can repair the cluster) regardless of cluster state.

- **`mutual-repair.ts`** — port of the mutual-repair concept. `MutualRepairPort`
  seam (`checkPeerHealth`/`repairPeer`/`repairCluster`), `MIN_PEERS_FOR_BFT = 3`,
  `canAttemptRepair` (BFT quorum so one broken agent can't cascade), and a
  deterministic `createMockMutualRepair` for DST. Outcomes are Result-shaped
  (MP-7), never thrown.

- **`room-initialization.ts`** — port of `PROVISIONING.md` "6 values per box".
  `RoomInitializationConfig` + pure `classifyProvisioningValues`
  (`public_identifier` vs `secret_material`, mirroring §08 `contentClass`) +
  `validateRoomInitializationConfig`.

**Donor↔doc reconciliation:** the §09 doc sketch lists lior `binary: "gemini"`;
the donor nix (the source of truth — AGENTS.md: the spec may be wrong, not the
code) ships lior `binary: "agy"` (Antigravity CLI, `-p` flag) per B-0850.3d.
Ported the donor's actual values + a test pinning it.

**Deferred (integration polish, same precedent):** `initializeRoom`,
`selfRegisterRoom`, and the `org-runtime.ts` / `work-os-runtime.ts` lifecycle
EXTENDs — these need §04 transport + §08 credential bootstrap + `createRealRoom`,
which aren't on `main` yet. The persona registry + lifecycle + mutual-repair
seams are the load-bearing new surface.

## Tests

`packages/application/test/merge1-agent-runtime.test.ts` — 12 tests: persona
registry (≥3 vendor-diverse, deterministic order, donor invocation contract,
distinct binaries), lifecycle (always-restart/cluster-independent defaults,
overrides, `renderAgentUnit` network-not-cluster + execStart), mutual repair (BFT
quorum, mock health/repair/cluster Result shapes), room init (public/secret
classification, mandatory-field validation).

Verification: `npm run typecheck` clean (6 pre-existing integration errors
untouched); `npm test` → **1547 pass / 0 fail / 7 skipped** (12 new).

This completes the Merge1 series (§01–§09).


Link to Devin session: https://app.devin.ai/sessions/77dac2be40e34088b799b6f1d927dbe3
Requested by: @maximdolphin