### PR TITLE
feat(setup): op cross-OS via mise; generalize cask framework (cvc5 off one-off)

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -66,6 +66,14 @@ actionlint = "1.7.12"
 # slim + ubuntu-24.04-arm runners don't ship shellcheck pre-
 # installed, so declarative pin here ensures dev/CI parity.
 shellcheck = "0.11.0"
+# 1Password CLI (`op`) — cross-OS secret/cert access for the private-key-custody lane
+# (Aaron 2026-06-21: "1password-cli ... we need to support on all operating systems ...
+# just the cli not the whole app ... make sure all our oses have it"). Via mise (the
+# cross-platform path — NOT per-OS brew/apt/scoop) so mac+linux+windows get the SAME
+# pinned `op` in one line. Scoped service accounts + `op` give least-privilege agent
+# secret retrieval; the desktop app (mac cask) is deliberately NOT a dep (CLI suffices).
+# Pin per dep-pin-search-first (mise ls-remote 2026-06-21): 1password-cli 2.34.1.
+"1password-cli" = "2.34.1"
 # Cluster integration + GitOps tooling (k3d/kind/kubectl/helm/kubeconform) moved to
 # .mise.full.toml (host-tier split, workitem 081KTWQZY7F08QG0R0034KN17T): full-tier hosts
 # (dev laptops, cluster nodes, CI k8s lanes) still converge on the one pinned tool graph

--- a/tools/setup/macos.sh
+++ b/tools/setup/macos.sh
@@ -130,11 +130,19 @@ if [ -f "$CASK_MANIFEST" ]; then
     echo "↓ installing brew casks from $(basename "$CASK_MANIFEST")..."
     printf '%s\n' "$CASKS" | while IFS= read -r cask_line; do
       required_tier="$(zeta_tier_of_line "$cask_line")"
-      cask="$(zeta_strip_tier "$cask_line" | awk '{print $1}')"
+      stripped="$(zeta_strip_tier "$cask_line")"
+      cask="$(printf '%s' "$stripped" | awk '{print $1}')"
       [ -z "$cask" ] && continue
+      # Optional `tap=<owner/tap>` token — a custom tap (e.g. cvc5/cvc5) is tapped + trusted
+      # before install. Generalizes the former cvc5 one-off into the manifest framework.
+      tap="$(printf '%s' "$stripped" | awk '{for(i=2;i<=NF;i++){if($i ~ /^tap=/){sub(/^tap=/,"",$i); print $i}}}')"
       if ! zeta_tier_allows "$required_tier"; then
         echo "→ $cask skipped: requires tier=$required_tier, host is $ZETA_HOST_TIER ($ZETA_HOST_TIER_SOURCE)"
         continue
+      fi
+      if [ -n "$tap" ]; then
+        brew tap "$tap" >/dev/null 2>&1 || true
+        brew trust "$tap" >/dev/null 2>&1 || true
       fi
       if brew list --cask "$cask" >/dev/null 2>&1; then
         brew upgrade --cask "$cask" >/dev/null 2>&1 || true
@@ -145,15 +153,6 @@ if [ -f "$CASK_MANIFEST" ]; then
   fi
 fi
 echo "✓ brew casks up to date"
-
-# Tap, trust, and install the official cvc5 cask (custom tap for macOS)
-if ! command -v cvc5 >/dev/null 2>&1; then
-  echo "↓ tapping and installing cvc5..."
-  brew tap cvc5/cvc5
-  brew trust cvc5/cvc5 || true
-  brew install --cask cvc5
-fi
-echo "✓ cvc5 installed"
 
 # ── 4. mise ─────────────────────────────────────────────────────────
 # Keep in sync with .mise.toml min_version and tools/setup/linux.sh MISE_PIN_VERSION.

--- a/tools/setup/manifests/brew-cask
+++ b/tools/setup/manifests/brew-cask
@@ -1,19 +1,24 @@
-# macOS Homebrew CASKS — GUI apps + cask-distributed CLIs, installed by
-# tools/setup/macos.sh (`brew install --cask`). Formulae live in manifests/brew.
-# Add a cask by appending a line. Comments start with `#`. Tier tags (tier=slim|
-# standard|full) are honored exactly as in manifests/brew.
+# macOS Homebrew CASKS — GUI apps + cask-only tools, installed by tools/setup/macos.sh
+# (`brew install --cask`). Formulae live in manifests/brew; cross-platform CLIs live in
+# .mise.toml. Add a cask by appending a line. Comments start with `#`. Tier tags
+# (tier=slim|standard|full) are honored exactly as in manifests/brew.
 #
-# Why a separate manifest: casks are `brew install --cask` + `brew list --cask`
-# (a different namespace than formulae). The formula loop in macos.sh uses
-# `brew list --formula`, so casks need their own declarative list + loop.
+# Why this manifest exists (Aaron 2026-06-21 — "general casks support for mac is good …
+# keep it"): casks are a separate brew namespace (`brew install --cask` / `brew list
+# --cask`) than formulae, so they need their own declarative list + loop (macos.sh §3b).
+# Standing infra for any future mac-only GUI app / cask-only tool.
+#
+# NOTE on 1Password: the CLI (`op`) is CROSS-OS and lives in .mise.toml (one pinned `op`
+# for mac+linux+windows — Aaron: "just the cli … all our oses"), NOT here. The 1Password
+# DESKTOP APP is intentionally NOT a dep (CLI + scoped service accounts suffice for agent
+# secret access; the app/SSH-agent can be added later if the custody lane needs it).
+#
+# Format: <cask> [tap=<owner/tap>] [tier=slim|standard|full]
+#   tap=<owner/tap> — a custom tap (tapped + trusted before install). Append real casks
+#   below as needed; the §3b loop installs them idempotently, tier-gated.
 
-# Secret / private-key custody (Aaron 2026-06-21 — "add 1password to our deps
-# desired state"). The private-key-custody lane: 1Password holds CA + machine
-# keys; its SSH agent SIGNS without exposing private bytes (same non-extractable
-# property as Vault/Secure Enclave), and `op` + service accounts give scoped,
-# least-privilege agent access. The bootstrap of the Vault + cert-manager model
-# (decision doc 2026-06-21-multi-owner-machines-…; backlog 081KVNMFYS8…).
-# Verified (dep-pin-search-first, brew 2026-06-21): cask `1password` 8.12.24 ✓,
-# cask `1password-cli` 2.34.1 ✓. brew default version; idempotent (skips if present).
-1password      # the desktop app — operator sign-in + the 1Password SSH agent
-1password-cli  # `op` — scoped service-account / CLI access for agent secret retrieval
+# cvc5 — SMT solver (formal-verification portfolio), distributed via a custom cask tap.
+# Migrated 2026-06-21 from a one-off block in macos.sh into this general framework (Aaron:
+# "update our special one off cask to use our new general framework too"). The tap= token
+# taps + trusts cvc5/cvc5 before the cask install.
+cvc5  tap=cvc5/cvc5


### PR DESCRIPTION
Refines the 1Password dep per Aaron 2026-06-21: (1) `op` → .mise.toml (`1password-cli = 2.34.1`) so all OSes get the CLI in one line (the cross-platform discipline); desktop app NOT a dep. (2) Kept the general mac cask framework. (3) Taught the cask loop a `tap=` token + migrated cvc5 from its one-off block into manifests/brew-cask. bash -n + shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)