### PR TITLE
fix(gate): secret-clip SC2015 + register new setup scripts in bash-retirement inventory

### DIFF
--- a/src/Core.TypeScript/hygiene/check-bash-retirement-inventory.ts
+++ b/src/Core.TypeScript/hygiene/check-bash-retirement-inventory.ts
@@ -108,7 +108,9 @@ export const EXPECTED_RETAINED_SHELL: readonly string[] = [
   "tools/setup/mechanisms/from-url.sh",
   "tools/setup/mechanisms/from-uv-tool.sh",
   "tools/setup/mechanisms/from-uv-venv.sh",
+  "tools/setup/op-token-setup.sh",
   "tools/setup/persona-keys/keyring.sh",
+  "tools/setup/secret-clip.sh",
 ];
 
 export const RETAINED_BASH_SCOPE = RETAINED_SHELL_SCOPE;
@@ -155,6 +157,11 @@ export const RETAINED_SHELL_CATEGORY_BY_FILE: Readonly<Record<string, RetainedSh
   "tools/setup/install.sh": "setup/bootstrap",
   "tools/setup/linux.sh": "setup/bootstrap",
   "tools/setup/macos.sh": "setup/bootstrap",
+  // Secret-edge scripts (Aaron 2026-06-21): capture a secret via masked TTY / secure dialog /
+  // clipboard and write it to the OS keystore (Keychain). Retained shell at the security edge
+  // (same rationale as keyring.sh) — secure input + `security`/`osascript` are OS-edge ops.
+  "tools/setup/op-token-setup.sh": "setup/bootstrap",
+  "tools/setup/secret-clip.sh": "setup/bootstrap",
   // keyring.sh is the intentionally-retained thin security EDGE: in-process seed
   // handling (`read -s`, umask-077, shred-on-exit) that must stay in shell; the
   // typed operational logic lives in keyset.ts ("bash only calls the edge").

--- a/tools/setup/secret-clip.sh
+++ b/tools/setup/secret-clip.sh
@@ -114,7 +114,13 @@ case "$ACTION" in
     ;;
   del)
     case "$OS" in
-      Darwin) security delete-generic-password -s "$NAME" >/dev/null 2>&1 && echo "✓ '$NAME' removed" >&2 || { echo "✗ '$NAME' not found" >&2; exit 1; } ;;
+      Darwin)
+        if security delete-generic-password -s "$NAME" >/dev/null 2>&1; then
+          echo "✓ '$NAME' removed" >&2
+        else
+          echo "✗ '$NAME' not found" >&2; exit 1
+        fi
+        ;;
       *) echo "✗ del backend PLANNED for $OS" >&2; exit 3 ;;
     esac
     ;;


### PR DESCRIPTION
Restores gate: SC2015 in secret-clip.sh del-branch → if-then-else; op-token-setup.sh + secret-clip.sh added to the bash-retirement allowlist (EXPECTED_RETAINED_SHELL + category map, setup/bootstrap). shellcheck clean (all levels) + inventory PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)