### PR TITLE
[codex] name no-forget bounded gset policy

### DIFF
--- a/src/Core/BoundedGSet.fs
+++ b/src/Core/BoundedGSet.fs
@@ -5,11 +5,13 @@ open System.Collections.Immutable
 /// How a bounded GSet decides what to forget when the finite room is full.
 ///
 /// Forgetting is heat: every policy that evicts a materialized value reports it
-/// on the result. `RejectNew` is the cold policy: it preserves the existing
-/// view and backpressures instead of silently losing history.
+/// on the result. `NoForgetBackpressure` is the cold policy: it preserves the
+/// existing view and backpressures instead of silently losing history.
 [<RequireQualifiedAccess>]
 type BoundedGSetForgetPolicy =
     /// Never evict a materialized value; reject new/out-of-window values.
+    | NoForgetBackpressure
+    /// Short legacy alias for `NoForgetBackpressure`.
     | RejectNew
     /// Forget the lowest-ranked values under canonical comparison.
     /// Use this for rolling logs when the key contains a monotone tick/sequence.
@@ -109,15 +111,18 @@ module BoundedGSet =
                   Heat = emptyHeat }
         else
             match config.ForgetPolicy with
+            | BoundedGSetForgetPolicy.NoForgetBackpressure
             | BoundedGSetForgetPolicy.RejectNew ->
                 Error(BoundedGSetError.CapacityExceeded(config.Capacity, items.Length))
-            | BoundedGSetForgetPolicy.ForgetHighest
+            | BoundedGSetForgetPolicy.ForgetHighest ->
+                let kept = GSet<'T>(ImmutableArray.Create(items, 0, keepCount))
+
+                Ok
+                    { State = { config = config; view = kept }
+                      Heat = heatOf (difference g kept) }
             | BoundedGSetForgetPolicy.ForgetLowest ->
                 let offset =
-                    match config.ForgetPolicy with
-                    | BoundedGSetForgetPolicy.ForgetHighest -> 0
-                    | BoundedGSetForgetPolicy.ForgetLowest -> items.Length - keepCount
-                    | BoundedGSetForgetPolicy.RejectNew -> 0
+                    items.Length - keepCount
 
                 let kept = GSet<'T>(ImmutableArray.Create(items, offset, keepCount))
 

--- a/src/Core/Heat.fs
+++ b/src/Core/Heat.fs
@@ -98,9 +98,9 @@ type RecordingHeatSink() =
             Ok()
 
 
-/// Bounded in-room heat storage. Use `RejectNew` for the no-forget mode; use a
-/// forgetting policy only for experiments that explicitly measure heat-channel
-/// self-shedding via `StorageHeat`.
+/// Bounded in-room heat storage. Use `NoForgetBackpressure` for the no-forget
+/// mode; use a forgetting policy only for experiments that explicitly measure
+/// heat-channel self-shedding via `StorageHeat`.
 [<Sealed>]
 type BoundedHeatSink(config: BoundedGSetConfig) =
     let lockObj = obj ()

--- a/tests/Tests.FSharp/Algebra/BoundedGSet.Tests.fs
+++ b/tests/Tests.FSharp/Algebra/BoundedGSet.Tests.fs
@@ -13,6 +13,10 @@ let private rejectNew3 =
     { Capacity = 3
       ForgetPolicy = BoundedGSetForgetPolicy.RejectNew }
 
+let private noForgetBackpressure3 =
+    { Capacity = 3
+      ForgetPolicy = BoundedGSetForgetPolicy.NoForgetBackpressure }
+
 let private forgetHighest3 =
     { Capacity = 3
       ForgetPolicy = BoundedGSetForgetPolicy.ForgetHighest }
@@ -72,6 +76,21 @@ let ``reject-new policy backpressures instead of forgetting`` () =
         capacity |> should equal 3
         count |> should equal 4
     | other -> failwithf "expected CapacityExceeded feedback, got %A" other
+
+[<Fact>]
+let ``no-forget backpressure policy is the canonical cold option`` () =
+    match BoundedGSet.ofSeq<int> noForgetBackpressure3 [ 1; 2; 3; 4 ] with
+    | Error(BoundedGSetError.CapacityExceeded(capacity, count)) ->
+        capacity |> should equal 3
+        count |> should equal 4
+    | other -> failwithf "expected CapacityExceeded feedback, got %A" other
+
+    let full = ofInts noForgetBackpressure3 [ 1; 2; 3 ]
+    let rejected = BoundedGSet.add 4 full |> unwrap
+    rejected.Admission |> should equal BoundedGSetAdmission.RejectedByBound
+    rejected.State |> BoundedGSet.toList |> should equal [ 1; 2; 3 ]
+    Assert.Empty(rejected.Heat.Forgotten |> GSet.toList)
+    rejected.Heat.Units |> should equal 0
 
 [<Fact>]
 let ``forget policies keep the configured side and report heat`` () =
@@ -190,6 +209,53 @@ let ``bounded heat adapter keeps empty heat cold`` () =
     match BoundedHeat.emit (sink :> IHeatSink) "bounded-gset-room" "bounded-gset.forgotten" "nothing forgotten" BoundedGSet.emptyHeat<int> with
     | Error feedback -> Assert.Fail(sprintf "unexpected heat sink feedback: %A" feedback)
     | Ok () -> Assert.Empty(sink.Signatures)
+
+[<Fact>]
+let ``bounded heat sink no-forget policy backpressures without losing stored heat`` () =
+    let sink =
+        BoundedHeatSink
+            { Capacity = 1
+              ForgetPolicy = BoundedGSetForgetPolicy.NoForgetBackpressure }
+
+    let port = sink :> IHeatSink
+    let first = HeatSignature.ofMass "chip8-room" "meta-cart.missing" 1 1.0 "first missing child cart"
+    let second = HeatSignature.ofMass "chip8-room" "meta-cart.denied" 1 1.0 "second denied child cart"
+
+    match port.Emit first with
+    | Error feedback -> Assert.Fail(sprintf "unexpected heat sink feedback: %A" feedback)
+    | Ok () -> ()
+
+    match port.Emit second with
+    | Error(HeatSinkFeedback.Backpressure(heat, capacity, count)) ->
+        heat |> should equal second
+        capacity |> should equal 1
+        count |> should equal 2
+        sink.Stored |> should equal [ first ]
+        Assert.Empty(sink.StorageHeat.Forgotten |> GSet.toList)
+        sink.StorageHeat.Units |> should equal 0
+    | other -> failwithf "expected heat-channel backpressure, got %A" other
+
+[<Fact>]
+let ``bounded heat sink rolling policy reports recursive heat explicitly`` () =
+    let sink =
+        BoundedHeatSink
+            { Capacity = 1
+              ForgetPolicy = BoundedGSetForgetPolicy.ForgetLowest }
+
+    let port = sink :> IHeatSink
+    let oldHeat = HeatSignature.ofMass "a-room" "bounded-gset.forgotten" 1 1.0 "old heat"
+    let newHeat = HeatSignature.ofMass "z-room" "bounded-gset.forgotten" 1 1.0 "new heat"
+
+    match port.Emit oldHeat with
+    | Error feedback -> Assert.Fail(sprintf "unexpected heat sink feedback: %A" feedback)
+    | Ok () -> ()
+
+    match port.Emit newHeat with
+    | Error feedback -> Assert.Fail(sprintf "unexpected heat sink feedback: %A" feedback)
+    | Ok () ->
+        sink.Stored |> should equal [ newHeat ]
+        sink.StorageHeat.Forgotten |> GSet.toList |> should equal [ oldHeat ]
+        sink.StorageHeat.Units |> should equal 1
 
 [<Fact>]
 let ``modulo GSet rejects collisions without forgetting`` () =


### PR DESCRIPTION
## Summary

- Adds `BoundedGSetForgetPolicy.NoForgetBackpressure` as the canonical cold bounded-GSet policy while keeping `RejectNew` as a compatibility alias.
- Updates heat sink docs to name the no-forget/backpressure mode directly.
- Adds tests proving no-forget heat storage backpressures without losing stored heat, while rolling heat storage reports recursive heat explicitly.

## Why

Bounded/rolling GSets need an explicit policy for what happens when a finite room fills. Forgetting is diagnostic heat; the no-forget mode should be a named first-class option that preserves information and reports backpressure rather than silently erasing.

## Validation

- `dotnet build -c Release`
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter FullyQualifiedName~BoundedGSet`
- `dotnet test Zeta.sln -c Release`
- `dotnet format --verify-no-changes`

Agency-Signature-Version: 1
Agent: Vera
Agent-Runtime: OpenAI Codex
Agent-Model: GPT-5.5
Credential-Identity: AceHack
Credential-Mode: dedicated-agent
Human-Review: explicit
Human-Review-Evidence: chat
Action-Mode: supervised
Task: none