### PR TITLE
[codex] recognize compact agency signatures

### DIFF
--- a/src/Core.TypeScript/backlog/auto-vivify.js
+++ b/src/Core.TypeScript/backlog/auto-vivify.js
@@ -125,11 +125,11 @@ function mintWorkItemZetaId() {
     const id = pack(obs, DEFAULT_ENV);
     return format(id);
 }
-// Search for workitem file matching zetaid recursively under workitems/
-function findWorkitemFile(zetaid) {
-    const workitemsDir = join(REPO_ROOT, "workitems");
-    if (!existsSync(workitemsDir))
-        return null;
+// Search for a ZetaId-keyed markdown file under the surfaces that can still
+// own backlog/work references. New work lives in workitems/; docs/backlog/
+// remains a legacy substrate with many ZetaId-keyed rows.
+function findZetaIdFile(zetaid) {
+    const roots = [join(REPO_ROOT, "workitems"), join(REPO_ROOT, "docs", "backlog")];
     function walk(d) {
         let entries;
         try {
@@ -152,14 +152,21 @@ function findWorkitemFile(zetaid) {
         }
         return null;
     }
-    return walk(workitemsDir);
+    for (const root of roots) {
+        if (!existsSync(root))
+            continue;
+        const found = walk(root);
+        if (found)
+            return found;
+    }
+    return null;
 }
 export function resolvePointer(cleanTarget, fromFile) {
     const currentDir = dirname(fromFile);
     const zetaid = extractZetaId(cleanTarget);
     // 1. Work Items: Target has a ZetaId
     if (zetaid) {
-        const existingFile = findWorkitemFile(zetaid);
+        const existingFile = findZetaIdFile(zetaid);
         if (existingFile) {
             return {
                 pointer: { raw: "", clean: cleanTarget, kind: "mdlink", line: 0 },

--- a/src/Core.TypeScript/backlog/auto-vivify.test.js
+++ b/src/Core.TypeScript/backlog/auto-vivify.test.js
@@ -39,3 +39,9 @@ test("resolvePointer correctly identifies type and candidate paths", () => {
     expect(nonExistsRes.exists).toBe(false);
     expect(nonExistsRes.type).toBe("db-dir"); // Defaults to directory/README structure since no extension
 });
+test("resolvePointer accepts legacy docs/backlog ZetaId rows as existing references", () => {
+    const res = resolvePointer("081KSGS9H0008QG0R003A37Z65", "workitems/example.md");
+    expect(res).not.toBeNull();
+    expect(res.exists).toBe(true);
+    expect(res.resolvedPath).toContain("docs/backlog/P1/081KSGS9H0008QG0R003A37Z65-");
+});

--- a/src/Core.TypeScript/backlog/auto-vivify.test.ts
+++ b/src/Core.TypeScript/backlog/auto-vivify.test.ts
@@ -46,3 +46,11 @@ test("resolvePointer correctly identifies type and candidate paths", () => {
   expect(nonExistsRes!.exists).toBe(false);
   expect(nonExistsRes!.type).toBe("db-dir"); // Defaults to directory/README structure since no extension
 });
+
+test("resolvePointer accepts legacy docs/backlog ZetaId rows as existing references", () => {
+  const res = resolvePointer("081KSGS9H0008QG0R003A37Z65", "workitems/example.md");
+
+  expect(res).not.toBeNull();
+  expect(res!.exists).toBe(true);
+  expect(res!.resolvedPath).toContain("docs/backlog/P1/081KSGS9H0008QG0R003A37Z65-");
+});

--- a/src/Core.TypeScript/backlog/auto-vivify.ts
+++ b/src/Core.TypeScript/backlog/auto-vivify.ts
@@ -141,10 +141,11 @@ function mintWorkItemZetaId(): string {
   return format(id);
 }
 
-// Search for workitem file matching zetaid recursively under workitems/
-function findWorkitemFile(zetaid: string): string | null {
-  const workitemsDir = join(REPO_ROOT, "workitems");
-  if (!existsSync(workitemsDir)) return null;
+// Search for a ZetaId-keyed markdown file under the surfaces that can still
+// own backlog/work references. New work lives in workitems/; docs/backlog/
+// remains a legacy substrate with many ZetaId-keyed rows.
+function findZetaIdFile(zetaid: string): string | null {
+  const roots = [join(REPO_ROOT, "workitems"), join(REPO_ROOT, "docs", "backlog")];
 
   function walk(d: string): string | null {
     let entries: string[];
@@ -166,7 +167,12 @@ function findWorkitemFile(zetaid: string): string | null {
     return null;
   }
 
-  return walk(workitemsDir);
+  for (const root of roots) {
+    if (!existsSync(root)) continue;
+    const found = walk(root);
+    if (found) return found;
+  }
+  return null;
 }
 
 // Resolve clean pointer target into an actual path and action
@@ -184,7 +190,7 @@ export function resolvePointer(cleanTarget: string, fromFile: string): ResolvedT
 
   // 1. Work Items: Target has a ZetaId
   if (zetaid) {
-    const existingFile = findWorkitemFile(zetaid);
+    const existingFile = findZetaIdFile(zetaid);
     if (existingFile) {
       return {
         pointer: { raw: "", clean: cleanTarget, kind: "mdlink", line: 0 },

--- a/src/Core.TypeScript/hygiene/audit-agencysignature-main-tip.js
+++ b/src/Core.TypeScript/hygiene/audit-agencysignature-main-tip.js
@@ -24,13 +24,16 @@ import { spawnSync } from "node:child_process";
 const SPAWN_MAX_BUFFER = 64 * 1024 * 1024;
 const SPEC_DOC = "docs/research/2026-04-26-gemini-deep-think-agencysignature-commit-attribution-convention-validation-and-refinement.md";
 const POSITIVE_INT_RE = /^[1-9]\d*$/;
-const V1_TRAILER_RE = /^Agency-Signature-Version:\s*1/im;
+const V1_TRAILER_RE = /^(?:Agency-Signature-Version:\s*1|AgencySignature-v1:)/im;
 const AGENT_COAUTHOR_RE = /^Co-authored-by:\s*(?:(?:Claude|Codex|Grok|Gemini|Kiro)\b|.*<noreply@(?:anthropic\.com|openai\.com|x\.ai|google\.com|kiro\.dev)>)/im;
 export function hasAgentCoauthorTrailer(trailers) {
     return AGENT_COAUTHOR_RE.test(trailers);
 }
 export function hasAgencySignatureV1(text) {
     return V1_TRAILER_RE.test(text);
+}
+export function hasAgentCoauthorSignal(trailers, message) {
+    return hasAgentCoauthorTrailer(trailers) || hasAgentCoauthorTrailer(message);
 }
 function gitOutput(args) {
     // eslint-disable-next-line sonarjs/no-os-command-from-path
@@ -143,8 +146,9 @@ function commitSubject(sha) {
 function classifyCommit(sha, ship) {
     const trailers = commitTrailers(sha);
     const hasV1Trailer = hasAgencySignatureV1(trailers);
-    const hasV1Message = hasV1Trailer || hasAgencySignatureV1(commitMessage(sha));
-    const hasCoauthor = hasAgentCoauthorTrailer(trailers);
+    const message = commitMessage(sha);
+    const hasV1Message = hasV1Trailer || hasAgencySignatureV1(message);
+    const hasCoauthor = hasAgentCoauthorSignal(trailers, message);
     if (ship === null) {
         return { status: "LEGACY", reason: "v1 not yet shipped on this branch" };
     }

--- a/src/Core.TypeScript/hygiene/audit-agencysignature-main-tip.test.ts
+++ b/src/Core.TypeScript/hygiene/audit-agencysignature-main-tip.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   hasAgencySignatureV1,
+  hasAgentCoauthorSignal,
   hasAgentCoauthorTrailer,
 } from "./audit-agencysignature-main-tip";
 
@@ -34,5 +35,33 @@ Co-authored-by: Codex <noreply@openai.com>
 `;
 
     expect(hasAgencySignatureV1(message)).toBe(true);
+  });
+
+  test("detects the compact AgencySignature-v1 block used by current squash commits", () => {
+    const message = `feat(core): name no-forget bounded gset policy (#8986)
+
+Co-Authored-By: Codex <noreply@openai.com>
+
+AgencySignature-v1:
+  persona: vera
+  actor: zeta-vera
+`;
+
+    expect(hasAgencySignatureV1(message)).toBe(true);
+  });
+});
+
+describe("hasAgentCoauthorSignal", () => {
+  test("falls back to the full commit message when parsed terminal trailers drop Co-Authored-By", () => {
+    const parsedTrailers = `AgencySignature-v1: persona: vera actor: zeta-vera`;
+    const message = `feat(core): name no-forget bounded gset policy (#8986)
+
+Co-Authored-By: Codex <noreply@openai.com>
+
+AgencySignature-v1:
+  persona: vera
+`;
+
+    expect(hasAgentCoauthorSignal(parsedTrailers, message)).toBe(true);
   });
 });

--- a/src/Core.TypeScript/hygiene/audit-agencysignature-main-tip.ts
+++ b/src/Core.TypeScript/hygiene/audit-agencysignature-main-tip.ts
@@ -33,7 +33,7 @@ const SPEC_DOC =
   "docs/research/2026-04-26-gemini-deep-think-agencysignature-commit-attribution-convention-validation-and-refinement.md";
 
 const POSITIVE_INT_RE = /^[1-9]\d*$/;
-const V1_TRAILER_RE = /^Agency-Signature-Version:\s*1/im;
+const V1_TRAILER_RE = /^(?:Agency-Signature-Version:\s*1|AgencySignature-v1:)/im;
 const AGENT_COAUTHOR_RE =
   /^Co-authored-by:\s*(?:(?:Claude|Codex|Grok|Gemini|Kiro)\b|.*<noreply@(?:anthropic\.com|openai\.com|x\.ai|google\.com|kiro\.dev)>)/im;
 
@@ -43,6 +43,10 @@ export function hasAgentCoauthorTrailer(trailers: string): boolean {
 
 export function hasAgencySignatureV1(text: string): boolean {
   return V1_TRAILER_RE.test(text);
+}
+
+export function hasAgentCoauthorSignal(trailers: string, message: string): boolean {
+  return hasAgentCoauthorTrailer(trailers) || hasAgentCoauthorTrailer(message);
 }
 
 interface ParsedArgs {
@@ -211,8 +215,9 @@ function classifyCommit(
 ): { status: Status; reason: string } | null {
   const trailers = commitTrailers(sha);
   const hasV1Trailer = hasAgencySignatureV1(trailers);
-  const hasV1Message = hasV1Trailer || hasAgencySignatureV1(commitMessage(sha));
-  const hasCoauthor = hasAgentCoauthorTrailer(trailers);
+  const message = commitMessage(sha);
+  const hasV1Message = hasV1Trailer || hasAgencySignatureV1(message);
+  const hasCoauthor = hasAgentCoauthorSignal(trailers, message);
 
   if (ship === null) {
     return { status: "LEGACY", reason: "v1 not yet shipped on this branch" };


### PR DESCRIPTION
## Summary

- Updates the post-merge AgencySignature auditor to recognize both `Agency-Signature-Version: 1` and compact `AgencySignature-v1:` blocks.
- Falls back to the full commit message for agent co-author detection when Git parses only the terminal compact block.
- Fixes auto-vivify so bare ZetaId references can resolve existing legacy `docs/backlog/**` rows before reporting missing `workitems/**` stubs.

## Why

PR #8986 exposed a real hygiene blind spot: the squash commit visibly included `Co-Authored-By: Codex` and `AgencySignature-v1:`, but the audit classified it as human-authored because Git parsed only the terminal compact block. The same quick preflight also exposed a false dangling-ref from a workitem to a legacy backlog ZetaId row.

## Validation

- `bun test src/Core.TypeScript/hygiene/audit-agencysignature-main-tip.test.ts src/Core.TypeScript/backlog/auto-vivify.test.ts`
- `bun src/Core.TypeScript/hygiene/audit-agencysignature-main-tip.ts --commit 9f92603211202676249c3ebc0e12f5cfd621791f`
- `bun src/Core.TypeScript/hygiene/audit-agencysignature-main-tip.js --commit 9f92603211202676249c3ebc0e12f5cfd621791f`
- `bun src/Core.TypeScript/backlog/auto-vivify.ts --check`
- `bun run preflight:quick`

Agency-Signature-Version: 1
Agent: Vera
Agent-Runtime: OpenAI Codex
Agent-Model: GPT-5.5
Credential-Identity: AceHack
Credential-Mode: dedicated-agent
Human-Review: explicit
Human-Review-Evidence: chat
Action-Mode: supervised
Task: none