### PR TITLE
fix(keys): purify GitHub key title — drop the @host (N+M consistency)

### DIFF
--- a/tools/setup/persona-keys/publish.test.ts
+++ b/tools/setup/persona-keys/publish.test.ts
@@ -67,7 +67,7 @@ test("gated-success: biometric ok:true → ghAddKey IS called with the PUBLIC ke
   expect(calls.biometricPrompts).toHaveLength(1); // gate WAS invoked
   expect(calls.ghAdds).toHaveLength(1); // write happened
   expect(calls.ghAdds[0]?.publicKey).toContain("ssh-ed25519");
-  expect(calls.ghAdds[0]?.title).toBe("aaron@mymac (zeta)");
+  expect(calls.ghAdds[0]?.title).toBe("aaron (zeta)"); // NO @host — purified (Aaron 2026-06-21)
   expect(calls.ghAdds[0]?.keyType).toBe("authentication");
 });
 
@@ -167,7 +167,7 @@ test("looksPrivate: catches OpenSSH/PEM/PGP private headers, passes a public lin
 });
 
 test("publishTitle + fingerprint: stable, public-derived, recognizable", () => {
-  expect(publishTitle("aaron", "MyMac.local")).toBe("aaron@mymac.local (zeta)");
+  expect(publishTitle("aaron")).toBe("aaron (zeta)"); // NO @host — user key is machine-independent
   // fingerprint is deterministic over the public line + never leaks the key bytes verbatim
   const fp = publicKeyFingerprint(PUB);
   expect(fp).toMatch(/^key-[0-9a-f]{16}$/);
@@ -188,7 +188,7 @@ test("formatResult published readout: shows biometric → ✅ → published <fp>
     hostname: "mymac",
     keyPath: "/repo/maintainers/aaron/machines/mymac.pub",
     keyType: "authentication",
-    title: "aaron@mymac (zeta)",
+    title: "aaron (zeta)",
     action: "published",
     fingerprint: "key-0123456789abcdef",
     biometric: { ok: true, platform: "macos-touchid" },

--- a/tools/setup/persona-keys/publish.ts
+++ b/tools/setup/persona-keys/publish.ts
@@ -136,9 +136,11 @@ export function looksPrivate(text: string): boolean {
   return PRIVATE_KEY_MARKERS.some((m) => up.includes(m));
 }
 
-/** The conventional GitHub key title: "<user>@<host> (zeta)" — recognizable + stable. */
-export function publishTitle(user: string, hostname: string): string {
-  return `${user}@${sanitizeHostname(hostname)} (zeta)`;
+/** The GitHub key title for the USER's machine-independent key: "<user> (zeta)" — NO @host
+ *  (Aaron 2026-06-21 "drop the @host"): the user key has no host coupling, and this avoids even
+ *  the textual user@host N×M shape. GitHub dedupes by key ⇒ one title per user key. */
+export function publishTitle(user: string): string {
+  return `${user} (zeta)`;
 }
 
 /** A stable, public-derived fingerprint token of the public-key line (for the readout,
@@ -177,7 +179,7 @@ export async function publishKey(fx: PublishEffects, opts: PublishOptions): Prom
   const hostname = sanitizeHostname(opts.hostname ?? "this-host");
   const keyType = opts.keyType ?? "authentication";
   const keyPath = resolveKeyPath(opts);
-  const title = publishTitle(opts.user, hostname);
+  const title = publishTitle(opts.user);
   const dryRun = opts.dryRun === true;
 
   const base = { dryRun, user: opts.user, hostname, keyPath, keyType, title } as const;


### PR DESCRIPTION
Aaron 2026-06-21: "purify it, drop the @host from the title." `publishTitle(user)` → "<user> (zeta)" (was "<user>@<host> (zeta)"). The user key is machine-independent; this removes the last textual user@host shape. Tests 13/0, lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)