### PR TITLE
feat(setup): secure op service-account token provisioning (Keychain + reusable blueprint)

### DIFF
--- a/.claude/skills/security/blueprints/op-service-account-token-provisioning.md
+++ b/.claude/skills/security/blueprints/op-service-account-token-provisioning.md
@@ -1,0 +1,65 @@
+# Blueprint: provision a 1Password service-account token for the agent (secure, reusable)
+
+**Purpose:** give an agent scoped, revocable 1Password access **without the agent ever
+seeing the token in its context/transcript**, on a machine with no desktop-app integration.
+The agent EXECUTES; the operator pastes the token into a native secure dialog (or has it on
+the clipboard); the token flows window/clipboard → macOS Keychain → runtime fetch. Aaron
+2026-06-21: *"reusable workflow/blueprint … pop up a secure window for me to type it in and
+you do everything … reuse our profile-edit scripts."*
+
+## When to use
+
+A dev/build machine needs `op` (1Password CLI) access for the agent, the desktop-app
+integration (Touch ID, token-free) is not enabled, and you want encrypted-at-rest custody
+of the service-account token (not a plaintext dotfile, not base64-in-a-workflow).
+
+## The one move
+
+```bash
+# operator creates the service account on 1password.com (Developer → Service Accounts),
+# scoped to ONE vault (least-privilege), then either copies the token to the clipboard OR
+# is ready to paste it into the secure dialog. Then the AGENT runs:
+bash tools/setup/op-token-setup.sh             # native secure dialog (hidden input)
+#   or
+bash tools/setup/op-token-setup.sh --clipboard # read from the clipboard
+bash tools/setup/common/shellenv.sh            # regen so shellenv sources secrets-env.sh
+```
+
+That script (idempotent, macOS): captures the `ops_…` token via `osascript` hidden-answer
+dialog or `pbpaste`, validates the prefix **without echoing**, stores it ENCRYPTED in the
+login Keychain (`security add-generic-password -U`), and writes the runtime FETCH line to
+`~/.config/zeta/secrets-env.sh` (mode 600) — `export OP_SERVICE_ACCOUNT_TOKEN="$(security
+find-generic-password -s zeta-op-service-account -w)"`. The managed `shellenv.sh` (already
+sourced by the profile via `profile-edit.sh`) sources `secrets-env.sh`, so every shell —
+including the agent's fresh subprocesses — gets the scoped token from the Keychain.
+
+## Security invariants (why an agent may run this)
+
+- **Token never enters the agent's context/transcript.** Capture is window/clipboard →
+  Keychain inside the script subprocess; the agent must NOT use its own ask/question tool for
+  a secret (that would transcript it). The native secure dialog is the "popup."
+- **Encrypted at rest** (Keychain), **in-process only at use** (`export` is `export` — the
+  plaintext window is minimized, never persisted to a dotfile). The repo holds only the
+  mechanism; `secrets-env.sh` lives in `~/.config`, never committed.
+- **Least-privilege + revocable**: scope the service account to ONE vault; delete it to
+  revoke instantly.
+- **NEVER** store/recover the token via `base64`-print in a CI log (trust-leak anti-pattern).
+  CI uses a GitHub Actions secret consumed in-step via `1password/load-secrets-action`.
+
+## Verify
+
+```bash
+op whoami                      # User Type: SERVICE_ACCOUNT
+op vault list                  # shows ONLY the scoped vault
+op item list --vault <vault>   # the granted items; nothing else
+```
+
+## Paths to the better, token-free custody (later)
+
+- **Desktop-app integration** (dev): Touch ID, no token at rest at all.
+- **Vault + cert-manager** (cluster): short-lived issuance, HSM custody.
+
+See `docs/research/2026-06-21-config-and-secrets-as-event-sourced-zset-dbsp-…` (custody +
+the event-sourced direction) and the `cluster-encryption-credential-substrate` trajectory.
+Reuses: `tools/setup/op-token-setup.sh`, `tools/setup/common/shellenv.sh`,
+`tools/setup/common/profile-edit.sh`.

--- a/tools/setup/common/shellenv.sh
+++ b/tools/setup/common/shellenv.sh
@@ -102,6 +102,13 @@ mkdir -p "$ZETA_ENV_DIR"
     echo "  eval \"\$(mise activate bash)\""
     echo "fi"
   fi
+
+  # Managed agent SECRETS env — a separate file (mode 600) holding Keychain-FETCH lines
+  # (e.g. `export OP_SERVICE_ACCOUNT_TOKEN="$(security find-generic-password ...)"`), written
+  # by tools/setup/op-token-setup.sh. Kept OUT of this regenerated file (which is wiped each
+  # run) so the secret-fetch survives. Sourced here so every shell that gets shellenv also
+  # gets the agent's scoped secrets. Absent ⇒ inert (the -f guard).
+  echo "[ -f \"\$HOME/.config/zeta/secrets-env.sh\" ] && . \"\$HOME/.config/zeta/secrets-env.sh\""
 } > "$ZETA_ENV_FILE"
 
 echo "✓ shellenv at $ZETA_ENV_FILE"

--- a/tools/setup/op-token-setup.sh
+++ b/tools/setup/op-token-setup.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# tools/setup/op-token-setup.sh — securely capture a 1Password SERVICE-ACCOUNT token
+# (`ops_…`) into the macOS Keychain + wire a runtime-fetch into the managed shell env.
+# Aaron 2026-06-21: "make some reusable workflow/blueprint … pop up a secure window for me
+# to type it in and you do everything … reuse our profile-edit scripts."
+#
+# SECURITY MODEL (why this is safe for an AGENT to run):
+#   - The token is captured via a NATIVE macOS secure dialog (osascript, hidden answer) OR
+#     from the clipboard (`--clipboard`). It NEVER passes through the agent's stdout, the
+#     terminal echo, or the conversation transcript — it flows window/clipboard → Keychain.
+#   - At REST it lives ENCRYPTED in the login Keychain (`security add-generic-password`),
+#     NOT in any dotfile in plaintext.
+#   - The shell env file holds only the FETCH command
+#     (`export OP_SERVICE_ACCOUNT_TOKEN="$(security find-generic-password -s … -w)"`),
+#     never the token value — so the secret is in-process only at use (export is export),
+#     with the plaintext window minimized. (Encrypt-at-rest yes; encrypt-in-use no — see
+#     the custody discussion 2026-06-21.)
+#   - This is the bootstrap; the desktop-app integration (Touch ID, no token) and Vault
+#     (short-lived issuance) are the later, token-free paths.
+#
+# Usage:
+#   bash tools/setup/op-token-setup.sh              # secure GUI dialog (hidden input)
+#   bash tools/setup/op-token-setup.sh --clipboard  # read the token from the clipboard
+#   bash tools/setup/op-token-setup.sh --service <name>   # Keychain item name (default below)
+#
+# Idempotent: re-running updates the Keychain item in place (`-U`) and rewrites secrets-env.sh.
+# macOS only (uses `security`; falls back with a clear message elsewhere — Linux/CI use the
+# GitHub-secret path instead, consumed in-step, never base64-printed).
+
+set -euo pipefail
+
+SERVICE="zeta-op-service-account"
+SOURCE="dialog"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --clipboard) SOURCE="clipboard" ;;
+    --service) SERVICE="${2:?--service needs a name}"; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "✗ op-token-setup.sh is macOS-only (uses the Keychain)." >&2
+  echo "  On Linux/CI use a GitHub Actions secret (OP_SERVICE_ACCOUNT_TOKEN), consumed" >&2
+  echo "  in-step via 1password/load-secrets-action — never base64-printed." >&2
+  exit 1
+fi
+
+# ── Capture the token WITHOUT echoing it ────────────────────────────
+TOKEN=""
+if [ "$SOURCE" = "clipboard" ]; then
+  TOKEN="$(pbpaste)"
+  [ -n "$TOKEN" ] || { echo "✗ clipboard empty" >&2; exit 1; }
+else
+  # Native secure prompt — hidden answer; token goes straight here, never to the terminal.
+  TOKEN="$(osascript <<'OSA' 2>/dev/null || true
+text returned of (display dialog "Paste your 1Password service-account token (ops_…). It goes straight to the macOS Keychain — never the terminal or the agent." default answer "" with hidden answer buttons {"Cancel", "Store"} default button "Store" with title "Zeta — store op service-account token")
+OSA
+)"
+  [ -n "$TOKEN" ] || { echo "✗ cancelled / empty (nothing stored)" >&2; exit 1; }
+fi
+
+# Validate shape WITHOUT printing the value.
+case "$TOKEN" in
+  ops_*) : ;;
+  *) echo "✗ that doesn't look like a service-account token (expected ops_…); nothing stored." >&2; exit 1 ;;
+esac
+
+# ── Store ENCRYPTED in the login Keychain (update in place if present) ──
+security add-generic-password -a "$USER" -s "$SERVICE" -U -w "$TOKEN"
+unset TOKEN  # drop it from this process ASAP
+
+# ── Wire the runtime FETCH into the managed secrets-env (mode 600) ──
+ZETA_ENV_DIR="$HOME/.config/zeta"
+SECRETS_ENV="$ZETA_ENV_DIR/secrets-env.sh"
+mkdir -p "$ZETA_ENV_DIR"
+umask 077
+cat > "$SECRETS_ENV" <<EOF
+# Zeta managed agent secrets — Keychain-FETCH lines (NOT secrets). mode 600.
+# Written by tools/setup/op-token-setup.sh. Sourced by ~/.config/zeta/shellenv.sh.
+export OP_SERVICE_ACCOUNT_TOKEN="\$(security find-generic-password -s $SERVICE -w 2>/dev/null)"
+EOF
+chmod 600 "$SECRETS_ENV"
+
+echo "✓ token stored ENCRYPTED in Keychain (service: $SERVICE) — value never printed."
+echo "✓ fetch wired into $SECRETS_ENV (mode 600; holds the fetch command, not the token)."
+echo "  New shells get OP_SERVICE_ACCOUNT_TOKEN via profile → shellenv.sh → secrets-env.sh."
+echo "  (Re-run tools/setup/common/shellenv.sh once so it sources secrets-env.sh.)"


### PR DESCRIPTION
Agent-runs/operator-provides-securely: `op-token-setup.sh` captures the `ops_…` token via a native macOS secure dialog (or --clipboard) — never through the agent's transcript — stores it ENCRYPTED in the Keychain, and wires a runtime fetch via secrets-env.sh (sourced by the existing shellenv). Reuses profile-edit/shellenv. Blueprint included. VERIFIED LIVE: real token → Keychain → fresh agent shell → `op` authed scoped to Lucent only. No secret in repo; bash+shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)