### PR TITLE
docs(research): crypto-agile PQ keychain — one seed → classical + PQ, good-crypto-not-secret

### DIFF
--- a/docs/research/2026-06-21-crypto-agile-postquantum-keychain-one-seed-classical-plus-pq-good-crypto-not-secret.md
+++ b/docs/research/2026-06-21-crypto-agile-postquantum-keychain-one-seed-classical-plus-pq-good-crypto-not-secret.md
@@ -1,0 +1,115 @@
+# Crypto-agile post-quantum keychain — one seed → classical + PQ (lattice + non-lattice), modern-by-default; good-crypto-not-secret-crypto
+
+**Date:** 2026-06-21 · **Driver:** Aaron · **Status:** synthesis (combine what we have + close the keychain gap) · **Trajectory:** cluster-encryption-credential-substrate
+
+## The ethos (Aaron 2026-06-21) — Kerckhoffs, zero-trust, nation-state-resistant
+
+> *"This is nation-state-resistant, secure-boot / supply-chain-compatible, full zero-trust code —
+> it's protecting our nation's power grid today, and not because the code is secret but because
+> it's GOOD crypto. We want to pull in our post-quantum and NIST + non-NIST key types, make them
+> part of the same derivation, support multi-lattice and even non-lattice crypto, combine it all
+> so we don't start from an insecure point, and push the most modern (post-quantum, or best
+> available) crypto everywhere."*
+
+**Carved:** security comes from **good, open, standard crypto + zero-trust**, never from secret
+code (Kerckhoffs's principle). The maintainer's Itron substrate proves it — open, audited,
+power-grid-grade. Zeta inherits that ethos: **modern/PQ-by-default, crypto-agile, hybrid where
+the protocol allows, never a bespoke-secret-algorithm.**
+
+## What we already have (don't start from scratch)
+
+- **`better-git-crypt`** (`src/Core.TypeScript/crypto/better-git-crypt/`) — **X-Wing (ML-KEM-768)
+  hybrid KEM + ML-DSA-65 signatures + ChaCha20-Poly1305**, canonical-CBOR `.zc` envelope,
+  multi-recipient. Working PQ KEM + PQ signature in-repo. (PRIMITIVE-REGISTRY §PQ codec;
+  081KSNY2Z0008QG0R002JKH50A.)
+- **Multi-cipher PQ substrate** backlog — `081KSNY2Z0008QG0R002ZAVMEK` (NIST + Saber + NTRU-Prime
+  + FrodoKEM) — the lattice variety intent.
+- **QRNG / gnrq** — post-quantum RNG (PRIMITIVE-REGISTRY).
+- **Classical HD keychain** — `derive.ts`: one BIP-39 seed → secp256k1/ed25519 for ETH/Solana/
+  Nostr/SSH/PGP.
+
+**The gap:** `derive.ts` derives ONLY classical keys. The keychain must also derive **PQ keys**
+from the same seed.
+
+## How PQ keys join the HD keychain (the one technical nuance)
+
+BIP-32 HD derivation is defined for secp256k1/ed25519 scalar arithmetic — ML-DSA/ML-KEM/SLH-DSA
+have no native BIP-32 child derivation. The clean, deterministic bridge: **derive a sub-seed at a
+coin-typed path, then feed it as the deterministic keygen RNG for the PQ scheme.**
+
+```
+pqSubSeed = HD.derive("m/44'/<pq-coin>'/0'/0'")        // deterministic sub-seed from the master
+mlDsaKey  = ML-DSA-65.keygen(seed = pqSubSeed)          // deterministic PQ keygen
+mlKemKey  = ML-KEM-768.keygen(seed = pqSubSeed')        // each scheme its own path
+```
+
+So one master seed deterministically yields BOTH classical AND PQ keys — byte-locked + DST-
+replayable (same seed → same keys, the existing keychain guarantee), now spanning PQ. (Assign
+SLIP-44-style private coin indices for each PQ scheme in our path table.)
+
+## Crypto-agility: a key-type registry (modern-by-default)
+
+A registry of key types behind the **`KeyCustody`/`CertAuthority` ports** (hexagonal), each with
+{ derivation path, deterministic keygen, sign/verify or encaps/decaps, status }:
+
+| Class | Schemes |
+|---|---|
+| Classical (compat) | ed25519, secp256k1 (SSH/PGP/wallets — interop with today's protocols) |
+| **PQ signature (lattice)** | **ML-DSA-65** (Dilithium; have it) · ML-DSA-87 |
+| **PQ signature (non-lattice, hash-based)** | **SLH-DSA** (SPHINCS+) — diversity against a lattice break |
+| **PQ KEM (lattice)** | **ML-KEM-768** (Kyber; have it) · FrodoKEM (conservative) · NTRU-Prime · Saber |
+| **Hybrid** | **X-Wing** (X25519 + ML-KEM-768; have it) — classical ⊕ PQ so a break of either still holds |
+
+**Modern-by-default policy:** prefer **hybrid (classical ⊕ PQ)** where the consuming protocol
+supports it (best of both, no regression if one breaks); pure-PQ where it's standardized and
+supported; classical only where interop forces it (e.g. today's SSH/git hosts) — and even then,
+*also* derive the PQ key so rotation to PQ is a state transition, not a re-keying. **Lattice +
+non-lattice** (ML-DSA *and* SLH-DSA) so a single-family cryptanalytic break isn't fatal.
+
+## Experimental / home-grown crypto (Adinkra) — allowed, but hybrid-only & unproven
+
+Aaron 2026-06-21: *"We're also going to try our own Adinkra crypto, but we're not sure it's
+actually secure yet."* Adinkras carry **Gates' doubly-even self-dual error-correcting codes**
+(the only-the-irreducible-is-primitive rule) — so "Adinkra crypto" is plausibly a **code-based
+(non-lattice)** scheme, which *would* add real non-lattice PQ diversity (McEliece-family lineage).
+**But it is UNPROVEN.** The good-crypto-not-secret ethos handles this precisely:
+
+- **Experimental crypto is welcome in the registry — as a RESEARCH-status adapter, NEVER the
+  default, NEVER sole protection.**
+- **Hybrid-only, never alone:** an unproven scheme may only ever be combined `⊕` a *proven* scheme
+  (X-Wing-style), so a total break of the experimental part **cannot reduce** security below the
+  proven floor. That is the whole point of the crypto-agile + hybrid design: you can safely TRY
+  Adinkra behind the port, in hybrid, with zero downside if it fails.
+- **Clearly flagged** `status: experimental-unproven`; promotion to load-bearing requires real
+  cryptanalysis / external review (IP-questionable until then — anchor-to-human-prior-art +
+  the checked-anchor / metering-test discipline).
+
+So Adinkra crypto is a *bet placed safely*: the hexagonal port + hybrid policy let a novel,
+unproven algorithm be exercised without ever being a single point of failure.
+
+## Composition with the rest of the substrate
+
+- **One seed** (the identity+crypto synthesis) now spans classical + PQ.
+- **Rotation** (the Itron KeyState/SKMS anchor): adding/retiring a key *type* is a `KeyState`
+  transition over Z-sets — so we migrate classical → hybrid → pure-PQ with **zero downtime**, the
+  same overlap-window machinery. Crypto-agility = key-type rotation.
+- **Hexagonal ports**: algorithms are adapters behind the ports; "swap SHA-x for the next
+  standard" is an adapter change, not a redesign.
+- **better-git-crypt** is the reference PQ envelope; the keychain reuses its ML-KEM/ML-DSA/X-Wing.
+
+## Build (backlog)
+
+Extend `derive.ts` to the PQ key types (sub-seed → deterministic keygen); a key-type registry +
+modern-by-default policy; wire `better-git-crypt`'s ML-KEM-768/ML-DSA-65/X-Wing; add SLH-DSA
+(non-lattice) + the multi-cipher lattice set (081KSNY2Z0008QG0R002ZAVMEK); all behind the
+KeyCustody/CertAuthority ports; rotation via the KeyState lifecycle. (New build workitem to follow;
+composes with the identity+crypto unify build 081KVNXBR4S0 + the rotation + hexagonal work.)
+
+## Anchors
+
+NIST PQC: FIPS 203 (ML-KEM), 204 (ML-DSA), 205 (SLH-DSA). X-Wing hybrid KEM (Barbosa et al. 2024).
+NTRU Prime, FrodoKEM, Saber (NIST round alternates — lattice variety). BIP-39/32/44 (the HD seed
++ sub-seed bridge). Kerckhoffs's principle (security from key secrecy + good open crypto, not
+algorithm secrecy). Human anchor: the maintainer's Itron power-grid security substrate (open,
+audited, deployed). In-repo: `better-git-crypt`, `derive.ts`, PRIMITIVE-REGISTRY (PQ codec, QRNG),
+081KSNY2Z0008QG0R002ZAVMEK (multi-cipher PQ), the hexagonal + rotation decisions (2026-06-21).

--- a/workitems/081KVNYZXQ608QG0R002G35565-crypto-agile-pq-keychain-extend-derive-ts-to-pq-key-types-ml.md
+++ b/workitems/081KVNYZXQ608QG0R002G35565-crypto-agile-pq-keychain-extend-derive-ts-to-pq-key-types-ml.md
@@ -1,0 +1,51 @@
+---
+id: 081KVNYZXQ608QG0R002G35565
+type: task
+state: backlog
+priority: P1
+slug: crypto-agile-pq-keychain-extend-derive-ts-to-pq-key-types-ml
+title: "Crypto-agile PQ keychain: extend derive.ts to PQ key types (ML-DSA-65/ML-KEM-768/X-Wing/SLH-DSA + lattice set), modern/hybrid-by-default, Adinkra experimental hybrid-only, behind KeyCustody port (Aaron 2026-06-21)"
+created: 2026-06-21T20:47:12.614Z
+depends_on: []
+composes_with: ["081KVNXBR4S08QG0R0015DHBBN", "081KSNY2Z0008QG0R002ZAVMEK"]
+---
+
+# Crypto-agile PQ keychain: extend derive.ts to PQ key types (ML-DSA-65/ML-KEM-768/X-Wing/SLH-DSA + lattice set), modern/hybrid-by-default, Adinkra experimental hybrid-only, behind KeyCustody port (Aaron 2026-06-21)
+
+<!-- Work-item body. ZetaId-keyed. -->
+
+## Carved sentence
+
+> Extend the HD keychain to **post-quantum** key types from the SAME seed (HD sub-seed →
+> deterministic PQ keygen), with a **crypto-agility registry** + **modern/hybrid-by-default**
+> policy, **lattice AND non-lattice** diversity, all behind the `KeyCustody`/`CertAuthority`
+> ports. Reuse what we have; don't start from an insecure point. Good crypto, not secret crypto.
+
+## Design
+
+`docs/research/2026-06-21-crypto-agile-postquantum-keychain-one-seed-classical-plus-pq-good-crypto-not-secret.md`.
+
+## Scope
+
+1. **Extend `derive.ts`** with PQ paths: `pqSubSeed = HD.derive("m/44'/<pq-coin>'/0'/0'")` →
+   deterministic keygen for **ML-DSA-65** (have, via better-git-crypt), **ML-KEM-768** (have),
+   **X-Wing** hybrid (have), **SLH-DSA** (non-lattice, add). Assign private coin indices per scheme.
+2. **Crypto-agility registry** — key-type table {path, keygen, sign/verify or encaps/decaps,
+   status}; reuse `src/Core.TypeScript/crypto/better-git-crypt/` for ML-KEM/ML-DSA/X-Wing.
+3. **Modern/hybrid-by-default policy** — prefer hybrid (classical ⊕ PQ); pure-PQ where supported;
+   classical only for interop, and even then derive the PQ key so → PQ is a rotation, not re-key.
+4. **Lattice + non-lattice diversity** — ML-DSA (lattice) + SLH-DSA (hash-based); compose the
+   multi-cipher lattice set (081KSNY2Z0008QG0R002ZAVMEK: NTRU-Prime/Saber/Frodo).
+5. **Experimental crypto (Adinkra)** — `status: experimental-unproven`, **hybrid-only / never
+   sole protection**, clearly flagged; promotion needs real cryptanalysis. (Code-based/non-lattice
+   lineage via Gates' doubly-even self-dual codes.)
+6. **Rotation = key-type transition** over the Itron KeyState lifecycle (classical→hybrid→pure-PQ,
+   0 downtime). Behind the hexagonal ports so algorithm swaps are adapter changes.
+7. Keep the keychain DST-byte-locked (same seed → same keys, now incl. PQ).
+
+## Composes / anchors
+
+Composes: identity+crypto unify (081KVNXBR4S08QG0R0015DHBBN), multi-cipher PQ
+(081KSNY2Z0008QG0R002ZAVMEK). Decisions: hexagonal ports, rotation (Itron KeyState), identity+crypto
+synthesis (all 2026-06-21). Code: `better-git-crypt` (ML-KEM-768/ML-DSA-65/X-Wing), `derive.ts`.
+Anchors: NIST FIPS 203/204/205; X-Wing (Barbosa et al. 2024); Kerckhoffs; Itron power-grid security.


### PR DESCRIPTION
Aaron 2026-06-21: pull PQ/NIST/non-NIST into the same derivation; lattice + non-lattice; modern-everywhere; good crypto not secret (Kerckhoffs). We already have ML-KEM-768/ML-DSA-65/X-Wing (better-git-crypt) + multi-cipher-PQ backlog + QRNG; gap = derive.ts (classical-only). Bridge: HD sub-seed → deterministic PQ keygen. Crypto-agility registry, hybrid-by-default, lattice+non-lattice; rotation = key-type transition (Itron KeyState). Adinkra = experimental-unproven, hybrid-only / never sole protection. Build backlogged 081KVNYZXQ60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)