### PR TITLE
backlog(credential-substrate): threshold-at-each-root + org-vs-user-CA conflict-resolution rule (math-findings follow-ups)

### DIFF
--- a/workitems/081KVP3GYW108QG0R003V7E6VT-threshold-shamir-k-of-n-at-each-ca-identity-root-true-never.md
+++ b/workitems/081KVP3GYW108QG0R003V7E6VT-threshold-shamir-k-of-n-at-each-ca-identity-root-true-never.md
@@ -1,0 +1,35 @@
+---
+id: 081KVP3GYW108QG0R003V7E6VT
+type: task
+state: backlog
+priority: P1
+slug: threshold-shamir-k-of-n-at-each-ca-identity-root-true-never
+title: "Threshold (Shamir k-of-n) at each CA/identity root — true never-single-key / ∅-blast-radius (math team refuted per-user-CA-alone; relocates SPOF to N single keys) (2026-06-21)"
+created: 2026-06-21T22:06:25.153Z
+depends_on: []
+composes_with: ["081KVNXBR4S08QG0R0015DHBBN", "081KVNTNTDQ08QG0R0017NBBWB"]
+---
+
+# Threshold (Shamir k-of-n) at each CA/identity root — true never-single-key / ∅-blast-radius (math team refuted per-user-CA-alone; relocates SPOF to N single keys) (2026-06-21)
+
+<!-- Work-item body. ZetaId-keyed (conflict-free, time-sortable). "Backlog" is a
+     STATE = this folder; completion moves the file to workitems/done/YYYY/MM/.
+     Identity is the zetaid prefix — resolve cross-refs by `081KVP3GYW108QG0R003V7E6VT-*.md` glob. -->
+
+## Carved sentence
+
+> Per-user CA alone does NOT remove the identity single-point-of-failure — the math team (Soraya,
+> 2026-06-21) proved it RELOCATES/partitions it to N per-principal single keys. To actually achieve
+> **never-single-key / ∅-blast-radius at the identity layer**, add **threshold (Shamir k-of-n)** at
+> each CA/identity root (per-user roots AND the CA crown jewel). This is Aaron's "1-of-2 seeds /
+> N-of-M" intuition applied to the CA roots, not just seeds.
+
+## Detail
+
+- **Why:** Claim 4 of the toy-model review FAILED ("removes" → actually "relocates"); each principal
+  still has exactly one forging key. Threshold k-of-n removes the single forging key.
+- **Where:** each per-user CA root + the CA trust root; ties to ai-sovereignty-path N-of-M HSM.
+- **Prove:** `IdentityReissuable` / never-single-key — **Alloy** path-existence (with/without shares)
+  + **Z3 (QF_BV/QF_LIA)** for the k-of-n share arithmetic (+ FsCheck for reconstruction). P0 → ≥2 tools.
+- **Anchors:** Shamir 1979 (secret sharing), threshold signatures. Findings doc:
+  `docs/research/2026-06-21-math-team-FINDINGS-ca-teardown-per-user-ca-relocates-spof-…`.

--- a/workitems/081KVP3GYWS08QG0R003TY4E96-define-org-ca-vs-user-ca-trust-graph-conflict-resolution-rul.md
+++ b/workitems/081KVP3GYWS08QG0R003TY4E96-define-org-ca-vs-user-ca-trust-graph-conflict-resolution-rul.md
@@ -1,0 +1,38 @@
+---
+id: 081KVP3GYWS08QG0R003TY4E96
+type: task
+state: backlog
+priority: P1
+slug: define-org-ca-vs-user-ca-trust-graph-conflict-resolution-rul
+title: "Define org-CA vs user-CA trust-graph conflict-resolution rule (SDSI/SPKI: self-root authoritative for identity, org-root for authorization) — trust graph non-confluent without it (math team finding) (2026-06-21)"
+created: 2026-06-21T22:06:25.177Z
+depends_on: []
+composes_with: ["081KVNTNTDQ08QG0R0017NBBWB"]
+---
+
+# Define org-CA vs user-CA trust-graph conflict-resolution rule (SDSI/SPKI: self-root authoritative for identity, org-root for authorization) — trust graph non-confluent without it (math team finding) (2026-06-21)
+
+<!-- Work-item body. ZetaId-keyed (conflict-free, time-sortable). "Backlog" is a
+     STATE = this folder; completion moves the file to workitems/done/YYYY/MM/.
+     Identity is the zetaid prefix — resolve cross-refs by `081KVP3GYWS08QG0R003TY4E96-*.md` glob. -->
+
+## Carved sentence
+
+> Once per-user CAs cross-sign, "is X a valid identity?" becomes graph reachability — and the math
+> team (Soraya, 2026-06-21) found the trust graph is **non-confluent**: org-CA and user-CA can
+> disagree with **no resolution rule on file** (two verifiers reach opposite verdicts). Define the
+> rule BEFORE proving confluence: **subject's own root is authoritative for self-identity; org-root
+> is authoritative only for org-authorization** (SDSI/SPKI local-name discipline — the same
+> identity↔authorization split the multi-owner ADR already draws for SSH).
+
+## Detail
+
+- **Why:** a correctness bug, not a robustness nicety — no tool can verify a confluence property
+  that hasn't been defined. Upstream of any formal proof (Kenji/Tariq design call).
+- **Also covers:** transitive revocation over the cross-sign closure (revoking a root must
+  invalidate its closure) — needs the KRL revocation primitive (081KVP2M1QS0).
+- **Prove (after defining):** **Alloy** trust-graph reachability + conflict-confluence (finds the
+  counterexample by construction).
+- **Anchors:** Rivest–Lampson 1996 (SDSI/SPKI local names); PGP web-of-trust. Findings doc:
+  `docs/research/2026-06-21-math-team-FINDINGS-ca-teardown-per-user-ca-relocates-spof-…`; the
+  multi-owner identity↔authorization ADR.


### PR DESCRIPTION
The two next-steps named by Soraya's adversarial review (#9020): (1) threshold (Shamir k-of-n) at each CA/identity root — per-user-CA alone only relocates the SPOF; k-of-n gets true never-single-key. (2) Define org-CA vs user-CA conflict-resolution rule (SDSI/SPKI: self-root for identity, org-root for authz) — trust graph non-confluent without it. Both carry prove-with (Alloy/Z3) + anchors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)