### PR TITLE
chore(keys): drop the static machines/principals.json seed — let the topology emerge

### DIFF
--- a/machines/principals.json
+++ b/machines/principals.json
@@ -1,3 +1,0 @@
-{
-  "acehacks-mac-studio.local": ["aaron"]
-}


### PR DESCRIPTION
Aaron 2026-06-21: "we don't need that static map ... let it emerge ... revoke is basically retract in DBSP zsets." Removes the mind-exercise seed; per the event-sourced reframe the topology is the fold of grant(+1)/revoke(−1) events, materialized later. Safe: loader fail-inert on absent, nix render guarded on exists+lists-host → absent = inert. Tests green (temp fixtures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)