### PR TITLE
[codex] summarize room heat transcripts

### DIFF
--- a/db/feedback_nothing_operator_run_only_operator_approved_via_biometric_aaron_2026_06_21
+++ b/db/feedback_nothing_operator_run_only_operator_approved_via_biometric_aaron_2026_06_21
@@ -1,0 +1,6 @@
+# feedback_nothing_operator_run_only_operator_approved_via_biometric_aaron_2026_06_21/
+
+**Carved sentence:** Root-bearing actions do not run merely because an
+agent can compute the request; the agent prepares the operation, and the
+human approves the trust-root use through an operator-held biometric/signing
+boundary without exposing the root to the agent.

--- a/src/Core/DarkHallScheduler.fs
+++ b/src/Core/DarkHallScheduler.fs
@@ -1,5 +1,7 @@
 namespace Zeta.Core
 
+open System.Collections.Generic
+
 /// Scheduler-facing boundary for Dark Hall rooms.
 ///
 /// `DarkHallRoomLoop` owns observe -> choose -> execute -> append. This module
@@ -15,6 +17,14 @@ module DarkHallScheduler =
     type HeatBoundaryRow =
         { Tick: int
           RoomName: string
+          HeatRejected: int
+          Backpressured: int
+          StorageErrors: int
+          HeatKinds: string list
+          Reasons: string list }
+
+    type HeatTranscriptSummary =
+        { Rows: int
           HeatRejected: int
           Backpressured: int
           StorageErrors: int
@@ -116,6 +126,29 @@ module DarkHallScheduler =
 
     let boundaryBackpressured (state: BoundaryScheduledRoomState<'K>) : bool =
         state.HeatRowsRev |> List.exists (fun row -> row.Backpressured > 0)
+
+    let private distinctOrdinal (values: string list) : string list =
+        let seen = HashSet<string>(System.StringComparer.Ordinal)
+
+        values
+        |> List.filter (fun value -> seen.Add value)
+
+    let summarizeHeatRows (rows: HeatBoundaryRow list) : HeatTranscriptSummary =
+        { Rows = rows.Length
+          HeatRejected = rows |> List.sumBy _.HeatRejected
+          Backpressured = rows |> List.sumBy _.Backpressured
+          StorageErrors = rows |> List.sumBy _.StorageErrors
+          HeatKinds = rows |> List.collect _.HeatKinds |> distinctOrdinal
+          Reasons = rows |> List.collect _.Reasons }
+
+    let heatTranscript (state: ScheduledRoomState) : HeatTranscriptSummary =
+        state |> heatRows |> summarizeHeatRows
+
+    let boundaryHeatTranscript (state: BoundaryScheduledRoomState<'K>) : HeatTranscriptSummary =
+        state |> boundaryHeatRows |> summarizeHeatRows
+
+    let transcriptHasHeat (summary: HeatTranscriptSummary) : bool =
+        summary.HeatRejected > 0 || summary.Backpressured > 0 || summary.StorageErrors > 0
 
     let private setColor (x: int) (y: int) (mask: byte) (frame: Chip8Cow.Frame) : Chip8Cow.Frame =
         let idx = y * Chip8.DisplayW + x

--- a/src/Core/RoomRun.fs
+++ b/src/Core/RoomRun.fs
@@ -42,13 +42,15 @@ module RoomRun =
     type UnifiedHeatRun<'K when 'K : comparison> =
         { Room: Scheduler.BoundaryScheduledRoomState<'K>
           SoftFrame: Chip8Cow.Frame
-          BoundaryHeatRows: Scheduler.HeatBoundaryRow list }
+          BoundaryHeatRows: Scheduler.HeatBoundaryRow list
+          HeatTranscript: Scheduler.HeatTranscriptSummary }
 
     type UnifiedHorizonRun<'K, 'S when 'K : comparison> =
         { Room: Scheduler.BoundaryScheduledRoomState<'K>
           SoftFrame: Chip8Cow.Frame
           HorizonReport: RoomHorizon.Report<'K, 'S>
-          HeatRows: Scheduler.HeatBoundaryRow list }
+          HeatRows: Scheduler.HeatBoundaryRow list
+          HeatTranscript: Scheduler.HeatTranscriptSummary }
 
     [<RequireQualifiedAccess>]
     type UnifiedHeatFeedback<'K when 'K : comparison> =
@@ -105,11 +107,14 @@ module RoomRun =
                         softPlan.Start
                 with
                 | Ok frame ->
+                    let rows = Scheduler.boundaryHeatRows room
+
                     return
                         Ok
                             { Room = room
                               SoftFrame = frame
-                              BoundaryHeatRows = Scheduler.boundaryHeatRows room }
+                              BoundaryHeatRows = rows
+                              HeatTranscript = Scheduler.summarizeHeatRows rows }
 
                 | Error feedback -> return Error(UnifiedHeatFeedback.SoftDriveFeedback(room, feedback))
         }
@@ -141,11 +146,14 @@ module RoomRun =
                             horizonPlan.SourceName
                             report
 
+                    let rows = run.BoundaryHeatRows @ [ horizonRow ]
+
                     let horizonRun =
                         { Room = run.Room
                           SoftFrame = run.SoftFrame
                           HorizonReport = report
-                          HeatRows = run.BoundaryHeatRows @ [ horizonRow ] }
+                          HeatRows = rows
+                          HeatTranscript = Scheduler.summarizeHeatRows rows }
 
                     match RoomHorizon.emitHeat sink horizonPlan.SourceName report with
                     | Ok() -> return Ok horizonRun

--- a/tests/Tests.FSharp/DarkHallScheduler.Tests.fs
+++ b/tests/Tests.FSharp/DarkHallScheduler.Tests.fs
@@ -121,6 +121,40 @@ let ``heat boundary rows render as a host visible CHIP-9 board`` () =
     Assert.Equal("0", firstDisplayRow.Substring(50, 1))
 
 [<Fact>]
+let ``heat transcript summary folds rows without losing distinct heat kinds`` () =
+    let rows: Scheduler.HeatBoundaryRow list =
+        [ { Tick = 1
+            RoomName = "darkhall"
+            HeatRejected = 1
+            Backpressured = 1
+            StorageErrors = 0
+            HeatKinds = [ "room-boundary.door-denied" ]
+            Reasons = [ "permission denied" ] }
+          { Tick = 2
+            RoomName = "darkhall"
+            HeatRejected = 2
+            Backpressured = 1
+            StorageErrors = 1
+            HeatKinds = [ "room-boundary.door-denied"; "soft-emu.prune" ]
+            Reasons = [ "capacity=1"; "pruned branch" ] } ]
+
+    let summary = Scheduler.summarizeHeatRows rows
+
+    Assert.Equal(2, summary.Rows)
+    Assert.Equal(3, summary.HeatRejected)
+    Assert.Equal(2, summary.Backpressured)
+    Assert.Equal(1, summary.StorageErrors)
+    Assert.Equal<string list>(
+        [ "room-boundary.door-denied"; "soft-emu.prune" ],
+        summary.HeatKinds
+    )
+    Assert.Equal<string list>(
+        [ "permission denied"; "capacity=1"; "pruned branch" ],
+        summary.Reasons
+    )
+    Assert.True(Scheduler.transcriptHasHeat summary)
+
+[<Fact>]
 let ``room horizon forgetting renders on the DarkHall heat board`` () =
     let current =
         BoundedGSet.ofSeq<int> (horizonConfig 2 BoundedGSetForgetPolicy.ForgetLowest) [ 1; 2 ]

--- a/tests/Tests.FSharp/RoomRun.Tests.fs
+++ b/tests/Tests.FSharp/RoomRun.Tests.fs
@@ -138,6 +138,11 @@ let ``room run exports boundary denial and soft prune heat through one sink`` ()
                 [ "room-boundary.door-denied" ],
                 run.BoundaryHeatRows |> List.collect _.HeatKinds
             )
+            Assert.Equal(1, run.HeatTranscript.Rows)
+            Assert.Equal(1, run.HeatTranscript.HeatRejected)
+            Assert.Equal(1, run.HeatTranscript.Backpressured)
+            Assert.Equal<string list>([ "room-boundary.door-denied" ], run.HeatTranscript.HeatKinds)
+            Assert.True(Scheduler.transcriptHasHeat run.HeatTranscript)
 
             let kinds = sink.Signatures |> Seq.map _.Kind |> Seq.toList
 
@@ -264,6 +269,9 @@ let ``room run appends finite horizon heat to the host visible transcript`` () =
             Assert.Equal(1, run.Room.CompletedTicks)
             Assert.Equal<string list>([ "old-b"; "zz-new" ], run.HorizonReport.HorizonAfter |> BoundedGSet.toList)
             Assert.Equal<string list>([ "room-horizon.forgotten" ], run.HeatRows |> List.collect _.HeatKinds)
+            Assert.Equal(2, run.HeatTranscript.Rows)
+            Assert.Equal(1, run.HeatTranscript.HeatRejected)
+            Assert.Equal<string list>([ "room-horizon.forgotten" ], run.HeatTranscript.HeatKinds)
             Assert.Equal<string list>([ "room-horizon.forgotten" ], sink.Signatures |> Seq.map _.Kind |> Seq.toList)
 
             let frame = Scheduler.heatBoardFrame 99UL run.HeatRows


### PR DESCRIPTION
## Summary
- add `HeatTranscriptSummary` over Dark Hall heat boundary rows, with helpers for scheduled and boundary room states
- carry heat transcript summaries on `RoomRun` outputs while keeping raw CHIP-9 heat-board rows intact
- add the missing non-secret `db/feedback_*` substrate row referenced by the vault-separation workitem so auto-vivify stays green

## Validation
- `dotnet test tests/Tests.FSharp/Tests.FSharp.fsproj -c Release --filter "FullyQualifiedName~DarkHallSchedulerTests|FullyQualifiedName~RoomRunTests"`
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test Zeta.sln -c Release`
- `bun run preflight:quick`

Agency-Signature-Version: 1
Agent: Codex
Agent-Runtime: Codex Desktop
Agent-Model: GPT-5.5
Credential-Identity: Codex
Credential-Mode: dedicated-agent
Human-Review: explicit
Human-Review-Evidence: chat
Action-Mode: human-directed
Task: none
