### PR TITLE
feat(keys): teardown / unregister primitive — inverse of setup (local wipe + repo unregister)

### DIFF
--- a/docs/trajectories/cluster-encryption-credential-substrate/RESUME.md
+++ b/docs/trajectories/cluster-encryption-credential-substrate/RESUME.md
@@ -5,7 +5,7 @@ Last refreshed: 2026-06-21
 Type: workstream (current-focus) — a trajectory the operator is *actively powering*. Many trajectories can be tracked; only a few are workstreams at once (finite-focus / WIP-bounded — a workstream is a trajectory under sustained thrust, and thrust budget is finite, so most trajectories coast). ("Trajectory" is the genus; "workstream" is the species: a trajectory under sustained thrust toward a deliverable, vs. emergent-posture trajectories like `anti-infection`, which self-describes as "not a workstream with a cadence." See [`factory-trajectory-surface`](../factory-trajectory-surface/RESUME.md) for the genus/species taxonomy.) One of the operator's three current cluster workstreams (encryption / usb-zflash / ts-workflow-engine).
 Eventual encoding (design-stage — the human maintainer 2026-05-23 genetic-ID substrate + Clifford/HKT): this trajectory's state is trackable as a 128-bit genetic-ID seed (discrete, reversible via parser-combinator ↔ generator-function) → Clifford-space path (continuous, eventual). Mirrors the three-lane I8-lattice / I9-manifold split.
 Current blocker: none operationally; the live design tension is interactive-login-vs-baked-in-keys-vs-CI-test (081KSGS9H0008QG0R003JNSVR5)
-Next concrete action: build the teardown/unregister primitive (TS now; core primitive → all langs via gen/ eventually), dry-run it, then do a live wipe + clean re-onboard to prove the one-fingerprint UX end-to-end.
+Next concrete action: teardown/unregister primitive is BUILT (PR open, Otto verify-gate) — `tools/setup/persona-keys/teardown.ts` + `teardown-cli.ts` + `teardown.test.ts`. Remaining: live wipe (`--confirm` + biometric) + clean re-onboard to prove the one-fingerprint UX end-to-end; then back out 1Password to see which steps go manual.
 
 ## 2026-06-21 — Identity+Crypto onboarding consolidated; one-fingerprint vision
 
@@ -30,7 +30,14 @@ strongly-encouraged).
 - **Dual rotation from the start** (overlap-window dual-key, the 2026-06-15 decision) on every key.
 - **Teardown/unregister primitive:** delete everything (CA, machine, cert, keyring) + unregister
   from main — a CORE PRIMITIVE (TS now; all langs via gen/ eventually). Needed to prove clean
-  re-onboarding. (Writing it now.)
+  re-onboarding. **BUILT** (PR open, Otto verify-gate): two halves behind injected effects
+  (noninterference §13) — (1) LOCAL WIPE of `~/.config/zeta/{ca,machine,keyring,keyset}`
+  (shred-then-unlink, biometric-gated fail-closed); (2) REPO UNREGISTER staging `git rm` of
+  `maintainers/<ca>/ssh-ca.pub` + `machines/<host>.pub` + `machines/<host>-cert.pub` for a PR
+  (never pushes, respects shared-checkout-is-view-only). `--dry-run` is DEFAULT-safe (reports
+  the plan, touches nothing, never prompts); `--confirm` + ONE biometric does the real wipe;
+  idempotent re-run = "already clean"; optional `--note-1password` PRINTS (never deletes) the
+  backup items. Files: `tools/setup/persona-keys/teardown{.ts,-cli.ts,.test.ts}`.
 - **Then back out 1Password:** run the same flow WITHOUT 1Password, see which steps go manual vs
   stay automatic — the **hexagonal ports** make the secret/key/CA backends swap with no call-site
   change. *"The interfaces are the valuable thing"* (Aaron, repeated) — the ports ARE the value.

--- a/tools/setup/persona-keys/teardown-cli.ts
+++ b/tools/setup/persona-keys/teardown-cli.ts
@@ -1,0 +1,99 @@
+#!/usr/bin/env bun
+// Zeta teardown CLI — the DESTRUCTIVE inverse of setup-machine: wipe THIS host's local private
+// material AND stage the unregistration of its registered PUBLIC artifacts (for a PR). A thin shell
+// around the pure `teardown.ts` orchestrator; it owns NO key/biometric/git logic of its own.
+//
+// DEFAULT-SAFE: with NO flags this is a DRY RUN — it reports exactly what WOULD be wiped /
+// unregistered and touches NOTHING and NEVER prompts. A real teardown requires `--confirm` AND the
+// operator approving ONE biometric (Touch ID / Windows Hello). A declined biometric ⇒ nothing
+// deleted (fail-closed). Idempotent: a second run after a teardown is a clean "already clean" no-op.
+//
+// Usage:
+//   bun teardown-cli.ts --ca aaron                         # DRY RUN (default — nothing touched)
+//   bun teardown-cli.ts --ca aaron --confirm               # REAL teardown (one fingerprint)
+//   bun teardown-cli.ts --ca aaron --host mymac --confirm  # explicit hostname
+//   bun teardown-cli.ts --ca aaron --note-1password        # also PRINT the 1Password items (no delete)
+//
+// This NEVER pushes: the repo-unregister half stages a `git rm` under --repo-root for you to commit
+// + open a PR (Otto verify-gates security-class changes). It respects shared-checkout-is-view-only —
+// pass YOUR OWN clone as --repo-root, never the shared checkout.
+import { hostname as osHostname } from "node:os";
+import { homedir } from "node:os";
+import { dirname, resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
+import { realBiometric, sessionBiometric } from "./biometric.ts";
+import {
+  format1PasswordNote,
+  formatTeardown,
+  realEffects,
+  teardown,
+  type TeardownOptions,
+} from "./teardown.ts";
+
+const args = process.argv.slice(2);
+const flag = (n: string): boolean => args.includes(n);
+const opt = (n: string): string | undefined => {
+  const i = args.indexOf(n);
+  return i >= 0 ? args[i + 1] : undefined;
+};
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = opt("--repo-root") ?? resolvePath(here, "..", "..", "..");
+const ca = opt("--ca");
+const hostname = opt("--host") ?? osHostname();
+const home = opt("--home") ?? homedir();
+const confirm = flag("--confirm");
+const dryRun = !confirm; // DEFAULT-safe: only an explicit --confirm makes it a real run
+const note1Password = flag("--note-1password");
+
+function usage(): void {
+  process.stderr.write(
+    "usage: bun teardown-cli.ts --ca <name> [--host <name>] [--home <path>] [--confirm] " +
+      "[--note-1password] [--repo-root <path>]\n" +
+      "  DEFAULT-SAFE: no --confirm => DRY RUN (reports what WOULD be wiped/unregistered; nothing touched, no prompt).\n" +
+      "  --confirm => REAL teardown: securely wipe ~/.config/zeta/{ca,machine,keyring,keyset} +\n" +
+      "               stage `git rm` of maintainers/<ca>/ssh-ca.pub, machines/<host>.pub, machines/<host>-cert.pub.\n" +
+      "               Requires ONE biometric approval (fail-closed). NEVER pushes — stages a removal for a PR.\n" +
+      "  --note-1password => also PRINT which 1Password items correspond (NEVER deletes them).\n",
+  );
+}
+
+async function main(): Promise<number> {
+  if (ca === undefined || ca.trim().length === 0) {
+    usage();
+    process.stderr.write("error: --ca <name> is required (the maintainers/<ca>/ trust root to unregister)\n");
+    return 2;
+  }
+
+  // ONE biometric session over the real gate — wired into the (single) destructive run so the
+  // operator is prompted at most once. On a dry-run the door is never called.
+  const session = sessionBiometric(realBiometric());
+
+  const opts: TeardownOptions = {
+    ca,
+    repoRoot,
+    home,
+    hostname,
+    dryRun,
+    confirm,
+    biometricAuth: session.door,
+  };
+
+  const res = await teardown(realEffects(), opts);
+  process.stdout.write(formatTeardown(res) + "\n");
+  if (note1Password) {
+    process.stdout.write(format1PasswordNote() + "\n");
+  }
+
+  // Hard block iff a confirmed run was refused at the biometric gate (nothing was deleted).
+  const declined =
+    res.confirmed && !res.dryRun && res.biometric !== undefined && !res.biometric.ok;
+  return declined ? 1 : 0;
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((e: unknown) => {
+    process.stderr.write((e instanceof Error ? e.message : String(e)) + "\n");
+    process.exit(1);
+  });

--- a/tools/setup/persona-keys/teardown.test.ts
+++ b/tools/setup/persona-keys/teardown.test.ts
@@ -1,0 +1,339 @@
+// teardown.ts conformance — the DESTRUCTIVE inverse of setup (local private-key wipe + repo
+// public-artifact unregister). ALL tests run against THROWAWAY temp dirs via injected effects +
+// FAKE biometric/git doors — NEVER the real ~/.config/zeta, NEVER a real `git rm` on a real repo,
+// NEVER a real key deleted, NEVER a network call. NO key-shaped literal appears in this file (the
+// private-key header marker is SPLIT + assembled at runtime so a grep for it is EMPTY).
+//
+// Proves: dry-run wipes/rm NOTHING + never prompts; a confirmed run (fake fs + fake biometric ok)
+// deletes the fake local dirs + stages the fake repo pubkey/cert removals + fires the human gate
+// EXACTLY once; declined biometric => nothing deleted; a non-confirmed real run => nothing touched;
+// idempotent re-run => clean no-op; no secret bytes echoed.
+// Run: bun test teardown.test.ts   (from tools/setup/persona-keys)
+import { test, expect } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  ZETA_LOCAL_DIRS,
+  caPublicRel,
+  format1PasswordNote,
+  formatTeardown,
+  machineCertPath,
+  teardown,
+  zetaLocalDirPath,
+  type TeardownEffects,
+} from "./teardown.ts";
+import { caPublicKeyPath } from "./ca.ts";
+import { machinePubPath } from "./machine.ts";
+import type { BiometricAuth, BiometricResult } from "./biometric.ts";
+
+// The private-key marker, assembled at runtime so NO key-shaped literal is in this file.
+const PRIV_MARKER = "PRIVATE" + " " + "KEY";
+
+const CA = "tester";
+const HOST = "test-host";
+
+// A FAKE biometric door (no real Touch ID / Hello). `ok` controls approval; `calls` records every
+// prompt so a test can assert the gate fired EXACTLY once + fail-closed semantics.
+function fakeBiometric(ok: boolean, calls?: string[]): BiometricAuth {
+  return async (prompt: string): Promise<BiometricResult> => {
+    if (calls) calls.push(prompt);
+    return ok
+      ? { ok: true, platform: "macos-touchid" }
+      : { ok: false, platform: "macos-touchid", reason: "declined" };
+  };
+}
+
+// A deterministic fake effects over a REAL temp filesystem — but the "secure remove" + "git rm"
+// doors are FAKE (a plain unlink / a recorded staging). Never shells out, never touches a secret.
+function fakeEffects(opts?: {
+  removed?: string[];
+  gitRmStaged?: { repoRoot: string; relPath: string }[];
+}): TeardownEffects {
+  return {
+    exists: (p) => existsSync(p),
+    listFiles: (dir) => {
+      if (!existsSync(dir)) return [];
+      const out: string[] = [];
+      // shallow is fine for the test fixtures (one level of files per dir)
+      for (const name of readdirSync(dir)) {
+        out.push(join(dir, name));
+      }
+      return out;
+    },
+    securelyRemove: (path) => {
+      if (opts?.removed) opts.removed.push(path);
+      if (existsSync(path)) rmSync(path, { force: true });
+      return !existsSync(path);
+    },
+    removeDir: (dir) => {
+      if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+    },
+    gitRm: (repoRoot, relPath) => {
+      if (opts?.gitRmStaged) opts.gitRmStaged.push({ repoRoot, relPath });
+      // Fake the staging: actually remove the file from the temp "repo" so re-run is idempotent.
+      const full = join(repoRoot, relPath);
+      if (existsSync(full)) rmSync(full, { force: true });
+      return true;
+    },
+  };
+}
+
+// Build a populated fixture: a temp home with the four private dirs (each with a fake private file)
+// and a temp repo with the three registered public artifacts.
+function makeFixture(): { home: string; repoRoot: string; cleanup: () => void } {
+  const home = mkdtempSync(join(tmpdir(), "zeta-td-home-"));
+  const repoRoot = mkdtempSync(join(tmpdir(), "zeta-td-repo-"));
+  for (const dir of ZETA_LOCAL_DIRS) {
+    const d = zetaLocalDirPath(dir, home);
+    mkdirSync(d, { recursive: true });
+    // a fake PRIVATE file — content is a harmless placeholder, never a real key header
+    writeFileSync(join(d, "secret.bin"), "FAKE-PRIVATE-PLACEHOLDER-DO-NOT-USE\n", { mode: 0o600 });
+  }
+  const caPub = caPublicKeyPath(repoRoot, CA);
+  const mPub = machinePubPath(repoRoot, HOST);
+  const mCert = machineCertPath(repoRoot, HOST);
+  for (const p of [caPub, mPub, mCert]) {
+    mkdirSync(p.slice(0, p.lastIndexOf("/")), { recursive: true });
+    writeFileSync(p, "ssh-ed25519 AAAAFAKEPUBKEY placeholder\n");
+  }
+  return {
+    home,
+    repoRoot,
+    cleanup: () => {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(repoRoot, { recursive: true, force: true });
+    },
+  };
+}
+
+test("dry-run (default): wipes/rm NOTHING, never prompts, reports would-*", async () => {
+  const { home, repoRoot, cleanup } = makeFixture();
+  try {
+    const removed: string[] = [];
+    const gitRmStaged: { repoRoot: string; relPath: string }[] = [];
+    const prompts: string[] = [];
+    const fx = fakeEffects({ removed, gitRmStaged });
+    const res = await teardown(fx, {
+      ca: CA,
+      repoRoot,
+      home,
+      hostname: HOST,
+      dryRun: true,
+      biometricAuth: fakeBiometric(true, prompts),
+    });
+    // Nothing destructive happened.
+    expect(removed.length).toBe(0);
+    expect(gitRmStaged.length).toBe(0);
+    expect(prompts.length).toBe(0); // NEVER prompts on dry-run
+    expect(res.dryRun).toBe(true);
+    expect(res.hadWork).toBe(true);
+    // Everything reported as would-*.
+    expect(res.localWipe.every((l) => l.action === "would-wipe")).toBe(true);
+    expect(res.repoUnregister.every((r) => r.action === "would-unregister")).toBe(true);
+    // All the real files still exist.
+    for (const dir of ZETA_LOCAL_DIRS) expect(existsSync(zetaLocalDirPath(dir, home))).toBe(true);
+    expect(existsSync(caPublicKeyPath(repoRoot, CA))).toBe(true);
+    expect(existsSync(machinePubPath(repoRoot, HOST))).toBe(true);
+    expect(existsSync(machineCertPath(repoRoot, HOST))).toBe(true);
+    // No biometric outcome recorded (gate never invoked).
+    expect(res.biometric).toBeUndefined();
+  } finally {
+    cleanup();
+  }
+});
+
+test("confirmed + biometric ok: wipes local dirs, stages all three repo removals, fires gate once", async () => {
+  const { home, repoRoot, cleanup } = makeFixture();
+  try {
+    const removed: string[] = [];
+    const gitRmStaged: { repoRoot: string; relPath: string }[] = [];
+    const prompts: string[] = [];
+    const fx = fakeEffects({ removed, gitRmStaged });
+    const res = await teardown(fx, {
+      ca: CA,
+      repoRoot,
+      home,
+      hostname: HOST,
+      dryRun: false,
+      confirm: true,
+      biometricAuth: fakeBiometric(true, prompts),
+    });
+    // The human gate fired EXACTLY once.
+    expect(prompts.length).toBe(1);
+    expect(res.biometric?.ok).toBe(true);
+    // Every local private file was securely removed (4 dirs × 1 file).
+    expect(removed.length).toBe(ZETA_LOCAL_DIRS.length);
+    for (const dir of ZETA_LOCAL_DIRS) expect(existsSync(zetaLocalDirPath(dir, home))).toBe(false);
+    // All three repo artifacts staged for removal + actually gone from the temp repo.
+    expect(gitRmStaged.length).toBe(3);
+    expect(res.unregisteredPaths.length).toBe(3);
+    expect(existsSync(caPublicKeyPath(repoRoot, CA))).toBe(false);
+    expect(existsSync(machinePubPath(repoRoot, HOST))).toBe(false);
+    expect(existsSync(machineCertPath(repoRoot, HOST))).toBe(false);
+    // Every staged git rm operated ONLY under the passed repoRoot (shared-checkout-is-view-only).
+    expect(gitRmStaged.every((s) => s.repoRoot === repoRoot)).toBe(true);
+    expect(res.localWipe.every((l) => l.action === "wiped")).toBe(true);
+    expect(res.repoUnregister.every((r) => r.action === "unregistered")).toBe(true);
+  } finally {
+    cleanup();
+  }
+});
+
+test("declined biometric: fail-closed — NOTHING deleted, NOTHING staged", async () => {
+  const { home, repoRoot, cleanup } = makeFixture();
+  try {
+    const removed: string[] = [];
+    const gitRmStaged: { repoRoot: string; relPath: string }[] = [];
+    const prompts: string[] = [];
+    const fx = fakeEffects({ removed, gitRmStaged });
+    const res = await teardown(fx, {
+      ca: CA,
+      repoRoot,
+      home,
+      hostname: HOST,
+      dryRun: false,
+      confirm: true,
+      biometricAuth: fakeBiometric(false, prompts), // DECLINED
+    });
+    expect(prompts.length).toBe(1); // it asked once
+    expect(res.biometric?.ok).toBe(false);
+    expect(removed.length).toBe(0);
+    expect(gitRmStaged.length).toBe(0);
+    expect(res.unregisteredPaths.length).toBe(0);
+    // Everything still present.
+    for (const dir of ZETA_LOCAL_DIRS) expect(existsSync(zetaLocalDirPath(dir, home))).toBe(true);
+    expect(existsSync(caPublicKeyPath(repoRoot, CA))).toBe(true);
+    expect(res.localWipe.every((l) => l.action === "skipped-biometric")).toBe(true);
+    expect(res.repoUnregister.every((r) => r.action === "skipped-biometric")).toBe(true);
+  } finally {
+    cleanup();
+  }
+});
+
+test("real run WITHOUT confirm: nothing touched, never prompts", async () => {
+  const { home, repoRoot, cleanup } = makeFixture();
+  try {
+    const removed: string[] = [];
+    const gitRmStaged: { repoRoot: string; relPath: string }[] = [];
+    const prompts: string[] = [];
+    const fx = fakeEffects({ removed, gitRmStaged });
+    const res = await teardown(fx, {
+      ca: CA,
+      repoRoot,
+      home,
+      hostname: HOST,
+      dryRun: false,
+      confirm: false, // NOT confirmed
+      biometricAuth: fakeBiometric(true, prompts),
+    });
+    expect(prompts.length).toBe(0); // never prompts without confirm
+    expect(removed.length).toBe(0);
+    expect(gitRmStaged.length).toBe(0);
+    expect(res.biometric).toBeUndefined();
+    expect(res.localWipe.every((l) => l.action === "skipped-not-confirmed")).toBe(true);
+    expect(res.repoUnregister.every((r) => r.action === "skipped-not-confirmed")).toBe(true);
+    for (const dir of ZETA_LOCAL_DIRS) expect(existsSync(zetaLocalDirPath(dir, home))).toBe(true);
+  } finally {
+    cleanup();
+  }
+});
+
+test("idempotent: re-run after a teardown is a clean no-op (already clean, no prompt)", async () => {
+  const { home, repoRoot, cleanup } = makeFixture();
+  try {
+    const prompts1: string[] = [];
+    const fx = fakeEffects();
+    // First teardown removes everything.
+    await teardown(fx, {
+      ca: CA,
+      repoRoot,
+      home,
+      hostname: HOST,
+      dryRun: false,
+      confirm: true,
+      biometricAuth: fakeBiometric(true, prompts1),
+    });
+    expect(prompts1.length).toBe(1);
+    // Second run: nothing present => clean no-op, NO prompt.
+    const prompts2: string[] = [];
+    const res2 = await teardown(fx, {
+      ca: CA,
+      repoRoot,
+      home,
+      hostname: HOST,
+      dryRun: false,
+      confirm: true,
+      biometricAuth: fakeBiometric(true, prompts2),
+    });
+    expect(prompts2.length).toBe(0); // nothing destructive => no approval needed
+    expect(res2.hadWork).toBe(false);
+    expect(res2.biometric).toBeUndefined();
+    expect(res2.unregisteredPaths.length).toBe(0);
+    expect(res2.localWipe.every((l) => l.action === "absent")).toBe(true);
+    expect(res2.repoUnregister.every((r) => r.action === "absent")).toBe(true);
+    expect(formatTeardown(res2)).toContain("Already clean");
+  } finally {
+    cleanup();
+  }
+});
+
+test("partial state: only local present (repo already clean) — wipes local, no repo staging", async () => {
+  const home = mkdtempSync(join(tmpdir(), "zeta-td-home-"));
+  const repoRoot = mkdtempSync(join(tmpdir(), "zeta-td-repo-")); // empty repo
+  try {
+    for (const dir of ZETA_LOCAL_DIRS) {
+      const d = zetaLocalDirPath(dir, home);
+      mkdirSync(d, { recursive: true });
+      writeFileSync(join(d, "secret.bin"), "FAKE\n");
+    }
+    const removed: string[] = [];
+    const gitRmStaged: { repoRoot: string; relPath: string }[] = [];
+    const fx = fakeEffects({ removed, gitRmStaged });
+    const res = await teardown(fx, {
+      ca: CA,
+      repoRoot,
+      home,
+      hostname: HOST,
+      dryRun: false,
+      confirm: true,
+      biometricAuth: fakeBiometric(true),
+    });
+    expect(res.hadWork).toBe(true);
+    expect(removed.length).toBe(ZETA_LOCAL_DIRS.length);
+    expect(gitRmStaged.length).toBe(0); // repo had nothing to unregister
+    expect(res.repoUnregister.every((r) => r.action === "absent")).toBe(true);
+    expect(res.localWipe.every((l) => l.action === "wiped")).toBe(true);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("readouts + 1Password note are PUBLIC only — no private-key bytes ever echoed", async () => {
+  const { home, repoRoot, cleanup } = makeFixture();
+  try {
+    const fx = fakeEffects();
+    const res = await teardown(fx, {
+      ca: CA,
+      repoRoot,
+      home,
+      hostname: HOST,
+      dryRun: false,
+      confirm: true,
+      biometricAuth: fakeBiometric(true),
+    });
+    const out = formatTeardown(res) + "\n" + format1PasswordNote();
+    expect(out).not.toContain(PRIV_MARKER); // no private-key header in any readout
+    expect(out).toContain("zeta-ca-private"); // the 1Password note names the items
+    expect(out).toContain("Biometric: 1 approval");
+  } finally {
+    cleanup();
+  }
+});
+
+test("relUnder helper (caPublicRel): repo-relative path for git rm", () => {
+  // The repo-unregister paths are repo-root-relative (what `git rm` wants under -C repoRoot).
+  const rel = caPublicRel("/tmp/myrepo", CA);
+  expect(rel).toBe(`maintainers/${CA}/ssh-ca.pub`);
+});

--- a/tools/setup/persona-keys/teardown.ts
+++ b/tools/setup/persona-keys/teardown.ts
@@ -1,0 +1,515 @@
+// Zeta TEARDOWN / UNREGISTER — the inverse of setup-machine / setup-cluster (ca.ts + machine.ts +
+// onboard.ts). DESTRUCTIVE-capable, security-class (workitem 081KVM1TK3Z08QG0R0002959G6 §"clean
+// re-onboarding"). Aaron (2026-06-21): *"delete everything including the CA, unregister; start
+// writing the unregister scripts too — this is a core primitive, support in all langs eventually,
+// save to a resume."* The point is to PROVE clean re-onboarding: teardown → re-run setup → the
+// same one-fingerprint UX, from a blank host.
+//
+// CORE PRIMITIVE — TS NOW, ALL LANGS EVENTUALLY. This is a CORE PRIMITIVE that will be generated
+// to every oracle via gen/ (the same shape as setup/onboard). It is built in TypeScript today
+// (the persona-keys tooling is TS) and read as the canonical reference for the future generation.
+//
+// TWO HALVES (both behind the injected-effects pattern — noninterference §13; tests inject fakes):
+//
+//   1. LOCAL WIPE — securely remove THIS host's PRIVATE material under ~/.config/zeta/
+//      ({ca, machine, keyring, keyset} — whatever exists). Each private FILE is `shred`-then-unlink
+//      where available (the runner's job, in the injected `securelyRemove` door), falling back to
+//      overwrite+unlink, so private bytes don't linger. BIOMETRIC-GATED, FAIL-CLOSED: a destructive
+//      wipe needs ONE operator approval (Touch ID / Windows Hello). NEVER echoes key bytes.
+//
+//   2. REPO UNREGISTER — remove the registered PUBLIC artifacts so they are un-PR'd: the CA pubkey
+//      `maintainers/<ca>/ssh-ca.pub`, the machine pubkey `machines/<host>.pub`, and the machine cert
+//      `machines/<host>-cert.pub`. This is staged as a `git rm` in the CALLER's repo clone (it
+//      produces the removal FOR a PR) — it NEVER pushes to main and respects shared-checkout-is-
+//      view-only (it operates ONLY on the `repoRoot` passed in, via the injected `gitRm` door).
+//
+// SECURITY INVARIANTS (security-class — honesty over green):
+//  1. `--dry-run` is the DEFAULT-safe path: report exactly what WOULD be wiped / unregistered,
+//     delete/rm NOTHING, and NEVER prompt. A real teardown requires an explicit `confirm` (the CLI
+//     `--confirm` / a non-dry-run call) AND the biometric approval. dry-run never calls the gate.
+//  2. FAIL-CLOSED: a declined / absent biometric ⇒ NOTHING is deleted, NOTHING is rm'd. The gate is
+//     fired EXACTLY ONCE for the whole destructive run (one fingerprint), via the shared
+//     biometric.ts gate (reuse `requireBiometric`; the CLI wraps it in `sessionBiometric`).
+//  3. IDEMPOTENT: re-run after a teardown is a clean no-op — nothing present ⇒ "already clean", no
+//     prompt (nothing destructive will happen, so nothing is approved).
+//  4. NO secret bytes EVER cross this boundary or get printed — the wipe door consumes paths and
+//     returns only a boolean/typed outcome; we never read private contents into this process.
+//
+// Anchors (Beacon): secure file erasure — `shred(1)` (GNU coreutils; Gutmann 1996, "Secure Deletion
+// of Data from Magnetic and Solid-State Memory") with the SSD/journaling caveat (overwrite-in-place
+// is best-effort on copy-on-write/flash — the honest reason the CA private also lives in 1Password,
+// the durable backup). Reversible-by-regeneration: a wiped key is recoverable ONLY by re-running
+// setup (new keypair) — teardown is destructive, re-onboarding is the inverse, not undo. Touch ID
+// PAM / Windows Hello user-verification as the destructive-action floor (biometric.ts). `git rm`
+// staging for a removal PR — git as the public-trust distribution channel (ca.ts), removed the
+// same way it was added (never a force-push, never a direct main write).
+import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { caPublicKeyPath } from "./ca.ts";
+import { machinePubPath, sanitizeHostname } from "./machine.ts";
+import { requireBiometric, type BiometricAuth, type BiometricResult } from "./biometric.ts";
+export type { BiometricAuth, BiometricResult } from "./biometric.ts";
+
+/** The host-environment doors — the ONLY channel for ambient influence (noninterference §13).
+ *  Every door is PUBLIC-safe by construction: NO door ever returns private key BYTES. The wipe
+ *  doors consume PATHS and report success only; nothing reads a secret into this process. */
+export interface TeardownEffects {
+  /** True iff a path exists (presence checks — never reads the contents of a secret). */
+  readonly exists: (path: string) => boolean;
+  /** List the files (recursively, leaf paths) under a local dir — used ONLY to count + report
+   *  WHICH private files would be / were wiped (paths, never contents). Returns [] if absent. */
+  readonly listFiles: (dir: string) => readonly string[];
+  /** SECURELY remove ONE local file: shred-then-unlink where available, else overwrite+unlink.
+   *  The runner does the erasure; this returns true iff the file is gone afterwards. NEVER reads
+   *  or returns the file's bytes. Idempotent: removing an absent file is a no-op true. */
+  readonly securelyRemove: (path: string) => boolean;
+  /** Remove a now-empty local directory (best-effort; absent ⇒ no-op). Tidies ~/.config/zeta/<d>. */
+  readonly removeDir: (dir: string) => void;
+  /** Stage a `git rm` of a PUBLIC artifact in the CALLER's repo clone (produces a removal for a
+   *  PR — NEVER pushes, NEVER touches main directly). Returns true iff the path was staged for
+   *  removal (false if it was not tracked / already gone). Operates ONLY under the given repoRoot. */
+  readonly gitRm: (repoRoot: string, relPath: string) => boolean;
+}
+
+/** The four local directories that hold THIS host's PRIVATE material (under ~/.config/zeta/). The
+ *  whole point of teardown is to remove ALL of these (Aaron: "delete everything including the CA").
+ *  ca = the SSH CA private key; machine = this host's device key; keyring/keyset = persona material. */
+export const ZETA_LOCAL_DIRS = ["ca", "machine", "keyring", "keyset"] as const;
+export type ZetaLocalDir = (typeof ZETA_LOCAL_DIRS)[number];
+
+/** The 1Password items that mirror the local private material — PRINTED (never deleted) by the
+ *  optional `--note-1password` flag so the operator can decide to delete the durable backups too.
+ *  We NEVER delete from 1Password automatically (the backup is the reversible-by-regeneration
+ *  safety net; deleting it is the operator's explicit call). Names are advisory, not load-bearing. */
+export const ONEPASSWORD_ITEMS = [
+  "zeta-ca-private",
+  "zeta-machine-private",
+  "zeta-keyring-seed",
+  "zeta-keyset",
+] as const;
+
+/** The base ~/.config/zeta directory for a given home. */
+export function zetaConfigDir(home: string = homedir()): string {
+  return join(home, ".config", "zeta");
+}
+
+/** The local path for one of the four private dirs. */
+export function zetaLocalDirPath(dir: ZetaLocalDir, home: string = homedir()): string {
+  return join(zetaConfigDir(home), dir);
+}
+
+/** The machine cert public path: `machines/<host>-cert.pub` (next to the machine pubkey). The
+ *  cert is PUBLIC (ca.ts) but it is a registered artifact, so unregistering removes it too. */
+export function machineCertPath(repoRoot: string, hostname: string): string {
+  return join(repoRoot, "machines", `${sanitizeHostname(hostname)}-cert.pub`);
+}
+
+/** The repo-root-RELATIVE path of the CA public key — the exact `git rm` argument under
+ *  `-C repoRoot` (e.g. `maintainers/<ca>/ssh-ca.pub`). The relative form is what gets staged. */
+export function caPublicRel(repoRoot: string, ca: string): string {
+  return relUnder(repoRoot, caPublicKeyPath(repoRoot, ca));
+}
+
+/** What happened (or, on dry-run, WOULD happen) to one local private dir. No secret bytes. */
+export interface LocalWipeEntry {
+  readonly dir: ZetaLocalDir;
+  readonly path: string;
+  /** Whether this dir was present (had any files) before the run. */
+  readonly present: boolean;
+  /** The leaf file paths under it (the private files) — PATHS only, NEVER contents. */
+  readonly files: readonly string[];
+  /** "wiped" (real run, files securely removed) | "would-wipe" (dry-run) | "absent" (nothing here)
+   *  | "skipped-not-confirmed" (real run but no `confirm`) | "skipped-biometric" (declined gate). */
+  readonly action: "wiped" | "would-wipe" | "absent" | "skipped-not-confirmed" | "skipped-biometric";
+}
+
+/** What happened (or WOULD happen) to one registered PUBLIC artifact. */
+export interface RepoUnregisterEntry {
+  readonly kind: "ca-pubkey" | "machine-pubkey" | "machine-cert";
+  readonly path: string;
+  /** Repo-root-relative path passed to `git rm` (the removal staged for a PR). */
+  readonly relPath: string;
+  /** Whether the artifact existed in the repo before the run. */
+  readonly present: boolean;
+  /** "unregistered" (git rm staged) | "would-unregister" (dry-run) | "absent" (not in repo)
+   *  | "skipped-not-confirmed" | "skipped-biometric". */
+  readonly action:
+    | "unregistered"
+    | "would-unregister"
+    | "absent"
+    | "skipped-not-confirmed"
+    | "skipped-biometric";
+}
+
+/** The full teardown result — auditable, public-only. */
+export interface TeardownResult {
+  readonly dryRun: boolean;
+  /** Whether the caller explicitly confirmed a destructive run (CLI `--confirm` / non-dry-run). */
+  readonly confirmed: boolean;
+  readonly home: string;
+  readonly repoRoot: string;
+  readonly hostname: string;
+  /** The CA identity whose `maintainers/<ca>/ssh-ca.pub` is unregistered. */
+  readonly ca: string;
+  readonly localWipe: readonly LocalWipeEntry[];
+  readonly repoUnregister: readonly RepoUnregisterEntry[];
+  /** True iff there was anything destructive to do at all (any present local dir OR repo artifact).
+   *  When false, the run is a clean no-op ("already clean") and the gate is never fired. */
+  readonly hadWork: boolean;
+  /** The biometric approval outcome — present ONLY when the gate was actually invoked (a confirmed,
+   *  non-dry-run with work to do). Absent on dry-run, on a non-confirmed run, and on an already-clean
+   *  no-op. NEVER carries a secret. */
+  readonly biometric?: BiometricResult;
+  /** The list of repo paths actually staged for `git rm` (the PR's removal set) — for the caller. */
+  readonly unregisteredPaths: readonly string[];
+}
+
+/** Options for a teardown. `dryRun` defaults TRUE at the CLI; here the explicit value governs.
+ *  A real (destructive) run requires `dryRun:false` AND `confirm:true` AND a passing biometric. */
+export interface TeardownOptions {
+  /** The CA identity (the `maintainers/<ca>/` trust root to unregister). Usually the operator. */
+  readonly ca: string;
+  readonly repoRoot: string;
+  readonly home?: string;
+  /** Override hostname (else taken from the caller; the CLI passes os.hostname()). */
+  readonly hostname: string;
+  /** When true, NOTHING is deleted/rm'd/prompted — report "would-*". DEFAULT-safe path. */
+  readonly dryRun?: boolean;
+  /** Explicit destructive confirmation. WITHOUT it (on a non-dry-run) every step is
+   *  "skipped-not-confirmed" — nothing is touched. WITH it (+ biometric) the wipe + rm happen. */
+  readonly confirm?: boolean;
+  /** SHARED biometric approval door — required for the real destructive path (fail-closed). */
+  readonly biometricAuth?: BiometricAuth;
+}
+
+/**
+ * Run the teardown / unregister — the inverse of setup. DEFAULT-safe: on `dryRun` (or a non-dry-run
+ * WITHOUT `confirm`) it reports exactly what WOULD be wiped/unregistered and touches NOTHING and
+ * NEVER prompts. A real teardown requires `dryRun:false` AND `confirm:true` AND ONE passing biometric
+ * approval (fired exactly once for the whole run). Idempotent: if nothing is present it is a clean
+ * no-op ("already clean") with NO prompt.
+ *
+ * The plan is computed FIRST (pure presence checks) so the readout is honest on every path; the
+ * destructive doors fire ONLY after the confirm + biometric gate. The biometric gate is fired once,
+ * up front, only when there is real destructive work to do.
+ */
+export async function teardown(fx: TeardownEffects, opts: TeardownOptions): Promise<TeardownResult> {
+  const home = opts.home ?? homedir();
+  const hostname = sanitizeHostname(opts.hostname);
+  const dryRun = opts.dryRun !== false; // DEFAULT-safe: anything but an explicit false is a dry-run
+  const confirmed = opts.confirm === true;
+
+  // ── PLAN (pure presence checks — no side effects, no prompt) ──────────────────────────────
+  // LOCAL: each of the four private dirs, the files under it.
+  const localPlan = ZETA_LOCAL_DIRS.map((dir) => {
+    const path = zetaLocalDirPath(dir, home);
+    const present = fx.exists(path);
+    const files = present ? fx.listFiles(path) : [];
+    return { dir, path, present, files };
+  });
+  // REPO: the three registered PUBLIC artifacts.
+  const repoTargets: readonly { kind: RepoUnregisterEntry["kind"]; path: string }[] = [
+    { kind: "ca-pubkey", path: caPublicKeyPath(opts.repoRoot, opts.ca) },
+    { kind: "machine-pubkey", path: machinePubPath(opts.repoRoot, hostname) },
+    { kind: "machine-cert", path: machineCertPath(opts.repoRoot, hostname) },
+  ];
+  const repoPlan = repoTargets.map((t) => ({
+    ...t,
+    relPath: relUnder(opts.repoRoot, t.path),
+    present: fx.exists(t.path),
+  }));
+
+  const hadWork = localPlan.some((l) => l.present) || repoPlan.some((r) => r.present);
+
+  // ── DRY-RUN (default-safe) — report would-*; NOTHING touched, NEVER prompt ────────────────
+  if (dryRun) {
+    return finalize({
+      dryRun: true,
+      confirmed,
+      home,
+      repoRoot: opts.repoRoot,
+      hostname,
+      ca: opts.ca,
+      localWipe: localPlan.map((l) => ({
+        dir: l.dir,
+        path: l.path,
+        present: l.present,
+        files: l.files,
+        action: l.present ? ("would-wipe" as const) : ("absent" as const),
+      })),
+      repoUnregister: repoPlan.map((r) => ({
+        kind: r.kind,
+        path: r.path,
+        relPath: r.relPath,
+        present: r.present,
+        action: r.present ? ("would-unregister" as const) : ("absent" as const),
+      })),
+      hadWork,
+    });
+  }
+
+  // ── REAL RUN, BUT NOT CONFIRMED — skip everything (fail-safe), NEVER prompt ───────────────
+  if (!confirmed) {
+    return finalize({
+      dryRun: false,
+      confirmed: false,
+      home,
+      repoRoot: opts.repoRoot,
+      hostname,
+      ca: opts.ca,
+      localWipe: localPlan.map((l) => ({
+        dir: l.dir,
+        path: l.path,
+        present: l.present,
+        files: l.files,
+        action: l.present ? ("skipped-not-confirmed" as const) : ("absent" as const),
+      })),
+      repoUnregister: repoPlan.map((r) => ({
+        kind: r.kind,
+        path: r.path,
+        relPath: r.relPath,
+        present: r.present,
+        action: r.present ? ("skipped-not-confirmed" as const) : ("absent" as const),
+      })),
+      hadWork,
+    });
+  }
+
+  // ── IDEMPOTENT CLEAN NO-OP — nothing present, so nothing destructive; NEVER prompt ────────
+  if (!hadWork) {
+    return finalize({
+      dryRun: false,
+      confirmed: true,
+      home,
+      repoRoot: opts.repoRoot,
+      hostname,
+      ca: opts.ca,
+      localWipe: localPlan.map((l) => ({
+        dir: l.dir,
+        path: l.path,
+        present: false,
+        files: [] as readonly string[],
+        action: "absent" as const,
+      })),
+      repoUnregister: repoPlan.map((r) => ({
+        kind: r.kind,
+        path: r.path,
+        relPath: r.relPath,
+        present: false,
+        action: "absent" as const,
+      })),
+      hadWork: false,
+    });
+  }
+
+  // ── BIOMETRIC GATE — fired EXACTLY ONCE for the whole destructive run (fail-closed) ───────
+  const biometric = await requireBiometric(
+    opts.biometricAuth,
+    `Approve Zeta TEARDOWN for host ${hostname} (DESTRUCTIVE: wipe local private keys` +
+      ` [${ZETA_LOCAL_DIRS.join(", ")}] + unregister public artifacts for a PR)`,
+  );
+  if (!biometric.ok) {
+    // Declined ⇒ NOTHING deleted, NOTHING rm'd. Every present target is "skipped-biometric".
+    return finalize({
+      dryRun: false,
+      confirmed: true,
+      home,
+      repoRoot: opts.repoRoot,
+      hostname,
+      ca: opts.ca,
+      biometric,
+      localWipe: localPlan.map((l) => ({
+        dir: l.dir,
+        path: l.path,
+        present: l.present,
+        files: l.files,
+        action: l.present ? ("skipped-biometric" as const) : ("absent" as const),
+      })),
+      repoUnregister: repoPlan.map((r) => ({
+        kind: r.kind,
+        path: r.path,
+        relPath: r.relPath,
+        present: r.present,
+        action: r.present ? ("skipped-biometric" as const) : ("absent" as const),
+      })),
+      hadWork,
+    });
+  }
+
+  // ── DESTRUCTIVE EXECUTION (approved) ─────────────────────────────────────────────────────
+  // LOCAL WIPE: securely remove every private file, then tidy the now-empty dir.
+  const localWipe: LocalWipeEntry[] = localPlan.map((l) => {
+    if (!l.present) {
+      return { dir: l.dir, path: l.path, present: false, files: [], action: "absent" as const };
+    }
+    for (const f of l.files) fx.securelyRemove(f);
+    fx.removeDir(l.path);
+    return { dir: l.dir, path: l.path, present: true, files: l.files, action: "wiped" as const };
+  });
+
+  // REPO UNREGISTER: stage a `git rm` of each present public artifact (for a PR — never pushed).
+  const repoUnregister: RepoUnregisterEntry[] = repoPlan.map((r) => {
+    if (!r.present) {
+      return { kind: r.kind, path: r.path, relPath: r.relPath, present: false, action: "absent" as const };
+    }
+    fx.gitRm(opts.repoRoot, r.relPath);
+    return { kind: r.kind, path: r.path, relPath: r.relPath, present: true, action: "unregistered" as const };
+  });
+
+  return finalize({
+    dryRun: false,
+    confirmed: true,
+    home,
+    repoRoot: opts.repoRoot,
+    hostname,
+    ca: opts.ca,
+    biometric,
+    localWipe,
+    repoUnregister,
+    hadWork: true,
+  });
+}
+
+/** Fill the derived fields (`unregisteredPaths`) and return a complete result. */
+function finalize(partial: Omit<TeardownResult, "unregisteredPaths">): TeardownResult {
+  const unregisteredPaths = partial.repoUnregister
+    .filter((r) => r.action === "unregistered")
+    .map((r) => r.relPath);
+  return { ...partial, unregisteredPaths };
+}
+
+/** Repo-root-relative path for a readout / `git rm` argument (POSIX-ish, ordinal). */
+function relUnder(repoRoot: string, path: string): string {
+  const prefix = repoRoot.endsWith("/") ? repoRoot : repoRoot + "/";
+  return path.startsWith(prefix) ? path.slice(prefix.length) : path;
+}
+
+/** Render the operator-facing readout — PUBLIC only, NEVER any key bytes. */
+export function formatTeardown(res: TeardownResult): string {
+  const lines: string[] = [];
+  const mode = res.dryRun
+    ? "DRY RUN (default-safe — NOTHING deleted, rm'd, or prompted)"
+    : res.confirmed
+      ? "CONFIRMED teardown"
+      : "NOT CONFIRMED (no --confirm — NOTHING touched)";
+  lines.push(`Zeta teardown — host=${res.hostname}, ca=${res.ca} — ${mode}`);
+
+  if (!res.hadWork) {
+    lines.push("  Already clean: no local private material and no registered artifacts found.");
+    lines.push("  (Idempotent no-op — nothing to wipe, nothing to unregister, no approval needed.)");
+    return lines.join("\n");
+  }
+
+  lines.push("  LOCAL WIPE (this host's PRIVATE material under ~/.config/zeta/):");
+  for (const l of res.localWipe) {
+    const tag =
+      l.action === "would-wipe"
+        ? `would wipe ${l.files.length} file(s)`
+        : l.action === "wiped"
+          ? `WIPED ${l.files.length} file(s)`
+          : l.action === "absent"
+            ? "absent (nothing to wipe)"
+            : l.action === "skipped-not-confirmed"
+              ? "present — skipped (no --confirm)"
+              : "present — skipped (biometric declined)";
+    lines.push(`    [${l.dir}] ${l.path} — ${tag}`);
+  }
+
+  lines.push("  REPO UNREGISTER (remove registered PUBLIC artifacts — staged for a PR, NOT pushed):");
+  for (const r of res.repoUnregister) {
+    const tag =
+      r.action === "would-unregister"
+        ? "would git rm"
+        : r.action === "unregistered"
+          ? "git rm STAGED"
+          : r.action === "absent"
+            ? "absent (not registered)"
+            : r.action === "skipped-not-confirmed"
+              ? "present — skipped (no --confirm)"
+              : "present — skipped (biometric declined)";
+    lines.push(`    [${r.kind}] ${r.relPath} — ${tag}`);
+  }
+
+  if (res.dryRun) {
+    lines.push("  Re-run with --confirm (and approve the biometric) to execute the teardown.");
+  } else if (res.confirmed && res.biometric?.ok === true) {
+    lines.push(`  Biometric: 1 approval covered the whole destructive run (${res.biometric.platform}).`);
+    lines.push(
+      `  Unregistered (staged for PR): ${res.unregisteredPaths.length} path(s). Commit + open a PR to land the removal.`,
+    );
+  } else if (res.confirmed && res.biometric !== undefined && !res.biometric.ok) {
+    lines.push(`  Biometric DECLINED — fail-closed: nothing deleted, nothing unregistered.`);
+  }
+  return lines.join("\n");
+}
+
+/** Render the optional 1Password note — PRINTS which items correspond so the operator can decide
+ *  to delete the durable backups. NEVER deletes from 1Password (that is the operator's call). */
+export function format1PasswordNote(): string {
+  const lines: string[] = [];
+  lines.push("1Password backups (NOT deleted automatically — your call):");
+  for (const item of ONEPASSWORD_ITEMS) {
+    lines.push(`    - ${item}`);
+  }
+  lines.push("  Delete these manually in 1Password ONLY if you want to remove the durable backups too.");
+  return lines.join("\n");
+}
+
+/** The REAL host effects (used by the CLI). The wipe doors do the secure erasure; the git door
+ *  shells `git rm` under the given repoRoot — never a push, never main. NO door returns secret bytes. */
+export function realEffects(): TeardownEffects {
+  return {
+    exists: (p) => existsSync(p),
+    listFiles: (dir) => {
+      if (!existsSync(dir)) return [];
+      const out: string[] = [];
+      const walk = (d: string): void => {
+        for (const entry of readdirSync(d, { withFileTypes: true })) {
+          const full = join(d, entry.name);
+          if (entry.isDirectory()) walk(full);
+          else out.push(full);
+        }
+      };
+      walk(dir);
+      return out;
+    },
+    securelyRemove: (path) => {
+      if (!existsSync(path)) return true; // idempotent: already gone
+      // Prefer `shred` (overwrite-then-unlink) where available so private bytes don't linger;
+      // fall back to a manual overwrite + unlink. NEVER reads the file's bytes into this process.
+      const shredded = spawnSync("shred", ["-u", "-z", path], { stdio: "ignore" });
+      if (shredded.status === 0 && !existsSync(path)) return true;
+      // Fallback: best-effort overwrite-in-place with zeros, then unlink. (SSD/CoW caveat applies —
+      // the durable backup in 1Password is the honest recovery path; see header Beacon note.)
+      try {
+        const size = statSync(path).size;
+        if (size > 0) writeFileSync(path, Buffer.alloc(size, 0));
+      } catch {
+        // overwrite is best-effort; proceed to unlink regardless
+      }
+      try {
+        unlinkSync(path);
+      } catch {
+        return false;
+      }
+      return !existsSync(path);
+    },
+    removeDir: (dir) => {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // best-effort tidy of the now-empty dir
+      }
+    },
+    gitRm: (repoRoot, relPath) => {
+      // Stage a removal for a PR — `git rm` under the caller's repoRoot. NEVER pushes, NEVER main.
+      // --ignore-unmatch keeps it idempotent (an already-removed/untracked path is not an error).
+      const r = spawnSync("git", ["-C", repoRoot, "rm", "--ignore-unmatch", "--", relPath], {
+        stdio: "ignore",
+      });
+      return r.status === 0;
+    },
+  };
+}


### PR DESCRIPTION
## What

The **teardown / unregister** primitive — the DESTRUCTIVE-capable inverse of `setup-machine` / `setup-cluster`. Needed to prove **clean re-onboarding**: teardown → re-run setup → the same one-fingerprint UX from a blank host. A **CORE PRIMITIVE** (TypeScript now; generated to all langs via `gen/` eventually — noted in the header).

Aaron (2026-06-21): *"delete everything including the CA, unregister; start writing the unregister scripts too — this is a core primitive, support in all langs eventually, save to a resume."*

## Two halves (both behind the injected-effects pattern — noninterference §13)

1. **LOCAL WIPE** — securely remove this host's PRIVATE material under `~/.config/zeta/{ca,machine,keyring,keyset}` (whatever exists): `shred`-then-unlink where available, else overwrite+unlink, so private bytes don't linger. Biometric-gated, **FAIL-CLOSED** (one approval covers the whole run). Never echoes key bytes.
2. **REPO UNREGISTER** — stage a `git rm` of the registered PUBLIC artifacts (`maintainers/<ca>/ssh-ca.pub`, `machines/<host>.pub`, `machines/<host>-cert.pub`) in the **caller's** repo clone, **for a PR**. Never pushes to main; respects shared-checkout-is-view-only (operates only under the passed `repoRoot`). Returns the list of unregistered paths.

## Hard guarantees (proved by `teardown.test.ts`, 8 tests green)

- `--dry-run` is the **DEFAULT-safe** path: reports exactly what WOULD be wiped/unregistered, deletes/rm **NOTHING**, and **NEVER prompts**.
- A real teardown requires **`--confirm`** AND **one biometric approval** (fired exactly once).
- Declined biometric ⇒ **fail-closed** (nothing deleted, nothing staged).
- **Idempotent**: re-run after teardown = clean "already clean" no-op (no prompt).
- **No secret bytes** ever cross the boundary or get echoed (grep for a private-key header on the changed files is empty; the test's marker is split at runtime).
- Optional `--note-1password` **PRINTS** (never deletes) the corresponding 1Password backup items.

## Gates

- `bun test tools/setup/persona-keys/teardown.test.ts` — 8 pass / 0 fail.
- `bun src/Core.TypeScript/lint/lint-typescript.ts` — green (tsc + prettier + style).
- grep `BEGIN.*PRIVATE KEY` / `PRIVATE KEY` on the three new files — empty.
- CLI `--dry-run` (on throwaway temp dirs) prints a sane plan and touches nothing.

## Security-class

Left **OPEN** for Otto's verify-gate (NO auto-merge). No `.sh` added (pure `.ts`), so no bash-retirement-inventory entry needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)