### PR TITLE
feat(keys): cluster-scoped teardown — exact inverse of setup-cluster (cascade-with-warnings)

### DIFF
--- a/tools/setup/persona-keys/teardown-cluster-cli.ts
+++ b/tools/setup/persona-keys/teardown-cluster-cli.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env bun
+// Zeta teardown-cluster CLI — the DESTRUCTIVE inverse of setup-cluster: wipe THIS cluster's CA private
+// key AND stage the unregistration of its registered PUBLIC trust-root artifacts (the CA pubkey + the
+// multi-CA trusted-user-ca-keys.pub trust set) for a PR. A thin shell around the pure
+// `teardown-cluster.ts` orchestrator; it owns NO key/biometric/git logic of its own.
+//
+// DEFAULT-SAFE: with NO flags this is a DRY RUN — it reports exactly what WOULD be wiped/unregistered
+// PLUS the cascade WARNINGS (cross-cluster peer trust, dependent machine certs, unrecoverable private)
+// and touches NOTHING and NEVER prompts. A real teardown requires `--confirm` AND the operator
+// approving ONE biometric (Touch ID / Windows Hello). A declined biometric ⇒ nothing deleted
+// (fail-closed). Idempotent: a second run after a teardown is a clean "already clean" no-op.
+//
+// Usage:
+//   bun teardown-cluster-cli.ts --ca acme                  # DRY RUN (default — nothing touched; shows warnings)
+//   bun teardown-cluster-cli.ts --ca acme --confirm        # REAL cluster teardown (one fingerprint)
+//   bun teardown-cluster-cli.ts --ca acme --note-1password # also PRINT the 1Password item (no delete)
+//
+// This NEVER pushes: the repo-unregister half stages a `git rm` under --repo-root for you to commit +
+// open a PR (Otto verify-gates security-class changes). It respects shared-checkout-is-view-only — pass
+// YOUR OWN clone as --repo-root, never the shared checkout.
+import { homedir } from "node:os";
+import { dirname, resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
+import { realBiometric, sessionBiometric } from "./biometric.ts";
+import {
+  format1PasswordNote,
+  formatClusterTeardown,
+  realEffects,
+  teardownCluster,
+  type ClusterTeardownOptions,
+} from "./teardown-cluster.ts";
+
+const args = process.argv.slice(2);
+const flag = (n: string): boolean => args.includes(n);
+const opt = (n: string): string | undefined => {
+  const i = args.indexOf(n);
+  return i >= 0 ? args[i + 1] : undefined;
+};
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = opt("--repo-root") ?? resolvePath(here, "..", "..", "..");
+const ca = opt("--ca");
+const home = opt("--home") ?? homedir();
+const confirm = flag("--confirm");
+const dryRun = !confirm; // DEFAULT-safe: only an explicit --confirm makes it a real run
+const note1Password = flag("--note-1password");
+
+function usage(): void {
+  process.stderr.write(
+    "usage: bun teardown-cluster-cli.ts --ca <name> [--home <path>] [--confirm] " +
+      "[--note-1password] [--repo-root <path>]\n" +
+      "  DEFAULT-SAFE: no --confirm => DRY RUN (reports what WOULD be wiped/unregistered + cascade warnings; nothing touched, no prompt).\n" +
+      "  --confirm => REAL cluster teardown: securely wipe ~/.config/zeta/ca + stage `git rm` of\n" +
+      "               maintainers/<ca>/ssh-ca.pub and maintainers/<ca>/trusted-user-ca-keys.pub.\n" +
+      "               Requires ONE biometric approval (fail-closed). NEVER pushes — stages a removal for a PR.\n" +
+      "  --note-1password => also PRINT which 1Password item corresponds (NEVER deletes it).\n",
+  );
+}
+
+async function main(): Promise<number> {
+  if (ca === undefined || ca.trim().length === 0) {
+    usage();
+    process.stderr.write("error: --ca <name> is required (the maintainers/<ca>/ trust root to tear down)\n");
+    return 2;
+  }
+
+  // ONE biometric session over the real gate — wired into the (single) destructive run so the operator
+  // is prompted at most once. On a dry-run the door is never called.
+  const session = sessionBiometric(realBiometric());
+
+  const opts: ClusterTeardownOptions = {
+    ca,
+    repoRoot,
+    home,
+    dryRun,
+    confirm,
+    biometricAuth: session.door,
+  };
+
+  const res = await teardownCluster(realEffects(), opts);
+  process.stdout.write(formatClusterTeardown(res) + "\n");
+  if (note1Password) {
+    process.stdout.write(format1PasswordNote() + "\n");
+  }
+
+  // Hard block iff a confirmed run was refused at the biometric gate (nothing was deleted).
+  const declined =
+    res.confirmed && !res.dryRun && res.biometric !== undefined && !res.biometric.ok;
+  return declined ? 1 : 0;
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((e: unknown) => {
+    process.stderr.write((e instanceof Error ? e.message : String(e)) + "\n");
+    process.exit(1);
+  });

--- a/tools/setup/persona-keys/teardown-cluster.test.ts
+++ b/tools/setup/persona-keys/teardown-cluster.test.ts
@@ -1,0 +1,468 @@
+// teardown-cluster.ts conformance — the DESTRUCTIVE inverse of setup-cluster (CA-private wipe + the
+// cluster trust-root PUBLIC artifacts: the CA pubkey + the multi-CA trusted-user-ca-keys.pub trust
+// set). ALL tests run against THROWAWAY temp dirs via injected effects + FAKE biometric/git doors —
+// NEVER the real ~/.config/zeta, NEVER a real `git rm` on a real repo, NEVER a real key deleted, NEVER
+// a network call. NO key-shaped literal appears in this file (the private-key header marker is SPLIT +
+// assembled at runtime so a grep for it is EMPTY).
+//
+// Proves: dry-run wipes/rm NOTHING + never prompts + reports the cascade WARNINGS; a confirmed run
+// (fake fs + fake biometric ok) wipes the fake CA-private dir + stages the fake CA-pubkey + trust-set
+// removals + fires the human gate EXACTLY once; declined biometric => nothing deleted; a non-confirmed
+// real run => nothing touched; idempotent re-run => clean no-op; cascade-with-warnings on extra-care
+// nodes (cross-cluster peers + dependent machine certs + unrecoverable private); a STANDALONE round-trip
+// (fake cluster state in temp dirs => teardown => re-setup-state => clean) converges; SANDBOX-ONLY
+// meta-test asserts every touched path is under tmpdir(); no secret bytes echoed.
+// Run: bun test teardown-cluster.test.ts   (from tools/setup/persona-keys)
+import { test, expect } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  caLocalDirPath,
+  caPublicRel,
+  countPeerCas,
+  format1PasswordNote,
+  formatClusterTeardown,
+  teardownCluster,
+  trustSetRel,
+  type ClusterTeardownEffects,
+} from "./teardown-cluster.ts";
+import { caPrivateKeyPath, caPublicKeyPath } from "./ca.ts";
+import { trustedUserCaKeysPath } from "./setup-cluster.ts";
+import { machineCertPath } from "./teardown.ts";
+import type { BiometricAuth, BiometricResult } from "./biometric.ts";
+
+// The private-key marker, assembled at runtime so NO key-shaped literal is in this file.
+const PRIV_MARKER = "PRIVATE" + " " + "KEY";
+
+const CA = "tester";
+const SELF_CA_LINE = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAASELF self-ca";
+const PEER_CA_LINE = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAPEER peer-ca";
+
+// A FAKE biometric door (no real Touch ID / Hello). `ok` controls approval; `calls` records every
+// prompt so a test can assert the gate fired EXACTLY once + fail-closed semantics.
+function fakeBiometric(ok: boolean, calls?: string[]): BiometricAuth {
+  return async (prompt: string): Promise<BiometricResult> => {
+    if (calls) calls.push(prompt);
+    return ok
+      ? { ok: true, platform: "macos-touchid" }
+      : { ok: false, platform: "macos-touchid", reason: "declined" };
+  };
+}
+
+// A deterministic fake effects over a REAL temp filesystem — but the "secure remove" + "git rm" doors
+// are FAKE (a plain unlink / a recorded staging). Never shells out, never touches a secret.
+function fakeEffects(opts?: {
+  removed?: string[];
+  gitRmStaged?: { repoRoot: string; relPath: string }[];
+}): ClusterTeardownEffects {
+  const walk = (dir: string): string[] => {
+    if (!existsSync(dir)) return [];
+    const out: string[] = [];
+    for (const name of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, name.name);
+      if (name.isDirectory()) out.push(...walk(full));
+      else out.push(full);
+    }
+    return out;
+  };
+  return {
+    exists: (p) => existsSync(p),
+    listFiles: walk,
+    readPublic: (p) => (existsSync(p) ? readFileSync(p, "utf8") : ""),
+    listMachineCerts: (repoRoot) => {
+      const dir = join(repoRoot, "machines");
+      if (!existsSync(dir)) return [];
+      return readdirSync(dir)
+        .filter((n) => n.endsWith("-cert.pub"))
+        .map((n) => join(dir, n));
+    },
+    securelyRemove: (path) => {
+      if (opts?.removed) opts.removed.push(path);
+      if (existsSync(path)) rmSync(path, { force: true });
+      return !existsSync(path);
+    },
+    removeDir: (dir) => {
+      if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+    },
+    gitRm: (repoRoot, relPath) => {
+      if (opts?.gitRmStaged) opts.gitRmStaged.push({ repoRoot, relPath });
+      // Fake the staging: actually remove the file from the temp "repo" so re-run is idempotent.
+      const full = join(repoRoot, relPath);
+      if (existsSync(full)) rmSync(full, { force: true });
+      return true;
+    },
+  };
+}
+
+/** Write the cluster state setup-cluster would CREATE, into temp dirs: the CA private (local), the CA
+ *  pubkey (repo), the multi-CA trust set (repo, self + N peers), and `withCerts` dependent machine
+ *  certs (the cascade blast radius). This is the FAKE-state side of the standalone round-trip. */
+function makeClusterFixture(opts?: {
+  peers?: number;
+  withCerts?: number;
+}): { home: string; repoRoot: string; cleanup: () => void } {
+  const home = mkdtempSync(join(tmpdir(), "zeta-tdc-home-"));
+  const repoRoot = mkdtempSync(join(tmpdir(), "zeta-tdc-repo-"));
+  // LOCAL: the CA private key file under ~/.config/zeta/ca/.
+  const caPriv = caPrivateKeyPath(home);
+  mkdirSync(dirname(caPriv), { recursive: true });
+  writeFileSync(caPriv, "FAKE-CA-PRIVATE-PLACEHOLDER-DO-NOT-USE\n", { mode: 0o600 });
+  // REPO: the CA pubkey + the multi-CA trust set (self + peers).
+  const caPub = caPublicKeyPath(repoRoot, CA);
+  mkdirSync(dirname(caPub), { recursive: true });
+  writeFileSync(caPub, SELF_CA_LINE + "\n");
+  const trustPath = trustedUserCaKeysPath(repoRoot, CA);
+  const peerN = opts?.peers ?? 0;
+  let trust = "# header\n# self cluster CA\n" + SELF_CA_LINE + "\n";
+  for (let i = 0; i < peerN; i++) {
+    trust += `# peer-${i} cluster CA\n${PEER_CA_LINE}\n`;
+  }
+  mkdirSync(dirname(trustPath), { recursive: true });
+  writeFileSync(trustPath, trust);
+  // Optional dependent machine certs (the cascade blast radius for the CA pubkey).
+  const certN = opts?.withCerts ?? 0;
+  if (certN > 0) {
+    const mdir = join(repoRoot, "machines");
+    mkdirSync(mdir, { recursive: true });
+    for (let i = 0; i < certN; i++) {
+      writeFileSync(join(mdir, `host-${i}-cert.pub`), "ssh-ed25519-cert placeholder\n");
+    }
+  }
+  return {
+    home,
+    repoRoot,
+    cleanup: () => {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(repoRoot, { recursive: true, force: true });
+    },
+  };
+}
+
+test("dry-run (default): wipes/rm NOTHING, never prompts, reports would-* + cascade warnings", async () => {
+  const { home, repoRoot, cleanup } = makeClusterFixture({ peers: 2, withCerts: 3 });
+  try {
+    const removed: string[] = [];
+    const gitRmStaged: { repoRoot: string; relPath: string }[] = [];
+    const prompts: string[] = [];
+    const fx = fakeEffects({ removed, gitRmStaged });
+    const res = await teardownCluster(fx, {
+      ca: CA,
+      repoRoot,
+      home,
+      dryRun: true,
+      biometricAuth: fakeBiometric(true, prompts),
+    });
+    expect(removed.length).toBe(0);
+    expect(gitRmStaged.length).toBe(0);
+    expect(prompts.length).toBe(0); // NEVER prompts on dry-run
+    expect(res.dryRun).toBe(true);
+    expect(res.hadWork).toBe(true);
+    expect(res.localCaWipe.action).toBe("would-wipe");
+    expect(res.clusterUnregister.every((r) => r.action === "would-unregister")).toBe(true);
+    // CASCADE WARNINGS present (cross-cluster peers + dependent certs + unrecoverable private).
+    const kinds = res.warnings.map((w) => w.kind);
+    expect(kinds).toContain("cross-cluster-peer");
+    expect(kinds).toContain("dependent-machine-certs");
+    expect(kinds).toContain("unrecoverable-private");
+    expect(res.warnings.find((w) => w.kind === "cross-cluster-peer")?.blastRadius).toBe(2);
+    expect(res.warnings.find((w) => w.kind === "dependent-machine-certs")?.blastRadius).toBe(3);
+    // Everything still on disk.
+    expect(existsSync(caPrivateKeyPath(home))).toBe(true);
+    expect(existsSync(caPublicKeyPath(repoRoot, CA))).toBe(true);
+    expect(existsSync(trustedUserCaKeysPath(repoRoot, CA))).toBe(true);
+    expect(res.biometric).toBeUndefined();
+    // The readout leads with the warnings.
+    expect(formatClusterTeardown(res)).toContain("CASCADE WARNINGS");
+  } finally {
+    cleanup();
+  }
+});
+
+test("confirmed + biometric ok: wipes CA private, stages CA-pubkey + trust-set removals, fires gate once", async () => {
+  const { home, repoRoot, cleanup } = makeClusterFixture({ peers: 1, withCerts: 2 });
+  try {
+    const removed: string[] = [];
+    const gitRmStaged: { repoRoot: string; relPath: string }[] = [];
+    const prompts: string[] = [];
+    const fx = fakeEffects({ removed, gitRmStaged });
+    const res = await teardownCluster(fx, {
+      ca: CA,
+      repoRoot,
+      home,
+      dryRun: false,
+      confirm: true,
+      biometricAuth: fakeBiometric(true, prompts),
+    });
+    expect(prompts.length).toBe(1); // ONE fingerprint
+    expect(res.biometric?.ok).toBe(true);
+    // CA private wiped (one file).
+    expect(removed.length).toBe(1);
+    expect(existsSync(caLocalDirPath(home))).toBe(false);
+    // Both cluster artifacts staged for removal + actually gone from the temp repo.
+    expect(gitRmStaged.length).toBe(2);
+    expect(res.unregisteredPaths.length).toBe(2);
+    expect(existsSync(caPublicKeyPath(repoRoot, CA))).toBe(false);
+    expect(existsSync(trustedUserCaKeysPath(repoRoot, CA))).toBe(false);
+    // Every staged git rm operated ONLY under the passed repoRoot (shared-checkout-is-view-only).
+    expect(gitRmStaged.every((s) => s.repoRoot === repoRoot)).toBe(true);
+    expect(res.localCaWipe.action).toBe("wiped");
+    expect(res.clusterUnregister.every((r) => r.action === "unregistered")).toBe(true);
+  } finally {
+    cleanup();
+  }
+});
+
+test("declined biometric: fail-closed — NOTHING deleted, NOTHING staged", async () => {
+  const { home, repoRoot, cleanup } = makeClusterFixture({ peers: 1 });
+  try {
+    const removed: string[] = [];
+    const gitRmStaged: { repoRoot: string; relPath: string }[] = [];
+    const prompts: string[] = [];
+    const fx = fakeEffects({ removed, gitRmStaged });
+    const res = await teardownCluster(fx, {
+      ca: CA,
+      repoRoot,
+      home,
+      dryRun: false,
+      confirm: true,
+      biometricAuth: fakeBiometric(false, prompts), // DECLINED
+    });
+    expect(prompts.length).toBe(1); // it asked once
+    expect(res.biometric?.ok).toBe(false);
+    expect(removed.length).toBe(0);
+    expect(gitRmStaged.length).toBe(0);
+    expect(res.unregisteredPaths.length).toBe(0);
+    expect(existsSync(caPrivateKeyPath(home))).toBe(true);
+    expect(existsSync(caPublicKeyPath(repoRoot, CA))).toBe(true);
+    expect(existsSync(trustedUserCaKeysPath(repoRoot, CA))).toBe(true);
+    expect(res.localCaWipe.action).toBe("skipped-biometric");
+    expect(res.clusterUnregister.every((r) => r.action === "skipped-biometric")).toBe(true);
+  } finally {
+    cleanup();
+  }
+});
+
+test("real run WITHOUT confirm: nothing touched, never prompts", async () => {
+  const { home, repoRoot, cleanup } = makeClusterFixture();
+  try {
+    const removed: string[] = [];
+    const gitRmStaged: { repoRoot: string; relPath: string }[] = [];
+    const prompts: string[] = [];
+    const fx = fakeEffects({ removed, gitRmStaged });
+    const res = await teardownCluster(fx, {
+      ca: CA,
+      repoRoot,
+      home,
+      dryRun: false,
+      confirm: false, // NOT confirmed
+      biometricAuth: fakeBiometric(true, prompts),
+    });
+    expect(prompts.length).toBe(0); // never prompts without confirm
+    expect(removed.length).toBe(0);
+    expect(gitRmStaged.length).toBe(0);
+    expect(res.biometric).toBeUndefined();
+    expect(res.localCaWipe.action).toBe("skipped-not-confirmed");
+    expect(res.clusterUnregister.every((r) => r.action === "skipped-not-confirmed")).toBe(true);
+    expect(existsSync(caPrivateKeyPath(home))).toBe(true);
+  } finally {
+    cleanup();
+  }
+});
+
+test("idempotent: re-run after a teardown is a clean no-op (already clean, no prompt)", async () => {
+  const { home, repoRoot, cleanup } = makeClusterFixture({ peers: 1, withCerts: 1 });
+  try {
+    const prompts1: string[] = [];
+    const fx = fakeEffects();
+    await teardownCluster(fx, {
+      ca: CA,
+      repoRoot,
+      home,
+      dryRun: false,
+      confirm: true,
+      biometricAuth: fakeBiometric(true, prompts1),
+    });
+    expect(prompts1.length).toBe(1);
+    // Second run: nothing present => clean no-op, NO prompt, NO warnings.
+    const prompts2: string[] = [];
+    const res2 = await teardownCluster(fx, {
+      ca: CA,
+      repoRoot,
+      home,
+      dryRun: false,
+      confirm: true,
+      biometricAuth: fakeBiometric(true, prompts2),
+    });
+    expect(prompts2.length).toBe(0);
+    expect(res2.hadWork).toBe(false);
+    expect(res2.biometric).toBeUndefined();
+    expect(res2.unregisteredPaths.length).toBe(0);
+    expect(res2.warnings.length).toBe(0);
+    expect(res2.localCaWipe.action).toBe("absent");
+    expect(res2.clusterUnregister.every((r) => r.action === "absent")).toBe(true);
+    expect(formatClusterTeardown(res2)).toContain("Already clean");
+  } finally {
+    cleanup();
+  }
+});
+
+test("partial state: only repo present (CA private already gone) — unregisters repo, no local wipe", async () => {
+  const home = mkdtempSync(join(tmpdir(), "zeta-tdc-home-")); // no ~/.config/zeta/ca
+  const repoRoot = mkdtempSync(join(tmpdir(), "zeta-tdc-repo-"));
+  try {
+    const caPub = caPublicKeyPath(repoRoot, CA);
+    mkdirSync(dirname(caPub), { recursive: true });
+    writeFileSync(caPub, SELF_CA_LINE + "\n");
+    const trustPath = trustedUserCaKeysPath(repoRoot, CA);
+    writeFileSync(trustPath, "# self cluster CA\n" + SELF_CA_LINE + "\n");
+    const removed: string[] = [];
+    const gitRmStaged: { repoRoot: string; relPath: string }[] = [];
+    const fx = fakeEffects({ removed, gitRmStaged });
+    const res = await teardownCluster(fx, {
+      ca: CA,
+      repoRoot,
+      home,
+      dryRun: false,
+      confirm: true,
+      biometricAuth: fakeBiometric(true),
+    });
+    expect(res.hadWork).toBe(true);
+    expect(removed.length).toBe(0); // nothing local to wipe
+    expect(res.localCaWipe.action).toBe("absent");
+    expect(gitRmStaged.length).toBe(2);
+    expect(res.clusterUnregister.every((r) => r.action === "unregistered")).toBe(true);
+    // No unrecoverable-private warning (no CA private present); no peers/certs ⇒ no other warnings.
+    expect(res.warnings.length).toBe(0);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("STANDALONE round-trip: setup-state → teardown → re-setup-state → teardown converges (idempotent)", async () => {
+  // setup-cluster can't be cleanly sandboxed end-to-end here (its CLI does real keygen via ca.ts), so
+  // we model the cluster STATE it CREATES in temp dirs, teardown to clean, RE-CREATE the same state
+  // (the new-fork re-setup), and teardown again — asserting both converge to the same clean state.
+  const { home, repoRoot, cleanup } = makeClusterFixture({ peers: 1, withCerts: 1 });
+  try {
+    const fx = fakeEffects();
+    // CYCLE 1 teardown.
+    const td1 = await teardownCluster(fx, {
+      ca: CA, repoRoot, home, dryRun: false, confirm: true, biometricAuth: fakeBiometric(true),
+    });
+    expect(td1.localCaWipe.action).toBe("wiped");
+    expect(td1.unregisteredPaths.length).toBe(2);
+    expect(existsSync(caLocalDirPath(home))).toBe(false);
+    expect(existsSync(caPublicKeyPath(repoRoot, CA))).toBe(false);
+    expect(existsSync(trustedUserCaKeysPath(repoRoot, CA))).toBe(false);
+
+    // RE-SETUP-STATE: re-create exactly what setup-cluster produces (the new-fork first-time path).
+    const caPriv = caPrivateKeyPath(home);
+    mkdirSync(dirname(caPriv), { recursive: true });
+    writeFileSync(caPriv, "FAKE-CA-PRIVATE-PLACEHOLDER-2\n", { mode: 0o600 });
+    const caPub = caPublicKeyPath(repoRoot, CA);
+    mkdirSync(dirname(caPub), { recursive: true });
+    writeFileSync(caPub, SELF_CA_LINE + "\n");
+    const trustPath = trustedUserCaKeysPath(repoRoot, CA);
+    writeFileSync(trustPath, "# self cluster CA\n" + SELF_CA_LINE + "\n");
+
+    // CYCLE 2 teardown — converges to the same clean state.
+    const td2 = await teardownCluster(fx, {
+      ca: CA, repoRoot, home, dryRun: false, confirm: true, biometricAuth: fakeBiometric(true),
+    });
+    expect(td2.localCaWipe.action).toBe("wiped");
+    expect(td2.unregisteredPaths.length).toBe(2);
+    expect(existsSync(caLocalDirPath(home))).toBe(false);
+    expect(existsSync(caPublicKeyPath(repoRoot, CA))).toBe(false);
+    expect(existsSync(trustedUserCaKeysPath(repoRoot, CA))).toBe(false);
+
+    // CONVERGENCE: a third teardown on the now-clean sandbox is an idempotent no-op (no prompt).
+    const prompts3: string[] = [];
+    const td3 = await teardownCluster(fx, {
+      ca: CA, repoRoot, home, dryRun: false, confirm: true, biometricAuth: fakeBiometric(true, prompts3),
+    });
+    expect(td3.hadWork).toBe(false);
+    expect(prompts3.length).toBe(0);
+  } finally {
+    cleanup();
+  }
+});
+
+test("readouts + 1Password note are PUBLIC only — no private-key bytes ever echoed", async () => {
+  const { home, repoRoot, cleanup } = makeClusterFixture({ peers: 1 });
+  try {
+    const fx = fakeEffects();
+    const res = await teardownCluster(fx, {
+      ca: CA,
+      repoRoot,
+      home,
+      dryRun: false,
+      confirm: true,
+      biometricAuth: fakeBiometric(true),
+    });
+    const out = formatClusterTeardown(res) + "\n" + format1PasswordNote();
+    expect(out).not.toContain(PRIV_MARKER); // no private-key header in any readout
+    expect(out).toContain("zeta-ca-private"); // the 1Password note names the item
+    expect(out).toContain("Biometric: 1 approval");
+  } finally {
+    cleanup();
+  }
+});
+
+test("countPeerCas counts only NON-self CA lines (the cross-cluster blast radius)", () => {
+  const trust = "# self cluster CA\nssh-ed25519 A self\n# peer-east cluster CA\nssh-ed25519 B east\n# peer-west cluster CA\nssh-ed25519 C west\n";
+  expect(countPeerCas(trust)).toBe(2);
+  expect(countPeerCas("# self cluster CA\nssh-ed25519 A self\n")).toBe(0);
+  expect(countPeerCas("")).toBe(0);
+});
+
+test("rel helpers: repo-relative paths for git rm", () => {
+  expect(caPublicRel("/tmp/myrepo", CA)).toBe(`maintainers/${CA}/ssh-ca.pub`);
+  expect(trustSetRel("/tmp/myrepo", CA)).toBe(`maintainers/${CA}/trusted-user-ca-keys.pub`);
+});
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// SANDBOX-ONLY meta-assertion: every path the cluster teardown touches lives strictly under tmpdir().
+// A path outside tmpdir() means we drifted toward real state — FAIL LOUD rather than touch it.
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+test("SANDBOX-ONLY: all wiped/staged paths live strictly under the temp root (never real state)", async () => {
+  const { home, repoRoot, cleanup } = makeClusterFixture({ peers: 1, withCerts: 1 });
+  try {
+    const root = tmpdir();
+    const removed: string[] = [];
+    const gitRmStaged: { repoRoot: string; relPath: string }[] = [];
+    const fx = fakeEffects({ removed, gitRmStaged });
+    const res = await teardownCluster(fx, {
+      ca: CA,
+      repoRoot,
+      home,
+      dryRun: false,
+      confirm: true,
+      biometricAuth: fakeBiometric(true),
+    });
+    // Every securely-removed local path is under the sandbox home (and tmpdir()).
+    for (const p of removed) {
+      expect(p.startsWith(root)).toBe(true);
+      expect(p.startsWith(home)).toBe(true);
+    }
+    // Every staged git rm is under the sandbox repoRoot (and tmpdir()).
+    for (const s of gitRmStaged) {
+      expect(s.repoRoot).toBe(repoRoot);
+      const full = join(s.repoRoot, s.relPath);
+      expect(full.startsWith(root)).toBe(true);
+      expect(full.startsWith(repoRoot)).toBe(true);
+    }
+    // The REAL ~/.config/zeta default CA path is NOT under our sandbox (we never used it).
+    expect(caPrivateKeyPath().startsWith(home)).toBe(false);
+    expect(caLocalDirPath().startsWith(home)).toBe(false);
+    void res;
+  } finally {
+    cleanup();
+  }
+});
+
+// Touch machineCertPath import so the dependent-cert blast-radius source is exercised + lint-clean.
+test("machineCertPath (teardown.ts) resolves the dependent-cert path used for blast radius", () => {
+  expect(machineCertPath("/tmp/r", "h")).toBe("/tmp/r/machines/h-cert.pub");
+});

--- a/tools/setup/persona-keys/teardown-cluster.ts
+++ b/tools/setup/persona-keys/teardown-cluster.ts
@@ -1,0 +1,575 @@
+// Zeta CLUSTER-SCOPED TEARDOWN / UNREGISTER — the exact inverse of setup-cluster.ts (the cluster
+// trust-root setup + cross-cluster trust), and the remaining teardown corner of the lifecycle triad.
+// DESTRUCTIVE-capable, security-class (workitem 081KVP2M1QS008QG0R000JSXE1E). teardown.ts (#9000)
+// covers the MACHINE scope (this host's private material + its machine pubkey/cert); this covers the
+// CLUSTER scope (the trust ROOT a cluster is stood up around). Built TS-first; a CORE PRIMITIVE that
+// will be generated to every oracle via gen/ (the same shape as setup-cluster / teardown).
+//
+// WHAT setup-cluster CREATES — and therefore what THIS removes/unregisters, exactly inverted:
+//   1. CA PRIVATE key (local) — ~/.config/zeta/ca/ (ensureCa, umask 077). LOCAL WIPE.
+//   2. CA PUBLIC key (repo)   — maintainers/<ca>/ssh-ca.pub (the git-distributed trust root). REPO
+//                               UNREGISTER (git rm staged for a PR).
+//   3. Multi-CA TRUST SET (repo) — maintainers/<ca>/trusted-user-ca-keys.pub (THIS cluster's CA pubkey
+//                               + any PEER cluster CA pubkeys; the value sshd's TrustedUserCAKeys points
+//                               at). REPO UNREGISTER. This is the cluster-specific artifact teardown.ts
+//                               did NOT cover — the clean gap this module closes.
+//   (setup-cluster only PRINTS the ssh-ca.nix snippet; it never writes a file, so there is nothing to
+//   remove for it. The machine pubkey/cert are the MACHINE scope — teardown.ts owns those.)
+//
+// TWO HALVES (both behind the injected-effects pattern — noninterference §13; tests inject fakes),
+// mirroring teardown.ts exactly:
+//   1. LOCAL WIPE — securely remove the CA PRIVATE key dir under ~/.config/zeta/ca/ (shred-then-unlink
+//      via the injected `securelyRemove` door). BIOMETRIC-GATED, FAIL-CLOSED. NEVER echoes key bytes.
+//   2. REPO UNREGISTER — `git rm` (staged for a PR, NEVER pushed) the CA pubkey + the trusted-user-ca-keys
+//      trust set, in the CALLER's own clone only (shared-checkout-is-view-only).
+//
+// CASCADE WITH WARNINGS (the smart-cascade design, docs/research/2026-06-21-smart-cascading-teardown-…):
+//   Tearing down a cluster trust ROOT cascades to everything derived from it — but the cascade is NEVER
+//   silent. We enumerate the blast radius FIRST and WARN on the extra-care classes, never blindly
+//   destroy:
+//     - CROSS-CLUSTER PEER TRUST — the trust set lists PEER cluster CA pubkeys; removing it means those
+//       peers no longer trust certs from THIS cluster (a federation effect on OTHER clusters). WARN.
+//     - DEPENDENT MACHINE CERTS — any machines/<host>-cert.pub signed by THIS CA become unverifiable
+//       once the CA pubkey is unregistered (orphaned trust). WARN with the count (the blast radius).
+//     - UNRECOVERABLE — a wiped CA private is recoverable ONLY by the durable 1Password backup +
+//       re-running setup (re-onboarding is the inverse, not undo). WARN.
+//   The warnings are REPORTED (the plan), never auto-acknowledged; the destructive doors fire only after
+//   the confirm + biometric gate. We do NOT auto-delete peer clusters' trust or other users' state.
+//
+// SECURITY INVARIANTS (security-class — honesty over green), identical to teardown.ts:
+//  1. `--dry-run` is the DEFAULT-safe path: report exactly what WOULD be wiped/unregistered + the
+//     cascade WARNINGS, delete/rm NOTHING, NEVER prompt. A real teardown needs explicit `confirm` AND
+//     the biometric. dry-run never calls the gate.
+//  2. FAIL-CLOSED: a declined/absent biometric ⇒ NOTHING deleted, NOTHING rm'd. The gate fires EXACTLY
+//     ONCE for the whole destructive run (one fingerprint).
+//  3. IDEMPOTENT: a re-run after a teardown is a clean no-op ("already clean"), no prompt.
+//  4. NO secret bytes EVER cross this boundary or get printed — the wipe door consumes paths, returns
+//     only a boolean; we never read CA-private contents into this process.
+//
+// Anchors (Beacon): secure file erasure — `shred(1)` (GNU coreutils; Gutmann 1996) with the SSD/CoW
+// caveat (the durable 1Password backup is the honest recovery path). OpenSSH `TrustedUserCAKeys`
+// multi-CA trust file (`sshd_config(5)`) — the federation artifact being unregistered. `git rm` staging
+// for a removal PR — git as the public-trust distribution channel (ca.ts), removed the same way it was
+// added (never a force-push, never a direct main write). SQL `ON DELETE CASCADE` — but guarded by
+// warnings, unlike silent SQL (the smart-cascade design). Reversible-by-regeneration: re-run
+// setup-cluster (new CA + re-rendered trust set) is the inverse.
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { caPublicKeyPath } from "./ca.ts";
+import { trustedUserCaKeysPath } from "./setup-cluster.ts";
+import { requireBiometric, type BiometricAuth, type BiometricResult } from "./biometric.ts";
+export type { BiometricAuth, BiometricResult } from "./biometric.ts";
+
+/** The host-environment doors — the ONLY channel for ambient influence (noninterference §13). Every
+ *  door is PUBLIC-safe by construction: NO door ever returns private key BYTES. The wipe door consumes
+ *  PATHS and reports success only; `readPublic` is used ONLY for PUBLIC artifacts (the trust set, to
+ *  enumerate the peer-CA blast radius) — never a private key. */
+export interface ClusterTeardownEffects {
+  /** True iff a path exists (presence checks — never reads the contents of a secret). */
+  readonly exists: (path: string) => boolean;
+  /** List leaf file paths under a local dir (PATHS only, never contents). Returns [] if absent. */
+  readonly listFiles: (dir: string) => readonly string[];
+  /** Read a PUBLIC artifact's text (the trust set — to enumerate peer CAs / blast radius). MUST only
+   *  ever be pointed at a PUBLIC file; NEVER the CA private key. Returns "" if absent. */
+  readonly readPublic: (path: string) => string;
+  /** List the dependent machine certs under the repo (machines/<host>-cert.pub) — the blast radius of
+   *  removing the CA pubkey (certs it signed become unverifiable). PATHS only. [] if absent. */
+  readonly listMachineCerts: (repoRoot: string) => readonly string[];
+  /** SECURELY remove ONE local file: shred-then-unlink where available, else overwrite+unlink. Returns
+   *  true iff gone afterwards. NEVER reads/returns the file's bytes. Idempotent (absent ⇒ no-op true). */
+  readonly securelyRemove: (path: string) => boolean;
+  /** Remove a now-empty local directory (best-effort; absent ⇒ no-op). */
+  readonly removeDir: (dir: string) => void;
+  /** Stage a `git rm` of a PUBLIC artifact in the CALLER's repo clone (produces a removal FOR a PR —
+   *  NEVER pushes, NEVER touches main). Returns true iff staged. Operates ONLY under repoRoot. */
+  readonly gitRm: (repoRoot: string, relPath: string) => boolean;
+}
+
+/** The 1Password item that mirrors the local CA private — PRINTED (never deleted) by the optional
+ *  `--note-1password` flag so the operator can decide to delete the durable backup too. We NEVER delete
+ *  from 1Password automatically (the backup is the reversible-by-regeneration safety net). */
+export const ONEPASSWORD_CLUSTER_ITEM = "zeta-ca-private" as const;
+
+/** The base ~/.config/zeta directory for a given home. */
+export function zetaConfigDir(home: string = homedir()): string {
+  return join(home, ".config", "zeta");
+}
+
+/** The local CA private dir (~/.config/zeta/ca/) — the cluster trust root's PRIVATE half. */
+export function caLocalDirPath(home: string = homedir()): string {
+  return join(zetaConfigDir(home), "ca");
+}
+
+/** What happened (or, on dry-run, WOULD happen) to the local CA private material. No secret bytes. */
+export interface LocalCaWipeEntry {
+  readonly path: string;
+  /** Whether the CA private dir was present (had any files) before the run. */
+  readonly present: boolean;
+  /** The leaf file paths under it — PATHS only, NEVER contents. */
+  readonly files: readonly string[];
+  readonly action: "wiped" | "would-wipe" | "absent" | "skipped-not-confirmed" | "skipped-biometric";
+}
+
+/** What happened (or WOULD happen) to one registered PUBLIC cluster artifact. */
+export interface ClusterUnregisterEntry {
+  readonly kind: "ca-pubkey" | "trust-set";
+  readonly path: string;
+  /** Repo-root-relative path passed to `git rm` (the removal staged for a PR). */
+  readonly relPath: string;
+  readonly present: boolean;
+  readonly action:
+    | "unregistered"
+    | "would-unregister"
+    | "absent"
+    | "skipped-not-confirmed"
+    | "skipped-biometric";
+}
+
+/** A cascade warning on an extra-care node — REPORTED before any destruction, never auto-acknowledged
+ *  (the smart-cascade design). PUBLIC only; no secret bytes. */
+export interface CascadeWarning {
+  readonly kind: "cross-cluster-peer" | "dependent-machine-certs" | "unrecoverable-private";
+  /** Human-readable warning naming the blast radius. */
+  readonly message: string;
+  /** The count of affected items where countable (peer CAs / dependent certs); else 0. */
+  readonly blastRadius: number;
+}
+
+/** The full cluster-teardown result — auditable, public-only. Mirrors TeardownResult's shape. */
+export interface ClusterTeardownResult {
+  readonly dryRun: boolean;
+  readonly confirmed: boolean;
+  readonly home: string;
+  readonly repoRoot: string;
+  /** The CA identity whose maintainers/<ca>/ trust root is torn down. */
+  readonly ca: string;
+  readonly localCaWipe: LocalCaWipeEntry;
+  readonly clusterUnregister: readonly ClusterUnregisterEntry[];
+  /** The cascade warnings on extra-care nodes (peer trust / dependent certs / unrecoverable private). */
+  readonly warnings: readonly CascadeWarning[];
+  /** True iff there was anything destructive to do (CA private present OR any repo artifact present).
+   *  When false, the run is a clean no-op ("already clean") and the gate is never fired. */
+  readonly hadWork: boolean;
+  /** The biometric outcome — present ONLY when the gate was actually invoked. NEVER a secret. */
+  readonly biometric?: BiometricResult;
+  /** The repo paths actually staged for `git rm` (the PR's removal set) — for the caller. */
+  readonly unregisteredPaths: readonly string[];
+}
+
+/** Options for a cluster teardown. `dryRun` defaults TRUE at the CLI; here the explicit value governs.
+ *  A real (destructive) run requires `dryRun:false` AND `confirm:true` AND a passing biometric. */
+export interface ClusterTeardownOptions {
+  /** The CA identity (the maintainers/<ca>/ trust root to tear down). */
+  readonly ca: string;
+  readonly repoRoot: string;
+  readonly home?: string;
+  /** When true, NOTHING is deleted/rm'd/prompted — report "would-*" + the warnings. DEFAULT-safe. */
+  readonly dryRun?: boolean;
+  /** Explicit destructive confirmation. WITHOUT it (on a non-dry-run) every step is
+   *  "skipped-not-confirmed". WITH it (+ biometric) the wipe + rm happen. */
+  readonly confirm?: boolean;
+  /** SHARED biometric approval door — required for the real destructive path (fail-closed). */
+  readonly biometricAuth?: BiometricAuth;
+}
+
+/** Repo-root-relative path for a readout / `git rm` argument (POSIX-ish, ordinal). */
+function relUnder(repoRoot: string, path: string): string {
+  const prefix = repoRoot.endsWith("/") ? repoRoot : repoRoot + "/";
+  return path.startsWith(prefix) ? path.slice(prefix.length) : path;
+}
+
+/** The repo-root-RELATIVE path of the CA public key (the `git rm` argument). */
+export function caPublicRel(repoRoot: string, ca: string): string {
+  return relUnder(repoRoot, caPublicKeyPath(repoRoot, ca));
+}
+
+/** The repo-root-RELATIVE path of the multi-CA trust set (the `git rm` argument). */
+export function trustSetRel(repoRoot: string, ca: string): string {
+  return relUnder(repoRoot, trustedUserCaKeysPath(repoRoot, ca));
+}
+
+/** Count the PEER cluster CA lines in a rendered trust set (the cross-cluster blast radius). The
+ *  trust-set file is `# <source> cluster CA` comment lines + one pubkey per line; "self" is THIS
+ *  cluster, every other named source is a PEER. PURE: text only, no IO, no secret. */
+export function countPeerCas(trustSetText: string): number {
+  let peers = 0;
+  for (const line of trustSetText.split("\n")) {
+    const m = /^#\s+(\S+)\s+cluster CA\s*$/.exec(line.trim());
+    if (m && m[1] !== "self") peers += 1;
+  }
+  return peers;
+}
+
+/**
+ * Run the cluster-scoped teardown / unregister — the exact inverse of setup-cluster. DEFAULT-safe: on
+ * `dryRun` (or a non-dry-run WITHOUT `confirm`) it reports exactly what WOULD be wiped/unregistered +
+ * the cascade WARNINGS and touches NOTHING and NEVER prompts. A real teardown requires `dryRun:false`
+ * AND `confirm:true` AND ONE passing biometric approval (fired exactly once). Idempotent: nothing
+ * present ⇒ a clean no-op ("already clean") with NO prompt.
+ *
+ * The plan + the cascade blast radius are computed FIRST (pure presence/PUBLIC reads) so the readout +
+ * warnings are honest on every path; the destructive doors fire ONLY after the confirm + biometric gate.
+ */
+export async function teardownCluster(
+  fx: ClusterTeardownEffects,
+  opts: ClusterTeardownOptions,
+): Promise<ClusterTeardownResult> {
+  const home = opts.home ?? homedir();
+  const dryRun = opts.dryRun !== false; // DEFAULT-safe: anything but an explicit false is a dry-run
+  const confirmed = opts.confirm === true;
+
+  // ── PLAN (pure presence checks — no side effects, no prompt) ──────────────────────────────────
+  // LOCAL: the CA private dir.
+  const caDir = caLocalDirPath(home);
+  const caDirPresent = fx.exists(caDir);
+  const caFiles = caDirPresent ? fx.listFiles(caDir) : [];
+
+  // REPO: the two registered PUBLIC cluster artifacts (CA pubkey + the multi-CA trust set).
+  const caPubPath = caPublicKeyPath(opts.repoRoot, opts.ca);
+  const trustSetPath = trustedUserCaKeysPath(opts.repoRoot, opts.ca);
+  const repoTargets: readonly { kind: ClusterUnregisterEntry["kind"]; path: string }[] = [
+    { kind: "ca-pubkey", path: caPubPath },
+    { kind: "trust-set", path: trustSetPath },
+  ];
+  const repoPlan = repoTargets.map((t) => ({
+    ...t,
+    relPath: relUnder(opts.repoRoot, t.path),
+    present: fx.exists(t.path),
+  }));
+
+  const hadWork = caDirPresent || repoPlan.some((r) => r.present);
+
+  // ── CASCADE BLAST RADIUS + WARNINGS (computed FIRST, on every path — never silent) ────────────
+  const warnings: CascadeWarning[] = [];
+  // Cross-cluster peer trust: how many PEER cluster CAs does the trust set list?
+  const trustSetText = repoPlan.find((r) => r.kind === "trust-set")?.present ? fx.readPublic(trustSetPath) : "";
+  const peerCount = countPeerCas(trustSetText);
+  if (peerCount > 0) {
+    warnings.push({
+      kind: "cross-cluster-peer",
+      blastRadius: peerCount,
+      message:
+        `CROSS-CLUSTER TRUST: the trust set lists ${peerCount} PEER cluster CA(s). Removing it means ` +
+        `those peers no longer trust certs from THIS cluster (a federation effect on OTHER clusters). ` +
+        `This teardown removes only THIS cluster's trust set — it does NOT touch the peers' own state.`,
+    });
+  }
+  // Dependent machine certs: certs signed by THIS CA become unverifiable once the CA pubkey is gone.
+  const dependentCerts = repoPlan.find((r) => r.kind === "ca-pubkey")?.present
+    ? fx.listMachineCerts(opts.repoRoot)
+    : [];
+  if (dependentCerts.length > 0) {
+    warnings.push({
+      kind: "dependent-machine-certs",
+      blastRadius: dependentCerts.length,
+      message:
+        `DEPENDENT CERTS: ${dependentCerts.length} machine cert(s) are signed by this CA and become ` +
+        `UNVERIFIABLE once the CA pubkey is unregistered (orphaned trust). Re-onboard each machine ` +
+        `(re-sign against the new CA) after re-running setup. Machine private keys are NOT touched here.`,
+    });
+  }
+  // Unrecoverable private: a wiped CA private is recoverable only via the durable backup + re-setup.
+  if (caDirPresent) {
+    warnings.push({
+      kind: "unrecoverable-private",
+      blastRadius: 0,
+      message:
+        `UNRECOVERABLE: wiping the CA PRIVATE key is reversible ONLY by re-running setup (a NEW keypair) ` +
+        `or restoring the durable 1Password backup (${ONEPASSWORD_CLUSTER_ITEM}). Teardown is destructive, ` +
+        `re-onboarding is the inverse — not undo.`,
+    });
+  }
+
+  const localAbsent: LocalCaWipeEntry = {
+    path: caDir,
+    present: caDirPresent,
+    files: caFiles,
+    action: "absent",
+  };
+
+  // ── DRY-RUN (default-safe) — report would-* + warnings; NOTHING touched, NEVER prompt ─────────
+  if (dryRun) {
+    return finalize({
+      dryRun: true,
+      confirmed,
+      home,
+      repoRoot: opts.repoRoot,
+      ca: opts.ca,
+      localCaWipe: {
+        ...localAbsent,
+        action: caDirPresent ? "would-wipe" : "absent",
+      },
+      clusterUnregister: repoPlan.map((r) => ({
+        kind: r.kind,
+        path: r.path,
+        relPath: r.relPath,
+        present: r.present,
+        action: r.present ? ("would-unregister" as const) : ("absent" as const),
+      })),
+      warnings,
+      hadWork,
+    });
+  }
+
+  // ── REAL RUN, BUT NOT CONFIRMED — skip everything (fail-safe), NEVER prompt ───────────────────
+  if (!confirmed) {
+    return finalize({
+      dryRun: false,
+      confirmed: false,
+      home,
+      repoRoot: opts.repoRoot,
+      ca: opts.ca,
+      localCaWipe: {
+        ...localAbsent,
+        action: caDirPresent ? "skipped-not-confirmed" : "absent",
+      },
+      clusterUnregister: repoPlan.map((r) => ({
+        kind: r.kind,
+        path: r.path,
+        relPath: r.relPath,
+        present: r.present,
+        action: r.present ? ("skipped-not-confirmed" as const) : ("absent" as const),
+      })),
+      warnings,
+      hadWork,
+    });
+  }
+
+  // ── IDEMPOTENT CLEAN NO-OP — nothing present, so nothing destructive; NEVER prompt ────────────
+  if (!hadWork) {
+    return finalize({
+      dryRun: false,
+      confirmed: true,
+      home,
+      repoRoot: opts.repoRoot,
+      ca: opts.ca,
+      localCaWipe: { path: caDir, present: false, files: [], action: "absent" },
+      clusterUnregister: repoPlan.map((r) => ({
+        kind: r.kind,
+        path: r.path,
+        relPath: r.relPath,
+        present: false,
+        action: "absent" as const,
+      })),
+      warnings: [],
+      hadWork: false,
+    });
+  }
+
+  // ── BIOMETRIC GATE — fired EXACTLY ONCE for the whole destructive run (fail-closed) ───────────
+  const biometric = await requireBiometric(
+    opts.biometricAuth,
+    `Approve Zeta CLUSTER TEARDOWN for ca=${opts.ca} (DESTRUCTIVE: wipe CA private key + unregister ` +
+      `the CA pubkey & multi-CA trust set for a PR; ${warnings.length} cascade warning(s))`,
+  );
+  if (!biometric.ok) {
+    return finalize({
+      dryRun: false,
+      confirmed: true,
+      home,
+      repoRoot: opts.repoRoot,
+      ca: opts.ca,
+      biometric,
+      localCaWipe: {
+        ...localAbsent,
+        action: caDirPresent ? "skipped-biometric" : "absent",
+      },
+      clusterUnregister: repoPlan.map((r) => ({
+        kind: r.kind,
+        path: r.path,
+        relPath: r.relPath,
+        present: r.present,
+        action: r.present ? ("skipped-biometric" as const) : ("absent" as const),
+      })),
+      warnings,
+      hadWork,
+    });
+  }
+
+  // ── DESTRUCTIVE EXECUTION (approved) ─────────────────────────────────────────────────────────
+  // LOCAL WIPE: securely remove every CA private file, then tidy the now-empty dir.
+  let localCaWipe: LocalCaWipeEntry;
+  if (caDirPresent) {
+    for (const f of caFiles) fx.securelyRemove(f);
+    fx.removeDir(caDir);
+    localCaWipe = { path: caDir, present: true, files: caFiles, action: "wiped" };
+  } else {
+    localCaWipe = { path: caDir, present: false, files: [], action: "absent" };
+  }
+
+  // REPO UNREGISTER: stage a `git rm` of each present cluster artifact (for a PR — never pushed).
+  const clusterUnregister: ClusterUnregisterEntry[] = repoPlan.map((r) => {
+    if (!r.present) {
+      return { kind: r.kind, path: r.path, relPath: r.relPath, present: false, action: "absent" as const };
+    }
+    fx.gitRm(opts.repoRoot, r.relPath);
+    return { kind: r.kind, path: r.path, relPath: r.relPath, present: true, action: "unregistered" as const };
+  });
+
+  return finalize({
+    dryRun: false,
+    confirmed: true,
+    home,
+    repoRoot: opts.repoRoot,
+    ca: opts.ca,
+    biometric,
+    localCaWipe,
+    clusterUnregister,
+    warnings,
+    hadWork: true,
+  });
+}
+
+/** Fill the derived fields (`unregisteredPaths`) and return a complete result. */
+function finalize(partial: Omit<ClusterTeardownResult, "unregisteredPaths">): ClusterTeardownResult {
+  const unregisteredPaths = partial.clusterUnregister
+    .filter((r) => r.action === "unregistered")
+    .map((r) => r.relPath);
+  return { ...partial, unregisteredPaths };
+}
+
+/** Render the operator-facing readout — PUBLIC only, NEVER any key bytes. Leads with the CASCADE
+ *  WARNINGS (the blast radius) so the operator sees them before deciding to --confirm. */
+export function formatClusterTeardown(res: ClusterTeardownResult): string {
+  const lines: string[] = [];
+  const mode = res.dryRun
+    ? "DRY RUN (default-safe — NOTHING deleted, rm'd, or prompted)"
+    : res.confirmed
+      ? "CONFIRMED cluster teardown"
+      : "NOT CONFIRMED (no --confirm — NOTHING touched)";
+  lines.push(`Zeta teardown-cluster — ca=${res.ca} — ${mode}`);
+
+  if (!res.hadWork) {
+    lines.push("  Already clean: no CA private material and no registered cluster artifacts found.");
+    lines.push("  (Idempotent no-op — nothing to wipe, nothing to unregister, no approval needed.)");
+    return lines.join("\n");
+  }
+
+  // CASCADE WARNINGS first — never silent (smart-cascade design).
+  if (res.warnings.length > 0) {
+    lines.push("  ⚠ CASCADE WARNINGS (extra-care nodes — review the blast radius BEFORE --confirm):");
+    for (const w of res.warnings) {
+      const radius = w.blastRadius > 0 ? ` [blast radius: ${w.blastRadius}]` : "";
+      lines.push(`    - ${w.message}${radius}`);
+    }
+  }
+
+  lines.push("  LOCAL WIPE (this cluster's CA PRIVATE key under ~/.config/zeta/ca/):");
+  {
+    const l = res.localCaWipe;
+    const tag =
+      l.action === "would-wipe"
+        ? `would wipe ${l.files.length} file(s)`
+        : l.action === "wiped"
+          ? `WIPED ${l.files.length} file(s)`
+          : l.action === "absent"
+            ? "absent (nothing to wipe)"
+            : l.action === "skipped-not-confirmed"
+              ? "present — skipped (no --confirm)"
+              : "present — skipped (biometric declined)";
+    lines.push(`    [ca] ${l.path} — ${tag}`);
+  }
+
+  lines.push("  REPO UNREGISTER (remove registered PUBLIC cluster artifacts — staged for a PR, NOT pushed):");
+  for (const r of res.clusterUnregister) {
+    const tag =
+      r.action === "would-unregister"
+        ? "would git rm"
+        : r.action === "unregistered"
+          ? "git rm STAGED"
+          : r.action === "absent"
+            ? "absent (not registered)"
+            : r.action === "skipped-not-confirmed"
+              ? "present — skipped (no --confirm)"
+              : "present — skipped (biometric declined)";
+    lines.push(`    [${r.kind}] ${r.relPath} — ${tag}`);
+  }
+
+  if (res.dryRun) {
+    lines.push("  Re-run with --confirm (and approve the biometric) to execute the cluster teardown.");
+  } else if (res.confirmed && res.biometric?.ok === true) {
+    lines.push(`  Biometric: 1 approval covered the whole destructive run (${res.biometric.platform}).`);
+    lines.push(
+      `  Unregistered (staged for PR): ${res.unregisteredPaths.length} path(s). Commit + open a PR to land the removal.`,
+    );
+  } else if (res.confirmed && res.biometric !== undefined && !res.biometric.ok) {
+    lines.push(`  Biometric DECLINED — fail-closed: nothing deleted, nothing unregistered.`);
+  }
+  return lines.join("\n");
+}
+
+/** Render the optional 1Password note — PRINTS the CA-private item so the operator can decide to delete
+ *  the durable backup too. NEVER deletes from 1Password (that is the operator's explicit call). */
+export function format1PasswordNote(): string {
+  return [
+    "1Password backup (NOT deleted automatically — your call):",
+    `    - ${ONEPASSWORD_CLUSTER_ITEM}`,
+    "  Delete this manually in 1Password ONLY if you want to remove the durable CA-private backup too.",
+  ].join("\n");
+}
+
+/** The REAL host effects (used by the CLI). The wipe door does the secure erasure; the git door shells
+ *  `git rm` under the given repoRoot — never a push, never main. NO door returns secret bytes. */
+export function realEffects(): ClusterTeardownEffects {
+  const walkFiles = (dir: string): string[] => {
+    if (!existsSync(dir)) return [];
+    const out: string[] = [];
+    const walk = (d: string): void => {
+      for (const entry of readdirSync(d, { withFileTypes: true })) {
+        const full = join(d, entry.name);
+        if (entry.isDirectory()) walk(full);
+        else out.push(full);
+      }
+    };
+    walk(dir);
+    return out;
+  };
+  return {
+    exists: (p) => existsSync(p),
+    listFiles: walkFiles,
+    readPublic: (p) => (existsSync(p) ? readFileSync(p, "utf8") : ""),
+    listMachineCerts: (repoRoot) => {
+      const dir = join(repoRoot, "machines");
+      if (!existsSync(dir)) return [];
+      return readdirSync(dir)
+        .filter((n) => n.endsWith("-cert.pub"))
+        .map((n) => join(dir, n));
+    },
+    securelyRemove: (path) => {
+      if (!existsSync(path)) return true; // idempotent: already gone
+      // Prefer `shred` (overwrite-then-unlink) where available so private bytes don't linger; fall
+      // back to a manual overwrite + unlink. NEVER reads the file's bytes into this process.
+      const shredded = spawnSync("shred", ["-u", "-z", path], { stdio: "ignore" });
+      if (shredded.status === 0 && !existsSync(path)) return true;
+      try {
+        const size = statSync(path).size;
+        if (size > 0) writeFileSync(path, Buffer.alloc(size, 0));
+      } catch {
+        // overwrite is best-effort; proceed to unlink regardless
+      }
+      try {
+        unlinkSync(path);
+      } catch {
+        return false;
+      }
+      return !existsSync(path);
+    },
+    removeDir: (dir) => {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // best-effort tidy of the now-empty dir
+      }
+    },
+    gitRm: (repoRoot, relPath) => {
+      // Stage a removal for a PR — `git rm` under the caller's repoRoot. NEVER pushes, NEVER main.
+      // --ignore-unmatch keeps it idempotent (an already-removed/untracked path is not an error).
+      const r = spawnSync("git", ["-C", repoRoot, "rm", "--ignore-unmatch", "--", relPath], {
+        stdio: "ignore",
+      });
+      return r.status === 0;
+    },
+  };
+}


### PR DESCRIPTION
## Why

`teardown.ts` (#9000) covers the **machine** scope; the **cluster** scope (the trust ROOT a cluster is stood up around, via `setup-cluster.ts`) had no inverse — the remaining clean gap in the lifecycle triad's teardown corner. The round-trip harness named it. This builds the precise inverse. **Backlog: 081KVP2M1QS008QG0R000JSXE1E.**

## What setup-cluster CREATES → what this removes (artifact-for-artifact)

| setup-cluster artifact | inverse |
|---|---|
| CA **private** key `~/.config/zeta/ca/` | secure shred-then-unlink **LOCAL WIPE** |
| CA **public** key `maintainers/<ca>/ssh-ca.pub` | `git rm` **staged for a PR** |
| multi-CA trust set `maintainers/<ca>/trusted-user-ca-keys.pub` | `git rm` staged — **the cluster-specific artifact `teardown.ts` did not cover** |

(setup-cluster only PRINTS the `ssh-ca.nix` snippet — nothing written, nothing to remove. Machine pubkey/cert stay in the machine scope owned by `teardown.ts`.)

## Cascade WITH WARNINGS (smart-cascade design)

Per `docs/research/2026-06-21-smart-cascading-teardown-…`: enumerate the **blast radius first**, **WARN** (never auto-destroy) on the three extra-care classes — cross-cluster **PEER trust** (counted from the trust set), **DEPENDENT machine certs** (counted under `machines/`), and the **UNRECOVERABLE** CA private. Warnings lead the readout so the operator sees them before `--confirm`.

## Security-class invariants (mirrors `teardown.ts` exactly)

- `--dry-run` **DEFAULT-safe**: reports plan + warnings, touches nothing, **no prompt**.
- `--confirm` + **ONE biometric** does the real wipe; **fail-closed** on decline.
- **Idempotent** re-run = "already clean".
- REPO half is `git rm` **staged for a PR only** — never a push; honors `shared-checkout-is-view-only`.
- **No private-key bytes** ever cross the boundary or get printed.

## Gate (all green)

- `bun test teardown-cluster.test.ts` → **12/12 pass**, fully sandboxed (temp HOME + temp repo + fake biometric + fake `git rm`).
- Standalone **round-trip**: setup-state → teardown → re-setup-state → teardown **converges** (idempotent).
- **SANDBOX-ONLY meta-test**: every wiped/staged path asserted under `tmpdir()`.
- `grep -E "BEGIN.*PRIVATE KEY"` / `"PRIVATE KEY"` → **empty** (test marker split at runtime).
- `bun src/Core.TypeScript/lint/lint-typescript.ts` → **green**.
- Not added to `onboarding-roundtrip.test.ts` because setup-cluster's CLI does real `ssh-keygen`; the standalone temp-dir round-trip proves convergence instead (the task's allowed alternative).

## Files

- `tools/setup/persona-keys/teardown-cluster.ts`
- `tools/setup/persona-keys/teardown-cluster-cli.ts`
- `tools/setup/persona-keys/teardown-cluster.test.ts`

**Security-class: NO auto-merge — left OPEN for Otto's verify-gate.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)