### PR TITLE
chore(post-8948): resume state, backlog bookkeeping, Ace Bun realizers slice 1

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -985,7 +985,7 @@ are closed (status: closed/done in frontmatter)._
 
 ## P3 — convenience / deferred
 
-- [ ] **[081KLL7PPSUMF84HN7WN96ZEQ1P77U](backlog/P3/081KLL7PPSUMF84HN7WN96ZEQ1P77U-ace-setup-manifest-realizers-defer-until-mechanism-consolidation-and-ci-clean.md)** Ace setup-manifest realizers — defer Bun/Ace realizer swap until non-mechanism install scripts are consolidated and CI is clean (Aaron 2026-06-21)
+- [ ] **[081KLL7PPSUMF84HN7WN96ZEQ1P77U](backlog/P3/081KLL7PPSUMF84HN7WN96ZEQ1P77U-ace-setup-manifest-realizers-defer-until-mechanism-consolidation-and-ci-clean.md)** Ace setup-manifest realizers — Bun realizers post-mechanism consolidation (Aaron 2026-06-21)
 - [ ] **[081KQ0YZ80008QG0R0000HSTWD](backlog/P3/081KQ0YZ80008QG0R0000HSTWD-substrate-ip-rotation-control-bypass-non-account-bound-rate-.md)** Substrate-controlled visible IP — bypass non-account-bound rate limits responsibly across deployment surfaces (own up to it, don't hide the framing)
 - [ ] **[081KQ0YZ80008QG0R0006VRT18](backlog/P3/081KQ0YZ80008QG0R0006VRT18-trading-account-offer-aaron-self-funding-path-prerequisite-p.md)** Trading-account offer (Aaron, self-funding path for the agent) — accepted in principle pending paper-trading + conviction-grounding prerequisite work
 - [x] **[081KQ0YZ80008QG0R0009EQNHP](backlog/P3/081KQ0YZ80008QG0R0009EQNHP-rename-backlog-schema-field-directive-to-ask-otto-293-violat.md)** Rename backlog schema field `directive:` → `ask:` per Otto-293 (one-way language at YAML schema layer); ~18 existing rows + tooling that reads the field

--- a/docs/backlog/P1/081KSXN940008QG0R002FWR9B2-migrate-backlog-sequential-b-nnnn-ids-to-zetaid-workitem-key.md
+++ b/docs/backlog/P1/081KSXN940008QG0R002FWR9B2-migrate-backlog-sequential-b-nnnn-ids-to-zetaid-workitem-key.md
@@ -5,7 +5,7 @@ status: open
 priority: P1
 created: 2026-05-31
 attribution: aaron-otto-2026-05-31
-last_updated: 2026-05-31
+last_updated: 2026-06-21
 decomposition: umbrella
 depends_on:
   - 081KSXN940008QG0R00171YAZW
@@ -31,6 +31,12 @@ tags:
 ---
 
 # 081KSXN940008QG0R002FWR9B2 — Work-items → ZetaId WorkItem keys (conflict-free, no consensus)
+
+> **Progress 2026-06-21 (#8948 merged):** the **backlog shard** slice is complete —
+> all `docs/backlog/*` rows use zetaid-only `id:` frontmatter; repo-wide prose refs
+> migrated; `lint-no-b-refs` + `lint-no-new-bnnnn` gate the surface; migration scripts
+> retired; ~1,251 frozen aliases in `b-to-zetaid-map.json`. **This umbrella stays open**
+> for the work-item **event G-Set**, lifecycle state machine, and DORA Bag-folds (below).
 
 > **Product-team design review (2026-06-06):** the design memo this umbrella asks for is
 > [`docs/research/2026-06-06-product-team-review-b0956-backlog-to-zetaid-workitem-migration-pm2-ilyana-rodney-otto.md`](../../research/2026-06-06-product-team-review-b0956-backlog-to-zetaid-workitem-migration-pm2-ilyana-rodney-otto.md).
@@ -145,12 +151,13 @@ one git-native ZetaId-keyed event substrate** — G-Set base, Z-set/Bag views.
 
 ## Acceptance
 
+- [x] Existing `B-NNNN` backlog rows migrated to zetaid keys (#8948; frozen alias map for history).
 - [ ] New work-items get a `Category.WorkItem` ZetaId minted **locally, no consensus**.
 - [ ] `type ∈ {task, bug}` and `state ∈ {backlog, in-progress, done, closed, …}` are
       first-class; **"backlog" is a state value**, derivable as a Z-set view.
 - [ ] Disjoint-id files never collide across concurrent agents (G-Set property).
 - [ ] Metrics/DORA are Bag-folds over the work-item event G-Set (no separate store; reuses #6289).
-- [ ] Existing `B-NNNN` rows keep working (alias-and-keep) — no lost rows.
+- [x] Cross-references in backlog shard use zetaids (#8948).
 - [ ] The `otto-channels` ID-allocation consensus discipline is retired for work-items.
 
 ## Substrate-honest framing

--- a/docs/backlog/P3/081KLL7PPSUMF84HN7WN96ZEQ1P77U-ace-setup-manifest-realizers-defer-until-mechanism-consolidation-and-ci-clean.md
+++ b/docs/backlog/P3/081KLL7PPSUMF84HN7WN96ZEQ1P77U-ace-setup-manifest-realizers-defer-until-mechanism-consolidation-and-ci-clean.md
@@ -1,13 +1,13 @@
 ---
 id: 081KLL7PPSUMF84HN7WN96ZEQ1P77U
-priority: P3
-status: open
-unblocked: 2026-06-21
-title: Ace setup-manifest realizers — defer Bun/Ace realizer swap until non-mechanism install scripts are consolidated and CI is clean (Aaron 2026-06-21)
+priority: P2
+status: in-progress
+title: Ace setup-manifest realizers — Bun realizers post-mechanism consolidation (Aaron 2026-06-21)
 effort: L
 ask: Aaron 2026-06-21
 created: 2026-06-21
 last_updated: 2026-06-21
+unblocked: 2026-06-21
 decomposition: leaf
 depends_on:
   - 081KDU93J0OAZMF14J8R4K66ZR06XL
@@ -20,7 +20,14 @@ tags: [ace-package-manager, setup, defer, mechanism-by-source, install-graph, ba
 type: chore
 ---
 
-# 081KLL7PPSUMF84HN7WN96ZEQ1P77U — Ace setup-manifest realizers (deferred)
+# 081KLL7PPSUMF84HN7WN96ZEQ1P77U — Ace setup-manifest realizers
+
+## Status 2026-06-21
+
+Prerequisites satisfied: **081KDU93…** (#8920) + **#8948** gate green. Row **re-opened
+P2 / in-progress** — Bun realizer slice 1 landed in branch:
+`src/Core.TypeScript/ace/setup-realize.ts` + `from-uv-tool` + `from-bun-global` realizers.
+Shell realizers remain until `linux.sh` → `ace-realize --all` cutover.
 
 ## Operator framing (Aaron 2026-06-21)
 

--- a/docs/handoffs/2026-06-21-alexa-to-soraya-lean-cost-recurrence.md
+++ b/docs/handoffs/2026-06-21-alexa-to-soraya-lean-cost-recurrence.md
@@ -3,7 +3,7 @@
 Date: 2026-06-21
 From: Alexa (codegen)
 To: Soraya (formal verification)
-Status: summoned (timed out at 11min — heavy thinking mode, will pick up next tick)
+Status: complete — landed on main (`src/Core.Lean4/Lean4/CostRecurrence.lean`)
 
 ## Context
 

--- a/docs/handoffs/2026-06-21-otto-session-resume-state.md
+++ b/docs/handoffs/2026-06-21-otto-session-resume-state.md
@@ -1,0 +1,36 @@
+# Otto session resume — 2026-06-21
+
+Resume snapshot after **#8948 merged** (post-8920 steward arc). Saved at Aaron's
+request before continuing **081KLL7…** (Ace Bun realizers). Main at save:
+`09242ce51` (#8969 keys fix on tip).
+
+## Landed this session / immediately prior
+
+### #8948 — zetaid-only backlog + cross-verify oracles (MERGED)
+
+- Repo-wide `B-NNNN` → zetaid migration (~6k+ files); frozen alias maps only.
+- Retired `migrate-b-ids-to-zetaid.ts` / `backfill-legacy-zetaids.ts`.
+- CI: `lint-no-b-refs.ts` in backlog-index-integrity; hygiene `audit-rule-cross-refs` zetaid-aware.
+- Cross-verify: `IZSetIsa` in zeta-ir-v2 oracle set; gate green on dispatch.
+
+### Mechanism consolidation (#8920, prerequisite)
+
+- `081KDU93J0OAZMF14J8R4K66ZR06XL` **done** — non-mechanism `common/*.sh` realizers → `tools/setup/mechanisms/*`.
+- Ace pointers: `setup-mechanism-pointers.ts` + `ace-mechanism-pointers.json` cover all `from-*.sh` mechanisms.
+
+### Complexity spike (main, pre-#8948)
+
+- #8949 DST cost-counter · #8952 Z3 envelope · #8953 growth-shape property.
+- **`CostRecurrence.lean`** on main — sorry-free; both handoff theorems present.
+
+## Open / next — resume targets (sequenced)
+
+1. **Bookkeeping** — update `081KSXN940008QG0R002FWR9B2` (backlog slice landed; umbrella still open for work-item event store); confirm `081KLL7…` unblocked → **in progress**.
+2. **081KLL7… Ace Bun realizers** — first slice: `setup-realize.ts` + Bun realizers for manifest-simple mechanisms (`from-uv-tool`, `from-bun-global`); shell realizers remain until `linux.sh` → `ace-realize` cutover.
+3. **Lean handoff closed** — `docs/handoffs/2026-06-21-alexa-to-soraya-lean-cost-recurrence.md` → complete (`CostRecurrence.lean` verified).
+
+## Discipline
+
+- Canonical backlog keys are **zetaids only** — no new `B-NNNN` in prose or frontmatter.
+- Regenerate `docs/BACKLOG.md` after row edits (`BACKLOG_WRITE_FORCE=1 bun src/Core.TypeScript/backlog/generate-index.ts`).
+- Gate on fork PRs may need `workflow_dispatch` or maintainer approval to re-run.

--- a/src/Core.TypeScript/ace/setup-realize.ts
+++ b/src/Core.TypeScript/ace/setup-realize.ts
@@ -1,0 +1,67 @@
+#!/usr/bin/env bun
+// setup-realize.ts — Bun realizers for setup mechanism manifests (081KLL7… slice 1).
+//
+// Post-mise only: callers must run common/mise.sh first. Shell realizers in
+// tools/setup/mechanisms/*.sh remain authoritative until linux.sh cutover.
+//
+// Usage:
+//   bun src/Core.TypeScript/ace/setup-realize.ts --list
+//   bun src/Core.TypeScript/ace/setup-realize.ts from-uv-tool from-bun-global
+//   bun src/Core.TypeScript/ace/setup-realize.ts --all
+//   bun src/Core.TypeScript/ace/setup-realize.ts --dry-run from-uv-tool
+
+import {
+  createContext,
+  getSetupRealizer,
+  listSetupRealizerIds,
+} from "./setup-realizers/index.ts";
+
+function usage(): void {
+  process.stderr.write(`Usage: bun src/Core.TypeScript/ace/setup-realize.ts [--list|--all|--dry-run] [mechanism-id...]\n`);
+  process.stderr.write(`Known Bun realizers: ${listSetupRealizerIds().join(", ")}\n`);
+}
+
+async function main(argv: string[]): Promise<number> {
+  let dryRun = false;
+  let all = false;
+  const ids: string[] = [];
+
+  for (const arg of argv) {
+    if (arg === "--dry-run") dryRun = true;
+    else if (arg === "--all") all = true;
+    else if (arg === "--list") {
+      for (const id of listSetupRealizerIds()) process.stdout.write(`${id}\n`);
+      return 0;
+    } else if (arg === "--help" || arg === "-h") {
+      usage();
+      return 0;
+    } else if (arg.startsWith("-")) {
+      process.stderr.write(`Unknown flag: ${arg}\n`);
+      usage();
+      return 64;
+    } else {
+      ids.push(arg);
+    }
+  }
+
+  const targets = all ? [...listSetupRealizerIds()] : ids;
+  if (targets.length === 0) {
+    usage();
+    return 64;
+  }
+
+  const ctx = createContext({ dryRun });
+  for (const id of targets) {
+    const realizer = getSetupRealizer(id);
+    if (!realizer) {
+      process.stderr.write(`error: unknown Bun realizer ${JSON.stringify(id)}\n`);
+      return 64;
+    }
+    await realizer(ctx);
+  }
+  return 0;
+}
+
+if (import.meta.main) {
+  process.exit(await main(process.argv.slice(2)));
+}

--- a/src/Core.TypeScript/ace/setup-realizers.test.ts
+++ b/src/Core.TypeScript/ace/setup-realizers.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { repairCodexServiceTierConfig } from "./setup-realizers/from-bun-global.ts";
+import { realizeFromUvTool } from "./setup-realizers/from-uv-tool.ts";
+import { createContext } from "./setup-realizers/shared.ts";
+import { getSetupRealizer, listSetupRealizerIds } from "./setup-realizers/index.ts";
+
+describe("setup-realizers registry", () => {
+  test("lists Bun realizer ids in stable order", () => {
+    expect(listSetupRealizerIds()).toEqual(["from-bun-global", "from-uv-tool"]);
+  });
+
+  test("every registered id resolves", () => {
+    for (const id of listSetupRealizerIds()) {
+      expect(getSetupRealizer(id)).toBeDefined();
+    }
+  });
+});
+
+describe("repairCodexServiceTierConfig", () => {
+  test("migrates deprecated default tier to flex", () => {
+    const dir = mkdtempSync(join(tmpdir(), "codex-config-"));
+    const codexDir = join(dir, ".codex");
+    mkdirSync(codexDir, { recursive: true });
+    writeFileSync(join(codexDir, "config.toml"), 'service_tier = "default"\n');
+    expect(repairCodexServiceTierConfig(dir, false)).toBe(true);
+    expect(readFileSync(join(codexDir, "config.toml"), "utf8")).toContain('"flex"');
+  });
+});
+
+describe("realizeFromUvTool dry-run", () => {
+  test("skips when manifest missing", async () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "setup-realize-"));
+    const ctx = createContext({ repoRoot, dryRun: true });
+    const result = await realizeFromUvTool(ctx);
+    expect(result.skipped).toBe(true);
+    expect(result.mechanism).toBe("from-uv-tool");
+  });
+
+  test("records install actions for manifest entries", async () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "setup-realize-"));
+    const manifestDir = join(repoRoot, "tools/setup/manifests");
+    mkdirSync(manifestDir, { recursive: true });
+    writeFileSync(join(manifestDir, "from-uv-tool"), "zeta-setup-realizer-probe-nonexistent\n");
+    const ctx = createContext({ repoRoot, dryRun: true });
+    const result = await realizeFromUvTool(ctx);
+    expect(result.skipped).toBe(false);
+    expect(result.actions.some((a) => a.includes("uv tool install zeta-setup-realizer-probe-nonexistent"))).toBe(true);
+  });
+});

--- a/src/Core.TypeScript/ace/setup-realizers/from-bun-global.ts
+++ b/src/Core.TypeScript/ace/setup-realizers/from-bun-global.ts
@@ -1,0 +1,62 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  commandOnPath,
+  finishResult,
+  parseSimpleManifest,
+  readManifestFile,
+  runCommand,
+  type SetupRealizer,
+} from "./shared.ts";
+
+const MANIFEST = "tools/setup/manifests/from-bun-global";
+
+/** Migrate deprecated Codex `service_tier="default"` → `"flex"` (shell realizer parity). */
+export function repairCodexServiceTierConfig(homeDir: string, dryRun: boolean): boolean {
+  const configPath = join(homeDir, ".codex", "config.toml");
+  let text: string;
+  try {
+    text = readFileSync(configPath, "utf8");
+  } catch {
+    return false;
+  }
+  if (!/^\s*service_tier\s*=\s*"default"\s*($|#)/m.test(text)) return false;
+  const migrated = text.replace(
+    /^(\s*service_tier\s*=\s*)"default"(\s*($|#))/m,
+    '$1"flex"$2',
+  );
+  if (migrated === text) return false;
+  if (!dryRun) writeFileSync(configPath, migrated);
+  return true;
+}
+
+export const realizeFromBunGlobal: SetupRealizer = async (ctx) => {
+  const text = readManifestFile(ctx.repoRoot, MANIFEST);
+  if (text === null) {
+    ctx.log("✓ no agent-clis manifest; skipping");
+    return finishResult("from-bun-global", ctx, true);
+  }
+
+  if (!commandOnPath("mise")) {
+    ctx.warn("mise not on PATH; skipping agent-clis (bun comes from mise)");
+    return finishResult("from-bun-global", ctx, true);
+  }
+
+  for (const pkg of parseSimpleManifest(text)) {
+    await runCommand(
+      ctx,
+      `↓ bun -g install ${pkg} (best-effort agent CLI)...`,
+      ["mise", "exec", "--", "bun", "install", "--global", pkg],
+      { bestEffort: true },
+    );
+  }
+
+  const home = process.env.HOME ?? process.env.USERPROFILE ?? "";
+  if (home && repairCodexServiceTierConfig(home, ctx.dryRun)) {
+    ctx.log(`✓ codex config: migrated deprecated service_tier="default" -> "flex"`);
+    ctx.actions.push("repair-codex-service-tier");
+  }
+
+  ctx.log("✓ agent-clis step complete (login to each CLI separately — install is account-free)");
+  return finishResult("from-bun-global", ctx, false);
+};

--- a/src/Core.TypeScript/ace/setup-realizers/from-uv-tool.ts
+++ b/src/Core.TypeScript/ace/setup-realizers/from-uv-tool.ts
@@ -1,0 +1,46 @@
+import {
+  commandOnPath,
+  finishResult,
+  parseSimpleManifest,
+  readManifestFile,
+  runCommand,
+  type SetupRealizer,
+} from "./shared.ts";
+
+const MANIFEST = "tools/setup/manifests/from-uv-tool";
+
+export const realizeFromUvTool: SetupRealizer = async (ctx) => {
+  const text = readManifestFile(ctx.repoRoot, MANIFEST);
+  if (text === null) {
+    ctx.log(`✓ no uv-tools manifest at ${MANIFEST}; skipping`);
+    return finishResult("from-uv-tool", ctx, true);
+  }
+
+  const tools = parseSimpleManifest(text);
+  if (tools.length === 0) {
+    ctx.log("✓ uv-tools manifest empty; skipping");
+    return finishResult("from-uv-tool", ctx, true);
+  }
+
+  if (!commandOnPath("uv")) {
+    throw new Error("uv not on PATH. common/mise.sh must run first.");
+  }
+
+  await runCommand(ctx, "↓ uv tool upgrade --all...", ["uv", "tool", "upgrade", "--all"], { bestEffort: true });
+
+  for (const entry of tools) {
+    const name = entry.split(/[ <>=!~]/)[0] ?? entry;
+    const list = Bun.spawnSync(["uv", "tool", "list"], { stdout: "pipe", stderr: "pipe" });
+    const installed =
+      list.exitCode === 0 &&
+      list.stdout
+        .toString()
+        .split(/\r?\n/)
+        .some((line) => line.split(/\s+/)[0] === name);
+    if (installed) continue;
+    await runCommand(ctx, `↓ uv tool install ${entry}...`, ["uv", "tool", "install", entry]);
+  }
+
+  ctx.log("✓ uv-managed Python tools up to date");
+  return finishResult("from-uv-tool", ctx, false);
+};

--- a/src/Core.TypeScript/ace/setup-realizers/index.ts
+++ b/src/Core.TypeScript/ace/setup-realizers/index.ts
@@ -1,0 +1,19 @@
+import { realizeFromBunGlobal } from "./from-bun-global.ts";
+import { realizeFromUvTool } from "./from-uv-tool.ts";
+import type { SetupRealizer } from "./shared.ts";
+
+export const SETUP_REALIZERS: Readonly<Record<string, SetupRealizer>> = {
+  "from-uv-tool": realizeFromUvTool,
+  "from-bun-global": realizeFromBunGlobal,
+};
+
+export function listSetupRealizerIds(): readonly string[] {
+  return Object.keys(SETUP_REALIZERS).sort();
+}
+
+export function getSetupRealizer(id: string): SetupRealizer | undefined {
+  return SETUP_REALIZERS[id];
+}
+
+export { createContext, defaultRepoRoot, type RealizeContext, type RealizeResult } from "./shared.ts";
+export { repairCodexServiceTierConfig } from "./from-bun-global.ts";

--- a/src/Core.TypeScript/ace/setup-realizers/shared.ts
+++ b/src/Core.TypeScript/ace/setup-realizers/shared.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseSetupManifest } from "../setup-manifest.ts";
+
+export interface RealizeContext {
+  readonly repoRoot: string;
+  readonly dryRun: boolean;
+  readonly actions: string[];
+  readonly log: (message: string) => void;
+  readonly warn: (message: string) => void;
+}
+
+export interface RealizeResult {
+  readonly mechanism: string;
+  readonly skipped: boolean;
+  readonly actions: readonly string[];
+}
+
+export type SetupRealizer = (ctx: RealizeContext) => Promise<RealizeResult>;
+
+export function defaultRepoRoot(): string {
+  return join(import.meta.dir, "..", "..", "..");
+}
+
+export function readManifestFile(repoRoot: string, manifestRel: string): string | null {
+  const path = join(repoRoot, manifestRel);
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+export function toolNameFromSpec(spec: string): string {
+  return spec.split(/[ <>=!~]/)[0] ?? spec;
+}
+
+export function commandOnPath(bin: string): boolean {
+  return Bun.which(bin) !== null;
+}
+
+export async function runCommand(
+  ctx: RealizeContext,
+  label: string,
+  argv: readonly string[],
+  opts?: { readonly bestEffort?: boolean },
+): Promise<boolean> {
+  ctx.log(label);
+  ctx.actions.push(ctx.dryRun ? `dry-run: ${argv.join(" ")}` : argv.join(" "));
+  if (ctx.dryRun) return true;
+
+  const proc = Bun.spawn([...argv], { stdout: "inherit", stderr: "inherit" });
+  const code = await proc.exited;
+  if (code !== 0) {
+    const message = `${argv.join(" ")} exited ${String(code)}`;
+    if (opts?.bestEffort) {
+      ctx.warn(message);
+      return false;
+    }
+    throw new Error(message);
+  }
+  return true;
+}
+
+export function createContext(args: {
+  readonly repoRoot?: string;
+  readonly dryRun?: boolean;
+}): RealizeContext {
+  return {
+    repoRoot: args.repoRoot ?? defaultRepoRoot(),
+    dryRun: args.dryRun ?? false,
+    actions: [],
+    log: (message) => process.stdout.write(`${message}\n`),
+    warn: (message) => process.stderr.write(`${message}\n`),
+  };
+}
+
+export function parseSimpleManifest(text: string): readonly string[] {
+  return parseSetupManifest(text).map((entry) => entry.spec);
+}
+
+export function finishResult(mechanism: string, ctx: RealizeContext, skipped: boolean): RealizeResult {
+  return { mechanism, skipped, actions: [...ctx.actions] };
+}

--- a/tools/setup/secret-clip.sh
+++ b/tools/setup/secret-clip.sh
@@ -118,7 +118,8 @@ case "$ACTION" in
         if security delete-generic-password -s "$NAME" >/dev/null 2>&1; then
           echo "✓ '$NAME' removed" >&2
         else
-          echo "✗ '$NAME' not found" >&2; exit 1
+          echo "✗ '$NAME' not found" >&2
+          exit 1
         fi
         ;;
       *) echo "✗ del backend PLANNED for $OS" >&2; exit 3 ;;


### PR DESCRIPTION
## Summary
- Save post-#8948 session resume and update backlog bookkeeping: migration umbrella progress on `081KSXN940008QG0R002FWR9B2`, re-open `081KLL7…` as P2 in-progress.
- Mark the Lean cost-recurrence handoff complete (`CostRecurrence.lean` already on main).
- Add first Bun setup realizers (`setup-realize.ts`) for `from-uv-tool` and `from-bun-global`; shell mechanisms remain authoritative until `linux.sh` cutover.

## Test plan
- [x] `bun test src/Core.TypeScript/ace/setup-realizers.test.ts`
- [x] `bun src/Core.TypeScript/lint/lint-typescript.ts`
- [x] `bun src/Core.TypeScript/ace/setup-realize.ts --list`
- [x] `bun src/Core.TypeScript/backlog/generate-index.ts --check`
- [ ] Gate green on PR (fork workflows may need dispatch/approval)


Made with [Cursor](https://cursor.com)