### PR TITLE
docs(research): synthesize Zeta identity+crypto substrate — one seed, dual rotation, schema-evolvable, hexagonal

### DIFF
--- a/docs/research/2026-06-21-zeta-identity-crypto-substrate-one-seed-hd-keychain-dual-rotation-schema-evolvable-over-zsets-hexagonal.md
+++ b/docs/research/2026-06-21-zeta-identity-crypto-substrate-one-seed-hd-keychain-dual-rotation-schema-evolvable-over-zsets-hexagonal.md
@@ -1,0 +1,96 @@
+# Zeta Identity & Crypto Substrate — one seed → HD keychain, dual rotation, vault-separated, schema-evolvable over Z-sets, hexagonal
+
+**Date:** 2026-06-21 · **Driver:** Aaron · **Status:** synthesis (pulls existing pieces together) · **Trajectory:** cluster-encryption-credential-substrate
+
+## The ask (Aaron 2026-06-21)
+
+> *"How does onboarding get the crypto part too — our whole keychain of derived keys and dual
+> rotation from the start? We have a bunch on this, we just have not mashed it all together;
+> might as well, and make it secure — investors are going to want it secure. Separate CA / Lucent
+> / Zeta / User vaults for now. We want it all to be able to be wrong and updatable in the future,
+> evolvable with our SchemaEvolution math, 0 downtime over Z-sets — but for our identity and
+> crypto too. Can we pull all this together?"*
+
+Yes — and the pieces already exist; this doc mashes them into ONE substrate. **Nothing new is
+invented; five shipped components are unified.**
+
+## The five pieces (already in the repo)
+
+1. **One seed → full HD keychain** — `tools/setup/persona-keys/derive.ts`: a BIP-39 mnemonic →
+   `HDKey.fromMasterSeed` derives, from the SAME master, every identity AND crypto key by
+   coin-typed BIP-44 path:
+   | Key | Path | Curve |
+   |---|---|---|
+   | Ethereum wallet | `m/44'/60'/0'/0/0` | secp256k1 |
+   | Solana wallet | `m/44'/501'/0'/0'` | ed25519 |
+   | Nostr | `m/44'/1237'/0'/0/0` | secp256k1 |
+   | SSH | `m/44'/1110'/0'/0'` | ed25519 |
+   | PGP | `m/44'/1111'/0'/0'` | ed25519 |
+   So **crypto is already part of the keychain** — onboarding just needs to *derive and custody
+   all of them*, not only SSH/PGP. One seed = identity + crypto.
+2. **Dual rotation (zero-downtime ID rotation)** — `docs/DECISIONS/2026-06-15-zero-downtime-id-rotation-pattern-overlap-window-dual-key.md`:
+   the overlap-window dual-key pattern. Apply it from the start to EVERY derived key (and the CA)
+   — old+new valid during an overlap window, then retire the old. No flag-day.
+3. **SchemaEvolution over Z-sets** — schemas-as-rows + grammar-as-versioned-events: the layout
+   (derivation paths, vault mapping, rotation policy, key set) is *data that evolves* via Z-set
+   deltas with 0 downtime. So the whole identity/crypto layout can be **wrong and fixed later**.
+4. **Hexagonal ports** — `docs/DECISIONS/2026-06-21-hexagonal-pki-and-secret-vault-ports-swappable-adapters.md`:
+   SecretStore / KeyCustody / CertAuthority / Consent behind stable ports; adapters swap to the
+   **DB-as-first-class-PKI** endgame.
+5. **Event-sourced authorization** — grant/revoke as Z-set deltas (revoke = retraction);
+   `docs/research/2026-06-21-config-and-secrets-as-event-sourced-zset-dbsp-…`.
+
+## The mashup: one coherent flow
+
+**Onboarding (one seed, one fingerprint):**
+seed (human custody) → `deriveKeyring` → **all** keys (SSH, PGP, Nostr, ETH, Solana) → custody
+each via the **KeyCustody port** into its class vault → register public material on GitHub →
+the **event log** records what was provisioned. Crypto wallets fall out for free (same seed,
+more paths). The seed stays the human's; the agent derives/uses leaves, never holds the master.
+
+**Dual rotation from day one:** every key (and the CA) is issued with an overlap window; rotation
+appends a Z-set event (new key +1, old key −1 after the window). Identity AND crypto rotate the
+same way — no special case.
+
+**Vault separation by class (now → 4 vaults, Aaron 2026-06-21):**
+| Vault | Holds | Reader |
+|---|---|---|
+| **CA** | CA private key (trust root) | human-only (end-state); agent-readable only under full-trust bootstrap |
+| **Lucent** | shared/work + infra secrets | agent + CI |
+| **Zeta** | substrate/service identities | agent (service scope) |
+| **User** (aaron) | the human's seed + derived personal keys (SSH/PGP/**wallets**) | human-only |
+
+(Today: lucent + aaron exist; CA + Zeta are the next split — extends backlog 081KVNTNTDQ0.)
+
+**Schema-evolvable, 0 downtime, over Z-sets:** the path table, the vault map, the rotation policy,
+the key set are all **versioned events**, evolved by the SchemaEvolution math — so when (not if)
+this layout is wrong, it changes with zero downtime, like every other Z-set view. Identity +
+crypto get the same evolvability as the rest of the substrate.
+
+**Hexagonal throughout:** all of it behind the ports → external adapters now (1Password/Vault),
+**our own DB as first-class PKI** eventually, no call-site change.
+
+## Why "secure" (the investor story)
+
+One auditable seed→keychain derivation (deterministic, byte-locked by DST); **dual rotation**
+(no long-lived keys, no flag-day); **least-privilege vault separation** (CA/User human-only,
+agent scoped); **biometric consent** on every sensitive op (fail-closed); **event-sourced +
+revocable** (grant/revoke fold, retraction); **schema-evolvable** (fixable with 0 downtime —
+mistakes aren't permanent); **hexagonal** (no vendor lock-in; migrates to self-hosted DB-PKI).
+The seed + wallets are **human custody**; the agent never holds the master or a wallet seed.
+
+## Build to pull it together (backlogged separately)
+
+Unify into one onboarding flow: derive ALL keys (incl. crypto) → KeyCustody per class vault →
+dual-rotation issuance → event-log the provisioning → all over the ports. Formalize the ports as
+explicit interfaces. The 4-vault split (CA/Lucent/Zeta/User). Make the path/vault/rotation tables
+SchemaEvolution-versioned. See the new workitem + composes-with: 081KVNTNTDQ0 (vault sep),
+081KVNMFYS8 (OSS vault via ArgoCD), 081KVNRSGVR0 (secret-clip cross-OS), the hexagonal +
+event-sourced decisions, and the 2026-06-15 dual-key rotation decision.
+
+## Anchors
+
+BIP-39/32/44 (mnemonic + HD derivation; coin types SLIP-44); `@scure/bip32`,`@scure/bip39`.
+Overlap-window dual-key rotation (the 2026-06-15 decision). SchemaEvolution / schemas-as-rows.
+DBSP/Z-sets (Budiu et al.). Hexagonal (Cockburn). In-repo: `derive.ts`, the hexagonal +
+event-sourced decision docs, the cluster-encryption-credential-substrate trajectory.

--- a/workitems/081KVNXBR4S08QG0R0015DHBBN-unify-identity-crypto-onboarding-one-seed-full-hd-keychain-s.md
+++ b/workitems/081KVNXBR4S08QG0R0015DHBBN-unify-identity-crypto-onboarding-one-seed-full-hd-keychain-s.md
@@ -1,0 +1,55 @@
+---
+id: 081KVNXBR4S08QG0R0015DHBBN
+type: task
+state: backlog
+priority: P1
+slug: unify-identity-crypto-onboarding-one-seed-full-hd-keychain-s
+title: "Unify identity+crypto onboarding: one seed → full HD keychain (SSH/PGP/Nostr/ETH/Solana) custodied per-class vault, dual-rotation from start, schema-evolvable over Z-sets, hexagonal (Aaron 2026-06-21 'mash it all together')"
+created: 2026-06-21T20:18:42.969Z
+depends_on: []
+composes_with: ["081KVNTNTDQ08QG0R0017NBBWB", "081KVNMFYS808QG0R002D0VM64", "081KVNRSGVR08QG0R003R3RNJX"]
+---
+
+# Unify identity+crypto onboarding: one seed → full HD keychain (SSH/PGP/Nostr/ETH/Solana) custodied per-class vault, dual-rotation from start, schema-evolvable over Z-sets, hexagonal (Aaron 2026-06-21 'mash it all together')
+
+<!-- Work-item body. ZetaId-keyed. -->
+
+## Carved sentence
+
+> Mash the five shipped pieces into ONE identity+crypto onboarding flow: a single human-custody
+> **seed** → `derive.ts` HD keychain (SSH/PGP/Nostr/**ETH/Solana**) → custody each leaf via the
+> **KeyCustody port** into its **class vault** → **dual-rotation** (overlap-window) from the
+> start → the provisioning + rotations are **Z-set events** so the whole layout is
+> **schema-evolvable, 0-downtime** (wrong-and-fixable) — all **hexagonal** (DB-as-PKI endgame).
+> Nothing new is invented; it's wiring existing components together + making it investor-secure.
+
+## Design
+
+Full design: `docs/research/2026-06-21-zeta-identity-crypto-substrate-one-seed-hd-keychain-dual-rotation-schema-evolvable-over-zsets-hexagonal.md`.
+
+## Scope (the wiring)
+
+1. **Onboarding derives ALL keys** (not just SSH/PGP): wire `derive.ts`'s ETH/Solana/Nostr paths
+   into the onboarding flow so the crypto wallets are provisioned from the same seed. Seed stays
+   human-custody; agent derives/uses leaves, never holds the master or a wallet seed.
+2. **Per-class vault custody** via the KeyCustody/SecretStore ports: the 4-vault split
+   **CA / Lucent / Zeta / User** (User + CA + wallet seeds human-only; agent scoped to Lucent/Zeta).
+3. **Dual rotation from the start** — apply the overlap-window dual-key pattern
+   (`docs/DECISIONS/2026-06-15-zero-downtime-id-rotation-pattern-overlap-window-dual-key.md`) to
+   every derived key + the CA; rotation = a Z-set event (new +1, old −1 after the window).
+4. **Schema-evolvable layout** — the derivation-path table, vault map, and rotation policy are
+   SchemaEvolution-versioned (schemas-as-rows / grammar-as-versioned-events) so they evolve with
+   0 downtime over Z-sets — the layout can be wrong and updated later.
+5. **Hexagonal** — all through the ports (hexagonal decision); external adapters now → our DB as
+   first-class PKI eventually, no call-site change.
+6. **Investor-grade security checklist** (make it demonstrable): deterministic byte-locked
+   derivation (DST), no long-lived keys (dual rotation), least-privilege vaults, biometric consent
+   fail-closed, event-sourced + revocable, schema-evolvable, no vendor lock-in.
+
+## Composes / anchors
+
+Composes: vault-separation (081KVNTNTDQ08QG0R0017NBBWB), OSS-vault-via-ArgoCD
+(081KVNMFYS808QG0R002D0VM64), secret-clip cross-OS (081KVNRSGVR08QG0R003R3RNJX). Decisions:
+hexagonal ports (2026-06-21), event-sourced config/secrets (2026-06-21), zero-downtime dual-key
+rotation (2026-06-15). Code: `tools/setup/persona-keys/derive.ts`. Anchors: BIP-39/32/44 +
+SLIP-44 coin types; DBSP/Z-sets; SchemaEvolution; Cockburn hexagonal.


### PR DESCRIPTION
Aaron 2026-06-21: pull it all together. The five pieces already exist (derive.ts one-seed→ETH/Solana/Nostr/SSH/PGP HD keychain; 2026-06-15 dual-key rotation; SchemaEvolution over Z-sets; hexagonal ports; event-sourced authz). Synthesis doc mashes them into one onboarding flow + 4-vault split (CA/Lucent/Zeta/User) + investor security story. Build backlogged (081KVNXBR4S0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)